### PR TITLE
refactor(frontend): using string as key for proxy dropdown

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { Dropdown } from '@podman-desktop/ui-svelte';
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PreferencesProxiesRendering from '/@/lib/preferences/PreferencesProxiesRendering.svelte';
+import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
+import { ProxyState } from '/@api/proxy';
+
+// mock the ui library
+vi.mock(import('@podman-desktop/ui-svelte'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('dropdown', () => {
+  test('dropdown should receive proper options', () => {
+    render(PreferencesProxiesRendering);
+
+    expect(Dropdown).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        options: Array.from(PROXY_LABELS.values()).map(label => ({
+          value: label,
+          label: label,
+        })),
+      }),
+    );
+  });
+
+  test('dropdown value should match window#getProxyState', async () => {
+    // mock disabled state
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_DISABLED);
+
+    render(PreferencesProxiesRendering);
+
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          value: PROXY_LABELS.get(ProxyState.PROXY_DISABLED),
+        }),
+      );
+    });
+  });
+
+  test('dropdown#onChange should update value', async () => {
+    // mock disabled state
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_DISABLED);
+
+    render(PreferencesProxiesRendering);
+
+    expect(Dropdown).toHaveBeenCalled();
+    const [, { onChange }] = vi.mocked(Dropdown).mock.calls[0];
+
+    expect(onChange).toBeDefined();
+    onChange?.(PROXY_LABELS.get(ProxyState.PROXY_MANUAL));
+
+    // dropdown component should have been updated with proxy manual value
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          value: PROXY_LABELS.get(ProxyState.PROXY_MANUAL),
+        }),
+      );
+    });
+  });
+
+  test('update button should reflect change', async () => {
+    // mock disabled state
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_DISABLED);
+
+    const { getByRole } = render(PreferencesProxiesRendering);
+
+    expect(Dropdown).toHaveBeenCalled();
+    const [, { onChange }] = vi.mocked(Dropdown).mock.calls[0];
+
+    expect(onChange).toBeDefined();
+    onChange?.(PROXY_LABELS.get(ProxyState.PROXY_MANUAL));
+
+    // dropdown component should have been updated with proxy manual value
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          value: PROXY_LABELS.get(ProxyState.PROXY_MANUAL),
+        }),
+      );
+    });
+
+    const updateBtn = getByRole('button', { name: 'Update' });
+    await fireEvent.click(updateBtn);
+
+    await vi.waitFor(() => {
+      expect(window.setProxyState).toHaveBeenCalledWith(ProxyState.PROXY_MANUAL);
+    });
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -27,10 +27,18 @@ import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
 import { ProxyState } from '/@api/proxy';
 
 // mock the ui library
-vi.mock(import('@podman-desktop/ui-svelte'));
+vi.mock(import('@podman-desktop/ui-svelte'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    Dropdown: vi.fn(),
+  };
+});
 
 beforeEach(() => {
   vi.resetAllMocks();
+
+  vi.mocked(window.getProviderInfos).mockResolvedValue([]);
 });
 
 describe('dropdown', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -3,6 +3,7 @@ import { faPen } from '@fortawesome/free-solid-svg-icons';
 import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
+import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
 import { ProxyState } from '/@api/proxy';
 
 import SettingsPage from './SettingsPage.svelte';
@@ -22,6 +23,13 @@ onMount(async () => {
   noProxy = proxySettings?.noProxy ?? '';
   proxyState = await window.getProxyState();
 });
+
+function onProxyStateChange(key: unknown): void {
+  const entry = PROXY_LABELS.entries().find(([_, label]) => label === key);
+  if (entry) {
+    proxyState = entry[0];
+  }
+}
 
 async function updateProxySettings(): Promise<void> {
   await window.setProxyState(proxyState);
@@ -73,11 +81,12 @@ function validate(event: any): void {
       <Dropdown
         class="text-sm max-w-28"
         id="toggle-proxy"
-        bind:value={proxyState}
-        options={[
-          {value: ProxyState.PROXY_SYSTEM, label:'System'},
-          {value: ProxyState.PROXY_MANUAL, label:'Manual'},
-          {value: ProxyState.PROXY_DISABLED, label:'Disabled'}]}>
+        onChange={onProxyStateChange}
+        value={PROXY_LABELS.get(proxyState)}
+        options={Array.from(PROXY_LABELS.values()).map((label) => ({
+          value: label,
+          label: label,
+        }))}>
       </Dropdown>
     </label>
 
@@ -132,7 +141,7 @@ function validate(event: any): void {
           required />
       </div>
       <div class="my-2 pt-4">
-        <Button on:click={updateProxySettings} class="w-full" icon={faPen}>Update</Button>
+        <Button on:click={updateProxySettings} class="w-full" title="Update" icon={faPen}>Update</Button>
       </div>
   </div>
 </SettingsPage>

--- a/packages/renderer/src/lib/preferences/proxy-state-labels.spec.ts
+++ b/packages/renderer/src/lib/preferences/proxy-state-labels.spec.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect, test } from 'vitest';
+
+import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
+
+test('PROXY_LABELS should have unique values', () => {
+  const set = new Set<string>();
+  // ensure each values is unique
+  for (const value of PROXY_LABELS.values()) {
+    expect(set).not.toContain(value);
+    set.add(value);
+  }
+});

--- a/packages/renderer/src/lib/preferences/proxy-state-labels.ts
+++ b/packages/renderer/src/lib/preferences/proxy-state-labels.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { ProxyState } from '/@api/proxy';
+
+export const PROXY_LABELS: Map<ProxyState, string> = new Map([
+  [ProxyState.PROXY_SYSTEM, 'System'],
+  [ProxyState.PROXY_MANUAL, 'Manual'],
+  [ProxyState.PROXY_DISABLED, 'Disabled'],
+]);


### PR DESCRIPTION
### What does this PR do?

To be able to fixes https://github.com/podman-desktop/podman-desktop/issues/10734 we need to change all usage of the dropdown component to use a string as a key.

The `PreferencesProxiesRendering.svelte` is using number, so adding a Map<ProxyState, string> to get a corresponding unique label, and use it as key.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/issues/10734

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

> :information_source: I added tests to cover `PreferencesProxiesRendering`
