### PR TITLE
chore: fixed insecure dialog visibility

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,34 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { Registry } from '@podman-desktop/api';
 import { waitFor } from '@testing-library/dom';
 import { render, screen } from '@testing-library/svelte';
 import { default as userEvent } from '@testing-library/user-event';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { registriesInfos } from '../../stores/registries';
 import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
-
-beforeEach(() => {
-  (window as any).window.ddExtensionInstall = vi.fn().mockResolvedValue(undefined);
-  (window as any).window.getImageRegistryProviderNames = vi.fn().mockResolvedValue(undefined);
-  (window as any).window.showMessageBox = vi.fn();
-  (window as any).window.checkImageCredentials = vi.fn();
-  (window as any).window.createImageRegistry = vi.fn().mockImplementation((...args: any[]) => {
-    console.log(args);
-  });
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
-});
 
 describe('PreferencesRegistriesEditing', () => {
   test('Expect that add registry button is visible and enabled', async () => {
@@ -94,7 +76,7 @@ describe('PreferencesRegistriesEditing', () => {
     render(PreferencesRegistriesEditing);
     const addRegistryBtn = screen.getByRole('button', { name: 'Add registry' });
     await userEvent.click(addRegistryBtn);
-    const button = screen.getByRole('button', { name: 'Add' });
+    let button = screen.getByRole('button', { name: 'Add' });
     const password = screen.getByPlaceholderText('password');
     const username = screen.getByPlaceholderText('username');
     const url = screen.getByPlaceholderText('https://registry.io');
@@ -112,6 +94,7 @@ describe('PreferencesRegistriesEditing', () => {
       .mockRejectedValueOnce(new Error('self signed certificate in certificate chain'));
     vi.mocked(window.showMessageBox).mockResolvedValueOnce({ response: 1 }).mockResolvedValueOnce({ response: 0 });
     await userEvent.click(button);
+    button = screen.getByRole('button', { name: 'Add' });
     await waitFor(() => expect(button).toBeEnabled());
     await userEvent.click(button);
     expect(window.showMessageBox).toHaveBeenCalledTimes(2);

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -180,13 +180,14 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry): Promise<
   // if we happen to get a certificate verification issue, as the user if they would like to
   // continue with the registry anyway.
   try {
-    await window.checkImageCredentials(registry);
+    await window.checkImageCredentials($state.snapshot(registry));
   } catch (error) {
     if (
       error instanceof Error &&
       (error.message.includes('unable to verify the first certificate') ||
         error.message.includes('self signed certificate in certificate chain'))
     ) {
+      showNewRegistryForm = false;
       const result = await window.showMessageBox({
         title: 'Invalid Certificate',
         type: 'warning',
@@ -198,6 +199,7 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry): Promise<
       } else {
         setErrorResponse(registry.serverUrl, error.message);
         loggingIn = false;
+        showNewRegistryForm = true;
         return;
       }
     }


### PR DESCRIPTION
### What does this PR do?
Fixes insecure registry dialog visibility

### Screenshot / video of UI


[Screencast_20251030_130859.webm](https://github.com/user-attachments/assets/8f5dee8f-cd26-474a-b215-f48e2c5a8347)


### What issues does this PR fix or reference?
Closes #9808 
Closes #11530 

### How to test this PR?
Follow steps in https://github.com/podman-desktop/podman-desktop/pull/2896 
Or try to add any insecure registry

- [x] Tests are covering the bug fix or the new feature
