### PR TITLE
fix(extensions/podman): inject WinPlatform and use the existing preflight checks

### DIFF
--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -22,6 +22,8 @@ import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { WinPlatform } from '/@/platforms/win-platform';
+
 import { getAssetsFolder } from '../utils/util';
 import { WinInstaller } from './win-installer';
 
@@ -50,12 +52,16 @@ const progress = {
 };
 
 const mockTelemetryLogger = {} as TelemetryLogger;
+const mockWinPlatform = {} as WinPlatform;
 
 vi.mock(import('./../utils/util'), () => ({
   getAssetsFolder: vi.fn(),
 }));
 
+let installer: WinInstaller;
+
 beforeEach(() => {
+  installer = new WinInstaller(extensionContext, mockTelemetryLogger, mockWinPlatform);
   vi.resetAllMocks();
   // reset array of subscriptions
   extensionContext.subscriptions.length = 0;
@@ -73,7 +79,6 @@ test('expect update on windows to show notification in case of 0 exit code', asy
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).toHaveBeenCalled();
@@ -88,7 +93,6 @@ test('expect update on windows not to show notification in case of 1602 exit cod
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
   const result = await installer.update();
   expect(result).toBeTruthy();
   expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
@@ -104,7 +108,6 @@ test('expect update on windows to throw error if non zero exit code', async () =
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);
 
-  const installer = new WinInstaller(extensionContext, mockTelemetryLogger);
   const result = await installer.update();
   expect(result).toBeFalsy();
   expect(extensionApi.window.showErrorMessage).toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -32,15 +32,8 @@ import {
 import { inject, injectable } from 'inversify';
 
 import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
+import { WinPlatform } from '/@/platforms/win-platform';
 
-import { OrCheck, SequenceCheck } from '../checks/base-check';
-import { HyperVCheck } from '../checks/windows/hyperv-check';
-import { VirtualMachinePlatformCheck } from '../checks/windows/virtual-machine-platform-check';
-import { WinBitCheck } from '../checks/windows/win-bit-check';
-import { WinMemoryCheck } from '../checks/windows/win-memory-check';
-import { WinVersionCheck } from '../checks/windows/win-version-check';
-import { WSLVersionCheck } from '../checks/windows/wsl-version-check';
-import { WSL2Check } from '../checks/windows/wsl2-check';
 import podman5Json from '../podman5.json';
 import { getAssetsFolder } from '../utils/util';
 import { BaseInstaller } from './base-installer';
@@ -52,6 +45,8 @@ export class WinInstaller extends BaseInstaller {
     readonly extensionContext: ExtensionContext,
     @inject(TelemetryLoggerSymbol)
     readonly telemetryLogger: TelemetryLogger,
+    @inject(WinPlatform)
+    readonly winPlatform: WinPlatform,
   ) {
     super();
   }
@@ -61,20 +56,7 @@ export class WinInstaller extends BaseInstaller {
   }
 
   getPreflightChecks(): InstallCheck[] {
-    return [
-      new WinBitCheck(),
-      new WinVersionCheck(),
-      new WinMemoryCheck(),
-      new OrCheck(
-        'Windows virtualization',
-        new SequenceCheck('WSL platform', [
-          new VirtualMachinePlatformCheck(this.telemetryLogger),
-          new WSLVersionCheck(),
-          new WSL2Check(this.telemetryLogger, this.extensionContext),
-        ]),
-        new HyperVCheck(this.telemetryLogger),
-      ),
-    ];
+    return this.winPlatform.getPreflightChecks();
   }
 
   update(): Promise<boolean> {


### PR DESCRIPTION
### What does this PR do?

This PR injects WinPlatform in WinInstaller.

Use preflight checks from WinPlatform.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for: https://github.com/podman-desktop/podman-desktop/issues/14292

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
