### PR TITLE
chore(test): waiting for podman machine startup after failure

### DIFF
--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -122,13 +122,14 @@ test.afterAll(async ({ runner, page, navigationBar }) => {
 });
 
 // eslint-disable-next-line no-empty-pattern
-test.afterEach(async ({}, testInfo) => {
+test.afterEach(async ({ page }, testInfo) => {
   if (testInfo.status !== testInfo.expectedStatus) {
     console.log(`Test "${testInfo.title}" has status ${testInfo.status}... Performing podman machine cleanup`);
 
     try {
       await resetPodmanMachinesFromCLI();
       await createPodmanMachineFromCLI();
+      await waitForPodmanMachineStartup(page);
     } catch (error) {
       console.log('Error occurred while resetting podman machines', error);
     }


### PR DESCRIPTION
### What does this PR do?
Waits for podman machine to reach running state after recreation.

### What issues does this PR fix or reference?

