### PR TITLE
refactor(podman): extract WinBitCheck to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/checks/win-bit-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/win-bit-check.spec.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ExtensionContext } from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { WinBitCheck } from './win-bit-check';
+
+const extensionContext = {
+  subscriptions: [],
+} as unknown as ExtensionContext;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // reset array of subscriptions
+  extensionContext.subscriptions.length = 0;
+});
+
+test('expect winbit preflight check return successful result if the arch is x64', async () => {
+  Object.defineProperty(process, 'arch', {
+    value: 'x64',
+  });
+
+  const winBitCheck = new WinBitCheck();
+  const result = await winBitCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winbit preflight check return successful result if the arch is arm64', async () => {
+  Object.defineProperty(process, 'arch', {
+    value: 'arm64',
+  });
+
+  const winBitCheck = new WinBitCheck();
+  const result = await winBitCheck.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect winbit preflight check return failure result if the arch is not supported', async () => {
+  Object.defineProperty(process, 'arch', {
+    value: 'x86',
+  });
+
+  const winBitCheck = new WinBitCheck();
+  const result = await winBitCheck.execute();
+  expect(result.description).equal('WSL2 works only on 64bit OS.');
+  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
+  expect(result.docLinks?.[0].url).equal(
+    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+  );
+  expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
+});

--- a/extensions/podman/packages/extension/src/checks/win-bit-check.ts
+++ b/extensions/podman/packages/extension/src/checks/win-bit-check.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2023-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { CheckResult } from '@podman-desktop/api';
+
+import { BaseCheck } from './base-check';
+
+export class WinBitCheck extends BaseCheck {
+  title = 'Windows 64bit';
+
+  private ARCH_X64 = 'x64';
+  private ARCH_ARM = 'arm64';
+
+  async execute(): Promise<CheckResult> {
+    const currentArch = process.arch;
+    if (this.ARCH_X64 === currentArch || this.ARCH_ARM === currentArch) {
+      return this.createSuccessfulResult();
+    } else {
+      return this.createFailureResult({
+        description: 'WSL2 works only on 64bit OS.',
+        docLinksDescription: 'Learn about WSL requirements:',
+        docLinks: {
+          url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
+          title: 'WSL2 Manual Installation Steps',
+        },
+      });
+    }
+  }
+}

--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -207,47 +207,6 @@ test('expect update on windows to throw error if non zero exit code', async () =
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();
 });
 
-test('expect winbit preflight check return successful result if the arch is x64', async () => {
-  Object.defineProperty(process, 'arch', {
-    value: 'x64',
-  });
-
-  const installer = new WinInstaller(extensionContext);
-  const preflights = installer.getPreflightChecks();
-  const winBitCheck = preflights[0];
-  const result = await winBitCheck.execute();
-  expect(result.successful).toBeTruthy();
-});
-
-test('expect winbit preflight check return successful result if the arch is arm64', async () => {
-  Object.defineProperty(process, 'arch', {
-    value: 'arm64',
-  });
-
-  const installer = new WinInstaller(extensionContext);
-  const preflights = installer.getPreflightChecks();
-  const winBitCheck = preflights[0];
-  const result = await winBitCheck.execute();
-  expect(result.successful).toBeTruthy();
-});
-
-test('expect winbit preflight check return failure result if the arch is not supported', async () => {
-  Object.defineProperty(process, 'arch', {
-    value: 'x86',
-  });
-
-  const installer = new WinInstaller(extensionContext);
-  const preflights = installer.getPreflightChecks();
-  const winBitCheck = preflights[0];
-  const result = await winBitCheck.execute();
-  expect(result.description).equal('WSL2 works only on 64bit OS.');
-  expect(result.docLinksDescription).equal('Learn about WSL requirements:');
-  expect(result.docLinks?.[0].url).equal(
-    'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-  );
-  expect(result.docLinks?.[0].title).equal('WSL2 Manual Installation Steps');
-});
-
 describe('getBundledPodmanVersion', () => {
   test('should return the podman 5 version', async () => {
     const version = getBundledPodmanVersion();

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -23,11 +23,12 @@ import { promisify } from 'node:util';
 import * as extensionApi from '@podman-desktop/api';
 import { compare } from 'compare-versions';
 
-import { BaseCheck, OrCheck, SequenceCheck } from '../checks/base-check';
+import { OrCheck, SequenceCheck } from '../checks/base-check';
 import { getDetectionChecks } from '../checks/detection-checks';
 import { HyperVCheck } from '../checks/hyperv-check';
 import { MacCPUCheck, MacMemoryCheck, MacPodmanInstallCheck, MacVersionCheck } from '../checks/macos-checks';
 import { VirtualMachinePlatformCheck } from '../checks/virtual-machine-platform-check';
+import { WinBitCheck } from '../checks/win-bit-check';
 import { WinMemoryCheck } from '../checks/win-memory-check';
 import { WinVersionCheck } from '../checks/win-version-check';
 import { WSLVersionCheck } from '../checks/wsl-version-check';
@@ -595,28 +596,5 @@ class MacOSInstaller extends BaseInstaller {
 
   getUpdatePreflightChecks(): extensionApi.InstallCheck[] {
     return [new MacPodmanInstallCheck()];
-  }
-}
-
-class WinBitCheck extends BaseCheck {
-  title = 'Windows 64bit';
-
-  private ARCH_X64 = 'x64';
-  private ARCH_ARM = 'arm64';
-
-  async execute(): Promise<extensionApi.CheckResult> {
-    const currentArch = process.arch;
-    if (this.ARCH_X64 === currentArch || this.ARCH_ARM === currentArch) {
-      return this.createSuccessfulResult();
-    } else {
-      return this.createFailureResult({
-        description: 'WSL2 works only on 64bit OS.',
-        docLinksDescription: 'Learn about WSL requirements:',
-        docLinks: {
-          url: 'https://docs.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2',
-          title: 'WSL2 Manual Installation Steps',
-        },
-      });
-    }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Extract the `WinBitCheck ` class from `extensions/podman/packages/extension/src/utils/podman-install.ts` to `extensions/podman/packages/extension/src/checks/win-bit-check.ts` and corresponding tests.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12017

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
