### PR TITLE
refactor(extension: podman): caching mechanism for `podman --version`

### DIFF
--- a/extensions/podman/packages/extension/src/checks/detection-checks.ts
+++ b/extensions/podman/packages/extension/src/checks/detection-checks.ts
@@ -18,7 +18,8 @@
 
 import type * as extensionApi from '@podman-desktop/api';
 
-import type { InstalledPodman } from '../utils/podman-cli';
+import type { InstalledPodman } from '/@/utils/podman-binary';
+
 import { getCustomBinaryPath, getInstallationPath } from '../utils/podman-cli';
 
 export function getDetectionChecks(installedPodman?: InstalledPodman): extensionApi.ProviderDetectionCheck[] {

--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.spec.ts
@@ -18,13 +18,15 @@
 
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { getPodmanInstallation } from '../../utils/podman-cli';
+import type { PodmanBinary } from '/@/utils/podman-binary';
+
 import { HyperVPodmanVersionCheck } from './hyper-v-podman-version-check';
 
 vi.mock(import('@podman-desktop/api'));
-vi.mock(import('../../utils/podman-cli'), () => ({
-  getPodmanInstallation: vi.fn(),
-}));
+
+const podmanBinaryMock: PodmanBinary = {
+  getBinaryInfo: vi.fn(),
+} as unknown as PodmanBinary;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -49,11 +51,11 @@ test.each<SuccessfulTestCase>([
     version: '5.3.0-dev',
   },
 ])('$name', async ({ version }) => {
-  vi.mocked(getPodmanInstallation).mockResolvedValue({
+  vi.mocked(podmanBinaryMock.getBinaryInfo).mockResolvedValue({
     version: version,
   });
 
-  const hyperVPodmanVersionCheck = new HyperVPodmanVersionCheck();
+  const hyperVPodmanVersionCheck = new HyperVPodmanVersionCheck(podmanBinaryMock);
   const result = await hyperVPodmanVersionCheck.execute();
 
   expect(result.successful).toBeTruthy();
@@ -77,10 +79,10 @@ test.each<FailureTestCase>([
     version: '4.4.0',
   },
 ])('$name', async ({ version, errorDescription }) => {
-  vi.mocked(getPodmanInstallation).mockResolvedValue({
+  vi.mocked(podmanBinaryMock.getBinaryInfo).mockResolvedValue({
     version: version,
   });
-  const hyperVPodmanVersionCheck = new HyperVPodmanVersionCheck();
+  const hyperVPodmanVersionCheck = new HyperVPodmanVersionCheck(podmanBinaryMock);
   const result = await hyperVPodmanVersionCheck.execute();
   expect(result.successful).toBeFalsy();
   expect(result.description).equal(errorDescription);

--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.ts
@@ -17,15 +17,23 @@
  ********************************************************************/
 import type { CheckResult } from '@podman-desktop/api';
 import { compareVersions } from 'compare-versions';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 
-import { getPodmanInstallation } from '../../utils/podman-cli';
+import { PodmanBinary } from '/@/utils/podman-binary';
+
 import { BaseCheck } from '../base-check';
 
 @injectable()
 export class HyperVPodmanVersionCheck extends BaseCheck {
   title = 'Minimum Podman Version for Hyper-V';
   static readonly PODMAN_MINIMUM_VERSION_FOR_HYPERV = '5.2.0';
+
+  constructor(
+    @inject(PodmanBinary)
+    private readonly podmanBinary: PodmanBinary,
+  ) {
+    super();
+  }
 
   async execute(): Promise<CheckResult> {
     const isPodmanVersionSupported = await this.isPodmanVersionSupported();
@@ -38,10 +46,8 @@ export class HyperVPodmanVersionCheck extends BaseCheck {
   }
 
   private async isPodmanVersionSupported(): Promise<boolean> {
-    const installedPodman = await getPodmanInstallation();
-    if (installedPodman?.version) {
-      return compareVersions(installedPodman?.version, HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
-    }
-    return false;
+    const binaryInfo = await this.podmanBinary.getBinaryInfo();
+    if (!binaryInfo) return false;
+    return compareVersions(binaryInfo?.version, HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
   }
 }

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -39,6 +39,7 @@ import { MacOSInstaller } from '/@/installer/mac-os-installer';
 import { PodmanInstall } from '/@/installer/podman-install';
 import { WinInstaller } from '/@/installer/win-installer';
 import { WinPlatform } from '/@/platforms/win-platform';
+import { PodmanBinary } from '/@/utils/podman-binary';
 
 import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from './symbols';
 
@@ -60,6 +61,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(TelemetryLoggerSymbol).toConstantValue(this.#telemetryLogger);
     this.#inversifyContainer.bind(PodmanInstall).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WinPlatform).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(PodmanBinary).toSelf().inSingletonScope();
 
     this.#inversifyContainer.bind(WinBitCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WinVersionCheck).toSelf().inSingletonScope();

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -21,10 +21,11 @@ import * as fs from 'node:fs';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { InstalledPodman, PodmanBinary } from '/@/utils/podman-binary';
+
 import * as extensionObj from '../extension';
 import { releaseNotes } from '../podman5.json';
 import { getBundledPodmanVersion } from '../utils/podman-bundled';
-import type { InstalledPodman } from '../utils/podman-cli';
 import type { PodmanInfo } from '../utils/podman-info';
 import * as utils from '../utils/util';
 import type { Installer } from './installer';
@@ -73,6 +74,9 @@ const INSTALLER_MOCK: Installer = {} as unknown as Installer;
 const PROVIDER_CLEANUP_MOCK = {
   getActions: vi.fn(),
 } as unknown as extensionApi.ProviderCleanup;
+const PODMAN_BINARY_MOCK: PodmanBinary = {
+  getBinaryInfo: vi.fn(),
+} as unknown as PodmanBinary;
 
 // mock filesystem
 vi.mock('node:fs');
@@ -111,9 +115,15 @@ vi.mock(import('../utils/util'), async () => {
 let podmanInstall: TestPodmanInstall;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
 
-  podmanInstall = new TestPodmanInstall(extensionContext, mockTelemetryLogger, INSTALLER_MOCK, PROVIDER_CLEANUP_MOCK);
+  podmanInstall = new TestPodmanInstall(
+    extensionContext,
+    mockTelemetryLogger,
+    INSTALLER_MOCK,
+    PROVIDER_CLEANUP_MOCK,
+    PODMAN_BINARY_MOCK,
+  );
   // reset array of subscriptions
   extensionContext.subscriptions.length = 0;
   console.error = consoleErrorMock;
@@ -403,6 +413,9 @@ describe('performUpdate', () => {
 });
 
 test('check that podman installation refreshed machine settings', async () => {
+  vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({
+    version: '5.0.0',
+  });
   vi.spyOn(podmanInstall, 'getLastRunInfo').mockResolvedValue({
     lastUpdateCheck: 0,
     podmanVersion: '5.0.0',
@@ -412,7 +425,6 @@ test('check that podman installation refreshed machine settings', async () => {
   // mock existSync being always false (we never find installers)
   vi.spyOn(fs, 'existsSync').mockReturnValue(false);
   vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Yes');
-  vi.mocked(extensionApi.process.exec).mockResolvedValue({ command: '', stderr: '', stdout: '5.0.0' });
   const mock = vi.spyOn(extensionObj, 'calcPodmanMachineSetting');
 
   await podmanInstall.checkForUpdate(undefined);

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -31,6 +31,7 @@ import {
 } from '/@/constants';
 import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 import { MachineJSON } from '/@/types';
+import { InstalledPodman, PodmanBinary } from '/@/utils/podman-binary';
 
 import { getDetectionChecks } from '../checks/detection-checks';
 import {
@@ -43,8 +44,7 @@ import {
 } from '../extension';
 import * as podman5JSON from '../podman5.json';
 import { getBundledPodmanVersion } from '../utils/podman-bundled';
-import type { InstalledPodman } from '../utils/podman-cli';
-import { getPodmanCli, getPodmanInstallation } from '../utils/podman-cli';
+import { getPodmanCli } from '../utils/podman-cli';
 import type { PodmanInfo } from '../utils/podman-info';
 import { PodmanInfoImpl } from '../utils/podman-info';
 import { Installer } from './installer';
@@ -72,6 +72,8 @@ export class PodmanInstall {
     @inject(ProviderCleanupSymbol)
     @optional()
     readonly providerCleanup: extensionApi.ProviderCleanup | undefined,
+    @inject(PodmanBinary)
+    readonly podmanBinary: PodmanBinary,
   ) {
     this.storagePath = extensionContext.storagePath;
   }
@@ -88,7 +90,7 @@ export class PodmanInstall {
     );
     if (dialogResult === 'Yes') {
       await this.installBundledPodman();
-      const newInstalledPodman = await getPodmanInstallation();
+      const newInstalledPodman = await this.podmanBinary.getBinaryInfo();
       // write podman version
       if (newInstalledPodman) {
         this.podmanInfo.podmanVersion = newInstalledPodman.version;

--- a/extensions/podman/packages/extension/src/utils/podman-binary.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-binary.spec.ts
@@ -1,0 +1,169 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import {
+  configuration as configurationAPI,
+  type Disposable,
+  process as processAPI,
+  type RunError,
+} from '@podman-desktop/api';
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PodmanBinary } from '/@/utils/podman-binary';
+
+vi.mock(import('/@/utils/podman-cli'));
+vi.mock('@podman-desktop/api', () => ({
+  process: {
+    exec: vi.fn(),
+  },
+  configuration: {
+    onDidChangeConfiguration: vi.fn(),
+  },
+}));
+
+const disposableMock: Disposable = {
+  dispose: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(processAPI.exec).mockResolvedValue({
+    stdout: 'podman version 5.6.2',
+    stderr: '',
+    command: '',
+  });
+  vi.mocked(configurationAPI.onDidChangeConfiguration).mockReturnValue(disposableMock);
+});
+
+test('PodmanBinary#getBinaryInfo should resolve undefined when processAPI.exec throw an error', async () => {
+  vi.mocked(processAPI.exec).mockRejectedValue({
+    exitCode: 1,
+    command: '',
+    stderr: '',
+    stdout: '',
+    killed: false,
+    name: 'error',
+  } as RunError);
+
+  const binary = new PodmanBinary();
+  const info = await binary.getBinaryInfo();
+  expect(info).toBeUndefined();
+});
+
+test('PodmanBinary#getBinaryInfo should cache the exec result', async () => {
+  const binary = new PodmanBinary();
+  const info = await binary.getBinaryInfo();
+  expect(processAPI.exec).toHaveBeenCalledOnce();
+  expect(info?.version).toEqual('5.6.2');
+
+  // call again
+  await binary.getBinaryInfo();
+  // assert the exec is not called again
+  expect(processAPI.exec).toHaveBeenCalledOnce();
+});
+
+test('PodmanBinary#invalidate should reset the cache', async () => {
+  const binary = new PodmanBinary();
+  const info = await binary.getBinaryInfo();
+  expect(processAPI.exec).toHaveBeenCalledOnce();
+  expect(info?.version).toEqual('5.6.2');
+
+  // invalidate the cache
+  binary.invalidate();
+
+  // update version stdout
+  vi.mocked(processAPI.exec).mockResolvedValue({
+    stdout: 'podman version 5.6.3',
+    stderr: '',
+    command: '',
+  });
+  const nInfo = await binary.getBinaryInfo();
+  expect(nInfo?.version).toEqual('5.6.3');
+
+  // ensure we call twice
+  expect(processAPI.exec).toHaveBeenCalledTimes(2);
+});
+
+describe('PodmanBinary#init', () => {
+  test('should register listener for configuration#onDidChangeConfiguration', () => {
+    const binary = new PodmanBinary();
+
+    expect(configurationAPI.onDidChangeConfiguration).not.toHaveBeenCalled();
+    binary.init();
+
+    expect(configurationAPI.onDidChangeConfiguration).toHaveBeenCalledOnce();
+  });
+
+  test('should call invalidate when appropriate configuration is changed', async () => {
+    const binary = new PodmanBinary();
+    binary.init();
+
+    // call once
+    const nInfo = await binary.getBinaryInfo();
+    expect(nInfo?.version).toEqual('5.6.2');
+
+    // get the onDidChangeConfiguration listener
+    const listener = vi.mocked(configurationAPI.onDidChangeConfiguration).mock.calls[0]?.[0];
+    assert(listener, 'listener should be registered with init');
+
+    listener({
+      affectsConfiguration: () => true,
+    });
+
+    // call again
+    await binary.getBinaryInfo();
+
+    // ensure we call twice
+    expect(processAPI.exec).toHaveBeenCalledTimes(2);
+  });
+
+  test('should not call invalidate when non affected configuration is changed', async () => {
+    const binary = new PodmanBinary();
+    binary.init();
+
+    // call once
+    const nInfo = await binary.getBinaryInfo();
+    expect(nInfo?.version).toEqual('5.6.2');
+
+    // get the onDidChangeConfiguration listener
+    const listener = vi.mocked(configurationAPI.onDidChangeConfiguration).mock.calls[0]?.[0];
+    assert(listener, 'listener should be registered with init');
+
+    listener({
+      affectsConfiguration: () => false,
+    });
+
+    // call again
+    await binary.getBinaryInfo();
+
+    // ensure we call once
+    expect(processAPI.exec).toHaveBeenCalledOnce();
+  });
+});
+
+test('PodmanBinary#dispose should unregister listener', () => {
+  const binary = new PodmanBinary();
+  binary.init();
+
+  expect(configurationAPI.onDidChangeConfiguration).toHaveBeenCalledOnce();
+  expect(disposableMock.dispose).not.toHaveBeenCalled();
+
+  binary.dispose();
+  expect(disposableMock.dispose).toHaveBeenCalledOnce();
+});

--- a/extensions/podman/packages/extension/src/utils/podman-binary.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-binary.ts
@@ -1,0 +1,82 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { configuration as configurationAPI, Disposable, process as processAPI } from '@podman-desktop/api';
+import { injectable, postConstruct, preDestroy } from 'inversify';
+
+import { getPodmanCli } from '/@/utils/podman-cli';
+
+export interface InstalledPodman {
+  version: string;
+}
+
+@injectable()
+export class PodmanBinary implements Disposable {
+  #cli: InstalledPodman | undefined = undefined;
+  #configurationDisposable: Disposable | undefined = undefined;
+
+  /**
+   * Given a path to a podman binary, return the version of podman
+   */
+  protected async getPodmanVersion(path: string): Promise<string> {
+    const { stdout: versionOut } = await processAPI.exec(path, ['--version']);
+    const versionArr = versionOut.split(' ');
+    return versionArr[versionArr.length - 1];
+  }
+
+  public invalidate(): void {
+    this.#cli = undefined;
+  }
+
+  /**
+   * The result will be undefined when we can't find podman installation
+   */
+  public async getBinaryInfo(): Promise<InstalledPodman | undefined> {
+    if (this.#cli) {
+      return this.#cli;
+    }
+    const path = getPodmanCli();
+    try {
+      const version = await this.getPodmanVersion(path);
+      this.#cli = {
+        version,
+      };
+      return this.#cli;
+    } catch (err: unknown) {
+      // no podman binary
+      return undefined;
+    }
+  }
+
+  @postConstruct()
+  init(): void {
+    /**
+     * If the user changed the podman binary path, we need to invalidate the cache
+     */
+    this.#configurationDisposable = configurationAPI.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration('podman.binary.path')) {
+        this.invalidate();
+      }
+    });
+  }
+
+  @preDestroy()
+  dispose(): void {
+    this.#configurationDisposable?.dispose();
+    this.#configurationDisposable = undefined;
+  }
+}

--- a/extensions/podman/packages/extension/src/utils/podman-cli.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.ts
@@ -105,19 +105,3 @@ export function getPodmanCli(): string {
 export function getCustomBinaryPath(): string | undefined {
   return extensionApi.configuration.getConfiguration('podman').get('binary.path');
 }
-
-export interface InstalledPodman {
-  version: string;
-}
-
-export async function getPodmanInstallation(): Promise<InstalledPodman | undefined> {
-  try {
-    const { stdout: versionOut } = await extensionApi.process.exec(getPodmanCli(), ['--version']);
-    const versionArr = versionOut.split(' ');
-    const version = versionArr[versionArr.length - 1];
-    return { version };
-  } catch (err) {
-    // no podman binary
-    return undefined;
-  }
-}

--- a/extensions/podman/packages/extension/src/utils/util.ts
+++ b/extensions/podman/packages/extension/src/utils/util.ts
@@ -20,7 +20,9 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
-import { findPodmanInstallations, getCustomBinaryPath, getPodmanCli, type InstalledPodman } from './podman-cli';
+import type { InstalledPodman } from '/@/utils/podman-binary';
+
+import { findPodmanInstallations, getCustomBinaryPath, getPodmanCli } from './podman-cli';
 
 const xdgDataDirectory = '.local/share/containers';
 export function appHomeDir(): string {


### PR DESCRIPTION
### What does this PR do?

Currently, everytime a function inside the podman extension needs to know the podman version, it calls `getPodmanInstallation` which exec `podman --version` internally.

Good news :tada: -  We can cache this information !

Addressing
- https://github.com/podman-desktop/podman-desktop/issues/11535
- https://github.com/podman-desktop/podman-desktop/issues/13280
- https://github.com/podman-desktop/podman-desktop/issues/10356

Every ~1200ms the `podman --version` command is ran, which lead to a lot of process spawned here is a video demonstrating on main

https://github.com/user-attachments/assets/7a17d59f-c7ee-4424-90f6-142522d4e754

> You can reproduce by adding `console.log('[DEBUG] Exec#exec', command, args);` in the following function
> https://github.com/podman-desktop/podman-desktop/blob/08f1e32c5aeb648fcfa3cb39a73c2fabb46082de/packages/main/src/plugin/util/exec.ts#L50

### Review Notes 

I separated the PR in several commits, this try to provide some separation of concern while getting the PR testable (don't hesitate to give feedback) or ask to split in several PR if this is not okay or worst (?)

**:information_source: Important commits**

-  (823922add935b6921223811816ada920f09ec06b) introduce PodmanBinary class: this adds the PodmanBinary, which is the class that will replace the `getPodmanInstallation`, this commit only adds the class and corresponding tests
-  (abd2855ac4068fdaef823aa17955e7568d263808) add PodmanBinary to inversify bindings: simply add a new line in the InversifyBinding class.

The 3 following commits replace step by step the usage of `getPodmanInstallation` with the `PodmanBinary#getPodmanInstallation` in dedicated part of the extension.

The last one is some cleanup!

:warning: there are two moments where the cache is invalidate =>
- :one:  if the user is installing / updating podman
- :two:  if the user modify the podman binary path in the preferences

:red_circle: out of scope of this PR the `podman machine list` that run every 5 seconds (this is a way more complicated issue)

### Screenshot / video of UI

| Before | After |
| --- | --- |
| <img width="531" height="633" alt="image" src="https://github.com/user-attachments/assets/c0527cc3-48ec-405a-ab53-ebf4a10e996f" /> | <img width="635" height="916" alt="image" src="https://github.com/user-attachments/assets/92bf9ba4-0a22-4d8c-8bbe-25fc52efd658" /> |

https://github.com/user-attachments/assets/c541414c-29c1-47ab-be4a-77a4ed613aba

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13777

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

The easiest way to test this PR is to add a console.log (E.g. `console.log('[DEBUG] Exec#exec', command, args);`)  inside the exec class

https://github.com/podman-desktop/podman-desktop/blob/08f1e32c5aeb648fcfa3cb39a73c2fabb46082de/packages/main/src/plugin/util/exec.ts#L50

Then, start Podman Desktop, and ensure we do not see `podman --version` every ~1200ms

You can also check that when changing the path of podman, we will run again the `podman --version`, as the user may have specified an absolute path, we invalidate the cache.