### PR TITLE
docs: fix a typo in index.md (Kubernetes/Existing Kubernetes)

### DIFF
--- a/website/docs/kubernetes/existing-kubernetes/index.md
+++ b/website/docs/kubernetes/existing-kubernetes/index.md
@@ -33,6 +33,6 @@ You can also use the Kubernetes CLI to configure access to your Kubernetes clust
 
 - You can [view and select the Kubernetes cluster in Podman Desktop](/docs/kubernetes/viewing-and-selecting-current-kubernetes-context)
 
-#### Additional resopurces
+#### Additional resources
 
 - [Kubernetes documentation: Configure access to multiple clusters](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)


### PR DESCRIPTION
docs: fix a typo in index.md (Kubernetes/Existing Kubernetes)

### What does this PR do?
It fixes a typo in index.md

### What issues does this PR fix or reference
A typo in the Documentation/Kubernetes/Existing Kubernetes

### How to test this PR?
The code will show the fix in index.md of the page being referenced.

- [x] Tests are covering the but fix or the new feature