### PR TITLE
test(renderer): faster debounce stores every 10 ms in test if not specified

### DIFF
--- a/packages/renderer/vite.tests.setup.js
+++ b/packages/renderer/vite.tests.setup.js
@@ -20,7 +20,7 @@ import path from 'node:path';
 import { readFileSync } from 'node:fs';
 import 'vitest-canvas-mock';
 import typescript from 'typescript';
-import { expect } from 'vitest';
+import { EventStore } from './src/stores/event-store';
 
 global.window.matchMedia = () => {};
 
@@ -84,3 +84,9 @@ class ResizeObserverMock {
 
 global.ResizeObserver = ResizeObserverMock;
 global.window.ResizeObserver = ResizeObserverMock;
+
+// Override the prototype of setupWithDebounce to ensure default values are 10ms
+const originalSetupWithDebounce = EventStore.prototype.setupWithDebounce;
+EventStore.prototype.setupWithDebounce = function (debounceTimeoutDelay = 10, debounceThrottleTimeoutDelay = 10) {
+  return originalSetupWithDebounce.call(this, debounceTimeoutDelay, debounceThrottleTimeoutDelay);
+};


### PR DESCRIPTION
### What does this PR do?

This PR improves the performance of Vitest unit tests for the renderer package by overriding the default debounce timing in the `EventStore` (a fixed, low debounce delay of 10ms).

The change resulted in a significant reduction in the "tests" duration when running the full renderer test suite:

| Metric | Before PR | After PR | Change (%) |
| :--- | :---: | :---: | :---: |
| Tests Duration | 268.28s | 211.58s | **~21% Faster** |
| Total Duration | 87.09s | 81.69s | ~6% Faster |

*(Measured on a Mac M2 Pro using `npx vitest --run --project=renderer --passWithNoTests`)*

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14796

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Run the renderer tests and compare performance metrics:
    ```bash
    pnpm vitest --run --project=renderer --passWithNoTests
    ```
2.  Ensure existing tests that rely on the `EventStore` and its debounce logic still pass.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
