### PR TITLE
test: add e2e test for kube play YAML build option

### DIFF
--- a/tests/playwright/resources/kube/foobar/Containerfile
+++ b/tests/playwright/resources/kube/foobar/Containerfile
@@ -1,0 +1,2 @@
+FROM docker.io/library/nginx:alpine
+ 

--- a/tests/playwright/resources/kube/foobar/Containerfile
+++ b/tests/playwright/resources/kube/foobar/Containerfile
@@ -1,2 +1,1 @@
 FROM docker.io/library/nginx:alpine
- 

--- a/tests/playwright/resources/kube/play-yaml-build-test.yaml
+++ b/tests/playwright/resources/kube/play-yaml-build-test.yaml
@@ -6,6 +6,8 @@ spec:
   containers:
     - name: container
       image: foobar
+      imagePullPolicy: Never
       ports:
         - name: http
           containerPort: 80
+ 

--- a/tests/playwright/resources/kube/play-yaml-build-test.yaml
+++ b/tests/playwright/resources/kube/play-yaml-build-test.yaml
@@ -9,4 +9,3 @@ spec:
       ports:
         - name: http
           containerPort: 80
- 

--- a/tests/playwright/resources/kube/play-yaml-build-test.yaml
+++ b/tests/playwright/resources/kube/play-yaml-build-test.yaml
@@ -10,4 +10,3 @@ spec:
       ports:
         - name: http
           containerPort: 80
- 

--- a/tests/playwright/resources/kube/play-yaml-build-test.yaml
+++ b/tests/playwright/resources/kube/play-yaml-build-test.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: play-yaml-build-test
+spec:
+  containers:
+    - name: container
+      image: foobar
+      ports:
+        - name: http
+          containerPort: 80
+ 

--- a/tests/playwright/src/model/core/states.ts
+++ b/tests/playwright/src/model/core/states.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,4 +68,9 @@ export enum ExtensionState {
   Running = 'RUNNING',
   NotInstalled = 'NOT-INSTALLED',
   Downloadable = 'DOWNLOADABLE',
+}
+
+export enum ImageState {
+  Used = 'USED',
+  Unused = 'UNUSED',
 }

--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -175,4 +175,13 @@ export class ContainersPage extends MainPage {
       return this;
     });
   }
+
+  async getContainerImage(name: string): Promise<string> {
+    const container = await this.getContainerRowByName(name);
+    const image = await container?.getByRole('cell').nth(5).textContent();
+    if (image) {
+      return image;
+    }
+    return '';
+  }
 }

--- a/tests/playwright/src/model/pages/play-kube-yaml-page.ts
+++ b/tests/playwright/src/model/pages/play-kube-yaml-page.ts
@@ -33,6 +33,7 @@ export class PlayKubeYamlPage extends BasePage {
   readonly kubernetesContext: Locator;
   readonly kubernetesNamespaces: Locator;
   readonly alertMessage: Locator;
+  readonly buildCheckbox: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -52,10 +53,12 @@ export class PlayKubeYamlPage extends BasePage {
     this.playButton = page.getByRole('button', { name: 'Play' });
     this.doneButton = page.getByRole('button', { name: 'Done' });
     this.alertMessage = this.page.getByLabel('Error Message Content');
+    this.buildCheckbox = page.getByRole('checkbox', { name: 'Enable build' }).locator('..');
   }
 
   async playYaml(
     pathToYaml: string,
+    buildImage: boolean = false,
     timeout: number = 120_000,
     { runtime, kubernetesContext, kubernetesNamespace }: PlayKubernetesOptions = {
       kubernetesContext: 'kind-kind-cluster',
@@ -99,6 +102,12 @@ export class PlayKubeYamlPage extends BasePage {
       }
 
       await this.yamlPathInput.fill(pathToYaml);
+      await playExpect(this.buildCheckbox).not.toBeChecked();
+      await playExpect(this.buildCheckbox).toBeEnabled();
+      if (buildImage) {
+        await this.buildCheckbox.check();
+        await playExpect(this.buildCheckbox).toBeChecked();
+      }
       await this.playButton.click();
       await playExpect(this.doneButton.or(this.alertMessage).first()).toBeVisible({ timeout: timeout });
 

--- a/tests/playwright/src/model/pages/pods-page.ts
+++ b/tests/playwright/src/model/pages/pods-page.ts
@@ -46,7 +46,9 @@ export class PodsPage extends MainPage {
       if (podRow === undefined) {
         throw Error(`Pod: ${name} does not exist`);
       }
-      await podRow.getByText(name, { exact: true }).click();
+      const openPodDetailsButton = podRow.getByRole('button').getByText(name, { exact: true });
+      await playExpect(openPodDetailsButton).toBeEnabled();
+      await openPodDetailsButton.click();
       return new PodDetailsPage(this.page, name);
     });
   }

--- a/tests/playwright/src/model/pages/pods-page.ts
+++ b/tests/playwright/src/model/pages/pods-page.ts
@@ -46,7 +46,7 @@ export class PodsPage extends MainPage {
       if (podRow === undefined) {
         throw Error(`Pod: ${name} does not exist`);
       }
-      await podRow.getByText(name).click();
+      await podRow.getByText(name, { exact: true }).click();
       return new PodDetailsPage(this.page, name);
     });
   }

