### PR TITLE
chore(test): add proxy smoke e2e tests

### DIFF
--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -102,3 +102,9 @@ export enum PodmanVirtualizationProviders {
   Qemu = 'Qemu',
   Native = '', //not a real provider, used for 'Connection Type' check in Resources page of Linux machines
 }
+
+export enum ProxyTypes {
+  Disabled = 'Disabled',
+  Manual = 'Manual',
+  System = 'System',
+}

--- a/tests/playwright/src/model/pages/proxy-page.ts
+++ b/tests/playwright/src/model/pages/proxy-page.ts
@@ -45,7 +45,6 @@ export class ProxyPage extends SettingsPage {
 
   public async getProxyType(): Promise<ProxyTypes> {
     const selectionOption = (await this.toggleProxyButton.textContent())?.trim();
-    console.log(`Checking: ${selectionOption}`);
     switch (selectionOption) {
       case 'Disabled':
         return ProxyTypes.Disabled;
@@ -54,7 +53,7 @@ export class ProxyPage extends SettingsPage {
       case 'System':
         return ProxyTypes.System;
       default:
-        throw new Error(`Unknown proxy type: ${await this.toggleProxyButton.textContent()}`);
+        throw new Error(`Unknown proxy type: ${selectionOption}`);
     }
   }
 
@@ -76,8 +75,9 @@ export class ProxyPage extends SettingsPage {
   }
 
   private async fillProxyInput(input: Locator, value: string): Promise<void> {
-    await test.step(`Filling ${await input.textContent()}: ${value}`, async () => {
-      await playExpect(input, `Proxy input field ${await input.textContent()} is not enabled`).toBeEnabled();
+    const inputName = await input.evaluate(el => el.getAttribute('id'));
+    await test.step(`Filling ${inputName}: ${value}`, async () => {
+      await playExpect(input, `Proxy input field ${inputName} is not enabled`).toBeEnabled();
       await input.fill('');
       await input.pressSequentially(value, { delay: 100 });
       await playExpect(input).toHaveValue(value);

--- a/tests/playwright/src/model/pages/proxy-page.ts
+++ b/tests/playwright/src/model/pages/proxy-page.ts
@@ -18,6 +18,8 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect as playExpect, test } from '@playwright/test';
 
+import { handleConfirmationDialog } from '/@/utility/operations';
+
 import { ProxyTypes } from '../core/types';
 import { SettingsPage } from './settings-page';
 
@@ -76,12 +78,21 @@ export class ProxyPage extends SettingsPage {
 
   private async fillProxyInput(input: Locator, value: string): Promise<void> {
     const inputName = await input.evaluate(el => el.getAttribute('id'));
-    await test.step(`Filling ${inputName}: ${value}`, async () => {
+    await test.step(`Filling ${inputName} textbox`, async () => {
       await playExpect(input, `Proxy input field ${inputName} is not enabled`).toBeEnabled();
-      await input.fill('');
+      await input.clear();
       await input.pressSequentially(value, { delay: 100 });
       await playExpect(input).toHaveValue(value);
     });
+  }
+
+  public async updateProxySettings(): Promise<void> {
+    await playExpect(this.updateButton).toBeEnabled();
+    // update proxy settings
+    await this.updateButton.click();
+    // dialog can be a warning or info, both has only OK button.
+    // on windows podman machine might needs to be restarted
+    await handleConfirmationDialog(this.page, 'Proxy Settings', true, 'OK');
   }
 
   public async fillHttpProxy(value: string): Promise<void> {

--- a/tests/playwright/src/model/pages/proxy-page.ts
+++ b/tests/playwright/src/model/pages/proxy-page.ts
@@ -1,0 +1,98 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { Locator, Page } from '@playwright/test';
+import { expect as playExpect, test } from '@playwright/test';
+
+import { ProxyTypes } from '../core/types';
+import { SettingsPage } from './settings-page';
+
+export class ProxyPage extends SettingsPage {
+  readonly heading: Locator;
+  readonly toggleProxyButton: Locator;
+  readonly updateButton: Locator;
+  readonly httpProxy: Locator;
+  readonly httpsProxy: Locator;
+  readonly noProxy: Locator;
+  readonly proxyAlert: Locator;
+  readonly proxyDialog: Locator;
+
+  constructor(page: Page) {
+    super(page, 'Proxy Settings');
+    this.heading = page.getByRole('heading').and(page.getByText('Proxy Settings', { exact: true }));
+    this.toggleProxyButton = this.content.getByRole('button').and(this.content.locator('#toggle-proxy'));
+    this.updateButton = this.content.getByRole('button', { name: 'Update' });
+    this.httpProxy = this.content.getByRole('textbox').and(this.content.locator('#httpProxy'));
+    this.httpsProxy = this.content.getByRole('textbox').and(this.content.locator('#httpsProxy'));
+    this.noProxy = this.content.getByRole('textbox').and(this.content.locator('#noProxy'));
+    this.proxyAlert = this.content.getByRole('alert', { name: 'Error Message Content' });
+    this.proxyDialog = this.page.getByRole('dialog', { name: 'Proxy Settings' });
+  }
+
+  public async getProxyType(): Promise<ProxyTypes> {
+    const selectionOption = (await this.toggleProxyButton.textContent())?.trim();
+    console.log(`Checking: ${selectionOption}`);
+    switch (selectionOption) {
+      case 'Disabled':
+        return ProxyTypes.Disabled;
+      case 'Manual':
+        return ProxyTypes.Manual;
+      case 'System':
+        return ProxyTypes.System;
+      default:
+        throw new Error(`Unknown proxy type: ${await this.toggleProxyButton.textContent()}`);
+    }
+  }
+
+  public async selectProxy(proxyType: ProxyTypes): Promise<void> {
+    if (proxyType !== (await this.getProxyType())) {
+      await test.step(`Select ${proxyType} proxy type`, async () => {
+        await playExpect(this.toggleProxyButton).toBeEnabled();
+        await this.toggleProxyButton.click();
+        const newProxySelection = this.content.getByRole('button', {
+          name: proxyType,
+          exact: true,
+        });
+        await playExpect(newProxySelection).toBeEnabled();
+        await newProxySelection.click();
+        await playExpect(newProxySelection).not.toBeVisible();
+        await playExpect(this.toggleProxyButton).toHaveText(proxyType);
+      });
+    }
+  }
+
+  private async fillProxyInput(input: Locator, value: string): Promise<void> {
+    await test.step(`Filling ${await input.textContent()}: ${value}`, async () => {
+      await playExpect(input, `Proxy input field ${await input.textContent()} is not enabled`).toBeEnabled();
+      await input.fill('');
+      await input.pressSequentially(value, { delay: 100 });
+      await playExpect(input).toHaveValue(value);
+    });
+  }
+
+  public async fillHttpProxy(value: string): Promise<void> {
+    await this.fillProxyInput(this.httpProxy, value);
+  }
+
+  public async fillHttpsProxy(value: string): Promise<void> {
+    await this.fillProxyInput(this.httpsProxy, value);
+  }
+
+  public async fillNoProxy(value: string): Promise<void> {
+    await this.fillProxyInput(this.noProxy, value);
+  }
+}

--- a/tests/playwright/src/specs/proxy-smoke.spec.ts
+++ b/tests/playwright/src/specs/proxy-smoke.spec.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { ProxyTypes } from '../model/core/types';
+import { ProxyPage } from '../model/pages/proxy-page';
+import { expect as playExpect, test } from '../utility/fixtures';
+import { handleConfirmationDialog } from '../utility/operations';
+
+const invalidProxyUrl = 'invalid-proxy-url';
+const httpProxyUrl = 'http://http.proxy:8080';
+const httpsProxyUrl = 'https://http.proxy:8443';
+const hostsDomains = 'localhost';
+
+let proxyPage: ProxyPage;
+
+test.beforeAll(async ({ page, runner, welcomePage }) => {
+  runner.setVideoAndTraceName('proxy-e2e');
+  await welcomePage.handleWelcomePage(true);
+  proxyPage = new ProxyPage(page);
+});
+
+test.afterAll(async ({ navigationBar, page, runner }) => {
+  await navigationBar.openDashboard();
+  const settingsBar = await navigationBar.openSettings();
+  await settingsBar.proxyTab.click();
+  await playExpect(proxyPage.heading).toBeVisible();
+  await proxyPage.selectProxy(ProxyTypes.System);
+  await proxyPage.updateButton.click();
+  await handleConfirmationDialog(page, 'Proxy Settings', true, 'OK');
+  await runner.close();
+});
+
+test.describe.serial('Proxy settings ', { tag: '@smoke' }, () => {
+  test.beforeEach(async ({ navigationBar }) => {
+    await navigationBar.openDashboard();
+    const settingsBar = await navigationBar.openSettings();
+    await settingsBar.proxyTab.click();
+    await playExpect(proxyPage.heading).toBeVisible();
+  });
+
+  test('Proxy page assets and System proxy setup', async () => {
+    await playExpect(proxyPage.toggleProxyButton).toBeVisible();
+    await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.System);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+    await playExpect(proxyPage.updateButton).toBeEnabled();
+  });
+
+  test('Manual proxy setup, validation and update', async ({ page }) => {
+    await proxyPage.selectProxy(ProxyTypes.Manual);
+    await playExpect(proxyPage.httpProxy).toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).toBeEnabled();
+    await playExpect(proxyPage.noProxy).toBeEnabled();
+    // vlaidation for http proxy input
+    await proxyPage.httpProxy.fill('invalid-proxy-url');
+    await playExpect(proxyPage.proxyAlert).toBeVisible();
+    await playExpect(proxyPage.proxyAlert).toContainText(`value ${invalidProxyUrl} should be an URL`, {
+      ignoreCase: true,
+    });
+    await proxyPage.fillHttpProxy(httpProxyUrl);
+    await playExpect(proxyPage.proxyAlert).not.toBeVisible();
+    // validation for https proxy input
+    await proxyPage.httpsProxy.fill(invalidProxyUrl);
+    await playExpect(proxyPage.proxyAlert).toBeVisible();
+    await playExpect(proxyPage.proxyAlert).toContainText(`value ${invalidProxyUrl} should be an URL`, {
+      ignoreCase: true,
+    });
+    await proxyPage.fillHttpsProxy(httpsProxyUrl);
+    await playExpect(proxyPage.proxyAlert).not.toBeVisible();
+    // check domains for no proxy
+    await proxyPage.fillNoProxy(hostsDomains);
+    await playExpect(proxyPage.updateButton).toBeEnabled();
+    // update proxy settings
+    await proxyPage.updateButton.click();
+    // dialog can be a warning or info, both has only OK button.
+    // on windows podman machine might needs to be restarted
+    await handleConfirmationDialog(page, 'Proxy Settings', true, 'OK');
+  });
+
+  test('Proxy settings persists when proxy page is switched', async () => {
+    // given that we always switch to dashboard and back to the proxy page in before each hook
+    // we should check previous test setup - manual proxy
+    await playExpect(proxyPage.toggleProxyButton).toBeVisible();
+    await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.Manual);
+    await playExpect(proxyPage.httpProxy).toBeEnabled();
+    await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
+  });
+
+  test('Disabled proxy setup', async ({ page }) => {
+    await proxyPage.selectProxy(ProxyTypes.Disabled);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+    await playExpect(proxyPage.updateButton).toBeEnabled();
+    await proxyPage.updateButton.click();
+    await handleConfirmationDialog(page, 'Proxy Settings', true, 'OK');
+  });
+});

--- a/tests/playwright/src/specs/proxy-smoke.spec.ts
+++ b/tests/playwright/src/specs/proxy-smoke.spec.ts
@@ -67,7 +67,7 @@ test.describe.serial('Proxy settings ', { tag: '@smoke' }, () => {
     await playExpect(proxyPage.httpProxy).toBeEnabled();
     await playExpect(proxyPage.httpsProxy).toBeEnabled();
     await playExpect(proxyPage.noProxy).toBeEnabled();
-    // vlaidation for http proxy input
+    // validation for http proxy input
     await proxyPage.httpProxy.fill('invalid-proxy-url');
     await playExpect(proxyPage.proxyAlert).toBeVisible();
     await playExpect(proxyPage.proxyAlert).toContainText(`value ${invalidProxyUrl} should be an URL`, {
@@ -100,6 +100,10 @@ test.describe.serial('Proxy settings ', { tag: '@smoke' }, () => {
     await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.Manual);
     await playExpect(proxyPage.httpProxy).toBeEnabled();
     await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
+    await playExpect(proxyPage.httpsProxy).toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
+    await playExpect(proxyPage.noProxy).toBeEnabled();
+    await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
   });
 
   test('Disabled proxy setup', async ({ page }) => {
@@ -110,5 +114,34 @@ test.describe.serial('Proxy settings ', { tag: '@smoke' }, () => {
     await playExpect(proxyPage.updateButton).toBeEnabled();
     await proxyPage.updateButton.click();
     await handleConfirmationDialog(page, 'Proxy Settings', true, 'OK');
+  });
+
+  test('Re-enabled Manual proxy settings persisted', async ({ page }) => {
+    await proxyPage.selectProxy(ProxyTypes.Disabled);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+
+    await proxyPage.selectProxy(ProxyTypes.Manual);
+    await playExpect(proxyPage.httpProxy).toBeEnabled();
+    await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
+    await playExpect(proxyPage.httpsProxy).toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
+    await playExpect(proxyPage.noProxy).toBeEnabled();
+    await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
+
+    await proxyPage.selectProxy(ProxyTypes.System);
+    await proxyPage.updateButton.click();
+    await handleConfirmationDialog(page, 'Proxy Settings', true, 'OK');
+  });
+
+  test('Proxy values are reset', async () => {
+    await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.System);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpProxy).not.toHaveValue(httpProxyUrl);
+    await playExpect(proxyPage.httpsProxy).not.toHaveValue(httpsProxyUrl);
+    await playExpect(proxyPage.noProxy).not.toHaveValue(hostsDomains);
   });
 });


### PR DESCRIPTION
### What does this PR do?
Add e2e tests manipulating the proxy settings page.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#14489 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
The test "Proxy settings" should be passing on Pr-check e2e tests job
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
