### PR TITLE
fix: margin in settings nav item

### DIFF
--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -73,7 +73,9 @@ function click(): void {
           <Fa class="mr-4" {icon} />
         {:else}
           {@const Icon = icon}
-          <Icon size="14" class="mr-4"/>
+          <div class="mr-4">
+            <Icon size="14" />
+          </div>
         {/if}
       {/if}
       {title}


### PR DESCRIPTION
### What does this PR do?
Fixes margin on settings nav item in PD svelte UI lib
The class in `Icon` element does not write-through
That is why I added `div` element

### Screenshot / video of UI

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/pull/10309

Required for https://github.com/containers/podman-desktop-extension-ai-lab/pull/2246

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
