### PR TITLE
chore: add unsubscribe for k8s deployments

### DIFF
--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -40,6 +40,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   (window as any).kubernetesGetContextsGeneralState = () => Promise.resolve(new Map());
   (window as any).kubernetesGetCurrentContextGeneralState = () => Promise.resolve({});
+  (window as any).window.kubernetesUnregisterGetCurrentContextResources = () => Promise.resolve(undefined);
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -48,6 +48,9 @@ export const kubernetesCurrentContextDeployments = readable<KubernetesObject[]>(
   window.events?.receive('kubernetes-current-context-deployments-update', (value: unknown) => {
     set(value as KubernetesObject[]);
   });
+  return () => {
+    window.kubernetesUnregisterGetCurrentContextResources('deployments');
+  };
 });
 
 export const deploymentSearchPattern = writable('');


### PR DESCRIPTION
chore: add unsubscribe for k8s deployments

### What does this PR do?

Adds the missing unsubscribe for deployments.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7336

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Tests cover the feature. Ex. `(window as
any).window.kubernetesUnregisterGetCurrentContextResources = () =>
Promise.resolve(undefined);` is added. If that was not there, it would
fail (it will try and call unsubscribe).

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
