### PR TITLE
feat: add getKubernetesProviders to api

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -840,6 +840,18 @@ declare module '@podman-desktop/api' {
     connection: ContainerProviderConnection;
   }
 
+  export interface ConnectionFactory {
+    type: 'container' | 'kubernetes' | 'vm';
+    providerId: string;
+  }
+
+  export interface ConnectionFactoryDetails extends ConnectionFactory {
+    creationDisplayName?: string;
+    creationButtonTitle?: string;
+    emptyConnectionMarkdownDescription?: string;
+    images?: ProviderImages;
+  }
+
   /**
    * Callback for openning shell session
    */
@@ -1020,6 +1032,18 @@ declare module '@podman-desktop/api' {
     export const onDidUpdateKubernetesConnection: Event<UpdateKubernetesConnectionEvent>;
     export const onDidUnregisterContainerConnection: Event<UnregisterContainerConnectionEvent>;
     export const onDidRegisterContainerConnection: Event<RegisterContainerConnectionEvent>;
+    /**
+     * Fired when a connection factory is set
+     */
+    export const onDidSetConnectionFactory: Event<ConnectionFactoryDetails>;
+    /**
+     * Fired when a connection factory is unset
+     */
+    export const onDidUnsetConnectionFactory: Event<ConnectionFactory>;
+    /**
+     * Returns the current connection factories
+     */
+    export function getConnectionFactories(): ConnectionFactoryDetails[];
     export function getContainerConnections(): ProviderContainerConnection[];
     /**
      * It returns the lifecycle context for the provider connection.

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -895,6 +895,15 @@ export class ExtensionLoader implements AsyncDisposable {
       onDidRegisterContainerConnection: (listener, thisArg, disposables) => {
         return providerRegistry.onDidRegisterContainerConnection(listener, thisArg, disposables);
       },
+      onDidSetConnectionFactory: (listener, thisArg, disposables) => {
+        return providerRegistry.onDidSetConnectionFactory(listener, thisArg, disposables);
+      },
+      onDidUnsetConnectionFactory: (listener, thisArg, disposables) => {
+        return providerRegistry.onDidUnsetConnectionFactory(listener, thisArg, disposables);
+      },
+      getConnectionFactories: () => {
+        return providerRegistry.getConnectionFactories();
+      },
       getContainerConnections: () => {
         return providerRegistry.getContainerConnections();
       },

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -213,9 +213,11 @@ export class ProviderImpl implements Provider, IDisposable {
   ): Disposable {
     this._containerProviderConnectionFactory = containerProviderConnectionFactory;
     this._connectionAuditor = connectionAuditor;
+    this.providerRegistry.onDidSetConnectionFactoryCallback(this, containerProviderConnectionFactory, 'container');
     return Disposable.create(() => {
       this._containerProviderConnectionFactory = undefined;
       this._connectionAuditor = undefined;
+      this.providerRegistry.onDidUnsetConnectionFactoryCallback(this, 'container');
     });
   }
 
@@ -225,9 +227,11 @@ export class ProviderImpl implements Provider, IDisposable {
   ): Disposable {
     this._kubernetesProviderConnectionFactory = kubernetesProviderConnectionFactory;
     this._connectionAuditor = connectionAuditor;
+    this.providerRegistry.onDidSetConnectionFactoryCallback(this, kubernetesProviderConnectionFactory, 'kubernetes');
     return Disposable.create(() => {
       this._kubernetesProviderConnectionFactory = undefined;
       this._connectionAuditor = undefined;
+      this.providerRegistry.onDidUnsetConnectionFactoryCallback(this, 'kubernetes');
     });
   }
 
@@ -248,9 +252,11 @@ export class ProviderImpl implements Provider, IDisposable {
   ): Disposable {
     this._vmProviderConnectionFactory = vmProviderConnectionFactory;
     this._connectionAuditor = connectionAuditor;
+    this.providerRegistry.onDidSetConnectionFactoryCallback(this, vmProviderConnectionFactory, 'vm');
     return Disposable.create(() => {
       this._vmProviderConnectionFactory = undefined;
       this._connectionAuditor = undefined;
+      this.providerRegistry.onDidUnsetConnectionFactoryCallback(this, 'vm');
     });
   }
 

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -22,6 +22,8 @@ import type {
   AutostartContext,
   CancellationToken,
   CheckResult,
+  ConnectionFactory,
+  ConnectionFactoryDetails,
   ContainerProviderConnection,
   InstallCheck,
   KubernetesProviderConnection,
@@ -31,6 +33,7 @@ import type {
   ProviderConnectionShellAccess,
   ProviderConnectionShellAccessSession,
   ProviderConnectionStatus,
+  ProviderImages,
   ProviderInstallation,
   ProviderLifecycle,
   ProviderUpdate,
@@ -135,6 +138,54 @@ test('should initialize provider if there is kubernetes connection provider', as
   } else {
     assert.fail('providerInternalId not initialized');
   }
+});
+
+test('onDidSetConnectionFactory is called when a container connection factory is set and onDidUnsetConnectionFactory is called when the disposable is disposed', async () => {
+  const onDidSetConnectionFactoryMock: (e: ConnectionFactoryDetails) => void = vi.fn();
+  providerRegistry.onDidSetConnectionFactory(onDidSetConnectionFactoryMock);
+
+  const onDidUnsetConnectionFactoryMock: (e: ConnectionFactory) => void = vi.fn();
+  providerRegistry.onDidUnsetConnectionFactory(onDidUnsetConnectionFactoryMock);
+
+  const images = {
+    icon: {
+      light: 'a light image',
+      dark: 'a dark image',
+    },
+    logo: {
+      light: 'a light image',
+      dark: 'a dark image',
+    },
+  } as ProviderImages;
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'aProviderId',
+    name: 'aProviderName',
+    status: 'installed',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description',
+    images,
+  });
+
+  const disposable = provider.setContainerProviderConnectionFactory({
+    initialize: async () => {},
+    create: async () => {},
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+  });
+
+  expect(onDidSetConnectionFactoryMock).toHaveBeenCalledWith({
+    type: 'container',
+    providerId: 'aProviderId',
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description',
+    images,
+  });
+
+  disposable.dispose();
+  expect(onDidUnsetConnectionFactoryMock).toHaveBeenCalledWith({
+    type: 'container',
+    providerId: 'aProviderId',
+  });
 });
 
 test('should initialize provider if there is VM connection provider', async () => {
@@ -257,6 +308,54 @@ test('should initialize provider if there is container connection provider', asy
   } else {
     assert.fail('providerInternalId not initialized');
   }
+});
+
+test('onDidSetConnectionFactory is called when a kubernetes connection factory is set and onDidUnsetConnectionFactory is called when the disposable is disposed', async () => {
+  const onDidSetConnectionFactoryMock: (e: ConnectionFactoryDetails) => void = vi.fn();
+  providerRegistry.onDidSetConnectionFactory(onDidSetConnectionFactoryMock);
+
+  const onDidUnsetConnectionFactoryMock: (e: ConnectionFactory) => void = vi.fn();
+  providerRegistry.onDidUnsetConnectionFactory(onDidUnsetConnectionFactoryMock);
+
+  const images = {
+    icon: {
+      light: 'a light image',
+      dark: 'a dark image',
+    },
+    logo: {
+      light: 'a light image',
+      dark: 'a dark image',
+    },
+  } as ProviderImages;
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'aProviderId',
+    name: 'aProviderName',
+    status: 'installed',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description',
+    images,
+  });
+
+  const disposable = provider.setKubernetesProviderConnectionFactory({
+    initialize: async () => {},
+    create: async () => {},
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+  });
+
+  expect(onDidSetConnectionFactoryMock).toHaveBeenCalledWith({
+    type: 'kubernetes',
+    providerId: 'aProviderId',
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description',
+    images,
+  });
+
+  disposable.dispose();
+  expect(onDidUnsetConnectionFactoryMock).toHaveBeenCalledWith({
+    type: 'kubernetes',
+    providerId: 'aProviderId',
+  });
 });
 
 test('connections should contain the display name provided when registering', async () => {
@@ -676,6 +775,54 @@ describe('a vm provider is registered', async () => {
       const token = {} as CancellationToken;
       await providerRegistry.createVmProviderConnection('0', params, logHandler, token);
       expect(factory.create).toHaveBeenCalledWith(params, logHandler, token);
+    });
+
+    test('onDidSetConnectionFactory is called when a vm connection factory is set and onDidUnsetConnectionFactory is called when the disposable is disposed', async () => {
+      const onDidSetConnectionFactoryMock: (e: ConnectionFactoryDetails) => void = vi.fn();
+      providerRegistry.onDidSetConnectionFactory(onDidSetConnectionFactoryMock);
+
+      const onDidUnsetConnectionFactoryMock: (e: ConnectionFactory) => void = vi.fn();
+      providerRegistry.onDidUnsetConnectionFactory(onDidUnsetConnectionFactoryMock);
+
+      const images = {
+        icon: {
+          light: 'a light image',
+          dark: 'a dark image',
+        },
+        logo: {
+          light: 'a light image',
+          dark: 'a dark image',
+        },
+      } as ProviderImages;
+      const provider = providerRegistry.createProvider('id', 'name', {
+        id: 'aProviderId',
+        name: 'aProviderName',
+        status: 'installed',
+        emptyConnectionMarkdownDescription: 'an empty connection markdown description',
+        images,
+      });
+
+      const disposable = provider.setVmProviderConnectionFactory({
+        initialize: async () => {},
+        create: async () => {},
+        creationDisplayName: 'a creation Display Name',
+        creationButtonTitle: 'a creation Button Title',
+      });
+
+      expect(onDidSetConnectionFactoryMock).toHaveBeenCalledWith({
+        type: 'vm',
+        providerId: 'aProviderId',
+        creationDisplayName: 'a creation Display Name',
+        creationButtonTitle: 'a creation Button Title',
+        emptyConnectionMarkdownDescription: 'an empty connection markdown description',
+        images,
+      });
+
+      disposable.dispose();
+      expect(onDidUnsetConnectionFactoryMock).toHaveBeenCalledWith({
+        type: 'vm',
+        providerId: 'aProviderId',
+      });
     });
   });
 });
@@ -2376,4 +2523,107 @@ test('should retrieve provider info from provider internal id', async () => {
   expect(provider2?.id).toBe('internal2');
   expect(provider2?.name).toBe('internal2name');
   expect(provider2?.extensionId).toBe('id2');
+});
+
+test('getConnectionFactories should return an empty array if there are no providers', async () => {
+  const connectionFactories = providerRegistry.getConnectionFactories();
+  expect(connectionFactories).toHaveLength(0);
+});
+
+test('getConnectionFactories should return the connection factories', async () => {
+  const provider1Images = {
+    icon: {
+      light: 'a light image 1',
+      dark: 'a dark image 1',
+    },
+    logo: {
+      light: 'a light image 1',
+      dark: 'a dark image 1',
+    },
+  } as ProviderImages;
+  const provider1 = providerRegistry.createProvider('id', 'name', {
+    id: 'provider1',
+    name: 'Provider1',
+    status: 'installed',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description for provider 1',
+    images: provider1Images,
+  });
+
+  provider1.setContainerProviderConnectionFactory({
+    initialize: async () => {},
+    create: async () => {},
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+  });
+  provider1.setKubernetesProviderConnectionFactory({
+    initialize: async () => {},
+    create: async () => {},
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+  });
+  provider1.setVmProviderConnectionFactory({
+    initialize: async () => {},
+    create: async () => {},
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+  });
+
+  const provider2Images = {
+    icon: {
+      light: 'a light image 2',
+      dark: 'a dark image 2',
+    },
+    logo: {
+      light: 'a light image 2',
+      dark: 'a dark image 2',
+    },
+  } as ProviderImages;
+
+  const provider2 = providerRegistry.createProvider('id', 'name', {
+    id: 'provider2',
+    name: 'Provider2',
+    status: 'installed',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description for provider 2',
+    images: provider2Images,
+  });
+  provider2.setContainerProviderConnectionFactory({
+    initialize: async () => {},
+    create: async () => {},
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+  });
+  const connectionFactories = providerRegistry.getConnectionFactories();
+  expect(connectionFactories).toHaveLength(4);
+  expect(connectionFactories).toContainEqual({
+    type: 'container',
+    providerId: 'provider1',
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description for provider 1',
+    images: provider1Images,
+  });
+  expect(connectionFactories).toContainEqual({
+    type: 'kubernetes',
+    providerId: 'provider1',
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description for provider 1',
+    images: provider1Images,
+  });
+  expect(connectionFactories).toContainEqual({
+    type: 'vm',
+    providerId: 'provider1',
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description for provider 1',
+    images: provider1Images,
+  });
+  expect(connectionFactories).toContainEqual({
+    type: 'container',
+    providerId: 'provider2',
+    creationDisplayName: 'a creation Display Name',
+    creationButtonTitle: 'a creation Button Title',
+    emptyConnectionMarkdownDescription: 'an empty connection markdown description for provider 2',
+    images: provider2Images,
+  });
 });


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds `onDidSetConnectionFactory`, `onDidUnsetConnectionFactory` and `getConnectionFactories`  functions to the podman desktop API

The function returns the information needed to implement https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/315

(the getter is necessary, at least for the case when an extension restarts, it will need to get the factories, as they won't be triggered by the other extensions, already started)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #14167 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
