### PR TITLE
docs: add documentation for managed-by config and settings config

### DIFF
--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -1,0 +1,19 @@
+---
+sidebar_position: 4
+title: Configuration
+description: Configure Podman Desktop settings and manage enterprise deployments
+tags: [podman-desktop, configuration, settings]
+keywords: [podman desktop, configuration, settings, preferences, managed]
+---
+
+# Configuration
+
+You can configure Podman Desktop settings:
+
+- [Settings reference](/docs/configuration/settings-reference)
+- [Configuring a managed user environment](/docs/configuration/managed-configuration)
+
+#### Next steps
+
+- [Configure proxy settings](/docs/proxy)
+- [Install extensions](/docs/extensions/install)

--- a/website/docs/configuration/managed-configuration-troubleshooting.md
+++ b/website/docs/configuration/managed-configuration-troubleshooting.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 12
+title: Troubleshooting managed configurations
+description: Common issues and solutions for managed configuration in enterprise environments.
+tags: [podman-desktop, configuration, enterprise, managed, troubleshooting]
+keywords: [podman desktop, configuration, managed, enterprise, troubleshooting, issues, problems]
+---
+
+# Troubleshooting managed configuration
+
+When implementing managed configuration in an enterprise environment, you may encounter some common issues often caused by file location, permissions, or syntax errors.
+
+## Locked configuration not working
+
+If your locked configuration is not being applied, try the following solutions:
+
+1. Verify file locations are correct for your operating system.
+2. Check file permissions (files must be owned by root/administrator).
+3. Ensure JSON syntax is valid (use a JSON validator).
+4. Restart Podman Desktop after creating configuration files.
+
+## Settings not being enforced
+
+If settings appear to be locked but values are not being enforced correctly:
+
+1. Check that the key name in `locked.json` exactly matches the key in `default-settings.json`.
+2. Verify the configuration key uses dot notation (e.g., `proxy.http`, not `proxy: { http: ... }`).
+3. Check console output for error messages.
+
+## Verifying configuration is loaded
+
+To verify that your managed configuration is being loaded correctly:
+
+1. Open Podman Desktop.
+2. Go to **Help > Troubleshooting**, and select the **Logs** tab to check for messages such as:
+3. Look for messages in the console like:
+   ```
+   [Managed-by]: Loaded managed ...
+   ```
+4. If you don't see these messages, the configuration files may not be in the correct location or may have syntax errors.
+
+## File permission issues
+
+On Linux and macOS, managed configuration files must have appropriate permissions:
+
+- Files must be owned by root/administrator
+- Files should be readable by all users but writable only by root/administrator
+- Use `chmod 644` for the configuration files on Linux/macOS
+
+## Additional resources
+
+- [Configuring a managed user environment](/docs/configuration/managed-configuration)
+- [Managed configuration use cases](/docs/configuration/managed-configuration-use-cases)
+- [Configuration settings reference](/docs/configuration/settings-reference)

--- a/website/docs/configuration/managed-configuration-use-cases.md
+++ b/website/docs/configuration/managed-configuration-use-cases.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 11
+title: Managed configuration use cases
+description: Common use cases and examples for enterprise managed configuration.
+tags: [podman-desktop, configuration, enterprise, managed, use-cases]
+keywords: [podman desktop, configuration, managed, enterprise, examples, use cases]
+---
+
+# Managed configuration use cases
+
+As an administrator, you can use managed configuration to enforce specific settings for all users in your organization. Below are some common use cases with example configurations.
+
+## Enforcing proxy settings
+
+Lock proxy configuration to ensure all users route traffic through corporate proxy servers.
+
+```json title="default-settings.json"
+{
+  "proxy.http": "http://corp-proxy.example.com:8080"
+}
+```
+
+```json title="locked.json"
+{
+  "locked": ["proxy.http"]
+}
+```
+
+## Managing telemetry
+
+Control telemetry settings for compliance or privacy requirements.
+
+```json title="default-settings.json"
+{
+  "telemetry.enabled": false
+}
+```
+
+```json title="locked.json"
+{
+  "locked": ["telemetry.enabled"]
+}
+```
+
+## Additional resources
+
+- [Configuring a managed user environment](/docs/configuration/managed-configuration)
+- [Configuration settings reference](/docs/configuration/settings-reference)

