### PR TITLE
fix(ui): quick-pick handle overflow

### DIFF
--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -344,4 +344,60 @@ describe('QuickPickInput', () => {
     expect(sendShowQuickPickOnSelectMock).toHaveBeenCalled();
     expect(sendShowQuickPickOnSelectMock).toHaveBeenCalledWith(123, -1);
   });
+
+  test('Expect item label to have ellipsis class', async () => {
+    const idRequest = 123;
+
+    const quickPickOptions: QuickPickOptions = {
+      items: [
+        { label: 'item1', description: 'my description1', detail: 'my detail1' },
+        { label: 'item2', description: 'my description2', detail: 'my detail2' },
+      ],
+      canPickMany: false,
+      placeHolder: 'placeHolder',
+      prompt: '',
+      id: idRequest,
+      onSelectCallback: false,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: QuickPickOptions) => void) => {
+      if (message === 'showQuickPick:add') {
+        callback(quickPickOptions);
+      }
+    });
+
+    const { getByText } = render(QuickPickInput, {});
+
+    const item1 = getByText('item1');
+    expect(item1).toBeDefined();
+    expect(item1.classList).toContain('overflow-hidden');
+    expect(item1.classList).toContain('text-ellipsis');
+  });
+
+  test('Expect item button to have full label in title', async () => {
+    const idRequest = 123;
+
+    const quickPickOptions: QuickPickOptions = {
+      items: [
+        { label: 'item1', description: 'my description1', detail: 'my detail1' },
+        { label: 'item2', description: 'my description2', detail: 'my detail2' },
+      ],
+      canPickMany: false,
+      placeHolder: 'placeHolder',
+      prompt: '',
+      id: idRequest,
+      onSelectCallback: false,
+    };
+
+    receiveFunctionMock.mockImplementation((message: string, callback: (options: QuickPickOptions) => void) => {
+      if (message === 'showQuickPick:add') {
+        callback(quickPickOptions);
+      }
+    });
+
+    const { getByTitle } = render(QuickPickInput, {});
+
+    const item1 = getByTitle('Select item1');
+    expect(item1).toBeDefined();
+  });
 });

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -288,7 +288,7 @@ function handleKeydown(e: KeyboardEvent) {
     <div class="flex justify-center items-center mt-1">
       <div
         bind:this={outerDiv}
-        class="w-[700px] {mode === 'InputBox' ? 'h-fit' : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm">
+        class="w-[700px] {mode === 'InputBox' ? 'h-fit' : ''} shadow-sm p-2 rounded shadow-zinc-700 text-sm overflow-hidden">
         {#if title}
           <div
             aria-label="title"
@@ -344,12 +344,13 @@ function handleKeydown(e: KeyboardEvent) {
                 <Checkbox class="mx-1 my-auto" bind:checked={item.checkbox} />
               {/if}
               <button
+                title="Select {item.value}"
                 on:click={() => clickQuickPickItem(item, i)}
                 class="text-[var(--pd-modal-dropdown-text)] text-left relative my-1 w-full px-1">
                 <div class="flex flex-col w-full">
                   <!-- first row is Value + optional description-->
                   <div class="flex flex-row w-full max-w-[700px] truncate">
-                    <div class="font-bold">{item.value}</div>
+                    <div class="font-bold overflow-hidden text-ellipsis">{item.value}</div>
                     {#if item.description}
                       <div class="text-[var(--pd-modal-dropdown-text)] text-xs ml-2">{item.description}</div>
                     {/if}


### PR DESCRIPTION
### What does this PR do?

Makes the quick-pick component handle very long label nicely. (overflow + title)

### Screenshot / video of UI

**Before**

![Image](https://github.com/user-attachments/assets/83373d79-8086-4a52-9b7d-f8edb0bb0618)

**after**

![image](https://github.com/user-attachments/assets/18be5827-dc8a-45c2-ab38-d55fad84da6f)b0618) |  |

with title on hover with full name in it

![image](https://github.com/user-attachments/assets/63740936-24c4-43c6-be61-04c2c7af38cb)

### What issues does this PR fix or reference?

Fixes https://github.com/containers/podman-desktop/issues/9526

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
