### PR TITLE
feat(store): add debounce/throttle option

### DIFF
--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -62,7 +62,7 @@ const containersEventStore = new EventStore<ContainerInfo[]>(
   listContainers,
   ContainerIcon,
 );
-containersEventStore.setup();
+containersEventStore.setupWithDebounce();
 
 export const searchPattern = writable('');
 

--- a/packages/renderer/src/stores/event-store.spec.ts
+++ b/packages/renderer/src/stores/event-store.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { beforeEach, expect, test, vi } from 'vitest';
-import { EventStore } from './event-store';
+import { EventStore, type EventStoreInfo } from './event-store';
 import { get, writable, type Writable } from 'svelte/store';
 
 // first, path window object
@@ -47,6 +47,17 @@ interface MyCustomTypeInfo {
   name: string;
 }
 
+class TestEventStore<T> extends EventStore<T> {
+  public async performUpdate(
+    needUpdate: boolean,
+    eventStoreInfo: EventStoreInfo,
+    eventName: string,
+    args?: unknown[],
+  ): Promise<void> {
+    return super.performUpdate(needUpdate, eventStoreInfo, eventName, args);
+  }
+}
+
 test('should call fetch method using window event', async () => {
   const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
   const checkForUpdateMock = vi.fn();
@@ -57,7 +68,7 @@ test('should call fetch method using window event', async () => {
   // return true to trigger the update
   checkForUpdateMock.mockResolvedValue(true);
 
-  const eventStore = new EventStore('my-test', myStoreInfo, checkForUpdateMock, [windowEventName], [], updater);
+  const eventStore = new TestEventStore('my-test', myStoreInfo, checkForUpdateMock, [windowEventName], [], updater);
 
   // callbacks are empty
   expect(callbacks.size).toBe(0);
@@ -106,7 +117,7 @@ test('should call fetch method using listener event', async () => {
   // return true to trigger the update
   checkForUpdateMock.mockResolvedValue(true);
 
-  const eventStore = new EventStore(
+  const eventStore = new TestEventStore(
     'my-listener-test',
     myStoreInfo,
     checkForUpdateMock,
@@ -154,4 +165,119 @@ test('should call fetch method using listener event', async () => {
   expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('skipped', false);
   expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('args', undefined);
   expect(eventStoreInfo.bufferEvents[0]).toHaveProperty('length', 1);
+});
+
+test('Check debounce', async () => {
+  const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
+  const checkForUpdateMock = vi.fn();
+
+  const windowEventName = 'my-custom-event';
+  const updater = vi.fn();
+
+  // return true to trigger the update
+  checkForUpdateMock.mockResolvedValue(true);
+
+  const eventStore = new TestEventStore('my-test', myStoreInfo, checkForUpdateMock, [windowEventName], [], updater);
+
+  // callbacks are empty
+  expect(callbacks.size).toBe(0);
+
+  // now call the setup with a debounce value of 200ms and no throttle
+  const eventStoreInfo = eventStore.setupWithDebounce(200, 0);
+
+  // spy performUpdate method
+  const performUpdateSpy = vi.spyOn(eventStore, 'performUpdate');
+
+  // check we have callbacks
+  expect(callbacks.size).toBe(1);
+
+  // now we call the listener
+  const callback = callbacks.get(windowEventName);
+  expect(callback).toBeDefined();
+
+  const myCustomTypeInfo: MyCustomTypeInfo = {
+    name: 'my-custom-type',
+  };
+  updater.mockResolvedValue([myCustomTypeInfo]);
+
+  // now, perform 20 calls every 50ms
+  for (let i = 0; i < 20; i++) {
+    await callback();
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+
+  // wait debounce being called for 2 seconds
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  // We did a lot of calls but with debounce, it should only be called once
+  expect(updater).toHaveBeenCalledOnce();
+
+  // check the store is updated
+  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+
+  // check the store is updated
+  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+
+  // check we have called performUpdate only once
+  expect(performUpdateSpy).toHaveBeenCalledOnce();
+
+  // check buffer events
+  expect(eventStoreInfo.bufferEvents.length).toBeGreaterThan(1);
+});
+
+// check that we're still calling the update method
+// every throttle even if we have lot of calls and are postponing with debounce
+test('Check debounce+delay', async () => {
+  const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
+  const checkForUpdateMock = vi.fn();
+
+  const windowEventName = 'my-custom-event';
+  const updater = vi.fn();
+
+  // return true to trigger the update
+  checkForUpdateMock.mockResolvedValue(true);
+
+  const eventStore = new EventStore('my-test', myStoreInfo, checkForUpdateMock, [windowEventName], [], updater);
+
+  // callbacks are empty
+  expect(callbacks.size).toBe(0);
+
+  // now call the setup with a debounce value of 200ms and a throttle of 1s
+  const eventStoreInfo = eventStore.setupWithDebounce(200, 1000);
+
+  // check we have callbacks
+  expect(callbacks.size).toBe(1);
+
+  // now we call the listener
+  const callback = callbacks.get(windowEventName);
+  expect(callback).toBeDefined();
+
+  const myCustomTypeInfo: MyCustomTypeInfo = {
+    name: 'my-custom-type',
+  };
+  updater.mockResolvedValue([myCustomTypeInfo]);
+
+  // now, perform 40 calls every 50ms
+  for (let i = 0; i < 20; i++) {
+    await callback();
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+
+  // wait debounce being called for 3 seconds
+  await new Promise(resolve => setTimeout(resolve, 3000));
+
+  // We did a lot of calls but with debounce and throttle it should be only like 2 calls
+  // get number of calls
+  const calls = updater.mock.calls.length;
+  expect(calls).toBeGreaterThan(1);
+  expect(calls).toBeLessThanOrEqual(4);
+
+  // check the store is updated
+  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+
+  // check the store is updated
+  expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+
+  // check buffer events
+  expect(eventStoreInfo.bufferEvents.length).toBeGreaterThan(1);
 });

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -65,7 +65,7 @@ const imagesEventStore = new EventStore<ImageInfo[]>(
   listImages,
   ImageIcon,
 );
-imagesEventStore.setup();
+imagesEventStore.setupWithDebounce();
 
 export const searchPattern = writable('');
 

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -64,7 +64,7 @@ const eventStore = new EventStore<PodInfo[]>(
   grabAllPods,
   PodIcon,
 );
-eventStore.setup();
+eventStore.setupWithDebounce();
 
 export async function grabAllPods(): Promise<PodInfo[]> {
   let result = await window.listPods();

--- a/packages/renderer/src/stores/volumes.spec.ts
+++ b/packages/renderer/src/stores/volumes.spec.ts
@@ -85,6 +85,9 @@ test('volumes should be updated in case of a container is removed', async () => 
   expect(containerRemovedCallback).toBeDefined();
   await containerRemovedCallback();
 
+  // wait debounce
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
   // check if the volumes are updated
   const volumes2 = get(volumeListInfos);
   expect(volumes2.length).toBe(0);

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -65,7 +65,7 @@ export const volumesEventStore = new EventStore<VolumeListInfo[]>(
   listVolumes,
   VolumeIcon,
 );
-const volumesEventStoreInfo = volumesEventStore.setup();
+const volumesEventStoreInfo = volumesEventStore.setupWithDebounce();
 
 export const searchPattern = writable('');
 


### PR DESCRIPTION
### What does this PR do?
allow to use debounce/throttle when updating stores

if there are 15 events in a row to update a store, it can be updated only once after all events completed in like 1.5s

### Screenshot/screencast of this PR

N/A

### What issues does this PR fix or reference?

related to https://github.com/containers/podman-desktop/issues/3376

### How to test this PR?

unit tests provided

another option: create like 10 containers and check how many HTTP requests are performed with or without this PR using `journalctl -f | grep HTTP` command

and then run for example command: `podman container prune`
