### PR TITLE
refactor(svelte-config): externalize the svelte config to a separate file

### DIFF
--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -38,7 +38,7 @@ export default defineConfig({
       '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
-  plugins: [tailwindcss(), svelte({ hot: !process.env.VITEST }), svelteTesting()],
+  plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js', hot: !process.env.VITEST }), svelteTesting()],
   optimizeDeps: {
     exclude: ['tinro'],
   },

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -37,7 +37,7 @@ export default defineConfig({
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
     },
   },
-  plugins: [tailwindcss(), svelte({ hot: !process.env.VITEST }), svelteTesting()],
+  plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js', hot: !process.env.VITEST }), svelteTesting()],
   test: {
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     globals: true,

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {};
+
+export default config;


### PR DESCRIPTION
### What does this PR do?
compilerOptions are only read from the root `svelte.config.js` file so we need to have such a file to bring async compiler option

svelte.config.ts is not supported by svelte-check.

https://github.com/sveltejs/language-tools/issues/2834

it's a no-op for now, it only brings the configuration file, no new feature

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/14362

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
