### PR TITLE
test(e2e): add podman machine privileges check

### DIFF
--- a/tests/playwright/src/model/core/types.ts
+++ b/tests/playwright/src/model/core/types.ts
@@ -103,6 +103,11 @@ export enum PodmanVirtualizationProviders {
   Native = '', //not a real provider, used for 'Connection Type' check in Resources page of Linux machines
 }
 
+export enum PodmanMachinePrivileges {
+  Rootful = 'rootful',
+  Rootless = 'rootless',
+}
+
 export enum ProxyTypes {
   Disabled = 'Disabled',
   Manual = 'Manual',

--- a/tests/playwright/src/model/pages/resource-connection-card-page.ts
+++ b/tests/playwright/src/model/pages/resource-connection-card-page.ts
@@ -28,6 +28,7 @@ export class ResourceConnectionCardPage extends ResourceCardPage {
   readonly resourceElementConnectionActions: Locator;
   readonly createButton: Locator;
   readonly connectionType: Locator;
+  readonly machinePrivileges: Locator;
 
   constructor(page: Page, resourceName: string, resourceElementVisibleName?: string) {
     super(page, resourceName);
@@ -42,6 +43,7 @@ export class ResourceConnectionCardPage extends ResourceCardPage {
       name: 'Create',
     });
     this.connectionType = this.resourceElement.getByLabel('Connection Type');
+    this.machinePrivileges = this.resourceElement.getByLabel('Machine with root privileges:');
   }
 
   public async doesResourceElementExist(): Promise<boolean> {

--- a/tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { ResourceElementState } from '../model/core/states';
-import { PodmanVirtualizationProviders } from '../model/core/types';
+import { PodmanMachinePrivileges, PodmanVirtualizationProviders } from '../model/core/types';
 import { CreateMachinePage } from '../model/pages/create-machine-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
@@ -30,6 +30,7 @@ import {
   ensureCliInstalled,
   handleConfirmationDialog,
   setStatusBarProvidersFeature,
+  verifyMachinePrivileges,
   verifyVirtualizationProvider,
 } from '../utility/operations';
 import { isLinux } from '../utility/platform';
@@ -123,6 +124,8 @@ test.describe.serial('Status bar providers feature verification', { tag: '@k8s_e
         (await machineCard.resourceElementConnectionStatus.innerText()).includes(ResourceElementState.Running),
       { timeout: 30_000, sendError: true },
     );
+
+    await verifyMachinePrivileges(machineCard, PodmanMachinePrivileges.Rootful); //default privileges
 
     await verifyVirtualizationProvider(machineCard, getVirtualizationProvider() ?? getDefaultVirtualizationProvider());
 

--- a/tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts
@@ -21,7 +21,7 @@ import * as os from 'node:os';
 import type { Locator, Page } from '@playwright/test';
 
 import { ResourceElementState } from '../model/core/states';
-import { PodmanVirtualizationProviders } from '../model/core/types';
+import { PodmanMachinePrivileges, PodmanVirtualizationProviders } from '../model/core/types';
 import type { DashboardPage } from '../model/pages/dashboard-page';
 import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
 import { PodmanOnboardingPage } from '../model/pages/podman-onboarding-page';
@@ -29,7 +29,13 @@ import { ResourceConnectionCardPage } from '../model/pages/resource-connection-c
 import { ResourcesPage } from '../model/pages/resources-page';
 import type { SettingsBar } from '../model/pages/settings-bar';
 import { expect as playExpect, test } from '../utility/fixtures';
-import { createPodmanMachineFromCLI, deletePodmanMachine, resetPodmanMachinesFromCLI } from '../utility/operations';
+import {
+  createPodmanMachineFromCLI,
+  deletePodmanMachine,
+  resetPodmanMachinesFromCLI,
+  verifyMachinePrivileges,
+  verifyVirtualizationProvider,
+} from '../utility/operations';
 import { isLinux } from '../utility/platform';
 import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '../utility/provider';
 import { waitForPodmanMachineStartup } from '../utility/wait';
@@ -193,10 +199,10 @@ test.describe
                 PODMAN_MACHINE_NAME,
               );
               await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: 10_000 });
