### PR TITLE
feat: filter catalog extensions

### DIFF
--- a/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
@@ -53,6 +53,8 @@ test('Expect to have more details working', async () => {
     publisherDisplayName: 'Foo publisher',
     isInstalled: false,
     shortDescription: 'my description',
+    categories: [],
+    keywords: [],
   };
 
   render(CatalogExtension, { catalogExtensionUI });
@@ -88,6 +90,8 @@ test('Expect to see featured and fetch button', async () => {
     publisherDisplayName: 'Foo publisher',
     isInstalled: false,
     shortDescription: 'my description',
+    categories: [],
+    keywords: [],
   };
 
   render(CatalogExtension, { catalogExtensionUI });
@@ -129,6 +133,8 @@ test('Expect to have version of installed one', async () => {
     publisherDisplayName: 'Foo publisher',
     isInstalled: true,
     shortDescription: 'my description',
+    categories: [],
+    keywords: [],
   };
 
   render(CatalogExtension, { catalogExtensionUI });

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.spec.ts
@@ -44,6 +44,8 @@ const extensionA: CatalogExtensionInfoUI = {
   publisherDisplayName: 'Foo publisher',
   isInstalled: false,
   shortDescription: 'my description1',
+  categories: [],
+  keywords: [],
 };
 
 const extensionB: CatalogExtensionInfoUI = {
@@ -56,6 +58,8 @@ const extensionB: CatalogExtensionInfoUI = {
   publisherDisplayName: 'Foo publisher',
   isInstalled: false,
   shortDescription: 'my description2',
+  categories: [],
+  keywords: [],
 };
 test('Check with empty', async () => {
   render(CatalogExtensionList, { catalogExtensions: [] });

--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -39,7 +39,7 @@ export const aFakeExtension: CatalogExtension = {
   publisherDisplayName: 'Foo Publisher',
   extensionName: 'a-extension',
   displayName: 'A Extension',
-  categories: [],
+  categories: ['foo'],
   keywords: [],
   unlisted: false,
   versions: [
@@ -65,7 +65,7 @@ export const bFakeExtension: CatalogExtension = {
   publisherDisplayName: 'Foo Publisher',
   extensionName: 'b-extension',
   displayName: 'B Extension',
-  categories: [],
+  categories: ['foo'],
   keywords: [],
   unlisted: false,
   versions: [
@@ -226,4 +226,20 @@ test('Expect to see local extensions tab content', async () => {
   // expect to see empty screen
   const emptyText = screen.getByText('Enable Preferences > Extensions > Development Mode to test local extensions');
   expect(emptyText).toBeInTheDocument();
+});
+
+test('Switching tabs keeps only terms in search term', async () => {
+  catalogExtensionInfos.set([aFakeExtension, bFakeExtension]);
+  extensionInfos.set([]);
+
+  render(ExtensionList, { searchTerm: 'bar category:bar not:installed' });
+
+  // Click on the catalog
+  const catalogTab = screen.getByRole('button', { name: 'Catalog' });
+  await fireEvent.click(catalogTab);
+
+  // Verify that the extension containing "bar" in the description is displayed (which is not in bar category and is installed)
+  // meaning that `category:bar not:installed` has been removed from search term
+  const myExtension1 = screen.getByRole('group', { name: 'A Extension' });
+  expect(myExtension1).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -50,6 +50,14 @@ function closeModal(): void {
 
 let screen: 'installed' | 'catalog' | 'development' = $state('installed');
 let installManualImageModal: boolean = $state(false);
+
+function changeScreen(newScreen: 'installed' | 'catalog' | 'development'): void {
+  if (screen === newScreen) {
+    return;
+  }
+  screen = newScreen;
+  searchTerm = extensionsUtils.filterTerms(searchTerm).join(' ');
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="extensions">
@@ -80,19 +88,19 @@ let installManualImageModal: boolean = $state(false);
     <Button
       type="tab"
       on:click={(): void => {
-        screen = 'installed';
+        changeScreen('installed');
       }}
       selected={screen === 'installed'}>Installed</Button>
     <Button
       type="tab"
       on:click={(): void => {
-        screen = 'catalog';
+        changeScreen('catalog');
       }}
       selected={screen === 'catalog'}>Catalog</Button>
       <Button
       type="tab"
       on:click={(): void => {
-        screen = 'development';
+        changeScreen('development');
       }}
       selected={screen === 'development'}>Local Extensions</Button>
  {/snippet}

--- a/packages/renderer/src/lib/extensions/catalog-extension-info-ui.ts
+++ b/packages/renderer/src/lib/extensions/catalog-extension-info-ui.ts
@@ -28,4 +28,6 @@ export interface CatalogExtensionInfoUI {
   isInstalled: boolean;
   installedVersion?: string;
   shortDescription: string;
+  categories: string[];
+  keywords: string[];
 }

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -324,8 +324,8 @@ describe('filters', () => {
     publisherDisplayName: 'Foo Publisher',
     extensionName: 'a-extension',
     displayName: 'A Extension',
-    categories: [],
-    keywords: [],
+    categories: ['category1', 'category2'],
+    keywords: ['keyword1', 'keyword2'],
     unlisted: false,
     versions: [
       {
@@ -390,6 +390,107 @@ describe('filters', () => {
     );
     expect(filteredCatalogExtensions.length).toBe(1);
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
+  test('filterCatalogExtensions with multiple words found', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar word',
+    );
+    expect(filteredCatalogExtensions.length).toBe(1);
+    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
+  test('filterCatalogExtensions with multiple words and one is not found', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar notfound',
+    );
+    expect(filteredCatalogExtensions.length).toBe(0);
+  });
+
+  test('filterCatalogExtensions with multiple words found and one category', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar word category:category1',
+    );
+    expect(filteredCatalogExtensions.length).toBe(1);
+    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
+  test('filterCatalogExtensions with multiple words found and multiple categories found', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar word category:category1 category:category2',
+    );
+    expect(filteredCatalogExtensions.length).toBe(1);
+    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
+  test('filterCatalogExtensions with multiple words found and multiple categories with one not found ', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar word category:category1 category:category3',
+    );
+    expect(filteredCatalogExtensions.length).toBe(0);
+  });
+
+  test('filterCatalogExtensions with multiple words found and one keyword', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar word keyword:keyword1',
+    );
+    expect(filteredCatalogExtensions.length).toBe(1);
+    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
+  test('filterCatalogExtensions with multiple words found and multiple keywords found', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar word keyword:keyword1 keyword:keyword2',
+    );
+    expect(filteredCatalogExtensions.length).toBe(1);
+    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
+  test('filterCatalogExtensions with multiple words found and multiple keywords with one not found ', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar word keyword:keyword1 keyword:keyword3',
+    );
+    expect(filteredCatalogExtensions.length).toBe(0);
   });
 
   test('filterInstalledExtensions with single word', () => {

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -392,6 +392,44 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
+  test('filterCatalogExtensions with single word and installed', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar is:installed',
+    );
+    expect(filteredCatalogExtensions.length).toBe(1);
+    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
+  test('filterCatalogExtensions with single word and not installed', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar not:installed',
+    );
+    expect(filteredCatalogExtensions.length).toBe(0);
+  });
+
+  test('filterCatalogExtensions with single word and installed and not installed, only first boolean is used', () => {
+    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
+      extensionsUtils.extractCatalogExtensions(
+        [aFakeExtension, bFakeExtension],
+        featuredExtensions,
+        installedExtensions,
+      ),
+      'bar is:installed not:installed',
+    );
+    expect(filteredCatalogExtensions.length).toBe(1);
+    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
+  });
+
   test('filterCatalogExtensions with multiple words found', () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
       extensionsUtils.extractCatalogExtensions(

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -217,6 +217,7 @@ export class ExtensionsUtils {
     const terms = this.filterTerms(lowerCaseSearchTerm);
     const categories = this.filterCategories(lowerCaseSearchTerm);
     const keywords = this.filterKeywords(lowerCaseSearchTerm);
+    const installed = this.filterBoolean(lowerCaseSearchTerm, 'installed');
     return extensions.filter(extension => {
       return (
         (terms.length === 0 ||
@@ -224,13 +225,22 @@ export class ExtensionsUtils {
         (categories.length === 0 ||
           categories.every(category => extension.categories.map(c => c.toLowerCase()).includes(category))) &&
         (keywords.length === 0 ||
-          keywords.every(keyword => extension.keywords.map(k => k.toLowerCase()).includes(keyword)))
+          keywords.every(keyword => extension.keywords.map(k => k.toLowerCase()).includes(keyword))) &&
+        (installed === undefined || installed === extension.isInstalled)
       );
     });
   }
 
   filterTerms(searchTerm: string): string[] {
-    return searchTerm.split(' ').filter(part => !part.startsWith('category:') && !part.startsWith('keyword:'));
+    return searchTerm
+      .split(' ')
+      .filter(
+        part =>
+          !part.startsWith('category:') &&
+          !part.startsWith('keyword:') &&
+          !part.startsWith('is:') &&
+          !part.startsWith('not:'),
+      );
   }
 
   filterCategories(searchTerm: string): string[] {
@@ -245,5 +255,14 @@ export class ExtensionsUtils {
       .split(' ')
       .filter(part => part.startsWith('keyword:'))
       .map(part => part.replace('keyword:', ''));
+  }
+
+  // filter for boolean values like is:installed or not:installed, and only get the first value in consideration
+  filterBoolean(searchTerm: string, key: string): boolean | undefined {
+    const filter = searchTerm.split(' ').find(part => part === `is:${key}` || part === `not:${key}`);
+    if (!filter) {
+      return undefined;
+    }
+    return filter === `is:${key}`;
   }
 }

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -173,7 +173,8 @@ export class ExtensionsUtils {
 
         const shortDescription = catalogExtension.shortDescription;
         const installedVersion = installed?.version;
-
+        const categories = catalogExtension.categories;
+        const keywords = catalogExtension.keywords;
         return {
           id: catalogExtension.id,
           displayName: catalogExtension.displayName,
@@ -186,6 +187,8 @@ export class ExtensionsUtils {
           isInstalled,
           installedVersion,
           shortDescription,
+          categories,
+          keywords,
         };
       });
 
@@ -211,8 +214,36 @@ export class ExtensionsUtils {
 
   filterCatalogExtensions(extensions: CatalogExtensionInfoUI[], searchTerm: string): CatalogExtensionInfoUI[] {
     const lowerCaseSearchTerm = searchTerm.toLowerCase();
+    const terms = this.filterTerms(lowerCaseSearchTerm);
+    const categories = this.filterCategories(lowerCaseSearchTerm);
+    const keywords = this.filterKeywords(lowerCaseSearchTerm);
     return extensions.filter(extension => {
-      return `${extension.displayName} ${extension.shortDescription}`.toLowerCase().includes(lowerCaseSearchTerm);
+      return (
+        (terms.length === 0 ||
+          terms.every(term => `${extension.displayName} ${extension.shortDescription}`.toLowerCase().includes(term))) &&
+        (categories.length === 0 ||
+          categories.every(category => extension.categories.map(c => c.toLowerCase()).includes(category))) &&
+        (keywords.length === 0 ||
+          keywords.every(keyword => extension.keywords.map(k => k.toLowerCase()).includes(keyword)))
+      );
     });
+  }
+
+  filterTerms(searchTerm: string): string[] {
+    return searchTerm.split(' ').filter(part => !part.startsWith('category:') && !part.startsWith('keyword:'));
+  }
+
+  filterCategories(searchTerm: string): string[] {
+    return searchTerm
+      .split(' ')
+      .filter(part => part.startsWith('category:'))
+      .map(part => part.replace('category:', ''));
+  }
+
+  filterKeywords(searchTerm: string): string[] {
+    return searchTerm
+      .split(' ')
+      .filter(part => part.startsWith('keyword:'))
+      .map(part => part.replace('keyword:', ''));
   }
 }


### PR DESCRIPTION
### What does this PR do?

Part of #14181 

Adds `category:`, `keyword:`, `is:installed` and `not:installed` filters (to be used in the search box) to the list of catalog extensions.

Note that the filter is only working on the catalog list, not the installed list, nor local extensions. Do we want to keep the `category:`, `keyword:`, `is:installed` and `not:installed` filters in the search box when the user switches to other tabs, or do we want to remove them (and keep only the search terms)? -> these terms are removed when switching


The next step will be to have a direct link to the page with the search box pre-filled with specific filters.

### Screenshot / video of UI

<img width="1048" height="698" alt="filtered-catalog-extenions" src="https://github.com/user-attachments/assets/315404ac-182f-4b35-8e84-f001c086fb3f" />

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
