### PR TITLE
fix(test): extend timeout for onboarding screen loading

### DIFF
--- a/tests/playwright/src/model/pages/welcome-page.ts
+++ b/tests/playwright/src/model/pages/welcome-page.ts
@@ -69,7 +69,7 @@ export class WelcomePage extends BasePage {
   async turnOffTelemetry(): Promise<void> {
     return test.step('Turn off Telemetry', async () => {
       // Extensions load sequentially (faster speed but can block ui)
-      await playExpect(this.startOnboarding).toBeEnabled({ timeout: 30_000 });
+      await playExpect(this.startOnboarding).toBeEnabled({ timeout: 45_000 });
 
       if (await this.telemetryConsent.isChecked()) {
         await playExpect(this.telemetryConsent).toBeChecked();


### PR DESCRIPTION
### What does this PR do?
Extends onboarding timeout, extension tiles are still sometime not loaded on CI agents so we need to extend timeout.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
References: https://github.com/podman-desktop/podman-desktop/issues/14348
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
all Update e2e tests should be passing. 
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
