### PR TITLE
nit: clean up links

### DIFF
--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -457,19 +457,19 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // add links
   providerOptions.links = [
     {
-      title: 'Visit the Podman website',
+      title: 'Website',
       url: 'https://podman.io/',
     },
     {
-      title: 'Read the Podman installation guide',
+      title: 'Installation guide',
       url: 'https://podman.io/getting-started/installation',
     },
     {
-      title: 'Read the Podman/Docker compatibility guide',
+      title: 'Docker compatibility guide',
       url: 'https://podman-desktop.io/docs/troubleshooting#warning-about-docker-compatibility-mode',
     },
     {
-      title: 'Join the Podman community',
+      title: 'Join the community',
       url: 'https://podman.io/community/',
     },
   ];


### PR DESCRIPTION
nit: clean up links

### What does this PR do?

A lot of repeated information / "Podman" ... and "Visit this". Makes all
the sentences long / hard to read on smaller width screens

This PR reduces the amount of wording from "Visit the Podman website" to
just "Website"

### Screenshot/screencast of this PR

<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot 2023-04-05 at 12 17 35 PM](https://user-images.githubusercontent.com/6422176/230142751-f3c1f70e-44cb-48f0-a34e-2555f20b9eb8.png)
![Screenshot 2023-04-05 at 12 19 10 PM](https://user-images.githubusercontent.com/6422176/230142761-16d0ee56-bd30-4d4c-85bd-d43cc9818bbc.png)



### What issues does this PR fix or reference?

<!-- Please include any related issue from Podman Desktop repository (or from another issue tracker).
-->

N/A

### How to test this PR?

<!-- Please explain steps to reproduce -->

`yarn watch`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
