### PR TITLE
chore(extensions/podman): move constants to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/constants.ts
+++ b/extensions/podman/packages/extension/src/constants.ts
@@ -1,0 +1,15 @@
+export const ROOTFUL_MACHINE_INIT_SUPPORTED_KEY = 'podman.isRootfulMachineInitSupported';
+export const USER_MODE_NETWORKING_SUPPORTED_KEY = 'podman.isUserModeNetworkingSupported';
+export const START_NOW_MACHINE_INIT_SUPPORTED_KEY = 'podman.isStartNowAtMachineInitSupported';
+export const CLEANUP_REQUIRED_MACHINE_KEY = 'podman.needPodmanMachineCleanup';
+export const PODMAN_MACHINE_CPU_SUPPORTED_KEY = 'podman.podmanMachineCpuSupported';
+export const PODMAN_MACHINE_MEMORY_SUPPORTED_KEY = 'podman.podmanMachineMemorySupported';
+export const PODMAN_MACHINE_DISK_SUPPORTED_KEY = 'podman.podmanMachineDiskSupported';
+export const PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY = 'podman.isLibkrunSupported';
+export const CREATE_WSL_MACHINE_OPTION_SELECTED_KEY = 'podman.isCreateWSLOptionSelected';
+export const WSL_HYPERV_ENABLED_KEY = 'podman.wslHypervEnabled';
+export const PODMAN_DOCKER_COMPAT_ENABLE_KEY = 'podman.podmanDockerCompatibilityEnabled';
+export const PODMAN_MACHINE_EDIT_CPU = 'podman.podmanMachineEditCPUSupported';
+export const PODMAN_MACHINE_EDIT_MEMORY = 'podman.podmanMachineEditMemorySupported';
+export const PODMAN_MACHINE_EDIT_DISK_SIZE = 'podman.podmanMachineEditDiskSizeSupported';
+export const PODMAN_MACHINE_EDIT_ROOTFUL = 'podman.podmanMachineEditRootfulSupported';

--- a/extensions/podman/packages/extension/src/constants.ts
+++ b/extensions/podman/packages/extension/src/constants.ts
@@ -1,3 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
 export const ROOTFUL_MACHINE_INIT_SUPPORTED_KEY = 'podman.isRootfulMachineInitSupported';
 export const USER_MODE_NETWORKING_SUPPORTED_KEY = 'podman.isUserModeNetworkingSupported';
 export const START_NOW_MACHINE_INIT_SUPPORTED_KEY = 'podman.isStartNowAtMachineInitSupported';

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -27,6 +27,19 @@ import { Disposable, provider as apiProvider } from '@podman-desktop/api';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import {
+  CLEANUP_REQUIRED_MACHINE_KEY,
+  CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
+  PODMAN_MACHINE_CPU_SUPPORTED_KEY,
+  PODMAN_MACHINE_DISK_SUPPORTED_KEY,
+  PODMAN_MACHINE_EDIT_CPU,
+  PODMAN_MACHINE_EDIT_DISK_SIZE,
+  PODMAN_MACHINE_EDIT_MEMORY,
+  PODMAN_MACHINE_EDIT_ROOTFUL,
+  PODMAN_MACHINE_MEMORY_SUPPORTED_KEY,
+  WSL_HYPERV_ENABLED_KEY,
+} from '/@/constants';
+
 import * as extension from './extension';
 import {
   initCheckAndRegisterUpdate,
@@ -1552,10 +1565,10 @@ test('provider is registered with edit capabilities on MacOS', async () => {
   expect(registeredConnection).toBeDefined();
   expect(registeredConnection?.lifecycle).toBeDefined();
   expect(registeredConnection?.lifecycle?.edit).toBeDefined();
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_CPU, true);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_MEMORY, true);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_DISK_SIZE, true);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_ROOTFUL, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_CPU, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_MEMORY, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_DISK_SIZE, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_ROOTFUL, true);
 });
 
 test('display name is beautified version of the name', async () => {
@@ -1625,10 +1638,10 @@ test('provider is registered with limited edit capabilities on (non-HyperV) Wind
   expect(registeredConnection).toBeDefined();
   expect(registeredConnection?.lifecycle).toBeDefined();
   expect(registeredConnection?.lifecycle?.edit).toBeDefined();
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_CPU, false);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_MEMORY, false);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_DISK_SIZE, false);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_ROOTFUL, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_CPU, false);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_MEMORY, false);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_DISK_SIZE, false);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_ROOTFUL, true);
 });
 
 test('provider is registered with limited edit capabilities on (HyperV) Windows', async () => {
@@ -1668,10 +1681,10 @@ test('provider is registered with limited edit capabilities on (HyperV) Windows'
   expect(registeredConnection).toBeDefined();
   expect(registeredConnection?.lifecycle).toBeDefined();
   expect(registeredConnection?.lifecycle?.edit).toBeDefined();
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_CPU, true);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_MEMORY, true);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_DISK_SIZE, false);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_ROOTFUL, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_CPU, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_MEMORY, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_DISK_SIZE, false);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_ROOTFUL, true);
 
   await registeredConnection?.lifecycle?.edit?.({} as unknown as extensionApi.LifecycleContext, {
     'podman.machine.cpus': 1,
@@ -1713,9 +1726,9 @@ test('provider is registered without edit capabilities on Linux', async () => {
   expect(registeredConnection).toBeDefined();
   expect(registeredConnection?.lifecycle).toBeDefined();
   expect(registeredConnection?.lifecycle?.edit).toBeUndefined();
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_CPU, false);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_MEMORY, false);
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_EDIT_DISK_SIZE, false);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_CPU, false);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_MEMORY, false);
+  expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_DISK_SIZE, false);
 });
 
 test('Even with getJSONMachineList erroring, do not show setup notification on Linux', async () => {
@@ -1753,7 +1766,7 @@ test('Should notify clean machine if getJSONMachineList is erroring due to an in
   });
   await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('description');
   expect(extensionApi.window.showNotification).toBeCalled();
-  expect(extensionApi.context.setValue).toBeCalledWith(extension.CLEANUP_REQUIRED_MACHINE_KEY, true);
+  expect(extensionApi.context.setValue).toBeCalledWith(CLEANUP_REQUIRED_MACHINE_KEY, true);
 });
 
 test('No updates of machines in parallel', async () => {
@@ -2438,9 +2451,9 @@ describe('calcPodmanMachineSetting', () => {
   test('setValue to true if OS is MacOS', async () => {
     vi.mocked(extensionApi.env).isWindows = false;
     await extension.calcPodmanMachineSetting();
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_CPU_SUPPORTED_KEY, true);
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, true);
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, true);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_CPU_SUPPORTED_KEY, true);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, true);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_DISK_SUPPORTED_KEY, true);
   });
   test('setValue to true if OS is Windows and uses HyperV', async () => {
     vi.mocked(extensionApi.env).isWindows = true;
@@ -2459,18 +2472,18 @@ describe('calcPodmanMachineSetting', () => {
       });
     });
     await extension.calcPodmanMachineSetting();
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_CPU_SUPPORTED_KEY, true);
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, true);
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, true);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_CPU_SUPPORTED_KEY, true);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, true);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_DISK_SUPPORTED_KEY, true);
   });
   test('setValue to true if OS is Windows and uses WSL', async () => {
     vi.mocked(extensionApi.env).isWindows = true;
     process.env.CONTAINERS_MACHINE_PROVIDER = 'wsl';
     vi.spyOn(podmanConfiguration, 'matchRegexpInContainersConfig').mockResolvedValue(false);
     await extension.calcPodmanMachineSetting();
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_CPU_SUPPORTED_KEY, false);
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, false);
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.PODMAN_MACHINE_DISK_SUPPORTED_KEY, false);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_CPU_SUPPORTED_KEY, false);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, false);
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_DISK_SUPPORTED_KEY, false);
   });
 });
 
