### PR TITLE
refactor(tests): use proper type for fs.promises.readdir return type

### DIFF
--- a/extensions/docker/packages/extension/src/docker-context-handler.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-context-handler.spec.ts
@@ -181,6 +181,10 @@ describe('listContexts', () => {
 });
 
 describe('getContexts', () => {
+  const readdirMock = vi.mocked(
+    fs.promises.readdir as (path: string, options?: { withFileTypes: true }) => Promise<fs.Dirent<string>[]>,
+  );
+
   test('should return contexts if directory does not exists', async () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(false);
     const contexts = await dockerContextHandler.getContexts();
@@ -207,15 +211,16 @@ describe('getContexts', () => {
 
   test('should return contexts if error reading JSON', async () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-    vi.spyOn(fs.promises, 'readdir').mockResolvedValue([
+
+    readdirMock.mockResolvedValue([
       {
         isDirectory: () => true,
         name: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
-      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
+      } as unknown as fs.Dirent<string>,
       {
         isDirectory: () => true,
         name: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
-      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
+      } as unknown as fs.Dirent<string>,
     ]);
 
     const spyReadFile = vi.spyOn(fs.promises, 'readFile');
@@ -235,15 +240,15 @@ describe('getContexts', () => {
 
   test('should return contexts if directory exists', async () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-    vi.spyOn(fs.promises, 'readdir').mockResolvedValue([
+    readdirMock.mockResolvedValue([
       {
         isDirectory: () => true,
         name: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
-      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
+      } as unknown as fs.Dirent<string>,
       {
         isDirectory: () => true,
         name: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
-      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
+      } as unknown as fs.Dirent<string>,
     ]);
 
     const spyReadFile = vi.spyOn(fs.promises, 'readFile');
@@ -262,12 +267,12 @@ describe('getContexts', () => {
 
   test('should filter contexts if invalid sha', async () => {
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-    vi.spyOn(fs.promises, 'readdir').mockResolvedValue([
-      { isDirectory: () => true, name: 'invalidsha' } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
+    readdirMock.mockResolvedValue([
+      { isDirectory: () => true, name: 'invalidsha' } as unknown as fs.Dirent<string>,
       {
         isDirectory: () => true,
         name: 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
-      } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
+      } as unknown as fs.Dirent<string>,
     ]);
     const spyReadFile = vi.spyOn(fs.promises, 'readFile');
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -160,6 +160,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('node:fs');
+// mock fs.promises.readdir and use string[] as return type
+const fsPromisesReaddirMock = vi.mocked(
+  fs.promises.readdir as (path: string, options?: { withFileTypes: false }) => Promise<string[]>,
+);
 
 vi.mock(import('./inject/inversify-binding'));
 
@@ -2352,7 +2356,7 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
       stderr: 'incompatible machine config',
     } as unknown as extensionApi.RunResult);
 
-    vi.mocked(fs.promises.readdir).mockResolvedValue(['foo.json'] as unknown as fs.Dirent<Buffer<ArrayBufferLike>>[]);
+    fsPromisesReaddirMock.mockResolvedValue(['foo.json']);
 
     // mock readfile
     vi.mocked(fs.promises.readFile).mockResolvedValueOnce('{"Driver": "podman"}');
@@ -2410,10 +2414,7 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
       stderr: 'cannot unmarshal string',
     } as unknown as extensionApi.RunResult);
 
-    vi.mocked(fs.promises.readdir).mockResolvedValue([
-      'foo.json',
-      'podman-machine-default.json',
-    ] as unknown as fs.Dirent<Buffer<ArrayBufferLike>>[]);
+    fsPromisesReaddirMock.mockResolvedValue(['foo.json', 'podman-machine-default.json']);
 
     // mock readfile
     vi.mocked(fs.promises.readFile).mockResolvedValueOnce('{"Driver": "podman"}');

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -738,9 +738,12 @@ test('init', async () => {
 
   vi.spyOn(contributionManager, 'loadBase64Icon').mockResolvedValue('icon');
 
-  vi.mocked(fs.promises.readdir).mockResolvedValue([
-    { isDirectory: () => true, name: 'contrib1' } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
-    { isDirectory: () => true, name: 'contrib2' } as unknown as fs.Dirent<Buffer<ArrayBufferLike>>,
+  const readdirMock = vi.mocked(
+    fs.promises.readdir as (path: string, options?: { withFileTypes: true }) => Promise<fs.Dirent<string>[]>,
+  );
+  readdirMock.mockResolvedValue([
+    { isDirectory: () => true, name: 'contrib1' } as unknown as fs.Dirent<string>,
+    { isDirectory: () => true, name: 'contrib2' } as unknown as fs.Dirent<string>,
   ]);
 
   // initialize the contribution manager


### PR DESCRIPTION
### What does this PR do?
tests are mocking `fs.promises.readdir` but they cast return type as Buffer. Type has been changed in recent Node.js versions.
Code is providing the option `{ withFileTypes: true }` meaning that the expected return type is Dirent<string> so we should in the mock says that we return `Dirent<string>` or `string` if  `{ withFileTypes: false }` mode instead of mocking the first return type of the function( which is the invalid one

TLDR; use Dirent<string> or `string` as return type for `fs.promises.readdir` as the code is expecting it.

It'll allow to rollout the @types/node upgrade that is changing ArrayBuffer return type but this is not the one we should use anyway.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/14484

### How to test this PR?

Tests should be ✅ . Only tests are updated, main/extension code is still the same.

- [x] Tests are covering the bug fix or the new feature
