### PR TITLE
refactor: extensions filtering

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -22,12 +22,8 @@ let { searchTerm = '' }: Props = $props();
 
 const extensionsUtils = new ExtensionsUtils();
 
-const lowerCaseSearchTerm = $derived(searchTerm.toLowerCase());
-
 const filteredInstalledExtensions: CombinedExtensionInfoUI[] = $derived(
-  $combinedInstalledExtensions.filter(extension => {
-    return `${extension.displayName} ${extension.description}`.toLowerCase().includes(lowerCaseSearchTerm);
-  }),
+  extensionsUtils.filterInstalledExtensions($combinedInstalledExtensions, searchTerm),
 );
 
 let filteredInstalledItems: number = $derived($combinedInstalledExtensions.length - filteredInstalledExtensions.length);
@@ -43,9 +39,7 @@ const enhancedCatalogExtensions: CatalogExtensionInfoUI[] = $derived(
 );
 
 const filteredCatalogExtensions: CatalogExtensionInfoUI[] = $derived(
-  enhancedCatalogExtensions.filter(extension => {
-    return `${extension.displayName} ${extension.shortDescription}`.toLowerCase().includes(lowerCaseSearchTerm);
-  }),
+  extensionsUtils.filterCatalogExtensions(enhancedCatalogExtensions, searchTerm),
 );
 
 let filteredCatalogItems: number = $derived(enhancedCatalogExtensions.length - filteredCatalogExtensions.length);

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -315,3 +315,86 @@ describe('extractExtensionDetail', () => {
     expect(extensionDetail?.error?.stack).toBe('line1\nline2');
   });
 });
+
+describe('filters', () => {
+  const aFakeExtension: CatalogExtension = {
+    id: 'idAInstalled',
+    publisherName: 'FooPublisher',
+    shortDescription: 'this is short A. The word bar appears here but not in the title',
+    publisherDisplayName: 'Foo Publisher',
+    extensionName: 'a-extension',
+    displayName: 'A Extension',
+    categories: [],
+    keywords: [],
+    unlisted: false,
+    versions: [
+      {
+        version: '1.0.0A',
+        preview: false,
+        files: [
+          {
+            assetType: 'icon',
+            data: 'iconA',
+          },
+        ],
+        ociUri: 'linkA',
+        lastUpdated: new Date(),
+      },
+    ],
+  };
+
+  const bFakeExtension: CatalogExtension = {
+    id: 'idB',
+    publisherName: 'FooPublisher',
+    shortDescription: 'this is short B',
+    publisherDisplayName: 'Foo Publisher',
+    extensionName: 'b-extension',
+    displayName: 'B Extension',
+    categories: [],
+    keywords: [],
+    unlisted: false,
+    versions: [
+      {
+        version: '1.0.0B',
+        preview: false,
+        files: [
+          {
+            assetType: 'icon',
+            data: 'iconB',
+          },
+        ],
+        ociUri: 'linkB',
+        lastUpdated: new Date(),
+      },
+    ],
+  };
+
+  const combined: CombinedExtensionInfoUI[] = [
+    {
+      id: 'idAInstalled',
+      displayName: 'A installed Extension',
+      description: 'The word bar appears here but not in the title',
+      removable: true,
+      state: 'started',
+    },
+  ] as unknown[] as CombinedExtensionInfoUI[];
+
+  test('filterCatalogExtensions with single word', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar',
+    );
+    expect(filteredCatalogExtensions.length).toBe(1);
+    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
+  test('filterInstalledExtensions with single word', () => {
+    const filteredInstalledExtensions = extensionsUtils.filterInstalledExtensions(combined, 'bar');
+    expect(filteredInstalledExtensions.length).toBe(1);
+    expect(filteredInstalledExtensions[0].id).toBe('idAInstalled');
+  });
+});

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -201,4 +201,18 @@ export class ExtensionsUtils {
     });
     return values;
   }
+
+  filterInstalledExtensions(extensions: CombinedExtensionInfoUI[], searchTerm: string): CombinedExtensionInfoUI[] {
+    const lowerCaseSearchTerm = searchTerm.toLowerCase();
+    return extensions.filter(extension => {
+      return `${extension.displayName} ${extension.description}`.toLowerCase().includes(lowerCaseSearchTerm);
+    });
+  }
+
+  filterCatalogExtensions(extensions: CatalogExtensionInfoUI[], searchTerm: string): CatalogExtensionInfoUI[] {
+    const lowerCaseSearchTerm = searchTerm.toLowerCase();
+    return extensions.filter(extension => {
+      return `${extension.displayName} ${extension.shortDescription}`.toLowerCase().includes(lowerCaseSearchTerm);
+    });
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Prior to #14181, this PR extracts the filter logic to the extensions-utils, to be able to enhance them and test them in isolation.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #14181

### How to test this PR?

Filtering extensions should work as before

- [x] Tests are covering the bug fix or the new feature

Filtering tests from ExtensionList have been ported to extensions-utils. 