### PR TITLE
fix(tests): typecheck errors after node api update

### DIFF
--- a/extensions/docker/src/docker-context-handler.spec.ts
+++ b/extensions/docker/src/docker-context-handler.spec.ts
@@ -211,11 +211,11 @@ describe('getContexts', () => {
       {
         isDirectory: () => true,
         name: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
-      } as fs.Dirent,
+      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
       {
         isDirectory: () => true,
         name: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
-      } as fs.Dirent,
+      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
     ]);
 
     const spyReadFile = vi.spyOn(fs.promises, 'readFile');
@@ -239,11 +239,11 @@ describe('getContexts', () => {
       {
         isDirectory: () => true,
         name: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
-      } as fs.Dirent,
+      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
       {
         isDirectory: () => true,
         name: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
-      } as fs.Dirent,
+      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
     ]);
 
     const spyReadFile = vi.spyOn(fs.promises, 'readFile');
@@ -263,11 +263,11 @@ describe('getContexts', () => {
   test('should filter contexts if invalid sha', async () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
     vi.spyOn(fs.promises, 'readdir').mockResolvedValue([
-      { isDirectory: () => true, name: 'invalidsha' } as fs.Dirent,
+      { isDirectory: () => true, name: 'invalidsha' } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
       {
         isDirectory: () => true,
         name: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
-      } as fs.Dirent,
+      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
     ]);
     const spyReadFile = vi.spyOn(fs.promises, 'readFile');
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2106,7 +2106,7 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
       stderr: 'incompatible machine config',
     } as unknown as extensionApi.RunResult);
 
-    vi.mocked(fs.promises.readdir).mockResolvedValue(['foo.json'] as unknown as fs.Dirent[]);
+    vi.mocked(fs.promises.readdir).mockResolvedValue(['foo.json'] as unknown as fs.Dirent<Buffer<ArrayBufferLike>>[]);
 
     // mock readfile
     vi.mocked(fs.promises.readFile).mockResolvedValueOnce('{"Driver": "podman"}');
@@ -2198,7 +2198,7 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
     vi.mocked(fs.promises.readdir).mockResolvedValue([
       'foo.json',
       'podman-machine-default.json',
-    ] as unknown as fs.Dirent[]);
+    ] as unknown as fs.Dirent<Buffer<ArrayBufferLike>>[]);
 
     // mock readfile
     vi.mocked(fs.promises.readFile).mockResolvedValueOnce('{"Driver": "podman"}');

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -739,8 +739,8 @@ test('init', async () => {
   vi.spyOn(contributionManager, 'loadBase64Icon').mockResolvedValue('icon');
 
   vi.mocked(fs.promises.readdir).mockResolvedValue([
-    { isDirectory: () => true, name: 'contrib1' } as fs.Dirent,
-    { isDirectory: () => true, name: 'contrib2' } as fs.Dirent,
+    { isDirectory: () => true, name: 'contrib1' } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
+    { isDirectory: () => true, name: 'contrib2' } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
   ]);
 
   // initialize the contribution manager

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -383,19 +383,19 @@ test('Should watch for files and load them at startup', async () => {
     isFile: () => true,
     isDirectory: () => false,
     name: 'foo.cdix',
-  } as unknown as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
 
   const ent2 = {
     isFile: () => true,
     isDirectory: () => false,
     name: 'bar.foo',
-  } as unknown as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
 
   const ent3 = {
     isFile: () => false,
     isDirectory: () => true,
     name: 'baz',
-  } as unknown as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
   readdirMock.mockResolvedValue([ent1, ent2, ent3]);
 
   // mock loadPackagedFile
@@ -2330,27 +2330,27 @@ test('withProgress should add the extension id to the routeId', async () => {
 describe('loading extension folders', () => {
   const fileEntry = {
     isDirectory: () => false,
-  } as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
   const nodeModulesEntry = {
     isDirectory: () => true,
     name: 'node_modules',
-  } as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
   const dirEntry = {
     isDirectory: () => true,
     name: 'extension1',
-  } as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
   const dirEntry2 = {
     isDirectory: () => true,
     name: 'extension2',
-  } as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
   const dirEntry3 = {
     isDirectory: () => true,
     name: 'extension3',
-  } as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
   const dirEntry4 = {
     isDirectory: () => true,
     name: 'extension4',
-  } as fs.Dirent;
+  } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>;
 
   describe('in dev mode', () => {
     beforeEach(() => {


### PR DESCRIPTION
### What does this PR do?

It fixes typecheck errors after update to node API 22.15.31.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to typecheck errors in [#12801](https://github.com/podman-desktop/podman-desktop/pull/12801)

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
