### PR TITLE
fix(extension/podman): extract + memoize user admin check

### DIFF
--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-check.spec.ts
@@ -25,6 +25,7 @@ import { getPowerShellClient } from '../../utils/powershell';
 import { HyperVCheck } from './hyper-v-check';
 import type { HyperVInstalledCheck } from './hyper-v-installed-check';
 import type { HyperVRunningCheck } from './hyper-v-running-check';
+import type { UserAdminCheck } from './user-admin-check';
 
 vi.mock(import('@podman-desktop/api'));
 vi.mock(import('../../utils/powershell'), () => ({
@@ -35,6 +36,7 @@ const mockTelemetryLogger = {} as TelemetryLogger;
 const isHyperVRunningCheck = { execute: vi.fn() } as unknown as HyperVRunningCheck;
 const isHyperVInstalledCheck = { execute: vi.fn() } as unknown as HyperVInstalledCheck;
 const isPodmanDesktopElevatedCheck = { execute: vi.fn() } as unknown as PodmanDesktopElevatedCheck;
+const userAdminCheck = { execute: vi.fn() } as unknown as UserAdminCheck;
 
 const SUCCESSFUL_CHECK_RESULT: CheckResult = { successful: true };
 const FAILED_CHECK_RESULT: CheckResult = { successful: false };
@@ -57,21 +59,22 @@ beforeEach(() => {
     isHyperVRunningCheck,
     isHyperVInstalledCheck,
     isPodmanDesktopElevatedCheck,
+    userAdminCheck,
   );
 });
 
 test('expect HyperV preflight check return failure result if non admin user', async () => {
+  vi.mocked(userAdminCheck.execute).mockResolvedValue({
+    ...FAILED_CHECK_RESULT,
+    description: 'userAdminCheck',
+  });
   const result = await hyperVCheck.execute();
   expect(result.successful).toBeFalsy();
-  expect(result.description).equal('You must have administrative rights to run Hyper-V Podman machines');
-  expect(result.docLinks?.[0].url).equal(
-    'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
-  );
-  expect(result.docLinks?.[0].title).equal('Hyper-V Manual Installation Steps');
+  expect(result.description).equal('userAdminCheck');
 });
 
 test('expect HyperV preflight check return failure result if Podman Desktop is not run with elevated privileges', async () => {
-  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
+  vi.mocked(userAdminCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isPodmanDesktopElevatedCheck.execute).mockResolvedValue({
     ...FAILED_CHECK_RESULT,
     description: 'isPodmanDesktopElevatedCheck',
@@ -84,7 +87,7 @@ test('expect HyperV preflight check return failure result if Podman Desktop is n
 });
 
 test('expect HyperV preflight check return failure result if HyperV not installed', async () => {
-  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
+  vi.mocked(userAdminCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isPodmanDesktopElevatedCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isHyperVInstalledCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isHyperVInstalledCheck.execute).mockResolvedValue({
@@ -98,7 +101,7 @@ test('expect HyperV preflight check return failure result if HyperV not installe
 });
 
 test('expect HyperV preflight check return failure result if HyperV not running', async () => {
-  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
+  vi.mocked(userAdminCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isPodmanDesktopElevatedCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isHyperVInstalledCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isHyperVRunningCheck.execute).mockResolvedValue({
@@ -112,7 +115,7 @@ test('expect HyperV preflight check return failure result if HyperV not running'
 });
 
 test('expect HyperV preflight check return OK', async () => {
-  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
+  vi.mocked(userAdminCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isPodmanDesktopElevatedCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isHyperVInstalledCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
   vi.mocked(isHyperVRunningCheck.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);

--- a/extensions/podman/packages/extension/src/checks/windows/user-admin-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/user-admin-check.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { TelemetryLogger } from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { PowerShellClient } from '/@/utils/powershell';
+import { getPowerShellClient } from '/@/utils/powershell';
+
+import { UserAdminCheck } from './user-admin-check';
+
+vi.mock(import('@podman-desktop/api'));
+vi.mock(import('/@/utils/powershell'), () => ({
+  getPowerShellClient: vi.fn(),
+}));
+
+const mockTelemetryLogger = {} as TelemetryLogger;
+
+let userAdminCheck: UserAdminCheck;
+
+const POWERSHELL_CLIENT: PowerShellClient = {
+  isUserAdmin: vi.fn(),
+  isHyperVInstalled: vi.fn(),
+  isVirtualMachineAvailable: vi.fn(),
+  isRunningElevated: vi.fn(),
+  isHyperVRunning: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(getPowerShellClient).mockResolvedValue(POWERSHELL_CLIENT);
+  userAdminCheck = new UserAdminCheck(mockTelemetryLogger);
+});
+
+test('expect UserAdminCheck returns successful result if user is admin', async () => {
+  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(true);
+  const result = await userAdminCheck.execute();
+  expect(result.successful).toBeTruthy();
+  expect(result.description).toBeUndefined();
+});
+
+test('expect UserAdminCheck returns failure result if user is not admin', async () => {
+  vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(false);
+  const result = await userAdminCheck.execute();
+  expect(result.successful).toBeFalsy();
+  expect(result.description).equal('You must have administrative rights to run Hyper-V Podman machines');
+  expect(result.docLinks?.[0].url).equal(
+    'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
+  );
+  expect(result.docLinks?.[0].title).equal('Hyper-V Manual Installation Steps');
+});

--- a/extensions/podman/packages/extension/src/checks/windows/user-admin-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/user-admin-check.spec.ts
@@ -57,9 +57,6 @@ test('expect UserAdminCheck returns failure result if user is not admin', async 
   vi.mocked(POWERSHELL_CLIENT.isUserAdmin).mockResolvedValue(false);
   const result = await userAdminCheck.execute();
   expect(result.successful).toBeFalsy();
-  expect(result.description).equal('You must have administrative rights to run Hyper-V Podman machines');
-  expect(result.docLinks?.[0].url).equal(
-    'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
-  );
-  expect(result.docLinks?.[0].title).equal('Hyper-V Manual Installation Steps');
+  expect(result.description).equal('You must have administrative rights');
+  expect(result.docLinks?.[0]).toBeUndefined();
 });

--- a/extensions/podman/packages/extension/src/checks/windows/user-admin-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/user-admin-check.ts
@@ -18,13 +18,13 @@
 import type { CheckResult, TelemetryLogger } from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
 
-import { BaseCheck } from '/@/checks/base-check';
+import { MemoizedBaseCheck } from '/@/checks/memoized-base-check';
 import { HYPER_V_DOC_LINKS } from '/@/checks/windows/constants';
 import { TelemetryLoggerSymbol } from '/@/inject/symbols';
 import { getPowerShellClient } from '/@/utils/powershell';
 
 @injectable()
-export class UserAdminCheck extends BaseCheck {
+export class UserAdminCheck extends MemoizedBaseCheck {
   title = 'User is Administrator';
 
   constructor(
@@ -39,7 +39,7 @@ export class UserAdminCheck extends BaseCheck {
     return client.isUserAdmin();
   }
 
-  async execute(): Promise<CheckResult> {
+  async executeImpl(): Promise<CheckResult> {
     if (await this.isUserAdmin()) {
       return this.createSuccessfulResult();
     } else {

--- a/extensions/podman/packages/extension/src/checks/windows/user-admin-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/user-admin-check.ts
@@ -19,7 +19,6 @@ import type { CheckResult, TelemetryLogger } from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
 
 import { MemoizedBaseCheck } from '/@/checks/memoized-base-check';
-import { HYPER_V_DOC_LINKS } from '/@/checks/windows/constants';
 import { TelemetryLoggerSymbol } from '/@/inject/symbols';
 import { getPowerShellClient } from '/@/utils/powershell';
 
@@ -44,9 +43,7 @@ export class UserAdminCheck extends MemoizedBaseCheck {
       return this.createSuccessfulResult();
     } else {
       return this.createFailureResult({
-        description: 'You must have administrative rights to run Hyper-V Podman machines',
-        docLinksDescription: 'Contact your Administrator to setup Hyper-V.',
-        docLinks: HYPER_V_DOC_LINKS,
+        description: 'You must have administrative rights',
       });
     }
   }

--- a/extensions/podman/packages/extension/src/checks/windows/user-admin-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/user-admin-check.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { CheckResult, TelemetryLogger } from '@podman-desktop/api';
+import { inject, injectable } from 'inversify';
+
+import { BaseCheck } from '/@/checks/base-check';
+import { HYPER_V_DOC_LINKS } from '/@/checks/windows/constants';
+import { TelemetryLoggerSymbol } from '/@/inject/symbols';
+import { getPowerShellClient } from '/@/utils/powershell';
+
+@injectable()
+export class UserAdminCheck extends BaseCheck {
+  title = 'User is Administrator';
+
+  constructor(
+    @inject(TelemetryLoggerSymbol)
+    private telemetryLogger: TelemetryLogger,
+  ) {
+    super();
+  }
+
+  async isUserAdmin(): Promise<boolean> {
+    const client = await getPowerShellClient(this.telemetryLogger);
+    return client.isUserAdmin();
+  }
+
+  async execute(): Promise<CheckResult> {
+    if (await this.isUserAdmin()) {
+      return this.createSuccessfulResult();
+    } else {
+      return this.createFailureResult({
+        description: 'You must have administrative rights to run Hyper-V Podman machines',
+        docLinksDescription: 'Contact your Administrator to setup Hyper-V.',
+        docLinks: HYPER_V_DOC_LINKS,
+      });
+    }
+  }
+}

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -25,6 +25,7 @@ import { HyperVInstalledCheck } from '/@/checks/windows/hyper-v-installed-check'
 import { HyperVPodmanVersionCheck } from '/@/checks/windows/hyper-v-podman-version-check';
 import { HyperVRunningCheck } from '/@/checks/windows/hyper-v-running-check';
 import { PodmanDesktopElevatedCheck } from '/@/checks/windows/podman-desktop-elevated-check';
+import { UserAdminCheck } from '/@/checks/windows/user-admin-check';
 import { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
 import { WinBitCheck } from '/@/checks/windows/win-bit-check';
 import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
@@ -70,6 +71,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(WSL2Check).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(HyperVRunningCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(HyperVInstalledCheck).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(UserAdminCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(PodmanDesktopElevatedCheck).toSelf().inSingletonScope();
 
     if (envAPI.isWindows) {


### PR DESCRIPTION
### What does this PR do?

This PR does two things in two commits:
- it extracts the check that the user is an adminitrator in a class BaseCheck (1st commit)
- it converts the BaseCheck to a MemoizedBaseCheck for the performance issue on Windows (2nd commit)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14296

Required for: 

https://github.com/podman-desktop/podman-desktop/issues/14296
https://github.com/podman-desktop/podman-desktop/issues/14294



<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
