### PR TITLE
chore(test): enable openshiftDockerExtension test

### DIFF
--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -35,7 +35,6 @@ import { SettingsBar } from '../model/pages/settings-bar';
 import { WelcomePage } from '../model/pages/welcome-page';
 import { NavigationBar } from '../model/workbench/navigation';
 import { Runner } from '../runner/podman-desktop-runner';
-import { isWindows } from '../utility/platform';
 
 let pdRunner: Runner;
 let page: Page;
@@ -65,8 +64,6 @@ for (const {
   extensionFullName,
 } of extensionsInstallationSmokeList) {
   test.describe.serial(`Extension installation for ${extensionName}`, { tag: '@smoke' }, () => {
-    test.skip(extensionName === openshiftDockerExtension.extensionName && !!isWindows); // Currently timing out in azure cicd https://github.com/podman-desktop/e2e/issues/396
-
     test.beforeAll(async () => {
       await _startup(extensionLabel);
     });


### PR DESCRIPTION
### What does this PR do?
Enable openshiftDockerExtension installation test.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes [396](https://github.com/podman-desktop/e2e/issues/396)
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Tested for:
- hyperv https://github.com/podman-desktop/e2e/actions/runs/17850906461
- wsl https://github.com/podman-desktop/e2e/actions/runs/17850853364
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
