### PR TITLE
chore: add an aggregate method for telemetry

### DIFF
--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -17,12 +17,14 @@
  ***********************************************************************/
 
 import type { TelemetrySender } from '@podman-desktop/api';
+import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ExtensionInfo } from '/@api/extension-info.js';
 
 import type { ConfigurationRegistry } from '../configuration-registry.js';
 import { TelemetryTrustedValue } from '../types/telemetry.js';
+import type { EventType } from './telemetry.js';
 import { Telemetry, TelemetryLoggerImpl } from './telemetry.js';
 import { TelemetrySettings } from './telemetry-settings.js';
 
@@ -55,6 +57,14 @@ class TelemetryTest extends Telemetry {
     return this.lastTimeEvents;
   }
 
+  public getAggregateTimeoutEvents(): Map<string, { timeout: NodeJS.Timeout; properties: unknown[] }> {
+    return this.aggregateTimeoutEvents;
+  }
+
+  public getPendingItems(): { eventName: string; properties?: unknown }[] {
+    return this.pendingItems;
+  }
+
   public override shouldDropEvent(eventName: string): boolean {
     return super.shouldDropEvent(eventName);
   }
@@ -65,6 +75,18 @@ class TelemetryTest extends Telemetry {
 
   public override createBuiltinTelemetrySender(extensionInfo: ExtensionInfo): TelemetrySender {
     return super.createBuiltinTelemetrySender(extensionInfo);
+  }
+
+  public setTelemetryInitialized(value: boolean): void {
+    this.telemetryInitialized = value;
+  }
+
+  public setTelemetryEnabled(value: boolean): void {
+    this.telemetryEnabled = value;
+  }
+
+  public override async internalTrack(event: EventType, eventProperties?: unknown): Promise<void> {
+    return super.internalTrack(event, eventProperties);
   }
 }
 
