### PR TITLE
feat(extensions/podman): add telemetry logger to notifications

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -214,9 +214,10 @@ beforeEach(() => {
     },
   };
   vi.resetAllMocks();
-  extension.resetShouldNotifySetup();
   (extensionApi.env.createTelemetryLogger as Mock).mockReturnValue(telemetryLogger);
   extension.initTelemetryLogger();
+  extension.initExtensionNotification();
+  extension.resetShouldNotifySetup();
 });
 
 const originalConsoleError = console.error;

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -133,7 +133,7 @@ let createWSLMachineOptionSelected = false;
 let wslAndHypervEnabledContextValue = false;
 let wslEnabled = false;
 
-const extensionNotifications = new ExtensionNotifications();
+let extensionNotifications: ExtensionNotifications;
 
 export function isIncompatibleMachineOutput(output: string | undefined): boolean {
   // apple HV v4 to v5 machine config error
@@ -1014,6 +1014,10 @@ export function initExtensionContext(extensionContext: extensionApi.ExtensionCon
   storedExtensionContext = extensionContext;
 }
 
+export function initExtensionNotification(): void {
+  extensionNotifications = new ExtensionNotifications(telemetryLogger);
+}
+
 const currentUpdatesDisposables: extensionApi.Disposable[] = [];
 export async function initCheckAndRegisterUpdate(
   provider: extensionApi.Provider,
@@ -1261,6 +1265,8 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   initExtensionContext(extensionContext);
 
   initTelemetryLogger();
+
+  initExtensionNotification();
 
   if (telemetryLogger) {
     await initializeCertificateDetection(telemetryLogger);

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -32,6 +32,7 @@ const config: Configuration = {
 };
 
 vi.mock('node:fs');
+const mockTelemetryLogger = {} as extensionApi.TelemetryLogger;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -140,7 +141,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
   });
 
   test('when isDisguisedPodman is true, error message should NOT be shown', async () => {
-    const extensionNotifications = new ExtensionNotifications();
+    const extensionNotifications = new ExtensionNotifications(mockTelemetryLogger);
 
     // macOS only
     vi.mocked(extensionApi.env).isMac = true;
@@ -160,7 +161,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
   });
 
   test('when isDisguisedPodman is false, error message should be shown', async () => {
-    const extensionNotifications = new ExtensionNotifications();
+    const extensionNotifications = new ExtensionNotifications(mockTelemetryLogger);
 
     // macOS only
     vi.mocked(extensionApi.env).isMac = true;
@@ -188,7 +189,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
   });
 
   test('do not show error message OR call function if on linux', async () => {
-    const extensionNotifications = new ExtensionNotifications();
+    const extensionNotifications = new ExtensionNotifications(mockTelemetryLogger);
 
     // linux
     vi.mocked(extensionApi.env).isMac = false;
@@ -204,7 +205,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
   });
 
   test('do not show error message OR call function if on windows', async () => {
-    const extensionNotifications = new ExtensionNotifications();
+    const extensionNotifications = new ExtensionNotifications(mockTelemetryLogger);
 
     // windows
     vi.mocked(extensionApi.env).isMac = false;
@@ -241,7 +242,7 @@ describe('podman-mac-helper tests', () => {
   });
 
   test('show setup podman mac helper notification if on mac and podman-mac-helper needs running', async () => {
-    const extensionNotifications = new ExtensionNotifications();
+    const extensionNotifications = new ExtensionNotifications(mockTelemetryLogger);
     vi.mocked(isDisguisedPodman).mockResolvedValue(false);
     await extensionNotifications.checkMacSocket();
 
@@ -258,7 +259,7 @@ describe('podman-mac-helper tests', () => {
   });
 
   test('set do not show configuration setting to true, make sure notification is NOT shown', async () => {
-    const extensionNotifications = new ExtensionNotifications();
+    const extensionNotifications = new ExtensionNotifications(mockTelemetryLogger);
 
     // Set configuration to always be true
     // mimicking the 'doNotShow' setting being true

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -22,6 +22,7 @@ import { getSocketCompatibility } from './compatibility-mode';
 import { isDisguisedPodman } from './warnings';
 
 export class ExtensionNotifications {
+  constructor(private readonly telemetryLogger: extensionApi.TelemetryLogger) {}
   // Configuration buttons
   private static readonly configurationCompatibilityModeMacSetupNotificationDoNotShow =
     'setting.doNotShowMacHelperNotification';


### PR DESCRIPTION
### What does this PR do?

This PR add the telemetry logger to the notification class of podman extension ExtensionNotifications.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/14384

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
