### PR TITLE
refactor(extension: podman): use vitest v4 compatible syntax

### DIFF
--- a/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
@@ -30,11 +30,6 @@ import { WinInstaller } from '/@/installer/win-installer';
 import { InversifyBinding } from './inversify-binding';
 import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from './symbols';
 
-vi.mock(import('/@/installer/win-installer'));
-vi.mock(import('/@/installer/mac-os-installer'));
-vi.mock(import('/@/cleanup/podman-cleanup-macos'));
-vi.mock(import('/@/cleanup/podman-cleanup-windows'));
-
 const extensionContextMock = {} as ExtensionContext;
 const telemetryLoggerMock = {} as TelemetryLogger;
 
@@ -79,16 +74,14 @@ describe('inversifyBinding', () => {
       const value = container.get(Installer);
       expect(value).not.toBeUndefined();
 
-      expect(WinInstaller).toHaveBeenCalledOnce();
-      expect(MacOSInstaller).not.toHaveBeenCalled();
+      expect(value).toBeInstanceOf(WinInstaller);
     });
 
     test('InversifyBinding#init should bind PodmanCleanupWindows for ProviderCleanupSymbol', async () => {
       const value = container.get(ProviderCleanupSymbol);
       expect(value).not.toBeUndefined();
 
-      expect(PodmanCleanupWindows).toHaveBeenCalledOnce();
-      expect(PodmanCleanupMacOS).not.toHaveBeenCalled();
+      expect(value).toBeInstanceOf(PodmanCleanupWindows);
     });
   });
 
@@ -103,16 +96,14 @@ describe('inversifyBinding', () => {
       const value = container.get(Installer);
       expect(value).not.toBeUndefined();
 
-      expect(WinInstaller).not.toHaveBeenCalled();
-      expect(MacOSInstaller).toHaveBeenCalled();
+      expect(value).toBeInstanceOf(MacOSInstaller);
     });
 
     test('InversifyBinding#init should bind PodmanCleanupMacOS for ProviderCleanupSymbol', async () => {
       const value = container.get(ProviderCleanupSymbol);
       expect(value).not.toBeUndefined();
 
-      expect(PodmanCleanupMacOS).toHaveBeenCalledOnce();
-      expect(PodmanCleanupWindows).not.toHaveBeenCalled();
+      expect(value).toBeInstanceOf(PodmanCleanupMacOS);
     });
   });
 
@@ -127,18 +118,12 @@ describe('inversifyBinding', () => {
       expect(() => {
         container.get(Installer);
       }).toThrowError('No bindings found for service: "Symbol(Installer)"');
-
-      expect(WinInstaller).not.toHaveBeenCalled();
-      expect(MacOSInstaller).not.toHaveBeenCalled();
     });
 
     test('InversifyBinding#init should not provide any binding for ProviderCleanupSymbol', async () => {
       expect(() => {
         container.get(ProviderCleanupSymbol);
       }).toThrowError('No bindings found for service: "Symbol(ProviderCleanup)"');
-
-      expect(PodmanCleanupMacOS).not.toHaveBeenCalled();
-      expect(PodmanCleanupWindows).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?

With vitest v4 we cannot mock constructor / newable anymore we should use let vitest properly handle the mocking and use the `prototype` to access mocked method 

Details in https://github.com/podman-desktop/podman-desktop/pull/14898

> :warning: some tests in the podman extension could not be migrated as they requires special synthax only working in vitest 4 :crying_cat_face: 

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

- CI should be :green_circle: 
