### PR TITLE
feat(PinRegistry): adding telemetry events

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -686,7 +686,7 @@ export class PluginSystem {
     );
     extensionDevelopmentFolders.init();
 
-    const pinRegistry = new PinRegistry(commandRegistry, apiSender, configurationRegistry, providerRegistry);
+    const pinRegistry = new PinRegistry(commandRegistry, apiSender, configurationRegistry, providerRegistry, telemetry);
     pinRegistry.init();
 
     this.extensionLoader = new ExtensionLoader(


### PR DESCRIPTION
### What does this PR do?

This PR adds telemetry for pinning, unpinning providers to the status bar. 3 events has been added

- `pin-registry:pin event`: trivial 
- `pin-registry:unpin`: trivial
- `pin-registry:options`: useful to have a global view of which provider are pinned (Goal is to have a bar chart, with the number of pinned providers, to determine which one are preferred)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12087

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
