### PR TITLE
feat: add the setting to start a podman machine after its creation

### DIFF
--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -113,6 +113,12 @@
           "scope": "ContainerProviderConnectionFactory",
           "markdownDescription": "User mode networking (traffic relayed by a user process). See [documentation](https://docs.podman.io/en/latest/markdown/podman-machine-init.1.html#user-mode-networking).",
           "when": "podman.isUserModeNetworkingSupported == true"
+        },
+        "podman.factory.machine.now": {
+          "type": "boolean",
+          "default": true,
+          "scope": "ContainerProviderConnectionFactory",
+          "description": "Start the machine now"
         }
       }
     },

--- a/extensions/podman/package.json
+++ b/extensions/podman/package.json
@@ -118,7 +118,8 @@
           "type": "boolean",
           "default": true,
           "scope": "ContainerProviderConnectionFactory",
-          "description": "Start the machine now"
+          "description": "Start the machine now",
+          "when": "podman.isStartNowAtMachineInitSupported"
         }
       }
     },

--- a/extensions/podman/src/extension.spec.ts
+++ b/extensions/podman/src/extension.spec.ts
@@ -207,6 +207,42 @@ test('verify create command called with correct values with user mode networking
   expect(console.error).not.toBeCalled();
 });
 
+test('verify create command called with now flag if start machine after creation is enabled', async () => {
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation(() => {
+    return Promise.resolve({} as extensionApi.RunResult);
+  });
+  await extension.createMachine(
+    {
+      'podman.factory.machine.cpus': '2',
+      'podman.factory.machine.image-path': 'path',
+      'podman.factory.machine.memory': '1048000000',
+      'podman.factory.machine.diskSize': '250000000000',
+      'podman.factory.machine.now': true,
+    },
+    undefined,
+    undefined,
+  );
+  const parameters = [
+    'machine',
+    'init',
+    '--cpus',
+    '2',
+    '--memory',
+    '999',
+    '--disk-size',
+    '232',
+    '--image-path',
+    'path',
+    '--now',
+  ];
+  expect(spyExecPromise).toBeCalledWith(getPodmanCli(), parameters, {
+    env: {},
+    logger: undefined,
+  });
+  expect(console.error).not.toBeCalled();
+});
+
 test('test checkDefaultMachine, if the machine running is not default, the function will prompt', async () => {
   await extension.checkDefaultMachine(fakeMachineJSON);
 

--- a/extensions/podman/src/extension.ts
+++ b/extensions/podman/src/extension.ts
@@ -666,6 +666,7 @@ async function registerUpdatesIfAny(
 
 export const ROOTFUL_MACHINE_INIT_SUPPORTED_KEY = 'podman.isRootfulMachineInitSupported';
 export const USER_MODE_NETWORKING_SUPPORTED_KEY = 'podman.isUserModeNetworkingSupported';
+export const START_NOW_MACHINE_INIT_SUPPORTED_KEY = 'podman.isStartNowAtMachineInitSupported';
 
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
   storedExtensionContext = extensionContext;
@@ -676,6 +677,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   if (version) {
     extensionApi.context.setValue(ROOTFUL_MACHINE_INIT_SUPPORTED_KEY, isRootfulMachineInitSupported(version));
+    extensionApi.context.setValue(START_NOW_MACHINE_INIT_SUPPORTED_KEY, isStartNowAtMachineInitSupported(version));
     extensionApi.context.setValue(USER_MODE_NETWORKING_SUPPORTED_KEY, isUserModeNetworkingSupported(version));
     isMovedPodmanSocket = isPodmanSocketLocationMoved(version);
   }
@@ -1085,6 +1087,13 @@ export async function deactivate(): Promise<void> {
       console.log('stopped autostarted machine', autoMachineName);
     }
   });
+}
+
+const PODMAN_MINIMUM_VERSION_FOR_NOW_FLAG_INIT = '4.0.0';
+
+// Checks if start now flag at machine init is supported.
+export function isStartNowAtMachineInitSupported(podmanVersion: string) {
+  return compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_NOW_FLAG_INIT) >= 0;
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_ROOTFUL_MACHINE_INIT = '4.1.0';

--- a/extensions/podman/src/podman-install.ts
+++ b/extensions/podman/src/podman-install.ts
@@ -34,6 +34,8 @@ import {
   ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
   isUserModeNetworkingSupported,
   USER_MODE_NETWORKING_SUPPORTED_KEY,
+  START_NOW_MACHINE_INIT_SUPPORTED_KEY,
+  isStartNowAtMachineInitSupported,
 } from './extension';
 
 const readFile = promisify(fs.readFile);
@@ -145,6 +147,10 @@ export class PodmanInstall {
           USER_MODE_NETWORKING_SUPPORTED_KEY,
           isUserModeNetworkingSupported(newInstalledPodman.version),
         );
+        extensionApi.context.setValue(
+          START_NOW_MACHINE_INIT_SUPPORTED_KEY,
+          isStartNowAtMachineInitSupported(newInstalledPodman.version),
+        );
       }
       // update detections checks
       provider.updateDetectionChecks(getDetectionChecks(newInstalledPodman));
@@ -197,6 +203,10 @@ export class PodmanInstall {
         extensionApi.context.setValue(
           USER_MODE_NETWORKING_SUPPORTED_KEY,
           isUserModeNetworkingSupported(updateInfo.bundledVersion),
+        );
+        extensionApi.context.setValue(
+          START_NOW_MACHINE_INIT_SUPPORTED_KEY,
+          isStartNowAtMachineInitSupported(updateInfo.bundledVersion),
         );
       } else if (answer === 'Ignore') {
         this.podmanInfo.ignoreVersionUpdate = updateInfo.bundledVersion;


### PR DESCRIPTION
### What does this PR do?

It allows to set the `--now` flag when executing the create podman machine command. 
The code was already implemented, the missing thing was the entry in the package.json.
This way when going through the workflow the user will create/start a podman machine or he can decide to disable the start now and just create a machine. 

### Screenshot/screencast of this PR

![image](https://github.com/containers/podman-desktop/assets/49404737/f4768833-ecfc-4d0b-8acf-d4afedb428d9)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

1. try to create a podman machine, you should see the new setting
