### PR TITLE
Light mode for FilesystemLayerView

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -253,6 +253,7 @@ export class ColorRegistry {
     this.initStatusBar();
     this.initOnboarding();
     this.initStates();
+    this.initFiles();
   }
 
   protected initDefaults(): void {
@@ -1275,6 +1276,27 @@ export class ColorRegistry {
     this.registerColor(`${state}error`, {
       dark: colorPalette.red[500],
       light: colorPalette.red[600],
+    });
+  }
+
+  // colors for image files explorer
+  protected initFiles(): void {
+    const fc = 'files-';
+    this.registerColor(`${fc}hidden`, {
+      dark: colorPalette.red[500],
+      light: colorPalette.red[500],
+    });
+    this.registerColor(`${fc}directory`, {
+      dark: colorPalette.sky[500],
+      light: colorPalette.sky[500],
+    });
+    this.registerColor(`${fc}symlink`, {
+      dark: colorPalette.sky[300],
+      light: colorPalette.sky[300],
+    });
+    this.registerColor(`${fc}executable`, {
+      dark: colorPalette.green[500],
+      light: colorPalette.green[500],
     });
   }
 }

--- a/packages/renderer/src/lib/image/FilesystemLayerView.svelte
+++ b/packages/renderer/src/lib/image/FilesystemLayerView.svelte
@@ -20,22 +20,22 @@ $: file = tree?.data;
 $: colorClass = getColor(tree);
 function getColor(tree: FilesystemNode<ImageFile>) {
   if (tree.hidden) {
-    return 'text-red-500';
+    return 'text-[var(--pd-files-hidden)]';
   }
   if (!tree.data) {
     if (tree.children.size) {
-      return 'text-sky-500';
+      return 'text-[var(--pd-files-directory)]';
     }
     return '';
   }
   if (tree.data.type === 'symlink') {
-    return 'text-sky-300';
+    return 'text-[var(--pd-files-symlink)]';
   }
   if (tree.data.type === 'directory') {
-    return 'text-sky-500';
+    return 'text-[var(--pd-files-directory)]';
   }
   if (isExec(tree.data)) {
-    return 'text-green-500';
+    return 'text-[var(--pd-files-executable)]';
   }
   return '';
 }
@@ -70,7 +70,7 @@ function getLink(file: ImageFile | undefined): string {
     {#if children?.size || (file && file.type === 'directory')}
       <button class={`text-left ml-${margin} ${colorClass}`} on:click={toggleExpansion}>
         <span class="cursor-pointer inline-block mr-1" class:rotate-90={arrowDown}>&gt;</span>
-        {label}<span class="text-gray-900">{getLink(tree?.data)}</span>
+        {label}<span class="text-[var(--pd-content-text)] opacity-70">{getLink(tree?.data)}</span>
       </button>
       {#if expanded && children}
         {#each children as [_, child]}
@@ -80,7 +80,7 @@ function getLink(file: ImageFile | undefined): string {
     {:else}
       <div class={`${colorClass}`}>
         <span class={`pl-4 ml-${margin}`}></span>
-        {label}<span class="text-gray-900">{getLink(tree?.data)}</span>
+        {label}<span class="text-[var(--pd-content-text)] opacity-70">{getLink(tree?.data)}</span>
       </div>
     {/if}
   {/if}

--- a/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
@@ -54,7 +54,7 @@ onDestroy(() => {
       </div>
       <div aria-label="tree" class="h-full w-full pr-4 overflow-y-auto pb-16">
         {#if selectedLayer}
-          <div class="text-xs grid grid-cols-[90px_60px_70px_1fr]">
+          <div class="grid grid-cols-[90px_60px_70px_1fr]">
             <FilesystemLayerView
               tree={showLayerOnly ? selectedLayer.layerTree.root : selectedLayer.stackTree.root}
               layerMode={showLayerOnly} />

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
@@ -24,9 +24,9 @@ function onLayerSelected(layer: ImageFilesystemLayerUI) {
     class:bg-[var(--pd-content-card-bg)]={layer.id !== currentLayerId}
     class:bg-[var(--pd-content-card-selected-bg)]={layer.id === currentLayerId}>
     <div>
-      <div class="text-sm">{layer.createdBy}</div>
-      <div class="text-xs text-gray-700">{layer.id}</div>
-      <div class="text-xs text-gray-700">
+      <div>{layer.createdBy}</div>
+      <div class="text-sm opacity-70">{layer.id}</div>
+      <div class="text-sm opacity-70">
         <span>{new ImageUtils().getHumanSize(layer.sizeInArchive)}</span>
         <span> | </span>
         <span>{new ImageUtils().getHumanSize(layer.sizeInContainer)}</span>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds light mode support for FilesystemLayerView, and re-increases font size, related to #6547

### Screenshot / video of UI


https://github.com/user-attachments/assets/0adfe050-62e6-44ad-9e59-988b76674838


### What issues does this PR fix or reference?

Fixes #7968 

### How to test this PR?

You can get and run PD with the extension https://github.com/feloy/podman-desktop-extension-image-files-fake 

- [x] Tests are covering the bug fix or the new feature
