### PR TITLE
chore(test):  introduce a parent class that encapsulates the shared functionality of all cluster creation pages

### DIFF
--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -35,6 +35,7 @@ export * from './model/core/types';
 export * from './model/pages/authentication-page';
 export * from './model/pages/base-page';
 export * from './model/pages/build-image-page';
+export * from './model/pages/cluster-creation-base-page';
 export * from './model/pages/compose-onboarding/compose-failed-page';
 export * from './model/pages/compose-onboarding/compose-local-install-page';
 export * from './model/pages/compose-onboarding/compose-onboarding-page';

--- a/tests/playwright/src/model/pages/cluster-creation-base-page.ts
+++ b/tests/playwright/src/model/pages/cluster-creation-base-page.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
+
+import { BasePage } from './base-page';
+
+export class CreateClusterBasePage extends BasePage {
+  readonly header: Locator;
+  readonly content: Locator;
+  readonly clusterPropertiesInformation: Locator;
+  readonly clusterNameField: Locator;
+  readonly clusterCreationButton: Locator;
+  readonly goBackButton: Locator;
+  readonly logsButton: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.header = this.page.getByRole('region', { name: 'Header' });
+    this.content = this.page.getByRole('region', { name: 'Tab Content' });
+    this.clusterPropertiesInformation = this.content.getByRole('form', {
+      name: 'Properties Information',
+    });
+    this.clusterNameField = this.clusterPropertiesInformation.getByRole('textbox', { name: 'Name', exact: true });
+    this.clusterCreationButton = this.clusterPropertiesInformation.getByRole('button', { name: 'Create', exact: true });
+    this.logsButton = this.content.getByRole('button', { name: 'Show Logs' });
+    this.goBackButton = this.page.getByRole('button', {
+      name: 'Go back to resources',
+    });
+    this.errorMessage = this.content.getByRole('alert', {
+      name: 'Error Message Content',
+    });
+  }
+
+  async createCluster(timeout: number = 300_000): Promise<void> {
+    return test.step('Create cluster', async () => {
+      await Promise.race([
+        (async (): Promise<void> => {
+          await playExpect(this.clusterCreationButton).toBeVisible();
+          await this.clusterCreationButton.click();
+          await this.logsButton.scrollIntoViewIfNeeded();
+          await this.logsButton.click();
+          await playExpect(this.goBackButton).toBeVisible({ timeout: timeout });
+          await this.goBackButton.click();
+        })(),
+        this.errorMessage.waitFor({ state: 'visible', timeout: timeout }).then(async () => {
+          throw new Error(`${await this.errorMessage.textContent()}`);
+        }),
+      ]);
+    });
+  }
+
+  async fillTextbox(textbox: Locator, text: string): Promise<void> {
+    return test.step(`Fill textbox with ${text}`, async () => {
+      await playExpect(textbox).toBeVisible({ timeout: 15_000 });
+      await textbox.fill(text);
+      await playExpect(textbox).toHaveValue(text);
+    });
+  }
+}

--- a/tests/playwright/src/model/pages/cluster-creation-base-page.ts
+++ b/tests/playwright/src/model/pages/cluster-creation-base-page.ts
@@ -20,7 +20,7 @@ import test, { expect as playExpect, type Locator, type Page } from '@playwright
 
 import { BasePage } from './base-page';
 
-export class CreateClusterBasePage extends BasePage {
+export abstract class CreateClusterBasePage extends BasePage {
   readonly header: Locator;
   readonly content: Locator;
   readonly clusterPropertiesInformation: Locator;

--- a/tests/playwright/src/model/pages/cluster-creation-base-page.ts
+++ b/tests/playwright/src/model/pages/cluster-creation-base-page.ts
@@ -24,7 +24,6 @@ export class CreateClusterBasePage extends BasePage {
   readonly header: Locator;
   readonly content: Locator;
   readonly clusterPropertiesInformation: Locator;
-  readonly clusterNameField: Locator;
   readonly clusterCreationButton: Locator;
   readonly goBackButton: Locator;
   readonly logsButton: Locator;
@@ -37,7 +36,6 @@ export class CreateClusterBasePage extends BasePage {
     this.clusterPropertiesInformation = this.content.getByRole('form', {
       name: 'Properties Information',
     });
-    this.clusterNameField = this.clusterPropertiesInformation.getByRole('textbox', { name: 'Name', exact: true });
     this.clusterCreationButton = this.clusterPropertiesInformation.getByRole('button', { name: 'Create', exact: true });
     this.logsButton = this.content.getByRole('button', { name: 'Show Logs' });
     this.goBackButton = this.page.getByRole('button', {
@@ -63,14 +61,6 @@ export class CreateClusterBasePage extends BasePage {
           throw new Error(`${await this.errorMessage.textContent()}`);
         }),
       ]);
-    });
-  }
-
-  async fillTextbox(textbox: Locator, text: string): Promise<void> {
-    return test.step(`Fill textbox with ${text}`, async () => {
-      await playExpect(textbox).toBeVisible({ timeout: 15_000 });
-      await textbox.fill(text);
-      await playExpect(textbox).toHaveValue(text);
     });
   }
 }

