### PR TITLE
test(e2e): include podman provider check after machine creation

### DIFF
--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -28,6 +28,7 @@ export * from './utility/fixtures';
 export * from './utility/kubernetes';
 export * from './utility/operations';
 export * from './utility/platform';
+export * from './utility/provider';
 export * from './utility/wait';
 
 // exports Podman Desktop Page Object Module
@@ -92,3 +93,6 @@ export * from './model/pages/troubleshooting-page';
 export * from './model/pages/welcome-page';
 export * from './model/workbench/navigation';
 export * from './model/workbench/status-bar';
+
+// export components
+export * from './model/components/dropdown-component';

--- a/tests/playwright/src/model/components/dropdown-component.ts
+++ b/tests/playwright/src/model/components/dropdown-component.ts
@@ -1,0 +1,226 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Locator, Page } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
+
+/**
+ * Reusable dropdown component for consistent dropdown interactions across the test suite.
+ * Handles the standard dropdown pattern used in Podman Desktop UI based on the Dropdown.svelte component.
+ *
+ * This component encapsulates the proper interaction patterns for dropdowns that follow the structure:
+ * - Container with aria-label
+ * - Button for triggering dropdown open/close
+ * - Hidden input that holds the actual selected value
+ * - Options list that appears when opened
+ */
+export class DropdownComponent {
+  private readonly page: Page;
+  private readonly containerLocator: Locator;
+  private readonly triggerButton: Locator;
+  private readonly hiddenInput: Locator;
+  private readonly ariaLabel: string;
+
+  /**
+   * Creates a new DropdownComponent instance
+   * @param page - The Playwright page object
+   * @param ariaLabel - The aria-label used to identify the dropdown container
+   */
+  constructor(page: Page, ariaLabel: string) {
+    this.page = page;
+    this.ariaLabel = ariaLabel;
+
+    // Find the dropdown container by its aria-label
+    this.containerLocator = page.getByLabel(ariaLabel, { exact: true });
+
+    // The trigger button is inside the container - first button element
+    this.triggerButton = this.containerLocator.getByRole('button').first();
+
+    // The hidden input holds the actual value
+    this.hiddenInput = this.containerLocator.getByLabel('hidden input', { exact: true });
+  }
+
+  /**
+   * Get the currently selected value from the dropdown's hidden input
+   * @returns The current value stored in the hidden input
+   */
+  async getCurrentValue(): Promise<string> {
+    return await this.hiddenInput.inputValue();
+  }
+
+  /**
+   * Get the currently displayed text (what the user sees on the trigger button)
+   * @returns The display text shown on the dropdown trigger
+   */
+  async getCurrentDisplayText(): Promise<string> {
+    return await this.triggerButton.innerText();
+  }
+
+  /**
+   * Select an option from the dropdown
+   * @param optionValue - The value to select (used for verification)
+   * @param optionText - The text to match when finding the option button (defaults to optionValue)
+   * @param exact - Whether to use exact text matching (defaults to false for case-insensitive matching)
+   */
+  async selectOption(optionValue: string, optionText?: string, exact: boolean = false): Promise<void> {
+    const displayText = optionText ?? optionValue;
+
+    return test.step(`Select dropdown option: ${displayText}`, async () => {
+      // Ensure dropdown container is visible
+      await playExpect(this.containerLocator).toBeVisible({ timeout: 10_000 });
+      await playExpect(this.triggerButton).toBeVisible({ timeout: 10_000 });
+
+      // Get current value to check if change is needed
+      const currentValue = await this.getCurrentValue();
+
+      if (currentValue !== optionValue) {
+        // Click to open the dropdown
+        await this.triggerButton.scrollIntoViewIfNeeded();
+        await this.triggerButton.click();
+
+        // Wait until at least one option (beyond the trigger) is visible
+        await playExpect(this.containerLocator.getByRole('button').nth(1)).toBeVisible();
+
+        // Find and click the option button
+        // Options appear as buttons within the container when dropdown is open
+        const optionButton = this.containerLocator.getByRole('button', {
+          name: displayText,
+          exact: exact,
+        });
+
+        await playExpect(optionButton).toBeVisible({ timeout: 10_000 });
+        await optionButton.click();
+
+        // Verify the selection was applied (case-insensitive due to windows options)
+        await playExpect
+          .poll(
+            async () => {
+              const actualValue = await this.hiddenInput.inputValue();
+              return actualValue.toLowerCase();
+            },
+            { timeout: 5_000 },
+          )
+          .toBe(optionValue.toLowerCase());
+      }
+    });
+  }
+
+  /**
+   * Check if the dropdown is currently open using ARIA semantics with fallback
+   * @returns True if the dropdown options are visible
+   */
+  async isOpen(): Promise<boolean> {
+    const expanded = await this.triggerButton.getAttribute('aria-expanded');
+    if (expanded !== null) return expanded === 'true';
+    // Fallback: when open, there should be more than one button (trigger + options)
+    return (await this.containerLocator.getByRole('button').count()) > 1;
+  }
+
+  /**
+   * Get all available options from the dropdown
+   * Note: This will open and close the dropdown to retrieve options
+   * @returns Array of option texts available in the dropdown
+   */
+  async getAvailableOptions(): Promise<string[]> {
+    return test.step('Get available dropdown options', async () => {
+      // Open dropdown if not already open
+      const wasOpen = await this.isOpen();
+      if (!wasOpen) {
+        await this.triggerButton.click();
+        await playExpect(this.containerLocator.getByRole('button').nth(1)).toBeVisible();
+      }
+
+      // Get all button texts (excluding the trigger button)
+      const allButtons = this.containerLocator.getByRole('button');
+      const buttonTexts = await allButtons.allInnerTexts();
+
+      // Exclude the trigger button (first entry)
+      const [, ...options] = buttonTexts;
+
+      // Close dropdown if we opened it
+      if (!wasOpen) {
+        await this.triggerButton.click();
+      }
+
+      return options;
+    });
+  }
+
+  /**
+   * Verify the dropdown is in the expected state
+   * @param expectedValue - The expected value in the hidden input
+   * @param expectedDisplayText - Optional expected display text on the trigger button
+   */
+  async verifyState(expectedValue: string, expectedDisplayText?: string): Promise<void> {
+    return test.step(`Verify dropdown state: ${expectedValue}`, async () => {
+      // Verify the hidden input value (case-insensitive due to windows options)
+      await playExpect
+        .poll(
+          async () => {
+            const actualValue = await this.hiddenInput.inputValue();
+            return actualValue.toLowerCase();
+          },
+          { timeout: 5_000 },
+        )
+        .toBe(expectedValue.toLowerCase());
+
+      if (expectedDisplayText) {
+        await playExpect(this.triggerButton).toContainText(expectedDisplayText, {
+          ignoreCase: true,
+          timeout: 5_000,
+        });
+      }
+    });
+  }
+
+  /**
+   * Wait for the dropdown to be ready for interaction
+   * @param timeout - Maximum time to wait in milliseconds
+   */
+  async waitForReady(timeout: number = 10_000): Promise<void> {
+    return test.step(`Wait for dropdown to be ready: ${this.ariaLabel}`, async () => {
+      await playExpect(this.containerLocator).toBeVisible({ timeout });
+      await playExpect(this.triggerButton).toBeVisible({ timeout });
+      await playExpect(this.hiddenInput).toBeAttached({ timeout });
+    });
+  }
+
+  /**
+   * Get the dropdown container locator for advanced operations
+   * @returns The container locator for this dropdown
+   */
+  getContainer(): Locator {
+    return this.containerLocator;
+  }
+
+  /**
+   * Get the trigger button locator for advanced operations
+   * @returns The trigger button locator for this dropdown
+   */
+  getTriggerButton(): Locator {
+    return this.triggerButton;
+  }
+
+  /**
+   * Get the hidden input locator for advanced operations
+   * @returns The hidden input locator for this dropdown
+   */
+  getHiddenInput(): Locator {
+    return this.hiddenInput;
+  }
+}

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -84,3 +84,12 @@ export const KubernetesResourceAttributes: Record<KubernetesResources, string[]>
   ],
   [KubernetesResources.Jobs]: ['Selected', 'Status', 'Name', 'Conditions', 'Completions', 'Age', 'Actions'],
 };
