### PR TITLE
refactor(main/filesystem-monitoring.spec.ts): use vitest v4 compatible syntax

### DIFF
--- a/packages/main/src/plugin/filesystem-monitoring.spec.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.spec.ts
@@ -49,6 +49,9 @@ afterEach(async () => {
 
 test(
   'should send event into onDid when a file is watched into an existing directory',
+  {
+    skip: isWindows(),
+  },
   async () => {
     const watchedFile = path.join(rootdir, 'file.txt');
     watcher = new FileSystemWatcherImpl(watchedFile);
@@ -85,9 +88,6 @@ test(
     await vi.waitFor(async () => {
       expect(unlinkListener).toHaveBeenCalledWith(Uri.file(watchedFile));
     });
-  },
-  {
-    skip: isWindows(),
   },
 );
 


### PR DESCRIPTION
### What does this PR do?

You cannot set anymore the options at the end of the `test` function, you should use either `test(<name>, <options>, <handle>)` or call skip in the test logic.

Details in https://github.com/podman-desktop/podman-desktop/pull/14898

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

- CI should be :green_circle: 