### PR TITLE
feat(extension-api): adding path property to CliToolInfo

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4702,6 +4702,7 @@ declare module '@podman-desktop/api' {
     markdownDescription: string;
     images: ProviderImages;
     version?: string;
+    path?: string;
     extensionInfo: {
       id: string;
       label: string;


### PR DESCRIPTION
### What does this PR do?

Adding the path property, technically it is already there, as the `CliToolImpl` exposes it, but our extension-api type does not  reflect it.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13655

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
