### PR TITLE
fix(status-bar): progress should be indeterminate when task is indeterminate

### DIFF
--- a/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import '@testing-library/jest-dom/vitest';
+
 import { fireEvent, render } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
@@ -114,4 +116,23 @@ test('task with defined progress value should display it', async () => {
   const { getByText } = render(TaskIndicator);
   const span = getByText('50%');
   expect(span).toBeDefined();
+});
+
+test('task with undefined progress value should show indeterminate progress', async () => {
+  tasksInfo.set([
+    {
+      name: 'Dummy Task',
+      state: 'running',
+      status: 'in-progress',
+      started: 0,
+      id: 'dummy-task',
+      progress: undefined, // indeterminate
+    },
+  ]);
+
+  const { getByRole } = render(TaskIndicator);
+
+  // expect the progress bar to have the indeterminate class
+  const progressBar = getByRole('progressbar');
+  expect(progressBar).toHaveClass('progress-bar-indeterminate');
 });

--- a/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
+++ b/packages/renderer/src/lib/statusbar/TaskIndicator.svelte
@@ -13,8 +13,8 @@ let title: string | undefined = $derived.by(() => {
 });
 
 let progress: number | undefined = $derived.by(() => {
-  if (runningTasks.length === 0) return undefined;
-  return runningTasks[0].progress ?? 0;
+  if (runningTasks.length !== 1) return undefined; // return indeterminate
+  return runningTasks[0].progress; // return task's progress value
 });
 
 function toggleTaskManager(): void {
@@ -28,9 +28,7 @@ function toggleTaskManager(): void {
       <button aria-label="Toggle Task Manager" onclick={toggleTaskManager}>
         <div class="flex items-center gap-x-2">
           <span role="status" class="max-w-32 text-ellipsis overflow-hidden whitespace-nowrap">{title}</span>
-          {#if (progress ?? 0) >= 0}
-            <ProgressBar class="items-center" height="h-1" width="w-20" progress={progress} />
-          {/if}
+          <ProgressBar class="items-center" height="h-1" width="w-20" progress={progress} />
         </div>
       </button>
     </Tooltip>


### PR DESCRIPTION
### What does this PR do?

Since https://github.com/podman-desktop/podman-desktop/pull/9791 the status bar progress indicator was not showing indeterminate progress.

This PR this that, and a regression test.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9939

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. checkout & watch
2. Start/stop podman machine
3. assert status bar progress is indeterminate
