### PR TITLE
refactor(podman): extract PodmanInfo to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-info.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-info.spec.ts
@@ -87,7 +87,7 @@ describe('lastUpdateCheck', () => {
 
   test('should not write to file when setting same lastUpdateCheck', () => {
     podmanInfo.lastUpdateCheck = 123456789;
-    vi.clearAllMocks();
+    vi.mocked(writeFile).mockClear();
 
     podmanInfo.lastUpdateCheck = 123456789;
     expect(writeFile).not.toHaveBeenCalled();
@@ -106,7 +106,7 @@ describe('ignoreVersionUpdate', () => {
 
   test('should not write to file when setting same ignoreVersionUpdate', () => {
     podmanInfo.ignoreVersionUpdate = '4.1.0';
-    vi.clearAllMocks();
+    vi.mocked(writeFile).mockClear();
 
     podmanInfo.ignoreVersionUpdate = '4.1.0';
     expect(writeFile).not.toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/utils/podman-info.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-info.spec.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PodmanInfoImpl } from './podman-info';
+
+const STORAGE_PATH_MOCK = '/mock/storage/path';
+
+// mock filesystem
+vi.mock(import('node:fs/promises'));
+
+let podmanInfo: PodmanInfoImpl;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  podmanInfo = new PodmanInfoImpl(undefined, STORAGE_PATH_MOCK);
+});
+
+describe('constructor', () => {
+  test('should initialize with default values when no podmanInfoValue provided', () => {
+    podmanInfo = new PodmanInfoImpl(undefined, STORAGE_PATH_MOCK);
+    expect(podmanInfo.lastUpdateCheck).toBe(0);
+    expect(podmanInfo.podmanVersion).toBeUndefined();
+    expect(podmanInfo.ignoreVersionUpdate).toBeUndefined();
+  });
+
+  test('should initialize with provided values', () => {
+    const initialValues = {
+      podmanVersion: '4.0.0',
+      lastUpdateCheck: 123456789,
+      ignoreVersionUpdate: '4.1.0',
+    };
+    podmanInfo = new PodmanInfoImpl(initialValues, STORAGE_PATH_MOCK);
+    expect(podmanInfo.podmanVersion).toBe('4.0.0');
+    expect(podmanInfo.lastUpdateCheck).toBe(123456789);
+    expect(podmanInfo.ignoreVersionUpdate).toBe('4.1.0');
+  });
+});
+
+describe('podmanVersion', () => {
+  test('should update podmanVersion and write to file when changed', async () => {
+    podmanInfo.podmanVersion = '4.0.0';
+
+    expect(writeFile).toHaveBeenCalledWith(
+      path.resolve(STORAGE_PATH_MOCK, 'podman-ext.json'),
+      JSON.stringify({ lastUpdateCheck: 0, podmanVersion: '4.0.0' }),
+    );
+  });
+
+  test('should not write to file when setting same podmanVersion', () => {
+    podmanInfo.podmanVersion = '4.0.0';
+    vi.mocked(writeFile).mockClear();
+
+    podmanInfo.podmanVersion = '4.0.0';
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('lastUpdateCheck', () => {
+  test('should update lastUpdateCheck and write to file when changed', async () => {
+    podmanInfo.lastUpdateCheck = 123456789;
+
+    expect(writeFile).toHaveBeenCalledWith(
+      path.resolve(STORAGE_PATH_MOCK, 'podman-ext.json'),
+      JSON.stringify({ lastUpdateCheck: 123456789 }),
+    );
+  });
+
+  test('should not write to file when setting same lastUpdateCheck', () => {
+    podmanInfo.lastUpdateCheck = 123456789;
+    vi.clearAllMocks();
+
+    podmanInfo.lastUpdateCheck = 123456789;
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('ignoreVersionUpdate', () => {
+  test('should update ignoreVersionUpdate and write to file when changed', async () => {
+    podmanInfo.ignoreVersionUpdate = '4.1.0';
+
+    expect(writeFile).toHaveBeenCalledWith(
+      path.resolve(STORAGE_PATH_MOCK, 'podman-ext.json'),
+      JSON.stringify({ lastUpdateCheck: 0, ignoreVersionUpdate: '4.1.0' }),
+    );
+  });
+
+  test('should not write to file when setting same ignoreVersionUpdate', () => {
+    podmanInfo.ignoreVersionUpdate = '4.1.0';
+    vi.clearAllMocks();
+
+    podmanInfo.ignoreVersionUpdate = '4.1.0';
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/podman/packages/extension/src/utils/podman-info.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-info.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export interface PodmanInfo {
+  podmanVersion?: string;
+  lastUpdateCheck: number;
+  ignoreVersionUpdate?: string;
+}
+
+export class PodmanInfoImpl implements PodmanInfo {
+  private podmanInfo: PodmanInfo;
+
+  constructor(
+    podmanInfoValue: PodmanInfo | undefined,
+    private readonly storagePath: string,
+  ) {
+    if (!podmanInfoValue) {
+      this.podmanInfo = { lastUpdateCheck: 0 } as PodmanInfo;
+    } else {
+      this.podmanInfo = podmanInfoValue;
+    }
+  }
+
+  set podmanVersion(version: string) {
+    if (this.podmanInfo.podmanVersion !== version) {
+      this.podmanInfo.podmanVersion = version;
+      this.writeInfo().catch((err: unknown) => console.error('Unable to write Podman Version', err));
+    }
+  }
+
+  get podmanVersion(): string | undefined {
+    return this.podmanInfo.podmanVersion;
+  }
+
+  set lastUpdateCheck(lastCheck: number) {
+    if (this.podmanInfo.lastUpdateCheck !== lastCheck) {
+      this.podmanInfo.lastUpdateCheck = lastCheck;
+      this.writeInfo().catch((err: unknown) => console.error('Unable to write Podman Version', err));
+    }
+  }
+
+  get lastUpdateCheck(): number {
+    return this.podmanInfo.lastUpdateCheck;
+  }
+
+  get ignoreVersionUpdate(): string | undefined {
+    return this.podmanInfo.ignoreVersionUpdate;
+  }
+
+  set ignoreVersionUpdate(version: string) {
+    if (this.podmanInfo.ignoreVersionUpdate !== version) {
+      this.podmanInfo.ignoreVersionUpdate = version;
+      this.writeInfo().catch((err: unknown) => console.error('Unable to write Podman Version', err));
+    }
+  }
+
+  private async writeInfo(): Promise<void> {
+    try {
+      const podmanInfoPath = path.resolve(this.storagePath, 'podman-ext.json');
+      await writeFile(podmanInfoPath, JSON.stringify(this.podmanInfo));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+}

--- a/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.spec.ts
@@ -26,7 +26,8 @@ import type { Installer } from '../installer/installer';
 import { releaseNotes } from '../podman5.json';
 import { getBundledPodmanVersion } from './podman-bundled';
 import type { InstalledPodman } from './podman-cli';
-import type { PodmanInfo, UpdateCheck } from './podman-install';
+import type { PodmanInfo } from './podman-info';
+import type { UpdateCheck } from './podman-install';
 import { PodmanInstall } from './podman-install';
 import * as utils from './util';
 

--- a/extensions/podman/packages/extension/src/utils/podman-install.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-install.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import * as fs from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -46,68 +46,8 @@ import * as podman5JSON from '../podman5.json';
 import { getBundledPodmanVersion } from './podman-bundled';
 import type { InstalledPodman } from './podman-cli';
 import { getPodmanCli, getPodmanInstallation } from './podman-cli';
-
-export interface PodmanInfo {
-  podmanVersion?: string;
-  lastUpdateCheck: number;
-  ignoreVersionUpdate?: string;
-}
-
-export class PodmanInfoImpl implements PodmanInfo {
-  private podmanInfo: PodmanInfo;
-  constructor(
-    podmanInfoValue: PodmanInfo | undefined,
-    private readonly storagePath: string,
-  ) {
-    if (!podmanInfoValue) {
-      this.podmanInfo = { lastUpdateCheck: 0 } as PodmanInfo;
-    } else {
-      this.podmanInfo = podmanInfoValue;
-    }
-  }
-
-  set podmanVersion(version: string) {
-    if (this.podmanInfo.podmanVersion !== version) {
-      this.podmanInfo.podmanVersion = version;
-      this.writeInfo().catch((err: unknown) => console.error('Unable to write Podman Version', err));
-    }
-  }
-
-  get podmanVersion(): string | undefined {
-    return this.podmanInfo.podmanVersion;
-  }
-
-  set lastUpdateCheck(lastCheck: number) {
-    if (this.podmanInfo.lastUpdateCheck !== lastCheck) {
-      this.podmanInfo.lastUpdateCheck = lastCheck;
-      this.writeInfo().catch((err: unknown) => console.error('Unable to write Podman Version', err));
-    }
-  }
-
-  get lastUpdateCheck(): number {
-    return this.podmanInfo.lastUpdateCheck;
-  }
-
-  get ignoreVersionUpdate(): string | undefined {
-    return this.podmanInfo.ignoreVersionUpdate;
-  }
-
-  set ignoreVersionUpdate(version: string) {
-    if (this.podmanInfo.ignoreVersionUpdate !== version) {
-      this.podmanInfo.ignoreVersionUpdate = version;
-      this.writeInfo().catch((err: unknown) => console.error('Unable to write Podman Version', err));
-    }
-  }
-
-  private async writeInfo(): Promise<void> {
-    try {
-      const podmanInfoPath = path.resolve(this.storagePath, 'podman-ext.json');
-      await writeFile(podmanInfoPath, JSON.stringify(this.podmanInfo));
-    } catch (err) {
-      console.error(err);
-    }
-  }
-}
+import type { PodmanInfo } from './podman-info';
+import { PodmanInfoImpl } from './podman-info';
 
 export interface UpdateCheck {
   hasUpdate: boolean;


### PR DESCRIPTION
### What does this PR do?

The `PodmanInfo` interface is small, so let' put it with the same file as `PodmanInfoImpl` class.

There was no test covering PodmanInfoImpl, so adding testing for it

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/12021 and https://github.com/podman-desktop/podman-desktop/issues/12024

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
