### PR TITLE
fix(ui: table): collapse icon is incorrect when the item do not have a name

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -18,11 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Table, TableColumn, tablePersistence } from '/@/lib';
+import { Icon } from '/@/lib/icons';
 import SimpleColumn from '/@/lib/table/SimpleColumn.svelte';
 import { Column, Row } from '/@/lib/table/table';
 
@@ -432,6 +434,63 @@ describe('Table#collapsed', () => {
     width: '3fr',
     renderMapping: (obj): string => obj.name ?? 'unknown',
     renderer: SimpleColumn,
+  });
+
+  describe('collapse icons', () => {
+    let chevronDown: HTMLImageElement;
+    let chevronRight: HTMLImageElement;
+
+    beforeEach(() => {
+      const { container: chevronDownContainer } = render(Icon, {
+        icon: faChevronDown,
+        size: '0.8x',
+        class: 'text-[var(--pd-table-body-text)] cursor-pointer',
+      });
+      chevronDown = within(chevronDownContainer).getByRole('img', { hidden: true });
+
+      const { container: chevronRightContainer } = render(Icon, {
+        icon: faChevronRight,
+      });
+      chevronRight = within(chevronRightContainer).getByRole('img', { hidden: true });
+    });
+
+    test('item without name should have correct icon when expanded', async () => {
+      const { getByRole } = render(Table<Item>, {
+        kind: 'demo',
+        data: [
+          {
+            id: 'foo',
+          },
+        ],
+        columns: [SIMPLE_COLUMN],
+        row: ROW,
+        key: ({ id }: Item): string => id,
+        // nothing is collapsed
+        collapsed: [],
+      });
+
+      const button = getByRole('button', { name: 'Collapse Row' });
+      expect(button).toContainHTML(chevronDown.innerHTML);
+    });
+
+    test('item without name should have correct icon when collapsed', async () => {
+      const { getByRole } = render(Table<Item>, {
+        kind: 'demo',
+        data: [
+          {
+            id: 'foo',
+          },
+        ],
+        columns: [SIMPLE_COLUMN],
+        row: ROW,
+        key: ({ id }: Item): string => id,
+        // the item is collapsed
+        collapsed: ['foo'],
+      });
+
+      const button = getByRole('button', { name: 'Expand Row' });
+      expect(button).toContainHTML(chevronRight.innerHTML);
+    });
   });
 
   test('Table#collapsed prop should be used for collapsed', async () => {

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -416,7 +416,7 @@ async function resetColumns(): Promise<void> {
         <div class="whitespace-nowrap justify-self-end place-self-center" role="columnheader"></div>
       {/if}
     </div>
-    
+
     <!-- Settings - only show when layout configuration is enabled -->
     {#if enableLayoutConfiguration && tablePersistence.storage}
       <div class="absolute top-0 right-0 h-7 flex items-center pr-2 z-10">
@@ -457,7 +457,7 @@ async function resetColumns(): Promise<void> {
               >
                 <Icon size="0.8x"
                   class="text-[var(--pd-table-body-text)] cursor-pointer"
-                  icon={object.name && !collapsed.includes(object.name) ? faChevronDown : faChevronRight}/>
+                  icon={!collapsed.includes(itemKey) ? faChevronDown : faChevronRight}/>
               </button>
             {/if}
           </div>


### PR DESCRIPTION
### What does this PR do?

Fix a niche problem happening if the `key` function is providing a different value than the `item.name`.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14511

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

test is added in a separate commit 070acc2b01c4170cd0bb4ed8d7a3c74998e74e6b it can be cherry pick to ensure that this is failing on the main branch.
