### PR TITLE
refactor(extension/podman): move podman desktop elevated check to Base Check

### DIFF
--- a/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.spec.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { TelemetryLogger } from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { PowerShellClient } from '/@/utils/powershell';
+import { getPowerShellClient } from '/@/utils/powershell';
+
+import { PodmanDesktopElevatedCheck } from './podman-desktop-elevated-check';
+
+vi.mock(import('@podman-desktop/api'));
+vi.mock(import('../../utils/powershell'), () => ({
+  getPowerShellClient: vi.fn(),
+}));
+
+const mockTelemetryLogger = {} as TelemetryLogger;
+
+const POWERSHELL_CLIENT: PowerShellClient = {
+  isUserAdmin: vi.fn(),
+  isHyperVInstalled: vi.fn(),
+  isHyperVRunning: vi.fn(),
+  isVirtualMachineAvailable: vi.fn(),
+  isRunningElevated: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getPowerShellClient).mockResolvedValue(POWERSHELL_CLIENT);
+});
+
+test('expect PodmanDesktopElevatedCheck preflight check return failure result if Podman Desktop is not elevated', async () => {
+  vi.mocked(POWERSHELL_CLIENT.isRunningElevated).mockResolvedValue(false);
+
+  const podmanDesktopElevatedCheck = new PodmanDesktopElevatedCheck(mockTelemetryLogger);
+  const result = await podmanDesktopElevatedCheck.execute();
+  expect(result.successful).toBeFalsy();
+  expect(result.description).equal(
+    'You must run Podman Desktop with administrative rights to run Hyper-V Podman machines.',
+  );
+  expect(result.docLinks).toBeUndefined();
+});
+
+test('expect PodmanDesktopElevatedCheck preflight check return OK if Podman Desktop is elevated', async () => {
+  vi.mocked(POWERSHELL_CLIENT.isRunningElevated).mockResolvedValue(true);
+
+  const podmanDesktopElevatedCheck = new PodmanDesktopElevatedCheck(mockTelemetryLogger);
+  const result = await podmanDesktopElevatedCheck.execute();
+  expect(result.successful).toBeTruthy();
+  expect(result.description).toBeUndefined();
+  expect(result.docLinks).toBeUndefined();
+});

--- a/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { CheckResult, TelemetryLogger } from '@podman-desktop/api';
+import { inject, injectable } from 'inversify';
+
+import { BaseCheck } from '/@/checks/base-check';
+import { TelemetryLoggerSymbol } from '/@/inject/symbols';
+import { getPowerShellClient } from '/@/utils/powershell';
+
+@injectable()
+export class PodmanDesktopElevatedCheck extends BaseCheck {
+  title = 'Podman Desktop Elevated';
+
+  constructor(
+    @inject(TelemetryLoggerSymbol)
+    private telemetryLogger: TelemetryLogger,
+  ) {
+    super();
+  }
+
+  async execute(): Promise<CheckResult> {
+    const client = await getPowerShellClient(this.telemetryLogger);
+    if (!(await client.isRunningElevated())) {
+      return this.createFailureResult({
+        description: 'You must run Podman Desktop with administrative rights to run Hyper-V Podman machines.',
+      });
+    }
+    return this.createSuccessfulResult();
+  }
+}

--- a/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.ts
@@ -18,12 +18,12 @@
 import type { CheckResult, TelemetryLogger } from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
 
-import { BaseCheck } from '/@/checks/base-check';
+import { MemoizedBaseCheck } from '/@/checks/memoized-base-check';
 import { TelemetryLoggerSymbol } from '/@/inject/symbols';
 import { getPowerShellClient } from '/@/utils/powershell';
 
 @injectable()
-export class PodmanDesktopElevatedCheck extends BaseCheck {
+export class PodmanDesktopElevatedCheck extends MemoizedBaseCheck {
   title = 'Podman Desktop Elevated';
 
   constructor(
@@ -33,7 +33,7 @@ export class PodmanDesktopElevatedCheck extends BaseCheck {
     super();
   }
 
-  async execute(): Promise<CheckResult> {
+  async executeImpl(): Promise<CheckResult> {
     const client = await getPowerShellClient(this.telemetryLogger);
     if (!(await client.isRunningElevated())) {
       return this.createFailureResult({

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -24,6 +24,7 @@ import { HyperVCheck } from '/@/checks/windows/hyper-v-check';
 import { HyperVInstalledCheck } from '/@/checks/windows/hyper-v-installed-check';
 import { HyperVPodmanVersionCheck } from '/@/checks/windows/hyper-v-podman-version-check';
 import { HyperVRunningCheck } from '/@/checks/windows/hyper-v-running-check';
+import { PodmanDesktopElevatedCheck } from '/@/checks/windows/podman-desktop-elevated-check';
 import { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
 import { WinBitCheck } from '/@/checks/windows/win-bit-check';
 import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
@@ -69,6 +70,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(WSL2Check).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(HyperVRunningCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(HyperVInstalledCheck).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(PodmanDesktopElevatedCheck).toSelf().inSingletonScope();
 
     if (envAPI.isWindows) {
       this.#inversifyContainer.bind(Installer).to(WinInstaller).inSingletonScope();


### PR DESCRIPTION
### What does this PR do?

This PR does two things in two commits:
- it extracts the check that Podman Desktop is elevated in a class BaseCheck (1st commit)
- it converts the BaseCheck to a MemoizedBaseCheck for the performance issue on Windows (2nd commit)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for: 

https://github.com/podman-desktop/podman-desktop/issues/14296
https://github.com/podman-desktop/podman-desktop/issues/14294



<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
