### PR TITLE
refactor(renderer: VolumesList): adding `label` prop to table usage

### DIFF
--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -179,6 +179,13 @@ const row = new TableRow<VolumeInfoUI>({
 function key(obj: VolumeInfoUI): string {
   return `${obj.engineId}:${obj.name}`;
 }
+
+/**
+ * Utility function for the Table to get the label to use for each item
+ */
+function label(obj: VolumeInfoUI): string {
+  return obj.name;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="volumes">
@@ -235,6 +242,7 @@ function key(obj: VolumeInfoUI): string {
         defaultSortColumn="Name"
         enableLayoutConfiguration={true}
         key={key}
+        label={label}
         on:update={(): VolumeInfoUI[] => (volumes = volumes)}>
       </Table>
     {/if}


### PR DESCRIPTION
### What does this PR do?

Adding `label` prop to `Table` usage in `VolumeList.svelte`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14520

### How to test this PR?

N/A
