### PR TITLE
fix(podman): display path for multiple installation of podman

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.ts
@@ -24,7 +24,7 @@ const macosExtraPath = '/opt/podman/bin:/usr/local/bin:/opt/homebrew/bin:/opt/lo
  * Finds all installations of podman in the system PATH (Windows, macOS, Linux)
  * @returns Array of unique podman installation paths found
  */
-async function findPodmanInstallations(): Promise<string[]> {
+export async function findPodmanInstallations(): Promise<string[]> {
   try {
     let result: extensionApi.RunResult;
     if (extensionApi.env.isWindows) {
@@ -40,7 +40,8 @@ async function findPodmanInstallations(): Promise<string[]> {
       result.stdout
         .trim()
         .split('\n')
-        .filter(line => line.trim().length > 0),
+        .filter(line => line.trim().length > 0)
+        .map(line => line.replace(/podman is /g, '')),
     );
     return Array.from(uniqueLines);
   } catch (error) {
@@ -97,15 +98,4 @@ export async function getPodmanInstallation(): Promise<InstalledPodman | undefin
     // no podman binary
     return undefined;
   }
-}
-
-// Checks if there are more than one version of podman installed (Windows, macOS, Linux)
-export async function isMultiplePodmanInstalled(): Promise<boolean> {
-  // Checks if custom binary path is set. If so, we don't need to check for multiple installations.
-  if (getCustomBinaryPath()) {
-    return false;
-  }
-  const installations = await findPodmanInstallations();
-  // If there are 2 or more unique installations, return true
-  return installations.length > 1;
 }

--- a/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
 import type { ProviderInfo } from '/@api/provider-info';
 
 import { providerInfos } from '../../stores/providers';
@@ -18,9 +21,11 @@ $: {
     {#each providerInfo.warnings as warn, index (index)}
       <div class="flex-row items-center align-middle mt-0.5" role="listitem" aria-label={warn.name}>
         <!-- Make line height center-->
-        <span class="ml-1 text-[var(--pd-content-text)]">⚠</span>
-        <span class="ml-1 text-[var(--pd-content-text)]">{warn.name}:</span>
-        <span class="ml-1 text-[var(--pd-content-text)]">{warn.details}</span>
+        <span class="ml-1 text-[var(--pd-content-card-text)]">
+          <Icon icon={faTriangleExclamation} class="text-[var(--pd-state-warning)] inline" /> {warn.name}:</span>
+        <div class="ml-1 text-[var(--pd-content-text)]">
+          {warn.details}
+        </div>
       </div>
     {/each}
   </div>


### PR DESCRIPTION
### What does this PR do?
This PR changes the current implementation of warning for multiple podman installations to also show paths to the detected executables.

The list of changes:

- Changes the wording to be more precise - detected "installation" may not always be correct, it's better to say the executable was found in the PATH.
- Includes all executables in the warning 
- Allows usage of markdown in provider warnings
- Minor visual improvement


### Screenshot / video of UI

Before:
<img width="1200" height="163" alt="image" src="https://github.com/user-attachments/assets/a70360ee-253f-4b1e-8f00-69ad887f4c3e" />

After:
<img width="1177" height="163" alt="image" src="https://github.com/user-attachments/assets/27dea257-f802-48ad-ab30-1608b4c44eb7" />

### What issues does this PR fix or reference?

Closes #13754
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
