### PR TITLE
feat: monitor current context only by default

### DIFF
--- a/packages/main/src/plugin/kubernetes/contexts-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-dispatcher.spec.ts
@@ -231,3 +231,37 @@ test('call update with a modifed context calls onUpdate', () => {
     config: new KubeConfigSingleContext(kc1, contexts[0]!),
   });
 });
+
+test('current context changes', async () => {
+  const onCurrentChangeMock = vi.fn();
+  const kcWith2contextsWithCurrent1 = {
+    ...kcWith2contexts,
+    currentContext: 'context1',
+  };
+  const kcWith2contextsWithCurrent2 = {
+    ...kcWith2contexts,
+    currentContext: 'context2',
+  };
+
+  dispatcher.onCurrentChange(onCurrentChangeMock);
+
+  const kc = new KubeConfig();
+  kc.loadFromOptions(kcWith2contextsWithCurrent1);
+  dispatcher.update(kc);
+
+  expect(onCurrentChangeMock).toHaveBeenCalledWith({
+    previous: undefined,
+    current: 'context1',
+    currentConfig: expect.anything(),
+  });
+
+  onCurrentChangeMock.mockClear();
+  kc.loadFromOptions(kcWith2contextsWithCurrent2);
+  dispatcher.update(kc);
+
+  expect(onCurrentChangeMock).toHaveBeenCalledWith({
+    previous: 'context1',
+    current: 'context2',
+    currentConfig: expect.anything(),
+  });
+});

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts
@@ -173,6 +173,7 @@ beforeEach(() => {
         name: 'user2',
       },
     ],
+    currentContext: 'context1',
   } as unknown as KubeConfig;
 
   vi.mocked(ContextHealthChecker).mockClear();
