### PR TITLE
refactor(extension: kind): use vitest v4 compatible syntax

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -18,7 +18,7 @@
 
 import * as fs from 'node:fs';
 
-import { KubeConfig } from '@kubernetes/client-node';
+import { KubeConfig, loadAllYaml } from '@kubernetes/client-node';
 import type { AuditRecord, TelemetryLogger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import type { Mock } from 'vitest';
@@ -28,21 +28,9 @@ import { connectionAuditor, createCluster, getKindClusterConfig, waitForCoreDNSR
 import { KindClusterWatcher } from './kind-cluster-watcher';
 import { getKindPath, getMemTotalInfo } from './util';
 
-vi.mock('./kind-cluster-watcher', () => ({
-  KindClusterWatcher: vi.fn().mockImplementation(() => ({
-    waitForNodesReady: vi.fn().mockResolvedValue(undefined),
-    waitForSystemPodsReady: vi.fn().mockResolvedValue(undefined),
-    dispose: vi.fn(),
-  })),
-}));
-
-vi.mock('@kubernetes/client-node', () => ({
-  KubeConfig: vi.fn().mockImplementation(() => ({
-    loadFromFile: vi.fn(),
-    makeApiClient: vi.fn(),
-  })),
-  loadAllYaml: vi.fn().mockReturnValue([{ kind: 'Namespace', metadata: { name: 'test' } }]),
-}));
+vi.mock(import('./kind-cluster-watcher'));
+vi.mock(import('@kubernetes/client-node'));
+vi.mock(import('./util'));
 
 vi.mock('node:fs', () => ({
   promises: {
@@ -87,16 +75,13 @@ vi.mock('@podman-desktop/api', async () => {
   };
 });
 
-vi.mock('./util', async () => {
-  return {
-    getKindPath: vi.fn(),
-    getMemTotalInfo: vi.fn(),
-  };
-});
-
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(fs.promises.mkdtemp).mockResolvedValue('/tmp/file');
+
+  vi.mocked(KindClusterWatcher.prototype.waitForNodesReady).mockResolvedValue(undefined);
+  vi.mocked(KindClusterWatcher.prototype.waitForSystemPodsReady).mockResolvedValue(undefined);
+  vi.mocked(loadAllYaml).mockReturnValue([{ kind: 'Namespace', metadata: { name: 'test' } }]);
 
   // mock kubeconfig changing immediately after registering for update
   vi.mocked(extensionApi.kubernetes.onDidUpdateKubeconfig).mockImplementation(listener => {
@@ -702,14 +687,6 @@ test('check that auditItems does not return error when multiple VMs exist and on
 });
 
 test('waitForCoreDNSReady should call watcher methods in correct order', async () => {
-  const mockWatcher = {
-    waitForNodesReady: vi.fn().mockResolvedValue(undefined),
-    waitForSystemPodsReady: vi.fn().mockResolvedValue(undefined),
-    dispose: vi.fn(),
-  };
-
-  vi.mocked(KindClusterWatcher).mockImplementation(() => mockWatcher as unknown as KindClusterWatcher);
-
   const logger = {
     log: vi.fn(),
     error: vi.fn(),
@@ -719,24 +696,18 @@ test('waitForCoreDNSReady should call watcher methods in correct order', async (
   await waitForCoreDNSReady(mockKubeConfig, logger);
 
   // Verify all watcher methods were called
-  expect(mockWatcher.waitForNodesReady).toHaveBeenCalledWith();
-  expect(mockWatcher.waitForSystemPodsReady).toHaveBeenCalledWith('component=kube-scheduler');
-  expect(mockWatcher.waitForSystemPodsReady).toHaveBeenCalledWith('component=kube-controller-manager');
-  expect(mockWatcher.waitForSystemPodsReady).toHaveBeenCalledWith('k8s-app=kube-dns');
+  expect(KindClusterWatcher.prototype.waitForNodesReady).toHaveBeenCalledWith();
+  expect(KindClusterWatcher.prototype.waitForSystemPodsReady).toHaveBeenCalledWith('component=kube-scheduler');
+  expect(KindClusterWatcher.prototype.waitForSystemPodsReady).toHaveBeenCalledWith('component=kube-controller-manager');
+  expect(KindClusterWatcher.prototype.waitForSystemPodsReady).toHaveBeenCalledWith('k8s-app=kube-dns');
 
   // Verify cleanup was called
-  expect(mockWatcher.dispose).toHaveBeenCalled();
+  expect(KindClusterWatcher.prototype.dispose).toHaveBeenCalled();
 });
 
 test('waitForCoreDNSReady should handle errors and cleanup properly', async () => {
   const mockError = new Error('Nodes not ready');
-  const mockWatcher = {
-    waitForNodesReady: vi.fn().mockRejectedValue(mockError),
-    waitForSystemPodsReady: vi.fn(),
-    dispose: vi.fn(),
-  };
-
-  vi.mocked(KindClusterWatcher).mockImplementation(() => mockWatcher as unknown as KindClusterWatcher);
+  vi.mocked(KindClusterWatcher.prototype.waitForNodesReady).mockRejectedValue(mockError);
 
   const logger = {
     log: vi.fn(),
@@ -748,5 +719,5 @@ test('waitForCoreDNSReady should handle errors and cleanup properly', async () =
     'Cluster not ready: Error: Nodes not ready',
   );
 
-  expect(mockWatcher.dispose).toHaveBeenCalled();
+  expect(KindClusterWatcher.prototype.dispose).toHaveBeenCalled();
 });

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -29,21 +29,10 @@ import { KindInstaller } from './kind-installer';
 import * as util from './util';
 
 vi.mock('node:fs');
-vi.mock('./util');
-vi.mock('./image-handler', () => {
-  return {
-    ImageHandler: vi.fn().mockImplementation(() => {
-      return {
-        moveImage: vi.fn(),
-      };
-    }),
-  };
-});
-vi.mock('./create-cluster', () => ({
-  createCluster: vi.fn(),
-}));
-
-vi.mock('./kind-installer');
+vi.mock(import('./util'));
+vi.mock(import('./image-handler'));
+vi.mock(import('./create-cluster'));
+vi.mock(import('./kind-installer'));
 
 vi.mock('@podman-desktop/api', () => ({
   window: {


### PR DESCRIPTION
### What does this PR do?

With vitest v4 we cannot mock constructor / newable anymore we should use let vitest properly handle the mocking and use the `prototype` to access mocked method 

Details in https://github.com/podman-desktop/podman-desktop/pull/14898

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

- CI should be :green_circle: 
