### PR TITLE
refactor(provider-registry): use discriminated unions in getMatchingConnectionFromProvider

### DIFF
--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -43,6 +43,7 @@ import type {
 import type {
   CheckStatus,
   PreflightChecksCallback,
+  ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
   ProviderKubernetesConnectionInfo,
   ProviderVmConnectionInfo,
@@ -481,6 +482,182 @@ test('expect isProviderContainerConnection returns false with a ProviderKubernet
   };
   const res = providerRegistry.isProviderContainerConnection(connection);
   expect(res).toBe(false);
+});
+
+describe('getMatchingConnectionFromProvider', () => {
+  test('should return container connection for connectionType: container', async () => {
+    const provider = providerRegistry.createProvider('id', 'name', {
+      id: 'internal',
+      name: 'internal',
+      status: 'installed',
+    });
+
+    const containerConnection: ProviderContainerConnectionInfo = {
+      connectionType: 'container',
+      name: 'test-container',
+      displayName: 'Test Container',
+      type: 'docker',
+      endpoint: { socketPath: '/test.sock' },
+      status: 'started',
+    } as ProviderContainerConnectionInfo;
+
+    provider.registerContainerProviderConnection({
+      name: 'test-container',
+      displayName: 'Test Container',
+      type: 'docker',
+      endpoint: { socketPath: '/test.sock' },
+      status: () => 'started',
+    });
+
+    const connection = providerRegistry.getMatchingConnectionFromProvider(
+      (provider as unknown as { internalId: string }).internalId,
+      containerConnection,
+    );
+    expect(connection).toBeDefined();
+    expect(providerRegistry.isContainerConnection(connection)).toBe(true);
+  });
+
+  test('should return kubernetes connection for connectionType: kubernetes', async () => {
+    const provider = providerRegistry.createProvider('id2', 'name2', {
+      id: 'internal2',
+      name: 'internal2',
+      status: 'installed',
+    });
+
+    const kubernetesConnection: ProviderKubernetesConnectionInfo = {
+      connectionType: 'kubernetes',
+      name: 'test-k8s',
+      endpoint: { apiURL: 'https://localhost:6443' },
+      status: 'started',
+    } as ProviderKubernetesConnectionInfo;
+
+    provider.registerKubernetesProviderConnection({
+      name: 'test-k8s',
+      endpoint: { apiURL: 'https://localhost:6443' },
+      status: () => 'started',
+    });
+
+    const connection = providerRegistry.getMatchingConnectionFromProvider(
+      (provider as unknown as { internalId: string }).internalId,
+      kubernetesConnection,
+    );
+    expect(connection).toBeDefined();
+    expect(providerRegistry.isKubernetesConnection(connection)).toBe(true);
+  });
+
+  test('should return vm connection for connectionType: vm', async () => {
+    const provider = providerRegistry.createProvider('id3', 'name3', {
+      id: 'internal3',
+      name: 'internal3',
+      status: 'installed',
+    });
+
+    const vmConnection: ProviderVmConnectionInfo = {
+      connectionType: 'vm',
+      name: 'test-vm',
+      status: 'started',
+    } as ProviderVmConnectionInfo;
+
+    provider.registerVmProviderConnection({
+      name: 'test-vm',
+      status: () => 'started',
+    });
+
+    const connection = providerRegistry.getMatchingConnectionFromProvider(
+      (provider as unknown as { internalId: string }).internalId,
+      vmConnection,
+    );
+    expect(connection).toBeDefined();
+    expect(providerRegistry.isContainerConnection(connection)).toBe(false);
+    expect(providerRegistry.isKubernetesConnection(connection)).toBe(false);
+  });
+
+  test('should throw error for missing connectionType', async () => {
+    const provider = providerRegistry.createProvider('id4', 'name4', {
+      id: 'internal4',
+      name: 'internal4',
+      status: 'installed',
+    });
+
+    const invalidConnection = {
+      name: 'test-invalid',
+      status: 'started',
+    } as ProviderConnectionInfo;
+
+    expect(() => {
+      providerRegistry.getMatchingConnectionFromProvider(
+        (provider as unknown as { internalId: string }).internalId,
+        invalidConnection,
+      );
+    }).toThrow('Unable to determine connection type');
+  });
+
+  test('should throw error when connection not found', async () => {
+    const provider = providerRegistry.createProvider('id5', 'name5', {
+      id: 'internal5',
+      name: 'internal5',
+      status: 'installed',
+    });
+
+    provider.registerContainerProviderConnection({
+      name: 'existing-container',
+      displayName: 'Existing',
+      type: 'docker',
+      endpoint: { socketPath: '/existing.sock' },
+      status: () => 'started',
+    });
+
+    const nonExistentConnection: ProviderContainerConnectionInfo = {
+      connectionType: 'container',
+      name: 'non-existent',
+      displayName: 'Non Existent',
+      type: 'docker',
+      endpoint: { socketPath: '/nonexistent.sock' },
+      status: 'started',
+    } as ProviderContainerConnectionInfo;
+
+    expect(() => {
+      providerRegistry.getMatchingConnectionFromProvider(
+        (provider as unknown as { internalId: string }).internalId,
+        nonExistentConnection,
+      );
+    }).toThrow();
+  });
+});
+describe('isProviderVmConnectionInfo', () => {
+  test('should return true for VM connection info', async () => {
+    const connection: ProviderVmConnectionInfo = {
+      connectionType: 'vm',
+      name: 'test-vm',
+      status: 'started',
+    } as ProviderVmConnectionInfo;
+    const result = providerRegistry.isProviderVmConnectionInfo(connection);
+    expect(result).toBe(true);
+  });
+
+  test('should return false for container connection info', async () => {
+    const connection: ProviderContainerConnectionInfo = {
+      connectionType: 'container',
+      name: 'test-container',
+      displayName: 'Test',
+      type: 'docker',
+      endpoint: { socketPath: '/test.sock' },
+      status: 'started',
+    } as ProviderContainerConnectionInfo;
+    const result = providerRegistry.isProviderVmConnectionInfo(connection);
+    expect(result).toBe(false);
+  });
+
+  test('should return false for kubernetes connection info', async () => {
+    const connection: ProviderKubernetesConnectionInfo = {
+      connectionType: 'kubernetes',
+      name: 'test-k8s',
+      endpoint: { apiURL: 'https://localhost:6443' },
+      status: 'started',
+    } as ProviderKubernetesConnectionInfo;
+    const result = providerRegistry.isProviderVmConnectionInfo(connection);
+    expect(result).toBe(false);
+  });
 });
 
 describe('a Kubernetes provider is registered', async () => {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1097,28 +1097,60 @@ export class ProviderRegistry {
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderConnectionInfo | ContainerProviderConnection,
   ): ProviderConnection {
+    // Check if this is a ProviderConnectionInfo with connectionType discriminator
+    if ('connectionType' in providerContainerConnectionInfo) {
+      const info = providerContainerConnectionInfo as ProviderConnectionInfo;
+      switch (info.connectionType) {
+        case 'container':
+          return this.getMatchingContainerConnectionFromProvider(internalProviderId, info);
+        case 'kubernetes':
+          return this.getMatchingKubernetesConnectionFromProvider(internalProviderId, info);
+        case 'vm':
+          return this.getMatchingVmConnectionFromProvider(internalProviderId, info);
+        default: {
+          const _exhaustiveCheck: never = info;
+          throw new Error(`Unknown connection type: ${JSON.stringify(_exhaustiveCheck)}`);
+        }
+      }
+    }
+
+    // Fallback for ContainerProviderConnection (API object without connectionType)
     if (this.isProviderContainerConnection(providerContainerConnectionInfo)) {
       return this.getMatchingContainerConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
-    } else if (this.isProviderKubernetesConnectionInfo(providerContainerConnectionInfo)) {
-      return this.getMatchingKubernetesConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
-    } else {
-      return this.getMatchingVmConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
     }
+
+    throw new Error(`Unable to determine connection type for provider ${internalProviderId}`);
   }
 
   isProviderContainerConnection(
     connection: ProviderConnectionInfo | ContainerProviderConnection,
   ): connection is ProviderContainerConnectionInfo | ContainerProviderConnection {
-    return (connection as ProviderContainerConnectionInfo).endpoint?.socketPath !== undefined;
+    // Check connectionType discriminator first if available
+    if ('connectionType' in connection) {
+      return connection.connectionType === 'container';
+    }
+    // Fallback to structural check for ContainerProviderConnection
+    return (connection as ContainerProviderConnection).endpoint?.socketPath !== undefined;
   }
 
   isProviderKubernetesConnectionInfo(
     connection: ProviderConnectionInfo | ContainerProviderConnection,
   ): connection is ProviderKubernetesConnectionInfo {
+    // Check connectionType discriminator first if available
+    if ('connectionType' in connection) {
+      return connection.connectionType === 'kubernetes';
+    }
+    // Fallback to structural check
     return (
       !this.isProviderContainerConnection(connection) &&
       (connection as ProviderKubernetesConnectionInfo).endpoint !== undefined
     );
+  }
+
+  isProviderVmConnectionInfo(
+    connection: ProviderConnectionInfo | ContainerProviderConnection,
+  ): connection is ProviderVmConnectionInfo {
+    return 'connectionType' in connection && connection.connectionType === 'vm';
   }
 
   isContainerConnection(connection: ProviderConnection): connection is ContainerProviderConnection {

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1098,28 +1098,60 @@ export class ProviderRegistry {
     internalProviderId: string,
     providerContainerConnectionInfo: ProviderConnectionInfo | ContainerProviderConnection,
   ): ProviderConnection {
+    // Check if this is a ProviderConnectionInfo with connectionType discriminator
+    if ('connectionType' in providerContainerConnectionInfo) {
+      const info = providerContainerConnectionInfo as ProviderConnectionInfo;
+      switch (info.connectionType) {
+        case 'container':
+          return this.getMatchingContainerConnectionFromProvider(internalProviderId, info);
+        case 'kubernetes':
+          return this.getMatchingKubernetesConnectionFromProvider(internalProviderId, info);
+        case 'vm':
+          return this.getMatchingVmConnectionFromProvider(internalProviderId, info);
+        default: {
+          const _exhaustiveCheck: never = info;
+          throw new Error(`Unknown connection type: ${JSON.stringify(_exhaustiveCheck)}`);
+        }
+      }
+    }
+
+    // Fallback for ContainerProviderConnection (API object without connectionType)
     if (this.isProviderContainerConnection(providerContainerConnectionInfo)) {
       return this.getMatchingContainerConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
-    } else if (this.isProviderKubernetesConnectionInfo(providerContainerConnectionInfo)) {
-      return this.getMatchingKubernetesConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
-    } else {
-      return this.getMatchingVmConnectionFromProvider(internalProviderId, providerContainerConnectionInfo);
     }
+
+    throw new Error(`Unable to determine connection type for provider ${internalProviderId}`);
   }
 
   isProviderContainerConnection(
     connection: ProviderConnectionInfo | ContainerProviderConnection,
   ): connection is ProviderContainerConnectionInfo | ContainerProviderConnection {
-    return (connection as ProviderContainerConnectionInfo).endpoint?.socketPath !== undefined;
+    // Check connectionType discriminator first if available
+    if ('connectionType' in connection) {
+      return connection.connectionType === 'container';
+    }
+    // Fallback to structural check for ContainerProviderConnection
+    return (connection as ContainerProviderConnection).endpoint?.socketPath !== undefined;
   }
 
   isProviderKubernetesConnectionInfo(
     connection: ProviderConnectionInfo | ContainerProviderConnection,
   ): connection is ProviderKubernetesConnectionInfo {
+    // Check connectionType discriminator first if available
+    if ('connectionType' in connection) {
+      return connection.connectionType === 'kubernetes';
+    }
+    // Fallback to structural check
     return (
       !this.isProviderContainerConnection(connection) &&
       (connection as ProviderKubernetesConnectionInfo).endpoint !== undefined
     );
+  }
+
+  isProviderVmConnectionInfo(
+    connection: ProviderConnectionInfo | ContainerProviderConnection,
+  ): connection is ProviderVmConnectionInfo {
+    return 'connectionType' in connection && connection.connectionType === 'vm';
   }
 
   isContainerConnection(connection: ProviderConnection): connection is ContainerProviderConnection {


### PR DESCRIPTION
## What does this PR do?

Refactors `getMatchingConnectionFromProvider` to use discriminated unions with explicit type checking, eliminating the unsafe fallback condition.

## Dependencies

 **This PR depends on #14839** ( Please review and merge that PR first as it adds the `connectionType` discriminators that this PR uses.)

## Changes

-  Replace if-else fallback with explicit `switch` statement on `connectionType`
-  Add TypeScript exhaustiveness checking in default case
-  Add `isProviderVmConnectionInfo` type guard for VM connections
-  Update `isProviderContainerConnection` and `isProviderKubernetesConnectionInfo` to check `connectionType` first
-  Add 8 comprehensive tests:
  - Test container connection matching
  - Test kubernetes connection matching
  - Test VM connection matching
  - Test missing connectionType error
  - Test connection not found error
  - Test all 3 `isProviderVmConnectionInfo` scenarios

## Why?

**Before:** The code had a dangerous fallback in an if-else chain:
```typescript
if (isContainer) { ... }
else if (isKubernetes) { ... }
else { 
  // UNSAFE: Assumes everything else is a VM!
  return getMatchingVmConnection(...);
}
```
**After: Explicit switch with exhaustiveness checking:**
```
switch (info.connectionType) {
  case 'container': return getMatchingContainerConnection(...);
  case 'kubernetes': return getMatchingKubernetesConnection(...);
  case 'vm': return getMatchingVmConnection(...);
  default: {
    const _exhaustiveCheck: never = info;  // Compile error if we miss a type!
    throw new Error(`Unknown connection type`);
  }
}
```
## Testing
- All 83 provider-registry tests passing
- TypeScript compilation clean
- Exhaustiveness checking ensures we can't miss a connection type
## Related
- Depends-on: #14839
- Fixes: #13530