### PR TITLE
chore: include run script in linux tar.gz target to wrap runner binary

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -194,6 +194,12 @@ const config = {
     category: 'Development',
     icon: './buildResources/icon-512x512.png',
     target: ['flatpak', { target: 'tar.gz', arch: ['x64', 'arm64'] }],
+    extraFiles: [
+      {
+        from: 'buildResources/run.sh',
+        to: '.',
+      },
+    ],
   },
   mac: {
     artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,

--- a/buildResources/run.sh
+++ b/buildResources/run.sh
@@ -6,4 +6,4 @@
 export XDG_SESSION_TYPE=x11
 
 # run the app
-"./podman-desktop" "$@"
+exec "./podman-desktop" "$@"

--- a/buildResources/run.sh
+++ b/buildResources/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# wrapper script allowing to set env vars before launching the application
+
+# https://github.com/podman-desktop/podman-desktop/issues/14387
+export XDG_SESSION_TYPE=x11
+
+# run the app
+"./podman-desktop" "$@"


### PR DESCRIPTION
### What does this PR do?
It provides a `run.sh` script in linux tar.gz build target which wraps the binary and adds `XDG_SESSION_TYPE=x11` env. var when running the app. 
It is a workaround for app not showing a dashboard when run from archive or with a binary. 
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#14387, additional part to https://github.com/podman-desktop/podman-desktop/issues/14123
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Download the linux tar.gz from pr check artifacts. Extract it. The root folder should contain `run.sh` script which can be executed. Application dashboard should be shown.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
