### PR TITLE
chore(test): refactor ensureKindCliInstalled to support installation of multiple CLI tools

### DIFF
--- a/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
+++ b/tests/playwright/src/specs/deploy-to-kubernetes.spec.ts
@@ -25,7 +25,7 @@ import {
   deleteContainer,
   deleteImage,
   deleteKindCluster,
-  ensureKindCliInstalled,
+  ensureCliInstalled,
 } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
@@ -54,7 +54,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     const settingsBar = await navigationBar.openSettings();
     await settingsBar.cliToolsTab.click();
 
-    await ensureKindCliInstalled(page);
+    await ensureCliInstalled(page, 'Kind');
   }
   await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
 });

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -25,7 +25,7 @@ import { expect as playExpect, test } from '../utility/fixtures';
 import {
   createKindCluster,
   deleteKindCluster,
-  ensureKindCliInstalled,
+  ensureCliInstalled,
   getVolumeNameForContainer,
 } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
@@ -65,7 +65,7 @@ test.describe.serial('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
         const settingsBar = await navigationBar.openSettings();
         await settingsBar.cliToolsTab.click();
 
-        await ensureKindCliInstalled(page);
+        await ensureCliInstalled(page, 'Kind');
       });
 
       test('Kind extension lifecycle', async ({ navigationBar }) => {

--- a/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-edit-yaml.spec.ts
@@ -27,7 +27,7 @@ import { expect as playExpect, test } from '../utility/fixtures';
 import {
   createKindCluster,
   deleteKindCluster,
-  ensureKindCliInstalled,
+  ensureCliInstalled,
   handleConfirmationDialog,
 } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
@@ -60,7 +60,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     const settingsBar = await navigationBar.openSettings();
     await settingsBar.cliToolsTab.click();
 
-    await ensureKindCliInstalled(page);
+    await ensureCliInstalled(page, 'Kind');
   }
   await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
 });

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -27,7 +27,7 @@ import {
   createKindCluster,
   deleteKindCluster,
   deletePod,
-  ensureKindCliInstalled,
+  ensureCliInstalled,
   handleConfirmationDialog,
 } from '../utility/operations';
 import { waitForPodmanMachineStartup } from '../utility/wait';
@@ -68,7 +68,7 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
     const settingsBar = await navigationBar.openSettings();
     await settingsBar.cliToolsTab.click();
 
-    await ensureKindCliInstalled(page);
+    await ensureCliInstalled(page, 'Kind');
   }
   await createKindCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
 });

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -294,21 +294,21 @@ export async function getVolumeNameForContainer(page: Page, containerName: strin
   });
 }
 
-export async function ensureKindCliInstalled(page: Page, timeout = 60_000): Promise<void> {
-  return test.step('Ensure Kind CLI is installed', async () => {
+export async function ensureCliInstalled(page: Page, resourceName: string, timeout = 60_000): Promise<void> {
+  return test.step(`Ensure ${resourceName} CLI is installed`, async () => {
     const cliToolsPage = new CLIToolsPage(page);
     await playExpect(cliToolsPage.toolsTable).toBeVisible({ timeout: 10_000 });
     await playExpect.poll(async () => await cliToolsPage.toolsTable.count()).toBeGreaterThan(0);
-    await playExpect(cliToolsPage.getToolRow('Kind')).toBeVisible({
+    await playExpect(cliToolsPage.getToolRow(resourceName)).toBeVisible({
       timeout: 10_000,
     });
 
-    if (!(await cliToolsPage.getCurrentToolVersion('Kind'))) {
-      await cliToolsPage.installTool('Kind');
+    if (!(await cliToolsPage.getCurrentToolVersion(resourceName))) {
+      await cliToolsPage.installTool(resourceName);
     }
 
     await playExpect
-      .poll(async () => await cliToolsPage.getCurrentToolVersion('Kind'), {
+      .poll(async () => await cliToolsPage.getCurrentToolVersion(resourceName), {
         timeout: timeout,
       })
       .toBeTruthy();


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

Refactors the ensureKindCliInstalled method to make it generic, enabling support for the installation of multiple CLI tools.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/9921

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
