### PR TITLE
feat(kind): add dynamic availability check for cluster creation

### DIFF
--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
@@ -25,7 +25,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ContextUI } from '/@/lib/context/context';
 import ProviderUpdateButton from '/@/lib/dashboard/ProviderUpdateButton.svelte';
-import type { ProviderInfo } from '/@api/provider-info';
+import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 import ProviderActionButtons from './ProviderActionButtons.svelte';
 
@@ -67,6 +67,28 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+function renderProviderActionButtons(
+  provider: ProviderInfo,
+  overrides?: {
+    globalContext?: ContextUI;
+    providerInstallationInProgress?: boolean;
+    onCreateNew?: (provider: ProviderInfo, displayName: string) => Promise<void>;
+    onUpdatePreflightChecks?: (checks: CheckStatus[]) => void;
+    isOnboardingEnabled?: (provider: ProviderInfo, context: ContextUI) => boolean;
+    hasAnyConfiguration?: (provider: ProviderInfo) => boolean;
+  },
+): ReturnType<typeof render> {
+  return render(ProviderActionButtons, {
+    provider,
+    globalContext: overrides?.globalContext ?? mockGlobalContext,
+    providerInstallationInProgress: overrides?.providerInstallationInProgress ?? false,
+    onCreateNew: overrides?.onCreateNew ?? vi.fn(),
+    onUpdatePreflightChecks: overrides?.onUpdatePreflightChecks ?? vi.fn(),
+    isOnboardingEnabled: overrides?.isOnboardingEnabled ?? vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: overrides?.hasAnyConfiguration ?? vi.fn().mockReturnValue(false),
+  });
+}
+
 describe('ProviderActionButtons', () => {
   test('shows only Setup button in onboarding mode when provider is not-installed', async () => {
     const provider: ProviderInfo = {
@@ -77,12 +99,7 @@ describe('ProviderActionButtons', () => {
     const isOnboardingEnabled = vi.fn().mockReturnValue(true);
     const hasAnyConfiguration = vi.fn().mockReturnValue(false);
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
+    renderProviderActionButtons(provider, {
       isOnboardingEnabled,
       hasAnyConfiguration,
     });
@@ -103,12 +120,7 @@ describe('ProviderActionButtons', () => {
     const isOnboardingEnabled = vi.fn().mockReturnValue(true);
     const hasAnyConfiguration = vi.fn().mockReturnValue(false);
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
+    renderProviderActionButtons(provider, {
       isOnboardingEnabled,
       hasAnyConfiguration,
     });
@@ -126,14 +138,8 @@ describe('ProviderActionButtons', () => {
 
     const isOnboardingEnabled = vi.fn().mockReturnValue(true);
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
+    renderProviderActionButtons(provider, {
       isOnboardingEnabled,
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
     });
 
     const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
@@ -151,13 +157,7 @@ describe('ProviderActionButtons', () => {
 
     const hasAnyConfiguration = vi.fn().mockReturnValue(true);
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    renderProviderActionButtons(provider, {
       hasAnyConfiguration,
     });
 
@@ -174,15 +174,7 @@ describe('ProviderActionButtons', () => {
       containerProviderConnectionCreationDisplayName: 'Podman Machine',
     };
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
-    });
+    renderProviderActionButtons(provider);
 
     const createButton = screen.getByRole('button', {
       name: `Create new ${provider.containerProviderConnectionCreationDisplayName}`,
@@ -198,15 +190,7 @@ describe('ProviderActionButtons', () => {
       containerProviderConnectionCreationDisplayName: 'Podman Machine',
     };
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
-    });
+    renderProviderActionButtons(provider);
 
     const createButton = screen.getByText('Initialize ...');
     expect(createButton).toBeInTheDocument();
@@ -219,15 +203,7 @@ describe('ProviderActionButtons', () => {
       kubernetesProviderConnectionCreationDisplayName: 'Kind Cluster',
     };
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
-    });
+    renderProviderActionButtons(provider);
 
     const createButton = screen.getByRole('button', {
       name: `Create new ${provider.kubernetesProviderConnectionCreationDisplayName}`,
@@ -242,15 +218,7 @@ describe('ProviderActionButtons', () => {
       vmProviderConnectionCreationDisplayName: 'Lima VM',
     };
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
-    });
+    renderProviderActionButtons(provider);
 
     const createButton = screen.getByRole('button', {
       name: `Create new ${provider.vmProviderConnectionCreationDisplayName}`,
@@ -267,14 +235,8 @@ describe('ProviderActionButtons', () => {
 
     const onCreateNew = vi.fn();
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
+    renderProviderActionButtons(provider, {
       onCreateNew,
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
     });
 
     const createButton = screen.getByRole('button', {
@@ -291,14 +253,8 @@ describe('ProviderActionButtons', () => {
       containerProviderConnectionCreation: true,
     };
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
+    renderProviderActionButtons(provider, {
       providerInstallationInProgress: true,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
     });
 
     const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
@@ -313,14 +269,8 @@ describe('ProviderActionButtons', () => {
 
     const isOnboardingEnabled = vi.fn().mockReturnValue(true);
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
+    renderProviderActionButtons(provider, {
       isOnboardingEnabled,
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
     });
 
     const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
@@ -335,13 +285,7 @@ describe('ProviderActionButtons', () => {
 
     const hasAnyConfiguration = vi.fn().mockReturnValue(true);
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    renderProviderActionButtons(provider, {
       hasAnyConfiguration,
     });
 
@@ -358,15 +302,7 @@ describe('ProviderActionButtons', () => {
       },
     };
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
-    });
+    renderProviderActionButtons(provider);
 
     expect(ProviderUpdateButton).toHaveBeenCalled();
   });
@@ -380,15 +316,7 @@ describe('ProviderActionButtons', () => {
       },
     };
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
-    });
+    renderProviderActionButtons(provider);
 
     expect(ProviderUpdateButton).not.toHaveBeenCalled();
   });
@@ -404,14 +332,8 @@ describe('ProviderActionButtons', () => {
 
     const onUpdatePreflightChecks = vi.fn();
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
+    renderProviderActionButtons(provider, {
       onUpdatePreflightChecks,
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
     });
 
     expect(ProviderUpdateButton).toHaveBeenCalledWith(
@@ -435,13 +357,7 @@ describe('ProviderActionButtons', () => {
 
     const hasAnyConfiguration = vi.fn().mockReturnValue(true);
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    renderProviderActionButtons(provider, {
       hasAnyConfiguration,
     });
 
@@ -464,15 +380,7 @@ describe('ProviderActionButtons', () => {
       containerProviderConnectionCreation: true,
     };
 
-    render(ProviderActionButtons, {
-      provider,
-      globalContext: mockGlobalContext,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
-      isOnboardingEnabled: vi.fn().mockReturnValue(false),
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
-    });
+    renderProviderActionButtons(provider);
 
     const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
     expect(createButton).toBeInTheDocument();
@@ -486,14 +394,9 @@ describe('ProviderActionButtons', () => {
 
     const isOnboardingEnabled = vi.fn().mockReturnValue(true);
 
-    render(ProviderActionButtons, {
-      provider,
+    renderProviderActionButtons(provider, {
       globalContext: undefined,
-      providerInstallationInProgress: false,
-      onCreateNew: vi.fn(),
-      onUpdatePreflightChecks: vi.fn(),
       isOnboardingEnabled,
-      hasAnyConfiguration: vi.fn().mockReturnValue(false),
     });
 
     // Should not show onboarding Setup button (because globalContext is undefined)
@@ -501,5 +404,87 @@ describe('ProviderActionButtons', () => {
     // Should either not exist or be in regular mode (not onboarding mode)
     // In this case, the component should show regular buttons mode
     expect(setupButtons.length).toBeLessThanOrEqual(1);
+  });
+
+  test('kubernetesProviderConnectionCreation shows enabled button with correct tooltip when provider status is ready', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      status: 'ready',
+      kubernetesProviderConnectionCreation: true,
+      kubernetesProviderConnectionCreationDisplayName: 'Kind Cluster',
+    };
+
+    renderProviderActionButtons(provider);
+
+    const createButton = screen.getByRole('button', {
+      name: `Create new ${provider.kubernetesProviderConnectionCreationDisplayName}`,
+    });
+    expect(createButton).toBeInTheDocument();
+    expect(createButton).toBeEnabled();
+
+    // Hover over the tooltip trigger to display the tooltip
+    const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+    await userEvent.hover(tooltipTrigger);
+
+    // Check tooltip text shows "Create new Kind Cluster"
+    const tooltip = await screen.findByLabelText('tooltip');
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip.textContent).toBe(`Create new ${provider.kubernetesProviderConnectionCreationDisplayName}`);
+  });
+
+  test.each([
+    {
+      status: 'stopped' as const,
+      warnings: [{ name: 'Provider Warning', details: 'Kubernetes provider is not running' }],
+      expectedTooltip: 'Kubernetes provider is not running',
+      description: 'warning tooltip when provider status is not ready',
+    },
+    {
+      status: 'not-installed' as const,
+      warnings: [],
+      expectedTooltip: 'Provider not ready',
+      description: 'default warning when provider status is not ready and no warnings',
+    },
+    {
+      status: 'unknown' as const,
+      warnings: [],
+      expectedTooltip: 'Provider not ready',
+      description: 'disabled button when provider status is unknown',
+    },
+    {
+      status: 'started' as const,
+      warnings: [],
+      expectedTooltip: 'Provider not ready',
+      description: 'disabled button when provider status is started',
+    },
+  ])('kubernetesProviderConnectionCreation shows disabled button with $description', async ({
+    status,
+    warnings,
+    expectedTooltip,
+  }) => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      status,
+      kubernetesProviderConnectionCreation: true,
+      kubernetesProviderConnectionCreationDisplayName: 'Kind Cluster',
+      warnings,
+    };
+
+    renderProviderActionButtons(provider);
+
+    const createButton = screen.getByRole('button', {
+      name: `Create new ${provider.kubernetesProviderConnectionCreationDisplayName}`,
+    });
+    expect(createButton).toBeInTheDocument();
+    expect(createButton).toBeDisabled();
+
+    // Hover over the tooltip trigger to display the tooltip
+    const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+    await userEvent.hover(tooltipTrigger);
+
+    // Check tooltip text
+    const tooltip = await screen.findByLabelText('tooltip');
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip.textContent).toBe(expectedTooltip);
   });
 });

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
@@ -68,6 +68,12 @@ const showSetupButton = $derived(
 
 const showUpdateButton = $derived(provider.updateInfo?.version && provider.version !== provider.updateInfo?.version);
 
+const isDisabled = $derived(provider.kubernetesProviderConnectionCreation && provider.status !== 'ready');
+
+const tooltipText = $derived(
+  isDisabled ? (provider.warnings?.[0]?.details ?? 'Provider not ready') : `Create new ${providerDisplayName}`,
+);
+
 function handleCreateNew(): Promise<void> {
   return onCreateNew(provider, providerDisplayName);
 }
@@ -92,9 +98,10 @@ function handleSetup(): void {
   {:else}
     <div class="flex flex-row justify-around flex-wrap gap-2">
       {#if showCreateNewButton}
-        <Tooltip bottom tip="Create new {providerDisplayName}">
+        <Tooltip bottom tip={tooltipText}>
           <Button
             aria-label="Create new {providerDisplayName}"
+            disabled={isDisabled}
             inProgress={providerInstallationInProgress}
             onclick={handleCreateNew}>
             {buttonTitle} ...


### PR DESCRIPTION
### What does this PR do?

Adds dynamic availability checking for Kubernetes provider connection creation. The Kind extension now checks for running container providers and disables the "Create Kind Cluster" button when prerequisites are not met, showing a contextual error message to the user.

The implementation leverages provider status management and connection auditing. The Kind extension monitors container connection lifecycle events (`onDidUpdateContainerConnection`, `onDidRegisterContainerConnection`, `onDidUnregisterContainerConnection`) to dynamically update its provider status and warnings. The UI layer reacts to provider status changes, disabling creation buttons and performing real-time connection parameter audits to surface prerequisite errors before the user initiates creation.

### Screenshot / video of UI

- Disable **Create new ...**  button if Podman machine is not running

<img width="1162" height="981" src="https://github.com/user-attachments/assets/1e2090ef-ae6d-4f0c-9e58-4d4628d2cedf" />

- Disable create new Kind cluster form, when Podman machine is stopped

<img width="1162" height="981" src="https://github.com/user-attachments/assets/7b2ef75a-0e91-4748-9da6-b864815fa859" />

- Enable **Create new ...**  button if Podman machine is running

<img width="1162" height="981" src="https://github.com/user-attachments/assets/976548b8-b66b-4abf-b088-32f357f28ca5" />


### What issues does this PR fix or reference?

fixes #14145 

### How to test this PR?

1. Start Podman Desktop without any running container providers or stop the Podman machine
2. Navigate to Kind section
3. Verify "Create new ..." button is disabled with appropriate error message
4. Start a container provider (e.g., Podman machine)
5. Verify button becomes enabled


- [x] Tests are covering the bug fix or the new feature
