### PR TITLE
refactor(extension: podman): replace isWslEnabled with WinPlatform#isWslEnabled

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2385,6 +2385,7 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
 
   test('check with previous podman v4 config files on Windows', async () => {
     vi.mocked(extensionApi.env).isWindows = true;
+    vi.mocked(WIN_PLATFORM_MOCK.isWSLEnabled).mockResolvedValue(true);
 
     // mock confirmation window message to true
     vi.mocked(extensionApi.window.showWarningMessage).mockResolvedValue('Yes');
@@ -2401,34 +2402,6 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
 
     vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
       stdout: 'unknown message: 1.2.5.0',
-      stderr: '',
-      command: 'command',
-    });
-
-    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
-      stdout: 'podman version 5.2.0',
-    } as unknown as extensionApi.RunResult);
-
-    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
-      stdout: 'True',
-      stderr: '',
-      command: 'command',
-    });
-
-    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
-      stdout: 'True',
-      stderr: '',
-      command: 'command',
-    });
-
-    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
-      stdout: 'True',
-      stderr: '',
-      command: 'command',
-    });
-
-    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
-      stdout: 'Running',
       stderr: '',
       command: 'command',
     });
@@ -2958,50 +2931,9 @@ test('isHypervEnabled should return true if hyperv is enabled', async () => {
   expect(wslHypervEnabled).toBeTruthy();
 });
 
-test('isWSLEnabled should return false if it is not windows', async () => {
-  vi.mocked(extensionApi.env).isWindows = false;
-  const wslEnabled = await extension.isWSLEnabled();
-  expect(wslEnabled).toBeFalsy();
-});
-
-test('isWSLEnabled should return false if wsl is not enabled', async () => {
-  vi.mocked(extensionApi.env).isWindows = true;
-  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({
-    stdout: 'unknown message: 1.2.5.0',
-    stderr: '',
-    command: 'command',
-  });
-  const wslEnabled = await extension.isWSLEnabled();
-  expect(wslEnabled).toBeFalsy();
-});
-
-test('isWSLEnabled should return true if wsl is enabled', async () => {
-  vi.mocked(extensionApi.env).isWindows = true;
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(command => {
-    return new Promise<extensionApi.RunResult>(resolve => {
-      if (command === 'wsl') {
-        resolve({
-          stdout:
-            'WSL version: 2.2.5.0\nKernel version: 5.15.90.1\nWSLg version: 1.0.51\nMSRDC version: 1.2.3770\nDirect3D version: 1.608.2-61064218\nDXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp\nWindows version: 10.0.22621.2134',
-          stderr: '',
-          command: 'command',
-        });
-      }
-      if (command === 'powershell.exe') {
-        resolve({
-          stdout: 'True',
-          stderr: '',
-          command: 'command',
-        });
-      }
-    });
-  });
-  const wslEnabled = await extension.isWSLEnabled();
-  expect(wslEnabled).toBeTruthy();
-});
-
 test('getJSONMachineList should only get machines from wsl if hyperv is not enabled', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
+  vi.mocked(WIN_PLATFORM_MOCK.isWSLEnabled).mockResolvedValue(true);
   vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
     return new Promise<extensionApi.RunResult>(resolve => {
       if (command !== 'wsl' && args?.[0] === '--version') {
@@ -3130,6 +3062,7 @@ test('getJSONMachineList should only get machines from hyperv if wsl is not enab
 
 test('getJSONMachineList should get machines from hyperv and wsl if both are enabled', async () => {
   vi.mocked(extensionApi.env).isWindows = true;
+  vi.mocked(WIN_PLATFORM_MOCK.isWSLEnabled).mockResolvedValue(true);
   vi.spyOn(podmanCli, 'getPodmanInstallation').mockResolvedValue({
     version: '5.2.1',
   });

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -198,6 +198,8 @@ describe('update checks', () => {
   });
 
   test('stopPodmanMachinesIfAnyBeforeUpdating with one machine running', async () => {
+    await extensionObj.initInversify(extensionContext, mockTelemetryLogger);
+
     vi.spyOn(extensionApi.process, 'exec').mockResolvedValueOnce({
       stdout: 'podman version 5.0.0',
     } as extensionApi.RunResult);


### PR DESCRIPTION
### What does this PR do?

Remove the global `isWslEnabled` function in the podman extension.ts. This method is replaced by the `WinPlatform#isWslEnabled`.

A lot of tests are removed from the `extension.spec.ts` because we provide a mock for the `WinPlatform` class, so we do not need to check that the proper exec are called, this is covered by each spec file for each check.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14673
Part of https://github.com/podman-desktop/podman-desktop/issues/14292

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
