### PR TITLE
refactor(renderer: KubernetesObjectsList.svelte): adding key props to table usage

### DIFF
--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -120,6 +120,13 @@ async function deleteSelectedObjects(): Promise<void> {
 }
 
 let selectedItemsNumber = $state<number>(0);
+
+/**
+ * Utility function for the Table to get the key to use for each item
+ */
+function key(obj: KubernetesObject): string {
+  return obj.metadata?.uid ?? `${obj.metadata?.namespace}:${obj.metadata?.name}`;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title={plural}>
@@ -156,6 +163,7 @@ let selectedItemsNumber = $state<number>(0);
       data={objects}
       columns={columns}
       row={row}
+      key={key}
       defaultSortColumn="Name">
     </Table>
 


### PR DESCRIPTION
### What does this PR do?

The `Table` component exposes a `key` optional props, this PR specify the proper key function for the `KubernetesObjectsList.svelte` component

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14503
Part of https://github.com/podman-desktop/podman-desktop/issues/13889

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

You can checkout and start Podman Desktop and go to any Kubernetes object page to ensure everything is working as expected

 