### PR TITLE
chore(test): ensure button enabling uses custom timeout

### DIFF
--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -184,7 +184,7 @@ export async function handleConfirmationDialog(
     const button = confirm
       ? dialog.getByRole('button', { name: confirmationButton })
       : dialog.getByRole('button', { name: cancelButton });
-    await playExpect(button).toBeEnabled();
+    await playExpect(button).toBeEnabled({ timeout: timeout });
     await button.click();
 
     if (moreThanOneConsecutiveDialogs) {


### PR DESCRIPTION
### What does this PR do?
Ensures that the waiter for button enablement in e2e tests uses custom timer for timeout.

### What issues does this PR fix or reference?