### PR TITLE
refactor(renderer: PortForwardingList.svelte): adding key props to table usage

### DIFF
--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
@@ -45,6 +45,13 @@ const columns = [
 ];
 
 const row = new TableRow<ForwardConfig>({});
+
+/**
+ * Utility function for the Table to get the key to use for each item
+ */
+function key(config: ForwardConfig): string {
+  return config.id;
+}
 </script>
 
 <NavPage searchEnabled={false} title="Port forwarding">
@@ -56,6 +63,7 @@ const row = new TableRow<ForwardConfig>({});
         data={$kubernetesCurrentContextPortForwards}
         columns={columns}
         row={row}
+        key={key}
         defaultSortColumn="Name">
       </Table>
     {:else}


### PR DESCRIPTION
### What does this PR do?

The `Table` component exposes a `key` optional props, this PR specify the proper key function for the `PortForwardingList.svelte` component

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14502
Part of https://github.com/podman-desktop/podman-desktop/issues/13889

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

You can checkout and start Podman Desktop and go to the PortForwardingList page to ensure everything is working as expected

 