### PR TITLE
refactor(configuration): replace node:fs with node:fs/promises

### DIFF
--- a/packages/main/src/plugin/default-configuration.spec.ts
+++ b/packages/main/src/plugin/default-configuration.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { promises as fsPromises } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -24,7 +24,7 @@ import { DefaultConfiguration } from './default-configuration.js';
 import type { Directories } from './directories.js';
 
 // mock the fs module
-vi.mock('node:fs');
+vi.mock('node:fs/promises');
 
 let defaultConfiguration: DefaultConfiguration;
 const getManagedDefaultsDirectoryMock = vi.fn();
@@ -42,7 +42,7 @@ describe('DefaultConfiguration', () => {
   test('should load managed defaults when file exists', async () => {
     getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
     const managedDefaults = { 'managed.setting': 'managedValue' };
-    vi.mocked(fsPromises.readFile).mockResolvedValue(JSON.stringify(managedDefaults));
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(managedDefaults));
 
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -57,7 +57,7 @@ describe('DefaultConfiguration', () => {
     getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
     const error = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
     error.code = 'ENOENT';
-    vi.mocked(fsPromises.readFile).mockRejectedValue(error);
+    vi.mocked(readFile).mockRejectedValue(error);
 
     const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
 
@@ -70,7 +70,7 @@ describe('DefaultConfiguration', () => {
 
   test('should handle corrupted managed defaults file gracefully', async () => {
     getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
-    vi.mocked(fsPromises.readFile).mockResolvedValue('invalid json');
+    vi.mocked(readFile).mockResolvedValue('invalid json');
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -87,7 +87,7 @@ describe('DefaultConfiguration', () => {
   test('should load managed defaults configuration with valid JSON', async () => {
     getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
     const managedDefaults = { 'managed.setting': 'managedValue', 'another.setting': 'anotherValue' };
-    vi.mocked(fsPromises.readFile).mockResolvedValue(JSON.stringify(managedDefaults));
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(managedDefaults));
 
     const result = await defaultConfiguration.getContent();
 

--- a/packages/main/src/plugin/default-configuration.ts
+++ b/packages/main/src/plugin/default-configuration.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as fs from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { inject, injectable } from 'inversify';
@@ -39,7 +39,7 @@ export class DefaultConfiguration {
     // It's important that we at least log to console what is happening here, as it's common for logs
     // to be shared when there are issues loading "managed-by" defaults, so having this information in the logs is useful.
     try {
-      const managedDefaultsContent = await fs.promises.readFile(managedDefaultsFile, 'utf-8');
+      const managedDefaultsContent = await readFile(managedDefaultsFile, 'utf-8');
       managedDefaultsData = JSON.parse(managedDefaultsContent);
       console.log(`[Managed-by]: Loaded managed defaults from: ${managedDefaultsFile}`);
     } catch (error) {


### PR DESCRIPTION
refactor(configuration): replace node:fs with node:fs/promises

### What does this PR do?    
    
Use the correct import when using node:fs/promise instead of node:fs    
importing.    
    
This means we aren't loading the entire module on load.    
    
### Screenshot / video of UI    
    
<!-- If this PR is changing UI, please include    
screenshots or screencasts showing the difference -->    
    
N/A    
    
### What issues does this PR fix or reference?    
    
<!-- Include any related issues from Podman Desktop    
repository (or from another issue tracker). -->    
    
Part of https://github.com/podman-desktop/podman-desktop/issues/13894    
    
### How to test this PR?    
    
<!-- Please explain steps to verify the functionality,                                                                                                                                                                                    
do not forget to provide unit/component tests -->    
    
- [X] Tests are covering the bug fix or the new feature   