### PR TITLE
feat: add when functionality for setting properties

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationRendering.svelte
@@ -3,7 +3,7 @@ import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/
 import type { ProviderInfo } from '../../../../main/src/plugin/api/provider-info';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
-import { getNormalizedDefaultNumberValue, writeToTerminal } from './Util';
+import { getNormalizedDefaultNumberValue, writeToTerminal, isPropertyValidInContext } from './Util';
 import ErrorMessage from '../ui/ErrorMessage.svelte';
 import {
   clearCreateTask,
@@ -31,7 +31,6 @@ import EmptyScreen from '../ui/EmptyScreen.svelte';
 import { faCubes } from '@fortawesome/free-solid-svg-icons';
 import Button from '../ui/Button.svelte';
 import type { ContextUI } from '/@/lib/context/context';
-import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import { context } from '/@/stores/context';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
@@ -94,11 +93,6 @@ $: if (logsTerminal && loggerHandlerKey) {
   }
 }
 
-function isPropertyValidInContext(when: string, context: ContextUI) {
-  const expr = ContextKeyExpr.deserialize(when);
-  return expr?.evaluate(context);
-}
-
 onMount(async () => {
   osMemory = await window.getOsMemory();
   osCpu = await window.getOsCpu();
@@ -107,7 +101,7 @@ onMount(async () => {
   configurationKeys = properties
     .filter(property => property.scope === propertyScope)
     .filter(property => property.id?.startsWith(providerInfo.id))
-    .filter(property => !property.when || isPropertyValidInContext(property.when, globalContext))
+    .filter(property => isPropertyValidInContext(property.when, globalContext))
     .map(property => {
       switch (property.maximum) {
         case 'HOST_TOTAL_DISKSIZE': {

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -17,8 +17,9 @@
  ***********************************************************************/
 
 import { test, expect, vi, afterEach } from 'vitest';
-import { getNormalizedDefaultNumberValue, isTargetScope, writeToTerminal } from './Util';
+import { getNormalizedDefaultNumberValue, isPropertyValidInContext, isTargetScope, writeToTerminal } from './Util';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
+import { ContextUI } from '../context/context';
 
 const xtermMock = {
   write: vi.fn(),
@@ -146,4 +147,29 @@ test('return true if scope is an array and targetScope is contained in it', () =
 test('return true if scope is a string and it is equal to targetScope', () => {
   const result = isTargetScope('DEFAULT', 'DEFAULT');
   expect(result).toBe(true);
+});
+
+test('test isPropertyValidInContext returns true if when is undefined', () => {
+  const contextMock = new ContextUI();
+  const result = isPropertyValidInContext(undefined, contextMock);
+  expect(result).toBe(true);
+});
+
+test('test isPropertyValidInContext returns false if when is defined but context is empty / undefined', () => {
+  const result = isPropertyValidInContext('config.test', new ContextUI());
+  expect(result).toBe(false);
+});
+
+test('test isPropertyValidInContext with valid when statements', () => {
+  const contextMock = new ContextUI();
+  contextMock.setValue('config.test', false);
+
+  // Test with single when statements
+  expect(isPropertyValidInContext('config.test', contextMock)).toBe(false);
+  expect(isPropertyValidInContext('!config.test', contextMock)).toBe(true);
+
+  // Test with multiple when statements
+  contextMock.setValue('config.test2', true);
+  expect(isPropertyValidInContext('config.test && config.test2', contextMock)).toBe(false);
+  expect(isPropertyValidInContext('config.test && !config.test2', contextMock)).toBe(false);
 });

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -24,6 +24,8 @@ import type {
 } from '../../../../main/src/plugin/api/provider-info';
 import type { IConfigurationPropertyRecordedSchema } from '../../../../main/src/plugin/configuration-registry';
 import { CONFIGURATION_DEFAULT_SCOPE } from '../../../../main/src/plugin/configuration-registry-constants';
+import { ContextKeyExpr } from '../context/contextKey';
+import type { ContextUI } from '../context/context';
 
 export interface IProviderConnectionConfigurationPropertyRecorded extends IConfigurationPropertyRecordedSchema {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,4 +108,17 @@ export function isTargetScope(
     return true;
   }
   return scope === targetScope;
+}
+
+export function isPropertyValidInContext(when: string | undefined, context: ContextUI): boolean {
+  if (!when) {
+    return true;
+  }
+  const expr = ContextKeyExpr.deserialize(when);
+
+  // Only evaluate if context is not undefined
+  if (expr && context !== undefined) {
+    return expr.evaluate(context);
+  }
+  return false;
 }


### PR DESCRIPTION
feat: add when functionality for setting properties

### What does this PR do?

Adds the ability to use "when" statements for setting properties.

For example, if you want to only show certain settings for certain
operating systems by using `"when": "isLinux"`.

### Screenshot/screencast of this PR

https://github.com/containers/podman-desktop/assets/6422176/3991565c-12a4-4e6c-a315-9343bfa25f65




### What issues does this PR fix or reference?

Closes https://github.com/containers/podman-desktop/issues/4141

### How to test this PR?

Edit `extensions/podman/package.json` configuration for binary path to:

```json
        "podman.binary.path": {
          "type": "string",
          "format": "file",
          "default": "",
          "description": "Custom path to Podman binary (Default is blank)",
          "when": "isLinux"
        },
```

When you check your preferences, it will now only show the binary path
if you are running Linux.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
