### PR TITLE
chore: modified github templates for issues to add projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/UX_Template.yml
+++ b/.github/ISSUE_TEMPLATE/UX_Template.yml
@@ -1,6 +1,7 @@
 name: UX Request
 description: UX Request Form
 labels: [UX/UI Issue, Graphic design]
+projects: ["podman-desktop/Podman Desktop Planning"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug 🐞
 description: Report a bug report
 labels: [kind/bug 🐞]
+projects: ["podman-desktop/Podman Desktop Planning"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,6 +1,7 @@
 name: Enhancement ✨
 description: Suggest an enhancement to an existing feature
 labels: [kind/enhancement ✨]
+projects: ["podman-desktop/Podman Desktop Planning"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,6 +1,7 @@
 name: Epic ⚡
 description: A high-level feature
 labels: [kind/epic ⚡]
+projects: ["podman-desktop/Podman Desktop Planning","podman-desktop/NEW Podman Desktop Future Goals / Planning"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature 💡
 description: Suggest an idea for this project
 labels: [kind/feature 💡]
+projects: ["podman-desktop/Podman Desktop Planning"]
 
 body:
   - type: markdown


### PR DESCRIPTION
### What does this PR do?
Currently when new issues are created  they dont get added on to the project board . This PR modifies the github templates  to add projects  key in the templates.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
