### PR TITLE
feat(BuildImage): add target dropdown

### DIFF
--- a/packages/api/src/containerfile-info.ts
+++ b/packages/api/src/containerfile-info.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ContainerfileInfo {
+  targets: string[];
+}

--- a/packages/main/src/plugin/__snapshots__/containerfile-parser.spec.ts.snap
+++ b/packages/main/src/plugin/__snapshots__/containerfile-parser.spec.ts.snap
@@ -1,0 +1,32 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Should parse info from container files > should parse targets from 'casing.Containerfile' 1`] = `
+[
+  "lower",
+  "UPPER",
+  "MiXeD",
+]
+`;
+
+exports[`Should parse info from container files > should parse targets from 'comments-and-empty-lines.Containerfile' 1`] = `
+[
+  "stage1",
+  "stage2",
+]
+`;
+
+exports[`Should parse info from container files > should parse targets from 'empty.Containerfile' 1`] = `[]`;
+
+exports[`Should parse info from container files > should parse targets from 'multiple-targets.Containerfile' 1`] = `
+[
+  "base",
+  "builder",
+  "final",
+]
+`;
+
+exports[`Should parse info from container files > should parse targets from 'single-target.Containerfile' 1`] = `
+[
+  "base",
+]
+`;

--- a/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/casing.Containerfile
+++ b/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/casing.Containerfile
@@ -1,0 +1,3 @@
+from alpine as lower
+FROM alpine AS UPPER
+FrOm alpine aS MiXeD

--- a/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/comments-and-empty-lines.Containerfile
+++ b/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/comments-and-empty-lines.Containerfile
@@ -1,0 +1,7 @@
+# This is a comment
+FROM alpine AS stage1
+
+  # Another comment with indentation
+FROM stage1 AS stage2
+
+RUN echo "test"

--- a/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/empty.Containerfile
+++ b/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/empty.Containerfile
@@ -1,0 +1,1 @@
+# Empty Containerfile

--- a/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/multiple-targets.Containerfile
+++ b/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/multiple-targets.Containerfile
@@ -1,0 +1,9 @@
+FROM alpine AS base
+RUN echo "hello"
+
+FROM base AS builder
+COPY . .
+RUN build
+
+FROM builder AS final
+CMD ["sh"]

--- a/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/single-target.Containerfile
+++ b/packages/main/src/plugin/__tests__/fixtures/containerfile-parser/single-target.Containerfile
@@ -1,0 +1,3 @@
+FROM alpine AS base
+RUN echo "hello"
+CMD ["sh"]

--- a/packages/main/src/plugin/containerfile-parser.spec.ts
+++ b/packages/main/src/plugin/containerfile-parser.spec.ts
@@ -1,0 +1,48 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ContainerfileParser } from './containerfile-parser.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const fixturesDir = join(__dirname, '__tests__', 'fixtures', 'containerfile-parser');
+
+describe('Should parse info from container files', async () => {
+  test.each(
+    readdirSync(fixturesDir).map(file => ({
+      name: file,
+      path: join(fixturesDir, file),
+    })),
+  )('should parse targets from $name', async ({ path }) => {
+    const info = await ContainerfileParser.parse(path);
+    expect(info.targets).toMatchSnapshot();
+  });
+
+  test('should throw error if file does not exist', async () => {
+    await expect(ContainerfileParser.parse('/tmp/nonexistent-Containerfile')).rejects.toThrow(
+      'ENOENT: no such file or directory',
+    );
+  });
+});

--- a/packages/main/src/plugin/containerfile-parser.ts
+++ b/packages/main/src/plugin/containerfile-parser.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2022-2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { readFile } from 'node:fs/promises';
+
+import type { ContainerfileInfo } from '/@api/containerfile-info.js';
+
+export class ContainerfileParser {
+  static async parse(containerfilePath: string): Promise<ContainerfileInfo> {
+    const content = await readFile(containerfilePath, 'utf-8');
+    const lines = content.split('\n');
+    const targets: string[] = [];
+
+    const fromAsRegex = /FROM\s+\S+\s+AS\s+(\S+)/i;
+
+    for (const line of lines) {
+      const match = fromAsRegex.exec(line);
+      if (match?.[1]) {
+        targets.push(match[1]);
+      }
+    }
+    return { targets };
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -50,6 +50,7 @@ import type { IpcMainInvokeEvent } from 'electron/main';
 import { Container } from 'inversify';
 
 import type { KubernetesGeneratorInfo } from '/@/plugin/api/KubernetesGeneratorInfo.js';
+import { ContainerfileParser } from '/@/plugin/containerfile-parser.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionWatcher } from '/@/plugin/extension/extension-watcher.js';
 import type {
@@ -84,6 +85,7 @@ import type {
 } from '/@api/container-info.js';
 import type { ContainerInspectInfo } from '/@api/container-inspect-info.js';
 import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
+import type { ContainerfileInfo } from '/@api/containerfile-info.js';
 import type { ContributionInfo } from '/@api/contribution-info.js';
 import type { MessageBoxOptions, MessageBoxReturnValue } from '/@api/dialog.js';
 import type { IDisposable } from '/@api/disposable.js';
@@ -1442,8 +1444,9 @@ export class PluginSystem {
         target?: string,
       ): Promise<unknown> => {
         // create task
+        const targetDisplay = target ? `(${target})` : '';
         const task = taskManager.createTask({
-          title: `Building image ${imageName ?? ''}`,
+          title: `Building image ${imageName ?? ''} ${targetDisplay}`,
           action: {
             name: 'Go to task >',
             execute: () => {
@@ -3150,6 +3153,10 @@ export class PluginSystem {
 
     this.ipcHandle('explore-features:closeFeatureCard', async (_listener, featureId: string): Promise<void> => {
       return exploreFeatures.closeFeatureCard(featureId);
+    });
+
+    this.ipcHandle('containerfile:getInfo', async (_listener, path: string): Promise<ContainerfileInfo> => {
+      return ContainerfileParser.parse(path);
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -61,6 +61,7 @@ import type {
 } from '/@api/container-info';
 import type { ContainerInspectInfo } from '/@api/container-inspect-info';
 import type { ContainerStatsInfo } from '/@api/container-stats-info';
+import type { ContainerfileInfo } from '/@api/containerfile-info';
 import type { ContributionInfo } from '/@api/contribution-info';
 import type { MessageBoxOptions, MessageBoxReturnValue } from '/@api/dialog';
 import type { IDisposable } from '/@api/disposable';
@@ -2611,6 +2612,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('closeFeatureCard', async (featureId: string): Promise<void> => {
     return ipcInvoke('explore-features:closeFeatureCard', featureId);
+  });
+
+  contextBridge.exposeInMainWorld('containerfileGetInfo', async (path: string): Promise<ContainerfileInfo> => {
+    return ipcInvoke('containerfile:getInfo', path);
   });
 
   contextBridge.exposeInMainWorld('contextCollectAllValues', async (): Promise<Record<string, unknown>> => {

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -19,11 +19,11 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { render, type RenderResult, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { tick } from 'svelte';
+import { type Component, tick } from 'svelte';
 import { get } from 'svelte/store';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import BuildImageFromContainerfile from '/@/lib/image/BuildImageFromContainerfile.svelte';
 import { buildImagesInfo, getNextTaskId } from '/@/stores/build-images';
@@ -38,17 +38,22 @@ vi.mock(import('@xterm/xterm'));
 beforeAll(() => {
   vi.mocked(window.openDialog).mockResolvedValue(['Containerfile']);
   vi.mocked(window.getCancellableTokenSource).mockResolvedValue(1234);
+  vi.mocked(window.containerfileGetInfo).mockResolvedValue({
+    targets: [],
+  });
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-async function waitRender(): Promise<void> {
-  render(BuildImageFromContainerfile);
+async function waitRender(): Promise<RenderResult<Component>> {
+  const res = render(BuildImageFromContainerfile);
 
   // Wait 200ms for "cards" for platform render correctly
   await new Promise(resolve => setTimeout(resolve, 200));
+
+  return res;
 }
 
 // the build image page expects to have a valid provider connection, so let's mock one
@@ -200,6 +205,7 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
     expect.anything(),
     expect.anything(),
     expect.anything(),
+    undefined,
   );
 
   expect(window.buildImage).toHaveBeenCalledWith(
@@ -213,6 +219,7 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
     expect.anything(),
     expect.anything(),
     expect.anything(),
+    undefined,
   );
 });
 
@@ -308,6 +315,7 @@ test('Selecting one platform only calls buildImage once with the selected platfo
     expect.anything(),
     expect.anything(),
     expect.anything(),
+    undefined,
   );
 });
 
@@ -604,4 +612,50 @@ test('Expect error to be displayed if uppercase character in image name', async 
   const buildButton = getByRole('button', { name: 'Build' });
   expect(buildButton).toBeInTheDocument();
   expect(buildButton).toBeDisabled();
+});
+
+describe('Build image that has an intermediate target', () => {
+  test.each([
+    { target: 'custom-target', expected: 'custom-target' },
+    { target: 'none', expected: undefined },
+  ])('should build with target $target', async ({ target, expected }) => {
+    vi.mocked(window.containerfileGetInfo).mockResolvedValue({
+      targets: ['custom-target'],
+    });
+    vi.mocked(window.getOsArch).mockResolvedValue('amd64');
+    setup();
+
+    const { getByRole } = await waitRender();
+
+    vi.mocked(window.pathRelative).mockResolvedValue('containerfile');
+    const containerFilePath = getByRole('textbox', { name: 'Containerfile path' });
+    await userEvent.type(containerFilePath, '/somepath/containerfile');
+
+    const imageName = getByRole('textbox', { name: 'Image name' });
+    await userEvent.type(imageName, 'foobar');
+
+    const targetDropdown = getByRole('button', { name: 'Target' });
+    await userEvent.click(targetDropdown);
+
+    await userEvent.click(getByRole('button', { name: target }));
+
+    const buildButton = getByRole('button', { name: 'Build' });
+    expect(buildButton).toBeEnabled();
+    await userEvent.click(buildButton);
+
+    expect(window.buildImage).toHaveBeenCalledTimes(1);
+    expect(window.buildImage).toHaveBeenCalledWith(
+      '/somepath',
+      'containerfile',
+      'foobar',
+      'linux/amd64',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      {},
+      expect.anything(),
+      expected,
+    );
+  });
 });

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -2,7 +2,7 @@
 /* eslint-disable no-useless-escape */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faCube, faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import { type OpenDialogOptions } from '@podman-desktop/api';
+import type { OpenDialogOptions } from '@podman-desktop/api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
 import { onDestroy } from 'svelte';
 import { get, type Unsubscriber } from 'svelte/store';
@@ -27,6 +27,7 @@ import TerminalWindow from '../ui/TerminalWindow.svelte';
 import { type BuildImageCallback, disconnectUI, eventCollect, reconnectUI, startBuild } from './build-image-task';
 import BuildImageFromContainerfileCards from './BuildImageFromContainerfileCards.svelte';
 import RecommendedRegistry from './RecommendedRegistry.svelte';
+import TargetDropdown from './TargetDropdown.svelte';
 
 interface Props {
   taskId?: number;
@@ -143,6 +144,7 @@ async function buildSinglePlatformImage(): Promise<void> {
       buildImageInfo.cancellableTokenId,
       formattedBuildArgs,
       buildImageInfo.taskId,
+      buildImageInfo.target,
     );
   } catch (error) {
     eventCollect(buildImageInfo.buildImageKey, 'error', String(error));
@@ -205,6 +207,7 @@ async function buildMultiplePlatformImagesAndCreateManifest(): Promise<void> {
         buildImageInfo.cancellableTokenId,
         formattedBuildArgs,
         buildImageInfo.taskId,
+        buildImageInfo.target,
       )) as BuildOutput;
 
       // Extract and store the build ID as this is required for creating the manifest, only if it is available.
@@ -385,6 +388,12 @@ let hasInvalidFields = $derived(
           error={errorContainerImageName}
           class="w-full" />
       </div>
+
+      {#if buildImageInfo.containerFilePath}
+        <div hidden={buildImageInfo.buildRunning}>
+            <TargetDropdown bind:target={buildImageInfo.target} containerFilePath={buildImageInfo.containerFilePath} />
+        </div>
+      {/if}
 
       {#if providerConnections.length > 1}
         <div hidden={buildImageInfo.buildRunning}>

--- a/packages/renderer/src/lib/image/TargetDropdown.spec.ts
+++ b/packages/renderer/src/lib/image/TargetDropdown.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import TargetDropdown from './TargetDropdown.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect Target dropdown to be visible with targets and select a target', async () => {
+  vi.mocked(window.containerfileGetInfo).mockResolvedValue({
+    targets: ['target1', 'target2', 'custom-target'],
+  });
+
+  const { findByRole, getByText, getByRole } = render(TargetDropdown, {
+    props: { containerFilePath: '/somepath/Containerfile', target: undefined },
+  });
+
+  const targetDropdown = await findByRole('button', { name: 'Target' });
+
+  expect(getByText('none')).toBeInTheDocument();
+
+  await userEvent.click(targetDropdown);
+
+  const target1Option = getByRole('button', { name: 'target1' });
+  expect(target1Option).toBeInTheDocument();
+  await userEvent.click(target1Option);
+
+  expect(getByText('target1')).toBeInTheDocument();
+
+  await userEvent.click(targetDropdown);
+
+  const customTargetOption = getByRole('button', { name: 'custom-target' });
+  await userEvent.click(customTargetOption);
+
+  expect(getByText('custom-target')).toBeInTheDocument();
+});
+
+test('Expect selecting "none" to set target to undefined', async () => {
+  vi.mocked(window.containerfileGetInfo).mockResolvedValue({
+    targets: ['target1', 'target2'],
+  });
+
+  const { findByRole, getByText, getByRole } = render(TargetDropdown, {
+    props: { containerFilePath: '/somepath/Containerfile', target: 'target1' },
+  });
+
+  const targetDropdown = await findByRole('button', { name: 'Target' });
+  expect(targetDropdown).toBeInTheDocument();
+
+  expect(getByText('target1')).toBeInTheDocument();
+
+  await userEvent.click(targetDropdown);
+
+  const noneOption = getByRole('button', { name: 'none' });
+  expect(noneOption).toBeInTheDocument();
+  await userEvent.click(noneOption);
+
+  expect(getByText('none')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/image/TargetDropdown.svelte
+++ b/packages/renderer/src/lib/image/TargetDropdown.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { Dropdown } from '@podman-desktop/ui-svelte';
+
+let { target = $bindable(), containerFilePath }: { target: string | undefined; containerFilePath: string } = $props();
+
+const DEFAULT = '<none>';
+
+function onChange(val: string): void {
+  if (val === DEFAULT) {
+    target = undefined;
+  } else {
+    target = val;
+  }
+}
+
+const infoPromise = $derived(window.containerfileGetInfo(containerFilePath));
+</script>
+
+<svelte:boundary>
+  {#await infoPromise then { targets }}
+    {#if targets.length > 0}
+      <div class="space-y-2">
+        <label for="target" class="block mb-2 font-semibold text-(--pd-content-card-header-text)">Target</label>
+        <Dropdown
+          value={target ?? DEFAULT}
+          onChange={onChange}
+          name="target"
+          id="target"
+          options={targets.map(target => ({ label: target, value: target })).concat({ label: 'none', value: DEFAULT })}
+          class="w-full" />
+      </div>
+    {/if}
+  {/await}
+</svelte:boundary>

--- a/packages/renderer/src/stores/build-images.ts
+++ b/packages/renderer/src/stores/build-images.ts
@@ -42,6 +42,7 @@ export interface BuildImageInfo {
   selectedProvider?: ProviderContainerConnectionInfo;
   logsTerminal?: Terminal;
   taskId: number;
+  target?: string;
 }
 
 let taskCounter = 0;
@@ -74,6 +75,7 @@ export function createDefaultBuildImageInfo(): BuildImageInfo {
     containerBuildContextDirectory: '',
     containerBuildPlatform: '',
     buildArgs: [{ key: '', value: '' }],
+    target: undefined,
   };
 }
 


### PR DESCRIPTION
### What does this PR do?

For the Dev Week, my proposition was to add the target dropdown when building an image.


https://github.com/user-attachments/assets/ca623daa-3f0f-430d-9343-12f9b9e06af0



Example used:

```Containerfile
FROM golang:1.24 AS build
WORKDIR /src
COPY <<EOF /src/main.go
package main

import "fmt"

func main() {
  fmt.Println("hello, world")
}
EOF
RUN go build -o /bin/hello ./main.go


FROM build AS stage1

RUN echo stage1


FROM build AS stage2

RUN echo stage2

FROM build AS stage33

RUN echo stage33

FROM scratch
COPY --from=build /bin/hello /bin/hello
CMD ["/bin/hello"]


```
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Relates to https://github.com/podman-desktop/podman-desktop/issues/14700

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature


TODO : 

- [x] Fix new UT

- [ ] Add telemetry
