### PR TITLE
feat: Enhance MessageBox and use for updates

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -41,7 +41,7 @@ import type {
 } from './api/provider-info';
 import type { WebContents } from 'electron';
 import { app } from 'electron';
-import { ipcMain, BrowserWindow, dialog } from 'electron';
+import { ipcMain, BrowserWindow } from 'electron';
 import type { ContainerCreateOptions, ContainerInfo, SimpleContainerInfo } from './api/container-info';
 import type { ImageInfo } from './api/image-info';
 import type { PullEvent } from './api/pull-event';
@@ -385,7 +385,7 @@ export class PluginSystem {
     // Register command 'version' that will display the current version and say that no update is available.
     // Only show the "no update available" command for macOS and Windows users, not linux users.
     commandRegistry.registerCommand('version', () => {
-      dialog.showMessageBox({
+      messageBox.showMessageBox({
         type: 'info',
         title: 'Version',
         message: `Using version ${currentVersion}`,
@@ -432,7 +432,7 @@ export class PluginSystem {
       autoUpdater.on('update-downloaded', async () => {
         updateAlreadyDownloaded = true;
         updateInProgress = false;
-        const result = await dialog.showMessageBox({
+        const result = await messageBox.showMessageBox({
           title: 'Update Downloaded',
           message: 'Update downloaded, Do you want to restart Podman Desktop ?',
           cancelId: 1,
@@ -473,10 +473,10 @@ export class PluginSystem {
         }
       }, 1000 * 60 * 60 * 12);
 
-      // Update will create the standard "autoUpdater" dialog / update process that Electron provides
+      // Update will create a standard "autoUpdater" dialog / update process
       commandRegistry.registerCommand('update', async () => {
         if (updateAlreadyDownloaded) {
-          const result = await dialog.showMessageBox({
+          const result = await messageBox.showMessageBox({
             type: 'info',
             title: 'Update',
             message: 'There is already an update downloaded. Please Restart Podman Desktop.',
@@ -490,7 +490,7 @@ export class PluginSystem {
         }
 
         if (updateInProgress) {
-          await dialog.showMessageBox({
+          await messageBox.showMessageBox({
             type: 'info',
             title: 'Update',
             message: 'There is already an update in progress. Please wait until it is downloaded',
@@ -502,7 +502,7 @@ export class PluginSystem {
         // Get the version of the update
         const updateVersion = updateCheckResult?.updateInfo.version ? `v${updateCheckResult?.updateInfo.version}` : '';
 
-        const result = await dialog.showMessageBox({
+        const result = await messageBox.showMessageBox({
           type: 'info',
           title: 'Update Available',
           message: `A new version ${updateVersion} of Podman Desktop is available. Do you want to update your current version ${currentVersion}?`,
@@ -518,7 +518,7 @@ export class PluginSystem {
             await autoUpdater.downloadUpdate();
           } catch (error) {
             console.error('Update error: ', error);
-            dialog.showMessageBox({
+            messageBox.showMessageBox({
               type: 'error',
               title: 'Update Failed',
               message: `An error occurred while trying to update to version ${updateVersion}. See the developer console for more information.`,

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -32,13 +32,25 @@ export interface MessageBoxOptions {
    */
   message: string;
   /**
+   * An additional (optional) detailed message.
+   */
+  detail?: string;
+  /**
    * Text for buttons.
    */
-  buttons: string[];
+  buttons?: string[];
   /**
    * The (optional) type, one of 'none' | 'info' | 'error' | 'question' | 'warning'.
    */
   type?: string;
+  /**
+   * The (optional) index of the default button.
+   */
+  defaultId?: number;
+  /**
+   * The (optional) index of the button to be used to cancel the dialog.
+   */
+  cancelId?: number;
 }
 
 export interface MessageBoxReturnValue {
@@ -67,8 +79,11 @@ export class MessageBox {
       id: this.callbackId,
       title: options.title,
       message: options.message,
+      detail: options.detail,
       buttons: options.buttons,
       type: options.type,
+      defaultId: options.defaultId,
+      cancelId: options.cancelId,
     };
 
     // need to send the options to the frontend

--- a/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
+++ b/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
@@ -43,6 +43,7 @@ describe('MessageBox', () => {
       id: idRequest,
       title: 'My custom title',
       message: 'My message',
+      detail: 'A more detailed message',
       buttons: ['OK', 'Not OK'],
     };
 
@@ -58,9 +59,32 @@ describe('MessageBox', () => {
     expect(title).toBeInTheDocument();
     const message = await screen.findByText(messageBoxOptions.message);
     expect(message).toBeInTheDocument();
+    const detail = await screen.findByText(messageBoxOptions.detail);
+    expect(detail).toBeInTheDocument();
     const button1 = await screen.findByText(messageBoxOptions.buttons[0]);
     expect(button1).toBeInTheDocument();
     const button2 = await screen.findByText(messageBoxOptions.buttons[1]);
     expect(button2).toBeInTheDocument();
+  });
+
+  test('Expect that default OK button is displayed', async () => {
+    const idRequest = 234;
+
+    const messageBoxOptions: MessageBoxOptions = {
+      id: idRequest,
+      title: 'My custom title',
+      message: 'My message',
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: MessageBoxOptions) => void) => {
+      if (message === 'showMessageBox:open') {
+        callback(messageBoxOptions);
+      }
+    });
+
+    render(MessageBox, {});
+
+    const ok = await screen.findByText('OK');
+    expect(ok).toBeInTheDocument();
   });
 });

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -128,7 +128,7 @@ function handleKeydown(e: KeyboardEvent) {
         {/if}
         <h1 class="grow text-lg font-bold capitalize">{title}</h1>
 
-        <button class="hover:text-gray-300 py-1" on:click="{() => clickButton(undefined)}">
+        <button class="hover:text-gray-300 py-1" on:click="{() => clickButton(cancelId >= 0 ? cancelId : undefined)}">
           <i class="fas fa-times" aria-hidden="true"></i>
         </button>
       </div>

--- a/packages/renderer/src/lib/dialogs/messagebox-input.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-input.ts
@@ -20,6 +20,9 @@ export interface MessageBoxOptions {
   id: number;
   title: string;
   message: string;
-  buttons: string[];
+  detail?: string;
+  buttons?: string[];
   type?: string;
+  defaultId?: number;
+  cancelId?: number;
 }


### PR DESCRIPTION
### What does this PR do?

Adds four 'missing' features used by our update mechanism that are in the Electron messagebox API, and switch the update mechanism to use our messagebox.

New features in messagebox:
- Make buttons optional. If none are provided, use a single OK button.
- Add an optional detail message that is shown under the regular message.
- Add optional defaultId and cancelId. Only the cancelId is used by the updater (and isn't strictly necessary since we'd pick up the cancel button by name anyway), but a good chance to add these and should do as a pair.

Tests updated to check for detail message and default OK button.

### Screenshot/screencast of this PR

<img width="525" alt="Screenshot 2023-04-26 at 12 00 16 PM" src="https://user-images.githubusercontent.com/19958075/234633827-60527289-704f-41fd-a49e-500c2f08fd3e.png">

### What issues does this PR fix or reference?

Another step towards issue #1807 and fixes issue #2245.

### How to test this PR?

Verify the update flow still works as before, confirm a couple other dialogs for no regressions.