### PR TITLE
docs: adding remark to containerEngine#listInfos

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3905,7 +3905,7 @@ declare module '@podman-desktop/api' {
      * @param options optional options for listing information
      * @returns A promise resolving to an array of engine information.
      *
-     * @remarks only return the {@link ContainerEngineInfo} of **running** connection
+     * @remarks only returns the {@link ContainerEngineInfo} of **running** connections
      * @example
      * // Example 1: List all engine information when no specific provider is provided.
      * const infos = await listInfos();

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3905,6 +3905,7 @@ declare module '@podman-desktop/api' {
      * @param options optional options for listing information
      * @returns A promise resolving to an array of engine information.
      *
+     * @remarks only return the {@link ContainerEngineInfo} of **running** connection
      * @example
      * // Example 1: List all engine information when no specific provider is provided.
      * const infos = await listInfos();


### PR DESCRIPTION
### What does this PR do?

I noticed that the `containerEngine#listInfos` can only work on running connections.  Looking at the implementation this make sense, but as an external user this could be misleading, I was getting `no engine matching this container` error throwed when calling it before understanding the issue.

So adding a small remark to the doc!

### Screenshot / video of UI

See https://67911d0c0155cd18ad095771--podman-desktop-pr.netlify.app/api/namespaces/containerEngine/functions/listInfos

![image](https://github.com/user-attachments/assets/feaf71a1-8300-43d7-aa4e-218ed417358d)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
