### PR TITLE
refactor(renderer: ListTable): adding `label` prop to table usage

### DIFF
--- a/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
@@ -51,6 +51,9 @@ let bulkDeleteInProgress = false;
 function key(extensionFolder: SelectableExtensionDevelopmentFolderInfoUI): string {
   return extensionFolder.path;
 }
+function label(extensionFolder: SelectableExtensionDevelopmentFolderInfoUI): string {
+  return extensionFolder.name;
+}
 </script>
 
 <Table
@@ -61,6 +64,7 @@ function key(extensionFolder: SelectableExtensionDevelopmentFolderInfoUI): strin
   bind:selectedItemsNumber
   defaultSortColumn="Name"
   key={key}
+  label={label}
   on:update={(): SelectableExtensionDevelopmentFolderInfoUI[] => (extensionFolderUIInfos = [...extensionFolderUIInfos])}>
 </Table>
 


### PR DESCRIPTION
### What does this PR do?

Adding `label` prop to `Table` usage in `ListTable.svelte`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14526

### How to test this PR?

N/A
