### PR TITLE
chore(test): remove/refactor deprecated code for playing yaml files to Kubernetes runtime

### DIFF
--- a/tests/playwright/src/model/core/operations.ts
+++ b/tests/playwright/src/model/core/operations.ts
@@ -22,8 +22,3 @@ export enum ResourceElementActions {
   Stop = 'Stop',
   Delete = 'Delete',
 }
-
-export enum PlayYamlRuntime {
-  Kubernetes,
-  Podman,
-}

--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PlayYamlRuntime } from './operations';
-
 export interface ContainerInteractiveParams {
   interactive?: boolean;
   attachTerminal?: boolean;
@@ -41,12 +39,6 @@ export interface DeployPodOptions {
   containerExposedPort?: string;
   isOpenShiftCluster?: boolean;
   useOpenShiftRoutes?: boolean;
-}
-
-export interface PlayKubernetesOptions {
-  runtime?: PlayYamlRuntime;
-  kubernetesNamespace?: string;
-  kubernetesContext: string;
 }
 
 export enum KubernetesResources {

--- a/tests/playwright/src/specs/kubernetes-image-push.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-image-push.spec.ts
@@ -19,7 +19,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
 import { canRunKindTests } from '../setupFiles/setup-kind';
@@ -37,14 +36,7 @@ const CLUSTER_NAME: string = 'kind-cluster';
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
 const RESOURCE_NAME: string = 'kind';
-const KUBERNETES_CONTEXT = `kind-${CLUSTER_NAME}`;
-const KUBERNETES_NAMESPACE = 'default';
 const DEPLOYMENT_NAME = 'test-image-push';
-const KUBERNETES_RUNTIME = {
-  runtime: PlayYamlRuntime.Kubernetes,
-  kubernetesContext: KUBERNETES_CONTEXT,
-  kubernetesNamespace: KUBERNETES_NAMESPACE,
-};
 const IMAGE_NAME = 'ghcr.io/linuxcontainers/alpine';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -112,13 +104,7 @@ test.describe.serial(
     });
     test('Create a Kubernetes deployment resource', async ({ page }) => {
       test.setTimeout(80_000);
-      await createKubernetesResource(
-        page,
-        KubernetesResources.Pods,
-        DEPLOYMENT_NAME + '-pod',
-        DEPLOYMENT_YAML_PATH,
-        KUBERNETES_RUNTIME,
-      );
+      await createKubernetesResource(page, KubernetesResources.Pods, DEPLOYMENT_NAME + '-pod', DEPLOYMENT_YAML_PATH);
 
       await checkKubernetesResourceState(
         page,

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -19,7 +19,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
@@ -42,16 +41,11 @@ const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
 const RESOURCE_NAME: string = 'kind';
 const KUBERNETES_CONTEXT: string = `kind-${CLUSTER_NAME}`;
-const KUBERNETES_NAMESPACE: string = 'default';
 
 const DEPLOYMENT_NAME: string = 'test-deployment-resource';
 const SERVICE_NAME: string = 'test-service-resource';
 const INGRESS_NAME: string = 'test-ingress-resource';
-const KUBERNETES_RUNTIME = {
-  runtime: PlayYamlRuntime.Kubernetes,
-  kubernetesContext: KUBERNETES_CONTEXT,
-  kubernetesNamespace: KUBERNETES_NAMESPACE,
-};
+
 const IMAGE_NAME: string = 'ghcr.io/podmandesktop-ci/nginx';
 const PULL_IMAGE_NAME: string = `${IMAGE_NAME}:latest`;
 const CONTAINER_NAME: string = 'nginx-container';
@@ -136,13 +130,7 @@ test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
 
       test('Create and verify a running Kubernetes deployment', async ({ page }) => {
         test.setTimeout(80_000);
-        await createKubernetesResource(
-          page,
-          KubernetesResources.Deployments,
-          DEPLOYMENT_NAME,
-          DEPLOYMENT_YAML_PATH,
-          KUBERNETES_RUNTIME,
-        );
+        await createKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, DEPLOYMENT_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.Deployments,
@@ -152,13 +140,7 @@ test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
         );
       });
       test('Create and verify a running Kubernetes service', async ({ page }) => {
-        await createKubernetesResource(
-          page,
-          KubernetesResources.Services,
-          SERVICE_NAME,
-          SERVICE_YAML_PATH,
-          KUBERNETES_RUNTIME,
-        );
+        await createKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME, SERVICE_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.Services,
@@ -168,13 +150,7 @@ test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
         );
       });
       test('Create and verify a running Kubernetes ingress', async ({ page }) => {
-        await createKubernetesResource(
-          page,
-          KubernetesResources.IngeressesRoutes,
-          INGRESS_NAME,
-          INGRESS_YAML_PATH,
-          KUBERNETES_RUNTIME,
-        );
+        await createKubernetesResource(page, KubernetesResources.IngeressesRoutes, INGRESS_NAME, INGRESS_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.IngeressesRoutes,

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -21,14 +21,12 @@ import { fileURLToPath } from 'node:url';
 
 import { expect as playExpect } from '@playwright/test';
 
-import { PlayYamlRuntime } from '../model/core/operations';
 import { KubernetesResourceState } from '../model/core/states';
 import { KubernetesResources } from '../model/core/types';
 import { canRunKindTests } from '../setupFiles/setup-kind';
 import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
 import { test } from '../utility/fixtures';
 import {
-  applyYamlFileToCluster,
   checkDeploymentReplicasInfo,
   checkKubernetesResourceState,
   createKubernetesResource,
@@ -42,8 +40,6 @@ const CLUSTER_NAME: string = 'kind-cluster';
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 const KIND_NODE: string = `${CLUSTER_NAME}-control-plane`;
 const RESOURCE_NAME: string = 'kind';
-const KUBERNETES_CONTEXT: string = `kind-${CLUSTER_NAME}`;
-const KUBERNETES_NAMESPACE: string = 'default';
 const PVC_NAME: string = 'test-pvc-resource';
 const PVC_POD_NAME: string = 'test-pod-pvcs';
 const CONFIG_MAP_NAME: string = 'test-configmap-resource';
@@ -51,12 +47,6 @@ const SECRET_NAME: string = 'test-secret-resource';
 const SECRET_POD_NAME: string = 'test-pod-configmaps-secrets';
 const DEPLOYMENT_NAME: string = 'test-deployment-resource';
 const CRON_JOB_NAME: string = 'test-cronjob-resource';
-
-const KUBERNETES_RUNTIME = {
-  runtime: PlayYamlRuntime.Kubernetes,
-  kubernetesContext: KUBERNETES_CONTEXT,
-  kubernetesNamespace: KUBERNETES_NAMESPACE,
-};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -206,11 +196,11 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
   test.describe
     .serial('PVC lifecycle test', () => {
       test('Create a new PVC resource', async ({ page }) => {
-        await createKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, PVC_YAML_PATH, KUBERNETES_RUNTIME);
+        await createKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, PVC_YAML_PATH);
         await checkKubernetesResourceState(page, KubernetesResources.PVCs, PVC_NAME, KubernetesResourceState.Stopped);
       });
       test('Bind the PVC to a pod', async ({ page }) => {
-        await applyYamlFileToCluster(page, PVC_POD_YAML_PATH, KUBERNETES_RUNTIME);
+        await createKubernetesResource(page, KubernetesResources.Pods, PVC_POD_NAME, PVC_POD_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.Pods,
@@ -231,7 +221,6 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
           KubernetesResources.ConfigMapsSecrets,
           CONFIG_MAP_NAME,
           CONFIG_MAP_YAML_PATH,
-          KUBERNETES_RUNTIME,
         );
         await checkKubernetesResourceState(
           page,
@@ -241,13 +230,7 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
         );
       });
       test('Create Secret resource', async ({ page }) => {
-        await createKubernetesResource(
-          page,
-          KubernetesResources.ConfigMapsSecrets,
-          SECRET_NAME,
-          SECRET_YAML_PATH,
-          KUBERNETES_RUNTIME,
-        );
+        await createKubernetesResource(page, KubernetesResources.ConfigMapsSecrets, SECRET_NAME, SECRET_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.ConfigMapsSecrets,
@@ -258,7 +241,7 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
       test('Can load config and secrets via env. var in pod', async ({ page }) => {
         test.setTimeout(120_000);
 
-        await applyYamlFileToCluster(page, SECRET_POD_YAML_PATH, KUBERNETES_RUNTIME);
+        await createKubernetesResource(page, KubernetesResources.Pods, SECRET_POD_NAME, SECRET_POD_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.Pods,
@@ -277,13 +260,7 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
     .serial('Deployment lifecycle test', () => {
       test('Create a Kubernetes deployment resource', async ({ page }) => {
         test.setTimeout(90_000);
-        await createKubernetesResource(
-          page,
-          KubernetesResources.Deployments,
-          DEPLOYMENT_NAME,
-          DEPLOYMENT_YAML_PATH,
-          KUBERNETES_RUNTIME,
-        );
+        await createKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, DEPLOYMENT_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.Deployments,
@@ -311,13 +288,7 @@ test.describe('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () =>
   test.describe
     .serial('Cronjobs lifecycle test', () => {
       test('Create and verify a running Kubernetes cronjob', async ({ page }) => {
-        await createKubernetesResource(
-          page,
-          KubernetesResources.Cronjobs,
-          CRON_JOB_NAME,
-          CRON_JOB_YAML_PATH,
-          KUBERNETES_RUNTIME,
-        );
+        await createKubernetesResource(page, KubernetesResources.Cronjobs, CRON_JOB_NAME, CRON_JOB_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.Cronjobs,


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

In this PR, the option for deploying Kubernetes YAML resources to the Kubernetes runtime was removed. The playYaml function was refactored to meet basic functionality requirements.

follow up pr: https://github.com/podman-desktop/podman-desktop/pull/14315

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/14179

### How to test this PR?

https://github.com/podman-desktop/e2e/actions/runs/18277071674