### PR TITLE
refactor(vitest.config): replace workspace by projects

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -25,11 +25,11 @@ const PODMAN_DESKTOP_EXCLUDED = [
 ];
 
 /**
- * vitest workspace configuration for unit tests
+ * vitest projects configuration for unit tests
  */
 export default defineConfig({
   test: {
-    workspace: [
+    projects: [
       '{extensions,packages,tools,storybook,website,scripts}/**/{vitest,vite}.config.{js,ts}',
       '!**/builtin/**',
     ],
@@ -37,7 +37,6 @@ export default defineConfig({
     reporters: process.env.CI ? [['junit', { includeConsoleOutput: false }], 'default'] : ['default'],
     outputFile: process.env.CI ? { junit: 'coverage/junit-results.xml' } : {},
     coverage: {
-      all: true,
       clean: true,
       excludeAfterRemap: true,
       provider: 'v8',


### PR DESCRIPTION
### What does this PR do?
workspace option is deprecated in v3.2 and is removed in v4 of vitest replace the usage
https://vitest.dev/guide/projects.html#test-projects

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

tests should still be ✅ 
- [x] Tests are covering the bug fix or the new feature
