### PR TITLE
feat: Use our own titlebar to avoid double titlebars on Linux/Windows

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -54,9 +54,11 @@ async function createWindow() {
     },
   };
 
+  // frameless window
+  browserWindowConstructorOptions.titleBarStyle = 'hidden';
   if (isMac()) {
-    // This property is not available on Linux.
-    browserWindowConstructorOptions.titleBarStyle = 'hiddenInset';
+    // change position of traffic light buttons
+    browserWindowConstructorOptions.trafficLightPosition = { x: 20, y: 13 };
   }
 
   const browserWindow = new BrowserWindow(browserWindowConstructorOptions);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1465,6 +1465,34 @@ export class PluginSystem {
       return app.getVersion();
     });
 
+    this.ipcHandle('window:minimize', async (): Promise<void> => {
+      const window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+      if (!window) {
+        return;
+      }
+      window.minimize();
+    });
+
+    this.ipcHandle('window:maximize', async (): Promise<void> => {
+      const window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+      if (!window) {
+        return;
+      }
+      if (window.isMaximized()) {
+        window.unmaximize();
+        return;
+      }
+      window.maximize();
+    });
+
+    this.ipcHandle('window:close', async (): Promise<void> => {
+      const window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
+      if (!window) {
+        return;
+      }
+      window.close();
+    });
+
     const dockerDesktopInstallation = new DockerDesktopInstallation(
       apiSender,
       containerProviderRegistry,

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1303,6 +1303,16 @@ function initExposure(): void {
   contextBridge.exposeInMainWorld('getPodmanDesktopVersion', async (): Promise<string> => {
     return ipcInvoke('app:getVersion');
   });
+
+  contextBridge.exposeInMainWorld('windowMinimize', async (): Promise<void> => {
+    return ipcInvoke('window:minimize');
+  });
+  contextBridge.exposeInMainWorld('windowMaximize', async (): Promise<void> => {
+    return ipcInvoke('window:maximize');
+  });
+  contextBridge.exposeInMainWorld('windowClose', async (): Promise<void> => {
+    return ipcInvoke('window:close');
+  });
 }
 
 // expose methods

--- a/packages/renderer/src/lib/images/WindowsExitIcon.svelte
+++ b/packages/renderer/src/lib/images/WindowsExitIcon.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+export let size = 16;
+</script>
+
+<svg
+  width="{size}"
+  height="{size}"
+  aria-hidden="true"
+  role="img"
+  viewBox="0 0 16 16"
+  version="1.1"
+  id="svg10085"
+  xmlns="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+    id="namedview10087"
+    pagecolor="#ffffff"
+    bordercolor="#666666"
+    borderopacity="1.0"
+    inkscape:showpageshadow="2"
+    inkscape:pageopacity="0"
+    inkscape:pagecheckerboard="true"
+    inkscape:deskcolor="#d1d1d1"
+    inkscape:document-units="px"
+    showgrid="true"
+    showguides="false"
+    inkscape:zoom="58.9375"
+    inkscape:cx="8"
+    inkscape:cy="8.0169671"
+    inkscape:window-width="1920"
+    inkscape:window-height="1131"
+    inkscape:window-x="0"
+    inkscape:window-y="0"
+    inkscape:window-maximized="1"
+    inkscape:current-layer="g18715">
+    <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>
+  </sodipodi:namedview>
+  <defs id="defs10082">
+    <inkscape:path-effect effect="spiro" id="path-effect18723" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect18719" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8380" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8384" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect19377" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect19381" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect21676" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8380-3" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8384-6" is_visible="true" lpeversion="1"></inkscape:path-effect>
+  </defs>
+  <g id="layer1">
+    <g
+      id="g18715"
+      style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:1.05105;stroke-opacity:1"
+      transform="matrix(2.9969164,0,0,2.9968662,-462.37487,-519.36282)">
+      <path
+        style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:0.333679;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+        d="m 155.45141,177.473 3.00313,-3.00314"
+        id="path18711"></path>
+      <path
+        style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:0.333679;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+        d="m 158.45454,177.473 -3.00313,-3.00314"
+        id="path18713"></path>
+    </g>
+    <g
+      id="g8366"
+      style="fill:#000000;fill-opacity:0;stroke:#999999;stroke-width:0.992722;stroke-opacity:1"
+      transform="matrix(3.8062595,0,0,3.8082135,-589.36999,-662.11189)"></g>
+  </g>
+</svg>

--- a/packages/renderer/src/lib/images/WindowsMaxIcon.svelte
+++ b/packages/renderer/src/lib/images/WindowsMaxIcon.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+export let size = 16;
+</script>
+
+<svg
+  width="{size}"
+  height="{size}"
+  aria-hidden="true"
+  role="img"
+  viewBox="0 0 16 16"
+  version="1.1"
+  id="svg10085"
+  xmlns="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+    id="namedview10087"
+    pagecolor="#ffffff"
+    bordercolor="#666666"
+    borderopacity="1.0"
+    inkscape:showpageshadow="2"
+    inkscape:pageopacity="0"
+    inkscape:pagecheckerboard="true"
+    inkscape:deskcolor="#d1d1d1"
+    inkscape:document-units="px"
+    showgrid="true"
+    showguides="false"
+    inkscape:zoom="58.625"
+    inkscape:cx="6.2771855"
+    inkscape:cy="8.2132196"
+    inkscape:window-width="1920"
+    inkscape:window-height="1131"
+    inkscape:window-x="0"
+    inkscape:window-y="0"
+    inkscape:window-maximized="1"
+    inkscape:current-layer="layer1">
+    <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>
+  </sodipodi:namedview>
+  <defs id="defs10082">
+    <inkscape:path-effect effect="spiro" id="path-effect18723" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect18719" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8380" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8384" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect19377" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect19381" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect21676" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8380-3" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8384-6" is_visible="true" lpeversion="1"></inkscape:path-effect>
+  </defs>
+  <g id="layer1">
+    <rect
+      style="fill:none;stroke:#ffffff;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4.4;stroke-dasharray:none;stroke-opacity:1"
+      id="rect19383"
+      width="9.000001"
+      height="9.000001"
+      x="3.4999995"
+      y="3.4999995"
+      ry="1.1388704"></rect>
+    <g
+      id="g8366"
+      style="fill:#000000;fill-opacity:0;stroke:#999999;stroke-width:0.992722;stroke-opacity:1"
+      transform="matrix(3.8062595,0,0,3.8082135,-589.36999,-662.11189)"></g>
+  </g>
+</svg>

--- a/packages/renderer/src/lib/images/WindowsMinIcon.svelte
+++ b/packages/renderer/src/lib/images/WindowsMinIcon.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+export let size = 16;
+</script>
+
+<svg
+  width="{size}"
+  height="{size}"
+  aria-hidden="true"
+  role="img"
+  viewBox="0 0 16 16"
+  version="1.1"
+  id="svg10085"
+  xmlns="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+    id="namedview10087"
+    pagecolor="#ffffff"
+    bordercolor="#666666"
+    borderopacity="1.0"
+    inkscape:showpageshadow="2"
+    inkscape:pageopacity="0"
+    inkscape:pagecheckerboard="true"
+    inkscape:deskcolor="#d1d1d1"
+    inkscape:document-units="px"
+    showgrid="true"
+    showguides="false"
+    inkscape:zoom="41.454135"
+    inkscape:cx="7.9847282"
+    inkscape:cy="8.2138971"
+    inkscape:window-width="1920"
+    inkscape:window-height="1131"
+    inkscape:window-x="0"
+    inkscape:window-y="0"
+    inkscape:window-maximized="1"
+    inkscape:current-layer="layer1">
+    <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>
+  </sodipodi:namedview>
+  <defs id="defs10082">
+    <inkscape:path-effect effect="spiro" id="path-effect18723" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect18719" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8380" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8384" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect19377" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect19381" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect21676" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8380-3" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8384-6" is_visible="true" lpeversion="1"></inkscape:path-effect>
+  </defs>
+  <g id="layer1">
+    <path
+      style="fill:none;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+      d="M 3,7.5 H 13"
+      id="path21672"></path>
+    <g
+      id="g8366"
+      style="fill:#000000;fill-opacity:0;stroke:#999999;stroke-width:0.992722;stroke-opacity:1"
+      transform="matrix(3.8062595,0,0,3.8082135,-589.36999,-662.11189)"></g>
+  </g>
+</svg>

--- a/packages/renderer/src/lib/images/WindowsUnmaxIcon.svelte
+++ b/packages/renderer/src/lib/images/WindowsUnmaxIcon.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+export let size = 16;
+</script>
+
+<svg
+  width="{size}"
+  height="{size}"
+  aria-hidden="true"
+  role="img"
+  viewBox="0 0 16 16"
+  version="1.1"
+  id="svg10085"
+  xmlns="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+    id="namedview10087"
+    pagecolor="#ffffff"
+    bordercolor="#666666"
+    borderopacity="1.0"
+    inkscape:showpageshadow="2"
+    inkscape:pageopacity="0"
+    inkscape:pagecheckerboard="true"
+    inkscape:deskcolor="#d1d1d1"
+    inkscape:document-units="px"
+    showgrid="true"
+    showguides="false"
+    inkscape:zoom="41.763494"
+    inkscape:cx="7.9974151"
+    inkscape:cy="8.0812204"
+    inkscape:window-width="1920"
+    inkscape:window-height="1131"
+    inkscape:window-x="0"
+    inkscape:window-y="0"
+    inkscape:window-maximized="1"
+    inkscape:current-layer="g22446">
+    <inkscape:grid type="xygrid" id="grid10569"></inkscape:grid>
+  </sodipodi:namedview>
+  <defs id="defs10082">
+    <inkscape:path-effect effect="spiro" id="path-effect18723" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect18719" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8380" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8384" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect19377" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect19381" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect21676" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8380-3" is_visible="true" lpeversion="1"></inkscape:path-effect>
+    <inkscape:path-effect effect="spiro" id="path-effect8384-6" is_visible="true" lpeversion="1"></inkscape:path-effect>
+  </defs>
+  <g id="layer1">
+    <g
+      id="g8366"
+      style="fill:#000000;fill-opacity:0;stroke:#999999;stroke-width:0.992722;stroke-opacity:1"
+      transform="matrix(3.8062595,0,0,3.8082135,-589.36999,-662.11189)"></g>
+    <g
+      id="g22446"
+      style="fill:#000000;fill-opacity:0;stroke:#999999;stroke-width:2.8433;stroke-opacity:1"
+      transform="matrix(1.9961952,0,0,1.961653,-148.29689,-127.64158)">
+      <rect
+        style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:0.505343;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4.4;stroke-dasharray:none;stroke-opacity:1"
+        id="rect22442"
+        width="3.5022812"
+        height="3.5728502"
+        x="76.045197"
+        y="67.869919"
+        ry="0.31626302"></rect>
+      <path
+        id="path22444"
+        style="fill:#000000;fill-opacity:0;stroke:#ffffff;stroke-width:0.505343;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4.4;stroke-dasharray:none;stroke-opacity:1"
+        d="m 77.2734,66.850371 c 0,0 2.800655,0.01211 2.961632,0.0017 0.160978,-0.01045 0.303772,0.159454 0.307213,0.313009 0.0034,0.153554 0.0069,3.022729 0.0069,3.022729"
+      ></path>
+    </g>
+  </g>
+</svg>

--- a/packages/renderer/src/lib/ui/TitleBar.spec.ts
+++ b/packages/renderer/src/lib/ui/TitleBar.spec.ts
@@ -1,0 +1,120 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import TitleBar from './TitleBar.svelte';
+
+const getOsPlatformMock = vi.fn();
+
+beforeAll(() => {
+  (window as any).getOsPlatform = getOsPlatformMock;
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+async function waitRender(customProperties: object): Promise<void> {
+  const result = render(TitleBar, { ...customProperties });
+  // wait that result.component.$$.ctx[0] is set
+  while (result.component.$$.ctx[0] === undefined) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}
+
+describe('macOS', () => {
+  beforeEach(() => {
+    getOsPlatformMock.mockReturnValue('darwin');
+  });
+
+  test('Check no control buttons as it is provided by the system', async () => {
+    await waitRender({});
+
+    const minimizeButton = screen.queryByRole('button', { name: 'Minimize' });
+    expect(minimizeButton).not.toBeInTheDocument();
+
+    const maximizeButton = screen.queryByRole('button', { name: 'Maximize' });
+    expect(maximizeButton).not.toBeInTheDocument();
+
+    const closeButton = screen.queryByRole('button', { name: 'Close' });
+    expect(closeButton).not.toBeInTheDocument();
+  });
+
+  test('Expect no title', async () => {
+    await waitRender({});
+
+    const title = screen.queryByText('Podman Desktop');
+    expect(title).not.toBeInTheDocument();
+  });
+});
+
+describe('linux', () => {
+  beforeEach(() => {
+    getOsPlatformMock.mockReturnValue('linux');
+  });
+
+  test('Check control buttons are defined', async () => {
+    await waitRender({});
+
+    const minimizeButton = screen.getByRole('button', { name: 'Minimize' });
+    expect(minimizeButton).toBeInTheDocument();
+
+    const maximizeButton = screen.queryByRole('button', { name: 'Maximize' });
+    expect(maximizeButton).toBeInTheDocument();
+
+    const closeButton = screen.queryByRole('button', { name: 'Close' });
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  test('Expect title', async () => {
+    await waitRender({});
+
+    const title = screen.queryByText('Podman Desktop');
+    expect(title).toBeInTheDocument();
+  });
+});
+
+describe('Windows', () => {
+  beforeEach(() => {
+    getOsPlatformMock.mockReturnValue('win32');
+  });
+
+  test('Check control buttons are defined', async () => {
+    await waitRender({});
+
+    const minimizeButton = screen.getByRole('button', { name: 'Minimize' });
+    expect(minimizeButton).toBeInTheDocument();
+
+    const maximizeButton = screen.queryByRole('button', { name: 'Maximize' });
+    expect(maximizeButton).toBeInTheDocument();
+
+    const closeButton = screen.queryByRole('button', { name: 'Close' });
+    expect(closeButton).toBeInTheDocument();
+  });
+
+  test('Expect title', async () => {
+    await waitRender({});
+
+    const title = screen.queryByText('Podman Desktop');
+    expect(title).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -1,18 +1,43 @@
 <script lang="ts">
-import Logo from '/@/lib/images/Logo.svelte';
+import { onMount } from 'svelte';
+import DesktopIcon from '../images/DesktopIcon.svelte';
+import WindowControlButtons from '../window-control-buttons/ControlButtons.svelte';
+
+let platform: string;
+
+const title = 'Podman Desktop';
+
+onMount(async () => {
+  platform = await window.getOsPlatform();
+});
 </script>
 
 <header
   id="navbar"
-  class="text-gray-700 bg-charcoal-900 body-font shadow-titlebar z-999;"
+  class="text-gray-700 {platform === 'win32'
+    ? 'bg-[#202020]'
+    : 'bg-charcoal-900'} body-font shadow-titlebar z-999 relative {platform === 'win32'
+    ? 'min-h-[32px]'
+    : 'min-h-[38px]'}"
   style="-webkit-app-region: drag;">
-  <div class="flex mx-auto flex-row p-2 items-center">
-    <div class="flex lg:w-2/5 flex-1 items-center text-base ml-auto"></div>
-    <div
-      class="flex order-none title-font font-medium items-center text-white align-middle justify-center mb-4 md:mb-0">
-      <Logo />
-      <span class="select-none ml-3 text-xl block text-gray-400">Podman Desktop</span>
-    </div>
-    <div class="lg:w-2/5 flex-1 lg:justify-end ml-5 lg:ml-0"></div>
+  <div class="flex select-none">
+    <!-- On Linux, title is centered and we have control buttons in the title bar-->
+    {#if platform === 'linux'}
+      <div class="flex mx-auto flex-row pt-[7px] pb-[6px] items-center">
+        <div class="absolute left-[10px] top-[10px]">
+          <DesktopIcon size="18" />
+        </div>
+        <div class="flex flex-1 justify-center text-base select-none text-gray-400">{title}</div>
+        <WindowControlButtons platform="{platform}" />
+      </div>
+    {:else if platform === 'win32'}
+      <div class="flex flex-row pt-[10px] pb-[10px] items-center">
+        <div class="absolute left-[7px] top-[7px]">
+          <DesktopIcon size="18" />
+        </div>
+        <div class="ml-[35px] text-left text-xs leading-3 text-gray-400">{title}</div>
+        <WindowControlButtons platform="{platform}" />
+      </div>
+    {/if}
   </div>
 </header>

--- a/packages/renderer/src/lib/window-control-buttons/ControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButton.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ControlButton from './ControlButton.svelte';
+
+describe.each([{ platform: 'linux' }, { platform: 'win32' }])('Platform($platform)', ({ platform }) => {
+  test('Check name', async () => {
+    render(ControlButton, { name: 'Maximize', platform });
+
+    const customButton = screen.getByRole('button', { name: 'Maximize' });
+    expect(customButton).toBeInTheDocument();
+  });
+
+  test('Check icon', async () => {
+    render(ControlButton, { name: 'Minimize', platform });
+
+    // check image is there
+    const icon = screen.getByRole('img', { hidden: true, name: '' });
+    expect(icon).toBeInTheDocument();
+  });
+
+  test('Check action', async () => {
+    const action = vi.fn();
+    render(ControlButton, { name: 'Close', platform, action });
+
+    // click on the button
+    const customButton = screen.getByRole('button', { name: 'Close' });
+    await fireEvent.click(customButton);
+
+    // check the action was called
+    expect(action).toBeCalled();
+  });
+});

--- a/packages/renderer/src/lib/window-control-buttons/ControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButton.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+import WindowControlLinuxButton from './LinuxControlButton.svelte';
+import WindowControlWindowsButton from './WindowsControlButton.svelte';
+
+export let name: string;
+export let action: () => void = () => {};
+export let platform;
+</script>
+
+{#if platform === 'linux'}
+  <WindowControlLinuxButton name="{name}" action="{action}" />
+{:else if platform === 'win32'}
+  <WindowControlWindowsButton name="{name}" action="{action}" />
+{/if}

--- a/packages/renderer/src/lib/window-control-buttons/ControlButtons.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButtons.spec.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect, vi, describe } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import ControlButtons from './ControlButtons.svelte';
+
+describe.each([{ platform: 'linux' }, { platform: 'win32' }])('Platform($platform)', ({ platform }) => {
+  test('Expect all 3 buttons are there', async () => {
+    render(ControlButtons, { platform });
+
+    const minimizeButton = screen.getByRole('button', { name: 'Minimize' });
+    const maximizeButton = screen.getByRole('button', { name: 'Maximize' });
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+
+    expect(minimizeButton).toBeInTheDocument();
+    expect(maximizeButton).toBeInTheDocument();
+    expect(closeButton).toBeInTheDocument();
+
+    // expect the order of buttons is correct
+    expect(minimizeButton.compareDocumentPosition(maximizeButton)).toBe(4);
+    expect(maximizeButton.compareDocumentPosition(closeButton)).toBe(4);
+    expect(minimizeButton.compareDocumentPosition(closeButton)).toBe(4);
+  });
+
+  test('Expect minimize is called', async () => {
+    render(ControlButtons, { platform });
+
+    const minimizeMock = vi.fn();
+    (window as any).windowMinimize = minimizeMock;
+
+    const minimizeButton = screen.getByRole('button', { name: 'Minimize' });
+    await fireEvent.click(minimizeButton);
+    expect(minimizeMock).toBeCalled();
+  });
+
+  test('Expect maximize is called', async () => {
+    render(ControlButtons, { platform });
+
+    const maximizeMock = vi.fn();
+    (window as any).windowMaximize = maximizeMock;
+
+    const maximizeButton = screen.getByRole('button', { name: 'Maximize' });
+    await fireEvent.click(maximizeButton);
+    expect(maximizeMock).toBeCalled();
+  });
+
+  test('Expect close is called', async () => {
+    render(ControlButtons, { platform });
+
+    const closeMock = vi.fn();
+    (window as any).windowClose = closeMock;
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    await fireEvent.click(closeButton);
+    expect(closeMock).toBeCalled();
+  });
+});

--- a/packages/renderer/src/lib/window-control-buttons/ControlButtons.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButtons.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+import WindowControlButton from './ControlButton.svelte';
+
+export let platform: string;
+
+function minimize() {
+  window.windowMinimize();
+}
+
+function maximize() {
+  window.windowMaximize();
+}
+
+function close() {
+  window.windowClose();
+}
+</script>
+
+<!-- Display the min, max and close buttons and avoid drag & drop on this region-->
+<div
+  class="absolute {platform === 'linux' ? 'top-[7px] right-3' : ''} {platform === 'win32' ? 'top-0 right-0' : ''}"
+  style="-webkit-app-region: none;">
+  <div class="flex flex-row {platform === 'linux' ? 'space-x-2' : 'space-x-[1px]'}">
+    <WindowControlButton platform="{platform}" name="Minimize" action="{() => minimize()}" />
+    <WindowControlButton platform="{platform}" name="Maximize" action="{() => maximize()}" />
+    <WindowControlButton platform="{platform}" name="Close" action="{() => close()}" />
+  </div>
+</div>

--- a/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.spec.ts
@@ -1,0 +1,34 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import LinuxControlButton from './LinuxControlButton.svelte';
+
+test('Check Minimize', async () => {
+  render(LinuxControlButton, { name: 'Minimize' });
+
+  const customButton = screen.getByRole('button', { name: 'Minimize' });
+  expect(customButton).toBeInTheDocument();
+
+  // check the title of the button is 'Maximize'
+  expect(customButton).toHaveAttribute('title', 'Minimize');
+});

--- a/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import Fa from 'svelte-fa/src/fa.svelte';
+import { onMount } from 'svelte';
+import { faMinus, faXmark, type IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faSquare } from '@fortawesome/free-regular-svg-icons';
+
+const iconSize = '14';
+
+export let name: string;
+export let action: () => void = () => {};
+
+let icon: IconDefinition;
+
+let titleName;
+
+onMount(() => {
+  if (name === 'Minimize') {
+    icon = faMinus;
+  } else if (name === 'Maximize') {
+    icon = faSquare;
+  } else if (name === 'Close') {
+    icon = faXmark;
+  }
+  titleName = name;
+});
+</script>
+
+<button
+  on:click="{() => action()}"
+  title="{titleName}"
+  aria-label="{name}"
+  class="h-[25px] w-[25px] cursor-pointer text-gray-400 hover:rounded-full hover:bg-charcoal-300 flex place-items-center justify-center">
+  <Fa size="{iconSize}" icon="{icon}" />
+</button>

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import '@testing-library/jest-dom';
+import { test, expect } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import WindowsControlButton from './WindowsControlButton.svelte';
+
+test('Check Maximize/Restore', async () => {
+  render(WindowsControlButton, { name: 'Maximize' });
+
+  const customButton = screen.getByRole('button', { name: 'Maximize' });
+  expect(customButton).toBeInTheDocument();
+
+  // check the title of the button is 'Maximize'
+  expect(customButton).toHaveAttribute('title', 'Maximize');
+
+  // click on the button
+  await fireEvent.click(customButton);
+
+  // check the title of the button is 'Restore'
+  expect(customButton).toHaveAttribute('title', 'Restore');
+
+  // click on the button
+  await fireEvent.click(customButton);
+
+  // check the title of the button is 'Maximize'
+  expect(customButton).toHaveAttribute('title', 'Maximize');
+});

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import WindowsExitIcon from '/@/lib/images/WindowsExitIcon.svelte';
+import WindowsMaxIcon from '/@/lib/images/WindowsMaxIcon.svelte';
+import WindowsUnmaxIcon from '/@/lib/images/WindowsUnmaxIcon.svelte';
+import WindowsMinIcon from '/@/lib/images/WindowsMinIcon.svelte';
+
+const iconSize = '16';
+let icon: any;
+let state = 'initial';
+
+export let name: string;
+
+export let action: () => void = () => {};
+
+let titleName;
+
+onMount(() => {
+  if (name === 'Minimize') {
+    icon = WindowsMinIcon;
+  } else if (name === 'Maximize') {
+    icon = WindowsMaxIcon;
+  } else if (name === 'Close') {
+    icon = WindowsExitIcon;
+  }
+  titleName = name;
+});
+
+function executeAction() {
+  // perform action
+  action();
+
+  // update the state
+  if (name === 'Minimize') {
+    state = 'minimized';
+  } else if (name === 'Maximize') {
+    if (state === 'maximized') {
+      state = 'restored';
+    } else {
+      state = 'maximized';
+    }
+  } else if (name === 'Close') {
+    state = 'closed';
+  }
+
+  if (state === 'maximized') {
+    icon = WindowsUnmaxIcon;
+    titleName = 'Restore';
+  } else if (state === 'restored') {
+    icon = WindowsMaxIcon;
+    titleName = 'Maximize';
+  }
+}
+</script>
+
+<button
+  on:click="{() => executeAction()}"
+  aria-label="{name}"
+  title="{titleName}"
+  class="h-[32px] w-[45px] cursor-pointer text-white {name === 'Close'
+    ? 'hover:bg-[#be4425]'
+    : 'hover:bg-[#2d2d2d]'} flex place-items-center justify-center">
+  <svelte:component this="{icon}" size="{iconSize}" />
+</button>


### PR DESCRIPTION
Change-Id: I3672a85cf7d777e8744e311e2b9a5abb75aa5c02

### What does this PR do?
Avoid double title bars on Windows and Linux

### Screenshot/screencast of this PR

example on Windows now:
![image](https://github.com/containers/podman-desktop/assets/436777/85608f91-55e8-4b92-aead-49e7f02996ea)


### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/1805

### How to test this PR?

<!-- Please explain steps to reproduce -->

Created so we can get feedback / comments
