### PR TITLE
refactor(package: renderer): use vitest v4 compatible syntax

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
@@ -26,13 +26,7 @@ import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from '../container/Con
 import ComposeDetailsLogs from './ComposeDetailsLogs.svelte';
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
-vi.mock('@xterm/xterm', () => {
-  return {
-    Terminal: vi
-      .fn()
-      .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn(), dispose: vi.fn() }),
-  };
-});
+vi.mock(import('@xterm/xterm'));
 
 beforeAll(() => {
   Object.defineProperty(window, 'getConfigurationValue', { value: vi.fn() });

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -48,8 +48,8 @@ const myContainer: ContainerInfo = {
   ImageBase64RepoTag: '',
 };
 
-vi.mock('@xterm/xterm');
-vi.mock('@xterm/addon-search');
+vi.mock(import('@xterm/xterm'));
+vi.mock(import('@xterm/addon-search'));
 
 const getConfigurationValueMock = vi.fn().mockReturnValue(12);
 

--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.spec.ts
@@ -29,15 +29,7 @@ import { containerLogsClearTimestamps } from '/@/stores/container-logs';
 import ContainerDetailsLogsClear from './ContainerDetailsLogsClear.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
-vi.mock('@xterm/xterm', () => {
-  const writeMock = vi.fn();
-  return {
-    writeMock,
-    Terminal: vi
-      .fn()
-      .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: writeMock, clear: vi.fn(), dispose: vi.fn() }),
-  };
-});
+vi.mock(import('@xterm/xterm'));
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -539,198 +539,194 @@ test('Expect clear filter in empty screen to clear serach term, except is:...', 
   expect(searchField).toHaveDisplayValue(/is:running/);
 });
 
-test(
-  'Expect to display running / stopped containers depending on tab',
-  async () => {
-    window.dispatchEvent(new CustomEvent('extensions-already-started'));
-    window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
-    window.dispatchEvent(new CustomEvent('tray:update-provider'));
+test('Expect to display running / stopped containers depending on tab', { timeout: 20_000 }, async () => {
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('tray:update-provider'));
 
-    // wait for the store to be cleared
-    await vi.waitFor(() => expect(get(containersInfos).length).toBe(0), { timeout: 5_000 });
+  // wait for the store to be cleared
+  await vi.waitFor(() => expect(get(containersInfos).length).toBe(0), { timeout: 5_000 });
 
-    vi.mocked(window.getProviderInfos).mockResolvedValue([
-      {
-        name: 'podman',
-        status: 'started',
-        internalId: 'podman-internal-id',
-        containerConnections: [
-          {
-            name: 'podman-machine-default',
-            status: 'started',
-          },
-        ],
-      } as ProviderInfo,
-    ]);
-
-    const pod1Id = 'pod1-id';
-    const pod2Id = 'pod2-id';
-    const pod3Id = 'pod3-id';
-
-    // 3 pods with 2 containers each
-    const mockedContainers = [
-      // 2 / 2 containers are running on this pod
-      {
-        Id: 'sha256:68347658374683476',
-        Image: 'sha256:234',
-        Names: ['container1-pod1'],
-        State: 'Running',
-        pod: {
-          name: 'pod1',
-          id: pod1Id,
-          status: 'Running',
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
         },
-        engineId: 'podman',
-        engineName: 'podman',
-        ImageID: 'dummy-image-id',
-      } as ContainerInfo,
-      {
-        Id: 'sha256:7897891234567890123',
-        Image: 'sha256:345',
-        Names: ['container2-pod1'],
-        State: 'Running',
-        pod: {
-          name: 'pod1',
-          id: pod1Id,
-          status: 'Running',
-        },
-        engineId: 'podman',
-        engineName: 'podman',
-        ImageID: 'dummy-image-id',
-      } as ContainerInfo,
+      ],
+    } as ProviderInfo,
+  ]);
 
