### PR TITLE
chore: change configuration registry init to async

### DIFF
--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -16,9 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as fs from 'node:fs';
-
-import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '/@/plugin/api.js';
 import type { IConfigurationNode } from '/@api/configuration/models.js';
@@ -28,16 +26,34 @@ import { ConfigurationRegistry } from './configuration-registry.js';
 import type { Directories } from './directories.js';
 import type { NotificationRegistry } from './tasks/notification-registry.js';
 
+// mock the fs module
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  cpSync: vi.fn(),
+  promises: {
+    access: vi.fn(),
+    mkdir: vi.fn(),
+    writeFile: vi.fn(),
+    readFile: vi.fn(),
+    copyFile: vi.fn(),
+  },
+}));
+
+// Import fs after mocking
+const fs = await import('node:fs');
+
 let configurationRegistry: ConfigurationRegistry;
 
-// mock the fs methods
-const readFileSync = vi.spyOn(fs, 'readFileSync');
-const cpSync = vi.spyOn(fs, 'cpSync');
-const accessMock = vi.spyOn(fs.promises, 'access');
-const mkdirMock = vi.spyOn(fs.promises, 'mkdir');
-const writeFileMock = vi.spyOn(fs.promises, 'writeFile');
-const readFileMock = vi.spyOn(fs.promises, 'readFile');
-const copyFileMock = vi.spyOn(fs.promises, 'copyFile');
+// Access mocked functions
+const readFileSync = vi.mocked(fs.readFileSync);
+const writeFileSync = vi.mocked(fs.writeFileSync);
+const cpSync = vi.mocked(fs.cpSync);
+const accessMock = vi.mocked(fs.promises.access);
+const mkdirMock = vi.mocked(fs.promises.mkdir);
+const writeFileMock = vi.mocked(fs.promises.writeFile);
+const readFileMock = vi.mocked(fs.promises.readFile);
+const copyFileMock = vi.mocked(fs.promises.copyFile);
 
 const getConfigurationDirectoryMock = vi.fn();
 const directories = {
@@ -52,11 +68,6 @@ const notificationRegistry = {
 } as unknown as NotificationRegistry;
 
 let registerConfigurationsDisposable: IDisposable;
-
-beforeAll(() => {
-  // mock the fs module
-  vi.mock('node:fs');
-});
 
 beforeEach(async () => {
   vi.resetAllMocks();
@@ -361,8 +372,6 @@ test('should remove the object configuration if value is equal to default one', 
       },
     },
   };
-
-  const writeFileSync = vi.spyOn(fs, 'writeFileSync');
 
   configurationRegistry.registerConfigurations([node]);
 

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -22,6 +22,9 @@ import type { ApiSenderType } from '/@/plugin/api.js';
 import type { IConfigurationNode } from '/@api/configuration/models.js';
 import type { IDisposable } from '/@api/disposable.js';
 
+// Import to access mocked functionionalities such as using vi.mock (we don't want to actually call node:fs methods)
+import * as fs from 'node:fs';
+
 import { ConfigurationRegistry } from './configuration-registry.js';
 import type { Directories } from './directories.js';
 import type { NotificationRegistry } from './tasks/notification-registry.js';
@@ -39,9 +42,6 @@ vi.mock('node:fs', () => ({
     copyFile: vi.fn(),
   },
 }));
-
-// Import fs after mocking
-const fs = await import('node:fs');
 
 let configurationRegistry: ConfigurationRegistry;
 

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
+import { promises as fsPromises } from 'node:fs';
 import * as path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 
@@ -76,19 +77,17 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     return path.resolve(this.directories.getConfigurationDirectory(), 'settings.json');
   }
 
-  public init(): NotificationCardOptions[] {
+  public async init(): Promise<NotificationCardOptions[]> {
     const notifications: NotificationCardOptions[] = [];
 
     const settingsFile = this.getSettingsFile();
     const parentDirectory = path.dirname(settingsFile);
-    if (!fs.existsSync(parentDirectory)) {
-      fs.mkdirSync(parentDirectory, { recursive: true });
-    }
-    if (!fs.existsSync(settingsFile)) {
-      fs.writeFileSync(settingsFile, JSON.stringify({}));
-    }
 
-    const settingsRawContent = fs.readFileSync(settingsFile, 'utf-8');
+    // Ensure the parent directory exists
+    // we don't have to try/catch since this will silently fail if the directory does not exist.
+    await fsPromises.mkdir(parentDirectory, { recursive: true });
+
+    const settingsRawContent = await fsPromises.readFile(settingsFile, 'utf-8');
     let configData: { [key: string]: unknown };
     try {
       configData = JSON.parse(settingsRawContent);
@@ -97,7 +96,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
 
       const backupFilename = `${settingsFile}.backup-${Date.now()}`;
       // keep original file as a backup
-      fs.cpSync(settingsFile, backupFilename);
+      await fsPromises.copyFile(settingsFile, backupFilename);
 
       // append notification for the user
       notifications.push({

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -53,11 +53,11 @@ import { HttpServer } from './webview/webview-registry.js';
 let pluginSystem: TestPluginSystem;
 
 class TestPluginSystem extends PluginSystem {
-  override initConfigurationRegistry(
+  override async initConfigurationRegistry(
     container: InversifyContainer,
     notifications: NotificationCardOptions[],
     configurationRegistryEmitter: Emitter<ConfigurationRegistry>,
-  ): ConfigurationRegistry {
+  ): Promise<ConfigurationRegistry> {
     if (!container.isBound(ConfigurationRegistry)) {
       container.bind<ConfigurationRegistry>(ConfigurationRegistry).toSelf().inSingletonScope();
     }
@@ -326,7 +326,7 @@ test('configurationRegistry propagated', async () => {
   inversifyContainer.bind<ApiSenderType>(ApiSenderType).toConstantValue(apiSenderMock);
   inversifyContainer.bind<Directories>(Directories).toConstantValue(directoriesMock);
 
-  const configurationRegistry = pluginSystem.initConfigurationRegistry(
+  const configurationRegistry = await pluginSystem.initConfigurationRegistry(
     inversifyContainer,
     notifications,
     configurationRegistryEmitter,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -431,13 +431,13 @@ export class PluginSystem {
     };
   }
 
-  protected initConfigurationRegistry(
+  protected async initConfigurationRegistry(
     container: Container,
     notifications: NotificationCardOptions[],
     configurationRegistryEmitter: Emitter<ConfigurationRegistry>,
-  ): ConfigurationRegistry {
+  ): Promise<ConfigurationRegistry> {
     const configurationRegistry = container.get<ConfigurationRegistry>(ConfigurationRegistry);
-    notifications.push(...configurationRegistry.init());
+    notifications.push(...(await configurationRegistry.init()));
     configurationRegistryEmitter.fire(configurationRegistry);
     return configurationRegistry;
   }
@@ -479,7 +479,7 @@ export class PluginSystem {
 
     container.bind<ConfigurationRegistry>(ConfigurationRegistry).toSelf().inSingletonScope();
     container.bind<IConfigurationRegistry>(IConfigurationRegistry).toService(ConfigurationRegistry);
-    const configurationRegistry = this.initConfigurationRegistry(
+    const configurationRegistry = await this.initConfigurationRegistry(
       container,
       notifications,
       configurationRegistryEmitter,


### PR DESCRIPTION
chore: change configuration registry init to async

### What does this PR do?

Changes our configuration registry init now use await.

This is so we can allow loading external files (such as other json
files) with async functionalist (such as fs promises).

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Relates to implementing: https://github.com/podman-desktop/podman-desktop/pull/13981

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
