### PR TITLE
chore: allow passing title to Icon component

### DIFF
--- a/packages/ui/src/lib/icons/Icon.spec.ts
+++ b/packages/ui/src/lib/icons/Icon.spec.ts
@@ -65,6 +65,13 @@ describe('font awesome', () => {
     const path = img.querySelector('path');
     expect(path).toHaveAttribute('fill', 'currentColor');
   });
+
+  test('icon should have title', () => {
+    const { getByTitle } = render(Icon, { icon: faGithub, title: 'test title' });
+
+    const img = getByTitle('test title');
+    expect(img).toBeInTheDocument();
+  });
 });
 
 describe('class icon', () => {
@@ -93,6 +100,13 @@ describe('class icon', () => {
     expect(img).toHaveClass('fas fa-icon');
     expect(img).toHaveClass('some-class');
   });
+
+  test('icon should have title', () => {
+    const { getByTitle } = render(Icon, { icon: 'fas fa-icon', title: 'test title' });
+
+    const img = getByTitle('test title');
+    expect(img).toBeInTheDocument();
+  });
 });
 
 describe('component icon', () => {
@@ -120,5 +134,12 @@ describe('component icon', () => {
     const imgComponent = img.firstChild;
     expect(imgComponent).toBeInTheDocument();
     expect(imgComponent).toHaveClass('some-class');
+  });
+
+  test('icon should have title', () => {
+    const { getByTitle } = render(Icon, { icon: ContainerIcon, title: 'test title' });
+
+    const img = getByTitle('test title');
+    expect(img).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -9,9 +9,10 @@ interface Props {
   icon: IconDefinition | Component | string;
   size?: IconSize | number | string;
   class?: string;
+  title?: string;
 }
 
-let { icon, size, class: className }: Props = $props();
+let { icon, size, class: className, title }: Props = $props();
 
 const role = 'img';
 const IconComponent = icon;
@@ -20,16 +21,16 @@ const IconComponent = icon;
 
 {#if isFontAwesomeIcon(icon)}
     {#if typeof size === 'undefined' || isFontAwesomeSize(size)}
-        <Fa {icon} {size} class={className}/>
+        <Fa {icon} {size} class={className} {title}/>
     {/if}
 {:else if typeof icon === 'string'}
     <!-- fas fa- and far fa- for Font awesome icons -->
     <!-- -icon for extension icons e.g. 'kind-icon' -->
     {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.endsWith('-icon')}
-        <i class={`${icon} ${size} ${className}`} {role}></i>
+        <i class={`${icon} ${size} ${className}`} {role} {title}></i>
     {/if}
 {:else}
     {#if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
-        <span {role}><IconComponent class={className} {size}/></span>
+        <span {role} {title}><IconComponent class={className} {size}/></span>
     {/if}
 {/if}


### PR DESCRIPTION
the name is self-descriptive

The main reason for this is accessibility and a possiblity to properly locate icons within tests.

Closes: #13370