@@ -215,14 +216,14 @@ describe('HealthChecker is built and start is called for each context the first 
 
   test('when context is not reachable', async () => {
     await manager.update(kc);
-    expect(ContextHealthChecker).toHaveBeenCalledTimes(2);
+    expect(ContextHealthChecker).toHaveBeenCalledTimes(1); // current context only
     const kc1 = new KubeConfig();
     kc1.loadFromOptions(kcWithContext1asDefault);
     expect(ContextHealthChecker).toHaveBeenCalledWith(new KubeConfigSingleContext(kc1, context1));
     const kc2 = new KubeConfig();
     kc2.loadFromOptions(kcWithContext2asDefault);
     expect(ContextHealthChecker).toHaveBeenCalledWith(new KubeConfigSingleContext(kc2, context2));
-    expect(healthStartMock).toHaveBeenCalledTimes(2);
+    expect(healthStartMock).toHaveBeenCalledTimes(1);
 
     expect(healthDisposeMock).not.toHaveBeenCalled();
 
@@ -244,12 +245,11 @@ describe('HealthChecker is built and start is called for each context the first 
     });
     await manager.update(kc);
 
-    // Twice for namespaced resources, twice for non-namespaced resources
-    expect(ContextPermissionsChecker).toHaveBeenCalledTimes(4);
+    // Once for namespaced resources, once for non-namespaced resources (on current context only)
+    expect(ContextPermissionsChecker).toHaveBeenCalledTimes(2);
     expect(ContextPermissionsChecker).toHaveBeenCalledWith(kcSingle1, 'context1', expect.anything());
-    expect(ContextPermissionsChecker).toHaveBeenCalledWith(kcSingle2, 'context2', expect.anything());
 
-    expect(permissionsStartMock).toHaveBeenCalledTimes(4);
+    expect(permissionsStartMock).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -289,14 +289,11 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
 
   test('permissions are correctly dispatched', async () => {
     const kcSingle1 = new KubeConfigSingleContext(kc, context1);
-    const kcSingle2 = new KubeConfigSingleContext(kc, context2);
-    let call = 0;
     let permissionCall = 0;
     onreachableMock.mockImplementation(f => {
-      call++;
       f({
-        kubeConfig: call === 1 ? kcSingle1 : kcSingle2,
-        contextName: call === 1 ? 'context1' : 'context2',
+        kubeConfig: kcSingle1,
+        contextName: 'context1',
         checking: false,
         reachable: true,
       } as ContextHealthState);
@@ -315,23 +312,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
         case 3:
         case 4:
           f({
-            kubeConfig: kcSingle2,
-            resources: ['resource1', 'resource2'],
-            permitted: true,
-          });
-          break;
-        case 5:
-        case 6:
-          f({
             kubeConfig: kcSingle1,
-            resources: ['resource3'],
-            permitted: true,
-          });
-          break;
-        case 7:
-        case 8:
-          f({
-            kubeConfig: kcSingle2,
             resources: ['resource3'],
             permitted: true,
           });
@@ -354,29 +335,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
     ];
     const permissions2: ContextResourcePermission[] = [
       {
-        contextName: 'context2',
-        resourceName: 'resource1',
-        attrs: {},
-        permitted: true,
-      },
-      {
-        contextName: 'context2',
-        resourceName: 'resource2',
-        attrs: {},
-        permitted: true,
-      },
-    ];
-    const permissions3: ContextResourcePermission[] = [
-      {
         contextName: 'context1',
-        resourceName: 'resource3',
-        attrs: {},
-        permitted: true,
-      },
-    ];
-    const permissions4: ContextResourcePermission[] = [
-      {
-        contextName: 'context2',
         resourceName: 'resource3',
         attrs: {},
         permitted: true,
@@ -396,10 +355,6 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
                 return permissions1;
               case 2:
                 return permissions2;
-              case 3:
-                return permissions3;
-              case 4:
-                return permissions4;
             }
             return [];
           }),
@@ -407,7 +362,7 @@ describe('HealthChecker pass and PermissionsChecker resturns a value', async () 
     );
     await manager.update(kc);
     const permissions = manager.getPermissions();
-    expect(permissions).toEqual([...permissions1, ...permissions2, ...permissions3, ...permissions4]);
+    expect(permissions).toEqual([...permissions1, ...permissions2]);
   });
 
   test('informer is started for each resource', async () => {
@@ -829,10 +784,12 @@ test('HealthChecker, PermissionsChecker and informers are disposed for each cont
   vi.mocked(permissionsStartMock).mockClear();
   vi.mocked(permissionsDisposeMock).mockClear();
 
+  // we remove context1 from kubeconfig
   const kc1 = {
-    contexts: [kcWith2contexts.contexts[0]],
-    clusters: [kcWith2contexts.clusters[0]],
-    users: [kcWith2contexts.users[0]],
+    contexts: [kcWith2contexts.contexts[1]],
+    clusters: [kcWith2contexts.clusters[1]],
+    users: [kcWith2contexts.users[1]],
+    currentContext: undefined,
   } as unknown as KubeConfig;
   kc.loadFromOptions(kc1);
   await manager.update(kc);
@@ -842,7 +799,7 @@ test('HealthChecker, PermissionsChecker and informers are disposed for each cont
 
   expect(permissionsDisposeMock).toHaveBeenCalledTimes(2); // one for namespaced, one for non-namespaced
 
-  expect(informerDisposeMock).toHaveBeenCalledTimes(1); // for resource1 on context2
+  expect(informerDisposeMock).toHaveBeenCalledTimes(1); // for resource1 on context1
 });
 
 test('getHealthCheckersStates calls getState for each health checker', async () => {
@@ -883,12 +840,6 @@ test('getHealthCheckersStates calls getState for each health checker', async () 
     kubeConfig: new KubeConfigSingleContext(kcWith2contexts, context1),
     contextName: 'context1',
     checking: true,
-    reachable: false,
-  });
-  expectedMap.set('context2', {
-    kubeConfig: new KubeConfigSingleContext(kcWith2contexts, context2),
-    contextName: 'context2',
-    checking: false,
     reachable: false,
   });
   expect(result).toEqual(expectedMap);
@@ -942,7 +893,7 @@ test('getPermissions calls getPermissions for each permissions checker', async (
   await manager.update(kc);
 
   manager.getPermissions();
-  expect(getPermissionsMock).toHaveBeenCalledTimes(4);
+  expect(getPermissionsMock).toHaveBeenCalledTimes(2);
 });
 
 test('dispose calls dispose for each health checker', async () => {
@@ -967,7 +918,7 @@ test('dispose calls dispose for each health checker', async () => {
   await manager.update(kc);
 
   manager.dispose();
-  expect(disposeMock).toHaveBeenCalledTimes(2);
+  expect(disposeMock).toHaveBeenCalledTimes(1);
 });
 
 test('dispose calls dispose for each permissions checker', async () => {
@@ -1020,5 +971,5 @@ test('dispose calls dispose for each permissions checker', async () => {
   await manager.update(kc);
 
   manager.dispose();
-  expect(permissionsDisposeMock).toHaveBeenCalledTimes(4);
+  expect(permissionsDisposeMock).toHaveBeenCalledTimes(2);
 });

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -32,7 +32,7 @@ import { ContextHealthChecker } from './context-health-checker.js';
 import type { ContextPermissionResult } from './context-permissions-checker.js';
 import { ContextPermissionsChecker } from './context-permissions-checker.js';
 import { ContextResourceRegistry } from './context-resource-registry.js';
-import type { DispatcherEvent } from './contexts-dispatcher.js';
+import type { CurrentChangeEvent, DispatcherEvent } from './contexts-dispatcher.js';
 import { ContextsDispatcher } from './contexts-dispatcher.js';
 import { CronjobsResourceFactory } from './cronjobs-resource-factory.js';
 import { DeploymentsResourceFactory } from './deployments-resource-factory.js';
@@ -52,11 +52,11 @@ const HEALTH_CHECK_TIMEOUT_MS = 5_000;
 
 /**
  * ContextsManagerExperimental receives new KubeConfig updates
- * and manages health checkers for each context of the KubeConfig.
+ * and manages the monitoring for each context of the KubeConfig.
  *
- * ContextsManagerExperimental fire events when a context is deleted, and to forward the states of the health checkers.
+ * ContextsManagerExperimental fire events when a context is deleted, and to forward the states of the health checkers, permission checkers and informers.
  *
- * ContextsManagerExperimental exposes the current state of the health checkers.
+ * ContextsManagerExperimental exposes the current state of the health checkers, permission checkers and informers.
  */
 export class ContextsManagerExperimental {
   #resourceFactoryHandler: ResourceFactoryHandler;
@@ -92,10 +92,10 @@ export class ContextsManagerExperimental {
     this.#informers = new ContextResourceRegistry<ResourceInformer<KubernetesObject>>();
     this.#objectCaches = new ContextResourceRegistry<ObjectCache<KubernetesObject>>();
     this.#dispatcher = new ContextsDispatcher();
-    this.#dispatcher.onAdd(this.onAdd.bind(this));
     this.#dispatcher.onUpdate(this.onUpdate.bind(this));
     this.#dispatcher.onDelete(this.onDelete.bind(this));
     this.#dispatcher.onDelete((state: DispatcherEvent) => this.#onContextDelete.fire(state));
+    this.#dispatcher.onCurrentChange(this.onCurrentChange.bind(this));
   }
 
   protected getResourceFactories(): ResourceFactory[] {
@@ -117,17 +117,26 @@ export class ContextsManagerExperimental {
     this.#dispatcher.update(kubeconfig);
   }
 
-  private async onAdd(event: DispatcherEvent): Promise<void> {
-    await this.startMonitoring(event.config, event.contextName);
-  }
-
   private async onUpdate(event: DispatcherEvent): Promise<void> {
-    // we don't try to update the checkers, we recreate them
-    return this.onAdd(event);
+    if (this.isMonitored(event.contextName)) {
+      // we don't try to update the checkers, we recreate them
+      return this.startMonitoring(event.config, event.contextName);
+    }
   }
 
   private onDelete(state: DispatcherEvent): void {
-    this.stopMonitoring(state.contextName);
+    if (this.isMonitored(state.contextName)) {
+      this.stopMonitoring(state.contextName);
+    }
+  }
+
+  private async onCurrentChange(state: CurrentChangeEvent): Promise<void> {
+    if (state.previous && this.isMonitored(state.previous)) {
+      this.stopMonitoring(state.previous);
+    }
+    if (state.current && state.currentConfig) {
+      await this.startMonitoring(state.currentConfig, state.current);
+    }
   }
 
   private onStateChange(state: ContextHealthState): void {
@@ -200,7 +209,14 @@ export class ContextsManagerExperimental {
     this.#onContextDelete.dispose();
   }
 
-  async refreshContextState(_contextName: string): Promise<void> {}
+  async refreshContextState(contextName: string): Promise<void> {
+    try {
+      const config = this.#dispatcher.getKubeConfigSingleContext(contextName);
+      await this.startMonitoring(config, contextName);
+    } catch (e: unknown) {
+      console.warn(`unable to refresh context ${contextName}`, String(e));
+    }
+  }
 
   // disposeAllHealthChecks disposes all health checks and removes them from registry
   private disposeAllHealthChecks(): void {
@@ -242,6 +258,10 @@ export class ContextsManagerExperimental {
         objectsCount: this.#objectCaches.get(informer.contextName, informer.resourceName)?.list().length,
       })),
     };
+  }
+
+  private isMonitored(contextName: string): boolean {
+    return this.#healthCheckers.has(contextName);
   }
 
   private async startMonitoring(config: KubeConfigSingleContext, contextName: string): Promise<void> {

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -264,7 +264,7 @@ export class ContextsManagerExperimental {
     return this.#healthCheckers.has(contextName);
   }
 
-  private async startMonitoring(config: KubeConfigSingleContext, contextName: string): Promise<void> {
+  protected async startMonitoring(config: KubeConfigSingleContext, contextName: string): Promise<void> {
     this.stopMonitoring(contextName);
 
     // register and start health checker
@@ -337,7 +337,7 @@ export class ContextsManagerExperimental {
     await newHealthChecker.start({ timeout: HEALTH_CHECK_TIMEOUT_MS });
   }
 
-  private stopMonitoring(contextName: string): void {
+  protected stopMonitoring(contextName: string): void {
     const healthChecker = this.#healthCheckers.get(contextName);
     healthChecker?.dispose();
     this.#healthCheckers.delete(contextName);


### PR DESCRIPTION
### What does this PR do?

Make the experimental mode behave as the classic mode in the choice of which context is monitored.

In Kubernetes experimental mode:

- only the current context is monitored by default
- the `Connect` button in Settings > Kubernetes becomes active, to start monitoring a non-current context

One important difference is that in classic mode, for non-current contexts, only Pods and Deployments are monitored. In experimental mode, at this moment, all resources are monitored.

### Screenshot / video of UI

(TODO)

### What issues does this PR fix or reference?

Fixes #11211 

### How to test this PR?

In experimental mode, have 2 contexts accessible, and check that only the current one is monitored when switching the current one.

Click the `Connect` button in Settings > Kubernetes to start the monitoring of other contexts.

You can check the Help > Troubleshooting > Kubernetes so see what is running in the background

- [x] Tests are covering the bug fix or the new feature
