### PR TITLE
chore: update network icon in empty network page

### DIFF
--- a/packages/renderer/src/lib/network/NetworkEmptyScreen.svelte
+++ b/packages/renderer/src/lib/network/NetworkEmptyScreen.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
-import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
+
+import NetworkIcon from '/@/lib/images/NetworkIcon.svelte';
 
 const firstNetwork = 'my-first-network';
 const commandLine = `podman network create ${firstNetwork}`;
 </script>
 
 <EmptyScreen
-  icon={ContainerIcon}
+  icon={NetworkIcon}
   title="No networks"
   message="Create your first network using the following command line:"
   commandline={commandLine}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR updates the icon in the empty network page to be the new network icon
Needs to be rebased after https://github.com/podman-desktop/podman-desktop/pull/14459 is merged

### Screenshot / video of UI
<img width="945" height="721" alt="Screenshot 2025-11-10 at 9 37 45 AM" src="https://github.com/user-attachments/assets/10452ad5-5f82-473b-8124-e4e0c2f3288c" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