@@ -3141,7 +3154,7 @@ describe('updateWSLHyperVEnabledValue', () => {
   });
   test('setValue should be called if new value is different than wslAndHypervEnabled', async () => {
     extension.updateWSLHyperVEnabledContextValue(false);
-    expect(extensionApi.context.setValue).toBeCalledWith(extension.WSL_HYPERV_ENABLED_KEY, false);
+    expect(extensionApi.context.setValue).toBeCalledWith(WSL_HYPERV_ENABLED_KEY, false);
   });
   test('setValue should not be called if new value is equal to wslAndHypervEnabled', async () => {
     extension.updateWSLHyperVEnabledContextValue(true);
@@ -3160,10 +3173,7 @@ describe('connectionAuditor', () => {
     await extension.connectionAuditor({
       'podman.factory.machine.win.provider': 'wsl',
     });
-    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(
-      extension.CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
-      true,
-    );
+    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(CREATE_WSL_MACHINE_OPTION_SELECTED_KEY, true);
   });
   test('check if podman.isCreateWSLOptionSelected is set to true if podman.factory.machine.win.provider is undefined but wsl is enabled', async () => {
     // be sure isCreateWSLOptionSelected is set to false
@@ -3177,10 +3187,7 @@ describe('connectionAuditor', () => {
     await extension.connectionAuditor({
       'podman.factory.machine.win.provider': undefined,
     });
-    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(
-      extension.CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
-      true,
-    );
+    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(CREATE_WSL_MACHINE_OPTION_SELECTED_KEY, true);
   });
   test('check if podman.isCreateWSLOptionSelected is set to false if podman.factory.machine.win.provider = hyperv', async () => {
     // be sure isCreateWSLOptionSelected is set to true
@@ -3192,10 +3199,7 @@ describe('connectionAuditor', () => {
     await extension.connectionAuditor({
       'podman.factory.machine.win.provider': 'hyperv',
     });
-    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(
-      extension.CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
-      false,
-    );
+    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(CREATE_WSL_MACHINE_OPTION_SELECTED_KEY, false);
   });
   test('check if podman.isCreateWSLOptionSelected is set to false if podman.factory.machine.win.provider is undefined and wsl is NOT enabled', async () => {
     // be sure isCreateWSLOptionSelected is set to true
@@ -3209,10 +3213,7 @@ describe('connectionAuditor', () => {
     await extension.connectionAuditor({
       'podman.factory.machine.win.provider': undefined,
     });
-    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(
-      extension.CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
-      false,
-    );
+    expect(extensionApi.context.setValue).toHaveBeenLastCalledWith(CREATE_WSL_MACHINE_OPTION_SELECTED_KEY, false);
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -27,6 +27,24 @@ import * as extensionApi from '@podman-desktop/api';
 import { Mutex } from 'async-mutex';
 import { compareVersions } from 'compare-versions';
 
+import {
+  CLEANUP_REQUIRED_MACHINE_KEY,
+  CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
+  PODMAN_DOCKER_COMPAT_ENABLE_KEY,
+  PODMAN_MACHINE_CPU_SUPPORTED_KEY,
+  PODMAN_MACHINE_DISK_SUPPORTED_KEY,
+  PODMAN_MACHINE_EDIT_CPU,
+  PODMAN_MACHINE_EDIT_DISK_SIZE,
+  PODMAN_MACHINE_EDIT_MEMORY,
+  PODMAN_MACHINE_EDIT_ROOTFUL,
+  PODMAN_MACHINE_MEMORY_SUPPORTED_KEY,
+  PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
+  ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
+  START_NOW_MACHINE_INIT_SUPPORTED_KEY,
+  USER_MODE_NETWORKING_SUPPORTED_KEY,
+  WSL_HYPERV_ENABLED_KEY,
+} from '/@/constants';
+
 import type { PodmanExtensionApi, PodmanRunOptions } from '../../api/src/podman-extension-api';
 import { SequenceCheck } from './checks/base-check';
 import { getDetectionChecks } from './checks/detection-checks';
@@ -1027,22 +1045,6 @@ export async function registerUpdatesIfAny(
     });
   }
 }
-
-export const ROOTFUL_MACHINE_INIT_SUPPORTED_KEY = 'podman.isRootfulMachineInitSupported';
-export const USER_MODE_NETWORKING_SUPPORTED_KEY = 'podman.isUserModeNetworkingSupported';
-export const START_NOW_MACHINE_INIT_SUPPORTED_KEY = 'podman.isStartNowAtMachineInitSupported';
-export const CLEANUP_REQUIRED_MACHINE_KEY = 'podman.needPodmanMachineCleanup';
-export const PODMAN_MACHINE_CPU_SUPPORTED_KEY = 'podman.podmanMachineCpuSupported';
-export const PODMAN_MACHINE_MEMORY_SUPPORTED_KEY = 'podman.podmanMachineMemorySupported';
-export const PODMAN_MACHINE_DISK_SUPPORTED_KEY = 'podman.podmanMachineDiskSupported';
-export const PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY = 'podman.isLibkrunSupported';
-export const CREATE_WSL_MACHINE_OPTION_SELECTED_KEY = 'podman.isCreateWSLOptionSelected';
-export const WSL_HYPERV_ENABLED_KEY = 'podman.wslHypervEnabled';
-export const PODMAN_DOCKER_COMPAT_ENABLE_KEY = 'podman.podmanDockerCompatibilityEnabled';
-export const PODMAN_MACHINE_EDIT_CPU = 'podman.podmanMachineEditCPUSupported';
-export const PODMAN_MACHINE_EDIT_MEMORY = 'podman.podmanMachineEditMemorySupported';
-export const PODMAN_MACHINE_EDIT_DISK_SIZE = 'podman.podmanMachineEditDiskSizeSupported';
-export const PODMAN_MACHINE_EDIT_ROOTFUL = 'podman.podmanMachineEditRootfulSupported';
 
 export function initTelemetryLogger(): void {
   telemetryLogger = extensionApi.env.createTelemetryLogger();

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -23,6 +23,12 @@ import * as extensionApi from '@podman-desktop/api';
 import { compare } from 'compare-versions';
 import { inject, injectable } from 'inversify';
 
+import {
+  PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
+  ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
+  START_NOW_MACHINE_INIT_SUPPORTED_KEY,
+  USER_MODE_NETWORKING_SUPPORTED_KEY,
+} from '/@/constants';
 import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 
 import { getDetectionChecks } from '../checks/detection-checks';
@@ -36,10 +42,6 @@ import {
   isRootfulMachineInitSupported,
   isStartNowAtMachineInitSupported,
   isUserModeNetworkingSupported,
-  PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
-  ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
-  START_NOW_MACHINE_INIT_SUPPORTED_KEY,
-  USER_MODE_NETWORKING_SUPPORTED_KEY,
 } from '../extension';
 import * as podman5JSON from '../podman5.json';
 import { getBundledPodmanVersion } from '../utils/podman-bundled';


### PR DESCRIPTION
### What does this PR do?

chore(extensions/podman): move constants to dedicated file

this is needed for https://github.com/podman-desktop/podman-desktop/pull/14451 to refactor further without UT error

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
