### PR TITLE
chore: enable async keyword usage in svelte

### DIFF
--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -38,7 +38,18 @@ export default defineConfig({
       '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
-  plugins: [tailwindcss(), svelte({ hot: !process.env.VITEST }), svelteTesting()],
+  plugins: [
+    tailwindcss(),
+    svelte({
+      hot: !process.env.VITEST,
+      compilerOptions: {
+        experimental: {
+          async: true,
+        },
+      },
+    }),
+    svelteTesting(),
+  ],
   optimizeDeps: {
     exclude: ['tinro'],
   },

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -37,7 +37,18 @@ export default defineConfig({
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
     },
   },
-  plugins: [tailwindcss(), svelte({ hot: !process.env.VITEST }), svelteTesting()],
+  plugins: [
+    tailwindcss(),
+    svelte({
+      hot: !process.env.VITEST,
+      compilerOptions: {
+        experimental: {
+          async: true,
+        },
+      },
+    }),
+    svelteTesting(),
+  ],
   test: {
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     globals: true,


### PR DESCRIPTION
### What does this PR do?
make `async` usage possible in `$derived` or other places.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/14362

### How to test this PR?

I have not faced glitches on basic workflows, but maybe I missed one.

- [] Tests are covering the bug fix or the new feature
