### PR TITLE
refactor(frontend): make ContainerGroupPartInfoUI id property non-nullable

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
@@ -65,6 +65,7 @@ const containerInfoUIMock: ContainerInfoUI = {
   groupInfo: {
     name: 'foobar',
     type: ContainerGroupInfoTypeUI.COMPOSE,
+    id: 'podman:foobar',
   },
   selected: false,
   created: 0,

--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.spec.ts
@@ -44,6 +44,7 @@ const fakeContainer1: ContainerInfoUI = {
   groupInfo: {
     name: 'group1',
     type: ContainerGroupInfoTypeUI.STANDALONE,
+    id: 'fakeContainerID1',
   },
   selected: false,
   created: 1234,
@@ -70,6 +71,7 @@ const fakeContainer2: ContainerInfoUI = {
   groupInfo: {
     name: 'group2',
     type: ContainerGroupInfoTypeUI.STANDALONE,
+    id: 'fakeContainerID2',
   },
   selected: false,
   created: 1234,

--- a/packages/renderer/src/lib/container/ContainerColumnEnvironment.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnEnvironment.spec.ts
@@ -45,6 +45,7 @@ test('Expect simple column styling', async () => {
     groupInfo: {
       name: '',
       type: ContainerGroupInfoTypeUI.STANDALONE,
+      id: 'sha256:1234567890123',
     },
     selected: false,
     created: 0,
@@ -67,6 +68,7 @@ test('Expect simple column styling - pod', async () => {
     name: '',
     engineType: ContainerGroupInfoTypeUI.PODMAN,
     engineId: '',
+    id: 'pod-id',
   };
   render(ContainerColumnEnvironment, { object: pod });
 
@@ -84,6 +86,7 @@ test('Expect simple column styling - compose', async () => {
     name: '',
     engineType: ContainerGroupInfoTypeUI.PODMAN,
     engineId: '',
+    id: 'podman:foo',
   };
   render(ContainerColumnEnvironment, { object: compose });
 

--- a/packages/renderer/src/lib/container/ContainerColumnName.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnName.spec.ts
@@ -45,6 +45,7 @@ const container: ContainerInfoUI = {
   groupInfo: {
     name: '',
     type: ContainerGroupInfoTypeUI.STANDALONE,
+    id: 'sha256:1234567890123',
   },
   selected: false,
   created: 0,
@@ -61,6 +62,7 @@ const pod: ContainerGroupInfoUI = {
   name: 'my-pod',
   engineType: ContainerGroupInfoTypeUI.PODMAN,
   engineId: 'engineId',
+  id: 'pod-id',
 };
 
 const compose: ContainerGroupInfoUI = {
@@ -72,6 +74,7 @@ const compose: ContainerGroupInfoUI = {
   name: 'my-compose',
   engineType: ContainerGroupInfoTypeUI.PODMAN,
   engineId: 'engine2',
+  id: 'podman:my-compose',
 };
 
 test('Expect simple column styling - container', async () => {

--- a/packages/renderer/src/lib/container/ContainerColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.spec.ts
@@ -64,6 +64,7 @@ test('Expect simple column styling - pod', async () => {
     allContainersCount: 0,
     containers: [],
     name: '',
+    id: '',
   };
   render(ContainerColumnStatus, { object: pod });
 
@@ -81,6 +82,7 @@ test('Expect simple column styling - compose', async () => {
     allContainersCount: 0,
     containers: [],
     name: '',
+    id: 'podman:foo',
   };
   render(ContainerColumnStatus, { object: compose });
 

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
@@ -75,6 +75,7 @@ const fakeStandaloneContainer: ContainerInfoUI = {
   groupInfo: {
     name: 'group2',
     type: ContainerGroupInfoTypeUI.STANDALONE,
+    id: 'fakeId2',
   },
   selected: false,
   created: 1234,

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -34,7 +34,7 @@ export interface ContainerGroupPartInfoUI {
 
   // Information regarding the entire group (ex. name of the pod)
   // as well as the "engine" running the group (ex. podman or docker)
-  id?: string;
+  id: string;
   engineId?: string;
   engineName?: string;
   engineType?: 'podman' | 'docker';

--- a/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
@@ -46,6 +46,7 @@ const myContainer: ContainerInfoUI = {
   groupInfo: {
     name: 'foobar',
     type: ContainerGroupInfoTypeUI.STANDALONE,
+    id: 'foobar',
   },
   selected: false,
   created: 0,

--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -214,6 +214,34 @@ test('container group status should be degraded when the pod status is degraded'
   expect(group.status).toBe('DEGRADED');
 });
 
+test('containers in same named compose project on two different engine should have different group id', async () => {
+  const COMPOSE_CONTAINER: ContainerInfo = {
+    engineId: '',
+    engineName: '',
+    engineType: 'podman',
+    Id: 'container1',
+    Image: 'registry.k8s.io/pause:3.7',
+    Labels: {
+      'com.docker.compose.project': 'compose',
+      'com.docker.compose.service': 'compose_container',
+    },
+    Names: ['/compose-compose_container-1'],
+    State: 'RUNNING',
+  } as unknown as ContainerInfo;
+
+  const foo = containerUtils.getContainerGroup({
+    ...COMPOSE_CONTAINER,
+    engineId: 'foo',
+  });
+
+  const bar = containerUtils.getContainerGroup({
+    ...COMPOSE_CONTAINER,
+    engineId: 'bar',
+  });
+
+  expect(foo.id).not.eq(bar.id);
+});
+
 test('should expect icon to be undefined if no context/view is passed', async () => {
   const containerInfo = {
     Image: 'docker.io/kindest/node:foobar',

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -42,7 +42,7 @@ export class ContainerUtils {
     // Safely determine if this is a compose project or not by checking the project label.
     const composeProject = containerInfo.Labels?.['com.docker.compose.project'];
 
-    /* 
+    /*
       When deploying with compose, the container name will be <project>-<service-name>-<container-number> under Names[0].
       This is added to the container name to make it unique.
       HOWEVER, if you specify container_name in the compose file, the container name will be whatever is is set to and
@@ -189,6 +189,7 @@ export class ContainerUtils {
     if (composeProject) {
       return {
         name: composeProject,
+        id: `${containerInfo.engineId}:${composeProject}`, // the ID must be unique per engineId, so let's concatenate the engineId and the compose project
         type: ContainerGroupInfoTypeUI.COMPOSE,
         engineId: containerInfo.engineId,
         engineType: containerInfo.engineType,
@@ -214,6 +215,7 @@ export class ContainerUtils {
       type: ContainerGroupInfoTypeUI.STANDALONE,
       status: (containerInfo.Status ?? '').toUpperCase(),
       engineType: containerInfo.engineType,
+      id: containerInfo.Id, // since the container is standalone, let's use its ID as groupInfo#id
     };
   }
 


### PR DESCRIPTION
### What does this PR do?

Today to group containers in the `ContainersList` ui, we use the group name, which is either the compose project or the pod name. However those field are only unique per engine. Meaning we are grouping same name resources among engines.

To fix https://github.com/podman-desktop/podman-desktop/issues/12842 we need to rely on a unique value, however the `groupInfo#id` is nullable because a compose project has no unique identifier, this PR makes the id property non-nullable, and uses `{engineId}:{composeProject}` as unique id for compose groups, making it unique across engines. 

For standalone containers, no id where provided for the group, we can just use the container id, as it is unique.

### Screenshot / video of UI

No visual changes

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/12842

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