+
+export enum PodmanVirtualizationProviders {
+  WSL = 'Wsl',
+  HyperV = 'Hyperv',
+  AppleHV = 'Apple HyperVisor',
+  LibKrun = 'default GPU enabled (LibKrun)',
+  Qemu = 'Qemu',
+  Native = '', //not a real provider, used for 'Connection Type' check in Resources page of Linux machines
+}

--- a/tests/playwright/src/model/pages/create-machine-page.ts
+++ b/tests/playwright/src/model/pages/create-machine-page.ts
@@ -19,6 +19,7 @@
 import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
+import type { PodmanVirtualizationProviders } from '../core/types';
 import { BasePage } from './base-page';
 import { MachineCreationForm } from './forms/machine-creation-form';
 import { ResourcesPage } from './resources-page';
@@ -39,13 +40,26 @@ export class CreateMachinePage extends BasePage {
 
   async createMachine(
     machineName: string,
-    { isRootful = true, enableUserNet = false, startNow = true, setAsDefault = true },
+    {
+      isRootful = true,
+      enableUserNet = false,
+      startNow = true,
+      setAsDefault = true,
+      virtualizationProvider,
+    }: {
+      isRootful?: boolean;
+      enableUserNet?: boolean;
+      startNow?: boolean;
+      setAsDefault?: boolean;
+      virtualizationProvider?: PodmanVirtualizationProviders;
+    },
   ): Promise<ResourcesPage> {
     return test.step(`Create Podman Machine: ${machineName}`, async () => {
       await this.machineCreationForm.setupAndCreateMachine(machineName, {
         isRootful,
         enableUserNet,
         startNow,
+        virtualizationProvider,
       });
 
       const successfulCreationMessage = this.page.getByText('Successful operation');

--- a/tests/playwright/src/model/pages/podman-onboarding-page.ts
+++ b/tests/playwright/src/model/pages/podman-onboarding-page.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Locator, Page } from '@playwright/test';
+import { type Locator, type Page } from '@playwright/test';
 
 import { MachineCreationForm } from './forms/machine-creation-form';
 import { OnboardingPage } from './onboarding-page';

--- a/tests/playwright/src/model/pages/resource-connection-card-page.ts
+++ b/tests/playwright/src/model/pages/resource-connection-card-page.ts
@@ -27,6 +27,7 @@ export class ResourceConnectionCardPage extends ResourceCardPage {
   readonly resourceElementConnectionStatus: Locator;
   readonly resourceElementConnectionActions: Locator;
   readonly createButton: Locator;
+  readonly connectionType: Locator;
 
   constructor(page: Page, resourceName: string, resourceElementVisibleName?: string) {
     super(page, resourceName);
@@ -40,6 +41,7 @@ export class ResourceConnectionCardPage extends ResourceCardPage {
     this.createButton = this.providerSetup.getByRole('button', {
       name: 'Create',
     });
+    this.connectionType = this.resourceElement.getByLabel('Connection Type');
   }
 
   public async doesResourceElementExist(): Promise<boolean> {

--- a/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
@@ -29,8 +29,10 @@ import {
   deletePodmanMachine,
   handleConfirmationDialog,
   resetPodmanMachinesFromCLI,
+  verifyVirtualizationProvider,
 } from '../utility/operations';
 import { isLinux } from '../utility/platform';
+import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '../utility/provider';
 import { waitForPodmanMachineStartup } from '../utility/wait';
 
 const DEFAULT_PODMAN_MACHINE = 'Podman Machine';
@@ -53,7 +55,7 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
 });
 
 test.afterAll(async ({ runner, page }) => {
-  test.setTimeout(120_000);
+  test.setTimeout(180_000);
 
   try {
     if (test.info().status === 'failed') {
@@ -72,7 +74,7 @@ test.afterAll(async ({ runner, page }) => {
 
 test.describe
   .serial(`Podman machine switching validation `, () => {
-    test.describe.configure({ timeout: 120_000 });
+    test.describe.configure({ timeout: 180_000 });
 
     test('Check data for available Podman Machine and stop machine', async ({ page, navigationBar }) => {
       await test.step('Open resources page', async () => {
@@ -158,12 +160,18 @@ test.describe
           isRootful: false,
           enableUserNet: true,
           startNow: false,
+          virtualizationProvider: getVirtualizationProvider(),
         });
         await playExpect(podmanMachineCreatePage.goBackButton).toBeEnabled({ timeout: 180_000 });
         await podmanMachineCreatePage.goBackButton.click();
       });
 
       await playExpect(resourcesPage.heading).toBeVisible();
+      const podmanResources = new ResourceConnectionCardPage(page, 'podman', ROOTLESS_PODMAN_MACHINE_VISIBLE);
+      await verifyVirtualizationProvider(
+        podmanResources,
+        getVirtualizationProvider() ?? getDefaultVirtualizationProvider(),
+      );
     });
 
     test('Switch to rootless podman machine', async ({ page }) => {

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -24,6 +24,7 @@ import test, { expect as playExpect } from '@playwright/test';
 
 import { ResourceElementActions } from '../model/core/operations';
 import { ResourceElementState } from '../model/core/states';
+import type { PodmanVirtualizationProviders } from '../model/core/types';
 import { CLIToolsPage } from '../model/pages/cli-tools-page';
 import { ExperimentalPage } from '../model/pages/experimental-page';
 import { PreferencesPage } from '../model/pages/preferences-page';
@@ -501,5 +502,26 @@ export async function readFileInVolumeFromCLI(volumeName: string, fileName: stri
     } catch (error) {
       throw new Error(`Error reading file: ${fileName} in volume: ${volumeName} from CLI: ${error}`);
     }
+  });
+}
+
+/**
+ * Verifies that a Podman machine has the specified virtualization provider type.
+ * This method checks that the machine card exists and displays the correct connection type.
+ *
+ * @param resourceConnectionCardPage - The resource connection card page to verify
+ * @param virtualizationProvider - The expected virtualization provider type (e.g., PodmanVirtualizationProviders.WSL, PodmanVirtualizationProviders.HyperV...)
+ * @returns A Promise that resolves when the verification is complete
+ * @throws Will throw an error if the expected virtualization provider is not found or doesn't match
+ */
+export async function verifyVirtualizationProvider(
+  resourceConnectionCardPage: ResourceConnectionCardPage,
+  virtualizationProvider: PodmanVirtualizationProviders,
+): Promise<void> {
+  return test.step(`Verify Podman Provider is ${virtualizationProvider}`, async () => {
+    await playExpect
+      .poll(async () => await resourceConnectionCardPage.doesResourceElementExist(), { timeout: 15_000 })
+      .toBeTruthy();
+    await playExpect(resourceConnectionCardPage.connectionType).toContainText(virtualizationProvider);
   });
 }

--- a/tests/playwright/src/utility/provider.ts
+++ b/tests/playwright/src/utility/provider.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { PodmanVirtualizationProviders } from '../model/core/types';
+import { isMac, isWindows } from './platform';
+
+export const envProvider = process.env.CONTAINERS_MACHINE_PROVIDER;
+
+const PROVIDER_MAP: Record<string, PodmanVirtualizationProviders> = {
+  wsl: PodmanVirtualizationProviders.WSL,
+  hyperv: PodmanVirtualizationProviders.HyperV,
+  applehv: PodmanVirtualizationProviders.AppleHV,
+  libkrun: PodmanVirtualizationProviders.LibKrun,
+  qemu: PodmanVirtualizationProviders.Qemu,
+};
+
+export function getVirtualizationProvider(): PodmanVirtualizationProviders | undefined {
+  return envProvider ? PROVIDER_MAP[envProvider?.toLowerCase()] : undefined;
+}
+
+export function getDefaultVirtualizationProvider(): PodmanVirtualizationProviders {
+  if (isWindows) {
+    return PodmanVirtualizationProviders.WSL;
+  }
+
+  if (isMac) {
+    return PodmanVirtualizationProviders.LibKrun;
+  }
+
+  return PodmanVirtualizationProviders.Native;
+}


### PR DESCRIPTION
### What does this PR do?
This PR adds a check after creating a podman machine that verifies if the proper provider has been assigned during machine creation.
### What issues does this PR fix or reference?
[#11187](https://github.com/podman-desktop/podman-desktop/issues/11187)
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

