### PR TITLE
refactor(extension: podman): create InstallerSymbol for binding platform-specific installer

### DIFF
--- a/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
@@ -21,11 +21,12 @@ import { env } from '@podman-desktop/api';
 import type { Container as InversifyContainer } from 'inversify';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { Installer } from '/@/installer/installer';
 import { MacOSInstaller } from '/@/installer/mac-os-installer';
 import { WinInstaller } from '/@/installer/win-installer';
 
 import { InversifyBinding } from './inversify-binding';
-import { ExtensionContextSymbol, InstallerSymbol, TelemetryLoggerSymbol } from './symbols';
+import { ExtensionContextSymbol, TelemetryLoggerSymbol } from './symbols';
 
 vi.mock(import('/@/installer/win-installer'));
 vi.mock(import('/@/installer/mac-os-installer'));
@@ -63,36 +64,36 @@ describe('inversifyBinding', () => {
     expect(container.get(TelemetryLoggerSymbol)).toBe(telemetryLoggerMock);
   });
 
-  test('InversifyBinding#init should bind WinInstaller for InstallerSymbol on windows', async () => {
+  test('InversifyBinding#init should bind WinInstaller for Installer on windows', async () => {
     vi.mocked(env).isWindows = true;
 
     const container = await inversifyBinding.init();
 
-    const value = container.get(InstallerSymbol);
+    const value = container.get(Installer);
     expect(value).not.toBeUndefined();
 
     expect(WinInstaller).toHaveBeenCalledOnce();
     expect(MacOSInstaller).not.toHaveBeenCalled();
   });
 
-  test('InversifyBinding#init should bind MacOSInstaller for InstallerSymbol on macos', async () => {
+  test('InversifyBinding#init should bind MacOSInstaller for Installer on macos', async () => {
     vi.mocked(env).isMac = true;
 
     const container = await inversifyBinding.init();
 
-    const value = container.get(InstallerSymbol);
+    const value = container.get(Installer);
     expect(value).not.toBeUndefined();
 
     expect(WinInstaller).not.toHaveBeenCalled();
     expect(MacOSInstaller).toHaveBeenCalled();
   });
 
-  test('InversifyBinding#init should bind undefined on InstallerSymbol on linux', async () => {
+  test('InversifyBinding#init should bind undefined on Installer on linux', async () => {
     vi.mocked(env).isLinux = true;
 
     const container = await inversifyBinding.init();
 
-    const value = container.get(InstallerSymbol);
+    const value = container.get(Installer);
     expect(value).toBeUndefined();
 
     expect(WinInstaller).not.toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
@@ -93,8 +93,9 @@ describe('inversifyBinding', () => {
 
     const container = await inversifyBinding.init();
 
-    const value = container.get(Installer);
-    expect(value).toBeUndefined();
+    expect(() => {
+      container.get(Installer);
+    }).toThrowError('No bindings found for service: "Symbol(Installer)"');
 
     expect(WinInstaller).not.toHaveBeenCalled();
     expect(MacOSInstaller).not.toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
@@ -68,7 +68,8 @@ describe('inversifyBinding', () => {
 
     const container = await inversifyBinding.init();
 
-    container.get(InstallerSymbol);
+    const value = container.get(InstallerSymbol);
+    expect(value).not.toBeUndefined();
 
     expect(WinInstaller).toHaveBeenCalledOnce();
     expect(MacOSInstaller).not.toHaveBeenCalled();
@@ -79,7 +80,8 @@ describe('inversifyBinding', () => {
 
     const container = await inversifyBinding.init();
 
-    container.get(InstallerSymbol);
+    const value = container.get(InstallerSymbol);
+    expect(value).not.toBeUndefined();
 
     expect(WinInstaller).not.toHaveBeenCalled();
     expect(MacOSInstaller).toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -28,12 +28,13 @@ import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
 import { WinVersionCheck } from '/@/checks/windows/win-version-check';
 import { WSLVersionCheck } from '/@/checks/windows/wsl-version-check';
 import { WSL2Check } from '/@/checks/windows/wsl2-check';
+import { Installer } from '/@/installer/installer';
 import { MacOSInstaller } from '/@/installer/mac-os-installer';
 import { PodmanInstall } from '/@/installer/podman-install';
 import { WinInstaller } from '/@/installer/win-installer';
 import { WinPlatform } from '/@/platforms/win-platform';
 
-import { ExtensionContextSymbol, InstallerSymbol, TelemetryLoggerSymbol } from './symbols';
+import { ExtensionContextSymbol, TelemetryLoggerSymbol } from './symbols';
 
 export class InversifyBinding {
   #inversifyContainer: InversifyContainer | undefined;
@@ -64,11 +65,11 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(WSL2Check).toSelf().inSingletonScope();
 
     if (envAPI.isWindows) {
-      this.#inversifyContainer.bind(InstallerSymbol).to(WinInstaller).inSingletonScope();
+      this.#inversifyContainer.bind(Installer).to(WinInstaller).inSingletonScope();
     } else if (envAPI.isMac) {
-      this.#inversifyContainer.bind(InstallerSymbol).to(MacOSInstaller).inSingletonScope();
+      this.#inversifyContainer.bind(Installer).to(MacOSInstaller).inSingletonScope();
     } else {
-      this.#inversifyContainer.bind(InstallerSymbol).toConstantValue(undefined);
+      this.#inversifyContainer.bind(Installer).toConstantValue(undefined);
     }
 
     return this.#inversifyContainer;

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -17,6 +17,7 @@
  ********************************************************************/
 
 import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
+import { env as envAPI } from '@podman-desktop/api';
 import { Container as InversifyContainer } from 'inversify';
 
 import { HyperVCheck } from '/@/checks/windows/hyperv-check';
@@ -27,10 +28,12 @@ import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
 import { WinVersionCheck } from '/@/checks/windows/win-version-check';
 import { WSLVersionCheck } from '/@/checks/windows/wsl-version-check';
 import { WSL2Check } from '/@/checks/windows/wsl2-check';
+import { MacOSInstaller } from '/@/installer/mac-os-installer';
 import { PodmanInstall } from '/@/installer/podman-install';
+import { WinInstaller } from '/@/installer/win-installer';
 import { WinPlatform } from '/@/platforms/win-platform';
 
-import { ExtensionContextSymbol, TelemetryLoggerSymbol } from './symbols';
+import { ExtensionContextSymbol, InstallerSymbol, TelemetryLoggerSymbol } from './symbols';
 
 export class InversifyBinding {
   #inversifyContainer: InversifyContainer | undefined;
@@ -59,6 +62,14 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(VirtualMachinePlatformCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WSLVersionCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WSL2Check).toSelf().inSingletonScope();
+
+    if (envAPI.isWindows) {
+      this.#inversifyContainer.bind(InstallerSymbol).to(WinInstaller).inSingletonScope();
+    } else if (envAPI.isMac) {
+      this.#inversifyContainer.bind(InstallerSymbol).to(MacOSInstaller).inSingletonScope();
+    } else {
+      this.#inversifyContainer.bind(InstallerSymbol).toConstantValue(undefined);
+    }
 
     return this.#inversifyContainer;
   }

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -68,8 +68,6 @@ export class InversifyBinding {
       this.#inversifyContainer.bind(Installer).to(WinInstaller).inSingletonScope();
     } else if (envAPI.isMac) {
       this.#inversifyContainer.bind(Installer).to(MacOSInstaller).inSingletonScope();
-    } else {
-      this.#inversifyContainer.bind(Installer).toConstantValue(undefined);
     }
 
     return this.#inversifyContainer;

--- a/extensions/podman/packages/extension/src/inject/symbols.ts
+++ b/extensions/podman/packages/extension/src/inject/symbols.ts
@@ -18,5 +18,3 @@
 
 export const ExtensionContextSymbol = Symbol.for('ExtensionContext');
 export const TelemetryLoggerSymbol = Symbol.for('TelemetryLogger');
-
-export const InstallerSymbol = Symbol.for('InstallerSymbol');

--- a/extensions/podman/packages/extension/src/inject/symbols.ts
+++ b/extensions/podman/packages/extension/src/inject/symbols.ts
@@ -18,3 +18,5 @@
 
 export const ExtensionContextSymbol = Symbol.for('ExtensionContext');
 export const TelemetryLoggerSymbol = Symbol.for('TelemetryLogger');
+
+export const InstallerSymbol = Symbol.for('InstallerSymbol');

--- a/extensions/podman/packages/extension/src/installer/installer.ts
+++ b/extensions/podman/packages/extension/src/installer/installer.ts
@@ -18,6 +18,7 @@
 
 import type { InstallCheck } from '@podman-desktop/api';
 
+export const Installer = Symbol.for('Installer');
 export interface Installer {
   getPreflightChecks(): InstallCheck[] | undefined;
   getUpdatePreflightChecks(): InstallCheck[] | undefined;


### PR DESCRIPTION
### What does this PR do?

Achieving goal to replace the following code

https://github.com/podman-desktop/podman-desktop/blob/a1244d45ac7684472283a135b89072323e27402f/extensions/podman/packages/extension/src/installer/podman-install.ts#L79-L85

with inversify logic. The next PR will replace the following code by adding  `inject(InstallerSymbol) installer` in the constructor of the PodmanInstall class. Which will allow to replace the following property 

https://github.com/podman-desktop/podman-desktop/blob/a1244d45ac7684472283a135b89072323e27402f/extensions/podman/packages/extension/src/installer/podman-install.ts#L66

with an injectable constructor property.


### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14535

### How to test this PR?

N/A
