### PR TITLE
fix(extension: docker): incorrect path for `@podman-desktop/api` mock alias

### DIFF
--- a/extensions/docker/packages/extension/vite.config.js
+++ b/extensions/docker/packages/extension/vite.config.js
@@ -58,7 +58,7 @@ const config = {
     environment: 'node',
     include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@podman-desktop/api.js'),
+      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '..', '..', '__mocks__/@podman-desktop/api.js'),
     },
   },
 };


### PR DESCRIPTION
### What does this PR do?

Required for vitest v4 migration. It has stricter requirements and lead to unfortunate errors. 

The path is incorrect since https://github.com/podman-desktop/podman-desktop/pull/14282 it moved the `vite.config.js` from `extensions/docker/vite.config.js` to `extensions/docker/packages/extension/vite.config.js`.

We need to go up two level since we moved two level deeper.

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/14545

### How to test this PR?

- CI should be :green_circle: 
