### PR TITLE
chore: preference browse buttons

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -138,8 +138,7 @@ test('Expect an input button with Browse as placeholder when record is type stri
   expect((readOnlyInput as HTMLInputElement).placeholder).toBe(record.placeholder);
   const input = screen.getByLabelText('button-record-description');
   expect(input).toBeInTheDocument();
-  expect(input instanceof HTMLInputElement).toBe(true);
-  expect((input as HTMLInputElement).placeholder).toBe('Browse ...');
+  expect(input.textContent).toBe('Browse ...');
 });
 
 test('Expect a select when record is type string and has enum values', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -7,6 +7,7 @@ import ErrorMessage from '../ui/ErrorMessage.svelte';
 import Markdown from '../markdown/Markdown.svelte';
 import { getNormalizedDefaultNumberValue } from './Util';
 import Tooltip from '../ui/Tooltip.svelte';
+import Button from '../ui/Button.svelte';
 
 let invalidEntry = false;
 let invalidText = undefined;
@@ -334,15 +335,11 @@ function assertNumericValueIsValid(value: number) {
           on:click="{event => handleCleanValue(event)}">
           <Fa icon="{faXmark}" />
         </button>
-        <input
+        <Button
           on:click="{() => selectFilePath()}"
           id="rendering.FilePath.{record.id}"
-          readonly
           aria-invalid="{invalidEntry}"
-          aria-label="button-{record.description}"
-          placeholder="Browse ..."
-          class="bg-violet-500 p-1 text-xs text-center hover:bg-zinc-700 placeholder-white rounded-sm cursor-pointer outline-0"
-          required />
+          aria-label="button-{record.description}">Browse ...</Button>
       </div>
     {:else if record.type === 'string' && record.enum && record.enum.length > 0}
       <select


### PR DESCRIPTION
### What does this PR do?

I noticed the Browse button for config properties is using some custom styling, which wasn't matching anywhere else. Changing it to use the Button component.

### Screenshot/screencast of this PR

Before:

<img width="215" alt="Screenshot 2023-08-14 at 5 03 47 PM" src="https://github.com/containers/podman-desktop/assets/19958075/c56157d2-40f5-4c6d-8dd6-ef3c0c3b5526">

After:

<img width="155" alt="Screenshot 2023-08-14 at 5 05 34 PM" src="https://github.com/containers/podman-desktop/assets/19958075/f3f068cd-005d-442b-bb24-a76b7b2f3c0a">

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A