### PR TITLE
test(e2e): add preferences text e2e test

### DIFF
--- a/tests/playwright/src/specs/preferences.spec.ts
+++ b/tests/playwright/src/specs/preferences.spec.ts
@@ -44,6 +44,7 @@ test.describe
       await playExpect(preferencesPage.heading).toBeVisible();
       await preferencesPage.kubePathInput.scrollIntoViewIfNeeded();
       await preferencesPage.selectKubeFile(preferencesTestString);
+      await playExpect(preferencesPage.kubePathInput).toHaveValue(preferencesTestString);
 
       //Change page and check new kubeconfig path persists
       await settingsBar.resourcesTab.click();

--- a/tests/playwright/src/specs/preferences.spec.ts
+++ b/tests/playwright/src/specs/preferences.spec.ts
@@ -32,7 +32,7 @@ test.afterAll(async ({ runner }) => {
 
 test.describe
   .serial(`Preferences text persistence validation `, () => {
-    test.describe.configure({ timeout: 20_000 });
+    test.describe.configure({ timeout: 60_000 });
 
     test('Check preferences text persistence', async ({ page, navigationBar }) => {
       //Open Settings/Preferences page
@@ -42,12 +42,13 @@ test.describe
       //Change kubeconfig path
       const preferencesPage = new PreferencesPage(page);
       await playExpect(preferencesPage.heading).toBeVisible();
+      await preferencesPage.kubePathInput.scrollIntoViewIfNeeded();
       await preferencesPage.selectKubeFile(preferencesTestString);
 
       //Change page and check new kubeconfig path persists'
       await settingsBar.resourcesTab.click();
       await settingsBar.preferencesTab.click();
       await playExpect(preferencesPage.heading).toBeVisible();
-      await playExpect(preferencesPage.kubePathInput).toHaveText(preferencesTestString);
+      await playExpect(preferencesPage.kubePathInput).toHaveValue(preferencesTestString);
     });
   });

--- a/tests/playwright/src/specs/preferences.spec.ts
+++ b/tests/playwright/src/specs/preferences.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2024-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { PreferencesPage } from '../model/pages/preferences-page';
+import { expect as playExpect, test } from '../utility/fixtures';
+
+const preferencesTestString = 'this text should persist through page change';
+
+test.beforeAll(async ({ runner, welcomePage }) => {
+  runner.setVideoAndTraceName('preferences-e2e');
+  await welcomePage.handleWelcomePage(true);
+});
+
+test.afterAll(async ({ runner }) => {
+  await runner.close();
+});
+
+test.describe
+  .serial(`Preferences text persistence validation `, () => {
+    test.describe.configure({ timeout: 20_000 });
+
+    test('Check preferences text persistence', async ({ page, navigationBar }) => {
+      //Open Settings/Preferences page
+      const settingsBar = await navigationBar.openSettings();
+      await settingsBar.preferencesTab.click();
+
+      //Change kubeconfig path
+      const preferencesPage = new PreferencesPage(page);
+      await playExpect(preferencesPage.heading).toBeVisible();
+      await preferencesPage.selectKubeFile(preferencesTestString);
+
+      //Change page and check new kubeconfig path persists'
+      await settingsBar.resourcesTab.click();
+      await settingsBar.preferencesTab.click();
+      await playExpect(preferencesPage.heading).toBeVisible();
+      await playExpect(preferencesPage.kubePathInput).toHaveText(preferencesTestString);
+    });
+  });

--- a/tests/playwright/src/specs/preferences.spec.ts
+++ b/tests/playwright/src/specs/preferences.spec.ts
@@ -31,7 +31,7 @@ test.afterAll(async ({ runner }) => {
 });
 
 test.describe
-  .serial(`Preferences text persistence validation `, () => {
+  .serial('Preferences text persistence validation', () => {
     test.describe.configure({ timeout: 60_000 });
 
     test('Check preferences text persistence', async ({ page, navigationBar }) => {
@@ -45,7 +45,7 @@ test.describe
       await preferencesPage.kubePathInput.scrollIntoViewIfNeeded();
       await preferencesPage.selectKubeFile(preferencesTestString);
 
-      //Change page and check new kubeconfig path persists'
+      //Change page and check new kubeconfig path persists
       await settingsBar.resourcesTab.click();
       await settingsBar.preferencesTab.click();
       await playExpect(preferencesPage.heading).toBeVisible();


### PR DESCRIPTION
### What does this PR do?
Completes https://github.com/podman-desktop/podman-desktop/issues/13604 by adding a new test case that checks if the text added to an input field on the preferences page persists after changing page.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
