### PR TITLE
refactor(extension: compose): use vitest v4 compatible syntax

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -72,20 +72,6 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
 }));
 
-const detectMock = {
-  checkSystemWideDockerCompose: vi.fn(),
-  checkSystemWidePodmanCompose: vi.fn(),
-  getDockerComposeBinaryInfo: vi.fn(),
-  getStoragePath: vi.fn(),
-  getExtensionStorageBin: vi.fn(),
-} as unknown as Detect;
-
-const composeDownloadMock = {
-  getLatestVersionAsset: vi.fn(),
-  download: vi.fn(),
-  promptUserForVersion: vi.fn(),
-} as unknown as ComposeDownload;
-
 const cliToolMock = {
   registerUpdate: vi.fn(),
   registerInstaller: vi.fn(),
@@ -94,23 +80,12 @@ const cliToolMock = {
   onDidUpdateVersion: vi.fn(),
 } as unknown as CliTool;
 
-vi.mock('./cli-run', () => ({
-  installBinaryToSystem: vi.fn(),
-  getSystemBinaryPath: vi.fn(),
-}));
-
-vi.mock('./detect', () => ({
-  Detect: vi.fn(),
-}));
-
-vi.mock('./download', () => ({
-  ComposeDownload: vi.fn(),
-}));
+vi.mock(import('./cli-run'));
+vi.mock(import('./detect'));
+vi.mock(import('./download'));
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(Detect).mockReturnValue(detectMock);
-  vi.mocked(ComposeDownload).mockReturnValue(composeDownloadMock);
   vi.mocked(extensionApi.cli.createCliTool).mockReturnValue(cliToolMock);
 });
 
@@ -152,23 +127,23 @@ test('provider registered', async () => {
 });
 
 test('downloadCommand should register cli tool if required', async () => {
-  vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(false);
-  vi.mocked(detectMock.getStoragePath).mockResolvedValue('');
-  vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+  vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
+  vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('');
+  vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
     version: 'v0.0.0',
     path: 'system-wide-path',
     updatable: false,
   });
 
