### PR TITLE
fix: send virtual machine check info to telemetry in case of error

### DIFF
--- a/extensions/podman/packages/extension/src/checks/hyperv-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/hyperv-check.spec.ts
@@ -65,6 +65,8 @@ vi.mock(import('../utils/util'), async () => {
   };
 });
 
+const mockTelemetryLogger = {} as extensionApi.TelemetryLogger;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
@@ -87,7 +89,7 @@ test('expect HyperV preflight check return failure result if podman is older tha
     throw new Error();
   });
 
-  const hyperVCheck = new HyperVCheck();
+  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeFalsy();
   expect(result.description).equal('Hyper-V is only supported with podman version >= 5.2.0.');
@@ -98,7 +100,7 @@ test('expect HyperV preflight skips podman version check if installationPrefligh
     throw new Error();
   });
 
-  const hyperVCheck = new HyperVCheck(true);
+  const hyperVCheck = new HyperVCheck(mockTelemetryLogger, true);
   const result = await hyperVCheck.execute();
   // exec should only be called once inside the isUserAdmin function, if so the podman check has been skipped as expected
   expect(execSpy).toBeCalledTimes(1);
@@ -122,7 +124,7 @@ test('expect HyperV preflight check return failure result if it fails when check
     }
   });
 
-  const hyperVCheck = new HyperVCheck();
+  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeFalsy();
   expect(result.description).equal('You must have administrative rights to run Hyper-V Podman machines');
@@ -150,7 +152,7 @@ test('expect HyperV preflight check return failure result if non admin user', as
     }
   });
 
-  const hyperVCheck = new HyperVCheck();
+  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeFalsy();
   expect(result.description).equal('You must have administrative rights to run Hyper-V Podman machines');
@@ -174,7 +176,7 @@ test('expect HyperV preflight check return failure result if Podman Desktop is n
     }
   });
 
-  const hyperVCheck = new HyperVCheck();
+  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeFalsy();
   expect(result.description).equal(
@@ -197,7 +199,7 @@ test('expect HyperV preflight check return failure result if HyperV not installe
     }
   });
 
-  const hyperVCheck = new HyperVCheck();
+  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeFalsy();
   expect(result.description).equal('Hyper-V is not installed on your system.');
@@ -221,7 +223,7 @@ test('expect HyperV preflight check return failure result if HyperV not running'
     }
   });
 
-  const hyperVCheck = new HyperVCheck();
+  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeFalsy();
   expect(result.description).equal('Hyper-V is not running on your system.');
@@ -245,7 +247,7 @@ test('expect HyperV preflight check return OK', async () => {
     }
   });
 
-  const hyperVCheck = new HyperVCheck();
+  const hyperVCheck = new HyperVCheck(mockTelemetryLogger);
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeTruthy();
   expect(result.description).toBeUndefined();

--- a/extensions/podman/packages/extension/src/checks/hyperv-check.ts
+++ b/extensions/podman/packages/extension/src/checks/hyperv-check.ts
@@ -26,27 +26,30 @@ export class HyperVCheck extends BaseCheck {
   title = 'Hyper-V installed';
   static readonly PODMAN_MINIMUM_VERSION_FOR_HYPERV = '5.2.0';
 
-  constructor(private installationPreflightMode: boolean = false) {
+  constructor(
+    private telemetryLogger: extensionApi.TelemetryLogger,
+    private installationPreflightMode: boolean = false,
+  ) {
     super();
   }
 
   async isUserAdmin(): Promise<boolean> {
-    const client = await getPowerShellClient();
+    const client = await getPowerShellClient(this.telemetryLogger);
     return client.isUserAdmin();
   }
 
   async isPodmanDesktopElevated(): Promise<boolean> {
-    const client = await getPowerShellClient();
+    const client = await getPowerShellClient(this.telemetryLogger);
     return client.isRunningElevated();
   }
 
   async isHyperVInstalled(): Promise<boolean> {
-    const client = await getPowerShellClient();
+    const client = await getPowerShellClient(this.telemetryLogger);
     return client.isHyperVInstalled();
   }
 
   async isHyperVRunning(): Promise<boolean> {
-    const client = await getPowerShellClient();
+    const client = await getPowerShellClient(this.telemetryLogger);
     return client.isHyperVRunning();
   }
 

--- a/extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { process } from '@podman-desktop/api';
+import { process, type TelemetryLogger } from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { VirtualMachinePlatformCheck } from './virtual-machine-platform-check';
@@ -26,6 +26,8 @@ vi.mock('@podman-desktop/api', () => ({
     exec: vi.fn(),
   },
 }));
+
+const mockTelemetryLogger = {} as TelemetryLogger;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -40,7 +42,7 @@ test('expect winVirtualMachine preflight check return successful result if the v
     }),
   );
 
