### PR TITLE
fix: reduce extension wording duplication on installed page

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
@@ -126,7 +126,7 @@ test('Expect to have details page', async () => {
 
   await waitRender({ extensionId });
 
-  const heading = screen.getByRole('heading', { name: 'A installed Extension extension' });
+  const heading = screen.getByRole('heading', { name: 'A installed Extension' });
   expect(heading).toBeInTheDocument();
 
   const extensionActions = screen.getByRole('group', { name: 'Extension Actions' });
@@ -188,6 +188,6 @@ test('Expect to have details page with id with spaces', async () => {
 
   await waitRender({ extensionId });
 
-  const heading = screen.getByRole('heading', { name: 'A Extension extension' });
+  const heading = screen.getByRole('heading', { name: 'A Extension' });
   expect(heading).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -39,7 +39,7 @@ $: extension = derived(
 </script>
 
 {#if $extension}
-  <DetailsPage title="{$extension.displayName} extension" subtitle={$extension.description} bind:this={detailsPage}>
+  <DetailsPage title={$extension.displayName} subtitle={$extension.description} bind:this={detailsPage}>
     {#snippet iconSnippet()}
       <div class="flex flex-col mt-1 items-baseline w-8">
         <div class="w-8 min-h-8">
@@ -105,7 +105,7 @@ $: extension = derived(
     {/snippet}
   </DetailsPage>
 {:else}
-  <DetailsPage title="{extensionId} extension" bind:this={detailsPage}>
+  <DetailsPage title={extensionId} bind:this={detailsPage}>
     {#snippet contentSnippet()}
       <div class="flex w-full h-full">
         <EmptyScreen

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.spec.ts
@@ -58,7 +58,7 @@ test('Expect to have link with displayIcon', async () => {
 
   render(ExtensionDetailsLink, { extension });
 
-  const detailsButton = screen.getByRole('button', { name: 'foo extension details' });
+  const detailsButton = screen.getByRole('button', { name: 'View details for This is the display name' });
   expect(detailsButton).toBeInTheDocument();
 
   // check text of the button
@@ -90,7 +90,7 @@ test('Expect to have link with spaces', async () => {
 
   render(ExtensionDetailsLink, { extension });
 
-  const detailsButton = screen.getByRole('button', { name: 'foo extension details' });
+  const detailsButton = screen.getByRole('button', { name: 'View details for This is the display name' });
   expect(detailsButton).toBeInTheDocument();
 
   // click the button

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -24,21 +24,24 @@ function resolveLabel(...candidates: Array<string | undefined | null>): string {
   return '';
 }
 
-let extensionLabel = resolveLabel(extension.displayName, extension.name, extension.id);
-let detailsLabel = extensionLabel ? `View details for ${extensionLabel}` : 'View extension details';
+function getExtensionLabel(): string {
+  return resolveLabel(extension.displayName, extension.name, extension.id);
+}
 
-$: extensionLabel = resolveLabel(extension.displayName, extension.name, extension.id);
-$: detailsLabel = extensionLabel ? `View details for ${extensionLabel}` : 'View extension details';
+function getDetailsLabel(): string {
+  const label = getExtensionLabel();
+  return label ? `View details for ${label}` : 'View extension details';
+}
 </script>
 
-<Tooltip top tip={detailsLabel}>
-  <button aria-label={detailsLabel} type="button" on:click={openDetailsExtension}>
+<Tooltip top tip={getDetailsLabel()}>
+  <button aria-label={getDetailsLabel()} type="button" on:click={openDetailsExtension}>
     <div class="flex flex-row items-center text-[var(--pd-content-header)]">
       {#if displayIcon}
         <Fa icon={faArrowUpRightFromSquare} />
       {/if}
       <div class="text-left before:{$$props.class}">
-        {extensionLabel}
+        {getExtensionLabel()}
       </div>
     </div>
   </button>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -6,9 +6,13 @@ import { router } from 'tinro';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 
-export let extension: CombinedExtensionInfoUI;
+interface Props {
+  extension: CombinedExtensionInfoUI;
+  displayIcon?: boolean;
+  class?: string;
+}
 
-export let displayIcon: boolean = true;
+let { extension, displayIcon = true, class: className = '' }: Props = $props();
 
 function openDetailsExtension(): void {
   router.goto(`/extensions/details/${encodeURIComponent(extension.id)}/`);
@@ -31,13 +35,13 @@ function getExtensionLabel(): string {
 const detailsLabel = $derived(getExtensionLabel() ? `View details for ${getExtensionLabel()}` : 'View extension details');
 </script>
 
-<Tooltip top tip={getDetailsLabel()}>
-  <button aria-label={getDetailsLabel()} type="button" on:click={openDetailsExtension}>
+<Tooltip top tip={detailsLabel}>
+  <button aria-label={detailsLabel} type="button" onclick={openDetailsExtension}>
     <div class="flex flex-row items-center text-[var(--pd-content-header)]">
       {#if displayIcon}
         <Fa icon={faArrowUpRightFromSquare} />
       {/if}
-      <div class="text-left before:{$$props.class}">
+      <div class={`text-left ${className}`}>
         {getExtensionLabel()}
       </div>
     </div>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -13,16 +13,32 @@ export let displayIcon: boolean = true;
 function openDetailsExtension(): void {
   router.goto(`/extensions/details/${encodeURIComponent(extension.id)}/`);
 }
+
+function resolveLabel(...candidates: Array<string | undefined | null>): string {
+  for (const candidate of candidates) {
+    if (candidate && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+
+  return '';
+}
+
+let extensionLabel = resolveLabel(extension.displayName, extension.name, extension.id);
+let detailsLabel = extensionLabel ? `View details for ${extensionLabel}` : 'View extension details';
+
+$: extensionLabel = resolveLabel(extension.displayName, extension.name, extension.id);
+$: detailsLabel = extensionLabel ? `View details for ${extensionLabel}` : 'View extension details';
 </script>
 
-<Tooltip top tip="{extension.name} extension details">
-  <button aria-label="{extension.name} extension details" type="button" on:click={openDetailsExtension}>
+<Tooltip top tip={detailsLabel}>
+  <button aria-label={detailsLabel} type="button" on:click={openDetailsExtension}>
     <div class="flex flex-row items-center text-[var(--pd-content-header)]">
       {#if displayIcon}
         <Fa icon={faArrowUpRightFromSquare} />
       {/if}
       <div class="text-left before:{$$props.class}">
-        {extension.displayName} extension
+        {extensionLabel}
       </div>
     </div>
   </button>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -28,10 +28,7 @@ function getExtensionLabel(): string {
   return resolveLabel(extension.displayName, extension.name, extension.id);
 }
 
-function getDetailsLabel(): string {
-  const label = getExtensionLabel();
-  return label ? `View details for ${label}` : 'View extension details';
-}
+const detailsLabel = $derived(getExtensionLabel() ? `View details for ${getExtensionLabel()}` : 'View extension details');
 </script>
 
 <Tooltip top tip={getDetailsLabel()}>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts
@@ -71,6 +71,6 @@ test('Expect to see icon, link, badge and actions', async () => {
   expect(icon).toHaveAttribute('src', 'iconOfMyExtension.png');
 
   // and the link
-  const detailsButton = screen.getByRole('button', { name: 'foo extension details' });
+  const detailsButton = screen.getByRole('button', { name: 'View details for foo' });
   expect(detailsButton).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- drop the extra "extension" suffix from details headers and link tooltips
- reuse a helper to pick the first non-empty label for installed extensions
- refresh affected renderer unit tests for the new copy

Fixes #13104.

## Testing
- `pnpm run build:preload:types`
- `pnpm run build:ui`
- `pnpm vitest run packages/renderer/src/lib/extensions/ExtensionDetailsLink.spec.ts packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts`