### PR TITLE
refactor(main/kubernetes): use vitest v4 compatible syntax

### DIFF
--- a/packages/main/src/plugin/kubernetes/context-health-checker.spec.ts
+++ b/packages/main/src/plugin/kubernetes/context-health-checker.spec.ts
@@ -23,7 +23,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ContextHealthChecker } from './context-health-checker.js';
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 
-vi.mock('@kubernetes/client-node');
+vi.mock(import('@kubernetes/client-node'));
 
 const context1 = {
   name: 'context1',
@@ -54,23 +54,15 @@ const config = {
 } as KubeConfigSingleContext;
 
 beforeEach(() => {
-  vi.mocked(Health).mockClear();
+  vi.resetAllMocks();
 });
 
 describe('readyz returns a value', async () => {
   const onStateChangeCB = vi.fn();
   const onReachableCB = vi.fn();
-  const readyzMock = vi.fn();
   let hc: ContextHealthChecker;
 
   beforeEach(async () => {
-    vi.mocked(Health).mockImplementation(
-      () =>
-        ({
-          readyz: readyzMock,
-        }) as unknown as Health,
-    );
-
     hc = new ContextHealthChecker(config);
 
     hc.onStateChange(onStateChangeCB);
@@ -78,7 +70,7 @@ describe('readyz returns a value', async () => {
   });
 
   test('onStateChange is fired with result of readyz', async () => {
-    readyzMock.mockResolvedValue(true);
+    vi.mocked(Health.prototype.readyz).mockResolvedValue(true);
     await hc.start();
 
     expect(onStateChangeCB).toHaveBeenCalledWith({
@@ -103,7 +95,7 @@ describe('readyz returns a value', async () => {
 
     onStateChangeCB.mockReset();
 
-    readyzMock.mockResolvedValue(false);
+    vi.mocked(Health.prototype.readyz).mockResolvedValue(false);
     await hc.start();
     expect(onStateChangeCB).toHaveBeenCalledWith({
       kubeConfig: config,
@@ -127,7 +119,7 @@ describe('readyz returns a value', async () => {
   });
 
   test('onReachable is fired when readyz returns true', async () => {
-    readyzMock.mockResolvedValue(true);
+    vi.mocked(Health.prototype.readyz).mockResolvedValue(true);
     await hc.start();
 
     expect(onReachableCB).toHaveBeenCalledWith({
@@ -139,28 +131,20 @@ describe('readyz returns a value', async () => {
 
     onReachableCB.mockReset();
 
-    readyzMock.mockResolvedValue(false);
+    vi.mocked(Health.prototype.readyz).mockResolvedValue(false);
     await hc.start();
     expect(onReachableCB).not.toHaveBeenCalled();
   });
 });
 
 test('onStateChange is not fired when readyz is rejected with an abort error', async () => {
-  const readyzMock = vi.fn();
-  vi.mocked(Health).mockImplementation(
-    () =>
-      ({
-        readyz: readyzMock,
-      }) as unknown as Health,
-  );
-
   const hc = new ContextHealthChecker(config);
   const onStateChangeCB = vi.fn();
   hc.onStateChange(onStateChangeCB);
 
   const err = new Error('a message');
   err.name = 'AbortError';
-  readyzMock.mockRejectedValue(err);
+  vi.mocked(Health.prototype.readyz).mockRejectedValue(err);
   await hc.start();
   expect(onStateChangeCB).toHaveBeenCalledOnce();
   expect(onStateChangeCB).toHaveBeenCalledWith({
@@ -178,19 +162,11 @@ test('onStateChange is not fired when readyz is rejected with an abort error', a
 });
 
 test('onReadiness is called with false when readyz is rejected with a generic error', async () => {
-  const readyzMock = vi.fn();
-  vi.mocked(Health).mockImplementation(
-    () =>
-      ({
-        readyz: readyzMock,
-      }) as unknown as Health,
-  );
-
   const hc = new ContextHealthChecker(config);
   const onStateChangeCB = vi.fn();
   hc.onStateChange(onStateChangeCB);
 
-  readyzMock.mockRejectedValue(new Error('a generic error'));
+  vi.mocked(Health.prototype.readyz).mockRejectedValue(new Error('a generic error'));
   await hc.start();
   expect(onStateChangeCB).toHaveBeenCalledWith({
     kubeConfig: config,
@@ -213,14 +189,6 @@ test('onReadiness is called with false when readyz is rejected with a generic er
 });
 
 test('onReadiness is called with false when readyz is rejected with a noent error', async () => {
-  const readyzMock = vi.fn();
-  vi.mocked(Health).mockImplementation(
-    () =>
-      ({
-        readyz: readyzMock,
-      }) as unknown as Health,
-  );
-
   const hc = new ContextHealthChecker(config);
   const onStateChangeCB = vi.fn();
   hc.onStateChange(onStateChangeCB);
@@ -228,7 +196,7 @@ test('onReadiness is called with false when readyz is rejected with a noent erro
   const enoentErr: NodeJS.ErrnoException = new Error('enoent error');
   enoentErr.code = 'ENOENT';
   enoentErr.path = '/path/to/command';
-  readyzMock.mockRejectedValue(enoentErr);
+  vi.mocked(Health.prototype.readyz).mockRejectedValue(enoentErr);
   await hc.start();
   expect(onStateChangeCB).toHaveBeenCalledWith({
     kubeConfig: config,

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { Cluster, Context, KubeConfig, User } from '@kubernetes/client-node';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ApiSenderType } from '../api.js';
 import type { ConfigurationRegistry } from '../configuration-registry.js';
@@ -94,11 +94,8 @@ describe('context tests', () => {
   }
 
   beforeEach(() => {
+    vi.resetAllMocks();
     client = createClient();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   test('should delete context from config', async () => {

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -26,6 +26,7 @@ import {
   BatchV1Api,
   CoreV1Api,
   Exec,
+  Health,
   KubeConfig,
   type KubernetesObject,
   type V1ConfigMap,
@@ -44,7 +45,7 @@ import {
 } from '@kubernetes/client-node';
 import * as clientNode from '@kubernetes/client-node';
 import type { FileSystemWatcher } from '@podman-desktop/api';
-import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
 import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
@@ -281,49 +282,37 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 
-vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-service', async () => {
-  const singletonGetServiceMock = vi.fn();
+vi.mock(import('/@/plugin/kubernetes/kubernetes-port-forward-service.js'));
+vi.mock(import('@kubernetes/client-node'), async importOriginal => {
+  const original = await importOriginal();
   return {
-    KubernetesPortForwardService: vi.fn(),
-    KubernetesPortForwardServiceProvider: vi.fn().mockImplementation(() => {
-      return {
-        getService: singletonGetServiceMock,
-      };
-    }),
-  };
+    // we need to use original ApiException
+    ...original,
+    KubeConfig: vi.fn(),
+    CoreV1Api: {},
+    AppsV1Api: {},
+    BatchV1Api: {},
+    CustomObjectsApi: {},
+    NetworkingV1Api: {},
+    VersionApi: {},
+    makeInformer: vi.fn(),
+    createConfiguration: vi.fn(),
+    KubernetesObjectApi: vi.fn(),
+    HttpError: class HttpError extends Error {
+      statusCode: number;
+      constructor(statusCode: number, message: string) {
+        super(message);
+        this.statusCode = statusCode;
+      }
+    },
+    Exec: vi.fn(),
+    V1DeleteOptions: vi.fn(),
+    V1Job: vi.fn(),
+    Health: vi.fn(),
+  } as unknown as typeof clientNode;
 });
 
 const execMock = vi.fn();
-beforeAll(() => {
-  vi.mock('@kubernetes/client-node', async importOriginal => {
-    const original = await importOriginal<typeof clientNode>();
-    return {
-      // we need to use original ApiException
-      ...original,
-      KubeConfig: vi.fn(),
-      CoreV1Api: {},
-      AppsV1Api: {},
-      BatchV1Api: {},
-      CustomObjectsApi: {},
-      NetworkingV1Api: {},
-      VersionApi: {},
-      makeInformer: vi.fn(),
-      createConfiguration: vi.fn(),
-      KubernetesObjectApi: vi.fn(),
-      HttpError: class HttpError extends Error {
-        statusCode: number;
-        constructor(statusCode: number, message: string) {
-          super(message);
-          this.statusCode = statusCode;
-        }
-      },
-      Exec: vi.fn(),
-      V1DeleteOptions: vi.fn(),
-      V1Job: vi.fn(),
-      Health: vi.fn(),
-    };
-  });
-});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -333,6 +322,7 @@ beforeEach(() => {
   KubeConfig.prototype.getContextObject = getContextObjectMock;
   KubeConfig.prototype.currentContext = 'context';
   Exec.prototype.exec = execMock;
+  Health.prototype.readyz = vi.fn();
 });
 
 test('Create Kubernetes resources with empty should return ok', async () => {
@@ -477,9 +467,7 @@ describe.each([
 });
 
 test('Check connection to Kubernetes cluster', async () => {
-  vi.mocked(clientNode.Health).mockReturnValue({
-    readyz: vi.fn().mockResolvedValue(true),
-  } as unknown as clientNode.Health);
+  vi.mocked(clientNode.Health.prototype.readyz).mockResolvedValue(true);
   const client = new KubernetesClient(
     {} as ApiSenderType,
     configurationRegistry,
@@ -492,9 +480,7 @@ test('Check connection to Kubernetes cluster', async () => {
 });
 
 test('Check connection to Kubernetes cluster in error', async () => {
-  vi.mocked(clientNode.Health).mockReturnValue({
-    readyz: vi.fn().mockRejectedValue(undefined),
-  } as unknown as clientNode.Health);
+  vi.mocked(clientNode.Health.prototype.readyz).mockRejectedValue(undefined);
 
   const client = new KubernetesClient(
     {} as ApiSenderType,
@@ -2535,8 +2521,7 @@ describe('port forward', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const providerInstance = new KubernetesPortForwardServiceProvider();
-    vi.mocked(providerInstance.getService).mockReturnValue(serviceMock);
+    vi.mocked(KubernetesPortForwardServiceProvider.prototype.getService).mockReturnValue(serviceMock);
   });
 
   test('expect forward to be returned', async () => {


### PR DESCRIPTION
### What does this PR do?

Details in https://github.com/podman-desktop/podman-desktop/pull/14898

> ⚠️ I cannot update the `packages/main/src/plugin/kubernetes/contexts-manager-experimental.spec.ts` because it requires vitest v4 synthax that is not compatible with vitest v3

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

- CI should be :green_circle: 