### PR TITLE
chore: send watch events only after we're starting the watch

### DIFF
--- a/packages/main/src/plugin/filesystem-monitoring.spec.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,8 @@ test('should send event onDidCreate when a directory is created into a watched d
     expect(readyListener).toHaveBeenCalled();
   });
 
-  expect(createListener).toHaveBeenCalledWith(Uri.file(rootdir));
+  // expect no calls as since we're watching, no files/folders have been created/modified/deleted
+  expect(createListener).not.toHaveBeenCalled();
   expect(changeListener).not.toHaveBeenCalled();
   expect(unlinkListener).not.toHaveBeenCalled();
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -61,6 +61,8 @@ import type { PodCreationSource, ScalableControllerType } from './kubernetes-cli
 import { KubernetesClient } from './kubernetes-client.js';
 import { ResizableTerminalWriter } from './kubernetes-exec-transmitter.js';
 
+vi.mock(import('node:fs'));
+
 const _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
 const configurationRegistry: ConfigurationRegistry = {
   onDidChangeConfiguration: _onDidChangeConfiguration.event,
@@ -1122,6 +1124,7 @@ test('Expect applyResourcesFromYAML to correctly call applyResources after loadi
 });
 
 test('setupWatcher sends kubernetes-context-update when kubeconfig file changes', async () => {
+  vi.mocked(fs.existsSync).mockReturnValue(true);
   const client = createTestClient();
   const fileSystemMonitoringSpy = vi.spyOn(fileSystemMonitoring, 'createFileSystemWatcher');
   const onDidChangeMock = vi.fn();


### PR DESCRIPTION
### What does this PR do?
Send events for the watcher after we initially subscribe to it.

from API, we have notifications when we update/delete/create files but here it was sending initial events.

I wanted to do that after we cut the release to see if we will have unexpected behaviors.
I noticed some extensions are flooded with events and do tons of no-op changes while they're only expecting events only if some changes happen after the start of the monitoring


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/12581

### How to test this PR?

you can check with your favorite(s) extension(s)

- [x] Tests are covering the bug fix or the new feature
