### PR TITLE
chore: use state.snapshot to pass provider to load images

### DIFF
--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -63,7 +63,7 @@ async function loadImages(): Promise<void> {
   for (const archive of archivesToLoad) {
     try {
       await window.loadImages({
-        provider: selectedProvider,
+        provider: $state.snapshot(selectedProvider),
         archives: [archive],
       });
     } catch (e) {


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Use `$state.snapshot` to pass the provider object to `window.loadImages`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/14136

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
