### PR TITLE
feat: Remove extension from its own page

### DIFF
--- a/packages/renderer/src/TelemetryService.ts
+++ b/packages/renderer/src/TelemetryService.ts
@@ -39,7 +39,9 @@ export class TelemetryService {
     }
 
     this.handlerFlusher = setTimeout(() => {
-      window.telemetryPage(pagePath);
+      if (window.telemetryPage) {
+        window.telemetryPage(pagePath);
+      }
     }, 200);
   }
 }

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.spec.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import PreferencesExtensionRendering from './PreferencesExtensionRendering.svelte';
+import { extensionInfos } from '../../stores/extensions';
+
+// fake the window.events object
+beforeAll(() => {
+  (window.events as unknown) = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    receive: (_channel: string, func: any) => {
+      func();
+    },
+  };
+});
+
+// extension page needs a mock extension to work correctly
+function setup(state: string): string {
+  const extensionInfo = {
+    id: 'test',
+    name: 'test',
+    version: '1.0',
+    displayName: 'Test extension',
+    state: state,
+    description: 'An extension for testing',
+    path: '/test',
+    publisher: 'podman-desktop',
+    removable: true,
+  };
+
+  extensionInfos.set([extensionInfo]);
+  return extensionInfo.id;
+}
+describe('PreferencesExtensionRendering', () => {
+  test('Expect that the buttons have the correct state when an extension is stopped', async () => {
+    const id = setup('stopped');
+    render(PreferencesExtensionRendering, { extensionId: id });
+
+    const start = screen.getByRole('button', { name: 'Start' });
+    expect(start).toBeInTheDocument();
+    expect(start).toBeEnabled();
+    const stop = screen.getByRole('button', { name: 'Stop' });
+    expect(stop).toBeInTheDocument();
+    expect(stop).toBeDisabled();
+    const remove = screen.getByRole('button', { name: 'Remove' });
+    expect(remove).toBeInTheDocument();
+    expect(remove).toBeEnabled();
+  });
+
+  test('Expect that the buttons have the correct state when an extension is started', async () => {
+    const id = setup('started');
+    render(PreferencesExtensionRendering, { extensionId: id });
+
+    const start = screen.getByRole('button', { name: 'Start' });
+    expect(start).toBeInTheDocument();
+    expect(start).toBeDisabled();
+    const stop = screen.getByRole('button', { name: 'Stop' });
+    expect(stop).toBeInTheDocument();
+    expect(stop).toBeEnabled();
+    const remove = screen.getByRole('button', { name: 'Remove' });
+    expect(remove).toBeInTheDocument();
+    expect(remove).toBeDisabled();
+  });
+
+  test('Expect that the buttons have the correct state when an extension is starting', async () => {
+    const id = setup('starting');
+    render(PreferencesExtensionRendering, { extensionId: id });
+
+    const start = screen.getByRole('button', { name: 'Start' });
+    expect(start).toBeInTheDocument();
+    expect(start).toBeDisabled();
+    const stop = screen.getByRole('button', { name: 'Stop' });
+    expect(stop).toBeInTheDocument();
+    expect(stop).toBeDisabled();
+    const remove = screen.getByRole('button', { name: 'Remove' });
+    expect(remove).toBeInTheDocument();
+    expect(remove).toBeDisabled();
+  });
+
+  test('Expect that the buttons have the correct state when an extension is stopping', async () => {
+    const id = setup('stopping');
+    render(PreferencesExtensionRendering, { extensionId: id });
+
+    const start = screen.getByRole('button', { name: 'Start' });
+    expect(start).toBeInTheDocument();
+    expect(start).toBeDisabled();
+    const stop = screen.getByRole('button', { name: 'Stop' });
+    expect(stop).toBeInTheDocument();
+    expect(stop).toBeDisabled();
+    const remove = screen.getByRole('button', { name: 'Remove' });
+    expect(remove).toBeInTheDocument();
+    expect(remove).toBeDisabled();
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesExtensionRendering.svelte
@@ -16,6 +16,10 @@ async function stopExtension() {
 async function startExtension() {
   await window.startExtension(extensionInfo.id);
 }
+async function removeExtension() {
+  window.location.href = '#/preferences/extensions';
+  await window.removeExtension(extensionInfo.id);
+}
 </script>
 
 <SettingsPage title="{extensionInfo.displayName} Extension">
@@ -31,8 +35,8 @@ async function startExtension() {
           <ConnectionStatus status="{extensionInfo.state}" />
         </div>
 
-        <div class="py-2 flex flex:row">
-          <!-- start is enabled only in stopped mode-->
+        <div class="py-2 flex flex-row items-center">
+          <!-- start is enabled only when stopped -->
           <div class="px-2 text-sm italic text-gray-700">
             <button
               disabled="{extensionInfo.state !== 'stopped'}"
@@ -46,7 +50,7 @@ async function startExtension() {
             </button>
           </div>
 
-          <!-- stop is enabled only in started mode-->
+          <!-- stop is enabled only when started -->
           <div class="px-2 text-sm italic text-gray-700">
             <button
               disabled="{extensionInfo.state !== 'started'}"
@@ -59,6 +63,24 @@ async function startExtension() {
               Stop
             </button>
           </div>
+
+          <!-- delete is enabled only when stopped -->
+          {#if extensionInfo.removable}
+            <div class="px-2 text-sm italic text-gray-700">
+              <button
+                disabled="{extensionInfo.state !== 'stopped'}"
+                on:click="{() => removeExtension()}"
+                class="pf-c-button pf-m-primary"
+                type="button">
+                <span class="pf-c-button__icon pf-m-start">
+                  <i class="fas fa-trash" aria-hidden="true"></i>
+                </span>
+                Remove
+              </button>
+            </div>
+          {:else}
+            <div class="text-gray-900 items-center px-2 text-sm">Default extension, cannot be removed</div>
+          {/if}
         </div>
       </Route>
     {/if}

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -28,25 +28,24 @@ export async function fetchExtensions() {
 export const extensionInfos: Writable<ExtensionInfo[]> = writable([]);
 
 // need to refresh when extension is started or stopped
-window?.events.receive('extension-starting', () => {
+window?.events?.receive('extension-starting', () => {
   fetchExtensions();
 });
-window?.events.receive('extension-started', () => {
+window?.events?.receive('extension-started', () => {
   fetchExtensions();
 });
-window?.events.receive('extension-stopping', () => {
+window?.events?.receive('extension-stopping', () => {
   fetchExtensions();
 });
-window?.events.receive('extension-stopped', () => {
+window?.events?.receive('extension-stopped', () => {
   fetchExtensions();
 });
-window?.events.receive('extension-removed', () => {
+window?.events?.receive('extension-removed', () => {
+  fetchExtensions();
+});
+window?.events?.receive('extensions-started', () => {
   fetchExtensions();
 });
 window.addEventListener('system-ready', () => {
-  fetchExtensions();
-});
-
-window.events?.receive('extensions-started', () => {
   fetchExtensions();
 });


### PR DESCRIPTION
### What does this PR do?

Today you can remove extensions from the main page, but not the child page specific to that extension. This adds an action to remove user extensions (bumping the user back to the main page), and a comment for built-in extensions that you can't remove them.

We haven't done a proper redesign for these pages, but it seems likely we'll need this action on every page and it resolves the first part of issue #1392 (hard to find delete action).

### Screenshot/screencast of this PR

<img width="509" alt="Screenshot 2023-04-26 at 9 33 30 AM" src="https://user-images.githubusercontent.com/19958075/234592079-f54ffb46-04a0-426d-8e85-3ce50d2e52d1.png">
<img width="509" alt="Screenshot 2023-04-26 at 9 33 41 AM" src="https://user-images.githubusercontent.com/19958075/234592080-ade9971a-94c3-41c3-8925-919b2b8d79ca.png">

### What issues does this PR fix or reference?

Fixes #1392 (the final part).

### How to test this PR?

Install an extension like http://ghcr.io/redhat-developer/podman-desktop-redhat-account-ext:latest, go to its page and remove; check a default extension as well.