### PR TITLE
chore(extensions/podman): add path alias for api

### DIFF
--- a/extensions/podman/packages/extension/tsconfig.json
+++ b/extensions/podman/packages/extension/tsconfig.json
@@ -15,7 +15,8 @@
     "emitDecoratorMetadata": true,
     "types": ["node"],
     "paths": {
-      "/@/*": ["./src/*"]
+      "/@/*": ["./src/*"],
+      "/@api/*": ["../../../../packages/api/src/*"]
     }
   },
   "include": ["src", "types/*.d.ts", "scripts"]


### PR DESCRIPTION
### What does this PR do?

Add API import path alias from Podman Extension in order to move the TelemetryLogger Symbol later to the common api package to be reused in other extensions.

Nice to have for https://github.com/podman-desktop/podman-desktop/pull/14301

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
