### PR TITLE
chore: add tooltip to show load balancer IP for service

### DIFF
--- a/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceColumnType.spec.ts
@@ -84,3 +84,20 @@ test('Expect column styling NodePort', async () => {
   expect(dot).toBeInTheDocument();
   expect(dot).toHaveClass('text-fuschia-600');
 });
+
+test('Expect tooltip to say loadBalancerIPs if it exists in service object', async () => {
+  service.type = 'LoadBalancer';
+  service.loadBalancerIPs = '10.0.0.1';
+  render(ServiceColumnType, { object: service });
+
+  const text = screen.getByText(service.type);
+  expect(text).toBeInTheDocument();
+  expect(text).toHaveClass('text-gray-500');
+
+  const dot = text.parentElement?.children[0].children[0];
+  expect(dot).toBeInTheDocument();
+  expect(dot).toHaveClass('text-purple-500');
+
+  const tooltip = screen.getByText(service.loadBalancerIPs);
+  expect(tooltip).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/service/ServiceColumnType.svelte
+++ b/packages/renderer/src/lib/service/ServiceColumnType.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faBalanceScale, faNetworkWired, faPlug, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Fa } from 'svelte-fa';
 
 import type { ServiceUI } from './ServiceUI';
@@ -25,7 +26,23 @@ function getTypeAttributes(type: string) {
 }
 </script>
 
-<div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
-  <Fa size="1x" icon="{getTypeAttributes(object.type).icon}" class="{getTypeAttributes(object.type).color} mr-1" />
-  {object.type}
+<div class="flex flex-row gap-1">
+  <Tooltip bottom>
+    <svelte:fragment slot="content">
+      <div class="flex flex-row bg-charcoal-500 items-center p-1 rounded-md text-xs text-gray-500">
+        <Fa
+          size="1x"
+          icon="{getTypeAttributes(object.type).icon}"
+          class="{getTypeAttributes(object.type).color} mr-1" />
+        {object.type}
+      </div>
+    </svelte:fragment>
+    <svelte:fragment slot="tip">
+      {#if object.loadBalancerIPs}
+        <div class="inline-block py-2 px-4 rounded-md bg-charcoal-800 text-xs text-white" aria-label="tooltip">
+          {object.loadBalancerIPs}
+        </div>
+      {/if}
+    </svelte:fragment>
+  </Tooltip>
 </div>

--- a/packages/renderer/src/lib/service/ServiceUI.ts
+++ b/packages/renderer/src/lib/service/ServiceUI.ts
@@ -24,5 +24,6 @@ export interface ServiceUI {
   selected: boolean;
   type: string;
   clusterIP: string;
+  loadBalancerIPs?: string;
   ports: string;
 }

--- a/packages/renderer/src/lib/service/ServicesList.svelte
+++ b/packages/renderer/src/lib/service/ServicesList.svelte
@@ -87,6 +87,7 @@ let namespaceColumn = new TableColumn<ServiceUI, string>('Namespace', {
 
 let typeColumn = new TableColumn<ServiceUI>('Type', {
   renderer: ServiceColumnType,
+  overflow: true,
   comparator: (a, b) => a.type.localeCompare(b.type),
 });
 

--- a/packages/renderer/src/lib/service/service-utils.spec.ts
+++ b/packages/renderer/src/lib/service/service-utils.spec.ts
@@ -40,3 +40,39 @@ test('expect basic UI conversion', async () => {
   expect(serviceUI.name).toEqual('my-service');
   expect(serviceUI.namespace).toEqual('test-namespace');
 });
+
+test('expect no loadBalancerIPs when it is not set in V1Service ingress', async () => {
+  const service = {
+    metadata: {
+      name: 'my-service',
+      namespace: 'test-namespace',
+    },
+    status: {
+      loadBalancer: {
+        ingress: [],
+      },
+    },
+  } as V1Service;
+  const serviceUI = serviceUtils.getServiceUI(service);
+  expect(serviceUI.loadBalancerIPs).toEqual('');
+});
+
+test('expect a loadBalancerIPs if set in service', async () => {
+  const service = {
+    metadata: {
+      name: 'my-service',
+      namespace: 'test-namespace',
+    },
+    status: {
+      loadBalancer: {
+        ingress: [
+          {
+            ip: '10.0.0.1',
+          },
+        ],
+      },
+    },
+  } as V1Service;
+  const serviceUI = serviceUtils.getServiceUI(service);
+  expect(serviceUI.loadBalancerIPs).toEqual('10.0.0.1');
+});

--- a/packages/renderer/src/lib/service/service-utils.ts
+++ b/packages/renderer/src/lib/service/service-utils.ts
@@ -30,6 +30,7 @@ export class ServiceUtils {
       selected: false,
       type: service.spec?.type ?? '',
       clusterIP: service.spec?.clusterIP ?? '',
+      loadBalancerIPs: service.status?.loadBalancer?.ingress?.map(ingress => ingress.ip).join(', '),
       ports: (service.spec?.ports ?? []).map(port => port.port + '/' + port.protocol).join(', '),
     };
   }


### PR DESCRIPTION
chore: add tooltip to show load balancer IP for service

### What does this PR do?

Adds a tooltip with the IP so you can easily see what the load balancer
IP is.

As a follow up PR, it'd be nice to copy this to clipboard.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/containers/podman-desktop/assets/6422176/022c3478-5a0b-4b26-a608-a0c4e19760ef




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/containers/podman-desktop/issues/7426

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Create a load balancer and hover over the badge.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
