### PR TITLE
refactor(extension-kube-context): reuse global mock for @podman-desktop/api

### DIFF
--- a/extensions/kube-context/src/extension.spec.ts
+++ b/extensions/kube-context/src/extension.spec.ts
@@ -29,17 +29,6 @@ const item = {
   text: '',
 };
 
-vi.mock('@podman-desktop/api', async () => {
-  return {
-    window: {
-      createStatusBarItem: vi.fn(),
-    },
-    tray: {
-      registerMenuItem: vi.fn(),
-    },
-  };
-});
-
 beforeAll(() => {
   (podmanDesktopApi.window.createStatusBarItem as Mock).mockReturnValue(item);
 });


### PR DESCRIPTION
### What does this PR do?
avoid defining custom mock for @podman-desktop/api, reuse the global mock

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14493


### How to test this PR?

CI should be ✅

- [x] Tests are covering the bug fix or the new feature
