### PR TITLE
refactor(extension: podman): inject Installer to PodmanInstall

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -39,6 +39,7 @@ import {
   PODMAN_MACHINE_MEMORY_SUPPORTED_KEY,
   WSL_HYPERV_ENABLED_KEY,
 } from '/@/constants';
+import type { Installer } from '/@/installer/installer';
 import type { ConnectionJSON, MachineInfo, MachineJSON } from '/@/types';
 
 import * as extension from './extension';
@@ -1494,7 +1495,7 @@ test('ensure showNotification is not called during update', async () => {
   );
 
   const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
-  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger);
+  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger, {} as unknown as Installer);
   vi.spyOn(podmanInstall, 'checkForUpdate').mockImplementation((_installedPodman: InstalledPodman | undefined) => {
     return Promise.resolve({
       hasUpdate: true,
@@ -2491,7 +2492,7 @@ describe('calcPodmanMachineSetting', () => {
 
 test('checkForUpdate func should be called if there is no podman installed', async () => {
   const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
-  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger);
+  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger, {} as unknown as Installer);
 
   vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue(undefined);
   vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -69,6 +69,7 @@ const provider: extensionApi.Provider = {
 };
 
 const mockTelemetryLogger = {} as extensionApi.TelemetryLogger;
+const INSTALLER_MOCK: Installer = {} as unknown as Installer;
 
 // mock filesystem
 vi.mock('node:fs');
@@ -141,7 +142,7 @@ let podmanInstall: TestPodmanInstall;
 beforeEach(() => {
   vi.clearAllMocks();
 
-  podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger);
+  podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger, INSTALLER_MOCK);
   // reset array of subscriptions
   extensionContext.subscriptions.length = 0;
   console.error = consoleErrorMock;

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -21,7 +21,7 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 import { compare } from 'compare-versions';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 
 import {
   PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
@@ -49,9 +49,7 @@ import type { InstalledPodman } from '../utils/podman-cli';
 import { getPodmanCli, getPodmanInstallation } from '../utils/podman-cli';
 import type { PodmanInfo } from '../utils/podman-info';
 import { PodmanInfoImpl } from '../utils/podman-info';
-import type { Installer } from './installer';
-import { MacOSInstaller } from './mac-os-installer';
-import { WinInstaller } from './win-installer';
+import { Installer } from './installer';
 
 export interface UpdateCheck {
   hasUpdate: boolean;
@@ -63,8 +61,6 @@ export interface UpdateCheck {
 export class PodmanInstall {
   private podmanInfo: PodmanInfo | undefined;
 
-  private installer: Installer | undefined;
-
   private readonly storagePath: string;
 
   protected providerCleanup: extensionApi.ProviderCleanup | undefined;
@@ -74,14 +70,15 @@ export class PodmanInstall {
     readonly extensionContext: extensionApi.ExtensionContext,
     @inject(TelemetryLoggerSymbol)
     readonly telemetryLogger: extensionApi.TelemetryLogger,
+    @inject(Installer)
+    @optional()
+    readonly installer: Installer | undefined,
   ) {
     this.storagePath = extensionContext.storagePath;
     if (extensionApi.env.isMac) {
       this.providerCleanup = new PodmanCleanupMacOS();
-      this.installer = new MacOSInstaller();
     } else if (extensionApi.env.isWindows) {
       this.providerCleanup = new PodmanCleanupWindows();
-      this.installer = new WinInstaller(extensionContext, telemetryLogger);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/14544, we delegated to inversify the platform specific code, therefore we can inject directly the `Installer` interface, that automatically be `WinInstaller` on windows, `MacOSInstaller` on MacOS and nothing on Linux.

> To give some background to reviewers, we bind to the `Installer` symbol the corresponding class given the platform we are on.
> https://github.com/podman-desktop/podman-desktop/blob/6bea17bb215fcfccdab3e7e14406565dc7ed5bf7/extensions/podman/packages/extension/src/inject/inversify-binding.ts#L67-L71

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14561

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
