### PR TITLE
fix(ui): adding missing mandatory children prop in Link.spec.ts

### DIFF
--- a/packages/ui/src/lib/link/Link.spec.ts
+++ b/packages/ui/src/lib/link/Link.spec.ts
@@ -22,9 +22,16 @@ import '@testing-library/jest-dom/vitest';
 
 import { faRocket } from '@fortawesome/free-solid-svg-icons';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
 import { expect, test, vi } from 'vitest';
 
 import Link from './Link.svelte';
+
+const SNIPPET_MOCK = createRawSnippet(() => {
+  return {
+    render: (): string => 'hello',
+  };
+});
 
 test('Check link styling', async () => {
   render(Link);
@@ -38,7 +45,7 @@ test('Check link styling', async () => {
 });
 
 test('Check icon styling', async () => {
-  render(Link, { icon: faRocket });
+  render(Link, { icon: faRocket, children: SNIPPET_MOCK });
 
   // check for the fa SVG child
   const link = screen.getByRole('link', { hidden: true });
@@ -50,7 +57,7 @@ test('Check icon styling', async () => {
 
 test('Check on:click action', async () => {
   const clickMock = vi.fn();
-  render(Link, { onclick: clickMock });
+  render(Link, { onclick: clickMock, children: SNIPPET_MOCK });
 
   // check on:click
   const link = screen.getByRole('link');


### PR DESCRIPTION
### What does this PR do?

Fixes one of the errors raised by `svelte-check --tsconfig=packages/ui/tsconfig.json`. 

> The errors occurred because tsc does not catch the type of Svelte Component, and svelte-check is misconfigured. (See https://github.com/podman-desktop/podman-desktop/pull/13903#issuecomment-3278928900 for full details)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/13912

### How to test this PR?

You can check that  `svelte-check --tsconfig=packages/ui/tsconfig.json` the `Link.spec.ts` file raise some type error before this PR, and don't after this PR.
