### PR TITLE
refactor(renderer: PodsList.svelte): adding key props to table usage

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -154,6 +154,13 @@ const columns = [
 ];
 
 const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
+
+/**
+ * Utility function for the Table to get the key to use for each item
+ */
+function key(pod: PodInfoUI): string {
+  return pod.id;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="pods">
@@ -250,6 +257,7 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
         row={row}
         defaultSortColumn="Name"
         enableLayoutConfiguration={true}
+        key={key}
         on:update={(): PodInfoUI[] => (pods = pods)}>
       </Table>
     {/if}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -159,7 +159,7 @@ const row = new TableRow<PodInfoUI>({ selectable: (_pod): boolean => true });
  * Utility function for the Table to get the key to use for each item
  */
 function key(pod: PodInfoUI): string {
-  return pod.id;
+  return `${pod.engineId}:${pod.id}`;
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?

The `Table` component exposes a `key` optional props, this PR specify the proper key function for the `PodsList.svelte` component

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14499

### How to test this PR?

- [x] Existing tests ensure no regression

You can checkout and start Podman Desktop and go to the PodsList page to ensure everything is working as expected

 
