### PR TITLE
chore: use static delta when downloading flathub freeplatform sdk

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -110,7 +110,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+          flatpak install flathub --user -y org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
 
       - name: Run Build
         timeout-minutes: 20


### PR DESCRIPTION
### What does this PR do?
it looks like disabling the option is causing error 503 for now

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

PR checks failing

### How to test this PR?

Linux PR check should be ✅ 

- [x] Tests are covering the bug fix or the new feature
