### PR TITLE
refactor(package: preload-webview): use vitest v4 compatible syntax

### DIFF
--- a/packages/preload-webview/src/index.spec.ts
+++ b/packages/preload-webview/src/index.spec.ts
@@ -20,19 +20,14 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { init } from '.';
 import * as webviewPreload from './webview-preload';
+import { WebviewPreload } from './webview-preload';
 
-vi.mock('./webview-preload', async () => {
-  return {
-    WebviewPreload: vi.fn().mockImplementation(() => {
-      return {
-        init: vi.fn().mockResolvedValue(undefined),
-      };
-    }),
-  };
-});
+vi.mock(import('./webview-preload'));
 
 beforeEach(() => {
   vi.clearAllMocks();
+
+  vi.mocked(WebviewPreload.prototype.init).mockResolvedValue(undefined);
 });
 
 test('check call constructor with correct web id by parsing window.location.search', () => {


### PR DESCRIPTION
### What does this PR do?

With vitest v4 we cannot mock constructor / newable anymore we should use let vitest properly handle the mocking and use the `prototype` to access mocked method 

Details in https://github.com/podman-desktop/podman-desktop/pull/14898

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

- CI should be :green_circle: 
