### PR TITLE
revert(renderer/PodDetails): some features were broken in the migration

### DIFF
--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import { ErrorMessage, StatusIcon, Tab } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
 import { router } from 'tinro';
-
-import type { PodInfo } from '/@api/pod-info';
 
 import Route from '../../Route.svelte';
 import { podsInfos } from '../../stores/pods';
@@ -18,90 +17,64 @@ import PodDetailsLogs from './PodDetailsLogs.svelte';
 import type { PodInfoUI } from './PodInfoUI';
 import PodmanPodDetailsSummary from './PodmanPodDetailsSummary.svelte';
 
-interface Props {
-  podName: string;
-  engineId: string;
-}
-let { podName, engineId }: Props = $props();
+export let podName: string;
+export let engineId: string;
 
-const podUtils = new PodUtils();
-let detailsPage: DetailsPage | undefined = $state();
+let pod: PodInfoUI;
+let detailsPage: DetailsPage;
 
-let podInfo: PodInfo | undefined = $derived(
-  $podsInfos.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId),
-);
+// update current route scheme
+let currentRouterPath: string;
 
-// Use $state instead of $derived to allow PodActions to mutate properties for immediate UI updates
-let pod = $state<PodInfoUI | undefined>(undefined);
-// Track the last podInfo to detect changes
-let lastPodInfo: PodInfo | undefined = $state(undefined);
+onMount(() => {
+  const podUtils = new PodUtils();
 
-// Update pod whenever podInfo changes from the store
-$effect(() => {
-  if (podInfo) {
-    // Only update if podInfo actually changed to avoid overwriting transient state
-    if (
-      !lastPodInfo ||
-      lastPodInfo.Id !== podInfo.Id ||
-      lastPodInfo.Status !== podInfo.Status ||
-      lastPodInfo.Created !== podInfo.Created
-    ) {
-      const newPod = podUtils.getPodInfoUI(podInfo);
-      // Preserve transient UI state (loading indicators, error messages) during store updates
-      if (pod && pod.id === newPod.id) {
-        newPod.actionInProgress = pod.actionInProgress;
-        newPod.actionError = pod.actionError;
-        // If the actual status changed in the store, update it and clear transient state
-        if (pod.status !== newPod.status) {
-          newPod.actionInProgress = false;
+  router.subscribe(route => {
+    currentRouterPath = route.path;
+  });
+
+  // loading pod info
+  return podsInfos.subscribe(pods => {
+    const matchingPod = pods.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId);
+    if (matchingPod) {
+      try {
+        pod = podUtils.getPodInfoUI(matchingPod);
+
+        if (currentRouterPath.endsWith('/')) {
+          router.goto(`${currentRouterPath}logs`);
         }
+      } catch (err) {
+        console.error(err);
       }
-      pod = newPod;
-      lastPodInfo = podInfo;
+    } else if (detailsPage) {
+      // the pod has been deleted
+      detailsPage.close();
     }
-  } else if (pod) {
-    // Pod was deleted from store
-    detailsPage?.close();
-    pod = undefined;
-    lastPodInfo = undefined;
-  }
-});
-
-$effect(() => {
-  if (podInfo) {
-    const currentRouterPath = $router.path;
-    if (currentRouterPath.endsWith('/')) {
-      router.goto(`${currentRouterPath}logs`);
-    }
-  }
+  });
 });
 </script>
 
 {#if pod}
-  {@const currentPod = pod}
-  <DetailsPage title={currentPod.name} subtitle={currentPod.shortId} bind:this={detailsPage}>
+  <DetailsPage title={pod.name} subtitle={pod.shortId} bind:this={detailsPage}>
     {#snippet iconSnippet()}
-      <StatusIcon icon={PodIcon} size={24} status={currentPod.status} />
+      <StatusIcon icon={PodIcon} size={24} status={pod.status} />
     {/snippet}
     {#snippet actionsSnippet()}
       <div class="flex items-center w-5">
-        {#if currentPod.actionError}
-          <ErrorMessage error={currentPod.actionError} icon wrapMessage />
+        {#if pod.actionError}
+          <ErrorMessage error={pod.actionError} icon wrapMessage />
         {:else}
           <div>&nbsp;</div>
         {/if}
       </div>
-      <PodActions
-        pod={currentPod}
-        detailed={true}
-        onUpdate={(): PodInfoUI => {
-          // Mutations are already tracked via $state, just return pod for the callback signature
-          return currentPod;
-        }} />
+      <PodActions pod={pod} detailed={true} on:update={(): PodInfoUI => {
+        pod = pod; // Keep this assignment for svelte 4 - can be safely removed when migrating to svelte 5
+        return pod;
+      }} />
     {/snippet}
     {#snippet detailSnippet()}
       <div class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
-        <StateChange state={currentPod.status} />
+        <StateChange state={pod.status} />
       </div>
     {/snippet}
     {#snippet tabsSnippet()}
@@ -112,16 +85,16 @@ $effect(() => {
     {/snippet}
     {#snippet contentSnippet()}
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
-        <PodmanPodDetailsSummary pod={currentPod} />
+        <PodmanPodDetailsSummary pod={pod} />
       </Route>
       <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
-        <PodDetailsLogs pod={currentPod} />
+        <PodDetailsLogs pod={pod} />
       </Route>
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
-        <PodDetailsInspect pod={currentPod} />
+        <PodDetailsInspect pod={pod} />
       </Route>
       <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
-        <PodDetailsKube pod={currentPod} />
+        <PodDetailsKube pod={pod} />
       </Route>
     {/snippet}
   </DetailsPage>


### PR DESCRIPTION
### What does this PR do?

This PR reverts Svelte 5 migration from https://github.com/podman-desktop/podman-desktop/pull/14331 because it has an issue: https://github.com/podman-desktop/podman-desktop/issues/14432

I will follow up with a new proposition for the migration. 


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix for  https://github.com/podman-desktop/podman-desktop/issues/14432

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
