### PR TITLE
chore(eslint): configure `svelte/block-lang` rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -270,6 +270,8 @@ export default [
       'sonarjs/no-nested-assignment': 'off',
       'sonarjs/no-alphabetical-sort': 'off',
       'svelte/no-reactive-literals': 'error',
+      // error if svelte script block do not specify attribute lang="ts".
+      'svelte/block-lang': ["error", { "script": "ts" }],
     },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -271,7 +271,7 @@ export default [
       'sonarjs/no-alphabetical-sort': 'off',
       'svelte/no-reactive-literals': 'error',
       // error if svelte script block do not specify attribute lang="ts".
-      'svelte/block-lang': ["error", { "script": "ts" }],
+      'svelte/block-lang': ["error", { "script": "ts", "style": ["postcss", null] }],
     },
   },
 


### PR DESCRIPTION
### What does this PR do?

Enforce `lang="ts"` in Svelte script block.

Ref https://sveltejs.github.io/eslint-plugin-svelte/rules/block-lang/

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
