### PR TITLE
chore: update loader-utils from react-dev-utils to v3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
   "resolutions": {
     "trim": "0.0.3",
     "ssh2": "1.11.0",
-    "@types/node": "^20"
+    "@types/node": "^20",
+    "**/react-dev-utils/loader-utils": "^3.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13878,10 +13878,10 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f"
-  integrity sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==
+loader-utils@^3.2.0, loader-utils@^3.2.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.3.1.tgz#735b9a19fd63648ca7adbd31c2327dfe281304e5"
+  integrity sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==
 
 local-pkg@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
### What does this PR do?
update loader utils 3.2.0 to 3.2.1 that includes a security fix
it was used by react-dev-utils

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
