### PR TITLE
test(renderer): reuse existing mock for window.showMessageBox

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -63,7 +63,6 @@ const compose: ComposeInfoUI = new ComposeInfoUIImpl(
 
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 type Deferred<T = void> = {
   promise: Promise<T>;
@@ -81,7 +80,6 @@ const createDeferred = <T = void>(): Deferred<T> => {
 };
 
 beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'startContainersByLabel', { value: vi.fn() });
   Object.defineProperty(window, 'stopContainersByLabel', { value: vi.fn() });
   Object.defineProperty(window, 'restartContainersByLabel', { value: vi.fn() });
@@ -143,7 +141,8 @@ test('Expect no error and status restarting compose', async () => {
 
 test('Expect no error and status deleting compose', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
   render(ComposeActions, { compose, onUpdate: updateMock });
 
   // click on delete button

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.spec.ts
@@ -25,7 +25,6 @@ import ConfigMapSecretActions from './ConfigMapSecretActions.svelte';
 import type { ConfigMapSecretUI } from './ConfigMapSecretUI';
 
 const deleteMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 const fakeConfigMap: ConfigMapSecretUI = {
   name: 'my-configmap',
@@ -46,7 +45,6 @@ const fakeSecret: ConfigMapSecretUI = {
 };
 
 beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'kubernetesDeleteConfigMap', { value: deleteMock });
   Object.defineProperty(window, 'kubernetesDeleteSecret', { value: deleteMock });
 });
@@ -57,7 +55,7 @@ afterEach(() => {
 });
 
 test('Expect no error when deleting configmap', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(ConfigMapSecretActions, { configMapSecret: fakeConfigMap });
 
   // click on delete button
@@ -69,7 +67,7 @@ test('Expect no error when deleting configmap', async () => {
 });
 
 test('Expect no error when deleting secret', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(ConfigMapSecretActions, { configMapSecret: fakeSecret });
 
   // click on delete button

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -50,12 +50,10 @@ const container: ContainerInfoUI = new ContainerInfoUIImpl(
 
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 vi.mock('/@/lib/actions/ContributionActions.svelte');
 
 beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'startContainer', { value: vi.fn() });
   Object.defineProperty(window, 'stopContainer', { value: vi.fn() });
   Object.defineProperty(window, 'restartContainer', { value: vi.fn() });
@@ -111,7 +109,7 @@ test('Expect no error and status restarting container', async () => {
 
 test('Expect no error and status deleting container', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(ContainerActions, { container, onUpdate: updateMock });
 
   // click on delete button

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -799,7 +799,6 @@ test('Sort containers based on selected parameter', async () => {
 test('Expect user confirmation to pop up when preferences require', async () => {
   vi.mocked(window.listContainers).mockResolvedValue([]);
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
-  Object.defineProperty(window, 'showMessageBox', { value: vi.fn() });
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
 
   window.dispatchEvent(new CustomEvent('extensions-already-started'));

--- a/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
@@ -25,7 +25,6 @@ import CronJobActions from './CronJobActions.svelte';
 import type { CronJobUI } from './CronJobUI';
 
 const deleteMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 const cronjob: CronJobUI = {
   uid: '123',
@@ -41,13 +40,12 @@ const cronjob: CronJobUI = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(window.showMessageBox).mockImplementation(showMessageBoxMock);
   vi.mocked(window.kubernetesDeleteCronJob).mockImplementation(deleteMock);
 });
 
 test('Expect no error and status deleting cronjob', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(CronJobActions, { cronjob, detailed: false });
 
   // click on delete button

--- a/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
@@ -57,11 +57,8 @@ const deployment: DeploymentUI = new DeploymentfUIImpl(
   [],
 ) as unknown as DeploymentUI;
 
-const showMessageBoxMock = vi.fn();
-
 beforeAll(() => {
   Object.defineProperty(window, 'kubernetesDeleteDeployment', { value: deleteMock });
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
 });
 
 afterEach(() => {
@@ -70,14 +67,14 @@ afterEach(() => {
 });
 
 test('Expect no error and status deleting deployment', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   render(DeploymentActions, { deployment });
 
   // click on delete buttons
   const deleteButton = screen.getByRole('button', { name: 'Delete Deployment' });
   await fireEvent.click(deleteButton);
-  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+  expect(window.showMessageBox).toHaveBeenCalledOnce();
 
   // Wait for confirmation modal to disappear after clicking on delete
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());

--- a/packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts
@@ -16,53 +16,47 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { withConfirmation } from './messagebox-utils';
-
-const showMessageBoxMock = vi.fn();
-
-beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
-});
 
 beforeEach(() => {
   vi.resetAllMocks();
 });
 
 test('expect withConfirmation call callback if result OK', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   const callback = vi.fn();
   withConfirmation(callback, 'Destroy world');
 
   await vi.waitFor(() => {
-    expect(showMessageBoxMock).toHaveBeenCalledOnce();
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
     expect(callback).toHaveBeenCalled();
   });
 });
 
 test('expect withConfirmation not to call callback if result not OK', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
 
   const callback = vi.fn();
   withConfirmation(callback, 'Destroy world');
 
   await vi.waitFor(() => {
-    expect(showMessageBoxMock).toHaveBeenCalledOnce();
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
     expect(callback).not.toHaveBeenCalled();
   });
 });
 
 test('expect withConfirmation to propagate error', async () => {
   const error = new Error('Dummy error');
-  showMessageBoxMock.mockRejectedValue(error);
+  vi.mocked(window.showMessageBox).mockRejectedValue(error);
 
   const callback = vi.fn();
   withConfirmation(callback, 'Destroy world');
 
   await vi.waitFor(() => {
-    expect(showMessageBoxMock).toHaveBeenCalledOnce();
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
     expect(callback).toHaveBeenCalledWith(error);
   });
 });

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.spec.ts
@@ -26,7 +26,6 @@ import CatalogExtensionList from './CatalogExtensionList.svelte';
 
 beforeAll(() => {
   Object.defineProperty(window, 'extensionInstallFromImage', { value: vi.fn() });
-  Object.defineProperty(window, 'showMessageBox', { value: vi.fn() });
   Object.defineProperty(window, 'refreshCatalogExtensions', { value: vi.fn() });
 });
 

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -27,7 +27,6 @@ import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import ImageActions from '/@/lib/image/ImageActions.svelte';
 import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 
-const showMessageBoxMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
 vi.mock('./image-utils', () => {
@@ -48,7 +47,6 @@ class ResizeObserver {
   unobserve = vi.fn();
 }
 beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver });
 
   Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
@@ -100,7 +98,7 @@ test('Expect showMessageBox to be called when error occurs', async () => {
   await fireEvent.click(button);
 
   await waitFor(() => {
-    expect(showMessageBoxMock).toHaveBeenCalledOnce();
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
   });
 
   expect(image.status).toBe('DELETING');

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -43,7 +43,6 @@ import ImageDetails from './ImageDetails.svelte';
 
 const listImagesMock = vi.fn();
 const getContributedMenusMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 const myImage: ImageInfo = {
   Id: 'myImage',
@@ -69,7 +68,6 @@ const deleteImageMock = vi.fn();
 const hasAuthMock = vi.fn();
 
 beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'listImages', { value: listImagesMock });
   Object.defineProperty(window, 'listContainers', { value: vi.fn() });
   Object.defineProperty(window, 'deleteImage', { value: deleteImageMock });
@@ -93,7 +91,7 @@ afterEach(() => {
 
 test('Expect redirect to previous page if image is deleted', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   const routerGotoSpy = vi.spyOn(router, 'goto');
   listImagesMock.mockResolvedValue([myImage]);

--- a/packages/renderer/src/lib/image/ImageEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/image/ImageEmptyScreen.spec.ts
@@ -29,11 +29,9 @@ import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provid
 import ImageEmptyScreen from './ImageEmptyScreen.svelte';
 
 const pullImageMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 beforeAll(() => {
   Object.defineProperty(window, 'pullImage', { value: pullImageMock });
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
 });
 
 beforeEach(() => {
@@ -93,7 +91,7 @@ test('expect error to show up in message box when pull has an error', async () =
 
   await userEvent.click(pullButton);
 
-  expect(showMessageBoxMock).toBeCalledWith({
+  expect(window.showMessageBox).toBeCalledWith({
     title: `Error while pulling image`,
     message: `Error while pulling image from test: Cannot pull image`,
   });
@@ -107,7 +105,7 @@ test('expect error to show up in message box with no providers', async () => {
 
   await userEvent.click(pullButton);
 
-  expect(showMessageBoxMock).toBeCalledWith({
+  expect(window.showMessageBox).toBeCalledWith({
     title: `Error while pulling image`,
     message: `No provider connections found`,
   });
@@ -122,5 +120,5 @@ test('expect image to be pulled successfully', async () => {
   await userEvent.click(pullButton);
 
   expect(pullImageMock).toBeCalled();
-  expect(showMessageBoxMock).not.toBeCalled();
+  expect(window.showMessageBox).not.toBeCalled();
 });

--- a/packages/renderer/src/lib/image/ManifestActions.spec.ts
+++ b/packages/renderer/src/lib/image/ManifestActions.spec.ts
@@ -24,7 +24,6 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 import ManifestActions from '/@/lib/image/ManifestActions.svelte';
 
-const showMessageBoxMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 
 class ResizeObserver {
@@ -33,7 +32,6 @@ class ResizeObserver {
   unobserve = vi.fn();
 }
 beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver });
 
   Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
@@ -57,7 +55,7 @@ test('Expect Delete Manifest to be there', async () => {
 
 test('Expect Push Manifest to be there', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
 
   render(ManifestActions, { manifest: fakedManifest, onPushManifest: vi.fn() });

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
@@ -27,12 +27,10 @@ import type { RouteUI } from './RouteUI';
 
 const deleteIngressMock = vi.fn();
 const deleteRoutesMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 beforeAll(() => {
   Object.defineProperty(window, 'kubernetesDeleteIngress', { value: deleteIngressMock });
   Object.defineProperty(window, 'kubernetesDeleteRoute', { value: deleteRoutesMock });
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
 });
 
 afterEach(() => {
@@ -54,7 +52,7 @@ class StatusHolder {
 }
 
 test('Expect no error and status deleting ingress', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 }); // Mock confirmation dialog
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 }); // Mock confirmation dialog
 
   const ingressUI: IngressUI = new StatusHolder('RUNNING') as unknown as IngressUI;
   ingressUI.name = 'my-ingress';
@@ -66,7 +64,7 @@ test('Expect no error and status deleting ingress', async () => {
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Ingress' });
   await fireEvent.click(deleteButton);
-  expect(showMessageBoxMock).toHaveBeenCalledOnce(); // Ensure confirmation dialog was shown
+  expect(window.showMessageBox).toHaveBeenCalledOnce(); // Ensure confirmation dialog was shown
 
   // Wait for the dialog to disappear
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
@@ -76,7 +74,7 @@ test('Expect no error and status deleting ingress', async () => {
 });
 
 test('Expect no error and status deleting route', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 }); // Mock confirmation dialog
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 }); // Mock confirmation dialog
 
   const routeUI: RouteUI = new StatusHolder('RUNNING') as unknown as RouteUI;
   routeUI.name = 'my-route';
@@ -96,7 +94,7 @@ test('Expect no error and status deleting route', async () => {
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Route' });
   await fireEvent.click(deleteButton);
-  expect(showMessageBoxMock).toHaveBeenCalledOnce(); // Ensure confirmation dialog was shown
+  expect(window.showMessageBox).toHaveBeenCalledOnce(); // Ensure confirmation dialog was shown
 
   // Wait for the dialog to disappear
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());

--- a/packages/renderer/src/lib/job/JobActions.spec.ts
+++ b/packages/renderer/src/lib/job/JobActions.spec.ts
@@ -25,7 +25,6 @@ import JobActions from './JobActions.svelte';
 import type { JobUI } from './JobUI';
 
 const deleteMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 const job: JobUI = {
   uid: '123',
@@ -40,13 +39,12 @@ const job: JobUI = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(window.showMessageBox).mockImplementation(showMessageBoxMock);
   vi.mocked(window.kubernetesDeleteJob).mockImplementation(deleteMock);
 });
 
 test('Expect no error and status deleting job', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(JobActions, { job, detailed: false });
 
   // click on delete button

--- a/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeApplyYAMLButton.spec.ts
@@ -28,7 +28,6 @@ const currentContext: string = 'test-context';
 const currentNamespace: string = 'test-namespace';
 const openDialogMock = vi.fn();
 const kubernetesApplyResourcesFromFileMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 // fake the window object
 beforeAll(() => {
@@ -40,7 +39,6 @@ beforeAll(() => {
     value: vi.fn().mockResolvedValue(currentContext),
   });
   Object.defineProperty(window, 'kubernetesApplyResourcesFromFile', { value: kubernetesApplyResourcesFromFileMock });
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
 });
 
 test('Verify clicking button will open file dialog and canceling will exit', async () => {
@@ -84,8 +82,8 @@ test('Verify success will open an info dialog', async () => {
   expect(openDialogMock).toHaveBeenCalled();
   expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, [filename], currentNamespace);
 
-  expect(showMessageBoxMock).toHaveBeenCalled();
-  expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
+  expect(window.showMessageBox).toHaveBeenCalled();
+  expect(window.showMessageBox).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
 });
 
 test('Verify multiple file success will open an info dialog', async () => {
@@ -107,8 +105,8 @@ test('Verify multiple file success will open an info dialog', async () => {
     currentNamespace,
   );
 
-  expect(showMessageBoxMock).toHaveBeenCalled();
-  expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
+  expect(window.showMessageBox).toHaveBeenCalled();
+  expect(window.showMessageBox).toHaveBeenCalledWith(expect.objectContaining({ type: 'info' }));
 });
 
 test('Verify no results will open a warning dialog', async () => {
@@ -125,8 +123,8 @@ test('Verify no results will open a warning dialog', async () => {
   expect(openDialogMock).toHaveBeenCalled();
   expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, [filename], currentNamespace);
 
-  expect(showMessageBoxMock).toHaveBeenCalled();
-  expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+  expect(window.showMessageBox).toHaveBeenCalled();
+  expect(window.showMessageBox).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
 });
 
 test('Verify failure will open an error dialog', async () => {
@@ -143,6 +141,6 @@ test('Verify failure will open an error dialog', async () => {
   expect(openDialogMock).toHaveBeenCalled();
   expect(kubernetesApplyResourcesFromFileMock).toHaveBeenCalledWith(currentContext, [filename], currentNamespace);
 
-  expect(showMessageBoxMock).toHaveBeenCalled();
-  expect(showMessageBoxMock).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  expect(window.showMessageBox).toHaveBeenCalled();
+  expect(window.showMessageBox).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
 });

--- a/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
@@ -29,7 +29,6 @@ import type { PodUI } from './PodUI';
 
 const restartMock = vi.fn();
 const deleteMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 class PodUIImpl {
   #status: string;
@@ -66,7 +65,6 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(window.kubernetesListRoutes).mockResolvedValue([]);
-  vi.mocked(window.showMessageBox).mockImplementation(showMessageBoxMock);
   vi.mocked(window.kubernetesGetCurrentNamespace).mockResolvedValue('ns');
   vi.mocked(window.kubernetesReadNamespacedPod).mockResolvedValue({ metadata: { labels: { app: 'foo' } } });
   vi.mocked(window.restartKubernetesPod).mockImplementation(restartMock);
@@ -75,14 +73,14 @@ beforeEach(() => {
 });
 
 test('Check deleting pod', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   render(PodActions, { pod });
 
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
   await fireEvent.click(deleteButton);
-  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+  expect(window.showMessageBox).toHaveBeenCalledOnce();
 
   // Wait for confirmation modal to disappear after clicking on delete
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
@@ -92,7 +90,7 @@ test('Check deleting pod', async () => {
 });
 
 test('Check restarting pod', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   render(PodActions, { pod });
 

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -57,7 +57,6 @@ const podmanPod: PodInfoUI = new Pod('pod', [{ Id: 'pod' }], 'RUNNING', 'podman'
 const listContainersMock = vi.fn();
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 const openExternalSpy = vi.fn();
 
 class ResizeObserver {
@@ -68,7 +67,6 @@ class ResizeObserver {
 
 beforeAll(() => {
   Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver });
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'listContainers', { value: listContainersMock });
   Object.defineProperty(window, 'startPod', { value: vi.fn() });
   Object.defineProperty(window, 'stopPod', { value: vi.fn() });
@@ -132,7 +130,7 @@ test('Expect no error and status restarting pod', async () => {
 
 test('Expect no error and status deleting pod', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   listContainersMock.mockResolvedValue([]);
 
   render(PodActions, { pod: podmanPod, onUpdate: updateMock });

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
@@ -36,7 +36,6 @@ vi.mock('/@/stores/providers', async () => {
 
 beforeAll(() => {
   Object.defineProperty(window, 'createPod', { value: vi.fn(), writable: true });
-  Object.defineProperty(window, 'showMessageBox', { value: vi.fn() });
   Object.defineProperty(window, 'clipboardWriteText', { value: vi.fn() });
   Object.defineProperty(window, 'pullImage', { value: vi.fn() });
   Object.defineProperty(window, 'listImages', { value: vi.fn() });

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -95,8 +95,6 @@ const mockContext5: KubeContext = {
 
 const kubernetesGetCurrentContextNameMock = vi.fn();
 
-const showMessageBoxMock = vi.fn();
-
 const kubernetesDuplicateContextMock = vi.fn();
 
 beforeAll(() => {
@@ -104,7 +102,6 @@ beforeAll(() => {
     value: vi.fn().mockResolvedValue(new Map<string, ContextGeneralState>()),
   });
   Object.defineProperty(window, 'kubernetesGetCurrentContextName', { value: kubernetesGetCurrentContextNameMock });
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'kubernetesDuplicateContext', { value: kubernetesDuplicateContextMock });
 });
 
@@ -160,7 +157,7 @@ test('Test that context-name2 is the current context', async () => {
 test('when deleting the current context, a popup should ask confirmation', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
-  showMessageBoxMock.mockResolvedValue({ result: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
 
   render(PreferencesKubernetesContextsRendering, {});
   const currentContext = screen.getAllByRole('row')[1];
@@ -172,13 +169,13 @@ test('when deleting the current context, a popup should ask confirmation', async
   const deleteBtn = within(currentContext).getByRole('button', { name: 'Delete Context' });
   expect(deleteBtn).toBeInTheDocument();
   await fireEvent.click(deleteBtn);
-  expect(showMessageBoxMock).toHaveBeenCalledOnce();
+  expect(window.showMessageBox).toHaveBeenCalledOnce();
 });
 
 test('when deleting the non current context, no popup should ask confirmation', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
-  showMessageBoxMock.mockResolvedValue({ result: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
 
   render(PreferencesKubernetesContextsRendering, {});
   const currentContext = screen.getAllByRole('row')[0];
@@ -190,7 +187,7 @@ test('when deleting the non current context, no popup should ask confirmation', 
   const deleteBtn = within(currentContext).getByRole('button', { name: 'Delete Context' });
   expect(deleteBtn).toBeInTheDocument();
   await fireEvent.click(deleteBtn);
-  expect(showMessageBoxMock).not.toHaveBeenCalled();
+  expect(window.showMessageBox).not.toHaveBeenCalled();
 });
 
 test('when editing context a modal dialog should be oppened', async () => {

--- a/packages/renderer/src/lib/pvc/PVCActions.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCActions.spec.ts
@@ -25,7 +25,6 @@ import PVCActions from './PVCActions.svelte';
 import type { PVCUI } from './PVCUI';
 
 const deleteMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 class StatusHolder {
   #status: string;
@@ -50,7 +49,6 @@ fakePVC.selected = false;
 fakePVC.size = '1Gi';
 
 beforeEach(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'kubernetesDeletePersistentVolumeClaim', { value: deleteMock });
   (window.events as unknown) = {
     receive: (_channel: string, func: () => void): void => {
@@ -65,7 +63,7 @@ afterEach(() => {
 });
 
 test('Expect no error and status deleting PVC', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(PVCActions, { pvc: fakePVC });
 
   // click on delete buttons

--- a/packages/renderer/src/lib/service/ServiceActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceActions.spec.ts
@@ -25,7 +25,6 @@ import ServiceActions from './ServiceActions.svelte';
 import type { ServiceUI } from './ServiceUI';
 
 const deleteMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 class ServiceUIImpl {
   #status: string;
@@ -54,7 +53,6 @@ class ServiceUIImpl {
 const service: ServiceUI = new ServiceUIImpl('123', 'my-service', 'RUNNING', '', false, '', '', '');
 
 beforeEach(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'kubernetesDeleteService', { value: deleteMock });
 });
 
@@ -65,7 +63,7 @@ afterEach(() => {
 
 test('Expect no error and status deleting service', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(ServiceActions, { service });
 
   // click on delete button

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -25,17 +25,15 @@ import { beforeAll, expect, test, vi } from 'vitest';
 
 import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte';
 
-const showMessageBoxMock = vi.fn();
 const cleanupProvidersMock = vi.fn();
 
 // fake the window.events object
 beforeAll(() => {
-  (window as any).window.showMessageBox = showMessageBoxMock;
   (window as any).window.cleanupProviders = cleanupProvidersMock;
 });
 
 test('Check cleanupProviders is called and button is in progress', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   render(TroubleshootingRepairCleanup);
 
@@ -65,7 +63,7 @@ test('Check cleanupProviders is called and button is in progress', async () => {
   });
 
   // check that we asked for confirmation
-  expect(showMessageBoxMock).toBeCalledWith({
+  expect(window.showMessageBox).toBeCalledWith({
     buttons: ['Yes', 'Cancel'],
     message: 'This action may delete data. Proceed?',
     title: 'Cleanup',
@@ -76,7 +74,7 @@ test('Check cleanupProviders is called and button is in progress', async () => {
 });
 
 test('Check errors are displayed with clipboard button', async () => {
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   render(TroubleshootingRepairCleanup);
 
@@ -92,7 +90,7 @@ test('Check errors are displayed with clipboard button', async () => {
   await fireEvent.click(cleanupButton);
 
   // check that we asked for confirmation
-  expect(showMessageBoxMock).toBeCalledWith({
+  expect(window.showMessageBox).toBeCalledWith({
     buttons: ['Yes', 'Cancel'],
     message: 'This action may delete data. Proceed?',
     title: 'Cleanup',

--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -24,7 +24,6 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import VolumeActions from './VolumeActions.svelte';
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
-const showMessageBoxMock = vi.fn();
 const removeVolumeMock = vi.fn();
 
 class VolumeInfoUIImpl {
@@ -45,13 +44,12 @@ class VolumeInfoUIImpl {
 }
 
 beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'removeVolume', { value: removeVolumeMock });
 });
 
 test('Expect prompt dialog and deletion', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   const volume: VolumeInfoUI = new VolumeInfoUIImpl('dummy', 'UNUSED') as unknown as VolumeInfoUI;
 
@@ -63,7 +61,7 @@ test('Expect prompt dialog and deletion', async () => {
   await fireEvent.click(button);
 
   await waitFor(() => {
-    expect(showMessageBoxMock).toHaveBeenCalledOnce();
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
   });
 
   expect(volume.status).toBe('DELETING');

--- a/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
@@ -30,7 +30,6 @@ import type { VolumeListInfo } from '/@api/volume-info';
 import VolumeDetails from './VolumeDetails.svelte';
 
 const listVolumesMock = vi.fn();
-const showMessageBoxMock = vi.fn();
 
 const myVolume: VolumeListInfo = {
   engineId: 'engine0',
@@ -55,7 +54,6 @@ const myVolume: VolumeListInfo = {
 const removeVolumeMock = vi.fn();
 
 beforeAll(() => {
-  Object.defineProperty(window, 'showMessageBox', { value: showMessageBoxMock });
   Object.defineProperty(window, 'listVolumes', { value: listVolumesMock });
   Object.defineProperty(window, 'removeVolume', { value: removeVolumeMock });
   Object.defineProperty(window, 'getConfigurationProperties', { value: vi.fn().mockResolvedValue({}) });
@@ -63,7 +61,7 @@ beforeAll(() => {
 
 test('Expect redirect to previous page if volume is deleted', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   const routerGotoSpy = vi.spyOn(router, 'goto');
   listVolumesMock.mockResolvedValue([myVolume]);
   window.dispatchEvent(new CustomEvent('extensions-already-started'));


### PR DESCRIPTION
### What does this PR do?

This PR refactors the tests in the renderer package to mock the `showMessageBox` function directly on the window.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Follow up of comment https://github.com/podman-desktop/podman-desktop/pull/14923#discussion_r2537029935

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
