### PR TITLE
chore: add telemetry for explore feature tiles

### DIFF
--- a/packages/renderer/src/lib/explore-features/ExploreFeatureCard.spec.ts
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatureCard.spec.ts
@@ -20,7 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { ExploreFeature } from '/@api/explore-feature';
 
@@ -47,6 +47,10 @@ const featureMock: ExploreFeature = {
 };
 
 const closeFeature = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 test('expect feature card to have all Feature properties', async () => {
   const { rerender } = render(ExploreFeatureCard, { feature: featureMock, closeFeature: closeFeature });
@@ -83,6 +87,9 @@ test('Click on close card', async () => {
 
   expect(closeFeature).toHaveBeenCalledWith('feature1');
   expect(window.closeFeatureCard).toHaveBeenCalledWith('feature1');
+  expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('dashboard.exploreFeatureDismissed', {
+    feature: 'Feature 1',
+  });
 });
 
 test('Click on learn more link', async () => {
@@ -104,6 +111,9 @@ test('Click on primary button', async () => {
 
   await fireEvent.click(primaryButton);
 
+  expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('dashboard.exploreFeatureClicked', {
+    feature: 'Feature 1',
+  });
   expect(router.goto).toHaveBeenCalledWith(featureMock.buttonLink);
 });
 

--- a/packages/renderer/src/lib/explore-features/ExploreFeatureCard.spec.ts
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatureCard.spec.ts
@@ -88,7 +88,7 @@ test('Click on close card', async () => {
   expect(closeFeature).toHaveBeenCalledWith('feature1');
   expect(window.closeFeatureCard).toHaveBeenCalledWith('feature1');
   expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('dashboard.exploreFeatureDismissed', {
-    feature: 'Feature 1',
+    feature: 'feature1',
   });
 });
 

--- a/packages/renderer/src/lib/explore-features/ExploreFeatureCard.svelte
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatureCard.svelte
@@ -24,6 +24,16 @@ async function openTutorial(): Promise<void> {
 async function closeCard(): Promise<void> {
   closeFeature(feature.id);
   await window.closeFeatureCard(feature.id);
+  await window.telemetryTrack('dashboard.exploreFeatureDismissed', {
+    feature: feature.title,
+  });
+}
+
+async function handleAction(): Promise<void> {
+  await window.telemetryTrack('dashboard.exploreFeatureClicked', {
+    feature: feature.title,
+  });
+  router.goto(feature.buttonLink);
 }
 </script>
 
@@ -42,7 +52,7 @@ async function closeCard(): Promise<void> {
       <Link class="flex flex-row w-fit" onclick={openLearnMore}>Learn more <Icon class="ml-1 self-center" icon={faUpRightFromSquare}/></Link>
     {/if}
     <div class="flex flex-row justify-start items-end flex-1 pt-4 gap-2">
-      <Button type="primary" icon={feature.buttonIcon} onclick={(): void => router.goto(feature.buttonLink)} title={feature.buttonTitle}
+      <Button type="primary" icon={feature.buttonIcon} onclick={handleAction} title={feature.buttonTitle}
         >{feature.buttonTitle}</Button>
       {#if feature.tutorialLink}
         <Button type="secondary" icon={faCirclePlay} onclick={openTutorial} title="Watch Tutorial">Watch Tutorial</Button>

--- a/packages/renderer/src/lib/explore-features/ExploreFeatureCard.svelte
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatureCard.svelte
@@ -25,7 +25,7 @@ async function closeCard(): Promise<void> {
   closeFeature(feature.id);
   await window.closeFeatureCard(feature.id);
   await window.telemetryTrack('dashboard.exploreFeatureDismissed', {
-    feature: feature.title,
+    feature: feature.id,
   });
 }
 


### PR DESCRIPTION
this pr adds telemetry for clicking on the primary action for the card and for closing the card

Assisted-by: Cursor claude sonnet 4.5

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/14401

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Test are included!

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
