### PR TITLE
refactor(extension-kubectl-cli): reuse global mock for @podman-desktop/api

### DIFF
--- a/extensions/kubectl-cli/src/cli-run.spec.ts
+++ b/extensions/kubectl-cli/src/cli-run.spec.ts
@@ -24,23 +24,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { installBinaryToSystem } from './cli-run';
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    window: {
-      showInformationMessage: vi.fn().mockReturnValue(Promise.resolve('Yes')),
-      showErrorMessage: vi.fn(),
-      withProgress: vi.fn(),
-      showNotification: vi.fn(),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    ProgressLocation: {
-      APP_ICON: 1,
-    },
-  };
-});
-
 // mock exists sync
 vi.mock('node:fs', async () => {
   return {

--- a/extensions/kubectl-cli/src/detect.spec.ts
+++ b/extensions/kubectl-cli/src/detect.spec.ts
@@ -40,14 +40,6 @@ vi.mock('shell-path', () => {
   };
 });
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 const originalConsoleDebug = console.debug;
 
 beforeEach(() => {

--- a/extensions/kubectl-cli/src/download.spec.ts
+++ b/extensions/kubectl-cli/src/download.spec.ts
@@ -87,16 +87,6 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-vi.mock('@podman-desktop/api', () => {
-  return {
-    window: {
-      showQuickPick: vi.fn(),
-      createStatusBarItem: vi.fn(),
-      showInformationMessage: vi.fn(),
-    },
-  };
-});
-
 test('expect getLatestVersionAsset to return the latest release from a list of releases', async () => {
   grabLatestsReleasesMetadataMock.mockResolvedValue(unsortedReleases);
 

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -47,39 +47,6 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
 }));
 
-vi.mock('@podman-desktop/api', () => {
-  return {
-    cli: {
-      createCliTool: vi.fn(),
-    },
-    process: {
-      exec: vi.fn(),
-    },
-    env: {
-      isMac: true,
-      isWindows: false,
-      isLinux: false,
-      createTelemetryLogger: vi.fn(),
-    },
-    configuration: {
-      getConfiguration: vi.fn(),
-      onDidChangeConfiguration: vi.fn(),
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-    commands: {
-      registerCommand: vi.fn(),
-    },
-    provider: {
-      createProvider: vi.fn(),
-    },
-    window: {
-      showQuickPick: vi.fn(),
-    },
-  };
-});
-
 beforeEach(() => {
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
     update: vi.fn(),

--- a/extensions/kubectl-cli/src/handler.spec.ts
+++ b/extensions/kubectl-cli/src/handler.spec.ts
@@ -18,38 +18,23 @@
 
 import type { Configuration } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { Detect } from './detect';
 import * as handler from './handler';
 
 vi.mock(import('./detect'));
-
-const config: Configuration = {
-  get: () => {
-    return true;
-  },
-  has: () => true,
-  update: () => Promise.resolve(),
-};
-
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    configuration: {
-      getConfiguration: (): Configuration => config,
-    },
-    window: {
-      showInformationMessage: vi.fn(),
-    },
-    context: {
-      setValue: vi.fn(),
-    },
-  };
-});
-
 const extensionContextMock: extensionApi.ExtensionContext = {
   storagePath: '/storage-path',
 } as unknown as extensionApi.ExtensionContext;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: vi.fn(),
+    update: vi.fn(),
+  } as unknown as Configuration);
+});
 
 test('updateConfigAndContextKubectlBinary: make sure configuration gets updated if checkSystemWideKubectl had returned true', async () => {
   vi.mocked(Detect.prototype.checkSystemWideKubectl).mockReturnValue(Promise.resolve(true));

--- a/extensions/kubectl-cli/src/utils.spec.ts
+++ b/extensions/kubectl-cli/src/utils.spec.ts
@@ -22,14 +22,6 @@ import { beforeEach, describe, expect, test, vi, vitest } from 'vitest';
 
 import { makeExecutable } from './utils';
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    process: {
-      exec: vi.fn(),
-    },
-  };
-});
-
 describe('makeExecutable', async () => {
   beforeEach(() => {
     vi.resetAllMocks();


### PR DESCRIPTION
### What does this PR do?
avoid defining custom mock for @podman-desktop/api, reuse the global mock related to #14493

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14493

### How to test this PR?

CI should be ✅

- [x] Tests are covering the bug fix or the new feature
