### PR TITLE
chore: added gh workflow for new contributor thanks msg

### DIFF
--- a/.github/workflows/new_contributor-thanks-msg.yaml
+++ b/.github/workflows/new_contributor-thanks-msg.yaml
@@ -113,7 +113,7 @@ jobs:
             let imageUrl = ``;
             let messageHeader = ``;
 
-            if (mergedCount == 50 {
+            if (mergedCount == 50) {
               imageUrl = images.fiftieth;
               messageHeader = `🏆 Amazing work @${login}! You've hit **50 merged PRs** — you're on fire!`;
             } else if (mergedCount == 25) {

--- a/.github/workflows/new_contributor-thanks-msg.yaml
+++ b/.github/workflows/new_contributor-thanks-msg.yaml
@@ -113,10 +113,10 @@ jobs:
             let imageUrl = ``;
             let messageHeader = ``;
 
-            if (mergedCount == 25) {
+            if (mergedCount == 50 {
               imageUrl = images.fiftieth;
               messageHeader = `🏆 Amazing work @${login}! You've hit **50 merged PRs** — you're on fire!`;
-            } else if (mergedCount == 20) {
+            } else if (mergedCount == 25) {
               imageUrl = images.twentyfifth;
               messageHeader = `🌟 Awesome @${login}! ** 25 merged PRs** — great momentum!`;
             } else if (mergedCount == 10) {

--- a/.github/workflows/new_contributor-thanks-msg.yaml
+++ b/.github/workflows/new_contributor-thanks-msg.yaml
@@ -1,0 +1,107 @@
+name: Thank Contributors on Merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  thank-you-contributor:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Debug context
+        run: |
+          echo "Author Association: ${{ github.event.pull_request.author_association }}"
+          echo "User: ${{ github.event.pull_request.user.login }}"
+          echo "Merged: ${{ github.event.pull_request.merged }}"
+
+      - name: Skip maintainers
+        id: check-maintainer
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const login = context.payload.pull_request.user.login;
+            const filePath = 'MAINTAINERS.md';
+
+            // Read the MAINTAINERS.md file
+            const content = fs.readFileSync(filePath, 'utf8');
+
+            // Extract all GitHub usernames (strip leading @)
+            const usernames = [...content.matchAll(/@([a-zA-Z0-9-]+)/g)].map(m => m[1].toLowerCase());
+            console.log("Parsed maintainers:", usernames);
+
+            if (usernames.includes(login.toLowerCase())) {
+              console.log(`User ${login} is a maintainer — skipping thank-you message.`);
+              core.setOutput('isMaintainer', 'true');
+            } else {
+              console.log(`User ${login} is NOT a maintainer.`);
+              core.setOutput('isMaintainer', 'false');
+            }
+
+      - name: Send thank-you message based on contribution level
+        if: steps.check-maintainer.outputs.isMaintainer == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const login = context.payload.pull_request.user.login;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = 'main';
+
+            // Fetch *all merged PRs* by this user in this repo
+            const { data: allPRs } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: "closed",
+              per_page: 100
+            });
+
+            // Count how many merged PRs they have
+            const mergedCount = allPRs.filter(pr => pr.user.login === login && pr.merged_at).length;
+            console.log(`Merged PR count for ${login}: ${mergedCount}`);
+
+            // Pick the correct sticker and message
+            // This part of the code will change as we need to have a separate repo for the images
+            // will modify this code when we decide on what images to use as stickers
+            let imageUrl = ``;
+            let messageHeader = ``;
+
+            if (mergedCount == 50) {
+              imageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/website/static/img/blog/podman-desktop-release-1.4/juggling.png`;
+              messageHeader = `🏆 Amazing work @${login}! You've hit **50 merged PRs** — you're on fire!`;
+            } else if (mergedCount == 25) {
+              imageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/website/static/img/blog/podman-desktop-release-1.5/onboarding-selkies.png`;
+              messageHeader = `🌟 Awesome @${login}! **25 merged PRs** — great momentum!`;
+            } else if (mergedCount == 10) {
+              imageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/website/static/img/blog/podman-desktop-release-1.6/santaseal.png`;
+              messageHeader = `🚀 Impressive @${login}! **10 merged PRs** — you're making an impact!`;
+            } else if (mergedCount == 1) {
+              imageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/website/static/img/blog/podman-desktop-release-1.7/renovations.png`;
+              messageHeader = `🎉 Huge thanks @${login} for your **first contribution**!! 🎉`;
+            }
+
+            // Only post if both exist
+            if (messageHeader && imageUrl) {
+              const message = `
+              ${messageHeader}
+
+              ![Sticker](${imageUrl})
+              `;
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner,
+                repo,
+                body: message
+              });
+            } else {
+              console.log("No messageHeader or imageUrl found — skipping comment.");
+            }

--- a/.github/workflows/new_contributor-thanks-msg.yaml
+++ b/.github/workflows/new_contributor-thanks-msg.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023-2024 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/new_contributor-thanks-msg.yaml
+++ b/.github/workflows/new_contributor-thanks-msg.yaml
@@ -1,4 +1,28 @@
+#
+# Copyright (C) 2023-2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Thank Contributors on Merge
+
+env:
+  # temp images picked within the repo, these will change based on what we decide as new images and a location to store them
+  IMAGE_1ST: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/website/static/img/blog/podman-desktop-release-1.7/renovations.png
+  IMAGE_10TH: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/website/static/img/blog/podman-desktop-release-1.6/santaseal.png
+  IMAGE_25TH: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/website/static/img/blog/podman-desktop-release-1.5/onboarding-selkies.png
+  IMAGE_50TH: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/website/static/img/blog/podman-desktop-release-1.4/juggling.png
 
 on:
   pull_request_target:
@@ -11,7 +35,7 @@ permissions:
 
 jobs:
   thank-you-contributor:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.merged == true
     steps:
       - name: Checkout repo
@@ -27,6 +51,7 @@ jobs:
         id: check-maintainer
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const login = context.payload.pull_request.user.login;
@@ -37,27 +62,24 @@ jobs:
 
             // Extract all GitHub usernames (strip leading @)
             const usernames = [...content.matchAll(/@([a-zA-Z0-9-]+)/g)].map(m => m[1].toLowerCase());
-            console.log("Parsed maintainers:", usernames);
 
             if (usernames.includes(login.toLowerCase())) {
-              console.log(`User ${login} is a maintainer — skipping thank-you message.`);
               core.setOutput('isMaintainer', 'true');
             } else {
-              console.log(`User ${login} is NOT a maintainer.`);
               core.setOutput('isMaintainer', 'false');
             }
 
-      - name: Send thank-you message based on contribution level
+      - name: Calculate contribution level
+        id: calc-prs
         if: steps.check-maintainer.outputs.isMaintainer == 'false'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const login = context.payload.pull_request.user.login;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const branch = 'main';
 
-            // Fetch *all merged PRs* by this user in this repo
             const { data: allPRs } = await github.rest.pulls.list({
               owner,
               repo,
@@ -65,27 +87,43 @@ jobs:
               per_page: 100
             });
 
-            // Count how many merged PRs they have
-            const mergedCount = allPRs.filter(pr => pr.user.login === login && pr.merged_at).length;
-            console.log(`Merged PR count for ${login}: ${mergedCount}`);
+            const mergedCount = allPRs.filter(pr => pr.user.login === login && pr.merged_at).length;    
+            return mergedCount;     
 
-            // Pick the correct sticker and message
-            // This part of the code will change as we need to have a separate repo for the images
-            // will modify this code when we decide on what images to use as stickers
+      - name: Send thank-you message 
+        if: steps.check-maintainer.outputs.isMaintainer == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+          script: |
+            const login = context.payload.pull_request.user.login;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = 'main';
+            const mergedCount = Number("${{ steps.calc-prs.outputs.result }}");
+
+            // Dynamically read image URLs from env
+            const images = {
+              first: process.env.IMAGE_1ST,
+              tenth: process.env.IMAGE_10TH,
+              twentyfifth: process.env.IMAGE_25TH,
+              fiftieth: process.env.IMAGE_50TH
+            };
+
             let imageUrl = ``;
             let messageHeader = ``;
 
-            if (mergedCount == 50) {
-              imageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/website/static/img/blog/podman-desktop-release-1.4/juggling.png`;
+            if (mergedCount == 25) {
+              imageUrl = images.fiftieth;
               messageHeader = `🏆 Amazing work @${login}! You've hit **50 merged PRs** — you're on fire!`;
-            } else if (mergedCount == 25) {
-              imageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/website/static/img/blog/podman-desktop-release-1.5/onboarding-selkies.png`;
-              messageHeader = `🌟 Awesome @${login}! **25 merged PRs** — great momentum!`;
+            } else if (mergedCount == 20) {
+              imageUrl = images.twentyfifth;
+              messageHeader = `🌟 Awesome @${login}! ** 25 merged PRs** — great momentum!`;
             } else if (mergedCount == 10) {
-              imageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/website/static/img/blog/podman-desktop-release-1.6/santaseal.png`;
-              messageHeader = `🚀 Impressive @${login}! **10 merged PRs** — you're making an impact!`;
+              imageUrl = images.tenth;
+              messageHeader = `🚀 Impressive @${login}! ** 10 merged PRs** — you're making an impact!`;
             } else if (mergedCount == 1) {
-              imageUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/website/static/img/blog/podman-desktop-release-1.7/renovations.png`;
+              imageUrl = images.first;
               messageHeader = `🎉 Huge thanks @${login} for your **first contribution**!! 🎉`;
             }
 
@@ -102,6 +140,4 @@ jobs:
                 repo,
                 body: message
               });
-            } else {
-              console.log("No messageHeader or imageUrl found — skipping comment.");
-            }
+            } 


### PR DESCRIPTION
Signed-off-by: Rujuta Shinde <rushinde@redhat.com>

### What does this PR do?

- This PR is meant to add a new workflow which will allow new users to get a thank you message with a sticker once their PR is merged. The associated ticket is #13646 
- At present the workflow is using images from within the repo website dir , this will be modified to use either a separate repo and/or directory dedicated for images to be sent to the  users (Will modify that once we get some feedback on this)
- The workflow provides message for 1,10,25,50 merges by external contributors and skips contributors from maintainers.md
- 

### Screenshot / video of UI
The current images show up like below, but with customized images it can look more concise

<img width="1360" height="1141" alt="image" src="https://github.com/user-attachments/assets/2c718863-c286-4195-b862-301ee0b6ca30" />
<img width="1605" height="1029" alt="image" src="https://github.com/user-attachments/assets/b91b5fa7-6ffa-4bdc-8733-445354020c1c" />
<img width="1361" height="1145" alt="image" src="https://github.com/user-attachments/assets/301ba5ff-71a2-4f49-8223-049835e5335a" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
The associated ticket is #13646 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
