### PR TITLE
feat: added workflow for adding kubernetes contexts

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -2826,6 +2826,32 @@ export class PluginSystem {
       return kubernetesClient.refreshContextState(context);
     });
 
+    this.ipcHandle(
+      'kubernetes-client:parseKubeconfigFile',
+      async (_listener, filePath: string): Promise<KubeContext[]> => {
+        return kubernetesClient.parseKubeconfigFile(filePath);
+      },
+    );
+
+    this.ipcHandle(
+      'kubernetes-client:importContextsFromFile',
+      async (
+        _listener,
+        yaml: string,
+        selectedContexts: string[],
+        conflictResolutions: Map<string, 'keep-both' | 'replace'>,
+      ): Promise<void> => {
+        return kubernetesClient.importContextsFromFile(yaml, selectedContexts, conflictResolutions);
+      },
+    );
+
+    this.ipcHandle(
+      'kubernetes-client:hasCertificateChanged',
+      async (_listener, filePath: string, contextName: string): Promise<boolean> => {
+        return kubernetesClient.hasCertificateChanged(filePath, contextName);
+      },
+    );
+
     this.ipcHandle('feedback:send', async (_listener, feedbackProperties: FeedbackProperties): Promise<void> => {
       return telemetry.sendFeedback(feedbackProperties);
     });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2279,6 +2279,28 @@ export function initExposure(): void {
     return ipcInvoke('kubernetes-client:refreshContextState', context);
   });
 
