### PR TITLE
refactor(NetworksList.svelte): adding key prop to table usage

### DIFF
--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -93,6 +93,13 @@ const row = new TableRow<NetworkInfoUI>({
   selectable: (network): boolean => network.status === 'UNUSED',
   disabledText: 'Network is used by a container',
 });
+
+/**
+ * Utility function for the Table to get the key to use for each item
+ */
+function key(network: NetworkInfoUI): string {
+  return `${network.engineId}:${network.id}`;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="networks">
@@ -130,6 +137,7 @@ const row = new TableRow<NetworkInfoUI>({
         data={networks}
         columns={columns}
         row={row}
+        key={key}
         defaultSortColumn="Name">
       </Table>
     {/if}


### PR DESCRIPTION
### What does this PR do?

Adding the `key` props to the table usage in recently added `NetworksList.svelte`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14514

### How to test this PR?

N/A
