### PR TITLE
feat(ui: table): adding optional label prop

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -412,6 +412,41 @@ test('Expect table to have proper css style', async () => {
   expect(dummyComponent.style.gridTemplateColumns).toBe('');
 });
 
+describe('Table#label', () => {
+  interface Item {
+    id: string;
+    name?: string;
+  }
+
+  const ROW = new Row<Item>({});
+
+  const SIMPLE_COLUMN = new Column<Item, string>('Name', {
+    width: '3fr',
+    renderMapping: (obj): string => obj.name ?? 'unknown',
+    renderer: SimpleColumn,
+  });
+
+  test('expect table to set aria-label from label prop if item has undefined name', () => {
+    const { queryByRole } = render(Table<Item>, {
+      kind: 'demo',
+      data: [
+        {
+          id: 'foo',
+        },
+      ],
+      columns: [SIMPLE_COLUMN],
+      row: ROW,
+      collapsed: ['foo'],
+      // create special value for the label
+      label: (item): string => `label-${item.id}`,
+      key: (item): string => item.id,
+    });
+
+    const row = queryByRole('row', { name: 'label-foo' });
+    expect(row).toBeDefined();
+  });
+});
+
 describe('Table#collapsed', () => {
   interface Item {
     id: string;

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -33,6 +33,12 @@ export let collapsed: string[] = [];
  * By default, it will use the object name property
  */
 export let key: (object: T) => string = item => item.name ?? String(item);
+/**
+ * Specify the aria-label for a given item
+ *
+ * By default, it will use the object name property
+ */
+export let label: (object: T) => string = item => item.name ?? String(item);
 
 export let enableLayoutConfiguration: boolean = false;
 
@@ -416,7 +422,7 @@ async function resetColumns(): Promise<void> {
         <div class="whitespace-nowrap justify-self-end place-self-center" role="columnheader"></div>
       {/if}
     </div>
-    
+
     <!-- Settings - only show when layout configuration is enabled -->
     {#if enableLayoutConfiguration && tablePersistence.storage}
       <div class="absolute top-0 right-0 h-7 flex items-center pr-2 z-10">
@@ -447,7 +453,7 @@ async function resetColumns(): Promise<void> {
           class:rounded-lg={collapsed.includes(itemKey) ||
             children.length === 0}
           role="row"
-          aria-label={object.name}>
+          aria-label={label(object)}>
           <div class="whitespace-nowrap place-self-center" role="cell">
             {#if children.length > 0}
               <button


### PR DESCRIPTION
### What does this PR do?

Adding the optional `label` property. No change for all usage, as it default to `item.name` if not provided.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14494

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