+  contextBridge.exposeInMainWorld('kubernetesParseKubeconfigFile', async (filePath: string): Promise<KubeContext[]> => {
+    return ipcInvoke('kubernetes-client:parseKubeconfigFile', filePath);
+  });
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesImportContextsFromFile',
+    async (
+      filePath: string,
+      selectedContexts: string[],
+      conflictResolutions: Map<string, 'keep-both' | 'replace'>,
+    ): Promise<void> => {
+      return ipcInvoke('kubernetes-client:importContextsFromFile', filePath, selectedContexts, conflictResolutions);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
+    'kubernetesHasCertificateChanged',
+    async (filePath: string, contextName: string): Promise<boolean> => {
+      return ipcInvoke('kubernetes-client:hasCertificateChanged', filePath, contextName);
+    },
+  );
+
   contextBridge.exposeInMainWorld('getKubernetesPortForwards', async (): Promise<ForwardConfig[]> => {
     return ipcInvoke('kubernetes-client:getPortForwards');
   });

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faQuestionCircle } from '@fortawesome/free-regular-svg-icons';
-import { faCopy, faPenToSquare, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCopy, faFileImport, faPenToSquare, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { Button, EmptyScreen, ErrorMessage, Spinner, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
@@ -219,7 +219,17 @@ async function connect(contextName: string): Promise<void> {
 }
 </script>
 
-<SettingsPage title="Kubernetes Contexts">
+{#snippet importConfig()}
+  <div class="flex flex-1 justify-end">
+    <div class="px-5" role="group" aria-label="actions">
+      <div class="space-x-2 flex flex-nowrap">
+        <Button type='primary' icon={faFileImport} onclick={(): void => router.goto('/preferences/kubernetes-contexts/import-file')}>Import</Button>
+      </div>
+    </div>
+  </div>
+{/snippet}
+
+<SettingsPage title="Kubernetes Contexts" actions={importConfig}>
   <div class="h-full" role="table" aria-label="Contexts">
     <!-- Use KubernetesIcon in the future / not EngineIcon -->
     <EmptyScreen

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingImportFile.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingImportFile.spec.ts
@@ -1,0 +1,229 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import PreferencesKubernetesContextsRenderingImportFile from './PreferencesKubernetesContextsRenderingImportFile.svelte';
+
+// Mock router
+vi.mock('tinro', () => ({
+  router: {
+    goto: vi.fn(),
+  },
+}));
+
+// Mock window APIs
+const mockOpenDialog = vi.fn();
+Object.defineProperty(window, 'openDialog', {
+  value: mockOpenDialog,
+});
+
+// Simplified test setup - no complex drag/drop mocking needed
+
+describe('PreferencesKubernetesContextsRenderingImportFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('should render the import file page', () => {
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    expect(screen.getByText('Import config file')).toBeInTheDocument();
+    expect(screen.getByText(/Drag & Drop or/)).toBeInTheDocument();
+    expect(screen.getByText('Choose file')).toBeInTheDocument();
+    expect(screen.getByText(/to import/)).toBeInTheDocument();
+    expect(screen.getByText('Supported formats: .yaml, .yml, config files')).toBeInTheDocument();
+  });
+
+  test('should show file input area by default', () => {
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const fileInputButton = screen.getByLabelText('config file input');
+    expect(fileInputButton).toBeInTheDocument();
+    expect(fileInputButton).toHaveClass('border-gray-800'); // Not dragging state
+  });
+
+  test('should open file dialog when clicking the input area', async () => {
+    mockOpenDialog.mockResolvedValue(['/path/to/kubeconfig.yaml']);
+
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const fileInputButton = screen.getByLabelText('config file input');
+    await fireEvent.click(fileInputButton);
+
+    expect(mockOpenDialog).toHaveBeenCalledWith({
+      title: 'Select Kubernetes config file to import',
+      selectors: ['openFile'],
+      filters: [
+        {
+          name: 'Kubernetes config files',
+          extensions: ['yaml', 'yml', 'config'],
+        },
+        {
+          name: 'All files',
+          extensions: ['*'],
+        },
+      ],
+    });
+  });
+
+  test('should show file details after selecting a file', async () => {
+    mockOpenDialog.mockResolvedValue(['/path/to/my-cluster.yaml']);
+
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const fileInputButton = screen.getByLabelText('config file input');
+    await fireEvent.click(fileInputButton);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('/path/to/my-cluster.yaml')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('my-cluster.yaml')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Config File Path')).toBeInTheDocument();
+    expect(screen.getByText('Display Name')).toBeInTheDocument();
+  });
+
+  test('should enable import button after selecting file', async () => {
+    mockOpenDialog.mockResolvedValue(['/path/to/kubeconfig.yaml']);
+
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    // Initially disabled
+    const importButton = screen.getByRole('button', { name: /Import Config/i });
+    expect(importButton).toBeDisabled();
+
+    // Select file
+    const fileInputButton = screen.getByLabelText('config file input');
+    await fireEvent.click(fileInputButton);
+
+    await waitFor(() => {
+      expect(importButton).not.toBeDisabled();
+    });
+  });
+
+  test('should navigate to review page when importing', async () => {
+    mockOpenDialog.mockResolvedValue(['/path/to/kubeconfig.yaml']);
+
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    // Select file
+    const fileInputButton = screen.getByLabelText('config file input');
+    await fireEvent.click(fileInputButton);
+
+    // Click import
+    const importButton = screen.getByRole('button', { name: /Import Config/i });
+    await fireEvent.click(importButton);
+
+    await waitFor(() => {
+      expect(router.goto).toHaveBeenCalledWith(
+        '/preferences/kubernetes-contexts/review-contexts/%2Fpath%2Fto%2Fkubeconfig.yaml',
+      );
+    });
+  });
+
+  test('should show error if no file is selected in dialog', async () => {
+    mockOpenDialog.mockResolvedValue([]); // No files selected
+
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const fileInputButton = screen.getByLabelText('config file input');
+    await fireEvent.click(fileInputButton);
+
+    // Should not show any file details or error
+    expect(screen.queryByText('Config File Path')).not.toBeInTheDocument();
+  });
+
+  test('should handle file dialog error', async () => {
+    mockOpenDialog.mockRejectedValue(new Error('Dialog failed'));
+
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const fileInputButton = screen.getByLabelText('config file input');
+    await fireEvent.click(fileInputButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error while selecting config file: Error: Dialog failed/)).toBeInTheDocument();
+    });
+  });
+
+  test('Expect file input to handle file selection', async () => {
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const fileInputButton = screen.getByLabelText('config file input');
+    expect(fileInputButton).toBeInTheDocument();
+
+    // The component should show the input area by default
+    expect(screen.getByRole('button', { name: /Import Config/i })).toBeDisabled();
+  });
+
+  test('Expect error area to be available for validation messages', async () => {
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const errorArea = screen.getByLabelText('importError');
+    expect(errorArea).toBeInTheDocument();
+  });
+
+  test('Expect file input styling to be correct', async () => {
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const fileInputButton = screen.getByLabelText('config file input');
+    expect(fileInputButton).toBeInTheDocument();
+    expect(fileInputButton).toHaveClass('border-gray-800');
+  });
+
+  test('should handle dragover and dragleave events', async () => {
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    const fileInputButton = screen.getByLabelText('config file input');
+
+    // Test dragover
+    await fireEvent.dragOver(fileInputButton);
+    expect(fileInputButton).toHaveClass('border-purple-400');
+
+    // Test dragleave
+    await fireEvent.dragLeave(fileInputButton);
+    expect(fileInputButton).toHaveClass('border-gray-800');
+  });
+
+  test('should allow editing display name', async () => {
+    mockOpenDialog.mockResolvedValue(['/path/to/kubeconfig.yaml']);
+
+    render(PreferencesKubernetesContextsRenderingImportFile);
+
+    // Select file
+    const fileInputButton = screen.getByLabelText('config file input');
+    await fireEvent.click(fileInputButton);
+
+    await waitFor(() => {
+      const displayNameInput = screen.getByLabelText('config file display name');
+      expect(displayNameInput).toBeInTheDocument();
+      expect(displayNameInput).toHaveValue('kubeconfig.yaml');
+    });
+
+    // Edit the display name
+    const displayNameInput = screen.getByLabelText('config file display name');
+    await fireEvent.input(displayNameInput, { target: { value: 'My Custom Config' } });
+
+    expect(displayNameInput).toHaveValue('My Custom Config');
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingImportFile.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingImportFile.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+import { faFileImport } from '@fortawesome/free-solid-svg-icons';
+import { Button, ErrorMessage, FormPage, Input } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { router } from 'tinro';
+
+interface KubeConfigImportInfo {
+  path: string;
+  name: string;
+  parsedContexts?: KubeContext[];
+}
+
+// Import the KubeContext type from the API
+import type { KubeContext } from '/@api/kubernetes-context';
+
+let kubeConfig: KubeConfigImportInfo | undefined = undefined;
+let errorMessage: string = '';
+let dragging: boolean = false;
+let loading: boolean = false;
+
+async function submit(): Promise<void> {
+  if (!kubeConfig) return;
+
+  loading = true;
+  try {
+    // Pass the file path as a route parameter
+    const encodedPath = encodeURIComponent(kubeConfig.path);
+    router.goto(`/preferences/kubernetes-contexts/review-contexts/${encodedPath}`);
+  } catch (err: unknown) {
+    errorMessage = `Failed to process config file: ${err}`;
+  } finally {
+    loading = false;
+  }
+}
+
+async function requestExplorerModal(): Promise<void> {
+  dragging = false;
+  errorMessage = '';
+  try {
+    const files = await window.openDialog({
+      title: 'Select Kubernetes config file to import',
+      selectors: ['openFile'],
+      filters: [
+        {
+          name: 'Kubernetes config files',
+          extensions: ['yaml', 'yml', 'config'],
+        },
+        {
+          name: 'All files',
+          extensions: ['*'],
+        },
+      ],
+    });
+    if (!files || files.length !== 1) {
+      return;
+    }
+
+    const filePath = files[0];
+    const lastSlashIndex = filePath.replace(/\\/g, '/').lastIndexOf('/') + 1;
+
+    kubeConfig = {
+      path: filePath,
+      name: filePath.substring(lastSlashIndex),
+    };
+  } catch (e) {
+    kubeConfig = undefined;
+    errorMessage = `Error while selecting config file: ${String(e)}`;
+  }
+}
+
+/**
+ * This would only work in Electron as the `path` property is
+ * not available is browser.
+ */
+function getFilesFromDropEvent(event: DragEvent): KubeConfigImportInfo[] {
+  if (!event.dataTransfer) return [];
+  const output: KubeConfigImportInfo[] = [];
+
+  let files: File[];
+  if (event.dataTransfer.files.length) {
+    files = Array.from(event.dataTransfer.files);
+  } else {
+    files = Array.from(event.dataTransfer.items)
+      .map(item => item.getAsFile())
+      .filter((item): item is File => !!item);
+  }
+  for (const file of files) {
+    if (file && 'path' in file && typeof file.path === 'string') {
+      output.push({ path: file.path, name: file.name });
+    }
+  }
+  return output;
+}
+
+/**
+ * User can drag&drop a file, this
+ * function is the drag event handler
+ * @param event
+ */
+async function onFile(event: DragEvent): Promise<void> {
+  dragging = false;
+  const files = getFilesFromDropEvent(event);
+  if (files.length !== 1) {
+    errorMessage = 'Please drop exactly one config file';
+    return;
+  }
+
+  const file = files[0];
+  // Basic validation for config files
+  const validExtensions = ['.yaml', '.yml', '.config'];
+  const hasValidExtension = validExtensions.some(
+    ext => file.name.toLowerCase().endsWith(ext) || file.name === 'config',
+  );
+
+  if (!hasValidExtension) {
+    errorMessage = 'Please drop a valid Kubernetes config file (.yaml, .yml, or config)';
+    return;
+  }
+
+  kubeConfig = {
+    path: file.path,
+    name: file.name,
+  };
+  errorMessage = '';
+}
+
+function handleDragOver(): void {
+  dragging = true;
+}
+
+function handleDragLeave(): void {
+  dragging = false;
+}
+
+function goToUpPage(): void {
+  router.goto(`/preferences/kubernetes-contexts`);
+}
+</script>
+
+<FormPage 
+  title="Import config file"
+  breadcrumbLeftPart="Kubernetes"
+  breadcrumbRightPart="Import config"
+  onclose={goToUpPage}
+  onbreadcrumbClick={goToUpPage}>
+
+  {#snippet icon()}
+    <Icon icon={faFileImport} />
+  {/snippet}
+
+  {#snippet content()}
+    <div class="flex m-5 flex-col w-full">
+      <!-- Error banner -->
+      <div aria-label="importError">
+          {#if errorMessage !== ''}
+              <ErrorMessage class="py-2" error={errorMessage} />
+          {/if}
+      </div>
+
+      <!-- form -->
+      <div class="bg-[var(--pd-content-card-bg)] space-y-6 px-8 sm:py-6 xl:py-8 rounded-lg h-fit text-[var(--pd-content-card-text)]">
+        <div class="w-full">
+          <!-- config file input -->
+          {#if kubeConfig === undefined}
+          <button
+            aria-label="config file input"
+            title="Click to open file explorer"
+            class:border-purple-400={dragging}
+            class:border-gray-800={!dragging}
+            on:click={requestExplorerModal}
+            on:drop|preventDefault={onFile}
+            on:dragover|preventDefault={handleDragOver}
+            on:dragleave|preventDefault={handleDragLeave}
+            class="w-full cursor-pointer flex-col px-4 py-8 border-2 border-dashed rounded-xs flex justify-center items-center">
+            <Icon size="1.1x" class="cursor-pointer text-[var(--pd-link)]" icon={faFileImport} />
+            <span>Drag & Drop or <strong class="text-[var(--pd-link)]">Choose file</strong> to import</span>
+            <span class="opacity-50 text-sm">Supported formats: .yaml, .yml, config files</span>
+          </button>
+          {:else}
+            <!-- showing path -->
+            <label for="path" class="w-full block mb-2 font-bold text-[var(--pd-content-card-header-text)]">Config File Path</label>
+            <Input class="grow" bind:value={kubeConfig.path} name="path" aria-label="config file path" readonly={true} />
+
+            <!-- Config file name -->
+            <label for="name" class="pt-4 w-full block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
+                >Display Name</label>
+            <Input
+                bind:value={kubeConfig.name}
+                name="name"
+                aria-label="config file display name"
+                placeholder="Config file display name"
+                class="grow" />
+          {/if}
+        </div>
+
+        <!-- action buttons -->
+        <div class="mt-4 flex">
+          <Button
+            class="grow"
+            on:click={submit}
+            inProgress={loading}
+            icon={faFileImport}
+            disabled={kubeConfig === undefined}
+            aria-label="Import config">
+            Import Config
+          </Button>
+        </div>
+      </div>
+    </div>
+  {/snippet}
+</FormPage>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingReview.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingReview.spec.ts
@@ -1,0 +1,175 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { readable } from 'svelte/store';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+
+import PreferencesKubernetesContextsRenderingReview from './PreferencesKubernetesContextsRenderingReview.svelte';
+
+vi.mock('tinro', () => ({
+  router: {
+    goto: vi.fn(),
+  },
+}));
+
+vi.mock('/@/stores/kubernetes-contexts', async () => {
+  return {
+    kubernetesContexts: readable([]),
+  };
+});
+
+const mockParseKubeconfigFile = vi.fn();
+const mockImportContextsFromFile = vi.fn();
+const mockHasCertificateChanged = vi.fn();
+
+Object.defineProperty(window, 'kubernetesParseKubeconfigFile', {
+  value: mockParseKubeconfigFile,
+});
+
+Object.defineProperty(window, 'kubernetesImportContextsFromFile', {
+  value: mockImportContextsFromFile,
+});
+
+Object.defineProperty(window, 'kubernetesHasCertificateChanged', {
+  value: mockHasCertificateChanged,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Mock default responses
+  mockParseKubeconfigFile.mockResolvedValue([
+    {
+      name: 'new-context',
+      cluster: 'new-cluster',
+      user: 'new-user',
+      namespace: 'production',
+      currentContext: false,
+      clusterInfo: {
+        name: 'new-cluster',
+        server: 'https://new-cluster:6443',
+      },
+    },
+    {
+      name: 'existing-context',
+      cluster: 'conflict-cluster',
+      user: 'conflict-user',
+      namespace: 'staging',
+      currentContext: false,
+      clusterInfo: {
+        name: 'conflict-cluster',
+        server: 'https://conflict:6443',
+      },
+    },
+  ]);
+  mockImportContextsFromFile.mockResolvedValue(undefined);
+  mockHasCertificateChanged.mockResolvedValue(false);
+
+  // Mock the store with existing contexts
+  vi.mocked(kubernetesContexts).subscribe = vi.fn(callback => {
+    callback([
+      {
+        name: 'existing-context',
+        cluster: 'existing-cluster',
+        user: 'existing-user',
+        namespace: 'default',
+        currentContext: true,
+        clusterInfo: {
+          name: 'existing-cluster',
+          server: 'https://existing:6443',
+        },
+      },
+    ]);
+    return (): void => {};
+  });
+});
+
+test('Expect import button to show correct text', async () => {
+  render(PreferencesKubernetesContextsRenderingReview, {
+    props: { filePath: 'path%2Fto%2Fkubeconfig.yaml' },
+  });
+
+  await vi.waitFor(() => {
+    const importButton = screen.getByRole('button', { name: /Import 2 contexts/ });
+    expect(importButton).toBeInTheDocument();
+    expect(importButton).not.toBeDisabled(); // Contexts are selected by default now
+  });
+});
+
+test('Expect review page to render with title', async () => {
+  render(PreferencesKubernetesContextsRenderingReview, {
+    props: { filePath: 'path%2Fto%2Fkubeconfig.yaml' },
+  });
+
+  expect(screen.getByText('Review contexts to import')).toBeInTheDocument();
+  expect(mockParseKubeconfigFile).toHaveBeenCalledWith('path/to/kubeconfig.yaml');
+});
+
+test('Expect error when no file path provided', async () => {
+  render(PreferencesKubernetesContextsRenderingReview, {
+    props: { filePath: '' },
+  });
+
+  await vi.waitFor(() => {
+    expect(screen.getByText('No kubeconfig file path found. Please go back and select a file.')).toBeInTheDocument();
+  });
+});
+
+test('Expect error when no contexts found in file', async () => {
+  mockParseKubeconfigFile.mockResolvedValue([]);
+
+  render(PreferencesKubernetesContextsRenderingReview, {
+    props: { filePath: 'path%2Fto%2Fkubeconfig.yaml' },
+  });
+
+  await vi.waitFor(() => {
+    expect(screen.getByText('No valid contexts found in the config file')).toBeInTheDocument();
+  });
+});
+
+test('Expect cancel button to navigate to import file page', async () => {
+  render(PreferencesKubernetesContextsRenderingReview, {
+    props: { filePath: 'path%2Fto%2Fkubeconfig.yaml' },
+  });
+
+  const cancelButton = screen.getByRole('button', { name: /Cancel/ });
+  expect(cancelButton).toBeInTheDocument();
+
+  await userEvent.click(cancelButton);
+
+  expect(router.goto).toHaveBeenCalledWith('/preferences/kubernetes-contexts/import-file');
+});
+
+test('Expect certificate changed to be called for each context', async () => {
+  mockHasCertificateChanged.mockResolvedValue(true);
+
+  render(PreferencesKubernetesContextsRenderingReview, {
+    props: { filePath: 'path%2Fto%2Fkubeconfig.yaml' },
+  });
+
+  await vi.waitFor(() => {
+    expect(mockHasCertificateChanged).toHaveBeenCalledWith('path/to/kubeconfig.yaml', 'new-context');
+    expect(mockHasCertificateChanged).toHaveBeenCalledWith('path/to/kubeconfig.yaml', 'existing-context');
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingReview.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingReview.svelte
@@ -1,0 +1,322 @@
+<script lang="ts">
+import { faFileImport, faUserCheck } from '@fortawesome/free-solid-svg-icons';
+import { Button, Checkbox, ErrorMessage, FormPage } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { onMount } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
+import { router } from 'tinro';
+
+import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
+import type { KubeContext } from '/@api/kubernetes-context';
+
+import WarningMessage from '../ui/WarningMessage.svelte';
+
+const KEEP_BOTH = 'keep-both';
+const REPLACE = 'replace';
+
+type ConflictResolution = typeof KEEP_BOTH | typeof REPLACE;
+
+interface LoadedContext extends KubeContext {
+  selected: boolean;
+  hasConflict: boolean;
+  conflictResolution: ConflictResolution;
+  originalName: string;
+  certificateChanged: boolean;
+}
+
+interface Props {
+  filePath: string;
+}
+
+const { filePath }: Props = $props();
+
+let loadedContexts: LoadedContext[] = $state([]);
+let existingContexts: KubeContext[] = $state([]);
+let loading: boolean = $state(false);
+let errorMessage: string = $state('');
+
+onMount(async () => {
+  existingContexts = $kubernetesContexts;
+
+  // Get the kubeconfig file path from props (passed via route parameter)
+  if (!filePath) {
+    errorMessage = 'No kubeconfig file path found. Please go back and select a file.';
+    return;
+  }
+
+  const decodedPath = decodeURIComponent(filePath);
+
+  try {
+    // Parse the kubeconfig file using the backend API
+    const parsedContexts = await window.kubernetesParseKubeconfigFile(decodedPath);
+
+    if (parsedContexts.length === 0) {
+      errorMessage = 'No valid contexts found in the config file';
+      return;
+    }
+
+    // Process loaded contexts and check for conflicts
+    loadedContexts = [];
+    for (let index = 0; index < parsedContexts.length; index++) {
+      const context = parsedContexts[index];
+      const hasConflict = existingContexts.some(existing => existing.name === context.name);
+      const certificateChanged = await window.kubernetesHasCertificateChanged(decodedPath, context.name);
+
+      loadedContexts.push({
+        ...context,
+        selected: true, // Default to selected
+        hasConflict,
+        conflictResolution: KEEP_BOTH,
+        originalName: context.name,
+        certificateChanged: certificateChanged,
+      });
+    }
+  } catch (error: unknown) {
+    errorMessage = `Failed to parse config file: ${error}`;
+  }
+});
+
+function updateConflictResolution(index: number, resolution: ConflictResolution): void {
+  loadedContexts[index].conflictResolution = resolution;
+}
+
+function generatePreviewName(contextName: string): string {
+  // Get all existing context names from the current kubeconfig
+  const existingNames = existingContexts.map(ctx => ctx.name);
+
+  let counter = 1;
+  let newName = `${contextName}-${counter}`;
+  while (existingNames.includes(newName)) {
+    counter += 1;
+    newName = `${contextName}-${counter}`;
+  }
+  return newName;
+}
+
+async function importSelectedContexts(): Promise<void> {
+  const selectedContexts = loadedContexts.filter(context => context.selected);
+
+  if (selectedContexts.length === 0) {
+    errorMessage = 'Please select at least one context to import';
+    return;
+  }
+
+  loading = true;
+  errorMessage = '';
+
+  try {
+    // Get the kubeconfig file path from props
+    if (!filePath) {
+      throw new Error('Original kubeconfig file path not found');
+    }
+
+    const decodedPath = decodeURIComponent(filePath);
+
+    // Prepare conflict resolutions
+    const conflictResolutions: SvelteMap<string, ConflictResolution> = new SvelteMap();
+    selectedContexts.forEach(context => {
+      if (context.hasConflict) {
+        conflictResolutions.set(context.originalName, context.conflictResolution);
+      }
+    });
+
+    // Import using backend API
+    await window.kubernetesImportContextsFromFile(
+      decodedPath,
+      selectedContexts.map(ctx => ctx.originalName),
+      conflictResolutions,
+    );
+
+    // Navigate back to contexts page
+    goToKubernetesContextsPage();
+  } catch (err: unknown) {
+    errorMessage = `Failed to import contexts: ${err}`;
+  } finally {
+    loading = false;
+  }
+}
+
+function goToKubernetesContextsPage(): void {
+  router.goto('/preferences/kubernetes-contexts');
+}
+
+function goToUpPage(): void {
+  router.goto('/preferences/kubernetes-contexts/import-file');
+}
+</script>
+
+<FormPage 
+  title="Review contexts to import"
+  breadcrumbLeftPart="Kubernetes"
+  breadcrumbRightPart="Import config"
+  onclose={goToUpPage}
+  onbreadcrumbClick={goToUpPage}>
+
+  {#snippet icon()}
+    <Icon icon={faUserCheck} />
+  {/snippet}
+
+  {#snippet content()}
+    <div class="flex m-5 flex-col w-full">
+      <!-- Error banner -->
+      <div aria-label="importError">
+        {#if errorMessage !== ''}
+          <ErrorMessage class="py-2" error={errorMessage} />
+        {/if}
+      </div>
+
+      <!-- Main content card -->
+      <div class="bg-[var(--pd-content-card-bg)] rounded-lg text-[var(--pd-content-card-text)] px-8 pt-6 pb-6" role="table" aria-label="Review contexts">
+        <!-- Context list -->
+        <div class="pr-2">
+      {#each loadedContexts as context, index (context.originalName)}
+        <div
+          role="row"
+          aria-label={context.originalName}
+          class="bg-[var(--pd-invert-content-card-bg)] rounded-md p-3 flex-nowrap"
+          class:mb-5={index < loadedContexts.length - 1}>
+          <div class="pb-2">
+            <div class="flex">
+              <!-- Checkbox for selection - moved to left -->
+              <div class="flex items-center pr-3">
+                <Checkbox 
+                  bind:checked={context.selected}
+                  title="Select context {context.originalName}" />
+              </div>
+                
+              {#if context?.icon}
+                {#if typeof context.icon === 'string'}
+                  <img
+                    src={context.icon}
+                    aria-label="Context Logo"
+                    alt="{context.originalName} logo"
+                    class="max-w-[40px] h-full" />
+                {/if}
+              {/if}
+                
+              <!-- Centered items div -->
+              <div class="pl-3 grow flex flex-col justify-center">
+                <div class="flex flex-col items-left">
+                  <span class="font-semibold text-[var(--pd-invert-content-card-header-text)]" aria-label="Context Name">
+                    {context.originalName}
+                  </span>
+                </div>
+              </div>
+
+              {#if context.certificateChanged}
+                <div class="text-[var(--pd-label-tertiary-text)] bg-[var(--pd-label-tertiary-bg)] text-xs px-2 py-1 rounded-md">
+                  Certificate updated
+                </div>
+              {/if}
+            </div>
+            {#if context.error}
+              <ErrorMessage class="text-sm" aria-label="Context Error" error={context.error} />
+            {/if}
+          </div>
+
+          <!-- Conflict resolution options - positioned below context name but above details -->
+          {#if context.hasConflict && context.selected}
+            <div class="flex items-center mb-3 space-x-3">
+              <WarningMessage class="text-sm" error="A context with this name already exists" />
+              <label for="keepBoth-{index}" class="ml-1 flex items-center cursor-pointer" aria-label="keep-both-radio">
+                <input
+                  bind:group={context.conflictResolution}
+                  type="radio"
+                  id="keepBoth-{index}"
+                  name="conflictResolution-{index}"
+                  value={KEEP_BOTH}
+                  onchange={(): void => updateConflictResolution(index, KEEP_BOTH)}
+                  class="sr-only peer"
+                  aria-label="keep-both-conflict-resolution-select" />
+                <div
+                  class="w-4 h-4 rounded-full border-2 border-[var(--pd-input-checkbox-unchecked)] mr-2 peer-checked:border-[var(--pd-input-checkbox-checked)] peer-checked:bg-[var(--pd-input-checkbox-checked)]">
+                </div>
+                <span>Keep existing</span>
+                <span class="ml-2 text-sm">
+                  (will import as: <span class="font-mono bg-[var(--pd-invert-content-bg)] px-1 py-0.5 rounded text-xs">
+                    {generatePreviewName(context.originalName)}
+                  </span>)
+                </span>
+              </label>
+              <label for="replace-{index}" class="ml-1 flex items-center cursor-pointer" aria-label="replace-radio">
+                <input
+                  bind:group={context.conflictResolution}
+                  type="radio"
+                  id="replace-{index}"
+                  name="conflictResolution-{index}"
+                  value={REPLACE}
+                  onchange={(): void => updateConflictResolution(index, 'replace')}
+                  class="sr-only peer"
+                  aria-label="replace-conflict-resolution-select" />
+                <div
+                  class="w-4 h-4 rounded-full border-2 border-[var(--pd-input-checkbox-unchecked)] mr-2 peer-checked:border-[var(--pd-input-checkbox-checked)] peer-checked:bg-[var(--pd-input-checkbox-checked)]">
+                </div>
+                <span>Replace</span>
+              </label>
+            </div>
+          {/if}
+
+          <div class="grow flex-column divide-gray-900"
+          class:text-[var(--pd-invert-content-card-text)]={context.selected}
+          class:text-[var(--pd-input-checkbox-disabled)]={!context.selected}>
+            <div class="flex flex-row">
+              <div class="grow text-sm">
+                <div class="bg-[var(--pd-invert-content-bg)] p-2 rounded-lg mt-1 grid grid-cols-6">
+                    <span class="my-auto font-bold col-span-1 text-right overflow-hidden text-ellipsis">CLUSTER</span>
+                    <span
+                    class="my-auto col-span-5 text-left ml-3 overflow-hidden text-ellipsis"
+                    aria-label="Context Cluster">{context.cluster}</span>
+                </div>
+
+                {#if context.clusterInfo !== undefined}
+                  <div class="bg-[var(--pd-invert-content-bg)] p-2 rounded-lg mt-1 grid grid-cols-6">
+                    <span class="my-auto font-bold col-span-1 text-right overflow-hidden text-ellipsis">SERVER</span>
+                    <span
+                        class="my-auto col-span-5 text-left ml-3 overflow-hidden text-ellipsis"
+                        aria-label="Context Server"
+                        >{context.clusterInfo.server}
+                    </span>
+                  </div>
+                {/if}
+
+                <div class="bg-[var(--pd-invert-content-bg)] p-2 rounded-lg mt-1 grid grid-cols-6">
+                  <span class="my-auto font-bold col-span-1 text-right overflow-hidden text-ellipsis">USER</span>
+                  <span class="my-auto col-span-5 text-left ml-3 overflow-hidden text-ellipsis" aria-label="Context User"
+                  >{context.user}</span>
+                </div>
+
+                {#if context.namespace}
+                  <div class="bg-[var(--pd-invert-content-bg)] p-2 rounded-lg mt-1 grid grid-cols-6">
+                  <span class="my-auto font-bold col-span-1 text-right overflow-hidden text-ellipsis">NAMESPACE</span>
+                  <span
+                      class="my-auto col-span-5 text-left ml-3 overflow-hidden text-ellipsis"
+                      aria-label="Context Namespace">{context.namespace}</span>
+                  </div>
+                {/if}
+              </div>
+            </div>
+          </div>
+        </div>
+        {/each}
+        </div>
+      </div>
+
+      <!-- Buttons below the card -->
+      <div class="py-4 flex justify-end space-x-4">
+        <Button
+          type='secondary'
+          on:click={goToUpPage}>
+          Cancel
+        </Button>
+        <Button
+          type='primary'
+          icon={faFileImport}
+          on:click={importSelectedContexts}
+          inProgress={loading}
+          disabled={loadedContexts.filter(c => c.selected).length === 0}>
+          Import {loadedContexts.filter(c => c.selected).length} contexts
+        </Button>
+      </div>
+    </div>
+  {/snippet}
+</FormPage>

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -14,6 +14,8 @@ import PreferencesCliToolsRendering from './PreferencesCliToolsRendering.svelte'
 import PreferencesContainerConnectionRendering from './PreferencesContainerConnectionRendering.svelte';
 import PreferencesKubernetesConnectionRendering from './PreferencesKubernetesConnectionRendering.svelte';
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
+import PreferencesKubernetesContextsRenderingImportFile from './PreferencesKubernetesContextsRenderingImportFile.svelte';
+import PreferencesKubernetesContextsRenderingReview from './PreferencesKubernetesContextsRenderingReview.svelte';
 import PreferencesProviderRendering from './PreferencesProviderRendering.svelte';
 import PreferencesProxiesRendering from './PreferencesProxiesRendering.svelte';
 import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
@@ -81,6 +83,12 @@ onMount(async () => {
   </Route>
   <Route path="/kubernetes-contexts" breadcrumb="Kubernetes Contexts">
     <PreferencesKubernetesContextsRendering />
+  </Route>
+  <Route path="/kubernetes-contexts/import-file" breadcrumb="Import config file">
+    <PreferencesKubernetesContextsRenderingImportFile />
+  </Route>
+  <Route path="/kubernetes-contexts/review-contexts/:filePath" breadcrumb="Review added contexts" let:meta>
+    <PreferencesKubernetesContextsRenderingReview filePath={meta.params.filePath} />
   </Route>
   <Route path="/proxies" breadcrumb="Proxy">
     <PreferencesProxiesRendering />

--- a/website/static/docs.json
+++ b/website/static/docs.json
@@ -1,0 +1,230 @@
+[
+  { "name": "AI lab/create playground", "url": "https://podman-desktop.io/docs/ai-lab/create-playground" },
+  { "name": "AI lab/download model", "url": "https://podman-desktop.io/docs/ai-lab/download-model" },
+  { "name": "AI lab/installing", "url": "https://podman-desktop.io/docs/ai-lab/installing" },
+  { "name": "AI lab/start inference server", "url": "https://podman-desktop.io/docs/ai-lab/start-inference-server" },
+  { "name": "AI lab/start recipe", "url": "https://podman-desktop.io/docs/ai-lab/start-recipe" },
+  { "name": "Compose/running compose", "url": "https://podman-desktop.io/docs/compose/running-compose" },
+  { "name": "Compose/setting up compose", "url": "https://podman-desktop.io/docs/compose/setting-up-compose" },
+  { "name": "Compose/troubleshooting", "url": "https://podman-desktop.io/docs/compose/troubleshooting" },
+  {
+    "name": "Containers/accessing the terminal",
+    "url": "https://podman-desktop.io/docs/containers/accessing-the-terminal"
+  },
+  { "name": "Containers/creating a pod", "url": "https://podman-desktop.io/docs/containers/creating-a-pod" },
+  {
+    "name": "Containers/images/building an image",
+    "url": "https://podman-desktop.io/docs/containers/images/building-an-image"
+  },
+  {
+    "name": "Containers/images/pulling an image",
+    "url": "https://podman-desktop.io/docs/containers/images/pulling-an-image"
+  },
+  {
+    "name": "Containers/images/pushing an image to a registry",
+    "url": "https://podman-desktop.io/docs/containers/images/pushing-an-image-to-a-registry"
+  },
+  { "name": "Containers/onboarding", "url": "https://podman-desktop.io/docs/containers/onboarding" },
+  {
+    "name": "Containers/registries/configuring mirror registries",
+    "url": "https://podman-desktop.io/docs/containers/registries/configuring-mirror-registries"
+  },
+  {
+    "name": "Containers/starting a container",
+    "url": "https://podman-desktop.io/docs/containers/starting-a-container"
+  },
+  {
+    "name": "Containers/viewing container logs",
+    "url": "https://podman-desktop.io/docs/containers/viewing-container-logs"
+  },
+  { "name": "Discover podman desktop", "url": "https://podman-desktop.io/docs/discover-podman-desktop" },
+  {
+    "name": "Extensions/debugging an extension",
+    "url": "https://podman-desktop.io/docs/extensions/debugging-an-extension"
+  },
+  {
+    "name": "Extensions/developing/adding icons",
+    "url": "https://podman-desktop.io/docs/extensions/developing/adding-icons"
+  },
+  {
+    "name": "Extensions/developing/adding ui components",
+    "url": "https://podman-desktop.io/docs/extensions/developing/adding-ui-components"
+  },
+  {
+    "name": "Extensions/developing/command palette",
+    "url": "https://podman-desktop.io/docs/extensions/developing/command-palette"
+  },
+  { "name": "Extensions/developing/commands", "url": "https://podman-desktop.io/docs/extensions/developing/commands" },
+  { "name": "Extensions/developing/config", "url": "https://podman-desktop.io/docs/extensions/developing/config" },
+  { "name": "Extensions/developing/menu", "url": "https://podman-desktop.io/docs/extensions/developing/menu" },
+  {
+    "name": "Extensions/developing/onboarding workflow",
+    "url": "https://podman-desktop.io/docs/extensions/developing/onboarding-workflow"
+  },
+  {
+    "name": "Extensions/developing/when clause context",
+    "url": "https://podman-desktop.io/docs/extensions/developing/when-clause-context"
+  },
+  {
+    "name": "Extensions/install/using extension",
+    "url": "https://podman-desktop.io/docs/extensions/install/using-extension"
+  },
+  {
+    "name": "Installation/linux install/install on rhel10",
+    "url": "https://podman-desktop.io/docs/installation/linux-install/install-on-rhel10"
+  },
+  {
+    "name": "Installation/linux install/installing podman desktop from a flatpak bundle",
+    "url": "https://podman-desktop.io/docs/installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle"
+  },
+  { "name": "Installation/macos install", "url": "https://podman-desktop.io/docs/installation/macos-install" },
+  { "name": "Intro", "url": "https://podman-desktop.io/docs/intro" },
+  {
+    "name": "Kind/building an image and testing it in kind",
+    "url": "https://podman-desktop.io/docs/kind/building-an-image-and-testing-it-in-kind"
+  },
+  {
+    "name": "Kind/configuring podman for kind on windows",
+    "url": "https://podman-desktop.io/docs/kind/configuring-podman-for-kind-on-windows"
+  },
+  { "name": "Kind/creating a kind cluster", "url": "https://podman-desktop.io/docs/kind/creating-a-kind-cluster" },
+  {
+    "name": "Kind/deleting your kind cluster",
+    "url": "https://podman-desktop.io/docs/kind/deleting-your-kind-cluster"
+  },
+  { "name": "Kind/installing", "url": "https://podman-desktop.io/docs/kind/installing" },
+  { "name": "Kind/installing extension", "url": "https://podman-desktop.io/docs/kind/installing-extension" },
+  { "name": "Kind/pushing an image to kind", "url": "https://podman-desktop.io/docs/kind/pushing-an-image-to-kind" },
+  {
+    "name": "Kind/restarting your kind cluster",
+    "url": "https://podman-desktop.io/docs/kind/restarting-your-kind-cluster"
+  },
+  {
+    "name": "Kind/working with your local kind cluster",
+    "url": "https://podman-desktop.io/docs/kind/working-with-your-local-kind-cluster"
+  },
+  {
+    "name": "Kubernetes/applying a yaml manifest",
+    "url": "https://podman-desktop.io/docs/kubernetes/applying-a-yaml-manifest"
+  },
+  {
+    "name": "Kubernetes/configuring editing kube object",
+    "url": "https://podman-desktop.io/docs/kubernetes/configuring-editing-kube-object"
+  },
+  {
+    "name": "Kubernetes/creating a kube cluster",
+    "url": "https://podman-desktop.io/docs/kubernetes/creating-a-kube-cluster"
+  },
+  {
+    "name": "Kubernetes/deploying a pod to kubernetes",
+    "url": "https://podman-desktop.io/docs/kubernetes/deploying-a-pod-to-kubernetes"
+  },
+  {
+    "name": "Kubernetes/managing a kube context",
+    "url": "https://podman-desktop.io/docs/kubernetes/managing-a-kube-context"
+  },
+  { "name": "Kubernetes/port forwarding", "url": "https://podman-desktop.io/docs/kubernetes/port-forwarding" },
+  { "name": "Kubernetes/pushing an image", "url": "https://podman-desktop.io/docs/kubernetes/pushing-an-image" },
+  {
+    "name": "Kubernetes/viewing and selecting current kubernetes context",
+    "url": "https://podman-desktop.io/docs/kubernetes/viewing-and-selecting-current-kubernetes-context"
+  },
+  {
+    "name": "Lima/creating a kubernetes instance",
+    "url": "https://podman-desktop.io/docs/lima/creating-a-kubernetes-instance"
+  },
+  { "name": "Lima/creating a lima instance", "url": "https://podman-desktop.io/docs/lima/creating-a-lima-instance" },
+  { "name": "Lima/customizing", "url": "https://podman-desktop.io/docs/lima/customizing" },
+  { "name": "Lima/installing", "url": "https://podman-desktop.io/docs/lima/installing" },
+  { "name": "Lima/pushing an image to lima", "url": "https://podman-desktop.io/docs/lima/pushing-an-image-to-lima" },
+  {
+    "name": "Migrating from docker/customizing docker compatibility",
+    "url": "https://podman-desktop.io/docs/migrating-from-docker/customizing-docker-compatibility"
+  },
+  {
+    "name": "Migrating from docker/importing saved containers",
+    "url": "https://podman-desktop.io/docs/migrating-from-docker/importing-saved-containers"
+  },
+  {
+    "name": "Migrating from docker/managing docker compatibility",
+    "url": "https://podman-desktop.io/docs/migrating-from-docker/managing-docker-compatibility"
+  },
+  {
+    "name": "Migrating from docker/using the docker_host environment variable",
+    "url": "https://podman-desktop.io/docs/migrating-from-docker/using-the-docker_host-environment-variable"
+  },
+  {
+    "name": "Minikube/building an image and testing it in minikube",
+    "url": "https://podman-desktop.io/docs/minikube/building-an-image-and-testing-it-in-minikube"
+  },
+  {
+    "name": "Minikube/configuring podman for minikube on windows",
+    "url": "https://podman-desktop.io/docs/minikube/configuring-podman-for-minikube-on-windows"
+  },
+  {
+    "name": "Minikube/creating a minikube cluster",
+    "url": "https://podman-desktop.io/docs/minikube/creating-a-minikube-cluster"
+  },
+  {
+    "name": "Minikube/deleting your minikube cluster",
+    "url": "https://podman-desktop.io/docs/minikube/deleting-your-minikube-cluster"
+  },
+  { "name": "Minikube/installing", "url": "https://podman-desktop.io/docs/minikube/installing" },
+  { "name": "Minikube/installing extension", "url": "https://podman-desktop.io/docs/minikube/installing-extension" },
+  {
+    "name": "Minikube/pushing an image to minikube",
+    "url": "https://podman-desktop.io/docs/minikube/pushing-an-image-to-minikube"
+  },
+  {
+    "name": "Minikube/restarting your minikube cluster",
+    "url": "https://podman-desktop.io/docs/minikube/restarting-your-minikube-cluster"
+  },
+  {
+    "name": "Minikube/working with your local minikube cluster",
+    "url": "https://podman-desktop.io/docs/minikube/working-with-your-local-minikube-cluster"
+  },
+  {
+    "name": "Podman/accessing podman from another wsl instance",
+    "url": "https://podman-desktop.io/docs/podman/accessing-podman-from-another-wsl-instance"
+  },
+  {
+    "name": "Podman/adding certificates to a podman machine",
+    "url": "https://podman-desktop.io/docs/podman/adding-certificates-to-a-podman-machine"
+  },
+  {
+    "name": "Podman/creating a podman machine",
+    "url": "https://podman-desktop.io/docs/podman/creating-a-podman-machine"
+  },
+  { "name": "Podman/gpu", "url": "https://podman-desktop.io/docs/podman/gpu" },
+  { "name": "Podman/podman remote", "url": "https://podman-desktop.io/docs/podman/podman-remote" },
+  { "name": "Podman/rosetta", "url": "https://podman-desktop.io/docs/podman/rosetta" },
+  {
+    "name": "Podman/setting podman machine default connection",
+    "url": "https://podman-desktop.io/docs/podman/setting-podman-machine-default-connection"
+  },
+  { "name": "Troubleshooting/access logs", "url": "https://podman-desktop.io/docs/troubleshooting/access-logs" },
+  {
+    "name": "Troubleshooting/troubleshooting extension issues",
+    "url": "https://podman-desktop.io/docs/troubleshooting/troubleshooting-extension-issues"
+  },
+  {
+    "name": "Troubleshooting/troubleshooting openshift local",
+    "url": "https://podman-desktop.io/docs/troubleshooting/troubleshooting-openshift-local"
+  },
+  {
+    "name": "Troubleshooting/troubleshooting podman",
+    "url": "https://podman-desktop.io/docs/troubleshooting/troubleshooting-podman"
+  },
+  {
+    "name": "Troubleshooting/troubleshooting podman on linux",
+    "url": "https://podman-desktop.io/docs/troubleshooting/troubleshooting-podman-on-linux"
+  },
+  {
+    "name": "Troubleshooting/troubleshooting podman on macos",
+    "url": "https://podman-desktop.io/docs/troubleshooting/troubleshooting-podman-on-macos"
+  },
+  {
+    "name": "Troubleshooting/troubleshooting podman on windows",
+    "url": "https://podman-desktop.io/docs/troubleshooting/troubleshooting-podman-on-windows"
+  }
+]

--- a/website/static/tutorials.json
+++ b/website/static/tutorials.json
@@ -1,0 +1,24 @@
+[
+  { "name": "Creating an extension", "url": "https://podman-desktop.io/tutorial/creating-an-extension" },
+  {
+    "name": "Deploying a kubernetes application",
+    "url": "https://podman-desktop.io/tutorial/deploying-a-kubernetes-application"
+  },
+  { "name": "Getting started with compose", "url": "https://podman-desktop.io/tutorial/getting-started-with-compose" },
+  {
+    "name": "Interacting with a database server",
+    "url": "https://podman-desktop.io/tutorial/interacting-with-a-database-server"
+  },
+  { "name": "Introduction", "url": "https://podman-desktop.io/tutorial" },
+  {
+    "name": "Managing your application resources",
+    "url": "https://podman-desktop.io/tutorial/managing-your-application-resources"
+  },
+  { "name": "Running a kubernetes cluster", "url": "https://podman-desktop.io/tutorial/running-a-kubernetes-cluster" },
+  {
+    "name": "Running a pod using a container docker file",
+    "url": "https://podman-desktop.io/tutorial/running-a-pod-using-a-container-docker-file"
+  },
+  { "name": "Running an AI application", "url": "https://podman-desktop.io/tutorial/running-an-ai-application" },
+  { "name": "Testcontainers with podman", "url": "https://podman-desktop.io/tutorial/testcontainers-with-podman" }
+]


### PR DESCRIPTION
Assisted by: Cursor

### What does this PR do?
Adds workflow that allows to add kubernetes context using file

### Screenshot / video of UI
+- should look like this: 


[Screencast_20250925_071316.webm](https://github.com/user-attachments/assets/6b4e94bd-b61b-4d30-83b0-2e94e69b4773)


### What issues does this PR fix or reference?

Closes podman-desktop/extension-kubernetes-contexts#77 

### How to test this PR?

Go to settings => kubernetes => import -> select kubeconfig 

- [x] Tests are covering the bug fix or the new feature
