### PR TITLE
fix(ci): allow deployment write for cloudflare in PR

### DIFF
--- a/.github/workflows/publish-website-pr-cloudflare.yaml
+++ b/.github/workflows/publish-website-pr-cloudflare.yaml
@@ -28,6 +28,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
 
 jobs:
   publish:


### PR DESCRIPTION
### What does this PR do?

The actions located at https://github.com/podman-desktop/podman-desktop/actions/workflows/publish-website-pr-cloudflare.yaml are not working with the error message:

`Error: Resource not accessible by integration - https://docs.github.com/rest/deployments/deployments#create-a-deployment`

so I am adding the `deployments: write` (because the error mentions "error not accessible... create a deployment")

and also because it is mentioned in here https://github.com/AdrianGonz97/refined-cf-pages-action/tree/main
<img width="858" height="1095" alt="Screenshot 2025-07-22 at 09 39 20" src="https://github.com/user-attachments/assets/ac991895-28d6-40f3-b65b-c932d3c2617a" />

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #13299

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
