### PR TITLE
refactor(extension: kubectl-cli): use vitest v4 compatible syntax

### DIFF
--- a/extensions/kubectl-cli/src/handler.spec.ts
+++ b/extensions/kubectl-cli/src/handler.spec.ts
@@ -20,8 +20,10 @@ import type { Configuration } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { expect, test, vi } from 'vitest';
 
-import type * as detect from './detect';
+import { Detect } from './detect';
 import * as handler from './handler';
+
+vi.mock(import('./detect'));
 
 const config: Configuration = {
   get: () => {
@@ -50,19 +52,9 @@ const extensionContextMock: extensionApi.ExtensionContext = {
 } as unknown as extensionApi.ExtensionContext;
 
 test('updateConfigAndContextKubectlBinary: make sure configuration gets updated if checkSystemWideKubectl had returned true', async () => {
-  vi.mock('./detect', () => {
-    // Create mock Detect
-    const detectMock: detect.Detect = {
-      checkSystemWideKubectl: vi.fn().mockReturnValue(Promise.resolve(true)),
-      checkForKubectl: vi.fn().mockReturnValue(Promise.resolve(true)),
-      getStoragePath: vi.fn().mockReturnValue(Promise.resolve('mockPath')),
-    } as unknown as detect.Detect;
-
-    // Make sure we return it with the above mocked values
-    return {
-      Detect: vi.fn().mockReturnValue(detectMock),
-    };
-  });
+  vi.mocked(Detect.prototype.checkSystemWideKubectl).mockReturnValue(Promise.resolve(true));
+  vi.mocked(Detect.prototype.checkForKubectl).mockReturnValue(Promise.resolve(true));
+  vi.mocked(Detect.prototype.getStoragePath).mockReturnValue(Promise.resolve('mockPath'));
 
   // Spy on setValue and configuration updates
   const contextUpdateSpy = vi.spyOn(extensionApi.context, 'setValue');


### PR DESCRIPTION
### What does this PR do?

With vitest v4 we cannot mock constructor / newable anymore we should use let vitest properly handle the mocking and use the `prototype` to access mocked method 

Details in https://github.com/podman-desktop/podman-desktop/pull/14898

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

- CI should be :green_circle: 
