### PR TITLE
chore: add removeNetwork and updateNetwork methods

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2487,6 +2487,47 @@ describe('listNetworks', () => {
   });
 });
 
+test('removeNetwork', async () => {
+  const removeMock = vi.fn();
+  const api = {
+    getNetwork: vi.fn().mockReturnValue({ remove: removeMock }),
+  } as unknown as Dockerode;
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+    },
+    api: api,
+  } as InternalContainerProvider);
+
+  await containerRegistry.removeNetwork('podman1', 'network1');
+
+  expect(api.getNetwork).toHaveBeenCalledWith('network1');
+  expect(removeMock).toHaveBeenCalled();
+});
+
+test('updateNetwork', async () => {
+  const libPodApi = {
+    updateNetwork: vi.fn(),
+  } as unknown as LibPod;
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+    },
+    api: {} as unknown as Dockerode,
+    libpodApi: libPodApi,
+  } as InternalContainerProvider);
+
+  await containerRegistry.updateNetwork('podman1', 'network1', ['1.1.1.1'], []);
+
+  expect(libPodApi.updateNetwork).toHaveBeenCalledWith('network1', ['1.1.1.1'], []);
+});
+
 describe('createVolume', () => {
   test('provided name', async () => {
     server = setupServer(http.post('http://localhost/volumes/create', () => HttpResponse.json('')));

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -190,6 +190,8 @@ export class ContainerProviderRegistry {
         this.apiSender.send('pod-event');
       } else if (jsonEvent?.Type === 'volume') {
         this.apiSender.send('volume-event');
+      } else if (jsonEvent?.Type === 'network') {
+        this.apiSender.send('network-event');
       } else if (jsonEvent.status === 'remove' && jsonEvent?.Type === 'container') {
         this.apiSender.send('container-removed-event', jsonEvent.id);
       } else if (jsonEvent.status === 'pull' && jsonEvent?.Type === 'image') {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -800,6 +800,35 @@ export class ContainerProviderRegistry {
     }
   }
 
+  async removeNetwork(engineId: string, networkId: string): Promise<void> {
+    let telemetryOptions = {};
+    try {
+      await this.getMatchingEngine(engineId).getNetwork(networkId).remove();
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('removeNetwork', telemetryOptions);
+    }
+  }
+
+  async updateNetwork(
+    engineId: string,
+    networkId: string,
+    addDNSServer: string[],
+    removeDNSServer: string[],
+  ): Promise<void> {
+    let telemetryOptions = {};
+    try {
+      await this.getMatchingPodmanEngineLibPod(engineId).updateNetwork(networkId, addDNSServer, removeDNSServer);
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('updateNetwork', telemetryOptions);
+    }
+  }
+
   async listVolumes(fetchUsage = false): Promise<VolumeListInfo[]> {
     let telemetryOptions = {};
     const volumes = await Promise.all(

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -434,3 +434,17 @@ test('check pod inspect', async () => {
   expect(response).toBeDefined();
   expect(response.Id).toStrictEqual('testId1');
 });
+
+test('Check update network', async () => {
+  server = setupServer(
+    http.post('http://localhost/v4.2.0/libpod/networks/network1/update', async info => {
+      const requestBoddy = await info.request.json();
+      expect(requestBoddy).toEqual({ adddnsservers: ['1.1.1.1'], removednsservers: [] });
+      return HttpResponse.json({}, { status: 204 });
+    }),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+  await (api as unknown as LibPod).updateNetwork('network1', ['1.1.1.1'], []);
+});

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -379,6 +379,11 @@ export interface GetImagesOptions {
   names: string[];
 }
 
+export interface NetworkUpdateOptions {
+  adddnsservers?: string[];
+  removednsservers?: string[];
+}
+
 // API of libpod that we want to expose on our side
 export interface LibPod {
   createPod(podOptions: PodCreateOptions): Promise<{ Id: string }>;
@@ -403,6 +408,7 @@ export interface LibPod {
   podmanInspectManifest(manifestName: string): Promise<ManifestInspectInfo>;
   podmanPushManifest(manifestOptions: ManifestPushOptions, authInfo?: Dockerode.AuthConfig): Promise<void>;
   podmanRemoveManifest(manifestName: string): Promise<void>;
+  updateNetwork(networkId: string, addDNSServer: string[], removeDNSServer: string[]): Promise<void>;
 }
 
 // change the method from private to public as we're overriding it
@@ -1084,6 +1090,33 @@ export class LibpodDockerode {
             return reject(err);
           }
           resolve(wrapAs<{ Names: string[] }>(data));
+        });
+      });
+    };
+
+    prototypeOfDockerode.updateNetwork = function (
+      networkId: string,
+      addDNSServer: string[],
+      removeDNSServer: string[],
+    ): Promise<void> {
+      const options: NetworkUpdateOptions = { adddnsservers: addDNSServer, removednsservers: removeDNSServer };
+      const optsf = {
+        path: `/v4.2.0/libpod/networks/${networkId}/update`,
+        method: 'POST',
+        options: options,
+        statusCodes: {
+          200: true,
+          204: true,
+          400: 'bad parameter',
+          500: 'server error',
+        },
+      };
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(wrapAs<void>(data));
         });
       });
     };

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -822,6 +822,24 @@ export class PluginSystem {
       return containerProviderRegistry.listNetworks();
     });
     this.ipcHandle(
+      'container-provider-registry:removeNetwork',
+      async (_listener, engine: string, networkId: string): Promise<void> => {
+        return containerProviderRegistry.removeNetwork(engine, networkId);
+      },
+    );
+    this.ipcHandle(
+      'container-provider-registry:updateNetwork',
+      async (
+        _listener,
+        engineId: string,
+        networkId: string,
+        addDNSServers: string[],
+        removeDNSServers: string[],
+      ): Promise<void> => {
+        return containerProviderRegistry.updateNetwork(engineId, networkId, addDNSServers, removeDNSServers);
+      },
+    );
+    this.ipcHandle(
       'container-provider-registry:listVolumes',
       async (_listener, fetchUsage: boolean): Promise<VolumeListInfo[]> => {
         return containerProviderRegistry.listVolumes(fetchUsage);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -304,6 +304,17 @@ export function initExposure(): void {
     return ipcInvoke('container-provider-registry:listNetworks');
   });
 
+  contextBridge.exposeInMainWorld('removeNetwork', async (engine: string, networkId: string): Promise<void> => {
+    return ipcInvoke('container-provider-registry:removeNetwork', engine, networkId);
+  });
+
+  contextBridge.exposeInMainWorld(
+    'updateNetwork',
+    async (engine: string, networkId: string, addDNSServers: string[], removeDNSServers: string[]): Promise<void> => {
+      return ipcInvoke('container-provider-registry:updateNetwork', engine, networkId, addDNSServers, removeDNSServers);
+    },
+  );
+
   contextBridge.exposeInMainWorld(
     'replicatePodmanContainer',
     async (


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds the Dockerode `removeNetwork` and LibPod `UpdateNetwork` methods that will be used for https://github.com/podman-desktop/podman-desktop/issues/14109

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Part of https://github.com/podman-desktop/podman-desktop/issues/14109

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
