### PR TITLE
test(renderer/KubePlayYAML): try to address flakiness

### DIFF
--- a/packages/renderer/vite.tests.setup.js
+++ b/packages/renderer/vite.tests.setup.js
@@ -22,7 +22,7 @@ import 'vitest-canvas-mock';
 import typescript from 'typescript';
 import { EventStore } from './src/stores/event-store';
 
-global.window.matchMedia = () => {};
+global.window.matchMedia = vi.fn();
 
 // read the given path and extract the method names from the Window interface
 function extractWindowMethods(filePath) {


### PR DESCRIPTION
### What does this PR do?

Tests inside `packages/renderer/src/lib/kube/KubePlayYAML.spec.ts` are very flaky, and this starts to be pretty annoying; after looking at the error `TypeError: Cannot read properties of undefined (reading 'matches')` we can safely assume the problems is related to the `window.matchMedia` this is currently defined as an arrow function inside the `vitest.setup.js` 

https://github.com/podman-desktop/podman-desktop/blob/9c53273634ef7bf62b5ae050a583d57bccdff512/packages/renderer/vite.tests.setup.js#L25

This is annoying because this forces component such as `KubePlayYAML` to use the dangerous and poorly typed `Object.defineProperty`

https://github.com/podman-desktop/podman-desktop/blob/9c53273634ef7bf62b5ae050a583d57bccdff512/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts#L94-L100
  
Moreover, this is done in the `beforeAll` hook, and test isolation is broken. Let's move the logic inside the `beforeEach`, enforce test isolation by running `vi.resetAllMock()` and make the `window.matchMedia` a mock by default in the vitest setup.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

kinda required for
- https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 