### PR TITLE
fix(preferences): replace share icon with info icon

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowUpRightFromSquare, faGear, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { faCircleInfo, faGear, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import type { ContainerProviderConnection } from '@podman-desktop/api';
 import { Button, DropdownMenu, EmptyScreen, Tooltip } from '@podman-desktop/ui-svelte';
 import { Buffer } from 'buffer';
@@ -544,7 +544,7 @@ $effect(() => {
                           container.name,
                         ).toString('base64')}/${Buffer.from(container.endpoint.socketPath).toString('base64')}/summary`,
                       )}>
-                    <Fa icon={faArrowUpRightFromSquare} />
+                    <Fa icon={faCircleInfo} />
                   </button>
                 </Tooltip>
               </div>
@@ -552,7 +552,7 @@ $effect(() => {
                 {container.displayName}
                 {#if rootfulInfo}
                   <span class="ml-2 text-sm text-[var(--pd-content-sub-header)]">
-                    (<BooleanEnumDisplay 
+                    (<BooleanEnumDisplay
                       value={rootfulInfo.value}
                       options={rootfulInfo.enum ?? []}
                       ariaLabel="{rootfulInfo.description}: {rootfulInfo.value}" />)
@@ -664,7 +664,7 @@ $effect(() => {
                           kubeConnection.endpoint.apiURL,
                         ).toString('base64')}/summary`,
                       )}>
-                    <Fa icon={faArrowUpRightFromSquare} />
+                    <Fa icon={faCircleInfo} />
                   </button>
                 </Tooltip>
               </div>
@@ -700,7 +700,7 @@ $effect(() => {
                     router.goto(
                       `/preferences/vm-connection/${provider.internalId}/${vmConnection.name}/terminal`,
                     )}>
-                  <Fa icon={faArrowUpRightFromSquare} />
+                  <Fa icon={faCircleInfo} />
                 </button>
               </Tooltip>
             </div>


### PR DESCRIPTION
This replaces the share icon `faArrowUpRightFromSquare` with the info icon `faCircleInfo` in the Resources settings.

### What does this PR do?

<img width="1700" height="1428" alt="CleanShot 2025-11-03 at 19 51 35@2x" src="https://github.com/user-attachments/assets/39687d64-ec33-4f98-9008-0fb96f0734e2" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13587

### How to test this PR?

1. Go to Settings → Resources
2. Observe the new icon, following the screenshot above.

- [ ] Tests are covering the bug fix or the new feature – **only icon changes present**

/c @MariaLeonova – do you agree with the icon?