### PR TITLE
fix: increase onboarding timeout to allow extensions to load

### DIFF
--- a/tests/playwright/src/model/pages/welcome-page.ts
+++ b/tests/playwright/src/model/pages/welcome-page.ts
@@ -53,7 +53,9 @@ export class WelcomePage extends BasePage {
       const isUpdateTest = test.info().tags.includes('@update-install');
 
       if (!isUpdateTest) {
-        await playExpect(this.startOnboarding).toBeEnabled({ timeout: 20_000 });
+        // Extensions load sequentially (faster speed but can block ui)
+        // Each extension timeout is 20s use 60s to provide a decent bufffer
+        await playExpect(this.startOnboarding).toBeEnabled({ timeout: 60_000 });
       }
 
       if (await this.telemetryConsent.isChecked()) {


### PR DESCRIPTION
The e2e tests were failing because the tests only waited 20s for the start onboard button to appear. Each extension loads sequentially and can block ui for up to 20s (max activation time). Increased the timeout to 60s to provide slow or failing extensions a longer buffer before test fails.

### What does this PR do?

see above

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13047

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

in extensions/kind/src/extension.ts 
add a timout like this in line 588

export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
  // Add a 20s delay to simulate a slow activation
  await new Promise(resolve => setTimeout(resolve, 20_000));
  console.log('Kind extension simulate slow activation');

then run 

pnpm run test:e2e:build
pnpm exec playwright test tests/playwright/src/specs/welcome-page-smoke.spec.ts --headed

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x ] Tests are covering the bug fix or the new feature