-              await playExpect(resourcesPodmanConnections.connectionType).toBeVisible({ timeout: 10_000 });
-              await playExpect(resourcesPodmanConnections.connectionType).toHaveText(
+              await verifyMachinePrivileges(resourcesPodmanConnections, PodmanMachinePrivileges.Rootful); //default privileges
+              await verifyVirtualizationProvider(
+                resourcesPodmanConnections,
                 getVirtualizationProvider() ?? getDefaultVirtualizationProvider(),
-                { ignoreCase: true },
               );
               await playExpect(resourcesPodmanConnections.resourceElement).toBeVisible({ timeout: 20_000 });
               await playExpect(resourcesPodmanConnections.resourceElementDetailsButton).toBeVisible();

--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -20,7 +20,7 @@ import type { Locator } from '@playwright/test';
 
 import { ResourceElementActions } from '../model/core/operations';
 import { ResourceElementState } from '../model/core/states';
-import { PodmanVirtualizationProviders } from '../model/core/types';
+import { PodmanMachinePrivileges, PodmanVirtualizationProviders } from '../model/core/types';
 import { CreateMachinePage } from '../model/pages/create-machine-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
 import { ResourcesPage } from '../model/pages/resources-page';
@@ -31,6 +31,7 @@ import {
   deletePodmanMachineFromCLI,
   handleConfirmationDialog,
   resetPodmanMachinesFromCLI,
+  verifyMachinePrivileges,
   verifyVirtualizationProvider,
 } from '../utility/operations';
 import { isLinux, isWindows } from '../utility/platform';
@@ -179,6 +180,10 @@ for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of mac
 
         await playExpect(resourcePage.heading).toBeVisible();
         const machineCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, PODMAN_MACHINE_NAME);
+        await verifyMachinePrivileges(
+          machineCard,
+          isRoot ? PodmanMachinePrivileges.Rootful : PodmanMachinePrivileges.Rootless,
+        );
         await verifyVirtualizationProvider(
           machineCard,
           getVirtualizationProvider() ?? getDefaultVirtualizationProvider(),

--- a/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
@@ -19,6 +19,7 @@
 import type { Locator } from '@playwright/test';
 
 import { ResourceElementState } from '../model/core/states';
+import { PodmanMachinePrivileges } from '../model/core/types';
 import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
 import { PodmanOnboardingPage } from '../model/pages/podman-onboarding-page';
 import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
@@ -29,6 +30,7 @@ import {
   deletePodmanMachine,
   handleConfirmationDialog,
   resetPodmanMachinesFromCLI,
+  verifyMachinePrivileges,
   verifyVirtualizationProvider,
 } from '../utility/operations';
 import { isLinux } from '../utility/platform';
@@ -168,6 +170,7 @@ test.describe
 
       await playExpect(resourcesPage.heading).toBeVisible();
       const podmanResources = new ResourceConnectionCardPage(page, 'podman', ROOTLESS_PODMAN_MACHINE_VISIBLE);
+      await verifyMachinePrivileges(podmanResources, PodmanMachinePrivileges.Rootless);
       await verifyVirtualizationProvider(
         podmanResources,
         getVirtualizationProvider() ?? getDefaultVirtualizationProvider(),

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -25,6 +25,7 @@ import test, { expect as playExpect } from '@playwright/test';
 import { ResourceElementActions } from '../model/core/operations';
 import { ResourceElementState } from '../model/core/states';
 import type { PodmanVirtualizationProviders } from '../model/core/types';
+import { PodmanMachinePrivileges } from '../model/core/types';
 import { CLIToolsPage } from '../model/pages/cli-tools-page';
 import { ExperimentalPage } from '../model/pages/experimental-page';
 import { PreferencesPage } from '../model/pages/preferences-page';
@@ -523,6 +524,29 @@ export async function verifyVirtualizationProvider(
       .poll(async () => await resourceConnectionCardPage.doesResourceElementExist(), { timeout: 15_000 })
       .toBeTruthy();
     await playExpect(resourceConnectionCardPage.connectionType).toContainText(virtualizationProvider, {
+      ignoreCase: true,
+    });
+  });
+}
+
+/**
+ * Verifies that a Podman machine has the specified machine privileges (rootful or rootless).
+ * This method checks that the machine card exists and displays the correct machine privileges.
+ *
+ * @param resourceConnectionCardPage - The resource connection card page to verify
+ * @param machinePrivileges - The expected machine privileges (e.g., PodmanMachinePrivileges.Rootful, PodmanMachinePrivileges.Rootless)
+ * @returns A Promise that resolves when the verification is complete
+ * @throws Will throw an error if the expected machine privileges are not found or doesn't match
+ */
+export async function verifyMachinePrivileges(
+  resourceConnectionCardPage: ResourceConnectionCardPage,
+  machinePrivileges: PodmanMachinePrivileges,
+): Promise<void> {
+  return test.step(`Verify Podman Machine Privileges are ${machinePrivileges === PodmanMachinePrivileges.Rootful ? 'rootful' : 'rootless'}`, async () => {
+    await playExpect
+      .poll(async () => await resourceConnectionCardPage.doesResourceElementExist(), { timeout: 15_000 })
+      .toBeTruthy();
+    await playExpect(resourceConnectionCardPage.machinePrivileges).toContainText(machinePrivileges, {
       ignoreCase: true,
     });
   });


### PR DESCRIPTION
### What does this PR do?
Adds a new check on the E2E tests that create Podman machines so that it is verified if the rootful/rootless machine privileges are correctly defined and displayed 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#14036 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run the tests with `pnpm test:e2e`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
