### PR TITLE
refactor(renderer: ImagesList): adding `label` prop to table usage

### DIFF
--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -290,6 +290,12 @@ const row = new TableRow<ImageInfoUI>({
 function key(item: ImageInfoUI): string {
   return `${item.engineId}:${item.id}`;
 }
+/**
+ * Utility function for the Table to get the label to use for each item
+ */
+function label(item: ImageInfoUI): string {
+  return item.name;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="images">
@@ -355,6 +361,7 @@ function key(item: ImageInfoUI): string {
         row={row}
         defaultSortColumn="Age"
         key={key}
+        label={label}
         enableLayoutConfiguration={true}
         on:update={(): ImageInfoUI[] => (images = images)}>
       </Table>


### PR DESCRIPTION
### What does this PR do?

Adding `label` prop to `Table` usage in `ImagesList.svelte`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14521

### How to test this PR?

N/A
