### PR TITLE
fix: disable native wayland by default

### DIFF
--- a/.electron-builder.config.js
+++ b/.electron-builder.config.js
@@ -64,7 +64,7 @@ const config = {
       // System notifications with libnotify
       '--talk-name=org.freedesktop.Notifications',
     ],
-    useWaylandFlags: 'true',
+    useWaylandFlags: 'false',
     artifactName: 'podman-desktop-${version}.${ext}',
     runtimeVersion: '21.08',
     branch: 'main',


### PR DESCRIPTION
Fixes https://github.com/containers/podman-desktop/issues/273

it fails on current electron builds with
libwayland: zxdg_exporter_v1@24: error 0: exported surface had an invalid role

Change-Id: I9c4d02d3307351da1456bb800f9e248fef4cf59b
Signed-off-by: Florent Benoit <fbenoit@redhat.com>