### PR TITLE
chore(test): try to detect bad machine state and heal it

### DIFF
--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -20,7 +20,7 @@ import type { Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
 import { NavigationBar } from '../model/workbench/navigation';
-import { createPodmanMachineFromCLI } from './operations';
+import { createPodmanMachineFromCLI, resetPodmanMachinesFromCLI } from './operations';
 
 export async function wait(
   waitFunction: () => Promise<boolean>,
@@ -125,6 +125,15 @@ export async function waitForPodmanMachineStartup(page: Page, timeoutOut = 30_00
       timeout: timeoutOut,
       sendError: false,
     });
+
+    try {
+      await playExpect(dashboardPage.podmanStatusLabel).not.toHaveText('STARTING', { timeout: timeoutOut });
+    } catch (error) {
+      console.log('Podman machine stuck in STARTING state, trying to restart it');
+      await resetPodmanMachinesFromCLI();
+      await createPodmanMachineFromCLI();
+    }
+
     await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', {
       timeout: timeoutOut,
     });

--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -126,7 +126,10 @@ export async function waitForPodmanMachineStartup(page: Page, timeoutOut = 30_00
       sendError: false,
     });
 
+    await dashboardPage.podmanStatusLabel.scrollIntoViewIfNeeded();
+
     try {
+      // sometimes the podman machine is stuck in STARTING state, so we try to reset it once
       await playExpect(dashboardPage.podmanStatusLabel).not.toHaveText('STARTING', { timeout: timeoutOut });
     } catch (error) {
       console.log('Podman machine stuck in STARTING state, trying to restart it');


### PR DESCRIPTION
### What does this PR do?
Tries to detect when the podman machine is stuck in STARTING state when the e2e test suite begins and tries to fix the state by reseting and recreating the machine.

### What issues does this PR fix or reference?

