### PR TITLE
feat(Icon): added support for img component

### DIFF
--- a/packages/ui/src/lib/icons/Icon.spec.ts
+++ b/packages/ui/src/lib/icons/Icon.spec.ts
@@ -143,3 +143,43 @@ describe('component icon', () => {
     expect(img).toBeInTheDocument();
   });
 });
+
+describe('string icon', () => {
+  test('basic icon should be created', () => {
+    const icon = 'data:image/png;base64,fooBar';
+    render(Icon, { icon: icon });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', icon);
+  });
+
+  test('icon should reflect prefered {number} size', () => {
+    const icon = 'data:image/png;base64,fooBar';
+    render(Icon, { icon: icon, size: 42 });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toHaveAttribute('style', 'width: 42px; height: 42px;');
+    expect(img).toHaveAttribute('src', icon);
+  });
+
+  test('icon should have class', () => {
+    const icon = 'data:image/png;base64,fooBar';
+    render(Icon, { icon: icon, class: 'some-class' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('some-class');
+    expect(img).toHaveAttribute('src', icon);
+  });
+
+  test('icon should have title', () => {
+    const icon = 'data:image/png;base64,fooBar';
+    render(Icon, { icon: icon, title: 'test title' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('alt', 'test title');
+    expect(img).toHaveAttribute('src', icon);
+  });
+});

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -28,8 +28,8 @@ const IconComponent = icon;
     <!-- -icon for extension icons e.g. 'kind-icon' -->
     {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.endsWith('-icon')}
         <i class={`${icon} ${size} ${className}`} {role} {title}></i>
-    {:else}
-        <img src={icon} alt={title ?? ''} {role} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
+    {:else if icon.startsWith('data:image/')}
+        <img src={icon} alt={title ?? ''} {title} {role} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
     {/if}
 {:else}
     {#if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -28,6 +28,8 @@ const IconComponent = icon;
     <!-- -icon for extension icons e.g. 'kind-icon' -->
     {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.endsWith('-icon')}
         <i class={`${icon} ${size} ${className}`} {role} {title}></i>
+    {:else}
+        <img src={icon} alt={title ?? ''} {role} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
     {/if}
 {:else}
     {#if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}


### PR DESCRIPTION
### What does this PR do?
Adds support for icon element in Icon component so yo can use `data:image/png;base64,fooBar` as a source (e.g. extensions)

### Screenshot / video of UI


### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/13960

### How to test this PR?
Unit tests
- [x] Tests are covering the bug fix or the new feature
