### PR TITLE
chore: navigate to kubernetes pods after deploy

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -535,12 +535,12 @@ test('Should display Open pod button after successful deployment', async () => {
 
   await waitFor(() =>
     kubernetesCreatePodMock.mockResolvedValue({
-      metadata: { name: 'foobar/api-fake-cluster.com:6443', namespace: 'default' },
+      metadata: { name: 'my-pod', namespace: 'default' },
     }),
   );
   await waitFor(() =>
     kubernetesReadNamespacedPodMock.mockResolvedValue({
-      metadata: { name: 'foobar/api-fake-cluster.com:6443' },
+      metadata: { name: 'my-pod', namespace: 'default' },
       status: {
         phase: 'Running',
       },
@@ -560,7 +560,11 @@ test('Should display Open pod button after successful deployment', async () => {
   expect(openPodButton).toBeEnabled();
 
   await fireEvent.click(openPodButton);
-  expect(router.goto).toHaveBeenCalledWith(`/pods/kubernetes/foobar%2Fapi-fake-cluster.com%3A6443/default/logs`);
+  expect(window.navigateToRoute).toBeCalledWith('kubernetes', {
+    kind: 'Pod',
+    name: 'my-pod',
+    namespace: 'default',
+  });
 });
 
 test('Done button should go back to previous page', async () => {

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -140,13 +140,16 @@ function goBackToHistory(): void {
   router.goto($lastPage.path);
 }
 
-function openPodDetails(): void {
-  if (!createdPod?.metadata?.name || !defaultContextName) {
+async function openPodDetails(): Promise<void> {
+  if (!createdPod?.metadata?.name || !createdPod?.metadata?.namespace) {
     return;
   }
-  router.goto(
-    `/pods/kubernetes/${encodeURIComponent(createdPod.metadata.name)}/${encodeURIComponent(defaultContextName)}/logs`,
-  );
+
+  await window.navigateToRoute('kubernetes', {
+    kind: 'Pod',
+    name: createdPod.metadata.name,
+    namespace: createdPod.metadata.namespace,
+  });
 }
 
 async function openRoute(route: V1Route): Promise<void> {
@@ -629,7 +632,7 @@ function updateKubeResult(): void {
         <Button on:click={goBackToHistory} aria-label="Done">Done</Button>
         <Button
           on:click={openPodDetails}
-          disabled={!createdPod?.metadata?.name || !defaultContextName}
+          disabled={!createdPod?.metadata?.name || !createdPod?.metadata?.namespace}
           aria-label="Open Pod">Open Pod</Button>
       </div>
     {/if}


### PR DESCRIPTION
### What does this PR do?

Found another case where the pod route is hard-coded: after deploying a pod we go to the pod's details under the Pods page. This switches it to use the Kubernetes route - open the Kubernetes > Pods details page instead.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #8819.

### How to test this PR?

Deploy to Kubernetes form and make sure the Open Pod button goes to Kubernetes > Pods > Pod Details.

- [x] Tests are covering the bug fix or the new feature

## Summary by Sourcery

Use the Kubernetes route to navigate to pod details after deploying a pod to Kubernetes.