### PR TITLE
feat: detect podman-compose installation before trying to install docker-compose

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -44,7 +44,7 @@
           ]
         },
         {
-          "id": "podmanComposeInstalled",
+          "id": "podmanComposeInstalledView",
           "title": "Found podman-compose installed",
           "when": "compose.isPodmanComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide",
           "content": [

--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -44,10 +44,22 @@
           ]
         },
         {
+          "id": "podmanComposeInstalled",
+          "title": "Found podman-compose installed",
+          "when": "compose.isPodmanComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide",
+          "content": [
+            [
+              {
+                "value": "#### We detected `podman-compose` binary being installed. It won't try to install docker-compose on your system. Unless you remove first podman-compose."
+              }
+            ]
+          ]
+        },
+        {
           "id": "welcomeDownloadView",
           "label": "Compose Download",
           "title": "Compose download",
-          "when": "!compose.isComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
           "content": [
             [
               {
@@ -72,7 +84,7 @@
           "id": "downloadCommand",
           "title": "Downloading Compose ${onboardingContext:composeDownloadVersion}",
           "description": "Downloading the binary.\n\nOnce downloaded, the next step will install Compose system-wide.",
-          "when": "!compose.isComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
           "command": "compose.onboarding.downloadCommand",
           "completionEvents": [
             "onCommand:compose.onboarding.downloadCommand"
@@ -81,13 +93,13 @@
         {
           "id": "downloadFailure",
           "title": "Failed downloading Compose",
-          "when": "!compose.isComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
           "state": "failed"
         },
         {
           "id": "downloadSuccessfulView",
           "title": "Compose successfully Downloaded",
-          "when": "!compose.isComposeInstalledSystemWide && !onboardingContext:composeIsNotDownloaded",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && !onboardingContext:composeIsNotDownloaded",
           "content": [
             [
               {
@@ -100,7 +112,7 @@
           "id": "installSystemWideCommand",
           "title": "Install Compose",
           "description": "Installing the binary system-wide.\n\n You may be prompted for elevated system privileges.",
-          "when": "!compose.isComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide",
           "command": "compose.onboarding.installSystemWideCommand",
           "completionEvents": [
             "onCommand:compose.onboarding.installSystemWideCommand"
@@ -109,7 +121,7 @@
         {
           "id": "installSystemWideFailure",
           "title": "Failed installing Compose",
-          "when": "!compose.isComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide",
           "state": "failed"
         },
         {
@@ -145,7 +157,7 @@
           "type": "boolean",
           "default": true,
           "markdownDescription": "Compose support installed. You can use `podman compose` using the podman CLI.",
-          "when": "(isMac || isWindows) && compose.isComposeInstalledSystemWide",
+          "when": "(isMac || isWindows) && compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide",
           "group": "podman-desktop.podman",
           "scope": "DockerCompatibility"
         },
@@ -153,7 +165,15 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Without compose support in podman you won't be able to use compose projects using the podman CLI. :button[Setup...]{command=compose.openComposeOnboarding}",
-          "when": "(isMac || isWindows) && !compose.isComposeInstalledSystemWide",
+          "when": "(isMac || isWindows) && !compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide",
+          "group": "podman-desktop.podman",
+          "scope": "DockerCompatibility"
+        },
+        "podman.compose.cli.support.podmancompose": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Compose support using `podman-compose` python implementation.",
+          "when": "compose.isPodmanComposeInstalledSystemWide",
           "group": "podman-desktop.podman",
           "scope": "DockerCompatibility"
         }

--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -86,6 +86,21 @@ describe('Check for Docker Compose', async () => {
   });
 });
 
+describe('Check for System Wide Podman Compose', async () => {
+  test('not installed', async () => {
+    const customError = { exitCode: -1 } as extensionApi.RunError;
+    vi.mocked(extensionApi.process.exec).mockRejectedValue(customError);
+    const result = await detect.checkSystemWidePodmanCompose();
+    expect(result).toBeFalsy();
+  });
+
+  test('installed', async () => {
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
+    const result = await detect.checkSystemWidePodmanCompose();
+    expect(result).toBeTruthy();
+  });
+});
+
 describe('Check for path', async () => {
   const customError = { exitCode: -1 } as extensionApi.RunError;
   test('not included', async () => {

--- a/extensions/compose/src/detect.ts
+++ b/extensions/compose/src/detect.ts
@@ -63,6 +63,19 @@ export class Detect {
     }
   }
 
+  // search if podman-compose (python) is available is installed system wide
+  async checkSystemWidePodmanCompose(): Promise<boolean> {
+    try {
+      await extensionApi.process.exec('podman-compose', ['--version'], {
+        env: { PATH: process.env.PATH ?? '' },
+      });
+      return true;
+    } catch (e) {
+      console.debug('Error trying to run the version on podman-compose. Binary might not be there', e);
+      return false;
+    }
+  }
+
   async getDockerComposeBinaryInfo(
     composeCliName: string,
     dir: string = '',

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -74,6 +74,7 @@ vi.mock('node:fs', () => ({
 
 const detectMock = {
   checkSystemWideDockerCompose: vi.fn(),
+  checkSystemWidePodmanCompose: vi.fn(),
   getDockerComposeBinaryInfo: vi.fn(),
   getStoragePath: vi.fn(),
   getExtensionStorageBin: vi.fn(),

--- a/extensions/compose/src/handler.spec.ts
+++ b/extensions/compose/src/handler.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as extensionApi from '@podman-desktop/api';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as detect from './detect';
 import * as handler from './handler';
@@ -62,5 +62,33 @@ test('updateConfigAndContextComposeBinary: make sure configuration gets updated 
   await handler.updateConfigAndContextComposeBinary(extensionContextMock);
 
   expect(configUpdateSpy).toHaveBeenCalledWith('binary.installComposeSystemWide', true);
+
+  describe('podman-compose', async () => {
+    test('updateConfigAndContextComposeBinary: should set isPodmanComposeInstalledSystemWide context to true when podman-compose is installed', async () => {
+      vi.mocked(detect.Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+      vi.mocked(detect.Detect.prototype.checkSystemWidePodmanCompose).mockResolvedValue(true);
+
+      // Run updateConfigAndContextComposeBinary
+      await handler.updateConfigAndContextComposeBinary(extensionContextMock);
+
+      expect(vi.mocked(extensionApi.context.setValue)).toHaveBeenCalledWith(
+        'compose.isPodmanComposeInstalledSystemWide',
+        true,
+      );
+    });
+
+    test('updateConfigAndContextComposeBinary: should set isPodmanComposeInstalledSystemWide context to false when podman-compose is not installed', async () => {
+      vi.mocked(detect.Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
+      vi.mocked(detect.Detect.prototype.checkSystemWidePodmanCompose).mockResolvedValue(false);
+
+      // Run updateConfigAndContextComposeBinary
+      await handler.updateConfigAndContextComposeBinary(extensionContextMock);
+
+      expect(vi.mocked(extensionApi.context.setValue)).toHaveBeenCalledWith(
+        'compose.isPodmanComposeInstalledSystemWide',
+        false,
+      );
+    });
+  });
   expect(contextUpdateSpy).toHaveBeenCalledWith('compose.isComposeInstalledSystemWide', true);
 });

--- a/extensions/compose/src/handler.ts
+++ b/extensions/compose/src/handler.ts
@@ -111,4 +111,8 @@ async function checkAndUpdateComposeBinaryInstalledContexts(detect: Detect): Pro
 
   // Update the compose onboarding context for installComposeSystemWide is either true or false
   extensionApi.context.setValue('compose.isComposeInstalledSystemWide', isDockerComposeInstalledSystemWide);
+
+  // check if 'podman-compose' is installed system-wide
+  const isPodmanComposeInstalledSystemWide = await detect.checkSystemWidePodmanCompose();
+  extensionApi.context.setValue('compose.isPodmanComposeInstalledSystemWide', isPodmanComposeInstalledSystemWide);
 }


### PR DESCRIPTION
### What does this PR do?
if users have `podman-compose`, do not try to download/setup/install docker-compose

- [x] will need a rebase once https://github.com/podman-desktop/podman-desktop/pull/14107 is merged as it includes the commit

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/13134

### How to test this PR?

1. check that "detect podman-compose" step works
remove/backup current configuration ` ~/.local/share/containers/podman-desktop/`
install `podman-compose` (brew install podman-compose or using pip install podman-compose)
starts podman destkop, do the onboarding flow it should say that podman compose is installed so do nothing

2. check that "install docker-compose" works
now, remove podman-compose 
remove docker-compose
remove/backup current configuration ` ~/.local/share/containers/podman-desktop/`
starts podman desktop, do the onboarding, it should suggest to install docker-compose


3. check that "it detects docker-compose"
 remove config ` ~/.local/share/containers/podman-desktop/`
have docker-compose installed

it'll report in onboarding flow that docker-compose is already installed



- [x] Tests are covering the bug fix or the new feature
