### PR TITLE
feat: added experimental configuration manager

### DIFF
--- a/packages/main/src/plugin/experimental-configuration-manager.spec.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.spec.ts
@@ -1,0 +1,295 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration } from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry } from './configuration-registry.js';
+import { ExperimentalConfigurationManager } from './experimental-configuration-manager.js';
+
+const mockedConfigurationRegistry = {
+  updateConfigurationValue: vi.fn(),
+  getConfiguration: vi.fn(),
+} as unknown as ConfigurationRegistry;
+
+let experimentalConfigurationManager: ExperimentalConfigurationManager;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  experimentalConfigurationManager = new ExperimentalConfigurationManager(mockedConfigurationRegistry);
+});
+
+describe('ExperimentalConfigurationManager', () => {
+  describe('parseKey', () => {
+    test('should parse valid configuration key with section and property', () => {
+      const result = experimentalConfigurationManager.parseKey('kubernetes.statesExperimental');
+      expect(result).toEqual({
+        section: 'kubernetes',
+        property: 'statesExperimental',
+      });
+    });
+
+    test('should parse key with multiple dots correctly', () => {
+      const result = experimentalConfigurationManager.parseKey('kubernetes.nested.property');
+      expect(result).toEqual({
+        section: 'kubernetes',
+        property: 'nested.property',
+      });
+    });
+
+    test('should return empty strings for key without dot', () => {
+      const result = experimentalConfigurationManager.parseKey('kubernetes');
+      expect(result).toEqual({
+        section: '',
+        property: '',
+      });
+    });
+
+    test('should return empty strings for key starting with dot', () => {
+      const result = experimentalConfigurationManager.parseKey('.kubernetes');
+      expect(result).toEqual({
+        section: '',
+        property: '',
+      });
+    });
+
+    test('should return empty strings for key ending with dot', () => {
+      const result = experimentalConfigurationManager.parseKey('kubernetes.');
+      expect(result).toEqual({
+        section: '',
+        property: '',
+      });
+    });
+
+    test('should return empty strings for empty string', () => {
+      const result = experimentalConfigurationManager.parseKey('');
+      expect(result).toEqual({
+        section: '',
+        property: '',
+      });
+    });
+  });
+
+  describe('updateExperimentalConfigurationValue', () => {
+    test('should update configuration with object value by stringifying and parsing', async () => {
+      const config = { enabled: true };
+      const key = 'kubernetes.statesExperimental';
+      const scope = 'DEFAULT';
+
+      await experimentalConfigurationManager.updateExperimentalConfigurationValue(key, config, scope);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, { enabled: true }, scope);
+    });
+
+    test('should update configuration with non-object value directly', async () => {
+      const config = 'string-value';
+      const key = 'kubernetes.statesExperimental';
+      const scope = 'DEFAULT';
+
+      await experimentalConfigurationManager.updateExperimentalConfigurationValue(key, config, scope);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, config, scope);
+    });
+
+    test('should update configuration without scope', async () => {
+      const config = { enabled: true };
+      const key = 'kubernetes.statesExperimental';
+
+      await experimentalConfigurationManager.updateExperimentalConfigurationValue(key, config);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(
+        key,
+        { enabled: true },
+        undefined,
+      );
+    });
+
+    test('should handle undefined config value', async () => {
+      const config = undefined;
+      const key = 'kubernetes.statesExperimental';
+      const scope = 'DEFAULT';
+
+      await experimentalConfigurationManager.updateExperimentalConfigurationValue(key, config, scope);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, undefined, scope);
+    });
+  });
+
+  describe('enableExperimentalConfiguration', () => {
+    test('should enable configuration with single scope', async () => {
+      const key = 'kubernetes.statesExperimental';
+      const scope = 'DEFAULT';
+
+      await experimentalConfigurationManager.enableExperimentalConfiguration(key, scope);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, {}, scope);
+    });
+
+    test('should enable configuration with array of scopes', async () => {
+      const key = 'kubernetes.statesExperimental';
+      const scopes = ['DEFAULT', 'ContainerConnection'];
+
+      await experimentalConfigurationManager.enableExperimentalConfiguration(key, scopes);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledTimes(2);
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenNthCalledWith(1, key, {}, scopes[0]);
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenNthCalledWith(2, key, {}, scopes[1]);
+    });
+
+    test('should enable configuration without scope', async () => {
+      const key = 'kubernetes.statesExperimental';
+
+      await experimentalConfigurationManager.enableExperimentalConfiguration(key);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, {}, undefined);
+    });
+  });
+
+  describe('disableExperimentalConfiguration', () => {
+    test('should disable configuration with single scope', async () => {
+      const key = 'kubernetes.statesExperimental';
+      const scope = 'DEFAULT';
+
+      await experimentalConfigurationManager.disableExperimentalConfiguration(key, scope);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, undefined, scope);
+    });
+
+    test('should disable configuration with array of scopes', async () => {
+      const key = 'kubernetes.statesExperimental';
+      const scopes = ['DEFAULT', 'ContainerConnection'];
+
+      await experimentalConfigurationManager.disableExperimentalConfiguration(key, scopes);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledTimes(2);
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenNthCalledWith(
+        1,
+        key,
+        undefined,
+        scopes[0],
+      );
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenNthCalledWith(
+        2,
+        key,
+        undefined,
+        scopes[1],
+      );
+    });
+
+    test('should disable configuration without scope', async () => {
+      const key = 'kubernetes.statesExperimental';
+
+      await experimentalConfigurationManager.disableExperimentalConfiguration(key);
+
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, undefined, undefined);
+    });
+  });
+
+  describe('isExperimentalConfigurationEnabled', () => {
+    test('should return true when configuration is an object', () => {
+      const key = 'kubernetes.statesExperimental';
+      const scope = 'DEFAULT';
+      const mockConfig = { get: vi.fn().mockReturnValue({ enabled: true }) };
+      vi.mocked(mockedConfigurationRegistry.getConfiguration).mockReturnValue(mockConfig as unknown as Configuration);
+
+      const result = experimentalConfigurationManager.isExperimentalConfigurationEnabled(key, scope);
+
+      expect(result).toBe(true);
+      expect(mockedConfigurationRegistry.getConfiguration).toHaveBeenCalledWith('kubernetes', scope);
+      expect(mockConfig.get).toHaveBeenCalledWith('statesExperimental');
+    });
+
+    test('should return false when configuration is not an object', () => {
+      const key = 'kubernetes.statesExperimental';
+      const scope = 'DEFAULT';
+      const mockConfig = { get: vi.fn().mockReturnValue('string-value') };
+      vi.mocked(mockedConfigurationRegistry.getConfiguration).mockReturnValue(mockConfig as unknown as Configuration);
+
+      const result = experimentalConfigurationManager.isExperimentalConfigurationEnabled(key, scope);
+
+      expect(result).toBe(false);
+    });
+
+    test('should return false when configuration is undefined', () => {
+      const key = 'kubernetes.statesExperimental';
+      const scope = 'DEFAULT';
+      const mockConfig = { get: vi.fn().mockReturnValue(undefined) };
+      vi.mocked(mockedConfigurationRegistry.getConfiguration).mockReturnValue(mockConfig as unknown as Configuration);
+
+      const result = experimentalConfigurationManager.isExperimentalConfigurationEnabled(key, scope);
+
+      expect(result).toBe(false);
+    });
+
+    test('should return false for invalid key without section or property', () => {
+      const key = 'invalid-key';
+
+      const result = experimentalConfigurationManager.isExperimentalConfigurationEnabled(key);
+
+      expect(result).toBe(false);
+      expect(mockedConfigurationRegistry.getConfiguration).not.toHaveBeenCalled();
+    });
+
+    test('should work without scope', () => {
+      const key = 'kubernetes.statesExperimental';
+      const mockConfig = { get: vi.fn().mockReturnValue({}) };
+      vi.mocked(mockedConfigurationRegistry.getConfiguration).mockReturnValue(mockConfig as unknown as Configuration);
+
+      const result = experimentalConfigurationManager.isExperimentalConfigurationEnabled(key);
+
+      expect(result).toBe(true);
+      expect(mockedConfigurationRegistry.getConfiguration).toHaveBeenCalledWith('kubernetes', undefined);
+    });
+
+    test('should check array of scopes and return true if any scope has object value', () => {
+      const key = 'kubernetes.statesExperimental';
+      const scopes = ['DEFAULT', 'ContainerConnection'];
+
+      const mockConfig1 = { get: vi.fn().mockReturnValue(undefined) };
+      const mockConfig2 = { get: vi.fn().mockReturnValue({ enabled: true }) };
+
+      vi.mocked(mockedConfigurationRegistry.getConfiguration)
+        .mockReturnValueOnce(mockConfig1 as unknown as Configuration)
+        .mockReturnValueOnce(mockConfig2 as unknown as Configuration);
+
+      const result = experimentalConfigurationManager.isExperimentalConfigurationEnabled(key, scopes);
+
+      expect(result).toBe(true);
+      expect(mockedConfigurationRegistry.getConfiguration).toHaveBeenCalledTimes(2);
+      expect(mockedConfigurationRegistry.getConfiguration).toHaveBeenNthCalledWith(1, 'kubernetes', scopes[0]);
+      expect(mockedConfigurationRegistry.getConfiguration).toHaveBeenNthCalledWith(2, 'kubernetes', scopes[1]);
+    });
+
+    test('should check array of scopes and return false if no scope has object value', () => {
+      const key = 'kubernetes.statesExperimental';
+      const scopes = ['DEFAULT', 'ContainerConnection'];
+
+      const mockConfig1 = { get: vi.fn().mockReturnValue(undefined) };
+      const mockConfig2 = { get: vi.fn().mockReturnValue('string') };
+
+      vi.mocked(mockedConfigurationRegistry.getConfiguration)
+        .mockReturnValueOnce(mockConfig1 as unknown as Configuration)
+        .mockReturnValueOnce(mockConfig2 as unknown as Configuration);
+
+      const result = experimentalConfigurationManager.isExperimentalConfigurationEnabled(key, scopes);
+
+      expect(result).toBe(false);
+      expect(mockedConfigurationRegistry.getConfiguration).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/main/src/plugin/experimental-configuration-manager.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.ts
@@ -32,6 +32,9 @@ export class ExperimentalConfigurationManager {
    */
   parseKey(key: string): { section: string; property: string } {
     const dotIndex = key.indexOf('.');
+    // If is the '.' not found
+    // if is the key '.property'
+    // If is the key 'section.'
     if (dotIndex === -1 || dotIndex === 0 || dotIndex === key.length - 1) {
       return { section: '', property: '' };
     }
@@ -53,12 +56,7 @@ export class ExperimentalConfigurationManager {
     config: unknown,
     scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
   ): Promise<void> {
-    // HACK: when setting `{}` as value we need to stringify and parse the svelte state
-    let settings = config;
-    if (typeof config === 'object') {
-      settings = JSON.parse(JSON.stringify(config));
-    }
-    await this.configurationRegistry.updateConfigurationValue(key, settings, scope);
+    await this.configurationRegistry.updateConfigurationValue(key, config, scope);
   }
 
   /**
@@ -70,8 +68,7 @@ export class ExperimentalConfigurationManager {
     key: string,
     scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
   ): Promise<void> {
-    // HACK: when setting `{}` as value we need to stringify and parse the svelte state
-    const settings = JSON.parse(JSON.stringify({}));
+    const settings = {};
 
     if (Array.isArray(scope)) {
       for (const scopeItem of scope) {

--- a/packages/main/src/plugin/experimental-configuration-manager.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.ts
@@ -1,0 +1,129 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type * as containerDesktopAPI from '@podman-desktop/api';
+import { inject, injectable } from 'inversify';
+
+import { ConfigurationRegistry } from './configuration-registry.js';
+
+@injectable()
+export class ExperimentalConfigurationManager {
+  constructor(@inject(ConfigurationRegistry) private configurationRegistry: ConfigurationRegistry) {}
+
+  /**
+   * Parse a configuration key into section and property
+   * @param key - Full configuration key (e.g., 'kubernetes.statesExperimental')
+   * @returns Object with section and property
+   */
+  parseKey(key: string): { section: string; property: string } {
+    const dotIndex = key.indexOf('.');
+    if (dotIndex === -1 || dotIndex === 0 || dotIndex === key.length - 1) {
+      return { section: '', property: '' };
+    }
+
+    const section = key.substring(0, dotIndex);
+    const property = key.substring(dotIndex + 1);
+
+    return { section, property };
+  }
+
+  /**
+   * Update an experimental configuration (enable or disable based on config)
+   * @param key - Full configuration key (e.g., 'kubernetes.statesExperimental')
+   * @param config - Configuration object for the feature. If undefined, disables the feature. If object (empty or with properties), enables the feature.
+   * @param scope - Configuration scope
+   */
+  async updateExperimentalConfigurationValue(
+    key: string,
+    config: unknown,
+    scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+  ): Promise<void> {
+    // HACK: when setting `{}` as value we need to stringify and parse the svelte state
+    let settings = config;
+    if (typeof config === 'object') {
+      settings = JSON.parse(JSON.stringify(config));
+    }
+    await this.configurationRegistry.updateConfigurationValue(key, settings, scope);
+  }
+
+  /**
+   * Enable an experimental configuration by setting it to an object
+   * @param key - Full configuration key (e.g., 'kubernetes.statesExperimental')
+   * @param scope - Configuration scope
+   */
+  async enableExperimentalConfiguration(
+    key: string,
+    scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+  ): Promise<void> {
+    // HACK: when setting `{}` as value we need to stringify and parse the svelte state
+    const settings = JSON.parse(JSON.stringify({}));
+
+    if (Array.isArray(scope)) {
+      for (const scopeItem of scope) {
+        await this.configurationRegistry.updateConfigurationValue(key, settings, scopeItem);
+      }
+    } else {
+      await this.configurationRegistry.updateConfigurationValue(key, settings, scope);
+    }
+  }
+
+  /**
+   * Disable an experimental configuration by setting it to undefined
+   * @param key - Full configuration key (e.g., 'kubernetes.statesExperimental')
+   * @param scope - Configuration scope
+   */
+  async disableExperimentalConfiguration(
+    key: string,
+    scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+  ): Promise<void> {
+    if (Array.isArray(scope)) {
+      for (const scopeItem of scope) {
+        await this.configurationRegistry.updateConfigurationValue(key, undefined, scopeItem);
+      }
+    } else {
+      await this.configurationRegistry.updateConfigurationValue(key, undefined, scope);
+    }
+  }
+
+  /**
+   * Check if an experimental configuration is enabled (has an object value)
+   * @param key - Full configuration key (e.g., 'kubernetes.statesExperimental')
+   * @param scope - Configuration scope
+   * @returns true if feature is enabled (has object value), false otherwise
+   */
+  isExperimentalConfigurationEnabled(
+    key: string,
+    scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+  ): boolean {
+    const { section, property } = this.parseKey(key);
+    if (!section || !property) {
+      return false;
+    }
+
+    if (Array.isArray(scope)) {
+      for (const scopeItem of scope) {
+        const config = this.configurationRegistry.getConfiguration(section, scopeItem).get(property);
+        if (typeof config === 'object' && config !== null) return true;
+      }
+      return false;
+    } else {
+      const config = this.configurationRegistry.getConfiguration(section, scope).get(property);
+      return typeof config === 'object' && config !== null;
+    }
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -160,6 +160,7 @@ import type {
 } from './dockerode/libpod-dockerode.js';
 import { EditorInit } from './editor-init.js';
 import type { Emitter } from './events/emitter.js';
+import { ExperimentalConfigurationManager } from './experimental-configuration-manager.js';
 import { ExtensionsCatalog } from './extension/catalog/extensions-catalog.js';
 import type { CatalogExtension } from './extension/catalog/extensions-catalog-api.js';
 import { ExtensionAnalyzer } from './extension/extension-analyzer.js';
@@ -473,6 +474,12 @@ export class PluginSystem {
       notifications,
       configurationRegistryEmitter,
     );
+
+    container.bind<ExperimentalConfigurationManager>(ExperimentalConfigurationManager).toSelf().inSingletonScope();
+    const experimentalConfigurationManager = container.get<ExperimentalConfigurationManager>(
+      ExperimentalConfigurationManager,
+    );
+
     container.bind<ColorRegistry>(ColorRegistry).to(InjectableColorRegistry).inSingletonScope();
     const colorRegistry = container.get<ColorRegistry>(ColorRegistry);
     colorRegistry.init();
@@ -2003,6 +2010,51 @@ export class PluginSystem {
         scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
       ): Promise<void> => {
         return configurationRegistry.updateConfigurationValue(key, value, scope);
+      },
+    );
+
+    this.ipcHandle(
+      'experimental-configuration-manager:updateExperimentalConfigurationValue',
+      async (
+        _listener: Electron.IpcMainInvokeEvent,
+        key: string,
+        value: unknown,
+        scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+      ): Promise<void> => {
+        return experimentalConfigurationManager.updateExperimentalConfigurationValue(key, value, scope);
+      },
+    );
+
+    this.ipcHandle(
+      'experimental-configuration-manager:isExperimentalConfigurationEnabled',
+      async (
+        _listener: Electron.IpcMainInvokeEvent,
+        key: string,
+        scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+      ): Promise<boolean> => {
+        return experimentalConfigurationManager.isExperimentalConfigurationEnabled(key, scope);
+      },
+    );
+
+    this.ipcHandle(
+      'experimental-configuration-manager:enableExperimentalConfiguration',
+      async (
+        _listener: Electron.IpcMainInvokeEvent,
+        key: string,
+        scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+      ): Promise<void> => {
+        return experimentalConfigurationManager.enableExperimentalConfiguration(key, scope);
+      },
+    );
+
+    this.ipcHandle(
+      'experimental-configuration-manager:disableExperimentalConfiguration',
+      async (
+        _listener: Electron.IpcMainInvokeEvent,
+        key: string,
+        scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+      ): Promise<void> => {
+        return experimentalConfigurationManager.disableExperimentalConfiguration(key, scope);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1526,6 +1526,47 @@ export function initExposure(): void {
     },
   );
 
+  contextBridge.exposeInMainWorld(
+    'isExperimentalConfigurationEnabled',
+    async (
+      key: string,
+      scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+    ): Promise<boolean> => {
+      return ipcInvoke('experimental-configuration-manager:isExperimentalConfigurationEnabled', key, scope);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'enableExperimentalConfiguration',
+    async (
+      key: string,
+      scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+    ): Promise<void> => {
+      return ipcInvoke('experimental-configuration-manager:enableExperimentalConfiguration', key, scope);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'disableExperimentalConfiguration',
+    async (
+      key: string,
+      scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+    ): Promise<void> => {
+      return ipcInvoke('experimental-configuration-manager:disableExperimentalConfiguration', key, scope);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'updateExperimentalConfigurationValue',
+    async (
+      key: string,
+      value: unknown,
+      scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
+    ): Promise<void> => {
+      return ipcInvoke('experimental-configuration-manager:updateExperimentalConfigurationValue', key, value, scope);
+    },
+  );
+
   contextBridge.exposeInMainWorld('getFeaturedExtensions', async (): Promise<FeaturedExtension[]> => {
     return ipcInvoke('featured:getFeaturedExtensions');
   });


### PR DESCRIPTION
Assisted-by: Cursor

### What does this PR do?
Adds experimental configuration manager 

In further PRs I'm using just isExperimentalConfigurationEnabled and updateExoerimentalConfigurationValue functions, other are either unused (for future?), or helper functions

### Screenshot / video of UI

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/issues/13095

### How to test this PR?
Unit tests 

1. checkout to https://github.com/podman-desktop/podman-desktop/pull/11992 
2. enable some features (not all of them)
3. go to "Experimental page", open `~/.local/share/containers/podman-desktop/configuration/settings.json`
4. click on enable all on top of the screen, you should see that the not enabled features should have `{}` value
PS: the other (previously enabled features) will probably have values like: 
```
some.feature: {
  remindAt: TIMESTAMP
  disabled: false
}
``` 
=> This is another PR (https://github.com/podman-desktop/podman-desktop/pull/13317)

- [x] Tests are covering the bug fix or the new feature
