### PR TITLE
chore(test): extend timeout for onboarding where exts. load up

### DIFF
--- a/tests/playwright/src/model/pages/welcome-page.ts
+++ b/tests/playwright/src/model/pages/welcome-page.ts
@@ -69,7 +69,7 @@ export class WelcomePage extends BasePage {
   async turnOffTelemetry(): Promise<void> {
     return test.step('Turn off Telemetry', async () => {
       // Extensions load sequentially (faster speed but can block ui)
-      await playExpect(this.startOnboarding).toBeEnabled({ timeout: 20_000 });
+      await playExpect(this.startOnboarding).toBeEnabled({ timeout: 30_000 });
 
       if (await this.telemetryConsent.isChecked()) {
         await playExpect(this.telemetryConsent).toBeChecked();


### PR DESCRIPTION
### What does this PR do?
Extends the timeout for onboarding. E2E tests are waiting for Start Onboarding button, that is only available after all extensions are loaded/active. On Windows 2025 on CI this is sometimes problematic. It might be a problem on slower machines in general. 
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Partially prevents https://github.com/podman-desktop/podman-desktop/issues/14348, but does not fix it. 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Update e2e tests on windows 2025 should always pass.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
