### PR TITLE
fix(searchbar): removed background for highlited items

### DIFF
--- a/packages/renderer/src/lib/dialogs/TextHighLight.svelte
+++ b/packages/renderer/src/lib/dialogs/TextHighLight.svelte
@@ -31,7 +31,7 @@ function highlightText(
 
 {#each highlightedParts as part, i (i)}
   {#if part.hasMatch}
-    <mark class="text-[var(--pd-label-primary-text)] font-semibold">{part.text}</mark>
+    <mark class="text-[var(--pd-label-primary-text)] font-semibold bg-transparent">{part.text}</mark>
   {:else}
     {part.text}
   {/if}


### PR DESCRIPTION
### What does this PR do?
Adds transparent background to highlighted text

This makes the text in searchbar hard to read
### Screenshot / video of UI
Prev: 

<img width="791" height="359" alt="image" src="https://github.com/user-attachments/assets/5bc9970d-abc3-4e08-ae06-e4a39979cc2b" />

<img width="803" height="337" alt="image" src="https://github.com/user-attachments/assets/a13234d2-3870-4003-ae08-fe6e53533be9" />

Now:

<img width="802" height="349" alt="image" src="https://github.com/user-attachments/assets/ce6fff8a-43ee-40f0-92ed-2f468ee8a434" />


<img width="790" height="356" alt="image" src="https://github.com/user-attachments/assets/4d304293-825e-40c5-8e06-51322a0aa3a3" />



### What issues does this PR fix or reference?

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
