### PR TITLE
fix(extension/podman): extract + memoize hyper-v installed check

### DIFF
--- a/extensions/podman/packages/extension/src/checks/windows/hyperv-installed-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyperv-installed-check.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { TelemetryLogger } from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { PowerShellClient } from '/@/utils/powershell';
+import { getPowerShellClient } from '/@/utils/powershell';
+
+import { HyperVInstalledCheck } from './hyperv-installed-check';
+
+vi.mock(import('@podman-desktop/api'));
+vi.mock(import('../../utils/powershell'), () => ({
+  getPowerShellClient: vi.fn(),
+}));
+
+const mockTelemetryLogger = {} as TelemetryLogger;
+
+const POWERSHELL_CLIENT: PowerShellClient = {
+  isUserAdmin: vi.fn(),
+  isHyperVInstalled: vi.fn(),
+  isHyperVRunning: vi.fn(),
+  isVirtualMachineAvailable: vi.fn(),
+  isRunningElevated: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getPowerShellClient).mockResolvedValue(POWERSHELL_CLIENT);
+});
+
+test('expect HyperVInstalledCheck preflight check return failure result if HyperV not installed', async () => {
+  vi.mocked(POWERSHELL_CLIENT.isHyperVInstalled).mockResolvedValue(false);
+
+  const hyperVInstalledCheck = new HyperVInstalledCheck(mockTelemetryLogger);
+  const result = await hyperVInstalledCheck.execute();
+  expect(result.successful).toBeFalsy();
+  expect(result.description).equal('Hyper-V is not installed on your system.');
+  expect(result.docLinks?.[0].url).equal(
+    'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
+  );
+  expect(result.docLinks?.[0].title).equal('Hyper-V Manual Installation Steps');
+});
+
+test('expect HyperVInstalledCheck preflight check return OK if HyperV is installed', async () => {
+  vi.mocked(POWERSHELL_CLIENT.isHyperVInstalled).mockResolvedValue(true);
+
+  const hyperVInstalledCheck = new HyperVInstalledCheck(mockTelemetryLogger);
+  const result = await hyperVInstalledCheck.execute();
+  expect(result.successful).toBeTruthy();
+  expect(result.description).toBeUndefined();
+  expect(result.docLinks).toBeUndefined();
+});

--- a/extensions/podman/packages/extension/src/checks/windows/hyperv-installed-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyperv-installed-check.ts
@@ -19,13 +19,13 @@
 import type extensionApi from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
 
-import { BaseCheck } from '/@/checks/base-check';
+import { MemoizedBaseCheck } from '/@/checks/memoized-base-check';
 import { HYPER_V_DOC_LINKS } from '/@/checks/windows/constants';
 import { TelemetryLoggerSymbol } from '/@/inject/symbols';
 import { getPowerShellClient } from '/@/utils/powershell';
 
 @injectable()
-export class HyperVInstalledCheck extends BaseCheck {
+export class HyperVInstalledCheck extends MemoizedBaseCheck {
   title = 'Hyper-V installed';
 
   constructor(
@@ -40,7 +40,7 @@ export class HyperVInstalledCheck extends BaseCheck {
     return client.isHyperVInstalled();
   }
 
-  async execute(): Promise<extensionApi.CheckResult> {
+  async executeImpl(): Promise<extensionApi.CheckResult> {
     const result = await this.checkHyperVInstalled();
     if (result) {
       return this.createSuccessfulResult();

--- a/extensions/podman/packages/extension/src/checks/windows/hyperv-installed-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyperv-installed-check.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type extensionApi from '@podman-desktop/api';
+import { inject, injectable } from 'inversify';
+
+import { BaseCheck } from '/@/checks/base-check';
+import { HYPER_V_DOC_LINKS } from '/@/checks/windows/constants';
+import { TelemetryLoggerSymbol } from '/@/inject/symbols';
+import { getPowerShellClient } from '/@/utils/powershell';
+
+@injectable()
+export class HyperVInstalledCheck extends BaseCheck {
+  title = 'Hyper-V installed';
+
+  constructor(
+    @inject(TelemetryLoggerSymbol)
+    private telemetryLogger: extensionApi.TelemetryLogger,
+  ) {
+    super();
+  }
+
+  protected async checkHyperVInstalled(): Promise<boolean> {
+    const client = await getPowerShellClient(this.telemetryLogger);
+    return client.isHyperVInstalled();
+  }
+
+  async execute(): Promise<extensionApi.CheckResult> {
+    const result = await this.checkHyperVInstalled();
+    if (result) {
+      return this.createSuccessfulResult();
+    }
+    return this.createFailureResult({
+      description: 'Hyper-V is not installed on your system.',
+      docLinksDescription: 'call DISM /Online /Enable-Feature /All /FeatureName:Microsoft-Hyper-V in a terminal',
+      docLinks: HYPER_V_DOC_LINKS,
+    });
+  }
+}

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -21,6 +21,7 @@ import { env as envAPI } from '@podman-desktop/api';
 import { Container as InversifyContainer } from 'inversify';
 
 import { HyperVCheck } from '/@/checks/windows/hyperv-check';
+import { HyperVInstalledCheck } from '/@/checks/windows/hyperv-installed-check';
 import { HyperVPodmanVersionCheck } from '/@/checks/windows/hyperv-podman-version-check';
 import { HyperVRunningCheck } from '/@/checks/windows/hyperv-running-check';
 import { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
@@ -67,6 +68,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(WSLVersionCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WSL2Check).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(HyperVRunningCheck).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(HyperVInstalledCheck).toSelf().inSingletonScope();
 
     if (envAPI.isWindows) {
       this.#inversifyContainer.bind(Installer).to(WinInstaller).inSingletonScope();


### PR DESCRIPTION
### What does this PR do?

This PR does two things in two commits:
- it extracts the check that Hyper-V is installed in a class BaseCheck (1st commit)
- it converts the BaseCheck to a MemoizedBaseCheck for the performance issue on Windows (2nd commit)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for: 

https://github.com/podman-desktop/podman-desktop/issues/14296
https://github.com/podman-desktop/podman-desktop/issues/14294


Needs a rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/14697

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
