### PR TITLE
test(e2e): improved execsync logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:unit:coverage": "pnpm run test:unit --coverage",
     "test:e2e": "pnpm run test:e2e:build && pnpm run test:e2e:run",
     "test:e2e:build": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser pnpm run build",
-    "test:e2e:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ --grep-invert @k8s_e2e",
+    "test:e2e:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts",
     "test:e2e:all": "pnpm run test:e2e:build && pnpm run test:e2e:all:run",
     "test:e2e:all:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/",
     "test:e2e:smoke": "pnpm run test:e2e:build && pnpm run test:e2e:smoke:run",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:e2e:all": "pnpm run test:e2e:build && pnpm run test:e2e:all:run",
     "test:e2e:all:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/",
     "test:e2e:smoke": "pnpm run test:e2e:build && pnpm run test:e2e:smoke:run",
-    "test:e2e:smoke:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @smoke",
+    "test:e2e:smoke:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/troubleshooting-smoke.spec.ts tests/playwright/src/specs/volume-smoke.spec.ts tests/playwright/src/specs/welcome-page-smoke.spec.ts tests/playwright/src/specs/yaml-smoke.spec.ts tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts",
     "test:e2e:ui-stress": "npm run test:e2e:build && npm run test:e2e:ui-stress:run",
     "test:e2e:ui-stress:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/ui-stress/ -g @ui-stress",
     "test:e2e:k8s": "pnpm run test:e2e:build && pnpm run test:e2e:k8s:run",

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -245,7 +245,9 @@ export async function deletePodmanMachine(page: Page, machineVisibleName: string
       await playExpect(podmanResourceCard.resourceElementConnectionActions).toBeVisible();
       await playExpect(podmanResourceCard.resourceElementConnectionStatus).toBeVisible();
       if ((await podmanResourceCard.resourceElementConnectionStatus.innerText()) === ResourceElementState.Starting) {
-        console.log('[deletePodmanMachine] Podman machine is in STARTING state, will send stop command via CLI');
+        console.log(
+          `[deletePodmanMachine] Podman machine is in STARTING state, stop it via CLI with 'podman machine stop ${machineVisibleName}'`,
+        );
         try {
           // eslint-disable-next-line sonarjs/os-command
           const output = execSync(`podman machine stop ${machineVisibleName}`, { encoding: 'utf-8' });
@@ -267,7 +269,9 @@ export async function deletePodmanMachine(page: Page, machineVisibleName: string
             { timeout: 30_000, sendError: true },
           );
         } catch (error) {
-          console.log('[deletePodmanMachine] UI stop failed, will try to stop it via CLI');
+          console.log(
+            `[deletePodmanMachine] UI stop failed, will try to stop it via CLI with 'podman machine stop ${machineVisibleName}'`,
+          );
           try {
             // eslint-disable-next-line sonarjs/os-command
             const output = execSync(`podman machine stop ${machineVisibleName}`, { encoding: 'utf-8' });
@@ -352,7 +356,9 @@ export async function createPodmanMachineFromCLI(): Promise<void> {
     const userModeNetworking = process.env.PODMAN_NETWORKING === '1' ? '--user-networking' : '';
 
     try {
-      console.log('[createPodmanMachineFromCLI] Executing: podman machine init');
+      console.log(
+        `[createPodmanMachineFromCLI] Executing: podman machine init ${podmanMachineMode} ${userModeNetworking}`,
+      );
       // eslint-disable-next-line sonarjs/no-os-command-from-path, sonarjs/os-command
       const output = execSync(`podman machine init ${podmanMachineMode} ${userModeNetworking}`, { encoding: 'utf-8' });
       console.log('[createPodmanMachineFromCLI] Init output:', output.toString().trim());


### PR DESCRIPTION
### What does this PR do?
Improves the visualization of the podman machine operations executed in `operations.ts` using execSync by logging the results of the Buffer object they generate

Testing the new logs here: https://github.com/podman-desktop/e2e/actions/runs/18716599107

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/15195
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run any test that uses the operations.ts methods, e.g. `z-podman-machine-onboarding.spec.ts`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
