### PR TITLE
feat(ui): make Input component exposes type in props

### DIFF
--- a/packages/ui/src/lib/inputs/Input.spec.ts
+++ b/packages/ui/src/lib/inputs/Input.spec.ts
@@ -21,7 +21,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import Input from './Input.svelte';
 
@@ -160,4 +160,25 @@ test('Expect inputClass styling', async () => {
   const element = screen.getByRole('textbox');
   expect(element).toBeInTheDocument();
   expect(element).toHaveClass(thisClass);
+});
+
+describe('input#type', () => {
+  test('default type should be text', () => {
+    const { getByTitle } = render(Input, {
+      title: 'potatoes',
+    });
+
+    const textbox = getByTitle('potatoes');
+    expect(textbox).toHaveAttribute('type', 'text');
+  });
+
+  test('expect type props to be propagated to input element', () => {
+    const { getByTitle } = render(Input, {
+      type: 'password',
+      title: 'potatoes',
+    });
+
+    const textbox = getByTitle('potatoes');
+    expect(textbox).toHaveAttribute('type', 'password');
+  });
 });

--- a/packages/ui/src/lib/inputs/Input.svelte
+++ b/packages/ui/src/lib/inputs/Input.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { faCircleExclamation, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { createEventDispatcher, type Snippet } from 'svelte';
-import type { Booleanish, FormEventHandler, KeyboardEventHandler } from 'svelte/elements';
+import type { Booleanish, FormEventHandler, HTMLInputTypeAttribute, KeyboardEventHandler } from 'svelte/elements';
 import { createBubbler } from 'svelte/legacy';
 
 import Icon from '../icons/Icon.svelte';
@@ -30,6 +30,7 @@ interface Props {
   oninput?: FormEventHandler<HTMLInputElement>;
   onkeypress?: KeyboardEventHandler<HTMLInputElement>;
   title?: string;
+  type?: HTMLInputTypeAttribute;
 }
 
 let {
@@ -53,6 +54,7 @@ let {
   oninput = bubble('input'),
   onkeypress = bubble('keypress'),
   title = '',
+  type = 'text',
 }: Props = $props();
 
 let enabled = $derived(!readonly && !disabled);
@@ -95,7 +97,7 @@ async function onClear(): Promise<void> {
       class:group-focus-within:bg-[var(--pd-input-field-hover-bg)]={enabled}
       class:group-hover-placeholder:text-[color:var(--pd-input-field-placeholder-text)]={enabled}
       {name}
-      type="text"
+      type={type}
       {disabled}
       {readonly}
       {required}


### PR DESCRIPTION
### What does this PR do?

Make our svelte Input component exposes the `type` attribute through the props to allow later, other component to set it properly (E.g. PasswordInput). See details in https://github.com/podman-desktop/podman-desktop/issues/13952#issue-3422852664

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13952

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
