### PR TITLE
feat: added component for handling enums for booleans

### DIFF
--- a/packages/renderer/src/lib/ui/BooleanEnumDisplay.spec.ts
+++ b/packages/renderer/src/lib/ui/BooleanEnumDisplay.spec.ts
@@ -28,8 +28,7 @@ describe('BooleanEnumDisplay', () => {
     const props = {
       value: false,
       options: ['disabled', 'enabled'],
-      description: 'Test property',
-      id: 'test.property',
+      ariaLabel: 'test.property',
     };
 
     const { getByText } = render(BooleanEnumDisplay, props);
@@ -40,8 +39,7 @@ describe('BooleanEnumDisplay', () => {
     const props = {
       value: true,
       options: ['disabled', 'enabled'],
-      description: 'Test property',
-      id: 'test.property',
+      ariaLabel: 'test.property',
     };
 
     const { getByText } = render(BooleanEnumDisplay, props);
@@ -52,34 +50,31 @@ describe('BooleanEnumDisplay', () => {
     const props = {
       value: true,
       options: ['only-one'],
-      description: 'Test property',
-      id: 'test.property',
+      ariaLabel: 'test.property',
     };
 
     const { queryByText } = render(BooleanEnumDisplay, props);
     expect(queryByText('only-one')).not.toBeInTheDocument();
   });
 
-  test('should include aria-label with description', () => {
+  test('should include aria-label when provided', () => {
     const props = {
       value: true,
       options: ['rootless', 'rootful'],
-      description: 'Machine with root privileges',
-      id: 'podman.machine.rootful',
+      ariaLabel: 'Machine with root privileges: rootful',
     };
 
     const { getByLabelText } = render(BooleanEnumDisplay, props);
     expect(getByLabelText('Machine with root privileges: rootful')).toBeInTheDocument();
   });
 
-  test('should use id as fallback for aria-label when description is not provided', () => {
+  test('should use displayText as fallback for aria-label when aria-label is not provided', () => {
     const props = {
       value: false,
       options: ['rootless', 'rootful'],
-      id: 'podman.machine.rootful',
     };
 
     const { getByLabelText } = render(BooleanEnumDisplay, props);
-    expect(getByLabelText('podman.machine.rootful: rootless')).toBeInTheDocument();
+    expect(getByLabelText('rootless')).toBeInTheDocument();
   });
 });

--- a/packages/renderer/src/lib/ui/BooleanEnumDisplay.spec.ts
+++ b/packages/renderer/src/lib/ui/BooleanEnumDisplay.spec.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+
+import BooleanEnumDisplay from './BooleanEnumDisplay.svelte';
+
+describe('BooleanEnumDisplay', () => {
+  test('should display first enum value when attrValue is false', () => {
+    const props = {
+      value: false,
+      options: ['disabled', 'enabled'],
+      description: 'Test property',
+      id: 'test.property',
+    };
+
+    const { getByText } = render(BooleanEnumDisplay, props);
+    expect(getByText('disabled')).toBeInTheDocument();
+  });
+
+  test('should display second enum value when attrValue is true', () => {
+    const props = {
+      value: true,
+      options: ['disabled', 'enabled'],
+      description: 'Test property',
+      id: 'test.property',
+    };
+
+    const { getByText } = render(BooleanEnumDisplay, props);
+    expect(getByText('enabled')).toBeInTheDocument();
+  });
+
+  test('should not render when enum has not 2 values', () => {
+    const props = {
+      value: true,
+      options: ['only-one'],
+      description: 'Test property',
+      id: 'test.property',
+    };
+
+    const { queryByText } = render(BooleanEnumDisplay, props);
+    expect(queryByText('only-one')).not.toBeInTheDocument();
+  });
+
+  test('should include aria-label with description', () => {
+    const props = {
+      value: true,
+      options: ['rootless', 'rootful'],
+      description: 'Machine with root privileges',
+      id: 'podman.machine.rootful',
+    };
+
+    const { getByLabelText } = render(BooleanEnumDisplay, props);
+    expect(getByLabelText('Machine with root privileges: rootful')).toBeInTheDocument();
+  });
+
+  test('should use id as fallback for aria-label when description is not provided', () => {
+    const props = {
+      value: false,
+      options: ['rootless', 'rootful'],
+      id: 'podman.machine.rootful',
+    };
+
+    const { getByLabelText } = render(BooleanEnumDisplay, props);
+    expect(getByLabelText('podman.machine.rootful: rootless')).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/ui/BooleanEnumDisplay.svelte
+++ b/packages/renderer/src/lib/ui/BooleanEnumDisplay.svelte
@@ -2,14 +2,22 @@
 interface Props {
   value: boolean;
   options: string[];
-  description?: string;
-  id?: string;
+  ariaLabel?: string;
 }
 
-const { value, options, description, id }: Props = $props();
+const { value, options, ariaLabel }: Props = $props();
 
+/**
+ * The display text is the second option if the value is true, otherwise the first option
+ * Convention: options[0] = false label, options[1] = true label
+ */
 const displayText = $derived.by(() => {
+  if (typeof value !== 'boolean') {
+    console.warn('BooleanEnumDisplay: value must be boolean, got:', typeof value, value);
+    return undefined;
+  }
   if (options.length !== 2) {
+    console.warn('BooleanEnumDisplay: options must have 2 values');
     return undefined;
   }
   return options[value ? 1 : 0];
@@ -17,7 +25,7 @@ const displayText = $derived.by(() => {
 </script>
 
 {#if displayText}
- <span aria-label="{description ?? id}: {displayText}">
+ <span aria-label="{ariaLabel ?? displayText}">
   {displayText}
  </span>
 {/if}

--- a/packages/renderer/src/lib/ui/BooleanEnumDisplay.svelte
+++ b/packages/renderer/src/lib/ui/BooleanEnumDisplay.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+interface Props {
+  value: boolean;
+  options: string[];
+  description?: string;
+  id?: string;
+}
+
+const { value, options, description, id }: Props = $props();
+
+const displayText = $derived.by(() => {
+  if (options.length !== 2) {
+    return undefined;
+  }
+  return options[value ? 1 : 0];
+});
+</script>
+
+{#if displayText}
+ <span aria-label="{description ?? id}: {displayText}">
+  {displayText}
+ </span>
+{/if}


### PR DESCRIPTION
Signed-off-by: Marcel Bertagnini <mbertagn@redhat.com>

### What does this PR do?

This PR creates a generic `BooleanEnumDisplay` component to handle boolean values with enum display options.
PR #14076 needs to display rootless/rootful status for containers. Instead of creating a specific solution, this PR provides a reusable component that can handle any boolean property with enum display values.

- Creates `BooleanEnumDisplay` component in `/packages/renderer/src/lib/ui/`
- Supports any boolean value with exactly 2 enum options (e.g., `["rootless", "rootful"]`)
- Includes accessibility with automatic `aria-label`

### Screenshot / video of UI

### What issues does this PR fix or reference?

Issue #13735 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
