### PR TITLE
fix: reset loggerhandlerKey after restarting machine (#5150)

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -288,3 +288,80 @@ test('Expect to see error message if action fails', async () => {
   // expect to see the delete failed button
   expect(deleteFailedButton).toBeInTheDocument();
 });
+
+test('Expect startContainerProvider to only be called once when restarting', async () => {
+  const socketPath = '/my/common-socket-path';
+  const podmanMachineName = 'podman machine';
+
+  const stopConnectionMock = vi.fn();
+  const startConnectionMock = vi.fn();
+  (window as any).stopProviderConnectionLifecycle = stopConnectionMock;
+  (window as any).startProviderConnectionLifecycle = startConnectionMock;
+
+  const providerInfo: ProviderInfo = {
+    id: 'podman',
+    name: 'podman',
+    images: {
+      icon: 'img',
+    },
+    status: 'started',
+    warnings: [],
+    containerProviderConnectionCreation: true,
+    detectionChecks: [],
+    containerConnections: [
+      {
+        name: podmanMachineName,
+        status: 'started',
+        endpoint: {
+          socketPath,
+        },
+        type: 'podman',
+        lifecycleMethods: ['start', 'stop'],
+      },
+    ],
+    installationSupport: false,
+    internalId: '0',
+    kubernetesConnections: [],
+    kubernetesProviderConnectionCreation: true,
+    links: [],
+    containerProviderConnectionInitialization: false,
+    containerProviderConnectionCreationDisplayName: 'Podman machine',
+    kubernetesProviderConnectionInitialization: false,
+    extensionId: '',
+  };
+
+  providerInfos.set([providerInfo]);
+
+  // encode name with base64 of the second machine
+  const name = Buffer.from(podmanMachineName).toString('base64');
+
+  const connection = Buffer.from(socketPath).toString('base64');
+
+  render(PreferencesContainerConnectionRendering, {
+    name,
+    connection,
+    providerInternalId: '0',
+  });
+
+  // restart the connection
+  const restartButton = screen.getByRole('button', { name: 'Restart' });
+
+  // click on it
+  await userEvent.click(restartButton);
+
+  // update provider connection status, simulate it was stopped
+  providerInfo.containerConnections[0].status = 'stopped';
+  providerInfos.set([providerInfo]);
+
+  // wait a bit
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  // update provider connection status - simulate it is started again
+  providerInfo.containerConnections[0].status = 'started';
+  providerInfos.set([providerInfo]);
+
+  // wait a bit
+  await new Promise(resolve => setTimeout(resolve, 1000));
+
+  expect(startConnectionMock).toBeCalledTimes(1);
+});

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -36,7 +36,7 @@ let connectionStatus: IConnectionStatus;
 let noLog = true;
 let connectionInfo: ProviderContainerConnectionInfo | undefined;
 let providerInfo: ProviderInfo | undefined;
-let loggerHandlerKey: symbol;
+let loggerHandlerKey: symbol | undefined;
 let configurationKeys: IConfigurationPropertyRecordedSchema[];
 $: configurationKeys = properties
   .filter(property => property.scope === 'ContainerConnection')
@@ -68,6 +68,7 @@ onMount(async () => {
           status: connectionInfo.status,
         };
         startContainerProvider(providerInfo, connectionInfo, loggerHandlerKey);
+        loggerHandlerKey = undefined;
       } else {
         connectionStatus = {
           inProgress: false,


### PR DESCRIPTION
### What does this PR do?

it resets the loggerHandlerKey which is used when restarting a podman machine. As that was not reset the startAction was called twice, resulting in a failure the second time as the machine was already running

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

it resolves #5150 

### How to test this PR?

1. restart a podman machine from its details page