-      // 1 / 2 containers are running on this pod
-      {
-        Id: 'sha256:876532948235',
-        Image: 'sha256:876',
-        Names: ['container1-pod2'],
-        State: 'Running',
-        pod: {
-          name: 'pod2',
-          id: pod2Id,
-          status: 'Running',
-        },
-        engineId: 'podman',
-        engineName: 'podman',
-        ImageID: 'dummy-image-id',
-      } as ContainerInfo,
-      {
-        Id: 'sha256:834752375490',
-        Image: 'sha256:834',
-        Names: ['container2-pod2'],
-        State: 'Stopped',
-        pod: {
-          name: 'pod2',
-          id: pod2Id,
-          status: 'Running',
-        },
-        engineId: 'podman',
-        engineName: 'podman',
-        ImageID: 'dummy-image-id',
-      } as ContainerInfo,
+  const pod1Id = 'pod1-id';
+  const pod2Id = 'pod2-id';
+  const pod3Id = 'pod3-id';
 
-      // 0 / 2 containers are running on this pod
-      {
-        Id: 'sha256:56283769268',
-        Image: 'sha256:562',
-        Names: ['container1-pod3'],
-        State: 'Stopped',
-        pod: {
-          name: 'pod3',
-          id: pod3Id,
-          status: 'Stopped',
-        },
-        engineId: 'podman',
-        engineName: 'podman',
-        ImageID: 'dummy-image-id',
-      } as ContainerInfo,
-      {
-        Id: 'sha256:834752375490',
-        Image: 'sha256:834',
-        Names: ['container2-pod3'],
-        State: 'Stopped',
-        pod: {
-          name: 'pod3',
-          id: pod3Id,
-          status: 'Stopped',
-        },
-        engineId: 'podman',
-        engineName: 'podman',
-        ImageID: 'dummy-image-id',
-      } as ContainerInfo,
-    ];
-
-    vi.mocked(window.listContainers).mockResolvedValue(mockedContainers);
-
-    window.dispatchEvent(new CustomEvent('extensions-already-started'));
-    window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
-    window.dispatchEvent(new CustomEvent('tray:update-provider'));
-
-    // wait until store is populated
-    await vi.waitFor(() => expect(get(containersInfos).length).toBe(6), { timeout: 5_000 });
-    await vi.waitFor(() => expect(get(providerInfos).length).toBe(1), { timeout: 5_000 });
-
-    await waitRender({});
-
-    const tests = [
-      {
-        tabLabel: undefined,
-        presentCells: [
-          'pod1 (pod) 2 containers',
-          'container1-pod1 RUNNING',
-          'container2-pod1 RUNNING',
-          'pod2 (pod) 2 containers',
-          'container1-pod2 RUNNING',
-          'container2-pod2 STOPPED',
-          'pod3 (pod) 2 containers',
-          'container1-pod3 STOPPED',
-          'container2-pod3 STOPPED',
-        ],
-        absentLabels: [],
+  // 3 pods with 2 containers each
+  const mockedContainers = [
+    // 2 / 2 containers are running on this pod
+    {
+      Id: 'sha256:68347658374683476',
+      Image: 'sha256:234',
+      Names: ['container1-pod1'],
+      State: 'Running',
+      pod: {
+        name: 'pod1',
+        id: pod1Id,
+        status: 'Running',
       },
-      {
-        tabLabel: 'Running',
-        presentCells: [
-          'pod1 (pod) 2 containers',
-          'container1-pod1 RUNNING',
-          'container2-pod1 RUNNING',
-          'pod2 (pod) 2 containers (1 filtered)',
-          'container1-pod2 RUNNING',
-        ],
-        absentLabels: [/container2-pod2.*/, /pod3 \(pod\).*/, /container1-pod3.*/, /container2-pod3.*/],
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'dummy-image-id',
+    } as ContainerInfo,
+    {
+      Id: 'sha256:7897891234567890123',
+      Image: 'sha256:345',
+      Names: ['container2-pod1'],
+      State: 'Running',
+      pod: {
+        name: 'pod1',
+        id: pod1Id,
+        status: 'Running',
       },
-      {
-        tabLabel: 'Stopped',
-        presentCells: [
-          'pod2 (pod) 2 containers (1 filtered)',
-          'container2-pod2 STOPPED',
-          'pod3 (pod) 2 containers',
-          'container1-pod3 STOPPED',
-          'container2-pod3 STOPPED',
-        ],
-        absentLabels: [/pod1 \(pod\).*/, /container1-pod1.*/, /container2-pod1.*/, /container1-pod2.*/],
-      },
-    ];
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'dummy-image-id',
+    } as ContainerInfo,
 
-    for (const tt of tests) {
-      if (tt.tabLabel) {
-        const tab = screen.getByRole('button', { name: tt.tabLabel });
-        await fireEvent.click(tab);
-      }
-      for (const presentCell of tt.presentCells) {
-        await vi.waitFor(() => {
-          expect(screen.getByRole('button', { name: presentCell })).toBeInTheDocument();
-        });
-      }
-      for (const absentCell of tt.absentLabels) {
-        await vi.waitFor(() => {
-          expect(screen.queryByText(absentCell)).not.toBeInTheDocument();
-        });
-      }
+    // 1 / 2 containers are running on this pod
+    {
+      Id: 'sha256:876532948235',
+      Image: 'sha256:876',
+      Names: ['container1-pod2'],
+      State: 'Running',
+      pod: {
+        name: 'pod2',
+        id: pod2Id,
+        status: 'Running',
+      },
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'dummy-image-id',
+    } as ContainerInfo,
+    {
+      Id: 'sha256:834752375490',
+      Image: 'sha256:834',
+      Names: ['container2-pod2'],
+      State: 'Stopped',
+      pod: {
+        name: 'pod2',
+        id: pod2Id,
+        status: 'Running',
+      },
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'dummy-image-id',
+    } as ContainerInfo,
+
+    // 0 / 2 containers are running on this pod
+    {
+      Id: 'sha256:56283769268',
+      Image: 'sha256:562',
+      Names: ['container1-pod3'],
+      State: 'Stopped',
+      pod: {
+        name: 'pod3',
+        id: pod3Id,
+        status: 'Stopped',
+      },
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'dummy-image-id',
+    } as ContainerInfo,
+    {
+      Id: 'sha256:834752375490',
+      Image: 'sha256:834',
+      Names: ['container2-pod3'],
+      State: 'Stopped',
+      pod: {
+        name: 'pod3',
+        id: pod3Id,
+        status: 'Stopped',
+      },
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'dummy-image-id',
+    } as ContainerInfo,
+  ];
+
+  vi.mocked(window.listContainers).mockResolvedValue(mockedContainers);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('tray:update-provider'));
+
+  // wait until store is populated
+  await vi.waitFor(() => expect(get(containersInfos).length).toBe(6), { timeout: 5_000 });
+  await vi.waitFor(() => expect(get(providerInfos).length).toBe(1), { timeout: 5_000 });
+
+  await waitRender({});
+
+  const tests = [
+    {
+      tabLabel: undefined,
+      presentCells: [
+        'pod1 (pod) 2 containers',
+        'container1-pod1 RUNNING',
+        'container2-pod1 RUNNING',
+        'pod2 (pod) 2 containers',
+        'container1-pod2 RUNNING',
+        'container2-pod2 STOPPED',
+        'pod3 (pod) 2 containers',
+        'container1-pod3 STOPPED',
+        'container2-pod3 STOPPED',
+      ],
+      absentLabels: [],
+    },
+    {
+      tabLabel: 'Running',
+      presentCells: [
+        'pod1 (pod) 2 containers',
+        'container1-pod1 RUNNING',
+        'container2-pod1 RUNNING',
+        'pod2 (pod) 2 containers (1 filtered)',
+        'container1-pod2 RUNNING',
+      ],
+      absentLabels: [/container2-pod2.*/, /pod3 \(pod\).*/, /container1-pod3.*/, /container2-pod3.*/],
+    },
+    {
+      tabLabel: 'Stopped',
+      presentCells: [
+        'pod2 (pod) 2 containers (1 filtered)',
+        'container2-pod2 STOPPED',
+        'pod3 (pod) 2 containers',
+        'container1-pod3 STOPPED',
+        'container2-pod3 STOPPED',
+      ],
+      absentLabels: [/pod1 \(pod\).*/, /container1-pod1.*/, /container2-pod1.*/, /container1-pod2.*/],
+    },
+  ];
+
+  for (const tt of tests) {
+    if (tt.tabLabel) {
+      const tab = screen.getByRole('button', { name: tt.tabLabel });
+      await fireEvent.click(tab);
     }
-  },
-  { timeout: 20_000 },
-);
+    for (const presentCell of tt.presentCells) {
+      await vi.waitFor(() => {
+        expect(screen.getByRole('button', { name: presentCell })).toBeInTheDocument();
+      });
+    }
+    for (const absentCell of tt.absentLabels) {
+      await vi.waitFor(() => {
+        expect(screen.queryByText(absentCell)).not.toBeInTheDocument();
+      });
+    }
+  }
+});
 
 test('Sort containers based on selected parameter', async () => {
   vi.mocked(window.listContainers).mockResolvedValue([]);

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
@@ -25,13 +25,6 @@ import ProviderConfigured from '/@/lib/dashboard/ProviderConfigured.svelte';
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 
 beforeAll(() => {
-  // Cannot mock with vi.mocked(window.ResizeObserver)
-  // we use "global" similar to PodDetails.spec.ts implementation
-  global.ResizeObserver = vi.fn().mockReturnValue({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  });
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
   // fake the window.events object
   (window.events as unknown) = {

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -28,11 +28,7 @@ import type { ProviderInfo } from '/@api/provider-info';
 
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 
-vi.mock('@xterm/xterm', () => {
-  return {
-    Terminal: vi.fn().mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), clear: vi.fn() }),
-  };
-});
+vi.mock(import('@xterm/xterm'));
 
 class InitializationContextImpl {
   #promise: unknown;
@@ -59,13 +55,6 @@ class InitializationContextImpl {
 
 // fake the window.events object
 beforeAll(() => {
-  // Cannot mock with vi.mocked(window.ResizeObserver)
-  // we use "global" similar to PodDetails.spec.ts implementation
-  global.ResizeObserver = vi.fn().mockReturnValue({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  });
   vi.mocked(window.initializeProvider).mockResolvedValue([]);
   (window.events as unknown) = {
     receive: (_channel: string, func: unknown): void => {

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -32,18 +32,7 @@ import { recommendedRegistries } from '/@/stores/recommendedRegistries';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 // xterm is used in the UI, but not tested, added in order to avoid the multiple warnings being shown during the test.
-vi.mock('@xterm/xterm', () => {
-  return {
-    Terminal: vi.fn().mockReturnValue({
-      loadAddon: vi.fn(),
-      open: vi.fn(),
-      write: vi.fn(),
-      clear: vi.fn(),
-      dispose: vi.fn(),
-      reset: vi.fn(),
-    }),
-  };
-});
+vi.mock(import('@xterm/xterm'));
 
 // fake the window.events object
 beforeAll(() => {

--- a/packages/renderer/src/lib/image/PushManifestModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushManifestModal.spec.ts
@@ -26,18 +26,7 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import type { ImageInfoUI } from './ImageInfoUI';
 import PushManifestModal from './PushManifestModal.svelte';
 
-vi.mock('@xterm/xterm', () => {
-  return {
-    Terminal: vi.fn().mockReturnValue({
-      loadAddon: vi.fn(),
-      open: vi.fn(),
-      write: vi.fn(),
-      clear: vi.fn(),
-      reset: vi.fn(),
-      dispose: vi.fn(),
-    }),
-  };
-});
+vi.mock(import('@xterm/xterm'));
 
 beforeAll(() => {
   Object.defineProperty(window, 'dispatchEvent', {

--- a/packages/renderer/src/lib/kube/pods/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.spec.ts
@@ -30,10 +30,9 @@ import * as states from '/@/stores/kubernetes-contexts-state';
 import { initListExperimental, initListsNonExperimental, type initListsReturnType } from '../tests-helpers/init-lists';
 import PodDetails from './PodDetails.svelte';
 
-vi.mock('@xterm/xterm');
-vi.mock('@xterm/addon-search');
-
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('@xterm/xterm'));
+vi.mock(import('@xterm/addon-search'));
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 const myPod: V1Pod = {
   apiVersion: 'v1',

--- a/packages/renderer/src/lib/markdown/micromark-listener-handler.spec.ts
+++ b/packages/renderer/src/lib/markdown/micromark-listener-handler.spec.ts
@@ -20,7 +20,7 @@ import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { createListener } from './micromark-listener-handler';
 
-let mockCommandCallback: ReturnType<typeof vi.fn>;
+let mockCommandCallback: (command: string, state: 'starting' | 'failed' | 'successful', value?: unknown) => void;
 let listener: ReturnType<typeof createListener>;
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -32,10 +32,8 @@ import PodDetails from './PodDetails.svelte';
 const mocks = vi.hoisted(() => ({
   TerminalMock: vi.fn(),
 }));
-vi.mock('@xterm/xterm', () => ({
-  Terminal: mocks.TerminalMock,
-}));
-vi.mock('@xterm/addon-search');
+vi.mock(import('@xterm/xterm'));
+vi.mock(import('@xterm/addon-search'));
 
 const listPodsMock = vi.fn();
 const listContainersMock = vi.fn();

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { router, type TinroRoute } from 'tinro';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import { podsInfos } from '/@/stores/pods';
@@ -29,16 +29,8 @@ import type { PodInfo } from '/@api/pod-info';
 
 import PodDetails from './PodDetails.svelte';
 
-const mocks = vi.hoisted(() => ({
-  TerminalMock: vi.fn(),
-}));
 vi.mock(import('@xterm/xterm'));
 vi.mock(import('@xterm/addon-search'));
-
-const listPodsMock = vi.fn();
-const listContainersMock = vi.fn();
-const showMessageBoxMock = vi.fn();
-const getConfigurationValueMock = vi.fn();
 
 const myPod: PodInfo = {
   Cgroup: '',
@@ -56,38 +48,20 @@ const myPod: PodInfo = {
   kind: 'podman',
 };
 
-const removePodMock = vi.fn();
-const getContributedMenusMock = vi.fn();
+beforeEach(() => {
+  vi.resetAllMocks();
 
-beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
-  Object.defineProperty(window, 'listPods', { value: listPodsMock });
-  Object.defineProperty(window, 'listContainers', { value: listContainersMock.mockResolvedValue([]) });
-  Object.defineProperty(window, 'removePod', { value: removePodMock });
-  Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
-  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock, writable: true });
-  Object.defineProperty(window, 'addEventListener', { value: vi.fn() });
-  Object.defineProperty(window, 'getConfigurationProperties', { value: vi.fn().mockResolvedValue({}) });
-  Object.defineProperty(window, 'getConfigurationValue', { value: vi.fn().mockResolvedValue(undefined) });
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
-  mocks.TerminalMock.mockReturnValue({
-    loadAddon: vi.fn(),
-    open: vi.fn(),
-    write: vi.fn(),
-    dispose: vi.fn(),
-  });
-  global.ResizeObserver = vi.fn().mockReturnValue({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  });
+  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
+  vi.mocked(window.listContainers).mockResolvedValue([]);
+  vi.mocked(window.getConfigurationProperties).mockResolvedValue({});
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
 });
 
 test('Expect redirect to previous page if pod is deleted', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   const routerGotoSpy = vi.spyOn(router, 'goto');
-  listPodsMock.mockResolvedValue([myPod]);
+  vi.mocked(window.listPods).mockResolvedValue([myPod]);
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   while (get(podsInfos).length !== 1) {
     await new Promise(resolve => setTimeout(resolve, 500));
@@ -95,7 +69,7 @@ test('Expect redirect to previous page if pod is deleted', async () => {
 
   // remove myPod from the store when we call 'removePod'
   // it will then refresh the store and update PodsDetails page
-  removePodMock.mockImplementation(() => {
+  vi.mocked(window.removePod).mockImplementation(async () => {
     podsInfos.update(pods => pods.filter(pod => pod.Id !== myPod.Id));
   });
 
@@ -117,7 +91,7 @@ test('Expect redirect to previous page if pod is deleted', async () => {
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
   // check that remove method has been called
-  expect(removePodMock).toHaveBeenCalled();
+  expect(window.removePod).toHaveBeenCalled();
 
   // expect that we have called the router when page has been removed
   // to jump to the previous page
@@ -130,14 +104,14 @@ test('Expect redirect to previous page if pod is deleted', async () => {
 
 test('Expect redirect to logs', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   const routerGotoSpy = vi.spyOn(router, 'goto');
   const subscribeSpy = vi.spyOn(router, 'subscribe');
   subscribeSpy.mockImplementation(listener => {
     listener({ path: '/pods/podman/myPod/engine0/' } as unknown as TinroRoute);
     return (): void => {};
   });
-  listPodsMock.mockResolvedValue([myPod]);
+  vi.mocked(window.listPods).mockResolvedValue([myPod]);
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   while (get(podsInfos).length !== 1) {
     await new Promise(resolve => setTimeout(resolve, 500));

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.spec.ts
@@ -25,8 +25,8 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import PodDetailsLogs from '/@/lib/pod/PodDetailsLogs.svelte';
 import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
 
-vi.mock('@xterm/xterm');
-vi.mock('@xterm/addon-search');
+vi.mock(import('@xterm/xterm'));
+vi.mock(import('@xterm/addon-search'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -35,19 +35,7 @@ import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provid
 
 import PreferencesConnectionCreationOrEditRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
 
-vi.mock('@xterm/xterm', () => {
-  return {
-    Terminal: vi.fn(() => {
-      return {
-        loadAddon: vi.fn(),
-        open: vi.fn(),
-        write: vi.fn(),
-        clear: vi.fn(),
-        dispose: vi.fn(),
-      };
-    }),
-  };
-});
+vi.mock(import('@xterm/xterm'));
 
 vi.mock(import('/@/lib/preferences/preferences-connection-rendering-task'), async importOriginal => {
   const original = await importOriginal();
@@ -102,7 +90,17 @@ beforeAll(() => {
 
 function mockCallback(
   callback: (keyLogger: (key: symbol, eventName: LoggerEventName, args: string[]) => void) => Promise<void>,
-): Mock<any> {
+): Mock<
+  (
+    param: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: any,
+    handlerKey: symbol,
+    collect: (key: symbol, eventName: 'log' | 'warn' | 'error' | 'finish', args: string[]) => void,
+    tokenId: number | undefined,
+    taskId: number | undefined,
+  ) => Promise<void>
+> {
   return vi.fn().mockImplementation(async function (
     _id: string,
     _params: unknown,

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
@@ -48,10 +48,6 @@ beforeAll(async () => {
     }
     return undefined;
   });
-  global.ResizeObserver = vi.fn().mockImplementation(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-  }));
 
   Terminal.prototype.open = vi.fn();
   Terminal.prototype.write = vi.fn();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
@@ -37,14 +37,6 @@ const shellInProviderConnectionResizeMock = vi.fn();
 const shellInProviderConnectionCloseMock = vi.fn();
 const receiveEndCallbackMock = vi.fn();
 
-vi.mock('xterm', () => {
-  return {
-    Terminal: vi
-      .fn()
-      .mockReturnValue({ loadAddon: vi.fn(), open: vi.fn(), write: vi.fn(), dispose: vi.fn(), onData: vi.fn() }),
-  };
-});
-
 beforeEach(() => {
   vi.resetAllMocks();
   getConfigurationValueMock.mockImplementation((key: string) => {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.spec.ts
@@ -32,7 +32,7 @@ vi.mock(import('@podman-desktop/ui-svelte'), async importOriginal => {
   const actual = await importOriginal();
   return {
     ...actual,
-    Dropdown: vi.fn(),
+    Dropdown: vi.fn() as unknown as typeof Dropdown,
   };
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -31,7 +31,7 @@ vi.mock(import('@podman-desktop/ui-svelte'), async importOriginal => {
   const actual = await importOriginal();
   return {
     ...actual,
-    Dropdown: vi.fn(),
+    Dropdown: vi.fn() as unknown as typeof Dropdown,
   };
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -117,9 +117,6 @@ beforeAll(() => {
   Object.defineProperty(window, 'telemetryTrack', { value: vi.fn().mockResolvedValue(undefined) });
   Object.defineProperty(window, 'telemetryPage', { value: vi.fn().mockResolvedValue(undefined) });
   Object.defineProperty(window, 'getOsPlatform', { value: getOsPlatformMock });
-  Object.defineProperty(window, 'ResizeObserver', {
-    value: vi.fn().mockReturnValue({ observe: vi.fn(), unobserve: vi.fn() }),
-  });
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
-import { expect, test, vi } from 'vitest';
+import { assert, expect, test, vi } from 'vitest';
 
 import type { ProviderInfo } from '/@api/provider-info';
 
@@ -224,6 +224,7 @@ test('startProviderConnectionLifecycle is called when addConnectionToRestartingQ
   // simulate PreferencesConnectionActions is calling addConnectionToRestartingQueue
   expect(preferencesConnectionActions.default).toHaveBeenCalledOnce();
   const params = vi.mocked(preferencesConnectionActions.default).mock.calls[0][1];
+  assert(params);
   const addConnectionToRestartingQueue = params['addConnectionToRestartingQueue'];
 
   addConnectionToRestartingQueue({

--- a/packages/renderer/src/lib/statusbar/PinActions.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinActions.spec.ts
@@ -48,14 +48,8 @@ const KUBERNETES_CONNECTION_PROVIDER = {
   images: {},
 } as unknown as ProviderInfo;
 
-const RESIZE_OBSERVER_MOCK: ResizeObserver = {
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-} as unknown as ResizeObserver;
-
 beforeAll(() => {
   Object.defineProperty(window, 'events', { value: { receive: vi.fn() } });
-  Object.defineProperty(window, 'ResizeObserver', { value: vi.fn() });
 });
 
 beforeEach(() => {
@@ -72,8 +66,6 @@ beforeEach(() => {
       pinned: true,
     },
   ]);
-
-  vi.mocked(window.ResizeObserver).mockReturnValue(RESIZE_OBSERVER_MOCK);
 
   vi.mocked(window.unpinStatusBar).mockResolvedValue(undefined);
   vi.mocked(window.pinStatusBar).mockResolvedValue(undefined);

--- a/packages/renderer/src/lib/statusbar/PinMenu.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinMenu.spec.ts
@@ -23,20 +23,13 @@ import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import PinMenu from '/@/lib/statusbar/PinMenu.svelte';
 
-const RESIZE_OBSERVER_MOCK: ResizeObserver = {
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-} as unknown as ResizeObserver;
-
 beforeAll(() => {
-  Object.defineProperty(window, 'ResizeObserver', { value: vi.fn() });
   Object.defineProperty(window, 'addEventListener', { value: vi.fn() });
   Object.defineProperty(window, 'removeEventListener', { value: vi.fn() });
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(window.ResizeObserver).mockReturnValue(RESIZE_OBSERVER_MOCK);
 });
 
 test('component on mount should resize listener', () => {

--- a/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
@@ -18,7 +18,6 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { Spinner } from '@podman-desktop/ui-svelte';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { toast } from '@zerodevx/svelte-toast';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -26,14 +25,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import type { TaskInfo } from '/@api/taskInfo';
 
 import ToastCustomUi from './ToastCustomUi.svelte';
-
-vi.mock(import('@podman-desktop/ui-svelte'), async importOriginal => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    Spinner: vi.fn(),
-  };
-});
 
 const started = new Date().getTime();
 const onpop = vi.fn();
@@ -97,7 +88,8 @@ test('Check with in-progress', async () => {
   // expect the in-progress is used
   const status = screen.getByRole('status', { name: 'in-progress' });
   expect(status).toBeInTheDocument();
-  expect(Spinner).toHaveBeenCalled();
+  const progressbar = screen.getByRole('progressbar');
+  expect(progressbar).toBeInTheDocument();
 
   // expect name is there
   const name = screen.getByText(IN_PROGRESS_TASK.name);

--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -28,11 +28,9 @@ import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
 
 import { TerminalSettings } from '../../../../main/src/plugin/terminal-settings';
 
-vi.mock('@xterm/xterm');
-
-vi.mock('@xterm/addon-fit');
-
-vi.mock('@xterm/addon-search');
+vi.mock(import('@xterm/xterm'));
+vi.mock(import('@xterm/addon-fit'));
+vi.mock(import('@xterm/addon-search'));
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -118,12 +116,6 @@ test('terminal constructor should contains fontSize and lineHeight from configur
 });
 
 test('addon fit should be loaded on mount', async () => {
-  const fitAddonMock = {
-    fit: vi.fn(),
-  } as unknown as FitAddon;
-
-  vi.mocked(FitAddon).mockReturnValue(fitAddonMock);
-
   render(TerminalWindow, {
     terminal: createTerminalMock(),
   });
@@ -132,7 +124,9 @@ test('addon fit should be loaded on mount', async () => {
     expect(Terminal).toHaveBeenCalled();
   });
 
-  expect(FitAddon).toHaveBeenCalled();
+  expect(FitAddon).toHaveBeenCalledOnce();
+  const fitAddonMock = vi.mocked(FitAddon).mock.instances[0];
+
   expect(Terminal.prototype.loadAddon).toHaveBeenCalledWith(fitAddonMock);
 });
 

--- a/packages/renderer/src/stores/dashboard/dashboard-page-registry.svelte.spec.ts
+++ b/packages/renderer/src/stores/dashboard/dashboard-page-registry.svelte.spec.ts
@@ -27,25 +27,11 @@ import {
 } from './dashboard-page-registry.svelte';
 
 // Mock the individual registry creation functions
-vi.mock(import('/@/lib/recommendation/ExtensionBanners.svelte'), () => ({
-  default: vi.fn(),
-}));
-
-vi.mock(import('/@/lib/learning-center/LearningCenter.svelte'), () => ({
-  default: vi.fn(),
-}));
-
-vi.mock(import('/@/lib/dashboard/ProvidersSection.svelte'), () => ({
-  default: vi.fn(),
-}));
-
-vi.mock(import('/@/lib/dashboard/ReleaseNotesBox.svelte'), () => ({
-  default: vi.fn(),
-}));
-
-vi.mock(import('/@/lib/explore-features/ExploreFeatures.svelte'), () => ({
-  default: vi.fn(),
-}));
+vi.mock(import('/@/lib/recommendation/ExtensionBanners.svelte'));
+vi.mock(import('/@/lib/learning-center/LearningCenter.svelte'));
+vi.mock(import('/@/lib/dashboard/ProvidersSection.svelte'));
+vi.mock(import('/@/lib/dashboard/ReleaseNotesBox.svelte'));
+vi.mock(import('/@/lib/explore-features/ExploreFeatures.svelte'));
 
 beforeEach(() => {
   vi.resetAllMocks();


### PR DESCRIPTION
### What does this PR do?

Most of the fixes are just removing unnecessary custom mocking of module, in vitest 4 this is causing some problems as we cannot mock constructor / newable.

A lot of tests are fixed in vitest 4 by just adding the `vi.resetAllMock()` in `beforeEach` errors are raised due to improper test isolation, some mocks made during tests are leaking in other tests, and sometime causes errors in Vitest 4.

Using `Object.defineProperty` seems to also causing a lot of problems with test isolation.

The terminal is the most annoying package, there are a lot of unnecessary mocking resulting from copy paste between tests.

We should not try to touch the ResizeObserver in Vitest 4, this is causing **a lot** of runtime type errors.

More details in https://github.com/podman-desktop/podman-desktop/pull/14898

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Need rebase after
- https://github.com/podman-desktop/podman-desktop/pull/14919

Required for 
- https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
