### PR TITLE
refactor(extensions: podman): adding win-related checks to WinPlatform

### DIFF
--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -1,0 +1,128 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import type { CheckResult, ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { HyperVCheck } from '/@/checks/windows/hyperv-check';
+import type { HyperVPodmanVersionCheck } from '/@/checks/windows/hyperv-podman-version-check';
+import type { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
+import type { WinBitCheck } from '/@/checks/windows/win-bit-check';
+import type { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
+import type { WinVersionCheck } from '/@/checks/windows/win-version-check';
+import type { WSLVersionCheck } from '/@/checks/windows/wsl-version-check';
+import type { WSL2Check } from '/@/checks/windows/wsl2-check';
+
+import { WinPlatform } from './win-platform';
+
+vi.mock('@podman-desktop/api', () => ({ env: { isWindows: false } }));
+
+const EXTENSION_CONTEXT_MOCK = {} as ExtensionContext;
+const TELEMETRY_LOGGER_MOCK = {} as TelemetryLogger;
+
+const WIN_BIT_CHECK_MOCK = { execute: vi.fn() } as unknown as WinBitCheck;
+const WIN_VERSION_CHECK_MOCK = { execute: vi.fn() } as unknown as WinVersionCheck;
+const WIN_MEMORY_CHECK_MOCK = { execute: vi.fn() } as unknown as WinMemoryCheck;
+const HYPERV_PODMAN_VERSION_CHECK_MOCK = { execute: vi.fn() } as unknown as HyperVPodmanVersionCheck;
+const HYPERV_CHECK_MOCK = { execute: vi.fn() } as unknown as HyperVCheck;
+const VIRTUAL_MACHINE_PLATFORM_CHECK_MOCK = { execute: vi.fn() } as unknown as VirtualMachinePlatformCheck;
+const WSL_VERSION_CHECK_MOCK = { execute: vi.fn() } as unknown as WSLVersionCheck;
+const WSL2_CHECK_MOCK = { execute: vi.fn() } as unknown as WSL2Check;
+
+const SUCCESSFUL_CHECK_RESULT: CheckResult = { successful: true };
+const FAILED_CHECK_RESULT: CheckResult = { successful: false };
+
+let winPlatform: WinPlatform;
+
+beforeEach(() => {
+  winPlatform = new WinPlatform(
+    EXTENSION_CONTEXT_MOCK,
+    TELEMETRY_LOGGER_MOCK,
+    WIN_BIT_CHECK_MOCK,
+    WIN_VERSION_CHECK_MOCK,
+    WIN_MEMORY_CHECK_MOCK,
+    HYPERV_PODMAN_VERSION_CHECK_MOCK,
+    HYPERV_CHECK_MOCK,
+    VIRTUAL_MACHINE_PLATFORM_CHECK_MOCK,
+    WSL_VERSION_CHECK_MOCK,
+    WSL2_CHECK_MOCK,
+  );
+});
+
+test('isHyperVEnabled should return false if it is not a Windows environment', async () => {
+  vi.mocked(extensionApi.env).isWindows = false;
+
+  const hypervEnabled = await winPlatform.isHyperVEnabled();
+
+  expect(hypervEnabled).toBeFalsy();
+});
+
+test('isHyperVEnabled should return false if Hyper-V check fails', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(HYPERV_CHECK_MOCK.execute).mockResolvedValue(FAILED_CHECK_RESULT);
+  vi.mocked(HYPERV_PODMAN_VERSION_CHECK_MOCK.execute).mockResolvedValue(FAILED_CHECK_RESULT);
+
+  const hypervEnabled = await winPlatform.isHyperVEnabled();
+
+  expect(hypervEnabled).toBeFalsy();
+});
+
+test('isHyperVEnabled should return true if all Hyper-V checks succeed', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(HYPERV_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+  vi.mocked(HYPERV_PODMAN_VERSION_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+
+  const hypervEnabled = await winPlatform.isHyperVEnabled();
+
+  expect(hypervEnabled).toBeTruthy();
+});
+
+test('isWSLEnabled should return false if not on Windows', async () => {
+  vi.mocked(extensionApi.env).isWindows = false;
+
+  const wslEnabled = await winPlatform.isWSLEnabled();
+
+  expect(wslEnabled).toBeFalsy();
+});
+
+test('isWSLEnabled should return false if any WSL check fails', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(VIRTUAL_MACHINE_PLATFORM_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+  vi.mocked(WSL_VERSION_CHECK_MOCK.execute).mockResolvedValue(FAILED_CHECK_RESULT);
+  vi.mocked(WSL2_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+
+  const wslEnabled = await winPlatform.isWSLEnabled();
+
+  expect(wslEnabled).toBeFalsy();
+});
+
+test('isWSLEnabled should return true if all WSL checks succeed', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(VIRTUAL_MACHINE_PLATFORM_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+  vi.mocked(WSL_VERSION_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+  vi.mocked(WSL2_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+
+  const wslEnabled = await winPlatform.isWSLEnabled();
+
+  expect(wslEnabled).toBeTruthy();
+});

--- a/extensions/podman/packages/extension/src/platforms/win-platform.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.ts
@@ -16,9 +16,79 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { injectable } from 'inversify';
+import type { InstallCheck } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+import { inject, injectable } from 'inversify';
+
+import { OrCheck, SequenceCheck } from '/@/checks/base-check';
+import { HyperVCheck } from '/@/checks/windows/hyperv-check';
+import { HyperVPodmanVersionCheck } from '/@/checks/windows/hyperv-podman-version-check';
+import { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
+import { WinBitCheck } from '/@/checks/windows/win-bit-check';
+import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
+import { WinVersionCheck } from '/@/checks/windows/win-version-check';
+import { WSLVersionCheck } from '/@/checks/windows/wsl-version-check';
+import { WSL2Check } from '/@/checks/windows/wsl2-check';
+import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 
 @injectable()
 export class WinPlatform {
   readonly type = 'win';
+
+  private readonly windowsVirtualizationCheck: OrCheck;
+  private readonly wslCheck: SequenceCheck;
+  private readonly hyperVSequenceCheck: SequenceCheck;
+
+  constructor(
+    @inject(ExtensionContextSymbol)
+    readonly extensionContext: extensionApi.ExtensionContext,
+    @inject(TelemetryLoggerSymbol)
+    readonly telemetryLogger: extensionApi.TelemetryLogger,
+    @inject(WinBitCheck)
+    readonly winBitCheck: WinBitCheck,
+    @inject(WinVersionCheck)
+    readonly winVersionCheck: WinVersionCheck,
+    @inject(WinMemoryCheck)
+    readonly winMemoryCheck: WinMemoryCheck,
+    @inject(HyperVPodmanVersionCheck)
+    readonly hyperVPodmanVersionCheck: HyperVPodmanVersionCheck,
+    @inject(HyperVCheck)
+    readonly hyperVCheck: HyperVCheck,
+    @inject(VirtualMachinePlatformCheck)
+    readonly virtualMachinePlatformCheck: VirtualMachinePlatformCheck,
+    @inject(WSLVersionCheck)
+    readonly wSLVersionCheck: WSLVersionCheck,
+    @inject(WSL2Check)
+    readonly wSL2Check: WSL2Check,
+  ) {
+    this.hyperVSequenceCheck = new SequenceCheck('Hyper-V Platform', [this.hyperVPodmanVersionCheck, this.hyperVCheck]);
+
+    this.wslCheck = new SequenceCheck('WSL platform', [
+      this.virtualMachinePlatformCheck,
+      this.wSLVersionCheck,
+      this.wSL2Check,
+    ]);
+
+    this.windowsVirtualizationCheck = new OrCheck('Windows virtualization', this.wslCheck, this.hyperVSequenceCheck);
+  }
+
+  getPreflightChecks(): InstallCheck[] {
+    return [this.winBitCheck, this.winVersionCheck, this.winMemoryCheck, this.windowsVirtualizationCheck];
+  }
+
+  async isWSLEnabled(): Promise<boolean> {
+    if (!extensionApi.env.isWindows) {
+      return false;
+    }
+    const wslCheckResult = await this.wslCheck.execute();
+    return wslCheckResult.successful;
+  }
+
+  async isHyperVEnabled(): Promise<boolean> {
+    if (!extensionApi.env.isWindows) {
+      return false;
+    }
+    const hyperVCheckResult = await this.hyperVSequenceCheck.execute();
+    return hyperVCheckResult.successful;
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Follow-up of the closed PR https://github.com/podman-desktop/podman-desktop/pull/14301, a request to split it in several part was made (ref https://github.com/podman-desktop/podman-desktop/pull/14301#issuecomment-3427066018). Here is the first part 👍 

### Notes

The `WinPlatform` class is not instantiated for now, so this code do not have any side effect.

The `if(extensionApi.env.isWindow)` are required to properly match the existing usage of `isWslEnabled` and `isHyperVEnabled` in the `extension.ts`. This can probably be deleted in the future when https://github.com/podman-desktop/podman-desktop/issues/10327 will be completed.

### What issues does this PR fix or reference?

Part one of https://github.com/podman-desktop/podman-desktop/issues/14292

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
