### PR TITLE
chore: align items correctly in status bar

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -48,7 +48,7 @@ onMount(async () => {
 
 <div class="flex items-center justify-between px-1 bg-[#302251] text-sm py-0.5 space-x-2">
   <div>
-    <ul class="flex flex-wrap gap-x-2 list-none">
+    <ul class="flex flex-wrap gap-x-2 list-none items-center">
       {#each leftEntries as entry}
         <li>
           <StatusBarItem entry="{entry}" />
@@ -57,7 +57,7 @@ onMount(async () => {
     </ul>
   </div>
   <div class="place-self-end">
-    <ul class="flex flex-wrap flex-row-reverse gap-x-2 list-none">
+    <ul class="flex flex-wrap flex-row-reverse gap-x-2 list-none items-center">
       {#each rightEntries as entry}
         <li>
           <StatusBarItem entry="{entry}" />


### PR DESCRIPTION
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What does this PR do?
fix vertical align of status bar

### Screenshot/screencast of this PR

note: I zoomed twice to get such a big status bar

before:
![image](https://github.com/containers/podman-desktop/assets/436777/aaa04591-72e2-4a59-9506-9ca067c574d9)

after:
![image](https://github.com/containers/podman-desktop/assets/436777/aff914e9-384e-4544-bddf-71a7aa396b02)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

look at statusbar
