### PR TITLE
chore: include arm based podman installer

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -112,7 +112,7 @@ const config = {
       });
       // add podman installer
       if (context.arch === Arch.x64) {
-        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-*-setup.exe`);
+        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-installer-windows-amd64.exe`);
         context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-x64.zst`);
       }
       if (context.arch === Arch.arm64) {

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -111,12 +111,13 @@ const config = {
         to: 'win-ca/roots.exe',
       });
       // add podman installer
-      context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-*.exe`);
       if (context.arch === Arch.x64) {
-        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-x64.zst`);
+        context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-*-amd64.exe');
+        context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-x64.zst');
       }
       if (context.arch === Arch.arm64) {
-        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-arm64.zst`);
+        context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-*-arm64.exe');
+        context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-arm64.zst');
       }
     }
   },

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -112,12 +112,12 @@ const config = {
       });
       // add podman installer
       if (context.arch === Arch.x64) {
-        context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-*-amd64.exe');
-        context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-x64.zst');
+        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-*-setup.exe`);
+        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-x64.zst`);
       }
       if (context.arch === Arch.arm64) {
-        context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-*-arm64.exe');
-        context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-arm64.zst');
+        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-installer-windows-arm64.exe`);
+        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-arm64.zst`);
       }
     }
   },

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -176,6 +176,17 @@ describe('macOS platform', () => {
       'podman-installer-macos-universal.pkg',
     );
   });
