### PR TITLE
chore(windows): update folder name managed-by config, add space

### DIFF
--- a/packages/main/src/plugin/managed-by-constants.ts
+++ b/packages/main/src/plugin/managed-by-constants.ts
@@ -28,5 +28,5 @@ export const SYSTEM_LOCKED_FILENAME = 'locked.json';
 
 // Folders for managed defaults on different platforms
 export const SYSTEM_DEFAULTS_FOLDER_MACOS = '/Library/Application Support/io.podman_desktop.PodmanDesktop';
-export const SYSTEM_DEFAULTS_FOLDER_WINDOWS = 'PodmanDesktop';
+export const SYSTEM_DEFAULTS_FOLDER_WINDOWS = 'Podman Desktop';
 export const SYSTEM_DEFAULTS_FOLDER_LINUX = '/usr/share/podman-desktop';


### PR DESCRIPTION
chore(windows): update folder name managed-by config, add space 

### What does this PR do?

The systems defaults folder should have a space for Windows
(`%PROGRAMDATA%`) as we use the following for our normal configuration:

`~/AppData/Roaming/Podman Desktop`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A, follow up to managed-by changes

### How to test this PR?

Will work like before, but just getting the settings from `Podman
Desktop` rather than `PodmanDesktop`.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