-  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
+  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck(mockTelemetryLogger);
   const result = await winVirtualMachinePlatformCheck.execute();
   expect(process.exec).toBeCalledWith(expect.anything(), expect.arrayContaining([expect.anything()]), {
     encoding: 'utf16le',
@@ -57,7 +59,7 @@ test('expect winVirtualMachine preflight check return successful result if the v
     }),
   );
 
-  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
+  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck(mockTelemetryLogger);
   const result = await winVirtualMachinePlatformCheck.execute();
   expect(result.description).equal('Virtual Machine Platform should be enabled to be able to run Podman.');
   expect(result.docLinksDescription).equal('Learn about how to enable the Virtual Machine Platform feature:');
@@ -72,7 +74,7 @@ test('expect winVirtualMachine preflight check return successful result if there
     throw new Error();
   });
 
-  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck();
+  const winVirtualMachinePlatformCheck = new VirtualMachinePlatformCheck(mockTelemetryLogger);
   const result = await winVirtualMachinePlatformCheck.execute();
   expect(result.description).equal('Virtual Machine Platform should be enabled to be able to run Podman.');
   expect(result.docLinksDescription).equal('Learn about how to enable the Virtual Machine Platform feature:');

--- a/extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.ts
+++ b/extensions/podman/packages/extension/src/checks/virtual-machine-platform-check.ts
@@ -24,8 +24,12 @@ import { BaseCheck } from './base-check';
 export class VirtualMachinePlatformCheck extends BaseCheck {
   title = 'Virtual Machine Platform Enabled';
 
+  constructor(private telemetryLogger: extensionApi.TelemetryLogger) {
+    super();
+  }
+
   protected async isVirtualMachineAvailable(): Promise<boolean> {
-    const client = await getPowerShellClient();
+    const client = await getPowerShellClient(this.telemetryLogger);
     return client.isVirtualMachineAvailable();
   }
 

--- a/extensions/podman/packages/extension/src/checks/wsl2-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/wsl2-check.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionContext, RunResult } from '@podman-desktop/api';
+import type { ExtensionContext, RunResult, TelemetryLogger } from '@podman-desktop/api';
 import { commands, process } from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -56,6 +56,8 @@ const extensionContext = {
   subscriptions: [],
 } as unknown as ExtensionContext;
 
+const mockTelemetryLogger = {} as TelemetryLogger;
+
 beforeEach(() => {
   vi.resetAllMocks();
   // reset array of subscriptions
@@ -81,7 +83,7 @@ test('expect winWSL2 preflight check return successful result if the machine has
     }
   });
 
-  const winWSLCheck = new WSL2Check(extensionContext);
+  const winWSLCheck = new WSL2Check(mockTelemetryLogger, extensionContext);
   const result = await winWSLCheck.execute();
   expect(result.successful).toBeTruthy();
 });
@@ -116,7 +118,7 @@ test('expect winWSL2 preflight check return failure result if the machine has WS
     }
   });
 
-  const winWSLCheck = new WSL2Check(extensionContext);
+  const winWSLCheck = new WSL2Check(mockTelemetryLogger, extensionContext);
   const result = await winWSLCheck.execute();
   expect(result.description).equal(
     'WSL2 seems to be installed but the system needs to be restarted so the changes can take effect.',
@@ -157,7 +159,7 @@ test('expect winWSL2 preflight check return successful result if the machine has
     }
   });
 
