### PR TITLE
chore(test): skip test in macos cicd pipeline

### DIFF
--- a/tests/playwright/src/specs/podman-compose-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-compose-smoke.spec.ts
@@ -58,6 +58,11 @@ test.afterAll(async ({ page, runner }) => {
   }
 });
 
+test.skip(
+  !!isCI && !!isMac,
+  'Tests suite should not run on Mac platform in CICD due to being unable  to ensure Compose is installed',
+);
+
 test.describe.serial('Compose compose workflow verification', { tag: '@smoke' }, () => {
   test.beforeEach(async () => {
     if (cliToolsPage.wasRateLimitReached()) {


### PR DESCRIPTION
### What does this PR do?
Skips one of the e2e tests on macos platform in cicd due to not being able to ensure compose is installed in the correct place due to security restrictions.

### What issues does this PR fix or reference?
