### PR TITLE
feat: handle extensionPack and extensionDependencies when installing extensions

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1706,7 +1706,12 @@ export class PluginSystem {
     const dockerExtensionAdapter = new DockerPluginAdapter(contributionManager);
     dockerExtensionAdapter.init();
 
-    const extensionInstaller = new ExtensionInstaller(apiSender, this.extensionLoader, imageRegistry);
+    const extensionInstaller = new ExtensionInstaller(
+      apiSender,
+      this.extensionLoader,
+      imageRegistry,
+      extensionsCatalog,
+    );
     await extensionInstaller.init();
 
     // launch the updater


### PR DESCRIPTION
### What does this PR do?
Install other extensions if extension has extensionDependencies field
Handle extension that provides extensionPack elements

example:
```json
{
  "name": "extension-pack-example",
  "version": "0.1.1",
  "publisher": "fbenoit",
  "displayName": "Red Hat Extension Pack",
  "description": "A collection of extensions published by Red Hat",
  "license": "apache-2.0",
  "icon": "extension.png",
  "keywords": [
    "Red Hat"
  ],
  "categories": [
    "Extension Packs"
  ],
  "engines": {
    "podman-desktop": "^1.0.0"
  },
  "extensionPack": [
    "redhat.redhat-sandbox",
    "redhat.openshift-local"
  ]
}
```

when deploying this example both `redhat.redhat-sandbox` and `redhat.openshift-local` will be deployed


### Screenshot/screencast of this PR


https://github.com/containers/podman-desktop/assets/436777/0cd4a199-06f4-4890-8414-4e93ca9178bc



### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/2829
fixes https://github.com/containers/podman-desktop/issues/2828

### How to test this PR?

Unit tests provided

You can also try by installing `quay.io/fbenoit/ext-pack-sample` extension (you'll get OpenShift Sandbox and OpenShift Local extensions if not already installed)