### PR TITLE
refactor(renderer: TaskManagerTable): adding `label` prop to table usage

### DIFF
--- a/packages/renderer/src/lib/task-manager/table/TaskManagerTable.svelte
+++ b/packages/renderer/src/lib/task-manager/table/TaskManagerTable.svelte
@@ -52,6 +52,12 @@ const row = new TableRow<TaskInfoUI>({
 function key(task: TaskInfoUI): string {
   return task.id;
 }
+/**
+ * Utility function for the Table to get the label to use for each item
+ */
+function label(task: TaskInfoUI): string {
+  return task.name;
+}
 </script>
 
 <Table
@@ -61,4 +67,5 @@ function key(task: TaskInfoUI): string {
   columns={columns}
   row={row}
   key={key}
+  label={label}
   defaultSortColumn="Age" />


### PR DESCRIPTION
### What does this PR do?

Adding `label` prop to `Table` usage in `TaskManagerTable.svelte`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14523

### How to test this PR?

N/A
