### PR TITLE
feat: route with typed parameters

### DIFF
--- a/packages/renderer/src/Route.spec.ts
+++ b/packages/renderer/src/Route.spec.ts
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { createRouteObject } from 'tinro/dist/tinro_lib';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import RouteSpec from '/@/RouteSpec.svelte';
+import RouteWithRequestSpec from '/@/RouteWithRequestSpec.svelte';
+
+vi.mock(import('tinro/dist/tinro_lib'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('renders the route with request parser', async () => {
+  vi.mocked(createRouteObject).mockImplementation(() => {
+    return {
+      update: vi.fn(),
+    };
+  });
+  const myParser = (request: {
+    query: Record<string, string>;
+    params: Record<string, string>;
+  }): { id: number; label: string } => {
+    return {
+      id: +request?.params?.id,
+      label: request?.query?.label || '',
+    };
+  };
+  render(RouteWithRequestSpec, {
+    requestParser: myParser,
+  });
+
+  expect(createRouteObject).toHaveBeenCalled();
+  const { onShow, onHide, onMeta } = createRouteObject.mock.calls[0][0];
+  onMeta({
+    query: { label: 'mylabel' },
+    params: { id: '123' },
+  });
+  onShow();
+  const expectedText = /{"id":123,"label":"mylabel"}/;
+  await vi.waitFor(() => {
+    screen.getByText(expectedText);
+  });
+  onHide();
+  await vi.waitFor(() => {
+    expect(screen.queryByText(expectedText)).not.toBeInTheDocument();
+  });
+});
+
+test('renders the route without request parser', async () => {
+  vi.mocked(createRouteObject).mockImplementation(() => {
+    return {
+      update: vi.fn(),
+    };
+  });
+  render(RouteSpec, {});
+
+  expect(createRouteObject).toHaveBeenCalled();
+  const { onShow, onHide, onMeta } = createRouteObject.mock.calls[0][0];
+  onMeta({
+    query: { label: 'mylabel' },
+    params: { id: '123' },
+  });
+  onShow();
+  const expectedText = /a content/;
+  await vi.waitFor(() => {
+    screen.getByText(expectedText);
+  });
+  onHide();
+  await vi.waitFor(() => {
+    expect(screen.queryByText(expectedText)).not.toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -20,7 +20,7 @@ export let requestParser:
 let showContent = false;
 let params: Record<string, string> = {};
 let meta: TinroRouteMeta = {} as TinroRouteMeta;
-let request: T = {} as T;
+let request: T | undefined = undefined;
 
 const route = createRouteObject({
   fallback,
@@ -78,7 +78,7 @@ $: route.update({
   breadcrumb,
 });
 
-$: request = requestParser && meta ? requestParser(meta) : ({} as T);
+$: request = requestParser && meta ? requestParser(meta) : undefined;
 
 onDestroy(() => {
   TelemetryService.getService().handlePageClose();

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" generics="Request">
+<script lang="ts" generics="T">
 import { onDestroy } from 'svelte';
 import type { TinroBreadcrumb, TinroRouteMeta } from 'tinro';
 import { createRouteObject } from 'tinro/dist/tinro_lib';
@@ -14,13 +14,13 @@ export let firstmatch = false;
 export let breadcrumb: string | undefined = undefined;
 export let navigationHint: NavigationHint | undefined = undefined;
 export let requestParser:
-  | ((request: { query: Record<string, string>; params: Record<string, string> }) => Request)
+  | ((request: { query: Record<string, string>; params: Record<string, string> }) => T)
   | undefined = undefined;
 
 let showContent = false;
 let params: Record<string, string> = {};
 let meta: TinroRouteMeta = {} as TinroRouteMeta;
-let request: Request = {} as Request;
+let request: T = {} as T;
 
 const route = createRouteObject({
   fallback,
@@ -78,7 +78,7 @@ $: route.update({
   breadcrumb,
 });
 
-$: request = requestParser && meta ? requestParser(meta) : ({} as Request);
+$: request = requestParser && meta ? requestParser(meta) : ({} as T);
 
 onDestroy(() => {
   TelemetryService.getService().handlePageClose();

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang="ts" generics="Request">
 import { onDestroy } from 'svelte';
 import type { TinroBreadcrumb, TinroRouteMeta } from 'tinro';
 import { createRouteObject } from 'tinro/dist/tinro_lib';
@@ -13,10 +13,14 @@ export let redirect = false;
 export let firstmatch = false;
 export let breadcrumb: string | undefined = undefined;
 export let navigationHint: NavigationHint | undefined = undefined;
+export let requestParser:
+  | ((request: { query: Record<string, string>; params: Record<string, string> }) => Request)
+  | undefined = undefined;
 
 let showContent = false;
 let params: Record<string, string> = {};
 let meta: TinroRouteMeta = {} as TinroRouteMeta;
+let request: Request = {} as Request;
 
 const route = createRouteObject({
   fallback,
@@ -74,11 +78,13 @@ $: route.update({
   breadcrumb,
 });
 
+$: request = requestParser && meta ? requestParser(meta) : ({} as Request);
+
 onDestroy(() => {
   TelemetryService.getService().handlePageClose();
 });
 </script>
 
 {#if showContent}
-  <slot params={params} meta={meta} />
+  <slot params={params} meta={meta} request={request} />
 {/if}

--- a/packages/renderer/src/RouteSpec.svelte
+++ b/packages/renderer/src/RouteSpec.svelte
@@ -1,0 +1,4 @@
+<script lang="ts">
+import Route from './Route.svelte';
+</script>
+<Route>a content</Route>

--- a/packages/renderer/src/RouteWithRequestSpec.svelte
+++ b/packages/renderer/src/RouteWithRequestSpec.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+import Route from './Route.svelte';
+
+export let requestParser: (request: { query: Record<string, string>; params: Record<string, string> }) => unknown;
+</script>
+<Route requestParser={requestParser} let:request={request}>{JSON.stringify(request)}</Route>


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds a `requestParser` to the `Route`, to be able to get typed parameters from the URL.

```
<script lang="ts">
import Route from './Route.svelte';

function requestParser: (request: { query: Record<string, string>; params: Record<string, string> }): { id: number, label: string } {
  return {
    id: +request?.params?.id,
    label: request?.query?.label || '',
  };
};
</script>
<Route requestParser={requestParser} let:request={request}>
{request.id}: {request.label}
</Route>
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #14743 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