--- a/tests/playwright/src/model/pages/create-kind-cluster-page.ts
+++ b/tests/playwright/src/model/pages/create-kind-cluster-page.ts
@@ -18,10 +18,13 @@
 
 import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
+import { fillTextbox } from '/@/utility/operations';
+
 import type { KindClusterOptions } from '../core/types';
 import { CreateClusterBasePage } from './cluster-creation-base-page';
 
 export class CreateKindClusterPage extends CreateClusterBasePage {
+  readonly clusterNameField: Locator;
   readonly controllerCheckbox: Locator;
   readonly providerTypeCombobox: Locator;
   readonly httpPort: Locator;
@@ -30,6 +33,7 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
 
   constructor(page: Page) {
     super(page);
+    this.clusterNameField = this.clusterPropertiesInformation.getByRole('textbox', { name: 'Name', exact: true });
     // Locator for the parent element of the ingress controller checkbox, used to change its value
     this.controllerCheckbox = this.clusterPropertiesInformation
       .getByRole('checkbox', {
@@ -44,7 +48,7 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
 
   public async createClusterDefault(clusterName: string = 'kind-cluster', timeout?: number): Promise<void> {
     return test.step('Create default cluster', async () => {
-      await this.fillTextbox(this.clusterNameField, clusterName);
+      await fillTextbox(this.clusterNameField, clusterName);
       await playExpect(this.providerTypeCombobox).toContainText('podman');
       await playExpect(this.httpPort).toHaveValue('9090');
       await playExpect(this.httpsPort).toHaveValue('9443');
@@ -60,7 +64,7 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
     timeout?: number,
   ): Promise<void> {
     return test.step('Create parametrized cluster', async () => {
-      await this.fillTextbox(this.clusterNameField, clusterName);
+      await fillTextbox(this.clusterNameField, clusterName);
 
       if (providerType) {
         await playExpect(this.providerTypeCombobox).toBeVisible();
@@ -74,10 +78,10 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
       }
 
       if (httpPort) {
-        await this.fillTextbox(this.httpPort, httpPort);
+        await fillTextbox(this.httpPort, httpPort);
       }
       if (httpsPort) {
-        await this.fillTextbox(this.httpsPort, httpsPort);
+        await fillTextbox(this.httpsPort, httpsPort);
       }
 
       await playExpect(this.controllerCheckbox).toBeEnabled();
@@ -90,7 +94,7 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
       }
 
       if (containerImage) {
-        await this.fillTextbox(this.containerImage, containerImage);
+        await fillTextbox(this.containerImage, containerImage);
       }
       await this.createCluster(timeout);
     });

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -18,7 +18,7 @@
 
 import { execSync } from 'node:child_process';
 
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
 import { ResourceElementActions } from '../model/core/operations';
@@ -440,5 +440,13 @@ export async function deletePodmanMachineFromCLI(podmanMachineName: string): Pro
         console.log(`Podman machine [${podmanMachineName}] does not exist, skipping deletion.`);
       }
     }
+  });
+}
+
+export async function fillTextbox(textbox: Locator, text: string): Promise<void> {
+  return test.step(`Fill textbox with ${text}`, async () => {
+    await playExpect(textbox).toBeVisible({ timeout: 15_000 });
+    await textbox.fill(text);
+    await playExpect(textbox).toHaveValue(text);
   });
 }


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

 introduces a parent class that encapsulates the shared functionality of all cluster creation pages


### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/10372

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
