### PR TITLE
refactor(extension-compose): reuse global mock for @podman-desktop/api

### DIFF
--- a/extensions/compose/src/cli-run.spec.ts
+++ b/extensions/compose/src/cli-run.spec.ts
@@ -24,24 +24,6 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { getSystemBinaryPath, installBinaryToSystem, localBinDir } from './cli-run';
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    window: {
-      showInformationMessage: vi.fn().mockReturnValue(Promise.resolve('Yes')),
-      showErrorMessage: vi.fn(),
-      withProgress: vi.fn(),
-      showNotification: vi.fn(),
-      showWarningMessage: vi.fn(),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    ProgressLocation: {
-      APP_ICON: 1,
-    },
-  };
-});
-
 // mock exists sync
 vi.mock('node:fs', async () => {
   return {

--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -43,19 +43,6 @@ vi.mock('shell-path', () => {
   };
 });
 
-vi.mock('@podman-desktop/api', () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      isLinux: false,
-      isWindows: false,
-      isMac: false,
-    },
-  };
-});
-
 const originalConsoleDebug = console.debug;
 
 beforeEach(() => {

--- a/extensions/compose/src/download.spec.ts
+++ b/extensions/compose/src/download.spec.ts
@@ -74,16 +74,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-vi.mock('@podman-desktop/api', () => {
-  return {
-    window: {
-      showQuickPick: vi.fn(),
-      createStatusBarItem: vi.fn(),
-      showInformationMessage: vi.fn(),
-    },
-  };
-});
-
 test('expect getLatestVersionAsset to return the first release from a list of releases', async () => {
   grabLatestsReleasesMetadataMock.mockImplementation(() => {
     return releases;

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -27,44 +27,6 @@ import { Detect } from './detect';
 import { ComposeDownload } from './download';
 import { activate, deactivate } from './extension';
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      isLinux: false,
-      isWindows: false,
-      isMac: false,
-      createTelemetryLogger: vi.fn(),
-    },
-    configuration: {
-      onDidChangeConfiguration: vi.fn(),
-      getConfiguration: (): extensionApi.Configuration =>
-        ({
-          update: vi.fn(),
-          get: vi.fn(),
-          has: vi.fn(),
-        }) as unknown as extensionApi.Configuration,
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-    commands: {
-      registerCommand: vi.fn(),
-    },
-    provider: {
-      createProvider: vi.fn(),
-    },
-    cli: {
-      createCliTool: vi.fn(),
-    },
-    window: {
-      showErrorMessage: vi.fn(),
-    },
-  };
-});
-
 vi.mock('node:fs', () => ({
   promises: {
     unlink: vi.fn(),
@@ -87,6 +49,11 @@ vi.mock(import('./download'));
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(extensionApi.cli.createCliTool).mockReturnValue(cliToolMock);
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    update: vi.fn(),
+    get: vi.fn(),
+    has: vi.fn(),
+  });
 });
 
 afterEach(() => {

--- a/extensions/compose/src/handler.spec.ts
+++ b/extensions/compose/src/handler.spec.ts
@@ -23,19 +23,6 @@ import * as detect from './detect';
 import * as handler from './handler';
 
 vi.mock('./detect');
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    configuration: {
-      getConfiguration: vi.fn(),
-    },
-    window: {
-      showInformationMessage: vi.fn(),
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-  };
-});
 
 const extensionContextMock: extensionApi.ExtensionContext = {
   storagePath: '/storage-path',

--- a/extensions/compose/src/utils.spec.ts
+++ b/extensions/compose/src/utils.spec.ts
@@ -22,14 +22,6 @@ import { beforeEach, describe, expect, test, vi, vitest } from 'vitest';
 
 import { makeExecutable } from './utils';
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 describe('makeExecutable', async () => {
   beforeEach(() => {
     vi.resetAllMocks();


### PR DESCRIPTION
### What does this PR do?
avoid defining custom mock for `@podman-desktop/api`, reuse the global mock

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14493

### How to test this PR?

CI should be ✅ 

- [x] Tests are covering the bug fix or the new feature
