### PR TITLE
refactor(renderer: TaskManagerTable.svelte): adding key props to table usage

### DIFF
--- a/packages/renderer/src/lib/task-manager/table/TaskManagerTable.svelte
+++ b/packages/renderer/src/lib/task-manager/table/TaskManagerTable.svelte
@@ -46,6 +46,12 @@ const row = new TableRow<TaskInfoUI>({
   selectable: (task): boolean => task.state === 'completed',
   disabledText: 'Task is still running',
 });
+/**
+ * Utility function for the Table to get the key to use for each item
+ */
+function key(task: TaskInfoUI): string {
+  return task.id;
+}
 </script>
 
 <Table
@@ -54,4 +60,5 @@ const row = new TableRow<TaskInfoUI>({
   data={tasks}
   columns={columns}
   row={row}
+  key={key}
   defaultSortColumn="Age" />


### PR DESCRIPTION
### What does this PR do?

The `Table` component exposes a `key` optional props, this PR specify the proper key function for the `TaskManagerTable.svelte` component

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14501
Part of https://github.com/podman-desktop/podman-desktop/issues/13889

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

You can checkout and start Podman Desktop and go to the TaskManagerTable page to ensure everything is working as expected