### PR TITLE
fix: wrong string for navigation when image has no name

### DIFF
--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -189,3 +189,23 @@ test('Expect clicking works for manifests', async () => {
   fireEvent.click(text);
   expect(routerGotoSpy).toBeCalledWith('/manifests/my-image/podman/bXktaW1hZ2UtbmFtZTpsYXRlc3Q=/summary');
 });
+
+test('Expect clicking works for images without tag (empty tag)', async () => {
+  const imageWithoutTag: ImageInfoUI = {
+    ...image,
+    name: 'my-untagged-image',
+    tag: '',
+    base64RepoTag: 'bXktdW50YWdnZWQtaW1hZ2U=', // base64 of 'my-untagged-image'
+  };
+  render(ImageColumnName, { object: imageWithoutTag });
+
+  const text = screen.getByText('my-untagged-image');
+  expect(text).toBeInTheDocument();
+
+  // test click - should use only the name when tag is empty
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+  fireEvent.click(text);
+
+  // Should navigate with just the name, when tag is empty
+  expect(routerGotoSpy).toBeCalledWith('/images/my-image/podman/bXktdW50YWdnZWQtaW1hZ2U=/summary');
+});

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -14,7 +14,7 @@ let { object }: Props = $props();
 function openDetails(image: ImageInfoUI): void {
   handleNavigation({
     page: image.isManifest ? NavigationPage.MANIFEST : NavigationPage.IMAGE,
-    parameters: { id: image.id, engineId: image.engineId, tag: image.name + ':' + image.tag },
+    parameters: { id: image.id, engineId: image.engineId, tag: image.tag ? `${image.name}:${image.tag}` : image.name },
   });
 }
 </script>


### PR DESCRIPTION
### What does this PR do?

When navigating to ImageDetails for images without tags, the tag parameter was incorrectly set as "imageName:" instead of just "imageName", causing a base64RepoTag mismatch that prevented the component from finding the image.

### Screenshot / video of UI

### What issues does this PR fix or reference?

closes #13730 

### How to test this PR?

1. Create image manifest (dockerfile: FROM ghcr.io/linuxcontainers/alpine)
2. Build an image using this dockerfile
3. Fill in the name
4. Pick up to build for multiple platforms (x86_64, arm64)
5. Check that Image manifest was successfully built
6. Open one of the specific platform image details
7. Details page must be shown

- [ ] Tests are covering the bug fix or the new feature
