### PR TITLE
refactor(extension-docker): reuse global mock for @podman-desktop/api

### DIFF
--- a/extensions/docker/packages/extension/src/docker-cli.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-cli.spec.ts
@@ -18,19 +18,9 @@
 
 import * as extensionApi from '@podman-desktop/api';
 import type { Mock } from 'vitest';
-import { expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { getDockerInstallation } from './docker-cli';
-
-// mock the API
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    env: {},
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
 
 test('should not return podman version', async () => {
   const podmanOutput = 'podman version 4.8.3';

--- a/extensions/docker/packages/extension/src/docker-compatibility-setup.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-compatibility-setup.spec.ts
@@ -23,23 +23,6 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { DockerCompatibilitySetup } from './docker-compatibility-setup.js';
 import type { DockerContextHandler } from './docker-context-handler.js';
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    context: {
-      setValue: vi.fn(),
-    },
-    configuration: {
-      onDidChangeConfiguration: vi.fn(),
-      getConfiguration: vi.fn(),
-    },
-    env: {
-      isLinux: false,
-      isWindows: false,
-      isMac: false,
-    },
-  };
-});
-
 const dockerContextHandler = {
   listContexts: vi.fn(),
   switchContext: vi.fn(),

--- a/extensions/docker/packages/extension/src/docker-config.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-config.spec.ts
@@ -22,15 +22,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { DockerConfig } from './docker-config.js';
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    configuration: {
-      getConfiguration: vi.fn(),
-      onDidChangeConfiguration: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   vi.resetAllMocks();
 });

--- a/extensions/docker/packages/extension/src/docker-context-handler.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-context-handler.spec.ts
@@ -43,16 +43,6 @@ class TestDockerContextHandler extends DockerContextHandler {
 // mock exists sync
 vi.mock('node:fs');
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    env: {
-      isLinux: false,
-      isWindows: false,
-      isMac: false,
-    },
-  };
-});
-
 const originalConsoleError = console.error;
 let dockerContextHandler: TestDockerContextHandler;
 


### PR DESCRIPTION
### What does this PR do?
avoid defining custom mock for @podman-desktop/api, reuse the global mock

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14493

### How to test this PR?

CI should be ✅

- [x] Tests are covering the bug fix or the new feature
