### PR TITLE
chore: add disabled prop to preference item formats

### DIFF
--- a/packages/api/src/configuration/models.ts
+++ b/packages/api/src/configuration/models.ts
@@ -52,6 +52,9 @@ export interface IConfigurationPropertyRecordedSchema extends IConfigurationProp
   title: string;
   parentId: string;
   extension?: IConfigurationExtensionInfo;
+
+  // Indicated if this property has been "disabled" for the UI (readonly / unable to change)
+  disabled?: boolean;
 }
 
 export interface IConfigurationPropertySchema {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -120,6 +120,7 @@ async function openGitHubDiscussion(): Promise<void> {
           updateResetButtonVisibility={updateResetButtonVisibility}
           resetToDefault={resetToDefault}
           enableAutoSave={true}
+          disabled={record.disabled}
           initialValue={getInitialValue(recordUI.original)} />
       {/if}
     </div>
@@ -129,6 +130,7 @@ async function openGitHubDiscussion(): Promise<void> {
         updateResetButtonVisibility={updateResetButtonVisibility}
         resetToDefault={resetToDefault}
         enableAutoSave={true}
+        disabled={record.disabled}
         initialValue={getInitialValue(recordUI.original)} />
     {/if}
   </div>

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -26,6 +26,7 @@ interface Props {
   resetToDefault?: boolean;
   enableAutoSave?: boolean;
   enableSlider?: boolean;
+  disabled?: boolean;
 }
 
 let {
@@ -39,6 +40,7 @@ let {
   resetToDefault = false,
   enableAutoSave = false,
   enableSlider = false,
+  disabled = false,
 }: Props = $props();
 
 let currentRecord: IConfigurationPropertyRecordedSchema;
@@ -201,43 +203,54 @@ function numberItemValue(): number {
     <BooleanItem
       record={record}
       checked={typeof givenValue === 'boolean' ? givenValue : !!recordValue}
-      onChange={onChange} />
+      onChange={onChange}
+      disabled={disabled} />
   {:else if record.type === 'object'}
     <BooleanItem
       record={record}
       checked={!!recordValue}
-      onChange={onChange} />
+      onChange={onChange}
+      disabled={disabled} />
   {:else if record.type === 'number' || record.type === 'integer'}
     {#if enableSlider && typeof record.maximum === 'number'}
       <SliderItem
         record={record}
         value={typeof givenValue === 'number' ? givenValue : getNormalizedDefaultNumberValue(record)}
-        onChange={onChange} />
+        onChange={onChange}
+        disabled={disabled} />
     {:else}
       <NumberItem
         record={record}
         value={numberItemValue()}
         onChange={onChange}
-        invalidRecord={invalidRecord} />
+        invalidRecord={invalidRecord}
+        disabled={disabled} />
     {/if}
   {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
     {#if record.format === 'file' || record.format === 'folder'}
       <FileItem
         record={record}
         value={typeof givenValue === 'string' ? givenValue : (recordValue ?? '')}
-        onChange={onChange} />
+        onChange={onChange}
+        disabled={disabled} />
     {:else if record.enum && record.enum.length > 0}
-      <EnumItem record={record} value={typeof givenValue === 'string' ? givenValue : recordValue} onChange={onChange} />
+      <EnumItem
+        record={record}
+        value={typeof givenValue === 'string' ? givenValue : recordValue}
+        onChange={onChange}
+        disabled={disabled} />
     {:else if record.format === 'password'}
       <PasswordStringItem
         record={record}
         value={typeof givenValue === 'string' ? givenValue : recordValue}
-        onChange={onChange} />
+        onChange={onChange}
+        disabled={disabled} />
     {:else}
       <StringItem
         record={record}
         value={typeof givenValue === 'string' ? givenValue : recordValue}
-        onChange={onChange} />
+        onChange={onChange}
+        disabled={disabled} />
     {/if}
   {:else if record.type === 'markdown'}
     <div class="text-sm">

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
@@ -94,4 +95,26 @@ test('Expect to see checkbox not checked if default is false', async () => {
   const button = screen.getByRole('checkbox');
   expect(button).toBeInTheDocument();
   expect(button).not.toBeChecked();
+});
+
+test('BooleanItem is disabled when disabled prop is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema & { default: boolean } = {
+    title: 'my boolean property',
+    id: 'myid',
+    parentId: '',
+    type: 'boolean',
+    default: true,
+  };
+  const onChange = vi.fn();
+  render(BooleanItem, { record, checked: record.default, disabled: true, onChange });
+  const button = screen.getByRole('checkbox');
+  expect(button).toBeInTheDocument();
+  expect(button).toBeChecked();
+
+  // Verify the checkbox is disabled
+  expect(button).toBeDisabled();
+
+  // Verify onChange is not called when trying to click
+  await userEvent.click(button);
+  expect(onChange).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -6,6 +6,7 @@ import SlideToggle from '../../ui/SlideToggle.svelte';
 export let record: IConfigurationPropertyRecordedSchema;
 export let checked = false;
 export let onChange = async (_id: string, _value: boolean): Promise<void> => {};
+export let disabled = false;
 let invalidEntry = false;
 
 function onChecked(state: boolean): void {
@@ -23,7 +24,7 @@ function onChecked(state: boolean): void {
   bind:checked={checked}
   on:checked={(event): void => onChecked(event.detail)}
   readonly={!!record.readonly}
-  disabled={!!record.readonly}
+  disabled={disabled}
   aria-invalid={invalidEntry}
   aria-label={record.description ?? record.markdownDescription}>
   <span class="text-xs">{checked ? 'Enabled' : 'Disabled'}</span>

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
@@ -59,3 +59,24 @@ test('Enum with default', async () => {
   expect(input).toBeInTheDocument();
   expect(input).toHaveTextContent('world');
 });
+
+test('EnumItem is disabled when disabled prop is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    enum: ['hello', 'world'],
+  };
+
+  const onChange = vi.fn();
+  render(EnumItem, { record, value: 'hello', disabled: true, onChange });
+  const dropdown = screen.getByLabelText('record-description');
+  expect(dropdown).toBeInTheDocument();
+
+  // Verify the dropdown shows disabled styling (readonly border)
+  expect(dropdown.className).toContain('border-b-[var(--pd-input-field-stroke-readonly)]');
+
+  // Verify onChange is not called
+  expect(onChange).not.toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -6,6 +6,7 @@ import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/m
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string | undefined;
 export let onChange = async (_id: string, _value: string): Promise<void> => {};
+export let disabled = false;
 
 let invalidEntry = false;
 
@@ -24,5 +25,6 @@ function onChangeHandler(newValue: unknown): void {
   bind:value={value}
   ariaInvalid={invalidEntry}
   ariaLabel={record.description}
+  disabled={disabled}
   options={record.enum?.map(recordEnum => ({label: recordEnum, value: recordEnum}))}>
 </Dropdown>

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -175,3 +175,25 @@ test('If FileItem has readonly = true, then expect readonly to show in the eleme
   expect(input).toBeInTheDocument();
   expect((input as HTMLInputElement).readOnly).toBe(true);
 });
+
+test('FileItem is disabled when disabled prop is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+  };
+
+  const onChange = vi.fn();
+  const { container } = render(FileItem, { record, value: 'initial', disabled: true, onChange });
+  const input = screen.getByLabelText('record-description') as HTMLInputElement;
+  expect(input).toBeInTheDocument();
+
+  // Verify component renders with disabled prop
+  expect(container).toBeDefined();
+
+  // Verify onChange hasn't been called on render
+  expect(onChange).not.toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -7,6 +7,7 @@ import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/m
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string = '';
 export let onChange = async (_id: string, _value: string): Promise<void> => {};
+export let disabled = false;
 
 let invalidEntry = false;
 let dialogOptions: OpenDialogOptions = {
@@ -30,6 +31,7 @@ function onChangeFileInput(value: string): void {
     bind:value={value}
     onChange={onChangeFileInput}
     readonly={record.readonly ?? false}
+    disabled={disabled}
     clearable={true}
     placeholder={record.placeholder}
     options={dialogOptions}

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -194,3 +194,28 @@ test('Expect onChange is not triggered in case of error on validation', async ()
   // then we should have the onChange call to be 1
   await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith('record', 1));
 });
+
+test('NumberItem is disabled when disabled prop is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 20,
+  };
+  const value = 10;
+  const onChange = vi.fn();
+  render(NumberItem, { record, value, disabled: true, onChange });
+
+  const input = screen.getByRole('textbox', { name: 'record-description' });
+  expect(input).toBeInTheDocument();
+
+  // Verify the input is disabled
+  expect(input).toBeDisabled();
+
+  // Verify onChange is not called when trying to type
+  await userEvent.type(input, '5');
+  expect(onChange).not.toHaveBeenCalled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -7,6 +7,7 @@ export let record: IConfigurationPropertyRecordedSchema;
 export let value: number | undefined;
 export let onChange = (_id: string, _value: number): void => {};
 export let invalidRecord = (_error: string): void => {};
+export let disabled = false;
 
 let valueUpdateTimeout: NodeJS.Timeout;
 
@@ -46,6 +47,7 @@ function onValidation(newValue: number, validationError?: string): void {
     step={record.step}
     type={record.type === 'integer' ? 'integer' : 'number'}
     maximum={record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}
-    showError={false}>
+    showError={false}
+    disabled={disabled}>
   </NumberInput>
 </Tooltip>

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
@@ -55,4 +56,27 @@ test('Ensure HTMLInputElement readonly', async () => {
   const input = screen.getByLabelText(record.description);
   expect(input).toBeInTheDocument();
   expect((input as HTMLInputElement).readOnly).toBeTruthy();
+});
+
+test('PasswordStringItem is disabled when disabled prop is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema & { description: string } = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'password',
+  };
+
+  const onChange = vi.fn();
+  render(PasswordStringItem, { record, value: '', onChange, disabled: true });
+  const input = screen.getByLabelText(record.description);
+  expect(input).toBeInTheDocument();
+
+  // Verify the input is disabled
+  expect(input).toBeDisabled();
+
+  // Verify onChange is not called when trying to type
+  await userEvent.type(input, 'password');
+  expect(onChange).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
@@ -6,9 +6,10 @@ interface Props {
   record: IConfigurationPropertyRecordedSchema;
   value: string | undefined;
   onChange: (id: string, value: string) => Promise<void>;
+  disabled?: boolean;
 }
 
-let { record, value, onChange }: Props = $props();
+let { record, value, onChange, disabled = false }: Props = $props();
 
 let invalidEntry = $state(false);
 
@@ -26,6 +27,7 @@ function onInput(event: Event): void {
   placeholder={record.placeholder}
   password={value}
   readonly={!!record.readonly}
+  disabled={disabled}
   id="input-standard-{record.id}"
   aria-invalid={invalidEntry}
   aria-label={record.description} />

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
@@ -45,4 +46,28 @@ test('Ensure HTMLInputElement', async () => {
   expect(input).toBeInTheDocument();
 
   expect(input instanceof HTMLInputElement).toBe(true);
+});
+
+test('SliderItem is disabled when disabled prop is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 4,
+    maximum: 34,
+  };
+
+  const onChange = vi.fn();
+  render(SliderItem, { record, value: 15, disabled: true, onChange });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  // Verify the input is disabled
+  expect(input).toBeDisabled();
+
+  // Verify onChange is not called when trying to interact
+  await userEvent.click(input);
+  expect(onChange).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -6,6 +6,7 @@ import { uncertainStringToNumber } from '../Util';
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: number;
 export let onChange = async (_id: string, _value: number): Promise<void> => {};
+export let disabled = false;
 
 async function onInput(event: Event): Promise<void> {
   const target = event.currentTarget as HTMLInputElement;
@@ -24,4 +25,5 @@ async function onInput(event: Event): Promise<void> {
   value={value}
   aria-label={record.description}
   on:input={onInput}
+  disabled={disabled}
   class="w-full h-1 bg-[var(--pd-input-toggle-on-bg)] rounded-lg appearance-none accent-[var(--pd-input-toggle-on-bg)] cursor-pointer range-xs mt-2" />

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,4 +97,26 @@ test('Ensure that after typing into the input, that onChange is called each time
   // Ensure it's been called 9 times as "new value" is 6 characters
   await userEvent.type(input, 'foobar');
   expect(onChange).toHaveBeenCalledTimes(6);
+});
+
+test('StringItem is disabled when disabled prop is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+  };
+
+  const onChange = vi.fn();
+  render(StringItem, { record, value: '', disabled: true, onChange });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+
+  // Verify the input is disabled
+  expect(input).toBeDisabled();
+
+  // Verify onChange is not called when trying to type
+  await userEvent.type(input, 'test');
+  expect(onChange).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -6,6 +6,7 @@ import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/m
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string | undefined;
 export let onChange = async (_id: string, _value: string): Promise<void> => {};
+export let disabled = false;
 
 let invalidEntry = false;
 
@@ -24,6 +25,7 @@ function onInput(event: Event): void {
   placeholder={record.placeholder}
   value={value}
   readonly={!!record.readonly}
+  disabled={disabled}
   id="input-standard-{record.id}"
   aria-invalid={invalidEntry}
   aria-label={record.description} />


### PR DESCRIPTION
chore: add disabled prop to preference item formats

### What does this PR do?

When implementing adding labels into the Preferences page I was unable
to pass in any "disabled" parameters to the components rendered by
preferences.

This PR adds the ability to pass in "disabled" into the UI, by adding
the `disabled` prop to PreferencesRenderingItemFormat.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes #14624

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

OR.

Pass in "disabled=true" and try and click on a component (ex.
`packages/renderer/src/lib/preferences/item-formats/StringItem.svelte`)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
