### PR TITLE
refactor(extension-kind): reuse global mock for @podman-desktop/api

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -42,41 +42,22 @@ vi.mock('node:fs', () => ({
   readFileSync: vi.fn(),
 }));
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    Logger: {},
-    kubernetes: {
-      createResources: vi.fn(),
-      getKubeconfig: vi.fn().mockReturnValue({ path: '/some/path' }),
-      onDidUpdateKubeconfig: vi.fn(),
-    },
-    provider: {
-      getContainerConnections: vi.fn().mockReturnValue([
-        {
-          providerId: 'docker',
-          connection: {
-            name: 'docker-connection',
-            type: 'docker',
-            endpoint: { socketPath: 'socket' },
-            status: (): extensionApi.ProviderConnectionStatus => 'started',
-          },
-        },
-      ]),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    window: {
-      showInformationMessage: vi.fn(),
-    },
-    net: {
-      getFreePort: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+  vi.mocked(extensionApi.kubernetes.getKubeconfig).mockReturnValue({
+    path: '/some/path',
+  } as unknown as extensionApi.Uri);
+  vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([
+    {
+      providerId: 'docker',
+      connection: {
+        name: 'docker-connection',
+        type: 'docker',
+        endpoint: { socketPath: 'socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+  ]);
   vi.mocked(fs.promises.mkdtemp).mockResolvedValue('/tmp/file');
 
   vi.mocked(KindClusterWatcher.prototype.waitForNodesReady).mockResolvedValue(undefined);

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -34,48 +34,6 @@ vi.mock(import('./image-handler'));
 vi.mock(import('./create-cluster'));
 vi.mock(import('./kind-installer'));
 
-vi.mock('@podman-desktop/api', () => ({
-  window: {
-    withProgress: vi.fn(),
-    createStatusBarItem: vi.fn(),
-    showInformationMessage: vi.fn(),
-  },
-  cli: {
-    createCliTool: vi.fn(),
-  },
-  ProgressLocation: {
-    TASK_WIDGET: 'TASK_WIDGET',
-  },
-  provider: {
-    onDidRegisterContainerConnection: vi.fn(),
-    onDidUnregisterContainerConnection: vi.fn(),
-    onDidUpdateProvider: vi.fn(),
-    onDidUpdateContainerConnection: vi.fn(),
-    onDidUpdateVersion: vi.fn(),
-    createProvider: vi.fn(),
-    registerUpdate: vi.fn(),
-  },
-  containerEngine: {
-    listContainers: vi.fn(),
-    onEvent: vi.fn(),
-  },
-  commands: {
-    registerCommand: vi.fn(),
-  },
-  context: {
-    setValue: vi.fn(),
-  },
-  env: {
-    isWindows: false,
-    isMac: false,
-    isLinux: true,
-    createTelemetryLogger: vi.fn(),
-  },
-  process: {
-    exec: vi.fn(),
-  },
-}));
-
 const CLI_TOOL_MOCK: extensionApi.CliTool = {
   displayName: 'test',
   dispose: vi.fn(),

--- a/extensions/kind/src/image-handler.spec.ts
+++ b/extensions/kind/src/image-handler.spec.ts
@@ -26,20 +26,6 @@ import { ImageHandler } from './image-handler';
 import { getKindPath } from './util';
 
 let imageHandler: ImageHandler;
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    containerEngine: {
-      saveImage: vi.fn(),
-    },
-    window: {
-      showNotification: vi.fn(),
-      showInformationMessage: vi.fn(),
-    },
-    process: {
-      exec: vi.fn().mockReturnValue({} as extensionApi.RunResult),
-    },
-  };
-});
 
 vi.mock('./util', async () => {
   return {

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -31,29 +31,6 @@ import * as util from './util';
 
 let installer: KindInstaller;
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    window: {
-      showInformationMessage: vi.fn(),
-      showErrorMessage: vi.fn(),
-      withProgress: vi.fn(),
-      showNotification: vi.fn(),
-      showQuickPick: vi.fn(),
-    },
-    ProgressLocation: {
-      APP_ICON: 1,
-    },
-    env: {
-      isLinux: false,
-      isMac: false,
-      isWindows: false,
-    },
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 vi.mock('node:os', async () => {
   return {
     platform: vi.fn(),


### PR DESCRIPTION
### What does this PR do?
avoid defining custom mock for @podman-desktop/api, reuse the global mock 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/14493

### How to test this PR?

CI should be ✅

- [x] Tests are covering the bug fix or the new feature
