### PR TITLE
style: reorder navbar items to position search button before Download

### DIFF
--- a/website/src/components/GitHubStarsButton.tsx
+++ b/website/src/components/GitHubStarsButton.tsx
@@ -16,7 +16,7 @@ export function GitHubStarsButton({ mobile = false }: { readonly mobile?: boolea
       className={
         mobile
           ? 'dropdown__link flex items-center gap-2 px-4 py-[9px] font-medium text-base'
-          : 'navbar__item navbar__link hidden xl:flex items-center gap-2 px-4 py-[9px] border border-black dark:border-white rounded-lg font-medium min-w-[9rem] text-base'
+          : 'navbar__item navbar__link hidden xl:flex items-center gap-2 px-4 mr-3 py-[9px] border border-black dark:border-white rounded-lg font-medium min-w-[9rem] text-base'
       }>
       <FontAwesomeIcon icon={faGithub} />
       <span>Star</span>

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -251,7 +251,6 @@ article .markdown ol ol {
 
 .navbar__items--right > *:nth-child(1) {
   order: 1;
-  margin-right: 1rem;
 }
 
 .navbar__items--right > *:nth-child(2) {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -244,3 +244,24 @@ article .markdown ol ol {
   background-color: transparent;
   color: var(--ifm-color-primary);
 }
+
+/**
+  Reorder navbar items to move search button to the left of Downloads button
+ */
+
+.navbar__items--right > *:nth-child(1) {
+  order: 1;
+  margin-right: 1rem;
+}
+
+.navbar__items--right > *:nth-child(2) {
+  order: 4;
+}
+
+.navbar__items--right > *:nth-child(3) {
+  order: 2;
+}
+
+.navbar__items--right > *:nth-child(4) {
+  order: 3;
+}


### PR DESCRIPTION
Signed-off-by: Adrian Barrio <statickidz@gmail.com>

### What does this PR do?

This PR improves the website's navbar layout by reordering the navigation elements to provide better user experience:

- Moves the search button to the left of the Downloads button for improved discoverability
- Reorders navbar items using CSS flexbox ordering without modifying HTML structure
- Uses child position selectors (`nth-child()`) instead of dynamic class names for better maintainability
- Maintains responsive design and accessibility features

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="1840" height="1187" alt="image" src="https://github.com/user-attachments/assets/13f9843a-4998-4391-a80c-60dc9da7f62e" />

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #12116 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Build and run the website locally:

2. Verify the following:
   - Search button appears to the left of the Downloads button in the navbar
   - All navbar elements are properly aligned and functional
   - Search functionality works correctly in its new position
   - Responsive design is maintained across different screen sizes
   - No visual regressions in the navbar layout
   - Theme toggle remains at the far right
   - GitHub stars button is properly positioned

3. Test on different browsers to ensure cross-browser compatibility

- [ ] Tests are covering the bug fix or the new feature
