### PR TITLE
chore(website): display all blog posts not only last 5

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -326,6 +326,8 @@ const config = {
           blogTitle: 'Podman Desktop blog!',
           blogDescription: 'Discover articles about Podman Desktop',
           postsPerPage: 'ALL',
+          blogSidebarTitle: 'All blog posts',
+          blogSidebarCount: 'ALL',
           feedOptions: {
             type: 'all',
             copyright: `Copyright © ${new Date().getFullYear()} Podman Desktop`,


### PR DESCRIPTION
### What does this PR do?
display all blog posts and not only the last 5
change also the title from 'recent' to 'all'

### Screenshot / video of UI

<!-- If this PR is changing UI, please include 
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/containers/podman-desktop/issues/5012

### How to test this PR?

Browse netlify content: https://657045d49cfcb0586fd0efd7--podman-desktop-pr.netlify.app/blog