### PR TITLE
refactor: add protocol when using the validator isURL utility for adding a registry host

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -820,7 +820,8 @@ export class ImageRegistry {
     const urlOptions = {
       require_tld: false,
     };
-    const isUrl = validator.default.isURL(serviceUrl, urlOptions);
+    // Validate the URL using http prefix protocol (to satisfy the validator)
+    const isUrl = validator.default.isURL(`http://${serviceUrl}`, urlOptions);
 
     // Check if the URL is undefined or not a valid URL
     if (serviceUrl === undefined || !isUrl) {


### PR DESCRIPTION
### What does this PR do?
newer versions of the library expect to have a protocol (like http or https) to ensure the given entry is working, add the prefix only to validate the URL

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related: https://github.com/podman-desktop/podman-desktop/security/dependabot/118

### How to test this PR?

should work as before when adding registries
- [x] Tests are covering the bug fix or the new feature
