### PR TITLE
chore(test): get error thrown in case of failure

### DIFF
--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -45,7 +45,7 @@ export class ExtensionsPage {
     this.installExtensionFromOCIImageButton = this.additionalActions.getByLabel('Install custom');
   }
 
-  public async installExtensionFromOCIImage(extension: string): Promise<ExtensionsPage> {
+  public async installExtensionFromOCIImage(extension: string, timeout = 100_000): Promise<ExtensionsPage> {
     return test.step(`Install extension from OCI image: ${extension}`, async () => {
       // open button to install extension from OCI image
       await playExpect(this.installExtensionFromOCIImageButton).toBeEnabled();
@@ -76,7 +76,7 @@ export class ExtensionsPage {
         name: 'Done',
         exact: true,
       });
-      await playExpect(doneButton).toBeEnabled({ timeout: 100_000 });
+      await playExpect(doneButton).toBeEnabled({ timeout: timeout });
       await doneButton.click();
 
       return this;

--- a/tests/playwright/src/model/pages/play-kube-yaml-page.ts
+++ b/tests/playwright/src/model/pages/play-kube-yaml-page.ts
@@ -32,6 +32,7 @@ export class PlayKubeYamlPage extends BasePage {
   readonly kubernetesRuntimeButton: Locator;
   readonly kubernetesContext: Locator;
   readonly kubernetesNamespaces: Locator;
+  readonly alertMessage: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -50,10 +51,12 @@ export class PlayKubeYamlPage extends BasePage {
     this.kubernetesNamespaces = this.kubernetesRuntimeButton.getByLabel('Kubernetes Namespace', { exact: true });
     this.playButton = page.getByRole('button', { name: 'Play' });
     this.doneButton = page.getByRole('button', { name: 'Done' });
+    this.alertMessage = this.page.getByLabel('Error Message Content');
   }
 
   async playYaml(
     pathToYaml: string,
+    timeout: number = 120_000,
     { runtime, kubernetesContext, kubernetesNamespace }: PlayKubernetesOptions = {
       kubernetesContext: 'kind-kind-cluster',
     },
@@ -97,7 +100,14 @@ export class PlayKubeYamlPage extends BasePage {
 
       await this.yamlPathInput.fill(pathToYaml);
       await this.playButton.click();
-      await playExpect(this.doneButton).toBeEnabled({ timeout: 120000 });
+      await playExpect(this.doneButton.or(this.alertMessage).first()).toBeVisible({ timeout: timeout });
+
+      if (await this.alertMessage.isVisible()) {
+        const errorMessage = await this.alertMessage.textContent();
+        throw Error(`Error while playing Kubernetes YAML: ${errorMessage}`);
+      }
+
+      await playExpect(this.doneButton).toBeEnabled();
       await this.doneButton.click();
       return new PodsPage(this.page);
     });

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -106,7 +106,7 @@ for (const {
 
       const extensionsPage = new ExtensionsPage(page);
 
-      await extensionsPage.installExtensionFromOCIImage(ociImageUrl);
+      await extensionsPage.installExtensionFromOCIImage(ociImageUrl, 180_000);
       if (extensionName !== openshiftDockerExtension.extensionName) {
         await extensionsPage.openCatalogTab();
         const extensionCatalog = new ExtensionCatalogCardPage(page, extensionName);


### PR DESCRIPTION
### What does this PR do?
Increases robustness in some e2e tests and now checks for error being thrown during yaml playing

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/12962