### PR TITLE
fix(ux): make whole button clickable

### DIFF
--- a/packages/renderer/src/lib/ui/LoadingIconButton.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIconButton.svelte
@@ -59,7 +59,7 @@ const style = $derived(
 </script>
 
 <Tooltip bottom tip={tooltip}>
-  <button aria-label={capitalize(action)} class="mx-2.5 my-2 {style}" onclick={clickAction} disabled={disable}>
+  <button aria-label={capitalize(action)} class="px-2.5 py-2 {style}" onclick={clickAction} disabled={disable}>
     <LoadingIcon
       icon={icon}
       loadingWidthClass="w-6"


### PR DESCRIPTION
### What does this PR do?

This PR uses a padding instead of a margin on the "LoadingIconButton" component to ensure that the zone around the icon but inside the button is also clickable.

### Screenshot / video of UI

https://github.com/user-attachments/assets/fbb4f8cf-b3d2-4122-ac6f-a007c193ffa6


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #13318 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
