### PR TITLE
perf(extensions/podman): check user admin only when not wsl 

### DIFF
--- a/extensions/podman/packages/extension/src/checks/windows/wsl2-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/wsl2-check.ts
@@ -55,14 +55,12 @@ export class WSL2Check extends MemoizedBaseCheck {
 
   async executeImpl(): Promise<CheckResult> {
     try {
-      const userAdminResult = await this.userAdminCheck.execute();
-      const isAdmin = userAdminResult.successful;
-
       const isWSL = await this.isWSLPresent();
       const isRebootNeeded = await this.isRebootNeeded();
 
       if (!isWSL) {
-        if (isAdmin) {
+        const userAdminResult = await this.userAdminCheck.execute();
+        if (userAdminResult.successful) {
           return this.createFailureResult({
             description: 'WSL2 is not installed.',
             docLinksDescription: `Call 'wsl --install --no-distribution' in a terminal.`,


### PR DESCRIPTION
### What does this PR do?

This PR optimizes a bit the Podman extension by moving the check for user admin rights only when WSL2 machine is not present.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

This is a follow up of comment https://github.com/podman-desktop/podman-desktop/pull/14722#discussion_r2486713756

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