@@ -233,5 +255,114 @@ describe('TelemetryLoggerImpl', () => {
     expect(telemetryLogger['commonProperties']).toMatchObject({ 'common.extensionVersion': '1.0.0' });
     telemetryLogger.dispose();
     expect(telemetryLogger['commonProperties']).toStrictEqual({});
+  });
+});
+
+// New tests for aggregateTrack
+describe('aggregateTrack', () => {
+  let internalTrackSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+    telemetry.setTelemetryInitialized(true);
+    telemetry.setTelemetryEnabled(true);
+    internalTrackSpy = vi.spyOn(telemetry, 'internalTrack').mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  test('should skip event if shouldDropEvent returns true', () => {
+    vi.spyOn(telemetry, 'shouldDropEvent').mockReturnValue(true);
+
+    telemetry.aggregateTrack('dropMe', { foo: 'bar' });
+    expect(telemetry.getAggregateTimeoutEvents().size).toBe(0);
+  });
+  test('should store in pendingItems if telemetry not initialized', () => {
+    telemetry.setTelemetryInitialized(false);
+
+    telemetry.aggregateTrack('eventA', { prop: 1 });
+    expect(telemetry.getPendingItems()).toEqual([{ eventName: 'eventA', properties: [{ prop: 1 }] }]);
+  });
+
+  test('should aggregate and send after delay', async () => {
+    telemetry.aggregateTrack('eventX', { count: 1 });
+    telemetry.aggregateTrack('eventX', { count: 2 });
+
+    expect(telemetry.getAggregateTimeoutEvents().get('eventX')?.properties).toEqual([{ count: 1 }, { count: 2 }]);
+
+    vi.runAllTimers();
+    await vi.waitFor(() =>
+      expect(internalTrackSpy).toBeCalledWith('eventX', { aggregated: [{ count: 1 }, { count: 2 }] }),
+    );
+  });
+
+  test('should clear previous timeout and reset it on repeated event', () => {
+    telemetry.aggregateTrack('eventY', { value: 'first' });
+
+    const initialTimeout = telemetry.getAggregateTimeoutEvents().get('eventY')?.timeout;
+    telemetry.aggregateTrack('eventY', { value: 'second' });
+
+    const updatedTimeout = telemetry.getAggregateTimeoutEvents().get('eventY')?.timeout;
+    expect(initialTimeout).not.toBe(updatedTimeout);
+
+    vi.runAllTimers();
+    expect(internalTrackSpy).toBeCalledWith('eventY', { aggregated: [{ value: 'first' }, { value: 'second' }] });
+  });
+
+  test('should use default delay if not provided', async () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    telemetry.aggregateTrack('eventZ', { key: 'val' });
+    vi.runAllTimers();
+    await vi.waitFor(() => expect(setTimeoutSpy).toBeCalledWith(expect.any(Function), 10_000));
+  });
+
+  test('should respect custom delay', async () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    telemetry.aggregateTrack('eventZ', { key: 'val' }, 5000);
+    vi.runAllTimers();
+    await vi.waitFor(() => expect(setTimeoutSpy).toBeCalledWith(expect.any(Function), 5_000));
+  });
+
+  test('should overwrite non-array properties in pendingItems if malformed', () => {
+    telemetry.setTelemetryInitialized(false);
+    telemetry.getPendingItems().push({
+      eventName: 'badEvent',
+      properties: { unexpected: 'format' }, // malformed
+    });
+
+    telemetry.aggregateTrack('badEvent', { corrected: true });
+    expect(telemetry.getPendingItems().find(e => e.eventName === 'badEvent')?.properties).toEqual([
+      { corrected: true },
+    ]);
+  });
+
+  test('should skip event if telemetry is disabled', () => {
+    telemetry.setTelemetryEnabled(false);
+
+    telemetry.aggregateTrack('disabledEvent', { foo: 'bar' });
+
+    expect(telemetry.getAggregateTimeoutEvents().size).toBe(0);
+    expect(internalTrackSpy).not.toHaveBeenCalled();
+  });
+
+  test('should append properties to existing pending event when telemetry is not initialized', () => {
+    telemetry.setTelemetryInitialized(false);
+
+    // Push an initial pending item for the same event
+    telemetry.getPendingItems().push({
+      eventName: 'initEvent',
+      properties: [{ foo: 1 }],
+    });
+
+    telemetry.aggregateTrack('initEvent', { bar: 2 });
+
+    const pending = telemetry.getPendingItems().find(item => item.eventName === 'initEvent');
+    expect(pending).toBeDefined();
+    expect(Array.isArray(pending?.properties)).toBe(true);
+    expect(pending?.properties).toEqual([{ foo: 1 }, { bar: 2 }]);
   });
 });

