### PR TITLE
chore: add update info to Kind provider

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -62,7 +62,9 @@ vi.mock('@podman-desktop/api', () => ({
     onDidUnregisterContainerConnection: vi.fn(),
     onDidUpdateProvider: vi.fn(),
     onDidUpdateContainerConnection: vi.fn(),
+    onDidUpdateVersion: vi.fn(),
     createProvider: vi.fn(),
+    registerUpdate: vi.fn(),
   },
   containerEngine: {
     listContainers: vi.fn(),
@@ -111,11 +113,19 @@ beforeEach(() => {
 
   vi.mocked(podmanDesktopApi.provider.createProvider).mockResolvedValue({
     setKubernetesProviderConnectionFactory: vi.fn(),
+    onDidUpdateVersion: vi.fn(),
+    updateVersion: vi.fn(),
+    registerUpdate: vi.fn(),
   } as unknown as extensionApi.Provider);
 
   const createProviderMock = vi.fn();
   podmanDesktopApi.provider.createProvider = createProviderMock;
-  createProviderMock.mockImplementation(() => ({ setKubernetesProviderConnectionFactory: vi.fn() }));
+  createProviderMock.mockImplementation(() => ({
+    setKubernetesProviderConnectionFactory: vi.fn(),
+    onDidUpdateVersion: vi.fn(),
+    updateVersion: vi.fn(),
+    registerUpdate: vi.fn(),
+  }));
 
   vi.mocked(podmanDesktopApi.containerEngine.listContainers).mockResolvedValue([]);
   vi.mocked(util.removeVersionPrefix).mockReturnValue('1.0.0');
@@ -227,7 +237,7 @@ describe('cli tool', () => {
     vi.mocked(util.getSystemBinaryPath).mockReturnValue('test-storage-path/kind');
     await activate();
 
-    expect(util.getKindBinaryInfo).toHaveBeenCalledTimes(2);
+    expect(util.getKindBinaryInfo).toHaveBeenCalledTimes(3);
     expect(podmanDesktopApi.cli.createCliTool).toHaveBeenCalledWith({
       displayName: 'Kind',
       path: 'test-storage-path/kind',
@@ -253,7 +263,11 @@ test('Ensuring a progress task is created when calling kind.image.move command',
 
   const createProviderMock = vi.fn();
   podmanDesktopApi.provider.createProvider = createProviderMock;
-  createProviderMock.mockImplementation(() => ({ setKubernetesProviderConnectionFactory: vi.fn() }));
+  createProviderMock.mockImplementation(() => ({
+    setKubernetesProviderConnectionFactory: vi.fn(),
+    onDidUpdateVersion: vi.fn(),
+    updateVersion: vi.fn(),
+  }));
 
   const listContainersMock = vi.fn();
   podmanDesktopApi.containerEngine.listContainers = listContainersMock;
@@ -493,6 +507,9 @@ describe('cli#uninstall', () => {
 describe('kubernetes create factory', () => {
   const PROVIDER_MOCK: podmanDesktopApi.Provider = {
     setKubernetesProviderConnectionFactory: vi.fn(),
+    onDidUpdateVersion: vi.fn(),
+    updateVersion: vi.fn(),
+    registerUpdate: vi.fn(),
   } as unknown as podmanDesktopApi.Provider;
 
   beforeEach(async () => {

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -328,8 +328,7 @@ export async function createProvider(
     }),
   );
 
-  const binaryVersion = kindCli?.version;
-  if (latestAsset && latestAsset.tag.slice(1) !== binaryVersion && providerUpdate) {
+  if (latestAsset && latestAsset.tag.slice(1) !== kindCli?.version && providerUpdate) {
     currentUpdateDisposable = provider.registerUpdate(providerUpdate);
   }
 

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -64,6 +64,7 @@ let kindPath: string | undefined;
 
 let installer: KindInstaller;
 let provider: extensionApi.Provider;
+let latestAsset: KindGithubReleaseArtifactMetadata | undefined = undefined;
 
 const imageHandler = new ImageHandler();
 
@@ -291,9 +292,8 @@ export function refreshKindClustersOnProviderConnectionUpdate(provider: extensio
 export async function registerUpdatesIfAny(
   provider: extensionApi.Provider,
 ): Promise<extensionApi.Disposable | undefined> {
-  const latestVersion = await installer.getLatestVersionAsset();
   const binaryVersion = (await getKindBinaryInfo('kind')).version;
-  if (latestVersion.tag.slice(1) !== binaryVersion) {
+  if (latestAsset && latestAsset.tag.slice(1) !== binaryVersion) {
     return provider.registerUpdate({
       version: binaryVersion,
       update: async () => {
@@ -487,7 +487,6 @@ async function registerCliTool(
   let releaseToUpdateTo: KindGithubReleaseArtifactMetadata | undefined;
   let releaseVersionToUpdateTo: string | undefined;
 
-  let latestAsset: KindGithubReleaseArtifactMetadata | undefined;
   try {
     latestAsset = await installer.getLatestVersionAsset();
   } catch (error: unknown) {

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -348,9 +348,13 @@ export async function createProvider(
       disposable.dispose();
     }
     currentUpdatesDisposables.length = 0;
-    const disposable = await registerUpdatesIfAny(provider);
-    if (disposable) {
-      currentUpdatesDisposables.push(disposable);
+    try {
+      const disposable = await registerUpdatesIfAny(provider);
+      if (disposable) {
+        currentUpdatesDisposables.push(disposable);
+      }
+    } catch (error: unknown) {
+      console.error('Error while checking for update', error);
     }
   };
   await checkForUpdate();

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -293,7 +293,6 @@ export async function registerUpdatesIfAny(
 ): Promise<extensionApi.Disposable | undefined> {
   const latestVersion = await installer.getLatestVersionAsset();
   const binaryVersion = (await getKindBinaryInfo('kind')).version;
-  console.log(binaryVersion);
   if (latestVersion.tag.slice(1) !== binaryVersion) {
     return provider.registerUpdate({
       version: binaryVersion,
@@ -354,7 +353,7 @@ export async function createProvider(
         currentUpdatesDisposables.push(disposable);
       }
     } catch (error: unknown) {
-      console.error('Error while checking for update', error);
+      console.error('Error while checking for provider update', error);
     }
   };
   await checkForUpdate();

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -330,11 +330,7 @@ export async function createProvider(
 
   const binaryVersion = kindCli?.version;
   if (latestAsset && latestAsset.tag.slice(1) !== binaryVersion && providerUpdate) {
-    try {
-      currentUpdateDisposable = provider.registerUpdate(providerUpdate);
-    } catch (error: unknown) {
-      console.error('Error while checking for provider update', error);
-    }
+    currentUpdateDisposable = provider.registerUpdate(providerUpdate);
   }
 
   // when containers are refreshed, update

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -501,6 +501,7 @@ async function registerCliTool(
       } else {
         update.version = latestVersion;
         if (providerUpdate) {
+          providerUpdate.version = latestVersion ?? providerUpdate.version;
           currentUpdateDisposable = provider.registerUpdate(providerUpdate);
         }
       }
@@ -515,6 +516,7 @@ async function registerCliTool(
     providerUpdate = {
       version: latestVersion,
       update: async (): Promise<void> => {
+        // ensures that we updates to the latest release
         releaseToUpdateTo = undefined;
         await update.doUpdate();
       },

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -501,7 +501,7 @@ async function registerCliTool(
       } else {
         update.version = latestVersion;
         if (providerUpdate) {
-          provider.registerUpdate(providerUpdate);
+          currentUpdateDisposable = provider.registerUpdate(providerUpdate);
         }
       }
       releaseVersionToUpdateTo = undefined;


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds update info (when available) to the Kind provider

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/11557

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
1. Go to the CLI tools page
2. Upgrade or downgrade the Kind version
3. Verify that the same change is shown in the Kind provider widget in the statusbar:
- If downgraded, you should see an arrow up icon in the provider widget that indicates there is an update available, and update available text in the provider's tooltip
- If upgraded to the newest version, the arrow up icon should disappear and there should be no update available text in the provider's tooltip

- [X] Tests are covering the bug fix or the new feature
