### PR TITLE
feat: add scrollback configuration option for terminal instances

### DIFF
--- a/packages/main/src/plugin/terminal-init.ts
+++ b/packages/main/src/plugin/terminal-init.ts
@@ -49,6 +49,13 @@ export class TerminalInit {
           minimum: 1,
           maximum: 4,
         },
+        [TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback]: {
+          description: 'The number of lines to keep in the terminal buffer.',
+          type: 'number',
+          default: 1000,
+          minimum: 100,
+          maximum: 100000,
+        },
       },
     };
 

--- a/packages/main/src/plugin/terminal-settings.ts
+++ b/packages/main/src/plugin/terminal-settings.ts
@@ -20,4 +20,5 @@ export enum TerminalSettings {
   SectionName = 'terminal',
   FontSize = 'integrated.fontSize',
   LineHeight = 'integrated.lineHeight',
+  Scrollback = 'integrated.scrollback',
 }

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -29,17 +29,13 @@ import type { ContainerInfoUI } from './ContainerInfoUI';
 
 let shellInContainerMock = vi.fn();
 
-const getConfigurationValueMock = vi.fn();
-
 beforeAll(() => {
-  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   Object.defineProperty(window, 'matchMedia', { value: vi.fn() });
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
-
-  getConfigurationValueMock.mockImplementation((key: string) => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
     if (key === 'terminal.integrated.scrollback') {
       return 1000;
     }

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -29,12 +29,22 @@ import type { ContainerInfoUI } from './ContainerInfoUI';
 
 let shellInContainerMock = vi.fn();
 
+const getConfigurationValueMock = vi.fn();
+
 beforeAll(() => {
+  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   Object.defineProperty(window, 'matchMedia', { value: vi.fn() });
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
+
+  getConfigurationValueMock.mockImplementation((key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000;
+    }
+    return undefined;
+  });
   shellInContainerMock = vi.mocked(window.shellInContainer);
   vi.mocked(window.matchMedia).mockReturnValue({
     addListener: vi.fn(),
@@ -279,7 +289,7 @@ test('prompt is not duplicated after restoring terminal from containerTerminals 
   const terminals = get(containerTerminals);
   expect(terminals.length).toBe(0);
 
-  // destroy the the terminal tab
+  // destroy the terminal tab
   renderObject.unmount();
   shellInContainerMock.mockClear();
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -115,6 +115,10 @@ async function refreshTerminal(): Promise<void> {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
+  const scrollback = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
+
   // get terminal if any
   const existingTerminal = getExistingTerminal(container.engineId, container.id);
 
@@ -123,6 +127,7 @@ async function refreshTerminal(): Promise<void> {
     lineHeight,
     screenReaderMode,
     theme: getTerminalTheme(),
+    scrollback: scrollback,
   });
   if (existingTerminal) {
     ignoreFirstData = true;

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -127,7 +127,7 @@ async function refreshTerminal(): Promise<void> {
     lineHeight,
     screenReaderMode,
     theme: getTerminalTheme(),
-    scrollback: scrollback,
+    scrollback,
   });
   if (existingTerminal) {
     ignoreFirstData = true;

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.spec.ts
@@ -28,6 +28,12 @@ const getConfigurationValueMock = vi.fn();
 const attachContainerMock = vi.fn();
 
 beforeAll(() => {
+  getConfigurationValueMock.mockImplementation((key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000;
+    }
+    return undefined;
+  });
   Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   Object.defineProperty(window, 'attachContainer', { value: attachContainerMock });
   Object.defineProperty(window, 'attachContainerSend', { value: vi.fn() });

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -116,15 +116,12 @@ const providerInfo = {
   installationSupport: undefined,
 } as unknown as ProviderInfo;
 
-const getConfigurationValueMock = vi.fn();
-
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
-  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   vi.mocked(window.listImages).mockResolvedValue(localImageList);
   vi.mocked(window.searchImageInRegistry).mockResolvedValue(registryImageList);
-  getConfigurationValueMock.mockImplementation((key: string) => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
     if (key === 'terminal.integrated.scrollback') {
       return 1000;
     }

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -116,11 +116,20 @@ const providerInfo = {
   installationSupport: undefined,
 } as unknown as ProviderInfo;
 
+const getConfigurationValueMock = vi.fn();
+
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.resetAllMocks();
+  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   vi.mocked(window.listImages).mockResolvedValue(localImageList);
   vi.mocked(window.searchImageInRegistry).mockResolvedValue(registryImageList);
+  getConfigurationValueMock.mockImplementation((key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000;
+    }
+    return undefined;
+  });
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
   Object.defineProperty(window, 'matchMedia', {
     value: () => {

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -54,7 +54,7 @@ async function refreshTerminal(): Promise<void> {
     disableStdin: true,
     theme: getTerminalTheme(),
     convertEol: true,
-    scrollback: scrollback,
+    scrollback,
   });
   termFit = new FitAddon();
   logsTerminal.loadAddon(termFit);

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -44,12 +44,17 @@ async function refreshTerminal(): Promise<void> {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
+  const scrollback = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
+
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
     theme: getTerminalTheme(),
     convertEol: true,
+    scrollback: scrollback,
   });
   termFit = new FitAddon();
   logsTerminal.loadAddon(termFit);

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -79,12 +79,17 @@ async function refreshTerminal(): Promise<void> {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
+  const scrollback = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
+
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
     theme: getTerminalTheme(),
     convertEol: true,
+    scrollback: scrollback,
   });
   termFit = new FitAddon();
   logsTerminal.loadAddon(termFit);

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -89,7 +89,7 @@ async function refreshTerminal(): Promise<void> {
     disableStdin: true,
     theme: getTerminalTheme(),
     convertEol: true,
-    scrollback: scrollback,
+    scrollback,
   });
   termFit = new FitAddon();
   logsTerminal.loadAddon(termFit);

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -36,10 +36,10 @@ const pullImageMock = vi.fn();
 const listImageTagsInRegistryMock = vi.fn();
 
 beforeAll(() => {
-  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
-  Object.defineProperty(window, 'resolveShortnameImage', { value: resolveShortnameImageMock });
-  Object.defineProperty(window, 'pullImage', { value: pullImageMock });
-  Object.defineProperty(window, 'listImageTagsInRegistry', { value: listImageTagsInRegistryMock });
+  vi.stubGlobal('getConfigurationValue', getConfigurationValueMock);
+  vi.stubGlobal('resolveShortnameImage', resolveShortnameImageMock);
+  vi.stubGlobal('pullImage', pullImageMock);
+  vi.stubGlobal('listImageTagsInRegistry', listImageTagsInRegistryMock);
 
   (window.events as unknown) = {
     receive: (_channel: string, func: () => void): void => {

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -75,7 +75,6 @@ const PROVIDER_INFO_MOCK: ProviderInfo = {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
-    // <-- Now async
     if (key === 'terminal.integrated.scrollback') {
       return 1000;
     }

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -30,13 +30,22 @@ import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provid
 
 import PullImage from './PullImage.svelte';
 
+const getConfigurationValueMock = vi.fn();
+const resolveShortnameImageMock = vi.fn();
+const pullImageMock = vi.fn();
+const listImageTagsInRegistryMock = vi.fn();
+
 beforeAll(() => {
+  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
+  Object.defineProperty(window, 'resolveShortnameImage', { value: resolveShortnameImageMock });
+  Object.defineProperty(window, 'pullImage', { value: pullImageMock });
+  Object.defineProperty(window, 'listImageTagsInRegistry', { value: listImageTagsInRegistryMock });
+
   (window.events as unknown) = {
     receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
-  vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
 
   Object.defineProperty(window, 'matchMedia', {
     value: () => {
@@ -74,7 +83,15 @@ const PROVIDER_INFO_MOCK: ProviderInfo = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.restoreAllMocks();
+  getConfigurationValueMock.mockImplementation((key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000;
+    }
+    return undefined;
+  });
+  resolveShortnameImageMock.mockResolvedValue(['docker.io/test1']);
+  pullImageMock.mockResolvedValue(undefined);
+  listImageTagsInRegistryMock.mockResolvedValue(['latest', 'other']);
 
   providerInfos.set([PROVIDER_INFO_MOCK]);
 });

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -30,23 +30,14 @@ import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provid
 
 import PullImage from './PullImage.svelte';
 
-const getConfigurationValueMock = vi.fn();
-const resolveShortnameImageMock = vi.fn();
-const pullImageMock = vi.fn();
-const listImageTagsInRegistryMock = vi.fn();
-
 beforeAll(() => {
-  vi.stubGlobal('getConfigurationValue', getConfigurationValueMock);
-  vi.stubGlobal('resolveShortnameImage', resolveShortnameImageMock);
-  vi.stubGlobal('pullImage', pullImageMock);
-  vi.stubGlobal('listImageTagsInRegistry', listImageTagsInRegistryMock);
-
   (window.events as unknown) = {
     receive: (_channel: string, func: () => void): void => {
       func();
     },
   };
 
+  vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
   Object.defineProperty(window, 'matchMedia', {
     value: () => {
       return {
@@ -83,15 +74,16 @@ const PROVIDER_INFO_MOCK: ProviderInfo = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  getConfigurationValueMock.mockImplementation((key: string) => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+    // <-- Now async
     if (key === 'terminal.integrated.scrollback') {
       return 1000;
     }
     return undefined;
   });
-  resolveShortnameImageMock.mockResolvedValue(['docker.io/test1']);
-  pullImageMock.mockResolvedValue(undefined);
-  listImageTagsInRegistryMock.mockResolvedValue(['latest', 'other']);
+  vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
+  vi.mocked(window.pullImage).mockResolvedValue(undefined);
+  vi.mocked(window.listImageTagsInRegistry).mockResolvedValue(['latest', 'other']);
 
   providerInfos.set([PROVIDER_INFO_MOCK]);
 });

--- a/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.spec.ts
@@ -33,6 +33,12 @@ const kubernetesExecMock = vi.fn();
 const kubernetesExecResizeMock = vi.fn();
 
 beforeAll(() => {
+  getConfigurationValueMock.mockImplementation((key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000;
+    }
+    return undefined;
+  });
   Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   Object.defineProperty(window, 'kubernetesExec', { value: kubernetesExecMock });
   Object.defineProperty(window, 'kubernetesExecResize', { value: kubernetesExecResizeMock });

--- a/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.svelte
@@ -96,11 +96,16 @@ async function initializeNewTerminal(container: HTMLElement): Promise<void> {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
+  const scrollback = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
+
   shellTerminal = new Terminal({
     fontSize,
     lineHeight,
     screenReaderMode,
     theme: getTerminalTheme(),
+    scrollback,
   });
 
   id = await window.kubernetesExec(

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
@@ -41,7 +41,17 @@ const containerConnection: ProviderContainerConnectionInfo = {
   type: 'podman',
 };
 
+const getConfigurationValueMock = vi.fn();
+
 beforeAll(async () => {
+  Object.defineProperty(window, 'getConfigurationValue', {
+    value: getConfigurationValueMock.mockImplementation((key: string) => {
+      if (key === 'terminal.integrated.scrollback') {
+        return 1000;
+      }
+      return undefined;
+    }),
+  });
   global.ResizeObserver = vi.fn().mockImplementation(() => ({
     observe: vi.fn(),
     unobserve: vi.fn(),

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
@@ -41,16 +41,12 @@ const containerConnection: ProviderContainerConnectionInfo = {
   type: 'podman',
 };
 
-const getConfigurationValueMock = vi.fn();
-
 beforeAll(async () => {
-  Object.defineProperty(window, 'getConfigurationValue', {
-    value: getConfigurationValueMock.mockImplementation((key: string) => {
-      if (key === 'terminal.integrated.scrollback') {
-        return 1000;
-      }
-      return undefined;
-    }),
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000;
+    }
+    return undefined;
   });
   global.ResizeObserver = vi.fn().mockImplementation(() => ({
     observe: vi.fn(),

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -55,12 +55,16 @@ onMount(async () => {
   const lineHeight = await window.getConfigurationValue<number>(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  const scrollback = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
   logsTerminal = new Terminal({
     fontSize,
     lineHeight,
     disableStdin: true,
     theme: getTerminalTheme(),
     convertEol: true,
+    scrollback: scrollback,
   });
   // Refresh the terminal on initial load
   await refreshTerminal();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -64,7 +64,7 @@ onMount(async () => {
     disableStdin: true,
     theme: getTerminalTheme(),
     convertEol: true,
-    scrollback: scrollback,
+    scrollback,
   });
   // Refresh the terminal on initial load
   await refreshTerminal();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
@@ -47,6 +47,12 @@ vi.mock('xterm', () => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  getConfigurationValueMock.mockImplementation((key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000; // A standard default value for scrollback
+    }
+    return undefined;
+  });
   Object.defineProperties(window, {
     getConfigurationValue: {
       value: getConfigurationValueMock,

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
@@ -133,6 +133,10 @@ async function refreshTerminal(): Promise<void> {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
+  const scrollback = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
+
   // get terminal if any
   const existingTerminal = getExistingTerminal(provider.internalId, connectionInfo.name);
   shellTerminal = new Terminal({
@@ -140,6 +144,7 @@ async function refreshTerminal(): Promise<void> {
     lineHeight,
     screenReaderMode,
     theme: getTerminalTheme(),
+    scrollback: scrollback,
   });
 
   if (existingTerminal) {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
@@ -144,7 +144,7 @@ async function refreshTerminal(): Promise<void> {
     lineHeight,
     screenReaderMode,
     theme: getTerminalTheme(),
-    scrollback: scrollback,
+    scrollback,
   });
 
   if (existingTerminal) {

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -59,7 +59,7 @@ async function refreshTerminal(): Promise<void> {
     theme: getTerminalTheme(),
     convertEol: convertEol,
     screenReaderMode: screenReaderMode,
-    scrollback: scrollback,
+    scrollback,
   });
   const fitAddon = new FitAddon();
   terminal.loadAddon(fitAddon);

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -48,6 +48,10 @@ async function refreshTerminal(): Promise<void> {
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
 
+  const scrollback = await window.getConfigurationValue<number>(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
+
   terminal = new Terminal({
     fontSize,
     lineHeight,
@@ -55,6 +59,7 @@ async function refreshTerminal(): Promise<void> {
     theme: getTerminalTheme(),
     convertEol: convertEol,
     screenReaderMode: screenReaderMode,
+    scrollback: scrollback,
   });
   const fitAddon = new FitAddon();
   terminal.loadAddon(fitAddon);

--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -112,6 +112,9 @@ test('terminal constructor should contains fontSize and lineHeight from configur
   expect(window.getConfigurationValue).toHaveBeenCalledWith(
     TerminalSettings.SectionName + '.' + TerminalSettings.LineHeight,
   );
+  expect(window.getConfigurationValue).toHaveBeenCalledWith(
+    TerminalSettings.SectionName + '.' + TerminalSettings.Scrollback,
+  );
 });
 
 test('addon fit should be loaded on mount', async () => {

--- a/packages/renderer/src/stores/kubernetes-terminal-state-store.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-terminal-state-store.spec.ts
@@ -24,9 +24,16 @@ import KubernetesTerminal from '/@/lib/kube/pods/terminal/KubernetesTerminal.sve
 import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
 
 const kubernetesExecMock = vi.fn();
+const getConfigurationValueMock = vi.fn();
 
 beforeAll(() => {
-  Object.defineProperty(window, 'getConfigurationValue', { value: vi.fn() });
+  getConfigurationValueMock.mockImplementation((key: string) => {
+    if (key === 'terminal.integrated.scrollback') {
+      return 1000;
+    }
+    return undefined;
+  });
+  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   Object.defineProperty(window, 'kubernetesExec', { value: kubernetesExecMock });
   Object.defineProperty(window, 'kubernetesExecResize', { value: vi.fn() });
 

--- a/packages/renderer/src/stores/kubernetes-terminal-state-store.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-terminal-state-store.spec.ts
@@ -24,16 +24,14 @@ import KubernetesTerminal from '/@/lib/kube/pods/terminal/KubernetesTerminal.sve
 import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
 
 const kubernetesExecMock = vi.fn();
-const getConfigurationValueMock = vi.fn();
 
 beforeAll(() => {
-  getConfigurationValueMock.mockImplementation((key: string) => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
     if (key === 'terminal.integrated.scrollback') {
       return 1000;
     }
     return undefined;
   });
-  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   Object.defineProperty(window, 'kubernetesExec', { value: kubernetesExecMock });
   Object.defineProperty(window, 'kubernetesExecResize', { value: vi.fn() });
 


### PR DESCRIPTION
### What does this PR do?
feat(terminal): Make scrollback buffer configurable

### What issues does this PR fix or reference?
Fixes #14702 

### What this PR does

This PR addresses the terminal's limited 1000-line scrollback buffer by:

- Introducing a new configuration setting: terminal.integrated.scrollback.

- Allowing users to override this default in their settings (e.g., to 50000) to find their own balance between history length and memory usage.

### Why this PR is important

The default 1000-line buffer is insufficient for many common tasks, such as container builds, docker-compose logs, or any application that produces a large volume of output. This results in the beginning of the logs being permanently lost, which severely hinders debugging.

This solution makes the buffer size configurable. It's important to note that a fixed-size buffer is necessary, as "infinite" or "dynamic" scrollback is not feasible. The terminal emulator discards old lines to make room for new ones, so the only way to retain more history is to allocate a larger buffer from the start.

### How it's implemented

- terminal-settings.ts: A new Scrollback = 'integrated.scrollback' property has been added to the TerminalSettings enum.

- TerminalWindow.svelte:

 1) The refreshTerminal function now reads the terminal.integrated.scrollback configuration value.

2) If the value is not set by the user, it defaults to 1000.

3) This scrollback value is then passed into the new Terminal() constructor.