### PR TITLE
refactor(extensions/podman): move state to class to prepare the refactoring

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -106,8 +106,6 @@ let wslEnabled = false;
 
 const extensionNotifications = new ExtensionNotifications();
 
-let notificationDisposable: extensionApi.Disposable;
-
 let disguisedPodmanNotificationDisposable: extensionApi.Disposable;
 
 let doNotShowMacHelperSetup = false;
@@ -179,9 +177,9 @@ export function isIncompatibleMachineOutput(output: string | undefined): boolean
 // to avoid having multiple notification of the same nature in the notifications list
 // we first dispose the old one and then push the same again
 function notifySetupPodman(): void {
-  if (!notificationDisposable) {
-    notificationDisposable = extensionApi.window.showNotification(ExtensionNotifications.setupPodmanNotification);
-  }
+  extensionNotifications.notificationDisposable ??= extensionApi.window.showNotification(
+    ExtensionNotifications.setupPodmanNotification,
+  );
 }
 
 function notifyDisguisedPodmanSocket(): void {
@@ -301,7 +299,7 @@ async function doUpdateMachines(
   // podman is correctly setup so if there is an old notification asking the user to take action
   // we dispose it as not needed anymore
   if (!shouldCleanMachine && machines.length > 0 && !extensionApi.env.isLinux) {
-    notificationDisposable?.dispose();
+    extensionNotifications.notificationDisposable?.dispose();
     extensionNotifications.shouldNotifySetup = true;
   }
 
@@ -811,7 +809,7 @@ async function doMonitorProvider(provider: extensionApi.Provider): Promise<void>
       if (extensionApi.env.isLinux) {
         extensionNotifications.shouldNotifySetup = true;
         // notification is no more required
-        notificationDisposable?.dispose();
+        extensionNotifications.notificationDisposable?.dispose();
       }
     }
   } catch (error) {
@@ -1343,7 +1341,7 @@ export function registerOnboardingRemoveUnsupportedMachinesCommand(): extensionA
 
       extensionNotifications.shouldNotifySetup = true;
       // notification is no more required
-      notificationDisposable?.dispose();
+      extensionNotifications.notificationDisposable?.dispose();
     }
 
     if (errors.length > 0) {
@@ -2347,7 +2345,7 @@ export async function createMachine(
   extensionApi.context.setValue('podmanMachineExists', true, 'onboarding');
   extensionNotifications.shouldNotifySetup = true;
   // notification is no more required
-  notificationDisposable?.dispose();
+  extensionNotifications.notificationDisposable?.dispose();
 }
 
 export function resetShouldNotifySetup(): void {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -106,12 +106,6 @@ let wslEnabled = false;
 
 const extensionNotifications = new ExtensionNotifications();
 
-let disguisedPodmanNotificationDisposable: extensionApi.Disposable;
-
-let doNotShowMacHelperSetup = false;
-
-let podmanMacHelperNotificationDisposable: extensionApi.Disposable;
-
 export type MachineJSON = {
   Name: string;
   CPUs: number;
@@ -183,16 +177,14 @@ function notifySetupPodman(): void {
 }
 
 function notifyDisguisedPodmanSocket(): void {
-  if (!disguisedPodmanNotificationDisposable) {
-    disguisedPodmanNotificationDisposable = extensionApi.window.showNotification(
-      ExtensionNotifications.disguisedPodmanNotification,
-    );
-  }
+  extensionNotifications.disguisedPodmanNotificationDisposable ??= extensionApi.window.showNotification(
+    ExtensionNotifications.disguisedPodmanNotification,
+  );
 }
 
 async function checkAndNotifySetupPodmanMacHelper(): Promise<void> {
   // Exit immediately if doNotShowMacHelperSetup is true
-  if (doNotShowMacHelperSetup) {
+  if (extensionNotifications.doNotShowMacHelperSetup) {
     return;
   }
 
@@ -209,7 +201,7 @@ async function checkAndNotifySetupPodmanMacHelper(): Promise<void> {
     notifySetupPodmanMacHelper();
   } else {
     // If it's already enabled, just dispose the notification
-    podmanMacHelperNotificationDisposable?.dispose();
+    extensionNotifications.podmanMacHelperNotificationDisposable?.dispose();
   }
 }
 
@@ -224,8 +216,8 @@ function getDoNotShowMacHelperSetting(): boolean {
 
 // Show the banner for running podman-mac-helper
 function notifySetupPodmanMacHelper(): void {
-  podmanMacHelperNotificationDisposable?.dispose();
-  podmanMacHelperNotificationDisposable = extensionApi.window.showNotification(
+  extensionNotifications.podmanMacHelperNotificationDisposable?.dispose();
+  extensionNotifications.podmanMacHelperNotificationDisposable = extensionApi.window.showNotification(
     ExtensionNotifications.setupMacHelperNotification,
   );
 }
@@ -1451,7 +1443,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // only available for macOS
   if (extensionApi.env.isMac) {
     // Get if we should never show the podman-mac-helper notification ever again
-    doNotShowMacHelperSetup = getDoNotShowMacHelperSetting();
+    extensionNotifications.doNotShowMacHelperSetup = getDoNotShowMacHelperSetting();
 
     // Register the command for disabling the do not show mac helper setting permanently
     extensionContext.subscriptions.push(
@@ -1463,10 +1455,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
           .update(configurationCompatibilityModeMacSetupNotificationDoNotShow, true);
 
         //  Set the global variable to true
-        doNotShowMacHelperSetup = true;
+        extensionNotifications.doNotShowMacHelperSetup = true;
 
         // Dismiss the notification
-        podmanMacHelperNotificationDisposable?.dispose();
+        extensionNotifications.podmanMacHelperNotificationDisposable?.dispose();
       }),
     );
 
@@ -2388,6 +2380,6 @@ async function checkAndNotifyDisguisedPodman(): Promise<void> {
     notifyDisguisedPodmanSocket();
   } else {
     // If it's already disguised, dispose of the notification.
-    disguisedPodmanNotificationDisposable?.dispose();
+    extensionNotifications.disguisedPodmanNotificationDisposable?.dispose();
   }
 }

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -44,4 +44,14 @@ export class ExtensionNotifications {
   public set shouldNotifySetup(shouldNotifySetup: boolean) {
     this._shouldNotifySetup = shouldNotifySetup;
   }
+
+  private _notificationDisposable?: extensionApi.Disposable;
+
+  public get notificationDisposable(): extensionApi.Disposable | undefined {
+    return this._notificationDisposable;
+  }
+
+  public set notificationDisposable(notificationDisposable: extensionApi.Disposable) {
+    this._notificationDisposable = notificationDisposable;
+  }
 }

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -54,4 +54,33 @@ export class ExtensionNotifications {
   public set notificationDisposable(notificationDisposable: extensionApi.Disposable) {
     this._notificationDisposable = notificationDisposable;
   }
+
+  private _disguisedPodmanNotificationDisposable?: extensionApi.Disposable;
+
+  public get disguisedPodmanNotificationDisposable(): extensionApi.Disposable | undefined {
+    return this._disguisedPodmanNotificationDisposable;
+  }
+
+  public set disguisedPodmanNotificationDisposable(disguisedPodmanNotificationDisposable: extensionApi.Disposable) {
+    this._disguisedPodmanNotificationDisposable = disguisedPodmanNotificationDisposable;
+  }
+
+  private _doNotShowMacHelperSetup = false;
+
+  public get doNotShowMacHelperSetup(): boolean {
+    return this._doNotShowMacHelperSetup;
+  }
+
+  public set doNotShowMacHelperSetup(doNotShowMacHelperSetup: boolean) {
+    this._doNotShowMacHelperSetup = doNotShowMacHelperSetup;
+  }
+
+  private _podmanMacHelperNotificationDisposable?: extensionApi.Disposable;
+  public get podmanMacHelperNotificationDisposable(): extensionApi.Disposable | undefined {
+    return this._podmanMacHelperNotificationDisposable;
+  }
+
+  public set podmanMacHelperNotificationDisposable(podmanMacHelperNotificationDisposable: extensionApi.Disposable) {
+    this._podmanMacHelperNotificationDisposable = podmanMacHelperNotificationDisposable;
+  }
 }

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -34,4 +34,14 @@ export class ExtensionNotifications {
     highlight: true,
     silent: true,
   };
+
+  private _shouldNotifySetup = true;
+
+  public get shouldNotifySetup(): boolean {
+    return this._shouldNotifySetup;
+  }
+
+  public set shouldNotifySetup(shouldNotifySetup: boolean) {
+    this._shouldNotifySetup = shouldNotifySetup;
+  }
 }


### PR DESCRIPTION
### What does this PR do?

For the podman extension, move the notification state to the ExtensionNotifications class, with getter and setter. This is to prepare refactoring the notification code to the class.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #13170 sub-issue
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
