### PR TITLE
chore: add a next identifier

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -56,7 +56,7 @@ jobs:
             PODMAN_DEKSTOP_VERSION=$(jq -r '.version' package.json)
             # remove the -next from the version
             STRIPPED_VERSION=${PODMAN_DEKSTOP_VERSION%-next}
-            TAG_PATTERN=${STRIPPED_VERSION}-$(date +'%Y%m%d%H%M')-${SHORT_SHA1}
+            TAG_PATTERN=${STRIPPED_VERSION}-next.$(date +'%Y%m%d%H%M')-${SHORT_SHA1}
             echo "githubTag=v$TAG_PATTERN" >> ${GITHUB_OUTPUT}
             echo "desktopVersion=$TAG_PATTERN" >> ${GITHUB_OUTPUT}
       - name: tag


### PR DESCRIPTION
### What does this PR do?
it should be seen as the first component release and electron updater takes the first component as the channel name
today the channel is the date+git commit so it's changing all the time

use it first else if added at the end, updater takes only the first one

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/10208

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
