### PR TITLE
chore: update explore features context values on init and add a store

### DIFF
--- a/packages/main/src/plugin/explore-features/explore-features.spec.ts
+++ b/packages/main/src/plugin/explore-features/explore-features.spec.ts
@@ -156,7 +156,14 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({
-    get: vi.fn().mockReturnValueOnce([]).mockReturnValueOnce(false),
+    get: vi.fn().mockImplementation((key: string): unknown => {
+      if (key === 'hiddenFeatures') {
+        return [];
+      } else if (key === 'enabled') {
+        return false;
+      }
+      return undefined;
+    }),
   } as unknown as Configuration);
 
   vi.mocked(containerProviderRegistryMock.listContainers).mockResolvedValue([]);
@@ -196,7 +203,14 @@ test('Get features list', async () => {
   vi.mocked(extensionLoaderMock.listExtensions).mockResolvedValue([]);
 
   vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({
-    get: vi.fn().mockReturnValueOnce(false).mockReturnValueOnce([]).mockReturnValueOnce(false),
+    get: vi.fn().mockImplementation((key: string): unknown => {
+      if (key === 'hiddenFeatures') {
+        return [];
+      } else if (key === 'enabled') {
+        return false;
+      }
+      return undefined;
+    }),
   } as unknown as Configuration);
   await exploreFeaturesMock.init();
   const features = await exploreFeaturesMock.downloadFeaturesList();
@@ -240,15 +254,16 @@ test.each([
     { ...extensionInfoMock, removable: true },
   ]);
 
-  if (funcName === 'downloadFeaturesList') {
-    vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({
-      get: vi.fn().mockReturnValueOnce([]).mockReturnValueOnce(false),
-    } as unknown as Configuration);
-  } else if (funcName === 'init') {
-    vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({
-      get: vi.fn().mockReturnValueOnce(false),
-    } as unknown as Configuration);
-  }
+  vi.mocked(configurationRegistryMock.getConfiguration).mockReturnValue({
+    get: vi.fn().mockImplementation((key: string): unknown => {
+      if (key === 'hiddenFeatures') {
+        return [];
+      } else if (key === 'enabled') {
+        return false;
+      }
+      return undefined;
+    }),
+  } as unknown as Configuration);
 
   await func();
 

--- a/packages/main/src/plugin/explore-features/explore-features.spec.ts
+++ b/packages/main/src/plugin/explore-features/explore-features.spec.ts
@@ -239,9 +239,9 @@ test('Get features list', async () => {
 });
 
 test.each([
-  ['downloadFeaturesList', (): Promise<ExploreFeature[]> => exploreFeaturesMock.downloadFeaturesList()],
-  ['init', (): Promise<void> => exploreFeaturesMock.init()],
-])('Context value are set when calling %s', async (funcName, func) => {
+  (): Promise<ExploreFeature[]> => exploreFeaturesMock.downloadFeaturesList(),
+  (): Promise<void> => exploreFeaturesMock.init(),
+])('Context value are set when calling %s', async func => {
   vi.mocked(containerProviderRegistryMock.listContainers).mockResolvedValue([containerInfoMock]);
 
   vi.mocked(providerRegistryMock.getProviderInfos).mockReturnValue([

--- a/packages/main/src/plugin/explore-features/explore-features.ts
+++ b/packages/main/src/plugin/explore-features/explore-features.ts
@@ -129,6 +129,8 @@ export class ExploreFeatures {
 
     this.configurationRegistry.registerConfigurations([exploreFeaturesConfiguration]);
 
+    await this.updateShowRequirements();
+
     for (const feature of featuresJson.features as ExploreFeature[]) {
       const imageFile = path.resolve(ExploreFeatures.MAIN_IMAGES_FOLDER, `${feature.id}.png`);
       if (existsSync(imageFile)) {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -747,7 +747,6 @@ export class PluginSystem {
 
     container.bind<ExploreFeatures>(ExploreFeatures).toSelf().inSingletonScope();
     const exploreFeatures = container.get<ExploreFeatures>(ExploreFeatures);
-    await exploreFeatures.init();
 
     // do not wait
     featured.init().catch((e: unknown) => {
@@ -3240,6 +3239,7 @@ export class PluginSystem {
       apiSender.send('extensions-started');
       this.markAsExtensionsStarted();
     }
+    await exploreFeatures.init();
     extensionsUpdater.init().catch((err: unknown) => console.error('Unable to perform extension updates', err));
     autoStartEngine.start().catch((err: unknown) => console.error('Unable to perform autostart', err));
     return this.extensionLoader;

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3239,9 +3239,10 @@ export class PluginSystem {
       apiSender.send('extensions-started');
       this.markAsExtensionsStarted();
     }
-    await exploreFeatures.init();
     extensionsUpdater.init().catch((err: unknown) => console.error('Unable to perform extension updates', err));
     autoStartEngine.start().catch((err: unknown) => console.error('Unable to perform autostart', err));
+    await exploreFeatures.init();
+    apiSender.send('explore-features-loaded');
     return this.extensionLoader;
   }
 

--- a/packages/renderer/src/lib/explore-features/ExploreFeatures.spec.ts
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatures.spec.ts
@@ -22,6 +22,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import { exploreFeaturesInfo } from '/@/stores/explore-features';
 import type { ExploreFeature } from '/@api/explore-feature';
 
 import ExploreFeatures from './ExploreFeatures.svelte';
@@ -67,11 +68,12 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  vi.mocked(window.listFeatures).mockResolvedValue(exploreFeatures);
+  exploreFeaturesInfo.set(exploreFeatures);
 });
 
 afterEach(() => {
   vi.resetAllMocks();
+  exploreFeaturesInfo.set([]);
 });
 
 test('Explore features carousel shows features', async () => {
@@ -84,7 +86,7 @@ test('Explore features carousel shows features', async () => {
 });
 
 test('Carousel does not show when there are 0 features to show', async () => {
-  vi.mocked(window.listFeatures).mockResolvedValue([{ ...exploreFeatures[0], show: false }]);
+  exploreFeaturesInfo.set([{ ...exploreFeatures[0], show: false }]);
 
   render(ExploreFeatures);
   await tick();
@@ -165,6 +167,7 @@ test('When a feature card is closed, it is removed from the carousel', async () 
   await vi.waitFor(() => {
     const carouselTitle = screen.getByText('Explore Features');
     expect(carouselTitle).toBeVisible();
+    expect(screen.getAllByRole('button', { name: 'Close' })).not.toHaveLength(0);
   });
 
   const closeButtons = screen.getAllByRole('button', { name: 'Close' });

--- a/packages/renderer/src/stores/explore-features.ts
+++ b/packages/renderer/src/stores/explore-features.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+import type { ExploreFeature } from '/@api/explore-feature';
+
+import { EventStore } from './event-store';
+
+const windowEvents = ['explore-features-loaded', 'provider-change', 'provider-container-connection-update-status'];
+const windowListeners = ['update-explore-features'];
+
+let readyToUpdate = false;
+
+export async function checkForUpdate(eventName: string): Promise<boolean> {
+  if ('explore-features-loaded' === eventName) {
+    readyToUpdate = true;
+  }
+
+  // do not fetch until extensions are all started
+  return readyToUpdate;
+}
+export const exploreFeaturesInfo: Writable<ExploreFeature[]> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const listExploreFeatures = (): Promise<ExploreFeature[]> => {
+  return window.listFeatures();
+};
+
+const iconsEventStore = new EventStore<ExploreFeature[]>(
+  'exploreFeatures',
+  exploreFeaturesInfo,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  listExploreFeatures,
+);
+iconsEventStore.setup();

--- a/packages/renderer/src/stores/explore-features.ts
+++ b/packages/renderer/src/stores/explore-features.ts
@@ -43,7 +43,7 @@ const listExploreFeatures = (): Promise<ExploreFeature[]> => {
   return window.listFeatures();
 };
 
-const iconsEventStore = new EventStore<ExploreFeature[]>(
+const exploreFeaturesEventStore = new EventStore<ExploreFeature[]>(
   'exploreFeatures',
   exploreFeaturesInfo,
   checkForUpdate,
@@ -51,4 +51,4 @@ const iconsEventStore = new EventStore<ExploreFeature[]>(
   windowListeners,
   listExploreFeatures,
 );
-iconsEventStore.setup();
+exploreFeaturesEventStore.setup();

--- a/packages/renderer/src/stores/explore-features.ts
+++ b/packages/renderer/src/stores/explore-features.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This context values needed for the explore features cards are now also updated upon init of explore features to prevent possibly having undefined context values on first rendering of the Dashboard page.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/14142
Fixes https://github.com/podman-desktop/podman-desktop/issues/14223

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
