### PR TITLE
fix: add ozone options through electron-builder configuration

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -194,6 +194,8 @@ const config = {
     category: 'Development',
     icon: './buildResources/icon-512x512.png',
     target: ['flatpak', { target: 'tar.gz', arch: ['x64', 'arm64'] }],
+    // Force X11 for all Linux launches
+    executableArgs: ['--ozone-platform=x11', '--enable-features=UseOzonePlatform'],
   },
   mac: {
     artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,


### PR DESCRIPTION
### What does this PR do?

adds --enable-features and --ozone-platform options to force electron to use x11

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

#14123.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
