### PR TITLE
chore: fixed comparing default value of object config properties

### DIFF
--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -18,6 +18,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
@@ -275,7 +276,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     const cloneConfig = { ...this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE) };
     // for each key being already the default value, remove the entry
     Object.keys(cloneConfig)
-      .filter(key => JSON.stringify(cloneConfig[key]) === JSON.stringify(this.configurationProperties[key]?.default))
+      .filter(key => isDeepStrictEqual(cloneConfig[key], this.configurationProperties[key]?.default))
       .filter(key => this.configurationProperties[key]?.type !== 'markdown')
       .forEach(key => {
         delete cloneConfig[key];

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -275,7 +275,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     const cloneConfig = { ...this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE) };
     // for each key being already the default value, remove the entry
     Object.keys(cloneConfig)
-      .filter(key => cloneConfig[key] === this.configurationProperties[key]?.default)
+      .filter(key => JSON.stringify(cloneConfig[key]) === JSON.stringify(this.configurationProperties[key]?.default))
       .filter(key => this.configurationProperties[key]?.type !== 'markdown')
       .forEach(key => {
         delete cloneConfig[key];


### PR DESCRIPTION
### What does this PR do?
Fixes comparing configuration objects with default values

### Screenshot / video of UI

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/13705

### How to test this PR?
You can try https://github.com/podman-desktop/podman-desktop/pull/13705 -> change some columns -> should be saved in settings.json -> then restore to default -> should disappear form config === this works 

- [x] Tests are covering the bug fix or the new feature
