### PR TITLE
fix(plugin): improves port validation and error handling in getFreePort method

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4919,7 +4919,10 @@ declare module '@podman-desktop/api' {
   export namespace net {
     /**
      * Finds a free port starting from the specified port and returns it.
-     * @param port The starting port number to search for a free port.
+     * @param port The starting port number to search for a free port. Must be between 0 and 65535.
+     *             If less than 1024, it defaults to 9000.
+     * @returns A promise that resolves to a free port number.
+     * @throws Error if the port is invalid (NaN or > 65535) or if no free port is found within the valid range (0-65535).
      */
     export function getFreePort(port: number): Promise<number>;
   }

--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -21,13 +21,26 @@ import { type NetworkInterfaceInfoIPv4, networkInterfaces } from 'node:os';
 
 /**
  * Find a free port starting from the given port
+ * @param port - The starting port number (must be between 0 and 65535, defaults to 9000 if < 1024)
+ * @returns A free port number
+ * @throws Error if the port is invalid (NaN or > 65535) or if no free port is found within the valid range
  */
 export async function getFreePort(port = 0): Promise<number> {
+  if (isNaN(port) || port > 65535) {
+    throw new Error('Please enter a port number between 0 and 65535.');
+  }
+
   if (port < 1024) {
     port = 9000;
   }
+
   let isFree = false;
   while (!isFree) {
+    // Check if we've exceeded the valid port range during iteration
+    if (port > 65535) {
+      throw new Error('Unable to find a free port: all ports in the valid range (1024-65535) are busy.');
+    }
+
     try {
       await isFreePort(port);
       isFree = true;


### PR DESCRIPTION
### What does this PR do?

The following PR improves port validation and error handling in the `getFreePort()` method and Kind extension:

1. **Prevents infinite loop in `getFreePort()`** - Added validation to reject invalid port numbers (> 65535 or NaN) at the entry point, preventing the application from hanging when invalid ports are provided
2. **Adds upper boundary check in port iteration** - Ensures the port search loop terminates when reaching the valid port range limit (65535)
3. **Refactors duplicated code in Kind extension** - Extracted `validateAndCheckPort()` function to eliminate code duplication and improve maintainability
4. **Improves error messages for better UX** - Provided additional error messages if user tries to enter port number that is out of valid range.

### Screenshot / video of UI

- When user tries to enter both ports that needs a root permissions and both are equal:

<img width="1162" height="1036" src="https://github.com/user-attachments/assets/d35ab943-d519-4c92-a776-a1a5a77ddb69" />

- When user tries to enter a single port that requires a root permissions, another one is valid:

<img width="1162" height="951" src="https://github.com/user-attachments/assets/171140e5-d8ec-45f0-b52c-6bef011aaa86" />

- When user enters both ports that are equal, but valid:

<img width="1162" height="951" src="https://github.com/user-attachments/assets/5b8b041c-f47c-41a6-b17e-bae94b0f77e2" />

- When user tries to enter port number that is out of valid range:

<img width="1162" height="927" src="https://github.com/user-attachments/assets/140d14e5-3bd0-46ed-b02b-43bfacacd015" />

- When user tries to enter port number that is out of valid range, another one is required a root permissions:

<img width="1162" height="981" src="https://github.com/user-attachments/assets/ebd52a7c-17cd-4790-b6df-22fa4583d1b7" />

- When user tries to enter both valid ports and are not equal:

<img width="1162" height="893" src="https://github.com/user-attachments/assets/096a5fbb-32d5-48dc-ae6d-28bf6ce3c578" />


### What issues does this PR fix or reference?

fixes #14353 

### How to test this PR?

1. Navigate to the **Kind Create** connection page through **Settings** -> **Resources** -> **Kind** -> **Create new ...**
2. Try to enter various integer values to the HTTP and HTTPS ports.
3. Podman Desktop should display an error message in case if port number is out of a valid range, e.g. > 65535 instead of freezing and crushing.

- [x] Tests are covering the bug fix or the new feature
