### PR TITLE
fix: include XDG_SESSION_TYPE=x11 to flatpak build file

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -180,6 +180,7 @@ const config = {
       '--talk-name=org.kde.StatusNotifierWatcher',
       // Allow to interact with Flatpak system to execute commands outside the application's sandbox
       '--talk-name=org.freedesktop.Flatpak',
+      '--env=XDG_SESSION_TYPE=x11'
     ],
     useWaylandFlags: 'false',
     artifactName: 'podman-desktop-${version}.${ext}',

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -180,7 +180,7 @@ const config = {
       '--talk-name=org.kde.StatusNotifierWatcher',
       // Allow to interact with Flatpak system to execute commands outside the application's sandbox
       '--talk-name=org.freedesktop.Flatpak',
-      '--env=XDG_SESSION_TYPE=x11'
+      '--env=XDG_SESSION_TYPE=x11',
     ],
     useWaylandFlags: 'false',
     artifactName: 'podman-desktop-${version}.${ext}',


### PR DESCRIPTION
### What does this PR do?
It adds XDG_SESSION_TYPE=x11 env.var and sets session to x11 to solve the issue with upgraded electron to version 38 when podman-desktop is installed from flatpak.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Partially fixes https://github.com/podman-desktop/podman-desktop/issues/14123
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Grab and extract the flatpak installer from PR check artifacts and install it on your system: `flatpak install --user podman-desktop.flatpak`. 
When you run PD via `flatpak run io.podman_desktop.PodmanDesktop` from cli or via installed app, the dashboard should be shown as usual. 

Should work on system with wayland (KDE+plasma/Gnome) and also on system which uses x11(Gnome) protocol. `XDG_SESSION_TYPE` env. var. should be one of `wayland` or `x11`.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
