### PR TITLE
refactor(renderer: TableList): adding key props to Table usage

### DIFF
--- a/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
@@ -47,6 +47,10 @@ const row = new TableRow<SelectableExtensionDevelopmentFolderInfoUI>({
 
 function deleteSelectedFolders(): void {}
 let bulkDeleteInProgress = false;
+
+function key(extensionFolder: SelectableExtensionDevelopmentFolderInfoUI): string {
+  return extensionFolder.path;
+}
 </script>
 
 <Table
@@ -56,6 +60,7 @@ let bulkDeleteInProgress = false;
   {row}
   bind:selectedItemsNumber
   defaultSortColumn="Name"
+  key={key}
   on:update={(): SelectableExtensionDevelopmentFolderInfoUI[] => (extensionFolderUIInfos = [...extensionFolderUIInfos])}>
 </Table>
 


### PR DESCRIPTION
### What does this PR do?

The `Table` component exposes a `key` optional props, this PR specify the proper key function for the `TableList.svelte` component

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14517
Part of https://github.com/podman-desktop/podman-desktop/issues/13889

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

You can checkout and start Podman Desktop and go to the TableList page (extension development) to ensure everything is working as expected

 