### PR TITLE
chore: move disposable group to API package

### DIFF
--- a/packages/api/src/disposable-group.ts
+++ b/packages/api/src/disposable-group.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IDisposable } from './disposable.js';
+
+export type DisposableGroup = { push(disposable: IDisposable): void } | { add(disposable: IDisposable): void };

--- a/packages/main/src/plugin/events/emitter.ts
+++ b/packages/main/src/plugin/events/emitter.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
 
-import type { IDisposable } from '../types/disposable.js';
+import type { DisposableGroup } from '/@api/disposable-group.js';
 
-export type DisposableGroup = { push(disposable: IDisposable): void } | { add(disposable: IDisposable): void };
+import type { IDisposable } from '../types/disposable.js';
 
 /**
  * Represents a typed event.


### PR DESCRIPTION
### What does this PR do?
for inversify, we bind the type so it'll change some imports from the type to the object
as renderer files are importing some files, changing the import from 'type' scope to default scope bring Node.js dependencies to the renderer side and make some loading failures

the idea is to move all interfaces imported (or transitively imported from the rendered side to the API package

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
