### PR TITLE
refactor(main): classify `security-restrictions.ts`

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -15,9 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
-import './security-restrictions';
-
 import dns from 'node:dns';
 
 import { app, ipcMain, Menu, Tray } from 'electron';

--- a/packages/main/src/main.spec.ts
+++ b/packages/main/src/main.spec.ts
@@ -18,6 +18,7 @@
 import type { App as ElectronApp } from 'electron';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
+import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isWindows } from '/@/util.js';
 
 import { Main } from './main.js';
@@ -25,6 +26,7 @@ import { Main } from './main.js';
 // mock electron
 vi.mock('electron');
 vi.mock('/@/util.js');
+vi.mock('/@/security-restrictions.js');
 
 const ELECTRON_APP_MOCK: ElectronApp = {
   name: 'dummy-electron-mock',
@@ -68,6 +70,13 @@ test('hardware acceleration should be disabled', async () => {
   code.main([]);
 
   expect(ELECTRON_APP_MOCK.disableHardwareAcceleration).toHaveBeenCalledOnce();
+});
+
+test('security restriction should be initialized', async () => {
+  const code = new Main(ELECTRON_APP_MOCK);
+  code.main([]);
+
+  expect(SecurityRestrictions.prototype.init).toHaveBeenCalledOnce();
 });
 
 test('on windows setAppUserModelId should be called', async () => {

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 import type { App as ElectronApp, BrowserWindow } from 'electron';
 
+import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isWindows } from '/@/util.js';
 
 import { Deferred } from './plugin/util/deferred.js';
@@ -63,6 +64,12 @@ export class Main {
       this.app.quit();
       process.exit(0);
     }
+
+    /**
+     * Enable security restrictions according to Electron guidelines
+     */
+    const security = new SecurityRestrictions(this.app);
+    security.init();
 
     /**
      * Disable Hardware Acceleration for more power-save


### PR DESCRIPTION
### What does this PR do?

To continue the work on https://github.com/podman-desktop/podman-desktop/issues/10042, _classifying_ the `security-restrictions.ts` file.

### Notes

- Creating `SecurityRestrictions` class with an `init` method.
- Creation `SecurityRestrictions` instance and calling `SecurityRestrictions#init` from `Main` class. (added in https://github.com/podman-desktop/podman-desktop/pull/11320)
- Removing `security-restrictions.ts` import from `index.ts`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/10042

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] https://github.com/podman-desktop/podman-desktop/pull/11325 ensure no regression
