### PR TITLE
refactor(renderer): remove unnecessary spyOn in tests

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -127,7 +127,7 @@ test('Expect installed provider does not show update button if version same', as
 });
 
 test('Expect to see the initialize context error if provider installation fails', async () => {
-  vi.spyOn(window, 'initializeProvider').mockRejectedValue('error');
+  vi.mocked(window.initializeProvider).mockRejectedValue('error');
   const provider: ProviderInfo = {
     containerConnections: [],
     containerProviderConnectionCreation: false,

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
@@ -94,7 +94,7 @@ testComponent('renders button to run first pod', async () => {
 });
 
 testComponent('button click creates and starts a pod', async () => {
-  vi.spyOn(window, 'createPod').mockResolvedValue(podInfo);
+  vi.mocked(window.createPod).mockResolvedValue(podInfo);
   await fireEvent.click(getButton());
   expect(window.createPod).toBeCalledWith({ name: 'my-first-pod' });
   expect(window.createAndStartContainer).toBeCalledWith(podInfo.engineId, {
@@ -104,14 +104,14 @@ testComponent('button click creates and starts a pod', async () => {
 });
 
 testComponent('button click shows error message if creating pod fails', async () => {
-  vi.spyOn(window, 'createPod').mockRejectedValue(error);
+  vi.mocked(window.createPod).mockRejectedValue(error);
   await fireEvent.click(getButton());
   expect(window.showMessageBox).toBeCalledWith(errorMessage);
 });
 
 testComponent('button click shows error message if starting pod fails', async () => {
-  vi.spyOn(window, 'createPod').mockResolvedValue(podInfo);
-  vi.spyOn(window, 'createAndStartContainer').mockRejectedValue(error);
+  vi.mocked(window.createPod).mockResolvedValue(podInfo);
+  vi.mocked(window.createAndStartContainer).mockRejectedValue(error);
   await fireEvent.click(getButton());
   await vi.waitFor(() => expect(window.showMessageBox).toBeCalledWith(errorMessage));
 });

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -339,27 +339,27 @@ describe.each([
 
   test(`Expect ${label} button to be disabled if itemsAudit returns errors or enabled otherwise`, async () => {
     const callback = vi.fn();
-    let auditSpy = vi.spyOn(window as any, 'auditConnectionParameters');
+    let auditSpy = vi.mocked(window.auditConnectionParameters);
     if (!connectionInfo) {
-      auditSpy = vi.spyOn(window as any, 'auditConnectionParameters').mockImplementationOnce(() => ({ records: [] }));
+      auditSpy = vi.mocked(window.auditConnectionParameters).mockResolvedValueOnce({ records: [] });
     }
     auditSpy = auditSpy
-      .mockImplementationOnce(() => ({
+      .mockResolvedValueOnce({
         records: [
           {
             type: 'error',
             record: 'error message',
           },
         ],
-      }))
-      .mockImplementationOnce(() => ({
+      })
+      .mockResolvedValueOnce({
         records: [
           {
             type: 'info',
             record: 'info message',
           },
         ],
-      }));
+      });
     // eslint-disable-next-line @typescript-eslint/await-thenable
     render(PreferencesConnectionCreationOrEditRendering, {
       properties: [
@@ -396,8 +396,8 @@ describe.each([
 
 test(`Check itemsAudit receive updated values`, async () => {
   const callback = mockCallback(async () => {});
-  const auditSpy = vi.spyOn(window as any, 'auditConnectionParameters').mockResolvedValue({ records: [] });
-  vi.spyOn(window as any, 'openDialog').mockResolvedValue(['somefile']);
+  const auditSpy = vi.mocked(window.auditConnectionParameters).mockResolvedValue({ records: [] });
+  vi.mocked(window.openDialog).mockResolvedValue(['somefile']);
   // eslint-disable-next-line @typescript-eslint/await-thenable
   render(PreferencesConnectionCreationOrEditRendering, {
     properties: [


### PR DESCRIPTION
### What does this PR do?

Interesting experiment with [ts-morph](https://github.com/dsherret/ts-morph), (thanks @eqqe for the idea); using ts-morph to manipulate the AST (Abstract Synthax Tree) and save changes.

Example snippet used to apply the changes, the goal here was to find a way to do a simple manipulation as a POC (updating the `vi.spyOn(window, "mocked")` to `vi.mocked(window.mocked)`) (This could have been a regex, but using ts-morph open more complex horizon) 

```ts
import { Project, ts, SyntaxKind  } from "ts-morph";

// open the renderer project
const project = new Project({
  tsConfigFilePath: 'renderer/tsconfig.json',
});

// get all spec files
const sources = project.getSourceFiles('renderer/src/**/*.spec.ts');

sources.forEach(source => {
  source.transform(traversal => {
    const node: ts.Node = traversal.visitChildren();

    // check for call expression such as `vi.spyOn(...)`
    if(!ts.isCallExpression(node) ) return node;
    
    [... validate the node is corresponding to something under the form we want to change ...]

    // replace our `vi.spyOn(window, "method")` with the corresponding vi.mocked
    return traversal.factory.updateCallExpression(
      node,
      traversal.factory.createPropertyAccessExpression(
        traversal.factory.createIdentifier("vi"),
        traversal.factory.createIdentifier("mocked")
      ),
      undefined,
      [
        traversal.factory.createPropertyAccessExpression(
          traversal.factory.createIdentifier("window"),
          traversal.factory.createIdentifier(arg2.text)
        )
      ]
    );
  });
});
```

To avoid replacing mock such as fetch (see example bellow)

https://github.com/podman-desktop/podman-desktop/blob/da503509aa3d754f72975fd96c6122190d9cdccf/packages/renderer/src/lib/extensions/ExtensionDetailsReadme.spec.ts#L52

I reused the function defined in `renderer/vite.tests.setup.js`

https://github.com/podman-desktop/podman-desktop/blob/6a8f4372262e376e2157d385de16dd49c38bab3f/packages/renderer/vite.tests.setup.js#L28

This allowed me to compare that the method mocked is corresponding to something we are mocking.

### What issues does this PR fix or reference?

Nothing really, I attached the script I used

[ast-experiment.zip](https://github.com/user-attachments/files/21143004/ast-experiment.zip)

