### PR TITLE
fix: updating of configuration with undefined value

### DIFF
--- a/packages/main/src/plugin/configuration-impl.spec.ts
+++ b/packages/main/src/plugin/configuration-impl.spec.ts
@@ -92,30 +92,3 @@ test('Uses localKey when deleting values', async () => {
     value: undefined,
   });
 });
-
-test.fails('Uses original update with section when deleting values', async () => {
-  // Test with globalSection to ensure localKey != section
-  const sendMock = vi.fn();
-  const map = new Map<string, { [key: string]: unknown }>();
-  const config = new TestConfigurationImpl({ send: sendMock } as unknown as ApiSenderType, vi.fn(), map, 'prefix');
-
-  // Set value
-  await config.originalUpdate('key', 'value');
-  // stored with section
-  expect(config['key']).toBe('value');
-  // NOT stored with localKey
-  expect(config['prefix.key']).toBeUndefined();
-  expect(config.get('key')).toBe('value');
-
-  // Delete value
-  await config.originalUpdate('key', undefined);
-
-  // THIS WILL FAIL, actualy it will be "value" and not undefined as expected
-  expect(config['key']).toBeUndefined();
-
-  // deleted using localKey
-  expect(config['prefix.key']).toBeUndefined();
-
-  // THIS WILL FAIL, actualy it will be "value" and not undefined as expected
-  expect(config.get('key')).toBeUndefined();
-});

--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -80,7 +80,7 @@ export class ConfigurationImpl implements containerDesktopAPI.Configuration {
     // remove the value if undefined
     if (value === undefined) {
       if (localView[localKey]) {
-        delete localView[section];
+        delete localView[localKey];
         delete this[localKey];
         this.apiSender.send('configuration-changed', configurationChangedEvent);
       }


### PR DESCRIPTION
### What does this PR do?
Updates index from `section` to `localKey`
Previously the index was wrong and when trying to set undefined the value was not set

### Screenshot / video of UI
### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/13227

### How to test this PR?
Unit tests 
OR 
https://github.com/podman-desktop/podman-desktop/pull/11992 
Where you need to go to experimental page and try to enable/disable some features with this change it should remove it from settings.json.
You can also try to switch back to "section" to see that it wont remove the configuration

- [x] Tests are covering the bug fix or the new feature
