### PR TITLE
feat: add update image build to backend

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6143,9 +6143,9 @@ describe('updateImage', () => {
     );
   });
 
-  test('should reject images with null RepoTags', async () => {
+  test('should reject images with empty RepoTags', async () => {
     const mockImage = {
-      inspect: vi.fn().mockResolvedValue({ RepoTags: null }),
+      inspect: vi.fn().mockResolvedValue({ RepoTags: [] }),
     };
     const engine = {
       getImage: vi.fn().mockReturnValue(mockImage),
@@ -6153,21 +6153,7 @@ describe('updateImage', () => {
     vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
 
     await expect(containerRegistry.updateImage('engine1', 'imageId', 'nginx:latest')).rejects.toThrowError(
-      `Tag 'nginx:latest' not found on this image`,
-    );
-  });
-
-  test('should reject images with undefined RepoTags', async () => {
-    const mockImage = {
-      inspect: vi.fn().mockResolvedValue({ RepoTags: undefined }),
-    };
-    const engine = {
-      getImage: vi.fn().mockReturnValue(mockImage),
-    };
-    vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
-
-    await expect(containerRegistry.updateImage('engine1', 'imageId', 'nginx:latest')).rejects.toThrowError(
-      `Tag 'nginx:latest' not found on this image`,
+      'Image has no tags and cannot be updated',
     );
   });
 

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6122,7 +6122,17 @@ describe('kube play', () => {
   });
 });
 
+const originalConsoleWarn = console.warn;
+
 describe('updateImage', () => {
+  beforeEach(() => {
+    console.warn = vi.fn();
+  });
+
+  afterEach(() => {
+    console.warn = originalConsoleWarn;
+  });
+
   test('should reject if no provider', async () => {
     await expect(containerRegistry.updateImage('dummy', 'imageId', 'nginx:latest')).rejects.toThrowError(
       'no engine matching this engine',
@@ -6311,13 +6321,10 @@ describe('updateImage', () => {
     };
     vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
     vi.spyOn(containerRegistry, 'deleteImage').mockRejectedValue(new Error('Deletion failed'));
-    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const result = await containerRegistry.updateImage('engine1', 'imageId', 'nginx:latest');
     expect(result).toBeUndefined();
     expect(getImageMock).toHaveBeenCalledTimes(2);
-    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringMatching(/Could not delete old image.*Deletion failed/));
-
-    consoleWarnSpy.mockRestore();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/Could not delete old image.*Deletion failed/));
   });
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1271,8 +1271,14 @@ export class ContainerProviderRegistry {
       // get image info to validate the image can be updated
       const imageInfo = await this.getMatchingImage(engineId, imageId).inspect();
 
+      // validate the image has tags
+      const repoTags = imageInfo.RepoTags;
+      if (!repoTags?.length) {
+        throw new Error('Image has no tags and cannot be updated');
+      }
+
       // validate the provided tag exists on this image
-      if (!imageInfo.RepoTags?.includes(tag)) {
+      if (!repoTags.includes(tag)) {
         throw new Error(`Tag '${tag}' not found on this image`);
       }
 
@@ -1282,7 +1288,7 @@ export class ContainerProviderRegistry {
       }
 
       // store whether the image originally had a single tag
-      const hadSingleTag = imageInfo.RepoTags?.length === 1;
+      const hadSingleTag = repoTags.length === 1;
 
       // check if this is an immutable tag (contains a SHA digest)
       if (tag.includes('@sha256:')) {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1265,6 +1265,66 @@ export class ContainerProviderRegistry {
     return crypto.createHash('sha512').update(imageName).digest('hex');
   }
 
+  async updateImage(engineId: string, imageId: string): Promise<void> {
+    let telemetryOptions = {};
+    try {
+      // first get image info to check if it has a registry
+      const imageInfo = await this.getMatchingImage(engineId, imageId).inspect();
+      if (!imageInfo.RepoTags || imageInfo.RepoTags.length === 0) {
+        throw new Error('Image has no registry tags and cannot be updated');
+      }
+      // get the first repo tag (we know it exists because length > 0)
+      const repoTag = imageInfo.RepoTags[0]!;
+
+      // check if this is a localhost image
+      if (repoTag.startsWith('localhost/') || repoTag.startsWith('127.0.0.1')) {
+        throw new Error('Local images cannot be updated');
+      }
+
+      // check if this is an immutable tag (contains a SHA digest)
+      if (repoTag.includes('@sha256:')) {
+        throw new Error('Image with digest-based tag is immutable and cannot be updated');
+      }
+
+      // store the current image ID to compare after pull
+      const oldImageId = imageInfo.Id;
+
+      // pull the latest build of the image
+      const authconfig = this.imageRegistry.getAuthconfigForImage(repoTag);
+      const matchingEngine = this.getMatchingEngine(engineId);
+      const pullStream = await matchingEngine.pull(repoTag, { authconfig });
+
+      await new Promise<void>((resolve, reject) => {
+        matchingEngine.modem.followProgress(pullStream, (err: Error | null) => {
+          if (err) return reject(err);
+          resolve();
+        });
+      });
+
+      // check if the image was actually updated
+      const updatedImageInfo = await matchingEngine.getImage(repoTag).inspect();
+
+      if (updatedImageInfo.Id === oldImageId) {
+        throw new Error('Image is already the latest version');
+      }
+
+      // Only delete the old image if it had a single tag
+      if (updatedImageInfo.RepoTags?.length === 1) {
+        try {
+          await this.deleteImage(engineId, oldImageId);
+        } catch (error) {
+          console.warn(`Could not delete old image ${oldImageId}:`, error);
+          // Don't fail the update if we can't delete the old image
+        }
+      }
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('updateImage', { imageName: this.getImageHash(imageId), ...telemetryOptions });
+    }
+  }
+
   async pingContainerEngine(providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<unknown> {
     let telemetryOptions = {};
     try {

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -930,6 +930,44 @@ describe('container-provider-registry:buildImage', () => {
 
     await vi.waitFor(() => {
       expect(navigateToImageBuildMock).toHaveBeenCalledExactlyOnceWith(55);
+describe('updateImage handler', () => {
+  test('should update image and set task status to success', async () => {
+    const handle = handlers.get('container-provider-registry:updateImage');
+    expect(handle).not.equal(undefined);
+
+    const engineId = 'engine1';
+    const imageId = 'alpine:latest';
+
+    vi.spyOn(ContainerProviderRegistry.prototype, 'updateImage').mockResolvedValue(undefined);
+
+    const createTaskSpy = vi.spyOn(TaskManager.prototype, 'createTask');
+
+    await handle(undefined, engineId, imageId);
+
+    expect(ContainerProviderRegistry.prototype.updateImage).toHaveBeenCalledWith(engineId, imageId);
+    expect(createTaskSpy).toHaveBeenCalledWith({
+      title: `Updating image '${imageId}'`,
+    });
+  });
+
+  test('should handle update errors and set task error', async () => {
+    const handle = handlers.get('container-provider-registry:updateImage');
+    expect(handle).not.equal(undefined);
+
+    const engineId = 'engine1';
+    const imageId = 'invalid:image';
+
+    vi.spyOn(ContainerProviderRegistry.prototype, 'updateImage').mockRejectedValue(new Error('Network error'));
+
+    const createTaskSpy = vi.spyOn(TaskManager.prototype, 'createTask');
+
+    const result = await handle(undefined, engineId, imageId);
+    expect(result).toHaveProperty('error');
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error.message).toBe('Network error');
+
+    expect(createTaskSpy).toHaveBeenCalledWith({
+      title: `Updating image '${imageId}'`,
     });
   });
 });

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -930,6 +930,10 @@ describe('container-provider-registry:buildImage', () => {
 
     await vi.waitFor(() => {
       expect(navigateToImageBuildMock).toHaveBeenCalledExactlyOnceWith(55);
+    });
+  });
+});
+
 describe('updateImage handler', () => {
   test('should update image and set task status to success', async () => {
     const handle = handlers.get('container-provider-registry:updateImage');

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -940,17 +940,18 @@ describe('updateImage handler', () => {
     expect(handle).not.equal(undefined);
 
     const engineId = 'engine1';
-    const imageId = 'alpine:latest';
+    const imageId = 'sha256:abc123';
+    const tag = 'alpine:latest';
 
     vi.spyOn(ContainerProviderRegistry.prototype, 'updateImage').mockResolvedValue(undefined);
 
     const createTaskSpy = vi.spyOn(TaskManager.prototype, 'createTask');
 
-    await handle(undefined, engineId, imageId);
+    await handle(undefined, engineId, imageId, tag);
 
-    expect(ContainerProviderRegistry.prototype.updateImage).toHaveBeenCalledWith(engineId, imageId);
+    expect(ContainerProviderRegistry.prototype.updateImage).toHaveBeenCalledWith(engineId, imageId, tag);
     expect(createTaskSpy).toHaveBeenCalledWith({
-      title: `Updating image '${imageId}'`,
+      title: `Updating image '${tag}'`,
     });
   });
 
@@ -959,19 +960,20 @@ describe('updateImage handler', () => {
     expect(handle).not.equal(undefined);
 
     const engineId = 'engine1';
-    const imageId = 'invalid:image';
+    const imageId = 'sha256:abc123';
+    const tag = 'invalid:image';
 
     vi.spyOn(ContainerProviderRegistry.prototype, 'updateImage').mockRejectedValue(new Error('Network error'));
 
     const createTaskSpy = vi.spyOn(TaskManager.prototype, 'createTask');
 
-    const result = await handle(undefined, engineId, imageId);
+    const result = await handle(undefined, engineId, imageId, tag);
     expect(result).toHaveProperty('error');
     expect(result.error).toBeInstanceOf(Error);
     expect(result.error.message).toBe('Network error');
 
     expect(createTaskSpy).toHaveBeenCalledWith({
-      title: `Updating image '${imageId}'`,
+      title: `Updating image '${tag}'`,
     });
   });
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1234,15 +1234,15 @@ export class PluginSystem {
 
     this.ipcHandle(
       'container-provider-registry:updateImage',
-      async (_listener, engineId: string, imageId: string): Promise<void> => {
+      async (_listener, engineId: string, imageId: string, tag: string): Promise<void> => {
         const task = taskManager.createTask({
-          title: `Updating image '${imageId}'`,
+          title: `Updating image '${tag}'`,
         });
         try {
-          await containerProviderRegistry.updateImage(engineId, imageId);
+          await containerProviderRegistry.updateImage(engineId, imageId, tag);
           task.status = 'success';
         } catch (error: unknown) {
-          task.error = String(error);
+          task.error = `Something went wrong while trying to update image: ${String(error)}`;
           task.status = 'failure';
           throw error;
         }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1231,6 +1231,23 @@ export class PluginSystem {
         );
       },
     );
+
+    this.ipcHandle(
+      'container-provider-registry:updateImage',
+      async (_listener, engineId: string, imageId: string): Promise<void> => {
+        const task = taskManager.createTask({
+          title: `Updating image '${imageId}'`,
+        });
+        try {
+          await containerProviderRegistry.updateImage(engineId, imageId);
+          task.status = 'success';
+        } catch (error: unknown) {
+          task.error = String(error);
+          throw error;
+        }
+      },
+    );
+
     this.ipcHandle(
       'container-provider-registry:pushImage',
       async (_listener, engine: string, imageId: string, callbackId: number): Promise<void> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1243,6 +1243,7 @@ export class PluginSystem {
           task.status = 'success';
         } catch (error: unknown) {
           task.error = String(error);
+          task.status = 'failure';
           throw error;
         }
       },

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -576,9 +576,12 @@ export function initExposure(): void {
     return ipcInvoke('container-provider-registry:saveImages', options);
   });
 
-  contextBridge.exposeInMainWorld('updateImage', async (engineId: string, imageId: string): Promise<void> => {
-    return ipcInvoke('container-provider-registry:updateImage', engineId, imageId);
-  });
+  contextBridge.exposeInMainWorld(
+    'updateImage',
+    async (engineId: string, imageId: string, tag: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:updateImage', engineId, imageId, tag);
+    },
+  );
 
   contextBridge.exposeInMainWorld('loadImages', async (options: ImageLoadOptions): Promise<void> => {
     return ipcInvoke('container-provider-registry:loadImages', options);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -576,6 +576,10 @@ export function initExposure(): void {
     return ipcInvoke('container-provider-registry:saveImages', options);
   });
 
+  contextBridge.exposeInMainWorld('updateImage', async (engineId: string, imageId: string): Promise<void> => {
+    return ipcInvoke('container-provider-registry:updateImage', engineId, imageId);
+  });
+
   contextBridge.exposeInMainWorld('loadImages', async (options: ImageLoadOptions): Promise<void> => {
     return ipcInvoke('container-provider-registry:loadImages', options);
   });


### PR DESCRIPTION
this is part of a larger issue to update the image to the latest build This pr adds the backend components needed to update the image to the latest build

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/923

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Heres a cool way to test backend functionality without ui

First lets look at the function (now that this is updated we also need the tag parameter but you can get that from the list output)

async updateImage(engineId: string, imageId: string): Promise<void> {
so we need the engine id and imageid. The imageid can be the actual name of the image or the shah ex

window.updateImage('podman.Podman', 'sha256:32b91e3161c8fc2e3baf2732a594305ca5093c82ff4e0c9f6ebbd2a879468e1d')

window.updateImage('podman.Podman', 'docker.io/library/alpine:latest')

So first use pnpm watch to open devtools

next in a seperate terminal window or the pd ui download alpne:3.15

in the console type `window.listImages() `and enter

you should see your list of images thats on your system after clicking on the promise array

<img width="924" height="547" alt="Screenshot From 2025-11-24 16-19-48" src="https://github.com/user-attachments/assets/d785d093-11f0-445a-a717-705ed6290429" />

now in the seperate terminal do `podman tag docker.io/library/alpine:3.15 docker.io/library/alpine:latest`

now youll have an image with manifest 3.15 tagged as latest simulating an old image with a rolling tag

now in the console do `window.updateImage('podman.Podman', 'docker.io/library/alpine:latest')`
(you can also use the shah as well like listed on the console)

you should see it update 
 

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
