### PR TITLE
chore(build): refactor electron-builder config

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -80,6 +80,7 @@ const config = {
   npmRebuild: false,
   beforePack: async context => {
     const DEFAULT_ASSETS = [];
+    const PODMAN_EXTENSION_ASSETS = 'extensions/podman/packages/extension/assets';
     context.packager.config.extraResources = DEFAULT_ASSETS;
 
     // universal build, add both pkg files
@@ -89,24 +90,18 @@ const config = {
       context.appOutDir.endsWith('mac-universal-arm64-temp')
     ) {
       context.packager.config.extraResources = DEFAULT_ASSETS;
-      context.packager.config.extraResources.push(
-        'extensions/podman/packages/extension/assets/podman-installer-macos-universal*.pkg',
-      );
+      context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-installer-macos-universal*.pkg`);
       return;
     }
 
     if (context.arch === Arch.arm64 && context.electronPlatformName === 'darwin') {
-      context.packager.config.extraResources.push(
-        'extensions/podman/packages/extension/assets/podman-installer-macos-aarch64-*.pkg',
-      );
-      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-arm64.zst');
+      context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-installer-macos-aarch64-*.pkg`);
+      context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-arm64.zst`);
     }
 
     if (context.arch === Arch.x64 && context.electronPlatformName === 'darwin') {
-      context.packager.config.extraResources.push(
-        'extensions/podman/packages/extension/assets/podman-installer-macos-amd64-*.pkg',
-      );
-      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-x64.zst');
+      context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-installer-macos-amd64-*.pkg`);
+      context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-x64.zst`);
     }
 
     if (context.electronPlatformName === 'win32') {
@@ -116,13 +111,13 @@ const config = {
         to: 'win-ca/roots.exe',
       });
       // add podman installer
-      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-*.exe');
-    }
-    if (context.arch === Arch.x64 && context.electronPlatformName === 'win32') {
-      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-x64.zst');
-    }
-    if (context.arch === Arch.arm64 && context.electronPlatformName === 'win32') {
-      context.packager.config.extraResources.push('extensions/podman/packages/extension/assets/podman-image-arm64.zst');
+      context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-*.exe`);
+      if (context.arch === Arch.x64) {
+        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-x64.zst`);
+      }
+      if (context.arch === Arch.arm64) {
+        context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-arm64.zst`);
+      }
     }
   },
   afterPack: async context => {


### PR DESCRIPTION
### What does this PR do?
Refactors electron builder config. Introduces shared part of the podman assets and improves shared if for win32 platform.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#13949 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
After #13948 is merged, we should see `extensions/podman/extension/script/podman-download.spec.ts` to be passing on unit tests.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
