### PR TITLE
fix: add link to the Podman/Docker compatibility guide

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -443,6 +443,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       url: 'https://podman.io/getting-started/installation',
     },
     {
+      title: 'Read the Podman/Docker compatibility guide',
+      url: 'https://podman-desktop.io/docs/troubleshooting#warning-about-docker-compatibility-mode',
+    },
+    {
       title: 'Join the Podman community',
       url: 'https://podman.io/community/',
     },


### PR DESCRIPTION
Fixes #1709

### What does this PR do?

Add a new link to the Podman/Desktop compatibily guide

### Screenshot/screencast of this PR

![image](https://user-images.githubusercontent.com/695993/226548826-eefd2a46-11ba-4420-aa33-712ef2a9f8b6.png)

### What issues does this PR fix or reference?

Fixes #1709

### How to test this PR?

1. Launch Podman Desktop
2. On the Dashboard in the Podman section, you should see a new link to the Podman/Docker compatibility guide