### PR TITLE
chore(extensions/podman): send to telemetry when mac cannot get disguised status

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1389,11 +1389,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       try {
         isDisguisedPodmanSocket = await isDisguisedPodman();
       } catch (error: unknown) {
+        telemetryLogger.logError('checkIfSocketDisguisedFailed', { error });
         console.debug('Error while check if the socket is disguised', error);
         await extensionApi.window.showInformationMessage('Could not get if Podman is disguised');
-        if (error instanceof Error) {
-          telemetryLogger.logError('checkIfSocketDisguisedFailed', { error: error.message });
-        }
         return;
       }
       // We use isEnabled() as we do not want to "renable" again if the user has already enabled it.

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1391,6 +1391,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       } catch (error: unknown) {
         console.debug('Error while check if the socket is disguised', error);
         await extensionApi.window.showInformationMessage('Could not get if Podman is disguised');
+        if (error instanceof Error) {
+          telemetryLogger.logError('checkIfSocketDisguisedFailed', { error: error.message });
+        }
         return;
       }
       // We use isEnabled() as we do not want to "renable" again if the user has already enabled it.

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -132,10 +132,8 @@ export class ExtensionNotifications {
     try {
       isDisguisedPodmanSocket = await isDisguisedPodman();
     } catch (error: unknown) {
+      this.telemetryLogger.logError('checkIfSocketDisguisedFailed', { error });
       console.debug('Error while check if the socket is disguised', error);
-      if (error instanceof Error) {
-        this.telemetryLogger.logError('checkIfSocketDisguisedFailed', { error: error.message });
-      }
       return;
     }
 
@@ -180,9 +178,7 @@ export class ExtensionNotifications {
     try {
       isDisguisedPodmanSocket = await isDisguisedPodman();
     } catch (error: unknown) {
-      if (error instanceof Error) {
-        this.telemetryLogger.logError('checkIfSocketDisguisedFailed', { error: error.message });
-      }
+      this.telemetryLogger.logError('checkIfSocketDisguisedFailed', { error });
       console.debug('Error while check if the socket is disguised', error);
       return;
     }

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -133,6 +133,9 @@ export class ExtensionNotifications {
       isDisguisedPodmanSocket = await isDisguisedPodman();
     } catch (error: unknown) {
       console.debug('Error while check if the socket is disguised', error);
+      if (error instanceof Error) {
+        this.telemetryLogger.logError('checkIfSocketDisguisedFailed', { error: error.message });
+      }
       return;
     }
 
@@ -177,6 +180,9 @@ export class ExtensionNotifications {
     try {
       isDisguisedPodmanSocket = await isDisguisedPodman();
     } catch (error: unknown) {
+      if (error instanceof Error) {
+        this.telemetryLogger.logError('checkIfSocketDisguisedFailed', { error: error.message });
+      }
       console.debug('Error while check if the socket is disguised', error);
       return;
     }


### PR DESCRIPTION
### What does this PR do?

This PR sends to telemetry when mac cannot get disguised status
<img width="1255" height="580" alt="Screenshot 2025-10-27 at 16 21 50" src="https://github.com/user-attachments/assets/8fab059d-41f1-45e5-8565-cfc465fe3c30" />

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix of https://github.com/podman-desktop/podman-desktop/issues/14384,

next PR: adding UT

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

I have removed this line 
<img width="1150" height="382" alt="Screenshot 2025-10-27 at 16 22 38" src="https://github.com/user-attachments/assets/3d1957b1-ae93-4e60-9f9d-151e4c9a5e88" />

(extensions/podman/packages/extension/src/extension.ts)

and stopped the podman machine.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