+
+  test('PodmanDownload artifacts do not contain whitespace character', async () => {
+    const podmanDownload = new TestPodmanDownload(podman5JSON, true);
+    // check called with the correct parameters
+    const artifactsToDownload = podmanDownload.getArtifactsToDownload();
+    artifactsToDownload.forEach(artifact => {
+      expect(artifact.version).not.toMatch(/\s/);
+      expect(artifact.artifactName).not.toMatch(/\s/);
+      expect(artifact.downloadName).not.toMatch(/\s/);
+    });
+  });
 });
 
 describe('windows platform', () => {
@@ -265,6 +276,17 @@ describe('windows platform', () => {
 
     // check no airgap download
     expect(podman5DownloadMachineOSSpy).not.toHaveBeenCalled();
+  });
+
+  test('PodmanDownload artifacts do not contain whitespace character', async () => {
+    const podmanDownload = new TestPodmanDownload(podman5JSON, true);
+    // check called with the correct parameters
+    const artifactsToDownload = podmanDownload.getArtifactsToDownload();
+    artifactsToDownload.forEach(artifact => {
+      expect(artifact.version).not.toMatch(/\s/);
+      expect(artifact.artifactName).not.toMatch(/\s/);
+      expect(artifact.downloadName).not.toMatch(/\s/);
+    });
   });
 });
 

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -27,10 +27,10 @@ import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { Octokit } from 'octokit';
 
 const mockedPodman5 = {
-  version: '5.6.1',
+  version: '5.0.0',
   platform: {
     win32: {
-      version: 'v5.6.1',
+      version: 'v5.0.0',
       arch: {
         x64: {
           fileName: 'podman-installer-windows-amd64.exe',
@@ -41,16 +41,16 @@ const mockedPodman5 = {
       },
     },
     darwin: {
-      version: 'v5.6.1',
+      version: 'v5.0.0',
       arch: {
         x64: {
-          fileName: 'podman-installer-macos-amd64-v5.6.1.pkg',
+          fileName: 'podman-installer-macos-amd64-v5.0.0.pkg',
         },
         arm64: {
-          fileName: 'podman-installer-macos-aarch64-v5.6.1.pkg',
+          fileName: 'podman-installer-macos-aarch64-v5.0.0.pkg',
         },
         universal: {
-          fileName: 'podman-installer-macos-universal-v5.6.1.pkg',
+          fileName: 'podman-installer-macos-universal-v5.0.0.pkg',
         },
       },
     },
@@ -159,20 +159,20 @@ describe('macOS platform', () => {
     // check called with the correct parameters
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       1,
-      'v5.6.1',
-      'podman-installer-macos-amd64-v5.6.1.pkg',
+      'v5.0.0',
+      'podman-installer-macos-amd64-v5.0.0.pkg',
       'podman-installer-macos-amd64.pkg',
     );
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       2,
-      'v5.6.1',
-      'podman-installer-macos-aarch64-v5.6.1.pkg',
+      'v5.0.0',
+      'podman-installer-macos-aarch64-v5.0.0.pkg',
       'podman-installer-macos-arm64.pkg',
     );
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       3,
-      'v5.6.1',
-      'podman-installer-macos-universal-v5.6.1.pkg',
+      'v5.0.0',
+      'podman-installer-macos-universal-v5.0.0.pkg',
       'podman-installer-macos-universal.pkg',
     );
   });
@@ -250,7 +250,7 @@ describe('windows platform', () => {
     // check called with the correct parameters
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       1,
-      'v5.6.1',
+      'v5.0.0',
       'podman-installer-windows-amd64.exe',
       'podman-installer-windows-amd64.exe',
     );
@@ -258,7 +258,7 @@ describe('windows platform', () => {
     // check called with the correct parameters for arm64 installer
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       2,
-      'v5.6.1',
+      'v5.0.0',
       'podman-installer-windows-arm64.exe',
       'podman-installer-windows-arm64.exe',
     );

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -27,13 +27,13 @@ import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { Octokit } from 'octokit';
 
 const mockedPodman5 = {
-  version: '5.6.0',
+  version: '5.6.1',
   platform: {
     win32: {
-      version: 'v5.6.0',
+      version: 'v5.6.1',
       arch: {
         x64: {
-          fileName: 'podman-5.6.0-setup.exe',
+          fileName: 'podman-installer-windows-amd64.exe',
         },
         arm64: {
           fileName: 'podman-installer-windows-arm64.exe',
@@ -41,16 +41,16 @@ const mockedPodman5 = {
       },
     },
     darwin: {
-      version: 'v5.6.0',
+      version: 'v5.6.1',
       arch: {
         x64: {
-          fileName: 'podman-installer-macos-amd64-v5.6.0.pkg',
+          fileName: 'podman-installer-macos-amd64-v5.6.1.pkg',
         },
         arm64: {
-          fileName: 'podman-installer-macos-aarch64-v5.6.0.pkg',
+          fileName: 'podman-installer-macos-aarch64-v5.6.1.pkg',
         },
         universal: {
-          fileName: 'podman-installer-macos-universal-v5.6.0.pkg',
+          fileName: 'podman-installer-macos-universal-v5.6.1.pkg',
         },
       },
     },
@@ -159,20 +159,20 @@ describe('macOS platform', () => {
     // check called with the correct parameters
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       1,
-      'v5.6.0',
-      'podman-installer-macos-amd64-v5.6.0.pkg',
+      'v5.6.1',
+      'podman-installer-macos-amd64-v5.6.1.pkg',
       'podman-installer-macos-amd64.pkg',
     );
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       2,
-      'v5.6.0',
-      'podman-installer-macos-aarch64-v5.6.0.pkg',
+      'v5.6.1',
+      'podman-installer-macos-aarch64-v5.6.1.pkg',
       'podman-installer-macos-arm64.pkg',
     );
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       3,
-      'v5.6.0',
-      'podman-installer-macos-universal-v5.6.0.pkg',
+      'v5.6.1',
+      'podman-installer-macos-universal-v5.6.1.pkg',
       'podman-installer-macos-universal.pkg',
     );
   });
@@ -220,8 +220,8 @@ describe('windows platform', () => {
     // check called with the correct parameters
     expect(downloadAndCheckShaSpy).toHaveBeenCalledWith(
       expect.stringContaining('v5.6'),
-      expect.stringContaining('podman-5.6.0-setup.exe'),
-      'podman-5.6.0-setup.exe',
+      expect.stringContaining('podman-installer-windows-amd64.exe'),
+      'podman-installer-windows-amd64.exe',
     );
     expect(downloadAndCheckShaSpy).toHaveBeenCalledWith(
       expect.stringContaining('v5.6'),
@@ -250,15 +250,15 @@ describe('windows platform', () => {
     // check called with the correct parameters
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       1,
-      'v5.6.0',
-      'podman-5.6.0-setup.exe',
-      'podman-5.6.0-setup.exe',
+      'v5.6.1',
+      'podman-installer-windows-amd64.exe',
+      'podman-installer-windows-amd64.exe',
     );
 
     // check called with the correct parameters for arm64 installer
     expect(downloadAndCheckShaSpy).toHaveBeenNthCalledWith(
       2,
-      'v5.6.0',
+      'v5.6.1',
       'podman-installer-windows-arm64.exe',
       'podman-installer-windows-arm64.exe',
     );

--- a/extensions/podman/packages/extension/scripts/podman-download.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.ts
@@ -101,13 +101,13 @@ export class PodmanDownload {
 
     if (this.#platform === 'win32') {
       const tagVersion = podmanJSON.platform.win32.version;
-      const downloadNameAmd64 = podmanJSON.platform.win32.arch.x64.fileName.trim();
+      const downloadNameAmd64 = podmanJSON.platform.win32.arch.x64.fileName;
       this.#artifactsToDownload.push({
         version: tagVersion,
         downloadName: downloadNameAmd64,
         artifactName: 'podman-installer-windows-amd64.exe',
       });
-      const downloadNameArm64 = podmanJSON.platform.win32.arch.arm64.fileName.trim();
+      const downloadNameArm64 = podmanJSON.platform.win32.arch.arm64.fileName;
       this.#artifactsToDownload.push({
         version: tagVersion,
         downloadName: downloadNameArm64,
@@ -115,14 +115,14 @@ export class PodmanDownload {
       });
     } else if (this.#platform === 'darwin') {
       const tagVersion = podmanJSON.platform.darwin.version;
-      const downloadNameAmd64 = podmanJSON.platform.darwin.arch.x64.fileName.trim();
+      const downloadNameAmd64 = podmanJSON.platform.darwin.arch.x64.fileName;
       this.#artifactsToDownload.push({
         version: tagVersion,
         downloadName: downloadNameAmd64,
         artifactName: 'podman-installer-macos-amd64.pkg',
       });
 
-      const downloadNameArm64 = podmanJSON.platform.darwin.arch.arm64.fileName.trim();
+      const downloadNameArm64 = podmanJSON.platform.darwin.arch.arm64.fileName;
       this.#artifactsToDownload.push({
         version: tagVersion,
         downloadName: downloadNameArm64,
@@ -130,7 +130,7 @@ export class PodmanDownload {
       });
 
       if (podmanJSON.platform.darwin.arch.universal) {
-        const downloadUniversalName = podmanJSON.platform.darwin.arch.universal.fileName.trim();
+        const downloadUniversalName = podmanJSON.platform.darwin.arch.universal.fileName;
         this.#artifactsToDownload.push({
           version: tagVersion,
           downloadName: downloadUniversalName,

--- a/extensions/podman/packages/extension/scripts/podman-download.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.ts
@@ -75,7 +75,10 @@ export class PodmanDownload {
     podmanJSON: {
       version: string;
       platform: {
-        win32: { version: string; fileName: string };
+        win32: {
+          version: string;
+          arch: { x64: { fileName: string }; arm64: { fileName: string } };
+        };
         darwin: {
           version: string;
           arch: { x64: { fileName: string }; arm64: { fileName: string }; universal?: { fileName: string } };
@@ -98,11 +101,17 @@ export class PodmanDownload {
 
     if (this.#platform === 'win32') {
       const tagVersion = podmanJSON.platform.win32.version;
-      const downloadName = podmanJSON.platform.win32.fileName;
+      const downloadName = podmanJSON.platform.win32.arch.x64.fileName;
       this.#artifactsToDownload.push({
         version: tagVersion,
-        downloadName,
+        downloadName: downloadName,
         artifactName: `podman-${this.#podmanVersion}-setup.exe`,
+      });
+      const downloadNameArm64 = podmanJSON.platform.win32.arch.arm64.fileName;
+      this.#artifactsToDownload.push({
+        version: tagVersion,
+        downloadName: downloadNameArm64,
+        artifactName: 'podman-installer-windows-arm64.exe',
       });
     } else if (this.#platform === 'darwin') {
       const tagVersion = podmanJSON.platform.darwin.version;

--- a/extensions/podman/packages/extension/scripts/podman-download.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.ts
@@ -101,13 +101,13 @@ export class PodmanDownload {
 
     if (this.#platform === 'win32') {
       const tagVersion = podmanJSON.platform.win32.version;
-      const downloadName = podmanJSON.platform.win32.arch.x64.fileName;
+      const downloadNameAmd64 = podmanJSON.platform.win32.arch.x64.fileName.trim();
       this.#artifactsToDownload.push({
         version: tagVersion,
-        downloadName: downloadName,
-        artifactName: `podman-${this.#podmanVersion}-setup.exe`,
+        downloadName: downloadNameAmd64,
+        artifactName: 'podman-installer-windows-amd64.exe',
       });
-      const downloadNameArm64 = podmanJSON.platform.win32.arch.arm64.fileName;
+      const downloadNameArm64 = podmanJSON.platform.win32.arch.arm64.fileName.trim();
       this.#artifactsToDownload.push({
         version: tagVersion,
         downloadName: downloadNameArm64,
@@ -115,14 +115,14 @@ export class PodmanDownload {
       });
     } else if (this.#platform === 'darwin') {
       const tagVersion = podmanJSON.platform.darwin.version;
-      const downloadNameAmd64 = podmanJSON.platform.darwin.arch.x64.fileName;
+      const downloadNameAmd64 = podmanJSON.platform.darwin.arch.x64.fileName.trim();
       this.#artifactsToDownload.push({
         version: tagVersion,
         downloadName: downloadNameAmd64,
         artifactName: 'podman-installer-macos-amd64.pkg',
       });
 
-      const downloadNameArm64 = podmanJSON.platform.darwin.arch.arm64.fileName;
+      const downloadNameArm64 = podmanJSON.platform.darwin.arch.arm64.fileName.trim();
       this.#artifactsToDownload.push({
         version: tagVersion,
         downloadName: downloadNameArm64,
@@ -130,7 +130,7 @@ export class PodmanDownload {
       });
 
       if (podmanJSON.platform.darwin.arch.universal) {
-        const downloadUniversalName = podmanJSON.platform.darwin.arch.universal.fileName;
+        const downloadUniversalName = podmanJSON.platform.darwin.arch.universal.fileName.trim();
         this.#artifactsToDownload.push({
           version: tagVersion,
           downloadName: downloadUniversalName,

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -17,6 +17,7 @@
  ********************************************************************/
 
 import fs from 'node:fs';
+import { arch } from 'node:os';
 import path from 'node:path';
 
 import type { ExtensionContext, InstallCheck, RunError, TelemetryLogger } from '@podman-desktop/api';
@@ -70,7 +71,10 @@ export class WinInstaller extends BaseInstaller {
   install(): Promise<boolean> {
     return window.withProgress({ location: ProgressLocation.APP_ICON }, async progress => {
       progress.report({ increment: 5 });
-      const setupPath = path.resolve(getAssetsFolder(), `podman-${getBundledPodmanVersion()}-setup.exe`);
+      let setupPath = path.resolve(getAssetsFolder(), `podman-${getBundledPodmanVersion()}-setup.exe`);
+      if (arch() === 'arm64') {
+        setupPath = path.resolve(getAssetsFolder(), `podman-installer-windows-arm64.exe`);
+      }
       try {
         if (fs.existsSync(setupPath)) {
           try {

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -75,7 +75,7 @@ export class WinInstaller extends BaseInstaller {
         arch() === 'arm64'
           ? podman5Json.platform.win32.arch.arm64.fileName
           : podman5Json.platform.win32.arch.x64.fileName;
-      const setupPath = path.resolve(getAssetsFolder(), `${fileName}`);
+      const setupPath = path.resolve(getAssetsFolder(), fileName);
       try {
         if (fs.existsSync(setupPath)) {
           try {

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -31,7 +31,7 @@ import { WinMemoryCheck } from '../checks/win-memory-check';
 import { WinVersionCheck } from '../checks/win-version-check';
 import { WSLVersionCheck } from '../checks/wsl-version-check';
 import { WSL2Check } from '../checks/wsl2-check';
-import { getBundledPodmanVersion } from '../utils/podman-bundled';
+import podman5Json from '../podman5.json';
 import { getAssetsFolder } from '../utils/util';
 import { BaseInstaller } from './base-installer';
 
@@ -71,10 +71,11 @@ export class WinInstaller extends BaseInstaller {
   install(): Promise<boolean> {
     return window.withProgress({ location: ProgressLocation.APP_ICON }, async progress => {
       progress.report({ increment: 5 });
-      let setupPath = path.resolve(getAssetsFolder(), `podman-${getBundledPodmanVersion()}-setup.exe`);
-      if (arch() === 'arm64') {
-        setupPath = path.resolve(getAssetsFolder(), `podman-installer-windows-arm64.exe`);
-      }
+      const fileName =
+        arch() === 'arm64'
+          ? podman5Json.platform.win32.arch.arm64.fileName
+          : podman5Json.platform.win32.arch.x64.fileName;
+      const setupPath = path.resolve(getAssetsFolder(), `${fileName}`);
       try {
         if (fs.existsSync(setupPath)) {
           try {

--- a/extensions/podman/packages/extension/src/podman5.json
+++ b/extensions/podman/packages/extension/src/podman5.json
@@ -8,7 +8,7 @@
       "version": "v5.6.1",
       "arch": {
         "x64": {
-          "fileName": " podman-5.6.1-setup.exe"
+          "fileName": "podman-installer-windows-amd64.exe"
         },
         "arm64": {
           "fileName": "podman-installer-windows-arm64.exe"

--- a/extensions/podman/packages/extension/src/podman5.json
+++ b/extensions/podman/packages/extension/src/podman5.json
@@ -6,7 +6,14 @@
   "platform": {
     "win32": {
       "version": "v5.6.1",
-      "fileName": "podman-5.6.1-setup.exe"
+      "arch": {
+        "x64": {
+          "fileName": " podman-5.6.1-setup.exe"
+        },
+        "arm64": {
+          "fileName": " podman-installer-windows-arm64.exe"
+        }
+      }
     },
     "darwin": {
       "version": "v5.6.1",

--- a/extensions/podman/packages/extension/src/podman5.json
+++ b/extensions/podman/packages/extension/src/podman5.json
@@ -11,7 +11,7 @@
           "fileName": " podman-5.6.1-setup.exe"
         },
         "arm64": {
-          "fileName": " podman-installer-windows-arm64.exe"
+          "fileName": "podman-installer-windows-arm64.exe"
         }
       }
     },

--- a/tests/playwright/src/special-specs/installation/podman-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/podman-install.spec.ts
@@ -21,7 +21,11 @@ import path from 'node:path';
 
 import { NavigationBar } from '../..';
 import { expect as playExpect, test } from '../../utility/fixtures';
+<<<<<<< HEAD
 import { isCI, isLinux, isMac, isWindows } from '../../utility/platform';
+=======
+import { isLinux, isMac, isWindows } from '../../utility/platform';
+>>>>>>> 3d82f10c028 (chore(test): include e2e tests for podman installer assets)
 
 test.skip(isLinux, 'Podman installation is not supported on Linux');
 
@@ -46,10 +50,13 @@ test.afterAll(async ({ runner }) => {
 
 test.describe.serial('Podman installer integration in Podman Desktop', { tag: '@update-install' }, () => {
   test('Dashboard Podman provider card assets check', async ({ page }) => {
+<<<<<<< HEAD
     test.skip(
       !isCI || process.env.GITHUB_ACTIONS !== 'true' || isLinux,
       'Only run on macOS and Windows in GitHub Actions',
     );
+=======
+>>>>>>> 3d82f10c028 (chore(test): include e2e tests for podman installer assets)
     const dashboardPage = await new NavigationBar(page).openDashboard();
     await playExpect(dashboardPage.heading).toBeVisible();
     await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: 25_000 });

--- a/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
+++ b/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
@@ -21,11 +21,7 @@ import path from 'node:path';
 
 import { NavigationBar } from '../..';
 import { expect as playExpect, test } from '../../utility/fixtures';
-<<<<<<< HEAD
 import { isCI, isLinux, isMac, isWindows } from '../../utility/platform';
-=======
-import { isLinux, isMac, isWindows } from '../../utility/platform';
->>>>>>> 3d82f10c028 (chore(test): include e2e tests for podman installer assets)
 
 test.skip(isLinux, 'Podman installation is not supported on Linux');
 
@@ -50,13 +46,10 @@ test.afterAll(async ({ runner }) => {
 
 test.describe.serial('Podman installer integration in Podman Desktop', { tag: '@update-install' }, () => {
   test('Dashboard Podman provider card assets check', async ({ page }) => {
-<<<<<<< HEAD
     test.skip(
       !isCI || process.env.GITHUB_ACTIONS !== 'true' || isLinux,
       'Only run on macOS and Windows in GitHub Actions',
     );
-=======
->>>>>>> 3d82f10c028 (chore(test): include e2e tests for podman installer assets)
     const dashboardPage = await new NavigationBar(page).openDashboard();
     await playExpect(dashboardPage.heading).toBeVisible();
     await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: 25_000 });
@@ -75,7 +68,7 @@ test.describe.serial('Podman installer integration in Podman Desktop', { tag: '@
     // x64 = amd64 for both windows and mac, arm64 = arm64 for win, and aarch64 for mac
     const archPart = process.arch === 'x64' ? 'amd64' : process.arch === 'arm64' ? (isMac ? 'aarch64' : 'arm64') : null;
     playExpect(archPart, { message: `Unsupported architecture: ${process.arch}` }).not.toBeNull();
-    const podmanInstallerFilePrefix = `podman-${isWindows ? '.*' : 'installer-macos'}`;
+    const podmanInstallerFilePrefix = `podman-${isWindows ? 'installer-windows' : 'installer-macos'}`;
     console.log(
       `Trying to find podman installer artifact: ${podmanInstallerFilePrefix}-${archPart}.${fileFormatRegexp}`,
     );
@@ -99,9 +92,9 @@ test.describe.serial('Podman installer integration in Podman Desktop', { tag: '@
     const files = await fs.promises.readdir(podmanAssetsPath);
     const findFiles = files.filter(file => new RegExp(`^${podmanInstallerFilePrefix}.*$`).exec(file));
     console.log(`Files found: ${findFiles}`);
-    // windows file check: "podman-installer-windows-arch.exe" or podman-5.6.1-setup.exe,
-    // on mac: "podman-installer-macos-(universal|arch-*.pkg"
-    const architecturePattern = isMac ? `(universal|${archPart})-.*` : `(setup|installer-windows-${archPart}).*`;
+    // windows file check: "podman-installer-windows-archXX.exe",
+    // on mac: "podman-installer-macos-(universal|archXX)-version.pkg"
+    const architecturePattern = isMac ? `(universal|${archPart})-.*` : `${archPart}.*`;
     playExpect(findFiles[0]).toMatch(
       new RegExp(`${podmanInstallerFilePrefix}-${architecturePattern}\\.${fileFormatRegexp}`),
     );

--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,7 +147,7 @@ test.describe.serial('Podman Desktop Update installation', { tag: '@update-insta
   // Running the test to make sure we download correct architecture of the installer file
   // setup.exe should contain both installers (for x64 and arm64) so that option is always valid
   // or depending on what process.arch returns
-  test(`Correct installer file is downloaded for ${process.arch} architecture during update`, async () => {
+  test(`Correct Podman Desktop installer file is downloaded for ${process.arch} architecture during update`, async () => {
     test.skip(isLinux, 'This test runs only on Windows and Mac platform');
     const fileFormatRegexp = isWindows ? 'exe' : 'zip|dmg';
     const generalInstallerPattern = isWindows ? 'setup' : 'universal';


### PR DESCRIPTION
### What does this PR do?
It include arm based podman installer in podman desktop. It is more of a proposal, I am not sure if it is gonna work correctly. 
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#12467 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Take built artifacts from this PR and try to check if the correct installer is present. Also, would require arm-based windows to test locally. ~We do not have tests yet.~

After enabling test in `extensions/podman/extension/scripts/` there is now unit test checking `podman-download` module, which should include also test for arm based installer.

And eventually e2e tests were added as well.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
