### PR TITLE
fix: remove quotes for Hide menu

### DIFF
--- a/packages/main/src/navigation-items-menu-builder.spec.ts
+++ b/packages/main/src/navigation-items-menu-builder.spec.ts
@@ -53,7 +53,7 @@ describe('buildHideMenuItem', async () => {
     getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
 
     const menu = navigationItemsMenuBuilder.buildHideMenuItem('Hello');
-    expect(menu?.label).toBe(`Hide 'Hello'`);
+    expect(menu?.label).toBe(`Hide Hello`);
     expect(menu?.click).toBeDefined();
     expect(menu?.visible).toBe(true);
 

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -72,7 +72,7 @@ export class NavigationItemsMenuBuilder {
     const itemDisplayName = this.escapeLabel(itemName);
 
     const item: MenuItemConstructorOptions = {
-      label: `Hide '${itemDisplayName}'`,
+      label: `Hide ${itemDisplayName}`,
       visible: true,
       click: (): void => {
         // flag the item as being disabled


### PR DESCRIPTION
Relates to #14788

### What does this PR do?

Remove the quotes in the Hide context menu

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

#14788 

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
