### PR TITLE
refactor(renderer: ImagesList.svelte): adding key props to table usage

### DIFF
--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -288,7 +288,7 @@ const row = new TableRow<ImageInfoUI>({
  * Utility function for the Table to get the key to use for each item
  */
 function key(item: ImageInfoUI): string {
-  return item.id;
+  return `${item.engineId}:${item.id}`;
 }
 </script>
 

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -283,6 +283,13 @@ const row = new TableRow<ImageInfoUI>({
     return image.children ?? [];
   },
 });
+
+/**
+ * Utility function for the Table to get the key to use for each item
+ */
+function key(item: ImageInfoUI): string {
+  return item.id;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="images">
@@ -347,6 +354,7 @@ const row = new TableRow<ImageInfoUI>({
         columns={columns}
         row={row}
         defaultSortColumn="Age"
+        key={key}
         enableLayoutConfiguration={true}
         on:update={(): ImageInfoUI[] => (images = images)}>
       </Table>


### PR DESCRIPTION
### What does this PR do?

The `Table` component exposes a `key` optional props, this PR specify the proper key function for the `ImagesList.svelte` component

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14498
Part of https://github.com/podman-desktop/podman-desktop/issues/13889

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

You can checkout and start Podman Desktop and go to the Images page to ensure everything is working as expected

 