### PR TITLE
chore(extension: podman): adding `/@/` path alias

### DIFF
--- a/extensions/podman/packages/extension/tsconfig.json
+++ b/extensions/podman/packages/extension/tsconfig.json
@@ -13,7 +13,10 @@
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "/@/*": ["./src/*"]
+    }
   },
   "include": ["src", "types/*.d.ts", "scripts"]
 }


### PR DESCRIPTION
### What does this PR do?

Adding the missing path alias for podman extension

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14308
