### PR TITLE
fix: pods should have kubernetes empty screen

### DIFF
--- a/packages/renderer/src/lib/kube/pods/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodEmptyScreen.spec.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import PodEmptyScreen from './PodEmptyScreen.svelte';
+
+test('Expect pod empty screen', async () => {
+  render(PodEmptyScreen);
+  const noPods = screen.getByRole('heading', { name: 'No pods' });
+  expect(noPods).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/kube/pods/PodEmptyScreen.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodEmptyScreen.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import PodIcon from '../../images/PodIcon.svelte';
+import KubernetesEmptyScreen from '../KubernetesEmptyScreen.svelte';
+</script>
+
+<KubernetesEmptyScreen
+  icon={PodIcon}
+  title="No pods"
+  message="Try switching to a different context or namespace" />

--- a/packages/renderer/src/lib/kube/pods/PodEmptyScreen.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodEmptyScreen.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-import PodIcon from '../../images/PodIcon.svelte';
-import KubernetesEmptyScreen from '../KubernetesEmptyScreen.svelte';
+import PodIcon from '/@/lib/images/PodIcon.svelte';
+import KubernetesEmptyScreen from '/@/lib/kube/KubernetesEmptyScreen.svelte';
 </script>
 
 <KubernetesEmptyScreen

--- a/packages/renderer/src/lib/kube/pods/PodsList.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodsList.svelte
@@ -6,12 +6,12 @@ import { kubernetesCurrentContextPodsFiltered, podSearchPattern } from '/@/store
 
 import PodIcon from '../../images/PodIcon.svelte';
 import KubernetesObjectsList from '../../objects/KubernetesObjectsList.svelte';
-import PodEmptyScreen from '../../pod/PodEmptyScreen.svelte';
 import NameColumn from '../column/Name.svelte';
 import { PodUtils } from './pod-utils';
 import PodColumnActions from './PodColumnActions.svelte';
 import PodColumnContainers from './PodColumnContainers.svelte';
 import PodColumnStatus from './PodColumnStatus.svelte';
+import PodEmptyScreen from './PodEmptyScreen.svelte';
 import type { PodUI } from './PodUI';
 
 let {


### PR DESCRIPTION
### What does this PR do?

The Kubernetes Pods screen shares its 'empty screen' with the regular Pods page, but it should have the same empty screen as all the other Kubernetes pages. This just aligns it with what every other Kube page does.

### Screenshot / video of UI

<img width="586" alt="Screenshot 2025-02-24 at 10 19 42 AM" src="https://github.com/user-attachments/assets/0ea0fcdf-0b1a-4dc2-9e6d-b38086056972" />

### What issues does this PR fix or reference?

Fixes #11231.

### How to test this PR?

Go to the Kubernetes > Pods page when there are no pods (e.g. disconnected/stopped context).

- [x] Tests are covering the bug fix or the new feature