### PR TITLE
test(e2e): revert hotfix in pr check

### DIFF
--- a/tests/playwright/src/model/pages/welcome-page.ts
+++ b/tests/playwright/src/model/pages/welcome-page.ts
@@ -68,13 +68,8 @@ export class WelcomePage extends BasePage {
 
   async turnOffTelemetry(): Promise<void> {
     return test.step('Turn off Telemetry', async () => {
-      const isUpdateTest = test.info().tags.includes('@update-install');
-
-      if (!isUpdateTest) {
-        // Extensions load sequentially (faster speed but can block ui)
-        // Each extension timeout is 20s use 60s to provide a decent bufffer
-        await playExpect(this.startOnboarding).toBeEnabled({ timeout: 60_000 });
-      }
+      // Extensions load sequentially (faster speed but can block ui)
+      await playExpect(this.startOnboarding).toBeEnabled({ timeout: 20_000 });
 
       if (await this.telemetryConsent.isChecked()) {
         await playExpect(this.telemetryConsent).toBeChecked();


### PR DESCRIPTION
### What does this PR do?
This PR reverts a hotfix introduced in https://github.com/podman-desktop/podman-desktop/commit/34ed20a28eee092503fa6a6d0e22fadcc2514467 so that pr-check did not break during @update-install PRs. This was supposedly fixed in https://github.com/podman-desktop/podman-desktop/commit/15a0a6a2105d8be39b3db449d18c41e4c5eb9a90 so in theory it should be fine to get it back to the original version. Through this PR I'll check that.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/e2e/issues/372
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
