### PR TITLE
refactor(extension: podman): inject ProviderCleanup to PodmanInstall

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1495,7 +1495,12 @@ test('ensure showNotification is not called during update', async () => {
   );
 
   const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
-  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger, {} as unknown as Installer);
+  const podmanInstall: PodmanInstall = new PodmanInstall(
+    extensionContext,
+    telemetryLogger,
+    {} as unknown as Installer,
+    {} as unknown as extensionApi.ProviderCleanup,
+  );
   vi.spyOn(podmanInstall, 'checkForUpdate').mockImplementation((_installedPodman: InstalledPodman | undefined) => {
     return Promise.resolve({
       hasUpdate: true,
@@ -2492,7 +2497,12 @@ describe('calcPodmanMachineSetting', () => {
 
 test('checkForUpdate func should be called if there is no podman installed', async () => {
   const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
-  const podmanInstall: PodmanInstall = new PodmanInstall(extensionContext, telemetryLogger, {} as unknown as Installer);
+  const podmanInstall: PodmanInstall = new PodmanInstall(
+    extensionContext,
+    telemetryLogger,
+    {} as unknown as Installer,
+    {} as unknown as extensionApi.ProviderCleanup,
+  );
 
   vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue(undefined);
   vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -29,12 +29,10 @@ import {
   START_NOW_MACHINE_INIT_SUPPORTED_KEY,
   USER_MODE_NETWORKING_SUPPORTED_KEY,
 } from '/@/constants';
-import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
+import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 import { MachineJSON } from '/@/types';
 
 import { getDetectionChecks } from '../checks/detection-checks';
-import { PodmanCleanupMacOS } from '../cleanup/podman-cleanup-macos';
-import { PodmanCleanupWindows } from '../cleanup/podman-cleanup-windows';
 import {
   calcPodmanMachineSetting,
   getJSONMachineList,
@@ -63,8 +61,6 @@ export class PodmanInstall {
 
   private readonly storagePath: string;
 
-  protected providerCleanup: extensionApi.ProviderCleanup | undefined;
-
   constructor(
     @inject(ExtensionContextSymbol)
     readonly extensionContext: extensionApi.ExtensionContext,
@@ -73,13 +69,11 @@ export class PodmanInstall {
     @inject(Installer)
     @optional()
     readonly installer: Installer | undefined,
+    @inject(ProviderCleanupSymbol)
+    @optional()
+    readonly providerCleanup: extensionApi.ProviderCleanup | undefined,
   ) {
     this.storagePath = extensionContext.storagePath;
-    if (extensionApi.env.isMac) {
-      this.providerCleanup = new PodmanCleanupMacOS();
-    } else if (extensionApi.env.isWindows) {
-      this.providerCleanup = new PodmanCleanupWindows();
-    }
   }
 
   public async doInstallPodman(provider: extensionApi.Provider): Promise<void> {


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/issues/14541

Similar to https://github.com/podman-desktop/podman-desktop/issues/14561, removing platform specific code in constructor of class `PodmanInstall`.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14657

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
