### PR TITLE
chore(tests,ui): adding aria-labels to task manager item elements

### DIFF
--- a/packages/renderer/src/lib/task-manager/LegacyTaskManagerItem.svelte
+++ b/packages/renderer/src/lib/task-manager/LegacyTaskManagerItem.svelte
@@ -61,7 +61,7 @@ async function doExecuteAction(task: TaskInfo): Promise<void> {
 </script>
 
 <!-- Display a task item-->
-<div class="flex flew-row w-full py-2">
+<div class="flex flew-row w-full py-2" title="Task Item">
   <!-- first column is the icon-->
   <div class="flex w-3 flex-col {iconColor}">
     <div class="align-top" role="img" aria-label="{task.status} icon of task {task.name}">
@@ -78,7 +78,7 @@ async function doExecuteAction(task: TaskInfo): Promise<void> {
     {/if}
   </div>
   <!-- second column is about the task-->
-  <div class="flex flex-col w-full pl-2">
+  <div class="flex flex-col w-full pl-2" title="Task Content">
     <div class="flex flex-row w-full">
       <div title={task.name} class="w-60 pb-1 cursor-default truncate text-[var(--pd-modal-text)]">
         {task.name}
@@ -100,7 +100,10 @@ async function doExecuteAction(task: TaskInfo): Promise<void> {
         </div>
       {/if}
     {:else if task.error}
-      <div class:hidden={!showError} class="text-xs my-2 break-words text-[var(--pd-modal-text)]">
+      <div
+        class:hidden={!showError}
+        class="text-xs my-2 break-words text-[var(--pd-modal-text)]"
+        role="status">
         {task.error}
       </div>
     {/if}
@@ -132,7 +135,10 @@ async function doExecuteAction(task: TaskInfo): Promise<void> {
     <!-- if failed task, display the error-->
     {#if task.status === 'failure'}
       <div class="flex flex-col w-full items-end">
-        <button on:click={(): boolean => (showError = !showError)} class="text-[var(--pd-button-secondary)] text-xs">
+        <button
+          class="text-[var(--pd-button-secondary)] text-xs"
+          on:click={(): boolean => (showError = !showError)}
+          aria-expanded={showError}>
           View Error
           {#if showError}
             <i class="fas fa-chevron-up"></i>


### PR DESCRIPTION
### What does this PR do?
* Adds ARIA functionality to Task Manager Item objects (view error button and error text)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/14841
https://github.com/containers/podman-desktop-extension-ai-lab/issues/3854
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
