### PR TITLE
refactor: use advanceTime option in fakeTimers in renderer unit tests

### DIFF
--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -117,7 +117,7 @@ const providerInfo = {
 } as unknown as ProviderInfo;
 
 beforeEach(() => {
-  vi.useFakeTimers();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
   vi.mocked(window.listImages).mockResolvedValue(localImageList);
   vi.mocked(window.searchImageInRegistry).mockResolvedValue(registryImageList);

--- a/packages/renderer/src/lib/kube/details/EventsTable.spec.ts
+++ b/packages/renderer/src/lib/kube/details/EventsTable.spec.ts
@@ -25,7 +25,7 @@ import type { EventUI } from '../../events/EventUI';
 import EventsTable from './EventsTable.svelte';
 
 beforeEach(() => {
-  vi.useFakeTimers();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -547,7 +547,7 @@ test('Should display Open pod button after successful deployment', async () => {
     }),
   );
 
-  vi.useFakeTimers();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   await fireEvent.click(createButton);
   await vi.runAllTimersAsync();
 

--- a/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
@@ -142,7 +142,7 @@ test('Check a toast is being updated after a task is updated', async () => {
 
 describe('Toast disappearing and notifying again', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
   afterEach(() => {
     vi.useRealTimers();


### PR DESCRIPTION
### What does this PR do?
use `vi.useFakeTimers({ shouldAdvanceTime: true });` to avoid hangs in tests (if compilerOptions async is enabled)

explanation/guideline comes with https://github.com/podman-desktop/podman-desktop/pull/14558

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14547
https://github.com/podman-desktop/podman-desktop/pull/14558

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