-  const winWSLCheck = new WSL2Check(extensionContext);
+  const winWSLCheck = new WSL2Check(mockTelemetryLogger, extensionContext);
   const result = await winWSLCheck.execute();
   expect(result.successful).toBeTruthy();
 });
@@ -179,7 +181,7 @@ test('expect winWSL2 preflight check return failure result if user do not have w
     }
   });
 
-  const winWSLCheck = new WSL2Check(extensionContext);
+  const winWSLCheck = new WSL2Check(mockTelemetryLogger, extensionContext);
   const result = await winWSLCheck.execute();
   expect(result.description).equal('WSL2 is not installed.');
   expect(result.docLinksDescription).equal(`Call 'wsl --install --no-distribution' in a terminal.`);
@@ -204,7 +206,7 @@ test('expect winWSL2 preflight check return failure result if user do not have w
     }
   });
 
-  const winWSLCheck = new WSL2Check(extensionContext);
+  const winWSLCheck = new WSL2Check(mockTelemetryLogger, extensionContext);
   const result = await winWSLCheck.execute();
   expect(result.description).equal('WSL2 is not installed or you do not have permissions to run WSL2.');
   expect(result.docLinksDescription).equal('Contact your Administrator to setup WSL2.');
@@ -225,7 +227,7 @@ test('expect winWSL2 preflight check return failure result if it fails when chec
     }
   });
 
-  const winWSLCheck = new WSL2Check(extensionContext);
+  const winWSLCheck = new WSL2Check(mockTelemetryLogger, extensionContext);
   const result = await winWSLCheck.execute();
   expect(result.description).equal('Could not detect WSL2');
   expect(result.docLinks?.[0].url).equal('https://learn.microsoft.com/en-us/windows/wsl/install');
