### PR TITLE
chore(flatpak): add keywords to Flatpak desktop entry

### DIFF
--- a/.flatpak.desktop
+++ b/.flatpak.desktop
@@ -6,4 +6,5 @@ Type=Application
 Icon=io.podman_desktop.PodmanDesktop
 StartupWMClass=Podman Desktop
 Categories=Development;
+Keywords=container;pod;image;volume;kubernetes;docker;kind;kubectl;
 X-Flatpak=io.podman_desktop.PodmanDesktop


### PR DESCRIPTION
### What does this PR do?

This adds keywords to the .desktop entry for Flatpak. It allows people to type related words like 'Kubernetes' in the software centre or on the desktop, and Podman Desktop being recommended to them.

Example with GZDoom:
https://github.com/flathub/org.zdoom.GZDoom/blob/master/org.zdoom.GZDoom.desktop

