### PR TITLE
chore(test): ensure pod cleanup before failure check

### DIFF
--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -77,12 +77,12 @@ test.afterAll(async ({ page, runner }) => {
   test.setTimeout(120_000);
 
   try {
+    await deletePod(page, podToRun);
     if (!resetTestData) return;
 
     for (const pod of podNames) {
       await deletePod(page, pod);
     }
-    await deletePod(page, podToRun);
 
     for (const container of containerNames) {
       await deleteContainer(page, container);

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -78,6 +78,11 @@ test.afterAll(async ({ page, runner }) => {
 
   try {
     await deletePod(page, podToRun);
+    await deleteContainer(page, backendContainer);
+    await deleteContainer(page, frontendContainer);
+    await deleteImage(page, backendImage);
+    await deleteImage(page, frontendImage);
+
     if (!resetTestData) return;
 
     for (const pod of podNames) {
@@ -87,10 +92,6 @@ test.afterAll(async ({ page, runner }) => {
     for (const container of containerNames) {
       await deleteContainer(page, container);
     }
-    await deleteContainer(page, backendContainer);
-    await deleteContainer(page, frontendContainer);
-    await deleteImage(page, backendImage);
-    await deleteImage(page, frontendImage);
   } finally {
     await runner.close();
   }

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -77,14 +77,9 @@ test.afterAll(async ({ page, runner }) => {
   test.setTimeout(120_000);
 
   try {
+    if (!resetTestData && test.info().retry < 1) return;
+
     await deletePod(page, podToRun);
-    await deleteContainer(page, backendContainer);
-    await deleteContainer(page, frontendContainer);
-    await deleteImage(page, backendImage);
-    await deleteImage(page, frontendImage);
-
-    if (!resetTestData) return;
-
     for (const pod of podNames) {
       await deletePod(page, pod);
     }
@@ -92,6 +87,11 @@ test.afterAll(async ({ page, runner }) => {
     for (const container of containerNames) {
       await deleteContainer(page, container);
     }
+
+    await deleteContainer(page, backendContainer);
+    await deleteContainer(page, frontendContainer);
+    await deleteImage(page, backendImage);
+    await deleteImage(page, frontendImage);
   } finally {
     await runner.close();
   }


### PR DESCRIPTION
### What does this PR do?
Moves the pod cleanup in the afterAll hook to be executed before checking for test failure

### What issues does this PR fix or reference?
