### PR TITLE
chore(extension-api): adding missing type for mounts

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2837,8 +2837,10 @@ declare module '@podman-desktop/api' {
     };
     Mounts: Array<{
       Name?: string;
+      Type: string;
       Source: string;
       Destination: string;
+      Driver?: string;
       Mode: string;
       RW: boolean;
       Propagation: string;

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -663,3 +663,20 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.removePod).toHaveBeenCalled());
 });
+
+test('Expect age column to be sortable', async () => {
+  getProvidersInfoMock.mockResolvedValue([provider]);
+  listPodsMock.mockResolvedValue([stoppedPod, runningPod]);
+  kubernetesListPodsMock.mockResolvedValue([]);
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+  const { getAllByRole } = render(PodsList);
+
+  // get all the column and found the age column by text content
+  const ageColumn = getAllByRole('columnheader').find(header => header.textContent?.trim() === 'Age');
+  expect(ageColumn).toBeDefined();
+
+  // Ensure the fa sort icon is visible
+  expect(Array.from(ageColumn?.children ?? []).some(child => child.classList.contains('fa-sort'))).toBeTruthy();
+});

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -146,6 +146,7 @@ let containersColumn = new TableColumn<PodInfoUI>('Containers', {
 
 let ageColumn = new TableColumn<PodInfoUI, Date | undefined>('Age', {
   renderer: TableDurationColumn,
+  comparator: (a, b): number => new Date(a.created).getTime() - new Date(b.created).getTime(),
   renderMapping(object): Date | undefined {
     return podUtils.getUpDate(object);
   },


### PR DESCRIPTION
### What does this PR do?

Just copy paste from `ContainerInfo`.

https://github.com/podman-desktop/podman-desktop/blob/028b59419d0516c999a68337cee444c2a1240049/packages/extension-api/src/extension-api.d.ts#L2552-L2561

Should we create a dedicated object?

### Screenshot / video of UI

![image](https://github.com/user-attachments/assets/70f98be1-69c0-4cf5-b507-e9cb11f30bd1)


### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