--- a/tests/playwright/src/specs/play-yaml-build-smoke.spec.ts
+++ b/tests/playwright/src/specs/play-yaml-build-smoke.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { PodState } from '../model/core/states';
+import { expect as playExpect, test } from '../utility/fixtures';
+import { deleteImage, deletePod } from '../utility/operations';
+import { isCI, isLinux } from '../utility/platform';
+import { waitForPodmanMachineStartup } from '../utility/wait';
+
+const POD_NAME: string = 'play-yaml-build-test';
+const LOCAL_IMAGE_NAME: string = 'localhost/foobar';
+const NGINX_IMAGE_NAME: string = 'docker.io/library/nginx';
+const CONTAINER_IMAGE: string = `${LOCAL_IMAGE_NAME}:latest`;
+const CONTAINER_NAME: string = `${POD_NAME}-container`;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const POD_YAML_PATH: string = path.resolve(__dirname, '..', '..', 'resources', 'kube', 'play-yaml-build-test.yaml');
+
+test.skip(!!isCI && isLinux, 'Skipping E2E test on GitHub Actions due to an outdated Podman version');
+
+test.beforeAll(async ({ runner, page, welcomePage }) => {
+  runner.setVideoAndTraceName('play-yaml-build-smoke');
+  await welcomePage.handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
+});
+
+test.afterAll(async ({ page, runner }) => {
+  try {
+    await deletePod(page, POD_NAME);
+    await deleteImage(page, LOCAL_IMAGE_NAME);
+    await deleteImage(page, NGINX_IMAGE_NAME);
+  } finally {
+    await runner.close();
+  }
+});
+
+test.describe.serial('Deploy pod via Play YAML using locally built image', { tag: '@smoke' }, () => {
+  test('Deploy pod from YAML using build option and verify it is running', async ({ navigationBar }) => {
+    const podsPage = await navigationBar.openPods();
+    await playExpect(podsPage.heading).toBeVisible();
+    const playYamlPage = await podsPage.openPlayKubeYaml();
+    await playExpect(playYamlPage.heading).toBeVisible();
+
+    await playYamlPage.playYaml(POD_YAML_PATH, true);
+    await playExpect(podsPage.heading).toBeVisible();
+    const podDetails = await podsPage.openPodDetails(POD_NAME);
+    await playExpect(podDetails.heading).toBeVisible();
+    await playExpect.poll(async () => await podDetails.getState(), { timeout: 15_000 }).toBe(PodState.Running);
+  });
+  test('Verify that the deployed pod container uses the localhost image', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+    await playExpect.poll(async () => await imagesPage.getCurrentStatusOfImage(LOCAL_IMAGE_NAME)).toBe('USED');
+
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+    await playExpect.poll(async () => containersPage.getContainerImage(CONTAINER_NAME)).toBe(CONTAINER_IMAGE);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
adds e2e test for kube play YAML build option

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/12212

### How to test this PR?

https://github.com/podman-desktop/e2e/actions/runs/16344239443
- [ ] Tests are covering the bug fix or the new feature
