### PR TITLE
feat(extension-api): add implementation for configuration change event

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -440,7 +440,7 @@ declare module '@podman-desktop/api' {
     /**
      * An event that is emitted when the {@link Configuration configuration} changed.
      */
-    // export const onDidChangeConfiguration: Event<ConfigurationChangeEvent>;
+    export const onDidChangeConfiguration: Event<ConfigurationChangeEvent>;
   }
 
   /**

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -1,0 +1,110 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import * as fs from 'node:fs';
+import type { IConfigurationNode } from './configuration-registry';
+import { ConfigurationRegistry } from './configuration-registry';
+
+let configurationRegistry: ConfigurationRegistry;
+
+// mock the fs methods
+const readFileSync = vi.spyOn(fs, 'readFileSync');
+
+beforeAll(() => {
+  // mock the fs module
+  vi.mock('node:fs');
+
+  configurationRegistry = new ConfigurationRegistry();
+  readFileSync.mockReturnValue(JSON.stringify({}));
+
+  configurationRegistry.init();
+
+  const node: IConfigurationNode = {
+    id: 'my.fake.property',
+    title: 'Fake Property',
+    type: 'object',
+    properties: {
+      ['my.fake.property']: {
+        description: 'Autostart container engine when launching Podman Desktop',
+        type: 'string',
+        default: 'myDefault',
+      },
+    },
+  };
+
+  configurationRegistry.registerConfigurations([node]);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('should be notified when a configuration is changed', async () => {
+  test('affectsConfiguration exact name', async () => {
+    let expectAffectsConfiguration;
+    let called = false;
+    let updatedValue;
+    configurationRegistry.onDidChangeConfigurationAPI(e => {
+      called = true;
+      expectAffectsConfiguration = e.affectsConfiguration('my.fake.property');
+      if (expectAffectsConfiguration) {
+        updatedValue = configurationRegistry.getConfiguration('my.fake')?.get<string>('property');
+      }
+    });
+    await configurationRegistry.updateConfigurationValue('my.fake.property', 'myValue');
+
+    expect(called).toBeTruthy();
+    expect(expectAffectsConfiguration).toBeTruthy();
+    expect(updatedValue).toEqual('myValue');
+  });
+
+  test('affectsConfiguration partial name', async () => {
+    let expectAffectsConfiguration;
+    let called = false;
+    let updatedValue;
+    configurationRegistry.onDidChangeConfigurationAPI(e => {
+      called = true;
+      // use a parent property name
+      expectAffectsConfiguration = e.affectsConfiguration('my.fake');
+      if (expectAffectsConfiguration) {
+        updatedValue = configurationRegistry.getConfiguration('my.fake')?.get<string>('property');
+      }
+    });
+    await configurationRegistry.updateConfigurationValue('my.fake.property', 'myValue');
+
+    expect(called).toBeTruthy();
+    expect(expectAffectsConfiguration).toBeTruthy();
+    expect(updatedValue).toEqual('myValue');
+  });
+
+  test('affectsConfiguration different name', async () => {
+    let expectAffectsConfiguration;
+    let called = false;
+
+    configurationRegistry.onDidChangeConfigurationAPI(e => {
+      called = true;
+      // should not match
+      expectAffectsConfiguration = e.affectsConfiguration('my.other.property');
+    });
+    await configurationRegistry.updateConfigurationValue('my.fake.property', 'myValue');
+
+    expect(called).toBeTruthy();
+    expect(expectAffectsConfiguration).toBeFalsy();
+  });
+});

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -103,6 +103,10 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   private readonly _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
   readonly onDidChangeConfiguration: Event<IConfigurationChangeEvent> = this._onDidChangeConfiguration.event;
 
+  private readonly _onDidChangeConfigurationAPI = new Emitter<containerDesktopAPI.ConfigurationChangeEvent>();
+  readonly onDidChangeConfigurationAPI: Event<containerDesktopAPI.ConfigurationChangeEvent> =
+    this._onDidChangeConfigurationAPI.event;
+
   // Contains the value of the current configuration
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private configurationValues: Map<string, any>;
@@ -224,6 +228,14 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     }
     const event = { key, value, scope };
     this._onDidChangeConfiguration.fire(event);
+
+    const affectsConfiguration = function (affectedSection: string, affectedScope?: ConfigurationScope): boolean {
+      if (affectedScope && affectedScope !== scope) {
+        return false;
+      }
+      return key.startsWith(affectedSection);
+    };
+    this._onDidChangeConfigurationAPI.fire({ affectsConfiguration });
     return promise;
   }
 

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -429,6 +429,9 @@ export class ExtensionLoader {
       ): containerDesktopAPI.Configuration {
         return configurationRegistry.getConfiguration(section, scope);
       },
+      onDidChangeConfiguration: (listener, thisArg, disposables) => {
+        return configurationRegistry.onDidChangeConfigurationAPI(listener, thisArg, disposables);
+      },
     };
 
     const imageRegistry = this.imageRegistry;


### PR DESCRIPTION
### What does this PR do?
add implementation for configuration change event

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1732


### How to test this PR?

You may try the code from the referenced issue

or

```
export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
  extensionApi.configuration.onDidChangeConfiguration(e => {
    console.log(`Configuration changed 1: ${e.affectsConfiguration('terminal.integrated.fontSize')}`);
  });
}
```

Change-Id: Ic9681cad8909ae71a9e547031db1819286979fc7
