### PR TITLE
feat: Add kubeconfig tab in PreferencesKubernetesConnectionRendering

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -224,6 +224,7 @@ declare module '@podman-desktop/api' {
   export interface KubernetesProviderConnection {
     name: string;
     endpoint: KubernetesProviderConnectionEndpoint;
+    kubeconfig?: string;
     lifecycle?: ProviderConnectionLifecycle;
     status(): ProviderConnectionStatus;
   }
@@ -1339,10 +1340,12 @@ declare module '@podman-desktop/api' {
     readonly location: Uri;
   }
 
+  export type EngineType = 'podman' | 'docker';
+
   export interface ContainerInfo {
     engineId: string;
     engineName: string;
-    engineType: 'podman' | 'docker';
+    engineType: EngineType;
     Id: string;
     Names: string[];
     Image: string;

--- a/packages/main/src/plugin/api/provider-info.ts
+++ b/packages/main/src/plugin/api/provider-info.ts
@@ -41,6 +41,7 @@ export interface ProviderContainerConnectionInfo {
 export interface ProviderKubernetesConnectionInfo {
   name: string;
   status: ProviderConnectionStatus;
+  kubeconfig?: string;
   endpoint: {
     apiURL: string;
   };

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -521,6 +521,7 @@ export class ProviderRegistry {
       providerConnection = {
         name: connection.name,
         status: connection.status(),
+        kubeconfig: connection.kubeconfig,
         endpoint: {
           apiURL: connection.endpoint.apiURL,
         },
@@ -845,6 +846,7 @@ export class ProviderRegistry {
           providerId: internalProviderId,
           connection: {
             name: providerConnectionInfo.name,
+            kubeconfig: providerConnectionInfo.kubeconfig,
             endpoint: providerConnectionInfo.endpoint,
             status: (): ProviderConnectionStatus => {
               return providerConnectionInfo.status;
@@ -895,6 +897,7 @@ export class ProviderRegistry {
           providerId: internalProviderId,
           connection: {
             name: providerConnectionInfo.name,
+            kubeconfig: providerConnectionInfo.kubeconfig,
             endpoint: providerConnectionInfo.endpoint,
             status: (): ProviderConnectionStatus => {
               return providerConnectionInfo.status;

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsKubeconfig.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsKubeconfig.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import MonacoEditor from '../editor/MonacoEditor.svelte';
+
+export let kubeconfig: string;
+</script>
+
+{#if kubeconfig}
+  <MonacoEditor content="{kubeconfig}" language="yaml" />
+{/if}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -17,6 +17,7 @@ import PreferencesKubernetesConnectionDetailsSummary from './PreferencesKubernet
 import PreferencesConnectionDetailsLogs from './PreferencesConnectionDetailsLogs.svelte';
 import DetailsPage from '../ui/DetailsPage.svelte';
 import CustomIcon from '../images/CustomIcon.svelte';
+import PreferencesConnectionDetailsKubeconfig from '/src/lib/preferences/PreferencesKubernetesConnectionDetailsKubeconfig.svelte';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
 export let providerInternalId: string = undefined;
@@ -146,6 +147,9 @@ function setNoLogs() {
         {#if connectionInfo.lifecycleMethods && connectionInfo.lifecycleMethods.length > 0}
           <Tab title="Logs" url="logs" />
         {/if}
+        {#if connectionInfo.kubeconfig}
+          <Tab title="Kubeconfig" url="kubeconfig" />
+        {/if}
       </svelte:fragment>
       <svelte:fragment slot="content">
         <div class="h-full">
@@ -161,6 +165,9 @@ function setNoLogs() {
               connectionInfo="{connectionInfo}"
               setNoLogs="{setNoLogs}"
               noLog="{noLog}" />
+          </Route>
+          <Route path="/kubeconfig" breadcrumb="kubeconfig" navigationHint="tab">
+            <PreferencesConnectionDetailsKubeconfig kubeconfig="{connectionInfo.kubeconfig}" />
           </Route>
         </div>
       </svelte:fragment>


### PR DESCRIPTION
fix: https://github.com/containers/podman-desktop/issues/3513

## Description

The goal is to allows extension providing `KubernetesProviderConnection` to provide a kubeconfig, that could be displayed in the Preferences page.

### Screenshot/screencast of this PR

TODO