--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -317,7 +317,9 @@ describe('aggregateTrack', () => {
     const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
     telemetry.aggregateTrack('eventZ', { key: 'val' });
     vi.runAllTimers();
-    await vi.waitFor(() => expect(setTimeoutSpy).toBeCalledWith(expect.any(Function), 10_000));
+    await vi.waitFor(() =>
+      expect(setTimeoutSpy).toBeCalledWith(expect.any(Function), Telemetry.DEFAULT_DELAY_AGGREGATE),
+    );
   });
 
   test('should respect custom delay', async () => {

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -64,6 +64,8 @@ export type EventType =
  */
 @injectable()
 export class Telemetry {
+  public static readonly DEFAULT_DELAY_AGGREGATE = 10_000; // 10 seconds
+
   private static readonly SEGMENT_KEY = 'Mhl7GXADk5M1vG6r9FXztbCqWRQY8XPy';
 
   private cachedTelemetrySettings: TelemetryRule[] | undefined;
@@ -353,7 +355,7 @@ export class Telemetry {
    * @param eventProperties all properties that will be aggregated into an array and be sent after the delay if there is no other event received during this time window
    * @param delay the delay in milliseconds before sending the aggregated event, default is 10 seconds
    */
-  aggregateTrack(event: EventType, eventProperties?: unknown, delay: number = 10_000): void {
+  aggregateTrack(event: EventType, eventProperties?: unknown, delay: number = Telemetry.DEFAULT_DELAY_AGGREGATE): void {
     // skip event ?
     if (this.shouldDropEvent(event)) {
       return;

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -75,13 +75,15 @@ export class Telemetry {
 
   private analytics: Analytics | undefined;
 
-  private telemetryEnabled = false;
+  protected telemetryEnabled = false;
 
-  private telemetryInitialized = false;
+  protected telemetryInitialized = false;
 
   private telemetryConfigured = false;
 
-  private pendingItems: { eventName: string; properties?: unknown }[] = [];
+  protected pendingItems: { eventName: string; properties?: unknown }[] = [];
+
+  protected aggregateTimeoutEvents: Map<string, { timeout: NodeJS.Timeout; properties: unknown[] }> = new Map();
 
   protected lastTimeEvents: Map<string, number>;
 
@@ -343,6 +345,69 @@ export class Telemetry {
     });
 
     return dropIt;
+  }
+
+  /**
+   * will cumulate the data for the given the event and send it to the telemetry system.
+   * @param event the event to send after the given delay
+   * @param eventProperties all properties that will be aggregated into an array and be sent after the delay if there is no other event received during this time window
+   * @param delay the delay in milliseconds before sending the aggregated event, default is 10 seconds
+   */
+  aggregateTrack(event: EventType, eventProperties?: unknown, delay: number = 10_000): void {
+    // skip event ?
+    if (this.shouldDropEvent(event)) {
+      return;
+    }
+
+    const eventPropertiesOrEmpty = eventProperties ?? {};
+
+    // if telemetry is not initialized, we store the event in a pending list
+    // but aggregate the data
+    if (!this.telemetryInitialized) {
+      // search an existing event
+      const existingItem = this.pendingItems.find(item => item.eventName === event);
+      if (existingItem) {
+        if (Array.isArray(existingItem.properties)) {
+          // push item to the existing array
+          existingItem.properties.push(eventPropertiesOrEmpty);
+        } else {
+          console.warn(`Event ${event} already exists in pending items, but properties is not an array. Overwriting.`);
+          // overwrite the properties
+          existingItem.properties = [eventPropertiesOrEmpty];
+        }
+      } else {
+        // create a new item
+        this.pendingItems.push({ eventName: event, properties: [eventPropertiesOrEmpty] });
+      }
+      return;
+    }
+    if (!this.telemetryEnabled) {
+      return;
+    }
+
+    // is there an existing timeout for this event name ?
+    const existingTimeoutData = this.aggregateTimeoutEvents.get(event);
+    let propertiesToSend: unknown[];
+    if (existingTimeoutData) {
+      propertiesToSend = existingTimeoutData.properties.concat(eventPropertiesOrEmpty);
+      // if yes, we clear it
+      clearTimeout(existingTimeoutData.timeout);
+    } else {
+      propertiesToSend = [eventPropertiesOrEmpty];
+    }
+
+    const timeout = setTimeout(() => {
+      // after delay, we send the aggregated event
+      const telemetryData = { aggregated: propertiesToSend };
+      this.internalTrack(event, telemetryData).catch((err: unknown) => {
+        console.warn(`Error sending aggregated event: ${event}`, err);
+      });
+      // remove the timeout from the map
+      this.aggregateTimeoutEvents.delete(event);
+    }, delay);
+
+    // sets a new timeout for this event name
+    this.aggregateTimeoutEvents.set(event, { timeout, properties: propertiesToSend });
   }
 
   track(event: EventType, eventProperties?: unknown): void {


### PR DESCRIPTION

### What does this PR do?
this method will send all data as an array of object as long as the method is called for a given event it will delay the sending of the data

example: If I try to propagate one event with {foo: 'bar'} and another one with {foo: 'baz'}, it will collect those
and it'll sent a single event with `[{foo: 'bar'}, {foo: 'baz'}]` data after a delay

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?


related to https://github.com/podman-desktop/podman-desktop/issues/12634 and https://github.com/podman-desktop/podman-desktop/issues/12633


### How to test this PR?

unit tests added
- [x] Tests are covering the bug fix or the new feature
