### PR TITLE
refactor(renderer: VolumesList.svelte): adding key props to table usage

### DIFF
--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -173,6 +173,12 @@ const row = new TableRow<VolumeInfoUI>({
   selectable: (volume): boolean => volume.status === 'UNUSED',
   disabledText: 'Volume is used by a container',
 });
+/**
+ * Utility function for the Table to get the key to use for each item
+ */
+function key(obj: VolumeInfoUI): string {
+  return `${obj.engineId}:${obj.name}`;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="volumes">
@@ -228,6 +234,7 @@ const row = new TableRow<VolumeInfoUI>({
         row={row}
         defaultSortColumn="Name"
         enableLayoutConfiguration={true}
+        key={key}
         on:update={(): VolumeInfoUI[] => (volumes = volumes)}>
       </Table>
     {/if}


### PR DESCRIPTION
### What does this PR do?

The `Table` component exposes a `key` optional props, this PR specify the proper key function for the `VolumesList.svelte` component

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14500
Part of https://github.com/podman-desktop/podman-desktop/issues/13889

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

You can checkout and start Podman Desktop and go to the Volumes page to ensure everything is working as expected

