### PR TITLE
refactor(extension: podman): inject platform specific class for ProvderCleanup

### DIFF
--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -28,13 +28,15 @@ import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
 import { WinVersionCheck } from '/@/checks/windows/win-version-check';
 import { WSLVersionCheck } from '/@/checks/windows/wsl-version-check';
 import { WSL2Check } from '/@/checks/windows/wsl2-check';
+import { PodmanCleanupMacOS } from '/@/cleanup/podman-cleanup-macos';
+import { PodmanCleanupWindows } from '/@/cleanup/podman-cleanup-windows';
 import { Installer } from '/@/installer/installer';
 import { MacOSInstaller } from '/@/installer/mac-os-installer';
 import { PodmanInstall } from '/@/installer/podman-install';
 import { WinInstaller } from '/@/installer/win-installer';
 import { WinPlatform } from '/@/platforms/win-platform';
 
-import { ExtensionContextSymbol, TelemetryLoggerSymbol } from './symbols';
+import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from './symbols';
 
 export class InversifyBinding {
   #inversifyContainer: InversifyContainer | undefined;
@@ -66,8 +68,10 @@ export class InversifyBinding {
 
     if (envAPI.isWindows) {
       this.#inversifyContainer.bind(Installer).to(WinInstaller).inSingletonScope();
+      this.#inversifyContainer.bind(ProviderCleanupSymbol).to(PodmanCleanupWindows).inSingletonScope();
     } else if (envAPI.isMac) {
       this.#inversifyContainer.bind(Installer).to(MacOSInstaller).inSingletonScope();
+      this.#inversifyContainer.bind(ProviderCleanupSymbol).to(PodmanCleanupMacOS).inSingletonScope();
     }
 
     return this.#inversifyContainer;

--- a/extensions/podman/packages/extension/src/inject/symbols.ts
+++ b/extensions/podman/packages/extension/src/inject/symbols.ts
@@ -15,6 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************/
-
 export const ExtensionContextSymbol = Symbol.for('ExtensionContext');
 export const TelemetryLoggerSymbol = Symbol.for('TelemetryLogger');
+/**
+ * Symbol for {@link import('@podman-desktop/api').ProviderCleanup}
+ */
+export const ProviderCleanupSymbol = Symbol.for('ProviderCleanup');


### PR DESCRIPTION
### What does this PR do?

Similar to https://github.com/podman-desktop/podman-desktop/issues/14535 we want to remove the platform specific code inside the `PodmanInstall`

https://github.com/podman-desktop/podman-desktop/blob/a1244d45ac7684472283a135b89072323e27402f/extensions/podman/packages/extension/src/installer/podman-install.ts#L79-L85

In a separate PR (https://github.com/podman-desktop/podman-desktop/pull/14644) we are dealing with the code for the Installer. In this PR we want to start dealing with the code related to the providerCleanup.

For inversify, we create a symbol, and depending on the platform we inject the right class: `PodmanCleanupMacOS` on MacOS and `PodmanCleanupWindows` on Windows.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14541

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
