### PR TITLE
test(ci): check major podman version is 5

### DIFF
--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -94,6 +94,15 @@ jobs:
             sudo apt-get -y install podman; }
           podman version
 
+          # Check if the major version is 5
+          PODMAN_VERSION=$(podman version | grep 'Version:' | awk '{print $2}')
+          if [[ "$PODMAN_VERSION" == 5.* ]]; then
+            echo "Podman major version is 5. Proceeding with the workflow."
+          else
+            echo "Error: Podman major version is not 5. Found: $PODMAN_VERSION"
+            exit 1 # Fail the step if the condition is not met
+          fi
+          
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |
           # allow unprivileged user namespace

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -107,6 +107,15 @@ jobs:
             sudo apt-get update && \
             sudo apt-get -y install podman; }
           podman version
+          
+          # Check if the major version is 5
+          PODMAN_VERSION=$(podman version | grep 'Version:' | awk '{print $2}')
+          if [[ "$PODMAN_VERSION" == 5.* ]]; then
+            echo "Podman major version is 5. Proceeding with the workflow."
+          else
+            echo "Error: Podman major version is not 5. Found: $PODMAN_VERSION"
+            exit 1 # Fail the step if the condition is not met
+          fi
 
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -340,6 +340,15 @@ jobs:
             sudo apt-get --allow-unauthenticated -y install podman; }
           podman version
 
+          # Check if the major version is 5
+          PODMAN_VERSION=$(podman version | grep 'Version:' | awk '{print $2}')
+          if [[ "$PODMAN_VERSION" == 5.* ]]; then
+            echo "Podman major version is 5. Proceeding with the workflow."
+          else
+            echo "Error: Podman major version is not 5. Found: $PODMAN_VERSION"
+            exit 1 # Fail the step if the condition is not met
+          fi
+          
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |
           # allow unprivileged user namespace


### PR DESCRIPTION
### What does this PR do?

This PR checks the podman version is the major 5 in the CI when updating it in ubuntu.
Because we have seen that in version 24.04 of Ubuntu today the major version was 4, so the goal of the task
"Update podman to 5.x" was not obtained. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
