### PR TITLE
feat: add getManagedDefaultsDirectory() to Directories

### DIFF
--- a/packages/main/src/plugin/directories-legacy.ts
+++ b/packages/main/src/plugin/directories-legacy.ts
@@ -22,7 +22,13 @@ import * as path from 'node:path';
 
 import { injectable } from 'inversify';
 
+import { isLinux, isMac, isWindows } from '../util.js';
 import type { Directories } from './directories.js';
+import {
+  SYSTEM_DEFAULTS_FOLDER_LINUX,
+  SYSTEM_DEFAULTS_FOLDER_MACOS,
+  SYSTEM_DEFAULTS_FOLDER_WINDOWS,
+} from './managed-by-constants.js';
 
 /**
  * Directory provider that uses the traditional/legacy directory structure
@@ -90,5 +96,18 @@ export class LegacyDirectories implements Directories {
 
   getDataDirectory(): string {
     return this.dataDirectory;
+  }
+
+  getManagedDefaultsDirectory(): string {
+    if (isMac()) {
+      return SYSTEM_DEFAULTS_FOLDER_MACOS;
+    } else if (isWindows()) {
+      const programData = process.env['PROGRAMDATA'] ?? 'C:\\ProgramData';
+      return path.join(programData, SYSTEM_DEFAULTS_FOLDER_WINDOWS);
+    } else if (isLinux()) {
+      return SYSTEM_DEFAULTS_FOLDER_LINUX;
+    }
+    // Fallback to Linux-style path
+    return SYSTEM_DEFAULTS_FOLDER_LINUX;
   }
 }

--- a/packages/main/src/plugin/directories-linux-xdg.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.ts
@@ -22,6 +22,7 @@ import * as path from 'node:path';
 import { injectable } from 'inversify';
 
 import type { Directories } from './directories.js';
+import { SYSTEM_DEFAULTS_FOLDER_LINUX } from './managed-by-constants.js';
 
 /**
  * Directory provider that follows XDG Base Directory Specification for Linux
@@ -82,5 +83,9 @@ export class LinuxXDGDirectories implements Directories {
 
   getDataDirectory(): string {
     return this.dataDirectory;
+  }
+
+  getManagedDefaultsDirectory(): string {
+    return SYSTEM_DEFAULTS_FOLDER_LINUX;
   }
 }

--- a/packages/main/src/plugin/managed-by-constants.ts
+++ b/packages/main/src/plugin/managed-by-constants.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2025 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const Directories = Symbol.for('Directories');
-export interface Directories {
-  getConfigurationDirectory(): string;
-  getPluginsDirectory(): string;
-  getPluginsScanDirectory(): string;
-  getExtensionsStorageDirectory(): string;
-  getContributionStorageDir(): string;
-  getSafeStorageDirectory(): string;
-  getDataDirectory(): string;
-  getManagedDefaultsDirectory(): string;
-}
+// Below is the location of the managed defaults file on different OS'
+// this will be the Managed by profile which will show some "suggested defaults" by
+// the system administrator.
+
+// Filename for the managed defaults file
+export const SYSTEM_DEFAULTS_FILENAME = 'default-settings.json';
+
+// Folders for managed defaults on different platforms
+export const SYSTEM_DEFAULTS_FOLDER_MACOS = '/Library/Application Support/com.podman.desktop';
+export const SYSTEM_DEFAULTS_FOLDER_WINDOWS = 'PodmanDesktop';
+export const SYSTEM_DEFAULTS_FOLDER_LINUX = '/usr/share/podman-desktop';


### PR DESCRIPTION
### What does this PR do?

Introduce the new method getManagedDefaultsDirectory() to Directories
that provides platform-specific paths for the "managed-by"
profile.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/13894

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>