### PR TITLE
refactor(extension-podman): reuse global mock for @podman-desktop/api

### DIFF
--- a/extensions/podman/packages/extension/src/certificate-detection/certificate-detection-service.spec.ts
+++ b/extensions/podman/packages/extension/src/certificate-detection/certificate-detection-service.spec.ts
@@ -29,16 +29,6 @@ import { type CertificateDetectionConfig, CertificateDetectionService } from './
 vi.mock('node:fs/promises');
 vi.mock('node:os');
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    env: {
-      isWindows: false,
-      isMac: false,
-      isLinux: false,
-    },
-  };
-});
-
 const mockTelemetryLogger: TelemetryLogger = {
   logUsage: vi.fn(),
   logError: vi.fn(),

--- a/extensions/podman/packages/extension/src/checks/macos-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/macos-check.spec.ts
@@ -33,14 +33,6 @@ vi.mock('node:os', () => {
   };
 });
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   macVersionCheck = new MacVersionCheck();
   vi.clearAllMocks();

--- a/extensions/podman/packages/extension/src/checks/windows/virtual-machine-platform-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/virtual-machine-platform-check.spec.ts
@@ -21,12 +21,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { VirtualMachinePlatformCheck } from './virtual-machine-platform-check';
 
-vi.mock('@podman-desktop/api', () => ({
-  process: {
-    exec: vi.fn(),
-  },
-}));
-
 const mockTelemetryLogger = {} as TelemetryLogger;
 
 beforeEach(() => {

--- a/extensions/podman/packages/extension/src/checks/windows/wsl-version-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/wsl-version-check.spec.ts
@@ -21,12 +21,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { WSLVersionCheck } from './wsl-version-check';
 
-vi.mock('@podman-desktop/api', () => ({
-  process: {
-    exec: vi.fn(),
-  },
-}));
-
 beforeEach(() => {
   vi.clearAllMocks();
 });

--- a/extensions/podman/packages/extension/src/checks/windows/wsl2-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/wsl2-check.spec.ts
@@ -27,15 +27,6 @@ import { WSL2Check } from './wsl2-check';
 
 const userAdminCheck = { execute: vi.fn() } as unknown as UserAdminCheck;
 
-vi.mock('@podman-desktop/api', () => ({
-  process: {
-    exec: vi.fn(),
-  },
-  commands: {
-    registerCommand: vi.fn(),
-  },
-}));
-
 // mock ps-list
 vi.mock('ps-list', async () => {
   return {

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-abstract.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-abstract.spec.ts
@@ -38,15 +38,6 @@ class TestAbsPodmanCleanup extends AbsPodmanCleanup {
 }
 let absPodmanCleanup: TestAbsPodmanCleanup;
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 // mock exists sync
 vi.mock('node:fs', async () => {
   return {

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-macos.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-macos.spec.ts
@@ -24,15 +24,6 @@ import { PodmanCleanupMacOS } from './podman-cleanup-macos';
 
 let podmanCleanupMacOS: PodmanCleanupMacOS;
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 // mock exists sync
 vi.mock('node:fs', async () => {
   return {

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.spec.ts
@@ -23,15 +23,6 @@ import { PodmanCleanupWindows } from './podman-cleanup-windows';
 
 let podmanCleanupWindows: PodmanCleanupWindows;
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 // mock exists sync
 vi.mock('node:fs', async () => {
   return {

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
@@ -40,27 +40,6 @@ vi.mock('node:os', async () => {
 });
 vi.mock('../extension');
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    commands: {
-      registerCommand: vi.fn(),
-      executeCommand: vi.fn(),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      isLinux: false,
-      isWindows: false,
-      isMac: false,
-    },
-    window: {
-      showQuickPick: vi.fn(),
-      showInputBox: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.resetAllMocks();

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -268,81 +268,6 @@ beforeEach(async () => {
 const originalConsoleError = console.error;
 const consoleErrorMock = vi.fn();
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    commands: {
-      registerCommand: vi.fn(),
-    },
-    configuration: {
-      getConfiguration: (): Configuration => config,
-      onDidChangeConfiguration: (): Disposable => {
-        return {
-          dispose: vi.fn(),
-        };
-      },
-    },
-    provider: {
-      onDidRegisterContainerConnection: vi.fn(),
-      onDidUnregisterContainerConnection: vi.fn(),
-      createProvider: (): extensionApi.Provider => provider,
-    },
-    registry: {
-      registerRegistryProvider: vi.fn(),
-      onDidRegisterRegistry: vi.fn(),
-      onDidUnregisterRegistry: vi.fn(),
-      onDidUpdateRegistry: vi.fn(),
-    },
-    proxy: {
-      isEnabled: (): boolean => false,
-      onDidUpdateProxy: vi.fn(),
-      onDidStateChange: vi.fn(),
-      getProxySettings: vi.fn(),
-    },
-    window: {
-      showErrorMessage: vi.fn(),
-      showInformationMessage: vi.fn(),
-      showWarningMessage: vi.fn(),
-      showNotification: vi.fn(),
-      withProgress: vi.fn(),
-      createStatusBarItem: () => ({
-        show: vi.fn(),
-        dispose: vi.fn(),
-      }),
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      createTelemetryLogger: vi.fn(),
-      isWindows: false,
-      isMac: false,
-      isLinux: false,
-    },
-    containerEngine: {
-      info: vi.fn(),
-    },
-    Disposable: {
-      from: vi.fn(),
-      create: vi.fn(),
-    },
-    CancellationToken: {},
-    ProgressLocation: {
-      TASK_WIDGET: 'TASK_WIDGET',
-      APP_ICON: 'APP_ICON',
-    },
-    fs: {
-      createFileSystemWatcher: vi.fn(),
-    },
-    EventEmitter: vi.fn().mockImplementation(() => ({
-      fire: vi.fn(),
-      dispose: vi.fn(),
-    })),
-  };
-});
-
 vi.mock('node:child_process', async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const childProcessActual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
@@ -386,7 +311,8 @@ vi.mock(import('./utils/util'), async importOriginal => {
 
 beforeEach(() => {
   console.error = consoleErrorMock;
-
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue(config);
+  vi.mocked(extensionApi.provider.createProvider).mockReturnValue(provider);
   vi.mocked(extensionApi.env).isMac = false;
   vi.mocked(extensionApi.env).isLinux = false;
   vi.mocked(extensionApi.env).isWindows = false;

--- a/extensions/podman/packages/extension/src/helpers/krunkit-helper.spec.ts
+++ b/extensions/podman/packages/extension/src/helpers/krunkit-helper.spec.ts
@@ -24,15 +24,6 @@ import { KrunkitHelper } from './krunkit-helper';
 
 let krunkitHelper: KrunkitHelper;
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   krunkitHelper = new KrunkitHelper();
   vi.resetAllMocks();

--- a/extensions/podman/packages/extension/src/helpers/podman-binary-location-helper.spec.ts
+++ b/extensions/podman/packages/extension/src/helpers/podman-binary-location-helper.spec.ts
@@ -24,15 +24,6 @@ import { PodmanBinaryLocationHelper } from './podman-binary-location-helper';
 
 let podmanBinaryLocationHelper: PodmanBinaryLocationHelper;
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   podmanBinaryLocationHelper = new PodmanBinaryLocationHelper();
   vi.resetAllMocks();

--- a/extensions/podman/packages/extension/src/helpers/podman-info-helper.spec.ts
+++ b/extensions/podman/packages/extension/src/helpers/podman-info-helper.spec.ts
@@ -24,15 +24,6 @@ import { PodmanInfoHelper } from './podman-info-helper';
 
 let podmanInfoHelper: PodmanInfoHelper;
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   podmanInfoHelper = new PodmanInfoHelper();
   vi.resetAllMocks();

--- a/extensions/podman/packages/extension/src/helpers/qemu-helper.spec.ts
+++ b/extensions/podman/packages/extension/src/helpers/qemu-helper.spec.ts
@@ -30,15 +30,6 @@ class TestQemuHelper extends QemuHelper {
   }
 }
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   qemuHelper = new TestQemuHelper();
   vi.resetAllMocks();

--- a/extensions/podman/packages/extension/src/helpers/wsl-helper.spec.ts
+++ b/extensions/podman/packages/extension/src/helpers/wsl-helper.spec.ts
@@ -24,15 +24,6 @@ import { WslHelper } from './wsl-helper';
 
 let wslHelper: WslHelper;
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   wslHelper = new WslHelper();
   vi.resetAllMocks();

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
@@ -33,16 +33,6 @@ import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } 
 const extensionContextMock = {} as ExtensionContext;
 const telemetryLoggerMock = {} as TelemetryLogger;
 
-vi.mock('@podman-desktop/api', () => {
-  return {
-    env: {
-      isWindows: false,
-      isMac: true,
-      isLinux: false,
-    },
-  };
-});
-
 describe('inversifyBinding', () => {
   let inversifyBinding: InversifyBinding;
 

--- a/extensions/podman/packages/extension/src/installer/mac-os-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/mac-os-installer.spec.ts
@@ -26,19 +26,6 @@ import { getAssetsFolder } from '../utils/util';
 import { MacOSInstaller } from './mac-os-installer';
 
 vi.mock('node:fs');
-vi.mock('@podman-desktop/api', () => ({
-  commands: {},
-  env: {},
-  window: {
-    withProgress: vi.fn(),
-    showNotification: vi.fn(),
-    showErrorMessage: vi.fn(),
-  },
-  ProgressLocation: {},
-  process: {
-    exec: vi.fn(),
-  },
-}));
 
 const extensionContext = {
   subscriptions: [],

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -95,38 +95,6 @@ vi.mock('node:os', async () => {
   };
 });
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    commands: {
-      registerCommand: vi.fn(),
-    },
-    env: {
-      isMac: true,
-      openExternal: vi.fn(),
-    },
-    window: {
-      withProgress: vi.fn(),
-      showNotification: vi.fn(),
-      showErrorMessage: vi.fn(),
-      showInformationMessage: vi.fn(),
-      showWarningMessage: vi.fn(),
-    },
-    ProgressLocation: {},
-    process: {
-      exec: vi.fn(),
-    },
-    configuration: {
-      getConfiguration: vi.fn(),
-    },
-    Uri: {
-      parse: vi.fn(),
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-  };
-});
-
 vi.mock(import('../utils/util'), async () => {
   return {
     getAssetsFolder: vi.fn().mockReturnValue(''),

--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -28,19 +28,6 @@ import { getAssetsFolder } from '../utils/util';
 import { WinInstaller } from './win-installer';
 
 vi.mock('node:fs');
-vi.mock('@podman-desktop/api', () => ({
-  commands: {},
-  env: {},
-  window: {
-    withProgress: vi.fn(),
-    showNotification: vi.fn(),
-    showErrorMessage: vi.fn(),
-  },
-  ProgressLocation: {},
-  process: {
-    exec: vi.fn(),
-  },
-}));
 
 const extensionContext = {
   subscriptions: [],

--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -31,8 +31,6 @@ import type { WSL2Check } from '/@/checks/windows/wsl2-check';
 
 import { WinPlatform } from './win-platform';
 
-vi.mock('@podman-desktop/api', () => ({ env: { isWindows: false } }));
-
 const EXTENSION_CONTEXT_MOCK = {} as ExtensionContext;
 const TELEMETRY_LOGGER_MOCK = {} as TelemetryLogger;
 

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
@@ -26,22 +26,6 @@ import type { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
 
 vi.mock('node:fs');
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    env: {
-      isWindows: true,
-    },
-    configuration: {
-      onDidChangeConfiguration: vi.fn(),
-      getConfiguration: vi.fn(),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 const extensionContext = {} as extensionApi.ExtensionContext;
 
 const provider = {} as extensionApi.Provider;

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
@@ -27,15 +27,6 @@ import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   vi.resetAllMocks();
 });

--- a/extensions/podman/packages/extension/src/utils/compatibility-mode.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/compatibility-mode.spec.ts
@@ -22,18 +22,6 @@ import { afterEach, expect, test, vi } from 'vitest';
 import * as extension from '../extension';
 import { DarwinSocketCompatibility, getSocketCompatibility, LinuxSocketCompatibility } from './compatibility-mode';
 
-vi.mock('@podman-desktop/api', () => {
-  return {
-    window: {
-      showErrorMessage: vi.fn(),
-      showInformationMessage: vi.fn(),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 afterEach(() => {
   vi.resetAllMocks();
   vi.restoreAllMocks();

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
-import type { Configuration, Disposable } from '@podman-desktop/api';
+import type { Configuration } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -42,78 +42,12 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    commands: {
-      registerCommand: vi.fn(),
-    },
-    configuration: {
-      getConfiguration: (): Configuration => config,
-      onDidChangeConfiguration: (): Disposable => {
-        return {
-          dispose: vi.fn(),
-        };
-      },
-    },
-    provider: {
-      onDidRegisterContainerConnection: vi.fn(),
-      onDidUnregisterContainerConnection: vi.fn(),
-    },
-    registry: {
-      registerRegistryProvider: vi.fn(),
-      onDidRegisterRegistry: vi.fn(),
-      onDidUnregisterRegistry: vi.fn(),
-      onDidUpdateRegistry: vi.fn(),
-    },
-    proxy: {
-      isEnabled: (): boolean => false,
-      onDidUpdateProxy: vi.fn(),
-      onDidStateChange: vi.fn(),
-      getProxySettings: vi.fn(),
-    },
-    window: {
-      showErrorMessage: vi.fn(),
-      showInformationMessage: vi.fn(),
-      showWarningMessage: vi.fn(),
-      showNotification: vi.fn(),
-      createStatusBarItem: () => ({
-        show: vi.fn(),
-        dispose: vi.fn(),
-      }),
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      createTelemetryLogger: vi.fn(),
-      isWindows: false,
-      isMac: false,
-      isLinux: false,
-    },
-    containerEngine: {
-      info: vi.fn(),
-    },
-    Disposable: {
-      from: vi.fn(),
-      create: vi.fn(),
-    },
-    fs: {
-      createFileSystemWatcher: vi.fn(),
-    },
-    EventEmitter: vi.fn().mockImplementation(() => ({
-      fire: vi.fn(),
-      dispose: vi.fn(),
-    })),
-  };
-});
-
 beforeEach(() => {
   vi.mocked(extensionApi.env).isMac = false;
   vi.mocked(extensionApi.env).isLinux = false;
   vi.mocked(extensionApi.env).isWindows = false;
+
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue(config);
 
   const mock = vi.spyOn(compatibilityModeLib, 'getSocketCompatibility');
   mock.mockReturnValue({

--- a/extensions/podman/packages/extension/src/utils/podman-cli.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.spec.ts
@@ -18,7 +18,7 @@
 
 import fs from 'node:fs';
 
-import { type Configuration, env, process } from '@podman-desktop/api';
+import { type Configuration, configuration, env, process } from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { findPodmanInstallations } from './podman-cli';
@@ -39,26 +39,10 @@ vi.mock('node:fs', () => {
   };
 });
 
-// Mock external dependencies
-vi.mock('@podman-desktop/api', () => {
-  return {
-    configuration: {
-      getConfiguration: (): Configuration => config,
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      isWindows: false,
-      isMac: true,
-      isLinux: false,
-    },
-  };
-});
-
 describe('findPodmanInstallations', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(configuration.getConfiguration).mockReturnValue(config);
     vi.mocked(env).isWindows = false;
     vi.mocked(env).isMac = true;
     vi.mocked(env).isLinux = false;

--- a/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
@@ -24,20 +24,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { PodmanConfiguration } from './podman-configuration';
 import { VMTYPE } from './util';
 
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      isWindows: false,
-      isMac: false,
-      isLinux: false,
-    },
-  };
-});
-
 const extensionContext: ExtensionContext = {} as unknown as ExtensionContext;
 
 // allows to call protected methods

--- a/extensions/podman/packages/extension/src/utils/podman-machine-stream.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-machine-stream.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { EventEmitter } from '@podman-desktop/api';
 import { Client } from 'ssh2';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -52,14 +53,8 @@ class TestProviderConnectionShellAccessImpl extends ProviderConnectionShellAcces
   }
 }
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    EventEmitter: vi.fn().mockImplementation(() => ({
-      fire: vi.fn(),
-      dispose: vi.fn(),
-    })),
-    Disposable: vi.fn(),
-  };
+beforeEach(() => {
+  EventEmitter.prototype.fire = vi.fn();
 });
 
 vi.mock('node:fs');

--- a/extensions/podman/packages/extension/src/utils/powershell.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.spec.ts
@@ -23,12 +23,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { PowerShellClient } from './powershell';
 import { getPowerShellClient } from './powershell';
 
-vi.mock('@podman-desktop/api', () => ({
-  process: {
-    exec: vi.fn(),
-  },
-}));
-
 const TELEMETRY_LOGGER_MOCK = {
   logUsage: vi.fn(),
 } as unknown as TelemetryLogger;

--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -45,19 +45,6 @@ let registrySetup: TestRegistrySetup;
 // mock the fs module
 vi.mock('node:fs');
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    registry: {
-      registerRegistryProvider: vi.fn(),
-      registerRegistry: vi.fn(),
-      unregisterRegistry: vi.fn(),
-      onDidRegisterRegistry: vi.fn(),
-      onDidUnregisterRegistry: vi.fn(),
-      onDidUpdateRegistry: vi.fn(),
-    },
-  };
-});
-
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 const consoleErroMock = vi.fn();

--- a/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
@@ -25,20 +25,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { PodmanConfiguration } from './podman-configuration';
 import { checkRosettaMacArm } from './rosetta';
 
-vi.mock('@podman-desktop/api', () => ({
-  process: {
-    exec: vi.fn(),
-  },
-  window: {
-    showInformationMessage: vi.fn(),
-  },
-  env: {
-    isMac: false,
-    isLinux: false,
-    isWindows: false,
-  },
-}));
-
 vi.mock('node:os', async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const osActual = await vi.importActual<typeof import('node:os')>('node:os');

--- a/extensions/podman/packages/extension/src/utils/util.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/util.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as extensionApi from '@podman-desktop/api';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as podmanCli from './podman-cli';
 import {
@@ -33,33 +33,15 @@ import {
   WSL_LABEL,
 } from './util';
 
-const config: extensionApi.Configuration = {
-  get: () => {
-    // not implemented
-  },
-  has: () => true,
-  update: vi.fn(),
-};
-
-vi.mock('@podman-desktop/api', () => {
-  return {
-    configuration: {
-      getConfiguration: (): extensionApi.Configuration => config,
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      isWindows: false,
-      isMac: false,
-      isLinux: false,
-    },
-  };
-});
-
-afterEach(() => {
+beforeEach(() => {
   vi.resetAllMocks();
   vi.restoreAllMocks();
+  vi.spyOn(podmanCli, 'findPodmanInstallations').mockResolvedValue([]);
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: vi.fn(),
+    has: () => true,
+    update: vi.fn(),
+  } as unknown as extensionApi.Configuration);
 });
 
 test('normalizeWSLOutput returns the same string if there is no need to normalize it', async () => {
@@ -172,11 +154,6 @@ test('expect hyperv label with hyperv provider wsl label', async () => {
 });
 
 describe('Check multiple Podman installations', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-    vi.spyOn(podmanCli, 'findPodmanInstallations').mockResolvedValue([]);
-  });
-
   test('should return empty warnings when no Podman installation provided', async () => {
     const warnings = await getMultiplePodmanInstallationsWarnings(undefined);
 


### PR DESCRIPTION
### What does this PR do?
avoid defining custom mock for @podman-desktop/api, reuse the global mock

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14493


### How to test this PR?

CI should be ✅

- [x] Tests are covering the bug fix or the new feature
