### PR TITLE
chore: add task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,20 @@
+name: Task
+description: A specific peice of work
+type: task
+projects: ["podman-desktop/4"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Tasks are normally created by the development team to plan work unrelated to features or bugs.
+        The issue type can be switched to Technical debt or Release as necessary.
+
+  - type: textarea
+    id: content
+    attributes:
+      label: Task content
+      description: A clear and concise description of the task.
+      placeholder: Podman Desktop should [...]
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,5 +1,5 @@
 name: Task
-description: A specific peice of work
+description: A specific piece of work
 type: task
 projects: ["podman-desktop/4"]
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 ## Pre-requisites
 
-- Create Enhancement Issue `Release vX.X.X` for current sprint (if such an issue does not already exist), then update the label to `kind/release` and assign it to yourself.
+- Create Task issue `Release vX.X.X` for the current sprint (if such an issue does not already exist), then update the type to Release and assign it to yourself.
 - Confirm with Podman Desktop maintainers that pending / need-to-go-in PR's have been merged.
 - Notify main contributors on Discord / Slack.
 - Release notes for the blog: Communicate with the person who has been tasked with creating the documentation. If you are assigned, see the below ["Documentation"](#documentation) section.


### PR DESCRIPTION
### What does this PR do?

We have kind/* labels for task, release, and technical debt, but our templates don't cover any of these - you have to create a feature or a bug and then change the type. This takes longer and leaves a bunch of odd fields in the issue, e.g. 'Is your feature request related to a problem?'

We're switching to use Github issue types which also includes these three types.

It should be easier to create one of these issue types, but we also don't want to clutter up the template list with lots of 'internal' types that will make it more confusing to external users. The proposal is just to add Task, which is generic enough and easier to switch to Technical debt or Release.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #14777.

### How to test this PR?

Merge and confirm new template.