### PR TITLE
feat(button): added support for class image in button component

### DIFF
--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -178,6 +178,14 @@ test('Check icon button with fab prefix is visible', async () => {
   expect(img).toBeInTheDocument();
 });
 
+test('Check icon button with class image is visible', async () => {
+  render(Button, { icon: 'fa-brands fa-github' });
+
+  // check for a few elements of the styling
+  const img = screen.getByRole('img', { hidden: true });
+  expect(img).toBeInTheDocument();
+});
+
 test('Button inProgress must have a spinner', async () => {
   // render the component
   render(Button, { inProgress: true });

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -42,7 +42,11 @@ let {
   children,
 }: Props = $props();
 
-let iconType: string = $derived(isFontAwesomeIcon(icon) ? 'fa' : 'unknown');
+let iconType: string = $derived.by(() => {
+  if (isFontAwesomeIcon(icon)) return 'fa';
+  else if (typeof icon === 'string') return 'string';
+  else return 'unknown';
+});
 
 let classes = $derived.by(() => {
   let result: string = '';
@@ -105,6 +109,8 @@ let classes = $derived.by(() => {
       {:else if iconType === 'unknown'}
         {@const Icon = icon}
         <Icon/>
+      {:else if iconType === 'string'}
+        <i role="img" class={icon}></i>
       {/if}
       {#if children}
         <span>{@render children()}</span>


### PR DESCRIPTION
### What does this PR do?
Adds support for showing image in button using class when calling from backend 
From frontend it can be shown using ImageDefiniction, but from backend there is no such way => class definition 

### Screenshot / video of UI
E.g.:
![image](https://github.com/user-attachments/assets/c359e008-2a41-4fe3-b0d4-111c3888106d)


### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/11992

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
