### PR TITLE
chore(test): ensure image exists before status check

### DIFF
--- a/tests/playwright/src/specs/play-yaml-build-smoke.spec.ts
+++ b/tests/playwright/src/specs/play-yaml-build-smoke.spec.ts
@@ -71,7 +71,10 @@ test.describe.serial('Deploy pod via Play YAML using locally built image', { tag
     const imagesPage = await navigationBar.openImages();
     await playExpect(imagesPage.heading).toBeVisible();
     await playExpect
-      .poll(async () => await imagesPage.getCurrentStatusOfImage(LOCAL_IMAGE_NAME), { timeout: 40_000 })
+      .poll(async () => await imagesPage.waitForImageExists(LOCAL_IMAGE_NAME, 40_000), { timeout: 0 })
+      .toBeTruthy();
+    await playExpect
+      .poll(async () => await imagesPage.getCurrentStatusOfImage(LOCAL_IMAGE_NAME), { timeout: 15_000 })
       .toBe('USED');
 
     const containersPage = await navigationBar.openContainers();

--- a/tests/playwright/src/specs/play-yaml-build-smoke.spec.ts
+++ b/tests/playwright/src/specs/play-yaml-build-smoke.spec.ts
@@ -75,7 +75,7 @@ test.describe.serial('Deploy pod via Play YAML using locally built image', { tag
       .toBeTruthy();
     await playExpect
       .poll(async () => await imagesPage.getCurrentStatusOfImage(LOCAL_IMAGE_NAME), { timeout: 15_000 })
-      .toBe('USED');
+      .toBe(ImageState.Used);
 
     const containersPage = await navigationBar.openContainers();
     await playExpect(containersPage.heading).toBeVisible();


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?
ensures image exists before status check in kube play build test

