### PR TITLE
chore(test): increase timeout for better cicd handling

### DIFF
--- a/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
+++ b/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
@@ -66,18 +66,19 @@ test.describe.serial('Verify docker compatibility feature', { tag: '@smoke' }, (
     await playExpect(dockerCompatibilityPage.serverInformationBox).toBeVisible();
   });
   test('Verify socket reachability is responding to podman machine status', async ({ page }) => {
+    test.setTimeout(180_000);
     const settingsBar = new SettingsBar(page);
     await settingsBar.openTabPage(ResourcesPage);
     const podmanMachineDetails = new PodmanMachineDetails(page, defaultMachine);
     await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
     await podmanMachineDetails.podmanMachineStopButton.click();
     await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
-      timeout: 50_000,
+      timeout: 60_000,
     });
 
     const dockerCompatibilityPage = await settingsBar.openTabPage(DockerCompatibilityPage);
     await playExpect
-      .poll(async () => await dockerCompatibilityPage.socketIsReachable(), { timeout: 50_000 })
+      .poll(async () => await dockerCompatibilityPage.socketIsReachable(), { timeout: 60_000 })
       .toBeFalsy();
     await playExpect(dockerCompatibilityPage.serverInformationBox).not.toBeVisible();
 
@@ -85,12 +86,12 @@ test.describe.serial('Verify docker compatibility feature', { tag: '@smoke' }, (
     await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
     await podmanMachineDetails.podmanMachineStartButton.click();
     await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
-      timeout: 50_000,
+      timeout: 120_000,
     });
 
     await settingsBar.openTabPage(DockerCompatibilityPage);
     await playExpect
-      .poll(async () => await dockerCompatibilityPage.socketIsReachable(), { timeout: 50_000 })
+      .poll(async () => await dockerCompatibilityPage.socketIsReachable(), { timeout: 60_000 })
       .toBeTruthy();
     await playExpect(dockerCompatibilityPage.serverInformationBox).toBeVisible();
   });


### PR DESCRIPTION
### What does this PR do?
Increases some waiter timeouts in docker e2e test suite to increase robustness on slower platforms.

### What issues does this PR fix or reference?