--- a/website/docs/configuration/managed-configuration.md
+++ b/website/docs/configuration/managed-configuration.md
@@ -1,0 +1,366 @@
+---
+sidebar_position: 10
+title: Configuring a managed user environment
+description: Using managed configuration to enforce settings in enterprise environments.
+tags: [podman-desktop, configuration, enterprise, managed]
+keywords: [podman desktop, configuration, managed, enterprise, locked, admin, policy]
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Configuring a managed user environment
+
+In enterprise environments, administrators can enforce specific configuration values that users are unable to override. This capability allows them to manage configurations, such as proxy servers, telemetry policies, and security policies, ensuring users operate within a controlled environment. Administrators can review and edit the configurations in the user settings file before applying the changes globally to all enterprise users.
+
+## How it works
+
+Podman Desktop stores values for the following types of configuration in three separate JSON files:
+
+1. **User configuration** - Editable user-enforced values for Podman Desktop customization.
+2. **Managed defaults configuration** - Read-only administrator-enforced default values that cannot be edited by the user.
+3. **Locked configuration** - Read-only administrator-enforced list of keys that must use managed values.
+
+When a configuration changes, Podman Desktop returns a value after checking the user configuration files in the following priority order:
+
+1. **Locked keys** - Return a value from the managed defaults configuration file, which is of highest priority
+2. **Unlocked keys** - Return a value from the user configuration file
+3. **Default value** - Returns the default value built into Podman Desktop
+
+## File locations
+
+<Tabs groupId="operating-systems">
+<TabItem value="linux" label="Linux">
+
+_User configuration_
+
+- Location: `~/.local/share/containers/podman-desktop/configuration/settings.json`
+- Permissions: User read/write
+- Purpose: Normal user settings configured through the UI
+
+_Managed defaults_
+
+- Location: `/usr/share/podman-desktop/default-settings.json`
+- Permissions: Root only
+- Purpose: Administrator-enforced configuration values
+
+_Locked configuration_
+
+- Location: `/usr/share/podman-desktop/locked.json`
+- Permissions: Root only
+- Purpose: List of configuration keys that are locked by an administrator
+
+</TabItem>
+<TabItem value="mac" label="macOS">
+
+_User configuration_
+
+- Location: `~/.local/share/containers/podman-desktop/configuration/settings.json`
+- Permissions: User read/write
+- Purpose: Normal user settings configured through the UI
+
+_Managed defaults_
+
+- Location: `/Library/Application Support/io.podman_desktop.PodmanDesktop/default-settings.json`
+- Permissions: Administrator only
+- Purpose: Administrator-enforced configuration values
+
+_Locked configuration_
+
+- Location: `/Library/Application Support/io.podman_desktop.PodmanDesktop/locked.json`
+- Permissions: Administrator only
+- Purpose: List of configuration keys that are locked by an administrator
+
+</TabItem>
+<TabItem value="win" label="Windows">
+
+_User configuration_
+
+- Location: `%APPDATA%\podman-desktop\configuration\settings.json`
+- Permissions: User read/write
+- Purpose: Normal user settings configured through the UI
+
+_Managed defaults_
+
+- Location: `%PROGRAMDATA%\Podman Desktop\default-settings.json`
+- Permissions: Administrator only
+- Purpose: Administrator-enforced configuration values
+
+_Locked configuration_
+
+- Location: `%PROGRAMDATA%\Podman Desktop\locked.json`
+- Permissions: Administrator only
+- Purpose: List of configuration keys that are locked by an administrator
+
+</TabItem>
+</Tabs>
+
+## Example: Enforcing corporate proxy and telemetry settings
+
+This example demonstrates how an administrator can lock the proxy and telemetry configuration to enforce corporate policy.
+
+#### Procedure
+
+1. Create a managed defaults file with corporate settings.
+2. Create a locked configuration file to enforce the corporate settings.
+3. Deploy both files to the appropriate system location.
+4. Restart Podman Desktop, the managed values will override user-configured values and enforce compliance.
+
+### User Configuration
+
+The user has configured a local proxy in their settings:
+
+```json title="~/.local/share/containers/podman-desktop/configuration/settings.json"
+{
+  "proxy.http": "https://127.0.0.1:8081",
+  "telemetry.enabled": true
+}
+```
+
+### Managed Defaults Configuration
+
+The administrator creates a managed defaults file with corporate settings:
+
+<Tabs groupId="operating-systems">
+<TabItem value="linux" label="Linux">
+
+```json title="/usr/share/containers/podman-desktop/default-settings.json"
+{
+  "proxy.http": "http://corp-proxy.example.com:8080",
+  "telemetry.enabled": false
+}
+```
+
+</TabItem>
+<TabItem value="mac" label="macOS">
+
+```json title="/Library/Application Support/io.podman_desktop.PodmanDesktop/default-settings.json"
+{
+  "proxy.http": "http://corp-proxy.example.com:8080",
+  "telemetry.enabled": false
+}
+```
+
+</TabItem>
+<TabItem value="win" label="Windows">
+
+```json title="%PROGRAMDATA%\Podman Desktop\default-settings.json"
+{
+  "proxy.http": "http://corp-proxy.example.com:8080",
+  "telemetry.enabled": false
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Locked Configuration
+
+The administrator creates a locked configuration file to enforce these settings:
+
+<Tabs groupId="operating-systems">
+<TabItem value="linux" label="Linux">
+
+```json title="/usr/share/containers/podman-desktop/locked.json"
+{
+  "locked": ["proxy.http", "telemetry.enabled"]
+}
+```
+
+</TabItem>
+<TabItem value="mac" label="macOS">
+
+```json title="/Library/Application Support/io.podman_desktop.PodmanDesktop/locked.json"
+{
+  "locked": ["proxy.http", "telemetry.enabled"]
+}
+```
+
+</TabItem>
+<TabItem value="win" label="Windows">
+
+```json title="%PROGRAMDATA%\Podman Desktop\locked.json"
+{
+  "locked": ["proxy.http", "telemetry.enabled"]
+}
+```
+
+</TabItem>
+</Tabs>
+
+### Result
+
+With this configuration in place, Podman Desktop returns:
+
+```json
+{
+  "proxy.http": "http://corp-proxy.example.com:8080",
+  "telemetry.enabled": false
+}
+```
+
+**Key observations:**
+
+- `proxy.http` - Returns managed value, user's local proxy is ignored
+- `telemetry.enabled` - Returns managed value, user cannot enable telemetry (set to false)
+
+:::tip
+
+As an administrator, you can implement several use cases to customize user settings based on your enterprise needs and apply those changes globally across your enterprise. For a comprehensive list of common use cases and examples, see [Managed configuration use cases](/docs/configuration/managed-configuration-use-cases).
+
+:::
+
+## Deploying a managed configuration
+
+#### Procedure
+
+<Tabs groupId="operating-systems">
+<TabItem value="linux" label="Linux">
+
+**Step 1: Create configuration files**
+
+Save the following files at `/usr/share/podman-desktop/`:
+
+_Managed defaults file:_
+
+```json title="/usr/share/podman-desktop/default-settings.json"
+{
+  "proxy.http": "http://proxy.corp.example.com:8080",
+  "telemetry.enabled": false
+}
+```
+
+_Locked configuration file:_
+
+```json title="/usr/share/podman-desktop/locked.json"
+{
+  "locked": ["proxy.http", "telemetry.enabled"]
+}
+```
+
+**Step 2: Deploy using a deployment tool**
+
+Choose a deployment tool: Ansible, Puppet, Chef, Salt, RPM/DEB packages, or shell scripts.
+
+**Step 3: Verify the deployment**
+
+1. Restart Podman Desktop.
+
+2. Go to **Help > Troubleshooting**, and select the **Logs** tab to check for messages such as:
+
+   ```
+   [Managed-by]: Loaded managed ...
+   ```
+
+3. Verify that locked settings cannot be changed through the UI.
+
+</TabItem>
+<TabItem value="mac" label="macOS">
+
+**Step 1: Create configuration files**
+
+Save the following files at `/Library/Application Support/io.podman_desktop.PodmanDesktop/`:
+
+_Managed defaults file:_
+
+```json title="/Library/Application Support/io.podman_desktop.PodmanDesktop/default-settings.json"
+{
+  "proxy.http": "http://proxy.corp.example.com:8080",
+  "telemetry.enabled": false
+}
+```
+
+_Locked configuration file:_
+
+```json title="/Library/Application Support/io.podman_desktop.PodmanDesktop/locked.json"
+{
+  "locked": ["proxy.http", "telemetry.enabled"]
+}
+```
+
+**Step 2: Deploy using a deployment tool**
+
+Choose a deployment tool: Jamf Pro, Microsoft Intune, Kandji, SimpleMDM, Ansible, or PKG installers.
+
+**Step 3: Verify the deployment**
+
+1. Restart Podman Desktop.
+
+2. Go to **Help > Troubleshooting**, and select the **Logs** tab to check for messages such as:
+
+   ```
+   [Managed-by]: Loaded managed ...
+   ```
+
+3. Verify that locked settings cannot be changed through the UI.
+
+</TabItem>
+<TabItem value="win" label="Windows">
+
+**Step 1: Create configuration files**
+
+Save the following files at `%PROGRAMDATA%\Podman Desktop\`:
+
+_Managed defaults file:_
+
+```json title="%PROGRAMDATA%\Podman Desktop\default-settings.json"
+{
+  "proxy.http": "http://proxy.corp.example.com:8080",
+  "telemetry.enabled": false
+}
+```
+
+_Locked configuration file:_
+
+```json title="%PROGRAMDATA%\Podman Desktop\locked.json"
+{
+  "locked": ["proxy.http", "telemetry.enabled"]
+}
+```
+
+**Step 2: Deploy using a deployment tool**
+
+Choose a deployment tool: Group Policy, Microsoft Intune, SCCM, Ansible, or PowerShell scripts.
+
+**Step 3: Verify the deployment**
+
+1. Restart Podman Desktop.
+
+2. Go to **Help > Troubleshooting**, and select the **Logs** tab to check for messages such as:
+
+   ```
+   [Managed-by]: Loaded managed ...
+   ```
+
+3. Verify that locked settings cannot be changed through the UI.
+
+</TabItem>
+</Tabs>
+
+## Locked configuration impact on users
+
+When a setting is locked:
+
+- **In the UI**: The setting appears grayed out or displays a lock icon
+- **Editing settings.json**: Changes to locked keys in the user's file are ignored
+- **Console output**: Log messages indicate when locked values are being used
+
+:::note
+
+Users are notified when settings are managed by administrators, ensuring transparency about which settings they can and cannot control.
+
+:::
+
+## Additional resources
+
+- [Troubleshooting managed configuration](/docs/configuration/managed-configuration-troubleshooting)
+
+- [Managed configuration use cases](/docs/configuration/managed-configuration-use-cases)
+- [Configuration settings reference](/docs/configuration/settings-reference)
+- [Configuration API Documentation](/api)
+- [Extension Configuration Guide](/docs/extensions/developing/config)
+
+## Next steps
+
+- [Configure proxy settings](/docs/proxy)
+- [Manage extensions](/docs/extensions)

--- a/website/docs/configuration/settings-reference.md
+++ b/website/docs/configuration/settings-reference.md
@@ -1,0 +1,134 @@
+---
+sidebar_position: 2
+title: Settings reference
+description: Complete reference of all configuration settings available in Podman Desktop
+tags: [podman-desktop, settings, configuration]
+keywords: [podman desktop, settings, configuration, preferences]
+---
+
+# Settings Reference
+
+To customize your Podman Desktop experience, modify the `settings.json` file located in your user configuration directory. You can also adjust these settings, except for internal settings, through the **Settings > Preferences** page in Podman Desktop.
+
+## Configuration File Location
+
+Your user settings are stored in a JSON file at the following locations:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="operating-systems">
+<TabItem value="windows" label="Windows">
+
+```
+%APPDATA%\podman-desktop\configuration\settings.json
+```
+
+</TabItem>
+<TabItem value="mac" label="macOS">
+
+```
+~/.local/share/podman-desktop/configuration/settings.json
+```
+
+</TabItem>
+<TabItem value="linux" label="Linux">
+
+```
+~/.local/share/podman-desktop/configuration/settings.json
+```
+
+</TabItem>
+</Tabs>
+
+## User Settings
+
+| Setting                                       | Type    | Default            | Description                                                                                               |
+| --------------------------------------------- | ------- | ------------------ | --------------------------------------------------------------------------------------------------------- |
+| `appearance.appearance`                       | string  | `"system"`         | Theme: `"system"`, `"dark"`, or `"light"`                                                                 |
+| `appearance.navigationAppearance`             | string  | `"IconAndTitle"`   | Navigation style: `"IconAndTitle"` or `"Icon"`                                                            |
+| `appearance.zoomLevel`                        | number  | `0`                | Zoom level (-3 to 3)                                                                                      |
+| `dockerCompatibility.enabled`                 | boolean | `false`            | Enable Docker compatibility section                                                                       |
+| `editor.fontSize`                             | number  | `10`               | Editor font size (6-100 px)                                                                               |
+| `extensions.autoCheckUpdates`                 | boolean | `true`             | Auto-check for extension updates                                                                          |
+| `extensions.autoUpdate`                       | boolean | `true`             | Auto-install extension updates                                                                            |
+| `feedback.dialog`                             | boolean | `true`             | Show experimental feature feedback dialog                                                                 |
+| `kubernetes.Kubeconfig`                       | string  | `"~/.kube/config"` | Path to kubeconfig file                                                                                   |
+| `kubernetes.statesExperimental`               | object  | `null`             | **EXPERIMENTAL:** New context monitoring. Example: `{}`                                                   |
+| `preferences.ExitOnClose`                     | boolean | Platform           | Quit app on close vs minimize to tray                                                                     |
+| `preferences.login.minimize`                  | boolean | `false`            | Minimize on login                                                                                         |
+| `preferences.login.start`                     | boolean | `true`             | Start on login                                                                                            |
+| `preferences.OpenDevTools`                    | string  | `"undocked"`       | DevTools position in dev mode                                                                             |
+| `preferences.TrayIconColor`                   | string  | `"default"`        | Tray icon color (requires restart)                                                                        |
+| `preferences.update.reminder`                 | string  | `"startup"`        | Update reminders: `"startup"` or `"never"`                                                                |
+| `preferences.{extensionId}.engine.autostart`  | boolean | `true`             | Autostart engine on launch (e.g., `preferences.podman.engine.autostart`)                                  |
+| `proxy.enabled`                               | number  | `0`                | Proxy mode: 0=System, 1=Manual, 2=Disabled                                                                |
+| `proxy.http`                                  | string  | `""`               | HTTP proxy URL                                                                                            |
+| `proxy.https`                                 | string  | `""`               | HTTPS proxy URL                                                                                           |
+| `proxy.no`                                    | string  | `""`               | No-proxy pattern (comma-separated)                                                                        |
+| `recommendations.ignoreBannerRecommendations` | boolean | `false`            | Disable recommendation banners                                                                            |
+| `recommendations.ignoreRecommendations`       | boolean | `false`            | Disable extension recommendations                                                                         |
+| `statusbarProviders.showProviders`            | object  | `null`             | **EXPERIMENTAL:** Show providers in status bar. Example: `{"remindAt": 1758312136049, "disabled": false}` |
+| `tasks.manager`                               | object  | `null`             | **EXPERIMENTAL:** New task manager widget. Example: `{}`                                                  |
+| `tasks.statusBar`                             | object  | `null`             | **EXPERIMENTAL:** Show tasks in status bar. Example: `{}`                                                 |
+| `tasks.toast`                                 | boolean | `false`            | Show task creation notifications                                                                          |
+| `telemetry.enabled`                           | boolean | `true`             | Send anonymous usage data to Red Hat                                                                      |
+| `terminal.fontSize`                           | number  | `10`               | Terminal font size (6-100 px)                                                                             |
+| `terminal.lineHeight`                         | number  | `1`                | Terminal line height (1-4)                                                                                |
+| `titleBar.searchBar`                          | object  | `null`             | **EXPERIMENTAL:** Enable titlebar searchbar. Example: `{}`                                                |
+| `userConfirmation.bulk`                       | boolean | `true`             | Confirm bulk actions                                                                                      |
+| `userConfirmation.fetchImageFiles`            | boolean | `true`             | Confirm fetching image layers                                                                             |
+| `windowSettings.restorePosition`              | boolean | `true`             | Restore window position on restart                                                                        |
+
+## Internal Settings
+
+These settings are automatically managed by Podman Desktop and should not typically be modified manually:
+
+| Setting                                          | Type    | Default                                                    | Description                                                                              |
+| ------------------------------------------------ | ------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `exploreFeatures.expanded`                       | boolean | `true`                                                     | Explore features expanded state                                                          |
+| `exploreFeatures.hiddenFeatures`                 | array   | `null`                                                     | Hidden feature IDs                                                                       |
+| `extensions.developmentExtensionsFolders`        | array   | `[]`                                                       | Development extension folders                                                            |
+| `extensions.registryUrl`                         | string  | `"https://registry.podman-desktop.io/api/extensions.json"` | Extensions catalog URL                                                                   |
+| `learningCenter.expanded`                        | boolean | `true`                                                     | Learning center expanded state                                                           |
+| `libpodApi.forImageList`                         | boolean | `true`                                                     | Use libpod API for images                                                                |
+| `list.{listKind}`                                | array   | Dynamic                                                    | Column preferences per list type (e.g., `list.containers`, `list.images`)                |
+| `navbar.disabledItems`                           | array   | `[]`                                                       | Disabled navigation items                                                                |
+| `preferences.update.disableDifferentialDownload` | boolean | Platform                                                   | Disable differential download                                                            |
+| `releaseNotesBanner.show`                        | string  | `"show"`                                                   | Release notes banner state                                                               |
+| `statusBar.pinnedItems`                          | array   | `["podman"]`                                               | Pinned status bar items                                                                  |
+| `telemetry.check`                                | boolean | `false`                                                    | Telemetry dialog shown                                                                   |
+| `welcome.version`                                | string  | `"undefined"`                                              | Welcome page version shown                                                               |
+| `windowSettings.bounds`                          | object  | `null`                                                     | Window position and size. Example: `{"x": 2008, "y": 310, "width": 1022, "height": 795}` |
+
+## Example Configuration
+
+```json
+{
+  "appearance.appearance": "dark",
+  "appearance.zoomLevel": 0,
+  "telemetry.enabled": false,
+  "terminal.fontSize": 12,
+  "editor.fontSize": 14,
+  "preferences.update.reminder": "never",
+  "kubernetes.Kubeconfig": "~/.kube/config",
+  "preferences.login.start": true,
+  "extensions.autoUpdate": true,
+  "userConfirmation.bulk": true,
+  "proxy.http": "https://127.0.0.1:8081",
+  "statusbarProviders.showProviders": {
+    "remindAt": 1758312136049,
+    "disabled": false
+  },
+  "windowSettings.bounds": {
+    "x": 2008,
+    "y": 310,
+    "width": 1022,
+    "height": 795
+  }
+}
+```
+
+## See Also
+
+- [Managed Configuration](/docs/configuration/managed-configuration) - Deploy and lock settings across multiple machines


### PR DESCRIPTION
docs: add documentation for managed-by config and settings config

### What does this PR do?

Adds documentation with regards to using managed-by configuration as
well as a list of settings that we reference.

This includes:

* File locations
* Tutorials
* Troubleshooting
* Refererence tables

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, see website / view the markdown.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/14333
Closes https://github.com/podman-desktop/podman-desktop/issues/13872

### How to test this PR?

Read the docs / go through the tutorial.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
