### PR TITLE
feat: add UPDATING status to statusicon component

### DIFF
--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -68,3 +68,16 @@ test('Expect deleting styling', async () => {
   expect(spinner).toBeInTheDocument();
   expect(spinner).toHaveAttribute('width', '1.4em');
 });
+
+test('Expect updating styling', async () => {
+  const status = 'UPDATING';
+  render(StatusIcon, { status });
+  const icon = screen.getByRole('status');
+  expect(icon).toBeInTheDocument();
+  expect(icon).toHaveAttribute('title', status);
+  expect(icon).not.toHaveAttribute('border');
+
+  const spinner = screen.getByRole('img');
+  expect(spinner).toBeInTheDocument();
+  expect(spinner).toHaveAttribute('width', '1.4em');
+});

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -4,9 +4,9 @@ import StarIcon from '../icons/StarIcon.svelte';
 import Spinner from '../progress/Spinner.svelte';
 
 interface Props {
-  // status: one of RUNNING, STARTING, USED, CREATED, DELETING, or DEGRADED
+  // status: one of RUNNING, STARTING, USED, CREATED, DELETING, UPDATING, or DEGRADED
   // any other status will result in a standard outlined box
-  status?: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'CREATED' | string;
+  status?: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'UPDATING' | 'CREATED' | string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon?: any;
   size?: number;
@@ -22,7 +22,7 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
     class:bg-[var(--pd-status-running)]={status === 'RUNNING' || status === 'USED'}
     class:bg-[var(--pd-status-starting)]={status === 'STARTING'}
     class:bg-[var(--pd-status-degraded)]={status === 'DEGRADED'}
-    class:border-2={!solid && status !== 'DELETING'}
+    class:border-2={!solid && status !== 'DELETING' && status !== 'UPDATING'}
     class:p-0.5={!solid}
     class:p-1={solid}
     class:border-[var(--pd-status-not-running)]={!solid}
@@ -30,7 +30,7 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
     class:text-[var(--pd-status-contrast)]={solid}
     role="status"
     title={status}>
-    {#if status === 'DELETING'}
+    {#if status === 'DELETING' || status === 'UPDATING'}
       <Spinner size="1.4em" />
     {:else if typeof icon === 'string'}
        <Icon icon={icon} />


### PR DESCRIPTION
This pr is part of a larger effort to add the ability to update an image to the latest build First we need to add this icon to add a spinner during the update.

### What does this PR do?

See above

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/923

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ x] Tests are covering the bug fix or the new feature