-  vi.mocked(composeDownloadMock.getLatestVersionAsset).mockResolvedValue({
+  vi.mocked(ComposeDownload.prototype.getLatestVersionAsset).mockResolvedValue({
     tag: 'v1.0.0',
   } as unknown as ComposeGithubReleaseArtifactMetadata);
 
   vi.mocked(extensionApi.commands.registerCommand).mockImplementation((command, callback) => {
     if (command === 'compose.onboarding.downloadCommand') {
       expect(extensionApi.cli.createCliTool).not.toHaveBeenCalled();
-      vi.mocked(detectMock.getStoragePath).mockResolvedValue('storage-path');
-      vi.mocked(detectMock.getExtensionStorageBin).mockResolvedValue('storage-path');
+      vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('storage-path');
+      vi.mocked(Detect.prototype.getExtensionStorageBin).mockResolvedValue('storage-path');
       callback();
     }
 
@@ -191,8 +166,8 @@ test('downloadCommand should register cli tool if required', async () => {
  * This function return the object provided to the registerUpdate method
  */
 async function getCliToolUpdate(updatable: boolean): Promise<extensionApi.CliToolSelectUpdate> {
-  vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
-  vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+  vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+  vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
     version: 'v0.0.0',
     path: 'system-wide-path',
     updatable: updatable,
@@ -219,8 +194,9 @@ async function getCliToolUpdate(updatable: boolean): Promise<extensionApi.CliToo
 
 describe('registerCLITool', () => {
   test('createCliTool already installed system wide', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
-    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
       version: 'v0.0.0',
       path: 'system-wide-path',
       updatable: false, // not updatable as unknown location
@@ -247,8 +223,8 @@ describe('registerCLITool', () => {
   });
 
   test('createCliTool already installed system wide by user', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
-    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
       version: 'v0.0.0',
       path: 'user-system-wide-path',
       updatable: false, // not updatable as unknown location
@@ -275,8 +251,8 @@ describe('registerCLITool', () => {
   });
 
   test('new version docker-compose available', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
-    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
       version: 'v0.0.0',
       path: 'system-wide-path',
       updatable: false, // not updatable as unknown location
@@ -306,7 +282,7 @@ describe('registerCLITool', () => {
   });
 
   test('update not updatable version should throw an error', async () => {
-    vi.mocked(composeDownloadMock.promptUserForVersion).mockResolvedValue({
+    vi.mocked(ComposeDownload.prototype.promptUserForVersion).mockResolvedValue({
       tag: 'v1.0.0',
     } as unknown as ComposeGithubReleaseArtifactMetadata);
     const update: extensionApi.CliToolSelectUpdate = await getCliToolUpdate(false);
@@ -318,18 +294,18 @@ describe('registerCLITool', () => {
   });
 
   test('update updatable version should update version', async () => {
-    vi.mocked(composeDownloadMock.promptUserForVersion).mockResolvedValue({
+    vi.mocked(ComposeDownload.prototype.promptUserForVersion).mockResolvedValue({
       tag: 'v1.0.0',
     } as unknown as ComposeGithubReleaseArtifactMetadata);
-    vi.mocked(detectMock.getStoragePath).mockResolvedValue('extension-storage-path');
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('extension-storage-path');
     const update: extensionApi.CliToolUpdate | extensionApi.CliToolSelectUpdate = await getCliToolUpdate(true);
     await update?.selectVersion();
     await update.doUpdate({} as unknown as Logger);
 
-    expect(composeDownloadMock.download).toHaveBeenCalledWith({
+    expect(ComposeDownload.prototype.download).toHaveBeenCalledWith({
       tag: 'v1.0.0',
     });
-    expect(detectMock.getStoragePath).toHaveBeenCalled();
+    expect(Detect.prototype.getStoragePath).toHaveBeenCalled();
     expect(cliRun.installBinaryToSystem).toHaveBeenCalledWith('extension-storage-path', 'docker-compose');
     expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
       installationSource: 'extension',
@@ -338,8 +314,8 @@ describe('registerCLITool', () => {
   });
 
   test('try to install when there is already an existing version should throw an error', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
-    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
       version: 'v0.0.0',
       path: 'system-wide-path',
       updatable: true,
@@ -364,8 +340,8 @@ describe('registerCLITool', () => {
   });
 
   test('try to install before selecting cli tool version should throw an error', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(false);
-    vi.mocked(detectMock.getStoragePath).mockResolvedValue('');
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('');
 
     let installer: extensionApi.CliToolInstaller | undefined;
     vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
@@ -385,8 +361,8 @@ describe('registerCLITool', () => {
   });
 
   test('doInstall should download and install latest version', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(false);
-    vi.mocked(detectMock.getStoragePath).mockResolvedValue('');
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('');
 
     let installer: extensionApi.CliToolInstaller | undefined;
     vi.mocked(cliToolMock.registerInstaller).mockImplementation(mInstaller => {
@@ -400,17 +376,17 @@ describe('registerCLITool', () => {
       expect(installer).toBeDefined();
     });
 
-    vi.mocked(composeDownloadMock.getLatestVersionAsset).mockResolvedValue({
+    vi.mocked(ComposeDownload.prototype.getLatestVersionAsset).mockResolvedValue({
       tag: 'v1.0.0',
     } as unknown as ComposeGithubReleaseArtifactMetadata);
 
     await installer?.selectVersion(true);
 
     await installer?.doInstall({} as unknown as Logger);
-    expect(composeDownloadMock.download).toHaveBeenCalledWith({
+    expect(ComposeDownload.prototype.download).toHaveBeenCalledWith({
       tag: 'v1.0.0',
     });
-    expect(detectMock.getStoragePath).toHaveBeenCalled();
+    expect(Detect.prototype.getStoragePath).toHaveBeenCalled();
     expect(cliRun.installBinaryToSystem).toHaveBeenCalledWith('', 'docker-compose');
     expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
       installationSource: 'extension',
@@ -419,14 +395,14 @@ describe('registerCLITool', () => {
   });
 
   test('by uninstalling it should delete all executables', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
-    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
       version: 'v0.0.0',
       path: 'system-wide-path',
       updatable: false, // not updatable as unknown location
     });
     vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
-    vi.mocked(detectMock.getStoragePath).mockResolvedValue('storage-path');
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('storage-path');
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
     vi.mocked(extensionApi.process.exec).mockResolvedValue({
@@ -452,14 +428,14 @@ describe('registerCLITool', () => {
   });
 
   test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
-    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
       version: 'v0.0.0',
       path: 'system-wide-path',
       updatable: false, // not updatable as unknown location
     });
     vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
-    vi.mocked(detectMock.getStoragePath).mockResolvedValue('storage-path');
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('storage-path');
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
     vi.mocked(fs.promises.unlink).mockRejectedValue({
       code: 'EACCES',
@@ -483,16 +459,16 @@ describe('registerCLITool', () => {
   });
 
   test('verify that can install after uninstalling', async () => {
-    vi.mocked(detectMock.checkSystemWideDockerCompose).mockResolvedValue(true);
-    vi.mocked(detectMock.getDockerComposeBinaryInfo).mockResolvedValue({
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
       version: 'v0.0.0',
       path: 'system-wide-path',
       updatable: false, // not updatable as unknown location
     });
     vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
-    vi.mocked(detectMock.getStoragePath).mockResolvedValue('storage-path');
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('storage-path');
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-    vi.mocked(composeDownloadMock.promptUserForVersion).mockResolvedValue({
+    vi.mocked(ComposeDownload.prototype.promptUserForVersion).mockResolvedValue({
       tag: 'v1.0.0',
     } as unknown as ComposeGithubReleaseArtifactMetadata);
     vi.mocked(extensionApi.process.exec).mockResolvedValue({
@@ -519,10 +495,10 @@ describe('registerCLITool', () => {
     await installer?.selectVersion();
 
     await installer?.doInstall({} as unknown as Logger);
-    expect(composeDownloadMock.download).toHaveBeenCalledWith({
+    expect(ComposeDownload.prototype.download).toHaveBeenCalledWith({
       tag: 'v1.0.0',
     });
-    expect(detectMock.getStoragePath).toHaveBeenCalled();
+    expect(Detect.prototype.getStoragePath).toHaveBeenCalled();
     expect(cliRun.installBinaryToSystem).toHaveBeenCalledWith('storage-path', 'docker-compose');
     expect(cliToolMock.updateVersion).toHaveBeenCalledWith({
       installationSource: 'extension',
@@ -533,7 +509,7 @@ describe('registerCLITool', () => {
   test('onboarding download command shows error message if version list cannot be obtained', async () => {
     await activate(extensionContextMock);
     const downloadCommandHandler = vi.mocked(extensionApi.commands.registerCommand).mock.calls[2][1];
-    vi.mocked(composeDownloadMock.getLatestVersionAsset).mockRejectedValue(new Error('API call error'));
+    vi.mocked(ComposeDownload.prototype.getLatestVersionAsset).mockRejectedValue(new Error('API call error'));
     vi.mocked(extensionApi.window.showErrorMessage).mockResolvedValue(undefined);
     await downloadCommandHandler();
     expect(extensionApi.window.showErrorMessage).toHaveBeenCalledOnce();

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -195,7 +195,6 @@ async function getCliToolUpdate(updatable: boolean): Promise<extensionApi.CliToo
 describe('registerCLITool', () => {
   test('createCliTool already installed system wide', async () => {
     vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
-    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
     vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
       version: 'v0.0.0',
       path: 'system-wide-path',


### PR DESCRIPTION
### What does this PR do?

With vitest v4 we cannot mock constructor / newable anymore we should use let vitest properly handle the mocking and use the `prototype` to access mocked method 

Details in https://github.com/podman-desktop/podman-desktop/pull/14898

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

- CI should be :green_circle: 
