### PR TITLE
fix: clarify extension search scope

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -20,7 +20,10 @@ interface Props {
   screen?: ExtensionListScreen;
 }
 
-let { searchTerm = '', screen = 'installed' }: Props = $props();
+let { searchTerm: initialSearchTerm = '', screen: initialScreen = 'installed' }: Props = $props();
+
+let searchTerm = $state(initialSearchTerm);
+let screen = $state(initialScreen);
 
 const extensionsUtils = new ExtensionsUtils();
 
@@ -69,7 +72,7 @@ const searchPlaceholder = $derived(
 );
 </script>
 
-<NavPage bind:searchTerm={searchTerm} title="extensions" searchPlaceholder="Search extensions by name, publisher, or keyword...">
+<NavPage bind:searchTerm={searchTerm} title="extensions" searchPlaceholder={searchPlaceholder}>
   {#snippet additionalActions()}
     <Button
       on:click={(): void => {

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -59,6 +59,14 @@ function changeScreen(newScreen: 'installed' | 'catalog' | 'development'): void 
   screen = newScreen;
   searchTerm = extensionsUtils.filterTerms(searchTerm).join(' ');
 }
+
+const searchPlaceholder = $derived(
+  screen === 'installed'
+    ? 'Search installed extensions...'
+    : screen === 'catalog'
+      ? 'Search catalog extensions...'
+      : 'Search local extensions...',
+);
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="extensions" searchPlaceholder="Search extensions by name, publisher, or keyword...">

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -61,7 +61,7 @@ function changeScreen(newScreen: 'installed' | 'catalog' | 'development'): void 
 }
 </script>
 
-<NavPage bind:searchTerm={searchTerm} title="extensions">
+<NavPage bind:searchTerm={searchTerm} title="extensions" searchPlaceholder="Search extensions by name, publisher, or keyword...">
   {#snippet additionalActions()}
     <Button
       on:click={(): void => {

--- a/packages/ui/src/lib/inputs/SearchInput.svelte
+++ b/packages/ui/src/lib/inputs/SearchInput.svelte
@@ -21,11 +21,8 @@ let {
   placeholder,
 }: Props = $props();
 
-let appliedPlaceholder = '';
-let appliedAriaLabel = '';
-
-$: appliedPlaceholder = placeholder ?? `Search ${title}...`;
-$: appliedAriaLabel = placeholder ?? `search ${title}`;
+const appliedPlaceholder = $derived(placeholder ?? `Search ${title}...`);
+const appliedAriaLabel = $derived(placeholder ? `Search: ${placeholder}` : `Search ${title}`);
 </script>
 
 <Input

--- a/packages/ui/src/lib/inputs/SearchInput.svelte
+++ b/packages/ui/src/lib/inputs/SearchInput.svelte
@@ -8,20 +8,33 @@ interface Props {
   searchTerm?: string;
   oninput?: (event: Event) => void;
   class?: string;
+  placeholder?: string;
 }
 
 const bubble = createBubbler();
 
-let { title = '', searchTerm = $bindable(''), oninput = bubble('input'), class: className = '' }: Props = $props();
+let {
+  title = '',
+  searchTerm = $bindable(''),
+  oninput = bubble('input'),
+  class: className = '',
+  placeholder,
+}: Props = $props();
+
+let appliedPlaceholder = '';
+let appliedAriaLabel = '';
+
+$: appliedPlaceholder = placeholder ?? `Search ${title}...`;
+$: appliedAriaLabel = placeholder ?? `search ${title}`;
 </script>
 
 <Input
   class={className}
   id="search-{title}"
   name="search-{title}"
-  placeholder="Search {title}..."
+  placeholder={appliedPlaceholder}
   bind:value={searchTerm}
-  aria-label="search {title}"
+  aria-label={appliedAriaLabel}
   clearable
   {oninput}>
   {#snippet left()}

--- a/packages/ui/src/lib/inputs/SearchInput.svelte
+++ b/packages/ui/src/lib/inputs/SearchInput.svelte
@@ -22,7 +22,7 @@ let {
 }: Props = $props();
 
 const appliedPlaceholder = $derived(placeholder ?? `Search ${title}...`);
-const appliedAriaLabel = $derived(placeholder ? `Search: ${placeholder}` : `Search ${title}`);
+const appliedAriaLabel = $derived(placeholder ? `Search: ${placeholder}` : `search ${title}`);
 </script>
 
 <Input

--- a/packages/ui/src/lib/layouts/NavPage.svelte
+++ b/packages/ui/src/lib/layouts/NavPage.svelte
@@ -7,6 +7,7 @@ interface Props {
   title: string;
   searchTerm?: string;
   searchEnabled?: boolean;
+  searchPlaceholder?: string;
   additionalActions?: Snippet;
   bottomAdditionalActions?: Snippet;
   tabs?: Snippet;
@@ -17,6 +18,7 @@ let {
   title,
   searchTerm = $bindable(''),
   searchEnabled = true,
+  searchPlaceholder,
   additionalActions,
   bottomAdditionalActions,
   tabs,
@@ -43,7 +45,7 @@ let {
     {#if searchEnabled}
       <div class="flex flex-row pb-4" role="region" aria-label="search">
         <div class="pl-5 w-72">
-          <SearchInput bind:searchTerm={searchTerm} title={title} />
+          <SearchInput bind:searchTerm={searchTerm} title={title} placeholder={searchPlaceholder} />
         </div>
         <div class="flex flex-1 px-5" role="group" aria-label="bottomAdditionalActions">
           {#if bottomAdditionalActions}


### PR DESCRIPTION
## Summary
- add optional placeholder overrides in the shared NavPage/SearchInput components
- show context-aware search hints for installed, catalog, and local extension tabs

Partial fix of #13276.

## Testing
- `pnpm vitest run packages/renderer/src/lib/extensions/ExtensionList.spec.ts`