### PR TITLE
fix: fine-grained configuration-changed

### DIFF
--- a/packages/renderer/src/stores/recommendedRegistries.ts
+++ b/packages/renderer/src/stores/recommendedRegistries.ts
@@ -19,6 +19,7 @@
 import { type Writable, writable } from 'svelte/store';
 
 import type { RecommendedRegistry } from '../../../main/src/plugin/recommendations/recommendations-api';
+import { RecommendationsSettings } from '../../../main/src/plugin/recommendations/recommendations-settings.js';
 import { EventStore } from './event-store';
 
 let readyToUpdate = false;
@@ -30,7 +31,7 @@ const windowEvents = [
   'extension-stopped',
   'extension-removed',
   'extensions-started',
-  'configuration-changed', // Required to capture the ignoreRecommendations preference change
+  `configuration-changed:${RecommendationsSettings.SectionName}.${RecommendationsSettings.IgnoreRecommendations}`,
 ];
 const windowListeners = ['extensions-already-started'];
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Change the `recommendedRegistries` store to react only on specific configuration change, to avoid calling the update method (which can make heavy tasks) for every configuration changed

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #12591 
Fixes #11882 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
