### PR TITLE
feat: add env related helper constants

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1800,6 +1800,30 @@ declare module '@podman-desktop/api' {
    */
   export namespace env {
     /**
+     * Flag indicating whether we are running on macOS (Mac OS X) operating system.
+     *
+     * If the value of this flag is true, it means the current system is macOS.
+     * If the value is false, it means the current system is not macOS.
+     */
+    export const isMac: boolean;
+
+    /**
+     * Flag indicating whether we are running on the Windows operating system.
+     *
+     * If the value of this flag is true, it means the current system is Windows.
+     * If the value is false, it means the current system is not Windows.
+     */
+    export const isWindows: boolean;
+
+    /**
+     * Flag indicating whether we are running on a Linux operating system.
+     *
+     * If the value of this flag is true, it means the current system is Linux.
+     * If the value is false, it means the current system is not Linux.
+     */
+    export const isLinux: boolean;
+
+    /**
      * Indicates whether the users has telemetry enabled.
      * Can be observed to determine if the extension should send telemetry.
      */

--- a/packages/main/src/plugin/extension-loader.ts
+++ b/packages/main/src/plugin/extension-loader.ts
@@ -56,6 +56,7 @@ import { clipboard as electronClipboard } from 'electron';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import type { IconRegistry } from './icon-registry.js';
 import type { Directories } from './directories.js';
+import { isLinux, isMac, isWindows } from '../util.js';
 
 /**
  * Handle the loading of an extension
@@ -851,6 +852,15 @@ export class ExtensionLoader {
 
     const telemetry = this.telemetry;
     const env: typeof containerDesktopAPI.env = {
+      get isMac() {
+        return isMac();
+      },
+      get isWindows() {
+        return isWindows();
+      },
+      get isLinux() {
+        return isLinux();
+      },
       openExternal: async (uri: containerDesktopAPI.Uri): Promise<boolean> => {
         const url = uri.toString();
         try {


### PR DESCRIPTION
### What does this PR do?

This changes proposal adds three constants to determine what operating system is used on the host machine.

```typescript
    /**
     * Flag indicating whether we are running on macOS (Mac OS X) operating system.
     *
     * If the value of this flag is true, it means the current system is macOS.
     * If the value is false, it means the current system is not macOS.
     */
    export const isMac: boolean;

    /**
     * Flag indicating whether we are running on the Windows operating system.
     *
     * If the value of this flag is true, it means the current system is Windows.
     * If the value is false, it means the current system is not Windows.
     */
    export const isWindows: boolean;

    /**
     * Flag indicating whether we are running on a Linux operating system.
     *
     * If the value of this flag is true, it means the current system is Linux.
     * If the value is false, it means the current system is not Linux.
     */
    export const isLinux: boolean;
```

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

need for #1585 

### How to test this PR?

Constants should be accessible from the extensions through the extension API
