### PR TITLE
fix: verify the ports requested for kind cluster are free

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -23,7 +23,6 @@ import * as extensionApi from '@podman-desktop/api';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import * as port from '../../../packages/main/src/plugin/util/port';
 import { connectionAuditor, createCluster, getKindClusterConfig } from './create-cluster';
 import { getKindPath, getMemTotalInfo } from './util';
 
@@ -55,6 +54,9 @@ vi.mock('@podman-desktop/api', async () => {
     },
     window: {
       showInformationMessage: vi.fn(),
+    },
+    net: {
+      getFreePort: vi.fn(),
     },
   };
 });
@@ -401,7 +403,7 @@ test('check cluster configuration null string image', async () => {
 });
 
 test('check that consilience check returns warning message', async () => {
-  vi.spyOn(port, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
+  vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
   (getMemTotalInfo as Mock).mockReturnValue(3000000000);
   const checks = await connectionAuditor('docker', {
     'kind.cluster.creation.http.port': 9090,
@@ -418,7 +420,7 @@ test('check that consilience check returns warning message', async () => {
 });
 
 test('check that consilience check returns no warning messages', async () => {
-  vi.spyOn(port, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
+  vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
   (getMemTotalInfo as Mock).mockReturnValue(6000000001);
   const checks = await connectionAuditor('docker', {
     'kind.cluster.creation.http.port': 9090,
@@ -431,7 +433,7 @@ test('check that consilience check returns no warning messages', async () => {
 });
 
 test('check that consilience check returns warning message when image has no sha256 digest', async () => {
-  vi.spyOn(port, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
+  vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
   const checks = await connectionAuditor('docker', {
     'kind.cluster.creation.controlPlaneImage': 'image:tag',
     'kind.cluster.creation.http.port': 9090,
@@ -446,6 +448,7 @@ test('check that consilience check returns warning message when image has no sha
 });
 
 test('check that consilience check returns warning message when config file is specified', async () => {
+  vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
   const checks = await connectionAuditor('docker', {
     'kind.cluster.creation.configFile': '/path',
     'kind.cluster.creation.http.port': 9090,
@@ -460,7 +463,7 @@ test('check that consilience check returns warning message when config file is s
 });
 
 test('check that auditItems returns error message when HTTP port is not available', async () => {
-  vi.spyOn(port, 'getFreePort').mockResolvedValueOnce(9091).mockResolvedValueOnce(9443);
+  vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9091).mockResolvedValueOnce(9443);
   const checks = await connectionAuditor('docker', {
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9443,
@@ -474,7 +477,7 @@ test('check that auditItems returns error message when HTTP port is not availabl
 });
 
 test('check that auditItems returns error message when HTTPS port is not available', async () => {
-  vi.spyOn(port, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9444);
+  vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9444);
   const checks = await connectionAuditor('docker', {
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9443,

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -96,6 +96,25 @@ export async function connectionAuditor(provider: string, items: AuditRequestIte
     });
   }
 
+  const httpPort = items['kind.cluster.creation.http.port'];
+  const freeHttpPort = await extensionApi.net.getFreePort(httpPort);
+  if (httpPort !== freeHttpPort) {
+    records.push({
+      type: 'error',
+      record: `HTTP Port ${httpPort} is not available. Please use next available port ${freeHttpPort}.`,
+    });
+  }
+
+  const httpsPort = items['kind.cluster.creation.https.port'];
+  const freeHttpsPort = await extensionApi.net.getFreePort(httpsPort);
+
+  if (httpsPort !== freeHttpsPort) {
+    records.push({
+      type: 'error',
+      record: `HTTPS Port ${httpsPort} is not available. Please use next available port ${freeHttpsPort}.`,
+    });
+  }
+
   const providerSocket = extensionApi.provider
     .getContainerConnections()
     .find(connection => connection.connection.type === provider);
@@ -111,7 +130,6 @@ export async function connectionAuditor(provider: string, items: AuditRequestIte
       record: 'It is recommend to install Kind on a virtual machine with at least 6GB of memory.',
     });
   }
-
   return auditResult;
 }
 


### PR DESCRIPTION
### What does this PR do?

PR checks if ports requested for kind cluster is free and show auditor error message.

### Screenshot / video of UI

https://github.com/user-attachments/assets/b65bf794-cb98-4ce8-8e46-317f47c5c5f2

### What issues does this PR fix or reference?

Fix #12405.

### How to test this PR?

Create two kind clusters. Creating second cluster should trigger request to use different free ports.

- [x] Tests are covering the bug fix or the new feature (TBD)
