### PR TITLE
chore(renderer/PodDetails): migrate to svelte 5

### DIFF
--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -54,24 +54,23 @@ $effect(() => {
 </script>
 
 {#if pod}
-  {@const currentPod = pod}
   <DetailsPage title={pod.name} subtitle={pod.shortId} bind:this={detailsPage}>
     {#snippet iconSnippet()}
-      <StatusIcon icon={PodIcon} size={24} status={currentPod.status} />
+      <StatusIcon icon={PodIcon} size={24} status={pod.status} />
     {/snippet}
     {#snippet actionsSnippet()}
       <div class="flex items-center w-5">
-        {#if currentPod.actionError}
-          <ErrorMessage error={currentPod.actionError} icon wrapMessage />
+        {#if pod.actionError}
+          <ErrorMessage error={pod.actionError} icon wrapMessage />
         {:else}
           <div>&nbsp;</div>
         {/if}
       </div>
-      <PodActions pod={currentPod} detailed={true}/>
+      <PodActions pod={pod} detailed={true}/>
     {/snippet}
     {#snippet detailSnippet()}
       <div class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">
-        <StateChange state={currentPod.status} />
+        <StateChange state={pod.status} />
       </div>
     {/snippet}
     {#snippet tabsSnippet()}
@@ -82,16 +81,16 @@ $effect(() => {
     {/snippet}
     {#snippet contentSnippet()}
       <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
-        <PodmanPodDetailsSummary pod={currentPod} />
+        <PodmanPodDetailsSummary pod={pod} />
       </Route>
       <Route path="/logs" breadcrumb="Logs" navigationHint="tab">
-        <PodDetailsLogs pod={currentPod} />
+        <PodDetailsLogs pod={pod} />
       </Route>
       <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
-        <PodDetailsInspect pod={currentPod} />
+        <PodDetailsInspect pod={pod} />
       </Route>
       <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
-        <PodDetailsKube pod={currentPod} />
+        <PodDetailsKube pod={pod} />
       </Route>
     {/snippet}
   </DetailsPage>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -13,7 +13,6 @@ import PodActions from './PodActions.svelte';
 import PodDetailsInspect from './PodDetailsInspect.svelte';
 import PodDetailsKube from './PodDetailsKube.svelte';
 import PodDetailsLogs from './PodDetailsLogs.svelte';
-import type { PodInfoUI } from './PodInfoUI';
 import PodmanPodDetailsSummary from './PodmanPodDetailsSummary.svelte';
 
 interface Props {
@@ -23,19 +22,22 @@ interface Props {
 
 let { podName, engineId }: Props = $props();
 
-let pod = $state<PodInfoUI | undefined>();
 let detailsPage = $state<DetailsPage | undefined>();
 
-const matchingPod = $derived(
-  $podsInfos.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId),
-);
 const podUtils = new PodUtils();
 
-$effect(() => {
-  if (matchingPod) {
-    try {
-      pod = podUtils.getPodInfoUI(matchingPod);
+const pod = $derived.by(() => {
+  const matchingPod = $podsInfos.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId);
 
+  if (matchingPod) {
+    return podUtils.getPodInfoUI(matchingPod);
+  }
+  return undefined;
+});
+
+$effect(() => {
+  if (pod) {
+    try {
       const currentRouterPath = $router.path;
 
       if (currentRouterPath.endsWith('/')) {


### PR DESCRIPTION
### What does this PR do?

This PR migrates the PodDetails component to svelte 5.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related  https://github.com/podman-desktop/podman-desktop/issues/14432

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
