### PR TITLE
chore: update license to correct one in website FAQ

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -127,10 +127,10 @@ function FAQ(): JSX.Element {
             title="Is Podman Desktop free?"
             text={
               <p>
-                Yes, Podman Desktop is an open-source project released under the GNU Lesser General Public License
-                (LGPL). This means that it is freely available for use, modification, and distribution by anyone,
-                without charge or licensing fees. Users can download and use Podman Desktop at no cost, making it
-                accessible to individuals and organizations alike.
+                Yes, Podman Desktop is an open-source project released under the Apache License 2.0. This means that it
+                is freely available for use, modification, and distribution by anyone, without charge or licensing fees.
+                Users can download and use Podman Desktop at no cost, making it accessible to individuals and
+                organizations alike.
               </p>
             }
           />


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Updates the license in the FAQ section of the website to `Apache License 2.0`.

### Screenshot / video of UI
<img width="1279" height="581" alt="Screenshot 2025-10-01 at 12 11 20 PM" src="https://github.com/user-attachments/assets/271e76b1-6981-44ac-b911-046185395841" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
