### PR TITLE
refactor(extensions/podman/windows): move windows base checks to corresponding class

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -414,7 +414,7 @@ describe.each([
     { version: '6.3.2', image: 'image' },
     { version: '5.0.0', image: 'image' },
     { version: '4.5.0', image: 'image-path' },
-  ])('verify create command called with correct values for %s', async ({ version, image }) => {
+  ])(`verify create command called with correct values for %s`, async ({ version, image }) => {
     vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
       stdout: `podman version ${version}`,
     } as extensionApi.RunResult);

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -50,7 +50,7 @@ import {
 } from './extension';
 import type { UpdateCheck } from './installer/podman-install';
 import { PodmanInstall } from './installer/podman-install';
-import { WinPlatform } from './platforms/win-platform';
+import type { WinPlatform } from './platforms/win-platform';
 import * as compatibilityModeLib from './utils/compatibility-mode';
 import type { InstalledPodman } from './utils/podman-cli';
 import * as podmanCli from './utils/podman-cli';
@@ -2487,11 +2487,7 @@ describe('calcPodmanMachineSetting', () => {
 
 test('checkForUpdate func should be called if there is no podman installed', async () => {
   const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
-  const podmanInstall: PodmanInstall = new PodmanInstall(
-    extensionContext,
-    telemetryLogger,
-    new WinPlatform(extensionContext, telemetryLogger),
-  );
+  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger, {} as WinPlatform);
 
   vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue(undefined);
   vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -21,8 +21,9 @@ import * as fs from 'node:fs';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { WinPlatform } from '/@/platforms/win-platform';
+
 import * as extensionObj from '../extension';
-import type { WinPlatform } from '../platforms/win-platform';
 import { releaseNotes } from '../podman5.json';
 import { getBundledPodmanVersion } from '../utils/podman-bundled';
 import type { InstalledPodman } from '../utils/podman-cli';

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -22,7 +22,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as extensionObj from '../extension';
-import { WinPlatform } from '../platforms/win-platform';
+import type { WinPlatform } from '../platforms/win-platform';
 import { releaseNotes } from '../podman5.json';
 import { getBundledPodmanVersion } from '../utils/podman-bundled';
 import type { InstalledPodman } from '../utils/podman-cli';
@@ -148,14 +148,11 @@ beforeAll(async () => {
   extensionObj.initExtensionContext(extensionContext);
   await extensionObj.initInversify(extensionContext, telemetryLogger);
 });
+
 beforeEach(() => {
   vi.clearAllMocks();
 
-  podmanInstall = new TestPodmanInstall(
-    extensionContext,
-    mockTelemetryLogger,
-    new WinPlatform(extensionContext, mockTelemetryLogger),
-  );
+  podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger, {} as WinPlatform);
   // reset array of subscriptions
   extensionContext.subscriptions.length = 0;
   console.error = consoleErrorMock;

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -43,6 +43,7 @@ import {
   isStartNowAtMachineInitSupported,
   isUserModeNetworkingSupported,
 } from '../extension';
+import { WinPlatform } from '../platforms/win-platform';
 import * as podman5JSON from '../podman5.json';
 import { getBundledPodmanVersion } from '../utils/podman-bundled';
 import type { InstalledPodman } from '../utils/podman-cli';
@@ -74,6 +75,8 @@ export class PodmanInstall {
     readonly extensionContext: extensionApi.ExtensionContext,
     @inject(TelemetryLoggerSymbol)
     readonly telemetryLogger: extensionApi.TelemetryLogger,
+    @inject(WinPlatform)
+    readonly winPlatform: WinPlatform,
   ) {
     this.storagePath = extensionContext.storagePath;
     if (extensionApi.env.isMac) {
@@ -81,7 +84,7 @@ export class PodmanInstall {
       this.installer = new MacOSInstaller();
     } else if (extensionApi.env.isWindows) {
       this.providerCleanup = new PodmanCleanupWindows();
-      this.installer = new WinInstaller(extensionContext, telemetryLogger);
+      this.installer = new WinInstaller(this.winPlatform);
     }
   }
 

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -30,6 +30,7 @@ import {
   USER_MODE_NETWORKING_SUPPORTED_KEY,
 } from '/@/constants';
 import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
+import { WinPlatform } from '/@/platforms/win-platform';
 import { MachineJSON } from '/@/types';
 
 import { getDetectionChecks } from '../checks/detection-checks';
@@ -43,7 +44,6 @@ import {
   isStartNowAtMachineInitSupported,
   isUserModeNetworkingSupported,
 } from '../extension';
-import { WinPlatform } from '../platforms/win-platform';
 import * as podman5JSON from '../podman5.json';
 import { getBundledPodmanVersion } from '../utils/podman-bundled';
 import type { InstalledPodman } from '../utils/podman-cli';

--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -22,7 +22,8 @@ import type { ExtensionContext } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { WinPlatform } from '../platforms/win-platform';
+import type { WinPlatform } from '/@/platforms/win-platform';
+
 import { getAssetsFolder } from '../utils/util';
 import { WinInstaller } from './win-installer';
 

--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -18,11 +18,11 @@
 
 import { existsSync, readdirSync } from 'node:fs';
 
-import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
+import type { ExtensionContext } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { WinPlatform } from '../platforms/win-platform';
+import type { WinPlatform } from '../platforms/win-platform';
 import { getAssetsFolder } from '../utils/util';
 import { WinInstaller } from './win-installer';
 
@@ -50,8 +50,6 @@ const progress = {
   report: (): void => {},
 };
 
-const mockTelemetryLogger = {} as TelemetryLogger;
-
 vi.mock(import('./../utils/util'), () => ({
   getAssetsFolder: vi.fn(),
 }));
@@ -68,13 +66,15 @@ beforeEach(() => {
   });
 });
 
+const WinPlatformMock = {} as WinPlatform;
+
 test('expect update on windows to show notification in case of 0 exit code', async () => {
   vi.mocked(extensionApi.process.exec).mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
 
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(new WinPlatform(extensionContext, mockTelemetryLogger));
+  const installer = new WinInstaller(WinPlatformMock);
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).toHaveBeenCalled();
@@ -89,7 +89,7 @@ test('expect update on windows not to show notification in case of 1602 exit cod
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(new WinPlatform(extensionContext, mockTelemetryLogger));
+  const installer = new WinInstaller(WinPlatformMock);
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
@@ -105,7 +105,7 @@ test('expect update on windows to throw error if non zero exit code', async () =
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(new WinPlatform(extensionContext, mockTelemetryLogger));
+  const installer = new WinInstaller(WinPlatformMock);
   const result = await installer.update();
   expect(result).toBeFalsy();
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -22,6 +22,7 @@ import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { WinPlatform } from '../platforms/win-platform';
 import { getAssetsFolder } from '../utils/util';
 import { WinInstaller } from './win-installer';
 
@@ -73,7 +74,7 @@ test('expect update on windows to show notification in case of 0 exit code', asy
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
+  const installer = new WinInstaller(new WinPlatform(extensionContext, mockTelemetryLogger));
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).toHaveBeenCalled();
@@ -88,7 +89,7 @@ test('expect update on windows not to show notification in case of 1602 exit cod
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
+  const installer = new WinInstaller(new WinPlatform(extensionContext, mockTelemetryLogger));
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
@@ -104,7 +105,7 @@ test('expect update on windows to throw error if non zero exit code', async () =
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
+  const installer = new WinInstaller(new WinPlatform(extensionContext, mockTelemetryLogger));
   const result = await installer.update();
   expect(result).toBeFalsy();
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -67,7 +67,7 @@ beforeEach(() => {
   });
 });
 
-const WinPlatformMock = {} as WinPlatform;
+const winPlatformMock = {} as WinPlatform;
 
 test('expect update on windows to show notification in case of 0 exit code', async () => {
   vi.mocked(extensionApi.process.exec).mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
@@ -75,7 +75,7 @@ test('expect update on windows to show notification in case of 0 exit code', asy
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(WinPlatformMock);
+  const installer = new WinInstaller(winPlatformMock);
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).toHaveBeenCalled();
@@ -90,7 +90,7 @@ test('expect update on windows not to show notification in case of 1602 exit cod
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(WinPlatformMock);
+  const installer = new WinInstaller(winPlatformMock);
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
@@ -106,7 +106,7 @@ test('expect update on windows to throw error if non zero exit code', async () =
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(WinPlatformMock);
+  const installer = new WinInstaller(winPlatformMock);
   const result = await installer.update();
   expect(result).toBeFalsy();
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -23,7 +23,8 @@ import path from 'node:path';
 import type { InstallCheck, RunError } from '@podman-desktop/api';
 import { process as processAPI, ProgressLocation, window } from '@podman-desktop/api';
 
-import type { WinPlatform } from '../platforms/win-platform';
+import type { WinPlatform } from '/@/platforms/win-platform';
+
 import podman5Json from '../podman5.json';
 import { getAssetsFolder } from '../utils/util';
 import { BaseInstaller } from './base-installer';

--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -21,15 +21,15 @@ import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { HyperVCheck } from '/@/checks/windows/hyperv-check';
+import type { HyperVPodmanVersionCheck } from '/@/checks/windows/hyperv-podman-version-check';
+import type { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
 import type { WinBitCheck } from '/@/checks/windows/win-bit-check';
 import type { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
 import type { WinVersionCheck } from '/@/checks/windows/win-version-check';
+import type { WSLVersionCheck } from '/@/checks/windows/wsl-version-check';
+import type { WSL2Check } from '/@/checks/windows/wsl2-check';
 
-import type { HyperVCheck } from '../checks/windows/hyperv-check';
-import type { HyperVPodmanVersionCheck } from '../checks/windows/hyperv-podman-version-check';
-import type { VirtualMachinePlatformCheck } from '../checks/windows/virtual-machine-platform-check';
-import type { WSLVersionCheck } from '../checks/windows/wsl-version-check';
-import type { WSL2Check } from '../checks/windows/wsl2-check';
 import { WinPlatform } from './win-platform';
 
 vi.mock('@podman-desktop/api', () => ({ env: { isWindows: false } }));

--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -1,0 +1,111 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+import { expect, test, vi } from 'vitest';
+
+import { HyperVCheck } from '../checks/windows/hyperv-check';
+import { HyperVPodmanVersionCheck } from '../checks/windows/hyperv-podman-version-check';
+import { VirtualMachinePlatformCheck } from '../checks/windows/virtual-machine-platform-check';
+import { WSLVersionCheck } from '../checks/windows/wsl-version-check';
+import { WSL2Check } from '../checks/windows/wsl2-check';
+import { WinPlatform } from './win-platform';
+
+vi.mock('@podman-desktop/api', () => ({ env: { isWindows: false } }));
+
+vi.mock(import('../checks/windows/hyperv-check'));
+vi.mock(import('../checks/windows/hyperv-podman-version-check'));
+vi.mock(import('../checks/windows/virtual-machine-platform-check'));
+vi.mock(import('../checks/windows/wsl-version-check'));
+vi.mock(import('../checks/windows/wsl2-check'));
+
+const extensionContextMock = {} as ExtensionContext;
+const telemetryLoggerMock = {} as TelemetryLogger;
+
+const successfulCheckResult = { successful: true };
+const failedCheckResult = { successful: false };
+
+test('isHyperVEnabled should return false if it is not a Windows environment', async () => {
+  vi.mocked(extensionApi.env).isWindows = false;
+
+  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
+  const hypervEnabled = await winPlatform.isHyperVEnabled();
+
+  expect(hypervEnabled).toBeFalsy();
+});
+
+test('isHyperVEnabled should return false if Hyper-V check fails', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(HyperVCheck.prototype.execute).mockResolvedValue(failedCheckResult);
+  vi.mocked(HyperVPodmanVersionCheck.prototype.execute).mockResolvedValue(failedCheckResult);
+
+  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
+  const hypervEnabled = await winPlatform.isHyperVEnabled();
+
+  expect(hypervEnabled).toBeFalsy();
+});
+
+test('isHyperVEnabled should return true if all Hyper-V checks succeed', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(HyperVCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(HyperVPodmanVersionCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
+
+  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
+  const hypervEnabled = await winPlatform.isHyperVEnabled();
+
+  expect(hypervEnabled).toBeTruthy();
+});
+
+test('isWSLEnabled should return false if not on Windows', async () => {
+  vi.mocked(extensionApi.env).isWindows = false;
+
+  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
+  const wslEnabled = await winPlatform.isWSLEnabled();
+
+  expect(wslEnabled).toBeFalsy();
+});
+
+test('isWSLEnabled should return false if any WSL check fails', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(VirtualMachinePlatformCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(WSLVersionCheck.prototype.execute).mockResolvedValue(failedCheckResult);
+  vi.mocked(WSL2Check.prototype.execute).mockResolvedValue(successfulCheckResult);
+
+  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
+  const wslEnabled = await winPlatform.isWSLEnabled();
+
+  expect(wslEnabled).toBeFalsy();
+});
+
+test('isWSLEnabled should return true if all WSL checks succeed', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(VirtualMachinePlatformCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(WSLVersionCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(WSL2Check.prototype.execute).mockResolvedValue(successfulCheckResult);
+
+  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
+  const wslEnabled = await winPlatform.isWSLEnabled();
+
+  expect(wslEnabled).toBeTruthy();
+});

--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -37,14 +37,14 @@ vi.mock('@podman-desktop/api', () => ({ env: { isWindows: false } }));
 const extensionContextMock = {} as ExtensionContext;
 const telemetryLoggerMock = {} as TelemetryLogger;
 
-const WinBitCheckMock = { execute: vi.fn() } as unknown as WinBitCheck;
-const WinVersionCheckMock = { execute: vi.fn() } as unknown as WinVersionCheck;
-const WinMemoryCheckMock = { execute: vi.fn() } as unknown as WinMemoryCheck;
-const HyperVPodmanVersionCheckMock = { execute: vi.fn() } as unknown as HyperVPodmanVersionCheck;
-const HyperVCheckMock = { execute: vi.fn() } as unknown as HyperVCheck;
-const VirtualMachinePlatformCheckMock = { execute: vi.fn() } as unknown as VirtualMachinePlatformCheck;
-const WSLVersionCheckMock = { execute: vi.fn() } as unknown as WSLVersionCheck;
-const WSL2CheckMock = { execute: vi.fn() } as unknown as WSL2Check;
+const winBitCheckMock = { execute: vi.fn() } as unknown as WinBitCheck;
+const winVersionCheckMock = { execute: vi.fn() } as unknown as WinVersionCheck;
+const winMemoryCheckMock = { execute: vi.fn() } as unknown as WinMemoryCheck;
+const hyperVPodmanVersionCheckMock = { execute: vi.fn() } as unknown as HyperVPodmanVersionCheck;
+const hyperVCheckMock = { execute: vi.fn() } as unknown as HyperVCheck;
+const virtualMachinePlatformCheckMock = { execute: vi.fn() } as unknown as VirtualMachinePlatformCheck;
+const wSLVersionCheckMock = { execute: vi.fn() } as unknown as WSLVersionCheck;
+const wSL2CheckMock = { execute: vi.fn() } as unknown as WSL2Check;
 
 const successfulCheckResult = { successful: true };
 const failedCheckResult = { successful: false };
@@ -55,14 +55,14 @@ beforeEach(() => {
   winPlatform = new WinPlatform(
     extensionContextMock,
     telemetryLoggerMock,
-    WinBitCheckMock,
-    WinVersionCheckMock,
-    WinMemoryCheckMock,
-    HyperVPodmanVersionCheckMock,
-    HyperVCheckMock,
-    VirtualMachinePlatformCheckMock,
-    WSLVersionCheckMock,
-    WSL2CheckMock,
+    winBitCheckMock,
+    winVersionCheckMock,
+    winMemoryCheckMock,
+    hyperVPodmanVersionCheckMock,
+    hyperVCheckMock,
+    virtualMachinePlatformCheckMock,
+    wSLVersionCheckMock,
+    wSL2CheckMock,
   );
 });
 
@@ -77,8 +77,8 @@ test('isHyperVEnabled should return false if it is not a Windows environment', a
 test('isHyperVEnabled should return false if Hyper-V check fails', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
 
-  vi.mocked(HyperVCheckMock.execute).mockResolvedValue(failedCheckResult);
-  vi.mocked(HyperVPodmanVersionCheckMock.execute).mockResolvedValue(failedCheckResult);
+  vi.mocked(hyperVCheckMock.execute).mockResolvedValue(failedCheckResult);
+  vi.mocked(hyperVPodmanVersionCheckMock.execute).mockResolvedValue(failedCheckResult);
 
   const hypervEnabled = await winPlatform.isHyperVEnabled();
 
@@ -88,8 +88,8 @@ test('isHyperVEnabled should return false if Hyper-V check fails', async () => {
 test('isHyperVEnabled should return true if all Hyper-V checks succeed', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
 
-  vi.mocked(HyperVCheckMock.execute).mockResolvedValue(successfulCheckResult);
-  vi.mocked(HyperVPodmanVersionCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(hyperVCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(hyperVPodmanVersionCheckMock.execute).mockResolvedValue(successfulCheckResult);
 
   const hypervEnabled = await winPlatform.isHyperVEnabled();
 
@@ -107,9 +107,9 @@ test('isWSLEnabled should return false if not on Windows', async () => {
 test('isWSLEnabled should return false if any WSL check fails', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
 
-  vi.mocked(VirtualMachinePlatformCheckMock.execute).mockResolvedValue(successfulCheckResult);
-  vi.mocked(WSLVersionCheckMock.execute).mockResolvedValue(failedCheckResult);
-  vi.mocked(WSL2CheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(virtualMachinePlatformCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(wSLVersionCheckMock.execute).mockResolvedValue(failedCheckResult);
+  vi.mocked(wSL2CheckMock.execute).mockResolvedValue(successfulCheckResult);
 
   const wslEnabled = await winPlatform.isWSLEnabled();
 
@@ -119,9 +119,9 @@ test('isWSLEnabled should return false if any WSL check fails', async () => {
 test('isWSLEnabled should return true if all WSL checks succeed', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
 
-  vi.mocked(VirtualMachinePlatformCheckMock.execute).mockResolvedValue(successfulCheckResult);
-  vi.mocked(WSLVersionCheckMock.execute).mockResolvedValue(successfulCheckResult);
-  vi.mocked(WSL2CheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(virtualMachinePlatformCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(wSLVersionCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(wSL2CheckMock.execute).mockResolvedValue(successfulCheckResult);
 
   const wslEnabled = await winPlatform.isWSLEnabled();
 

--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -19,33 +19,56 @@
 
 import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
-import { HyperVCheck } from '../checks/windows/hyperv-check';
-import { HyperVPodmanVersionCheck } from '../checks/windows/hyperv-podman-version-check';
-import { VirtualMachinePlatformCheck } from '../checks/windows/virtual-machine-platform-check';
-import { WSLVersionCheck } from '../checks/windows/wsl-version-check';
-import { WSL2Check } from '../checks/windows/wsl2-check';
+import type { WinBitCheck } from '/@/checks/windows/win-bit-check';
+import type { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
+import type { WinVersionCheck } from '/@/checks/windows/win-version-check';
+
+import type { HyperVCheck } from '../checks/windows/hyperv-check';
+import type { HyperVPodmanVersionCheck } from '../checks/windows/hyperv-podman-version-check';
+import type { VirtualMachinePlatformCheck } from '../checks/windows/virtual-machine-platform-check';
+import type { WSLVersionCheck } from '../checks/windows/wsl-version-check';
+import type { WSL2Check } from '../checks/windows/wsl2-check';
 import { WinPlatform } from './win-platform';
 
 vi.mock('@podman-desktop/api', () => ({ env: { isWindows: false } }));
 
-vi.mock(import('../checks/windows/hyperv-check'));
-vi.mock(import('../checks/windows/hyperv-podman-version-check'));
-vi.mock(import('../checks/windows/virtual-machine-platform-check'));
-vi.mock(import('../checks/windows/wsl-version-check'));
-vi.mock(import('../checks/windows/wsl2-check'));
-
 const extensionContextMock = {} as ExtensionContext;
 const telemetryLoggerMock = {} as TelemetryLogger;
+
+const WinBitCheckMock = { execute: vi.fn() } as unknown as WinBitCheck;
+const WinVersionCheckMock = { execute: vi.fn() } as unknown as WinVersionCheck;
+const WinMemoryCheckMock = { execute: vi.fn() } as unknown as WinMemoryCheck;
+const HyperVPodmanVersionCheckMock = { execute: vi.fn() } as unknown as HyperVPodmanVersionCheck;
+const HyperVCheckMock = { execute: vi.fn() } as unknown as HyperVCheck;
+const VirtualMachinePlatformCheckMock = { execute: vi.fn() } as unknown as VirtualMachinePlatformCheck;
+const WSLVersionCheckMock = { execute: vi.fn() } as unknown as WSLVersionCheck;
+const WSL2CheckMock = { execute: vi.fn() } as unknown as WSL2Check;
 
 const successfulCheckResult = { successful: true };
 const failedCheckResult = { successful: false };
 
+let winPlatform: WinPlatform;
+
+beforeEach(() => {
+  winPlatform = new WinPlatform(
+    extensionContextMock,
+    telemetryLoggerMock,
+    WinBitCheckMock,
+    WinVersionCheckMock,
+    WinMemoryCheckMock,
+    HyperVPodmanVersionCheckMock,
+    HyperVCheckMock,
+    VirtualMachinePlatformCheckMock,
+    WSLVersionCheckMock,
+    WSL2CheckMock,
+  );
+});
+
 test('isHyperVEnabled should return false if it is not a Windows environment', async () => {
   vi.mocked(extensionApi.env).isWindows = false;
 
-  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
   const hypervEnabled = await winPlatform.isHyperVEnabled();
 
   expect(hypervEnabled).toBeFalsy();
@@ -54,10 +77,9 @@ test('isHyperVEnabled should return false if it is not a Windows environment', a
 test('isHyperVEnabled should return false if Hyper-V check fails', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
 
-  vi.mocked(HyperVCheck.prototype.execute).mockResolvedValue(failedCheckResult);
-  vi.mocked(HyperVPodmanVersionCheck.prototype.execute).mockResolvedValue(failedCheckResult);
+  vi.mocked(HyperVCheckMock.execute).mockResolvedValue(failedCheckResult);
+  vi.mocked(HyperVPodmanVersionCheckMock.execute).mockResolvedValue(failedCheckResult);
 
-  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
   const hypervEnabled = await winPlatform.isHyperVEnabled();
 
   expect(hypervEnabled).toBeFalsy();
@@ -66,10 +88,9 @@ test('isHyperVEnabled should return false if Hyper-V check fails', async () => {
 test('isHyperVEnabled should return true if all Hyper-V checks succeed', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
 
-  vi.mocked(HyperVCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
-  vi.mocked(HyperVPodmanVersionCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(HyperVCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(HyperVPodmanVersionCheckMock.execute).mockResolvedValue(successfulCheckResult);
 
-  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
   const hypervEnabled = await winPlatform.isHyperVEnabled();
 
   expect(hypervEnabled).toBeTruthy();
@@ -78,7 +99,6 @@ test('isHyperVEnabled should return true if all Hyper-V checks succeed', async (
 test('isWSLEnabled should return false if not on Windows', async () => {
   vi.mocked(extensionApi.env).isWindows = false;
 
-  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
   const wslEnabled = await winPlatform.isWSLEnabled();
 
   expect(wslEnabled).toBeFalsy();
@@ -87,11 +107,10 @@ test('isWSLEnabled should return false if not on Windows', async () => {
 test('isWSLEnabled should return false if any WSL check fails', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
 
-  vi.mocked(VirtualMachinePlatformCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
-  vi.mocked(WSLVersionCheck.prototype.execute).mockResolvedValue(failedCheckResult);
-  vi.mocked(WSL2Check.prototype.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(VirtualMachinePlatformCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(WSLVersionCheckMock.execute).mockResolvedValue(failedCheckResult);
+  vi.mocked(WSL2CheckMock.execute).mockResolvedValue(successfulCheckResult);
 
-  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
   const wslEnabled = await winPlatform.isWSLEnabled();
 
   expect(wslEnabled).toBeFalsy();
@@ -100,11 +119,10 @@ test('isWSLEnabled should return false if any WSL check fails', async () => {
 test('isWSLEnabled should return true if all WSL checks succeed', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
 
-  vi.mocked(VirtualMachinePlatformCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
-  vi.mocked(WSLVersionCheck.prototype.execute).mockResolvedValue(successfulCheckResult);
-  vi.mocked(WSL2Check.prototype.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(VirtualMachinePlatformCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(WSLVersionCheckMock.execute).mockResolvedValue(successfulCheckResult);
+  vi.mocked(WSL2CheckMock.execute).mockResolvedValue(successfulCheckResult);
 
-  const winPlatform = new WinPlatform(extensionContextMock, telemetryLoggerMock);
   const wslEnabled = await winPlatform.isWSLEnabled();
 
   expect(wslEnabled).toBeTruthy();

--- a/extensions/podman/packages/extension/src/platforms/win-platform.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.ts
@@ -20,16 +20,16 @@ import type { InstallCheck } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
 
-import { OrCheck, SequenceCheck } from '../checks/base-check';
-import { HyperVCheck } from '../checks/windows/hyperv-check';
-import { HyperVPodmanVersionCheck } from '../checks/windows/hyperv-podman-version-check';
-import { VirtualMachinePlatformCheck } from '../checks/windows/virtual-machine-platform-check';
-import { WinBitCheck } from '../checks/windows/win-bit-check';
-import { WinMemoryCheck } from '../checks/windows/win-memory-check';
-import { WinVersionCheck } from '../checks/windows/win-version-check';
-import { WSLVersionCheck } from '../checks/windows/wsl-version-check';
-import { WSL2Check } from '../checks/windows/wsl2-check';
-import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '../inject/symbols';
+import { OrCheck, SequenceCheck } from '/@/checks/base-check';
+import { HyperVCheck } from '/@/checks/windows/hyperv-check';
+import { HyperVPodmanVersionCheck } from '/@/checks/windows/hyperv-podman-version-check';
+import { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
+import { WinBitCheck } from '/@/checks/windows/win-bit-check';
+import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
+import { WinVersionCheck } from '/@/checks/windows/win-version-check';
+import { WSLVersionCheck } from '/@/checks/windows/wsl-version-check';
+import { WSL2Check } from '/@/checks/windows/wsl2-check';
+import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 
 @injectable()
 export class WinPlatform {


### PR DESCRIPTION
### What does this PR do?


This PR moves Windows base checks to the dedicated class created in a previous PR.

Ready for review.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14292
Fixes https://github.com/podman-desktop/podman-desktop/issues/14293

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