@@ -234,7 +236,7 @@ test('expect winWSL2 preflight check return failure result if it fails when chec
 
 test('expect winWSL2 init to register WSLInstall command', async () => {
   const registerCommandMock = vi.mocked(commands.registerCommand);
-  const winWSLCheck = new WSL2Check(extensionContext);
+  const winWSLCheck = new WSL2Check(mockTelemetryLogger, extensionContext);
   await winWSLCheck.init?.();
   expect(registerCommandMock).toBeCalledWith('podman.onboarding.installWSL', expect.any(Function));
 });
@@ -245,7 +247,7 @@ test('expect winWSL2 command to be registered as disposable', async () => {
     dispose: vi.fn(),
   };
   registerCommandMock.mockReturnValue(disposableMock);
-  const winWSLCheck = new WSL2Check(extensionContext);
+  const winWSLCheck = new WSL2Check(mockTelemetryLogger, extensionContext);
   await winWSLCheck.init?.();
   expect(registerCommandMock).toBeCalledWith('podman.onboarding.installWSL', expect.any(Function));
 

--- a/extensions/podman/packages/extension/src/checks/wsl2-check.ts
+++ b/extensions/podman/packages/extension/src/checks/wsl2-check.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { CheckResult, ExtensionContext, RunError } from '@podman-desktop/api';
+import type extensionApi from '@podman-desktop/api';
 import { commands, process } from '@podman-desktop/api';
 
 import { getPowerShellClient } from '../utils/powershell';
@@ -27,7 +28,10 @@ export class WSL2Check extends BaseCheck {
   title = 'WSL2 Installed';
   installWSLCommandId = 'podman.onboarding.installWSL';
 
-  constructor(private extensionContext?: ExtensionContext) {
+  constructor(
+    private telemetryLogger: extensionApi.TelemetryLogger,
+    private extensionContext?: ExtensionContext,
+  ) {
     super();
   }
 
@@ -45,7 +49,7 @@ export class WSL2Check extends BaseCheck {
   }
 
   async isUserAdmin(): Promise<boolean> {
-    const client = await getPowerShellClient();
+    const client = await getPowerShellClient(this.telemetryLogger);
     return client.isUserAdmin();
   }
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1419,7 +1419,7 @@ test('ensure showNotification is not called during update', async () => {
   );
 
   const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
-  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext);
+  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger);
   vi.spyOn(podmanInstall, 'checkForUpdate').mockImplementation((_installedPodman: InstalledPodman | undefined) => {
     return Promise.resolve({
       hasUpdate: true,
@@ -2302,7 +2302,7 @@ describe('calcPodmanMachineSetting', () => {
 
 test('checkForUpdate func should be called if there is no podman installed', async () => {
   const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
-  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext);
+  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger);
 
   vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue(undefined);
   vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -88,7 +88,7 @@ const containerProviderConnections = new Map<string, extensionApi.ContainerProvi
 const configurationCompatibilityModeMacSetupNotificationDoNotShow = 'setting.doNotShowMacHelperNotification';
 
 // Telemetry
-let telemetryLogger: extensionApi.TelemetryLogger | undefined;
+let telemetryLogger: extensionApi.TelemetryLogger;
 
 const wslHelper = new WslHelper();
 const qemuHelper = new QemuHelper();
@@ -1380,7 +1380,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
 
   initTelemetryLogger();
 
-  const podmanInstall = new PodmanInstall(extensionContext);
+  const podmanInstall = new PodmanInstall(extensionContext, telemetryLogger);
 
   const installedPodman = await getPodmanInstallation();
   const version: string | undefined = installedPodman?.version;
@@ -2047,7 +2047,10 @@ export async function isWSLEnabled(): Promise<boolean> {
   if (!extensionApi.env.isWindows) {
     return false;
   }
-  const wslCheck = new SequenceCheck('WSL platform', [new WSLVersionCheck(), new WSL2Check()]);
+  const wslCheck = new SequenceCheck('WSL platform', [
+    new WSLVersionCheck(),
+    new WSL2Check(telemetryLogger, storedExtensionContext),
+  ]);
   const wslCheckResult = await wslCheck.execute();
   return wslCheckResult.successful;
 }
@@ -2056,7 +2059,7 @@ export async function isHyperVEnabled(): Promise<boolean> {
   if (!extensionApi.env.isWindows) {
     return false;
   }
-  const hyperVCheck = new HyperVCheck();
+  const hyperVCheck = new HyperVCheck(telemetryLogger);
   const hyperVCheckResult = await hyperVCheck.execute();
   return hyperVCheckResult.successful;
 }

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1142,6 +1142,10 @@ export function initTelemetryLogger(): void {
   telemetryLogger = extensionApi.env.createTelemetryLogger();
 }
 
+export function getTelemetryLogger(): extensionApi.TelemetryLogger | undefined {
+  return telemetryLogger;
+}
+
 export function initExtensionContext(extensionContext: extensionApi.ExtensionContext): void {
   storedExtensionContext = extensionContext;
 }

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1142,10 +1142,6 @@ export function initTelemetryLogger(): void {
   telemetryLogger = extensionApi.env.createTelemetryLogger();
 }
 
-export function getTelemetryLogger(): extensionApi.TelemetryLogger | undefined {
-  return telemetryLogger;
-}
-
 export function initExtensionContext(extensionContext: extensionApi.ExtensionContext): void {
   storedExtensionContext = extensionContext;
 }

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -68,6 +68,8 @@ const provider: extensionApi.Provider = {
   onDidUpdateDetectionChecks: vi.fn(),
 };
 
+const mockTelemetryLogger = {} as extensionApi.TelemetryLogger;
+
 // mock filesystem
 vi.mock('node:fs');
 
@@ -173,7 +175,7 @@ class TestPodmanInstall extends PodmanInstall {
 
 describe('update checks', () => {
   test('stopPodmanMachinesIfAnyBeforeUpdating with an error', async () => {
-    const podmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
 
     // return empty machine list
     vi.mocked(extensionApi.process.exec).mockRejectedValue('invalid');
@@ -185,7 +187,7 @@ describe('update checks', () => {
   });
 
   test('stopPodmanMachinesIfAnyBeforeUpdating with no machine running', async () => {
-    const podmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
 
     // return empty machine list
     vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
@@ -199,7 +201,7 @@ describe('update checks', () => {
   });
 
   test('stopPodmanMachinesIfAnyBeforeUpdating with one machine running', async () => {
-    const podmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
 
     vi.spyOn(extensionApi.process, 'exec').mockResolvedValueOnce({
       stdout: 'podman version 5.0.0',
@@ -227,7 +229,7 @@ describe('update checks', () => {
   });
 
   test('wipeAllDataBeforeUpdatingToV5 with podman 4.9 -> 5.0', async () => {
-    const podmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
 
     // mock the getActions
     const providerCleanup = podmanInstall.getProviderCleanup();
@@ -265,7 +267,7 @@ describe('update checks', () => {
   });
 
   test('wipeAllDataBeforeUpdatingToV5 no action with podman 4.9.1 -> 4.9.2', async () => {
-    const podmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
 
     // mock the getActions
     const providerCleanup = podmanInstall.getProviderCleanup();
@@ -290,14 +292,14 @@ describe('update checks', () => {
 });
 
 test('checkForUpdate should return no installed version if there is no lastRunInfo', async () => {
-  const podmanInstall = new TestPodmanInstall(extensionContext);
+  const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
   vi.spyOn(podmanInstall, 'getLastRunInfo').mockResolvedValue(undefined);
   const result = await podmanInstall.checkForUpdate(undefined);
   expect(result).toStrictEqual({ installedVersion: undefined, hasUpdate: false, bundledVersion: undefined });
 });
 
 test('checkForUpdate should return no installed version if there is lastRunInfo but it has no version', async () => {
-  const podmanInstall = new TestPodmanInstall(extensionContext);
+  const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
   vi.spyOn(podmanInstall, 'getLastRunInfo').mockResolvedValue({
     lastUpdateCheck: 0,
   });
@@ -306,7 +308,7 @@ test('checkForUpdate should return no installed version if there is lastRunInfo 
 });
 
 test('checkForUpdate should return installed version and no update if the installed version is the latest', async () => {
-  const podmanInstall = new TestPodmanInstall(extensionContext);
+  const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
   vi.spyOn(podmanInstall, 'getInstaller').mockReturnValue({
     requireUpdate: vi.fn().mockReturnValue(false),
   } as unknown as Installer);
@@ -324,7 +326,7 @@ test('checkForUpdate should return installed version and no update if the instal
 });
 
 test('checkForUpdate should return installed version and update if the installed version is NOT the latest', async () => {
-  const podmanInstall = new TestPodmanInstall(extensionContext);
+  const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
   vi.spyOn(podmanInstall, 'getInstaller').mockReturnValue({
     requireUpdate: vi.fn().mockReturnValue(true),
   } as unknown as Installer);
@@ -345,7 +347,7 @@ const providerMock: extensionApi.Provider = {} as unknown as extensionApi.Provid
 
 describe('performUpdate', () => {
   test('should raise an error if no podmanInfo provided', async () => {
-    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
 
     await expect(() => {
       return podmanInstall.performUpdate(providerMock, undefined);
@@ -353,7 +355,7 @@ describe('performUpdate', () => {
   });
 
   test('should call showWarningMessage if stopPodmanMachinesIfAnyBeforeUpdating resolve false', async () => {
-    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
     // mock initialized
     podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
     // mock checkForUpdate
@@ -373,7 +375,7 @@ describe('performUpdate', () => {
   test('should call showInformationMessage ', async () => {
     vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue(undefined);
 
-    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
     // mock initialized
     podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
 
@@ -403,7 +405,7 @@ describe('performUpdate', () => {
   test('user clicking on Open release note should open external link', async () => {
     vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Open release notes');
 
-    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
     // mock initialized
     podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
 
@@ -427,7 +429,7 @@ describe('performUpdate', () => {
 
   test('should not start instalation when updating from Podman 5.3.1 to 5.4.X', async () => {
     vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Yes');
-    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext);
+    const podmanInstall: TestPodmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
     (extensionApi.env.isWindows as boolean) = true;
     // all podman machine are stopped
     vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
@@ -459,7 +461,7 @@ describe('performUpdate', () => {
 });
 
 test('check that podman installation refreshed machine settings', async () => {
-  const podmanInstall = new TestPodmanInstall(extensionContext);
+  const podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
 
   vi.spyOn(podmanInstall, 'getLastRunInfo').mockResolvedValue({
     lastUpdateCheck: 0,

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -64,9 +64,12 @@ export class PodmanInstall {
 
   protected providerCleanup: extensionApi.ProviderCleanup | undefined;
 
-  constructor(readonly extensionContext: extensionApi.ExtensionContext) {
+  constructor(
+    readonly extensionContext: extensionApi.ExtensionContext,
+    readonly telemetryLogger: extensionApi.TelemetryLogger,
+  ) {
     this.storagePath = extensionContext.storagePath;
-    this.installers.set('win32', new WinInstaller(extensionContext));
+    this.installers.set('win32', new WinInstaller(extensionContext, telemetryLogger));
     this.installers.set('darwin', new MacOSInstaller());
     if (extensionApi.env.isMac) {
       this.providerCleanup = new PodmanCleanupMacOS();

--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -18,7 +18,7 @@
 
 import { existsSync, readdirSync } from 'node:fs';
 
-import type { ExtensionContext } from '@podman-desktop/api';
+import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -49,6 +49,8 @@ const progress = {
   report: (): void => {},
 };
 
+const mockTelemetryLogger = {} as TelemetryLogger;
+
 vi.mock(import('./../utils/util'), () => ({
   getAssetsFolder: vi.fn(),
 }));
@@ -71,7 +73,7 @@ test('expect update on windows to show notification in case of 0 exit code', asy
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext);
+  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).toHaveBeenCalled();
@@ -86,7 +88,7 @@ test('expect update on windows not to show notification in case of 1602 exit cod
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext);
+  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
@@ -102,7 +104,7 @@ test('expect update on windows to throw error if non zero exit code', async () =
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext);
+  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
   const result = await installer.update();
   expect(result).toBeFalsy();
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -19,7 +19,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { ExtensionContext, InstallCheck, RunError } from '@podman-desktop/api';
+import type { ExtensionContext, InstallCheck, RunError, TelemetryLogger } from '@podman-desktop/api';
 import { process as processAPI, ProgressLocation, window } from '@podman-desktop/api';
 
 import { OrCheck, SequenceCheck } from '../checks/base-check';
@@ -35,7 +35,10 @@ import { getAssetsFolder } from '../utils/util';
 import { BaseInstaller } from './base-installer';
 
 export class WinInstaller extends BaseInstaller {
-  constructor(private extensionContext: ExtensionContext) {
+  constructor(
+    private extensionContext: ExtensionContext,
+    private telemetryLogger: TelemetryLogger,
+  ) {
     super();
   }
 
@@ -51,11 +54,11 @@ export class WinInstaller extends BaseInstaller {
       new OrCheck(
         'Windows virtualization',
         new SequenceCheck('WSL platform', [
-          new VirtualMachinePlatformCheck(),
+          new VirtualMachinePlatformCheck(this.telemetryLogger),
           new WSLVersionCheck(),
-          new WSL2Check(this.extensionContext),
+          new WSL2Check(this.telemetryLogger, this.extensionContext),
         ]),
-        new HyperVCheck(true),
+        new HyperVCheck(this.telemetryLogger, true),
       ),
     ];
   }

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -63,7 +63,7 @@ class PowerShell5Client implements PowerShellClient {
       telemetry['killed'] = execError.killed;
     }
     const telemetryLogger = getTelemetryLogger();
-    telemetryLogger?.logError('check.isVirtualMachineAvailable', telemetry);
+    telemetryLogger?.logUsage('check.isVirtualMachineAvailable', telemetry);
     return false;
   }
 

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -51,6 +51,14 @@ class PowerShell5Client implements PowerShellClient {
     } catch (err) {
       // ignore error, this means that VirtualMachinePlatform not enabled
       telemetry['error'] = err;
+      const execError = err as extensionApi.RunError;
+      telemetry['message'] = execError.message;
+      telemetry['exitCode'] = execError.exitCode;
+      telemetry['command'] = execError.command;
+      telemetry['stdout'] = execError.stdout;
+      telemetry['stderr'] = execError.stderr;
+      telemetry['cancelled'] = execError.cancelled;
+      telemetry['killed'] = execError.killed;
     }
     const telemetryLogger = extensionApi.env.createTelemetryLogger();
     telemetryLogger.logError('check.isVirtualMachineAvailable', telemetry);

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 import * as extensionApi from '@podman-desktop/api';
 
-export async function getPowerShellClient(): Promise<PowerShellClient> {
-  return new PowerShell5Client();
+export async function getPowerShellClient(telemetryLogger: extensionApi.TelemetryLogger): Promise<PowerShellClient> {
+  return new PowerShell5Client(telemetryLogger);
 }
 
 export interface PowerShellClient {
@@ -31,6 +31,8 @@ export interface PowerShellClient {
 
 const PowerShell5Exe = 'powershell.exe';
 class PowerShell5Client implements PowerShellClient {
+  constructor(private telemetryLogger: extensionApi.TelemetryLogger) {}
+
   async isVirtualMachineAvailable(): Promise<boolean> {
     const telemetry: Record<string, unknown> = {};
     try {
@@ -60,8 +62,7 @@ class PowerShell5Client implements PowerShellClient {
       telemetry['cancelled'] = execError.cancelled;
       telemetry['killed'] = execError.killed;
     }
-    const telemetryLogger = extensionApi.env.createTelemetryLogger();
-    telemetryLogger.logError('check.isVirtualMachineAvailable', telemetry);
+    this.telemetryLogger.logError('check.isVirtualMachineAvailable', telemetry);
     return false;
   }
 

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -63,7 +63,7 @@ class PowerShell5Client implements PowerShellClient {
       telemetry['killed'] = execError.killed;
     }
     const telemetryLogger = getTelemetryLogger();
-    telemetryLogger?.logUsage('check.isVirtualMachineAvailable', telemetry);
+    telemetryLogger?.logError('check.isVirtualMachineAvailable', telemetry);
     return false;
   }
 

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -17,6 +17,8 @@
  ***********************************************************************/
 import * as extensionApi from '@podman-desktop/api';
 
+import { getTelemetryLogger } from '../extension';
+
 export async function getPowerShellClient(): Promise<PowerShellClient> {
   return new PowerShell5Client();
 }
@@ -60,8 +62,8 @@ class PowerShell5Client implements PowerShellClient {
       telemetry['cancelled'] = execError.cancelled;
       telemetry['killed'] = execError.killed;
     }
-    const telemetryLogger = extensionApi.env.createTelemetryLogger();
-    telemetryLogger.logError('check.isVirtualMachineAvailable', telemetry);
+    const telemetryLogger = getTelemetryLogger();
+    telemetryLogger?.logError('check.isVirtualMachineAvailable', telemetry);
     return false;
   }
 

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -17,8 +17,6 @@
  ***********************************************************************/
 import * as extensionApi from '@podman-desktop/api';
 
-import { getTelemetryLogger } from '../extension';
-
 export async function getPowerShellClient(): Promise<PowerShellClient> {
   return new PowerShell5Client();
 }
@@ -62,8 +60,8 @@ class PowerShell5Client implements PowerShellClient {
       telemetry['cancelled'] = execError.cancelled;
       telemetry['killed'] = execError.killed;
     }
-    const telemetryLogger = getTelemetryLogger();
-    telemetryLogger?.logError('check.isVirtualMachineAvailable', telemetry);
+    const telemetryLogger = extensionApi.env.createTelemetryLogger();
+    telemetryLogger.logError('check.isVirtualMachineAvailable', telemetry);
     return false;
   }
 

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -62,7 +62,7 @@ class PowerShell5Client implements PowerShellClient {
       telemetry['cancelled'] = execError.cancelled;
       telemetry['killed'] = execError.killed;
     }
-    this.telemetryLogger.logError('check.isVirtualMachineAvailable', telemetry);
+    this.telemetryLogger.logUsage('check.isVirtualMachineAvailable', telemetry);
     return false;
   }
 


### PR DESCRIPTION
Relates to #10462

### What does this PR do?

Send info to telemetry when virtual machine check is negative or errored

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#10462

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
