### PR TITLE
fix(renderer/pods): introduce a state to keep overrides on pod UI globally

### DIFF
--- a/packages/renderer/src/states/pods-info-ui-overrides.svelte.ts
+++ b/packages/renderer/src/states/pods-info-ui-overrides.svelte.ts
@@ -1,0 +1,6 @@
+import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
+
+export type TransientStatus = 'STARTING' | 'STOPPING' | 'RESTARTING' | 'DELETING' | 'ERROR';
+export type PodInfoOverride = Partial<PodInfoUI & { status: TransientStatus }>;
+
+export const podsInfoUiOverrides = $state<{ value: Record<string, PodInfoOverride> }>({ value: {} });


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new state to keep overrides on pod UI, it is available globally.
In next PR, I will update this store from PodActions and reset it when we list the pods again.
This is needed to migrate component PodDetails to Svelte 5.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/14583

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
