### PR TITLE
fix: added different key to containers when no id is found

### DIFF
--- a/packages/renderer/src/lib/ui/Dots.svelte
+++ b/packages/renderer/src/lib/ui/Dots.svelte
@@ -19,7 +19,7 @@ $: organizedContainers = organizeContainers(containers);
   {/each}
 {:else}
   {#each Object.entries(organizedContainers) as [status, c] (status)}
-    {#each c as container (container.Id || `${container.Names}-${status}`)}
+    {#each c as container, i (i)}
       <StatusDot status={status} name={container.Names} />
     {/each}
   {/each}

--- a/packages/renderer/src/lib/ui/Dots.svelte
+++ b/packages/renderer/src/lib/ui/Dots.svelte
@@ -19,7 +19,7 @@ $: organizedContainers = organizeContainers(containers);
   {/each}
 {:else}
   {#each Object.entries(organizedContainers) as [status, c] (status)}
-    {#each c as container (container.Id)}
+    {#each c as container (container.Id || `${container.Names}-${status}`)}
       <StatusDot status={status} name={container.Names} />
     {/each}
   {/each}


### PR DESCRIPTION
### What does this PR do?
This PR added a different key for  "each loop" for containers in pods list when Id is not provided. This can occur when containers are in being created or in "waiting" status making duplication of pods in pods list.

### What issues does this PR fix or reference?

fixes #13048 

### How to test this PR?

1. Create a kind cluster
2. Go to pods page
3. Select projectcontour namespace
4. When creating or, for example, deleting multiple pods, the list of pods should never contain duplicates.

- [ ] Tests are covering the bug fix or the new feature
