### PR TITLE
refactor(extension: podman): use vitest v4 syntax in podman-machine-stream.spec.ts

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-machine-stream.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-machine-stream.spec.ts
@@ -16,34 +16,36 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { EventEmitter } from '@podman-desktop/api';
-import { Client } from 'ssh2';
+import { Client, type ClientChannel } from 'ssh2';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { MachineInfo } from '/@/types';
 
 import { ProviderConnectionShellAccessImpl } from './podman-machine-stream';
 
-const onMock = vi.fn();
 const onStreamMock = vi.fn();
 const streamMock = {
   on: onStreamMock,
   write: vi.fn(),
   close: vi.fn(),
-};
+} as unknown as ClientChannel;
 
-let client: Client;
 let providerConnectionShellAccess: TestProviderConnectionShellAccessImpl;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   const machineInfo: MachineInfo = {
     port: 12345,
     remoteUsername: 'user',
     identityPath: 'path/to/privateKey',
   } as unknown as MachineInfo;
 
-  client = new Client();
+  vi.mocked(Client.prototype.on).mockReturnThis();
+  vi.mocked(Client.prototype.shell).mockImplementation(function (this: Client, callback) {
+    callback(undefined, streamMock);
+    return this;
+  });
+
   providerConnectionShellAccess = new TestProviderConnectionShellAccessImpl(machineInfo);
 });
 
@@ -53,36 +55,24 @@ class TestProviderConnectionShellAccessImpl extends ProviderConnectionShellAcces
   }
 }
 
-beforeEach(() => {
-  EventEmitter.prototype.fire = vi.fn();
-});
-
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 
 // Mock ssh2 Client
-vi.mock('ssh2', () => {
-  return {
-    Client: vi.fn().mockImplementation(() => ({
-      on: onMock,
-      connect: vi.fn(),
-      shell: vi.fn(callback => {
-        callback(undefined, streamMock);
-      }),
-      emit: vi.fn(),
-      end: vi.fn(),
-      destroy: vi.fn(),
-    })),
-  };
-});
+vi.mock(import('ssh2'));
 
 describe('Test SSH Client', () => {
+  let client: Client;
+  beforeEach(() => {
+    client = new Client();
+  });
+
   test('should register the ready event', () => {
     const onReady = vi.fn();
 
     // Adds callback for 'ready'
     client.on('ready', onReady);
 
-    expect(onMock).toHaveBeenCalledWith('ready', onReady);
+    expect(client.on).toHaveBeenCalledWith('ready', onReady);
   });
 
   test('should register the error event', () => {
@@ -91,15 +81,16 @@ describe('Test SSH Client', () => {
     // Adds callback for 'error'
     client.on('error', onError);
 
-    expect(onMock).toHaveBeenCalledWith('error', onError);
+    expect(client.on).toHaveBeenCalledWith('error', onError);
   });
 
   test('should emit ready event', () => {
-    onMock.mockImplementation((eventName, fn) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    vi.mocked(Client.prototype.on).mockImplementation(function (this: Client, eventName: string, fn: Function): Client {
       if (eventName === 'ready') {
         fn();
       }
-      return client;
+      return this;
     });
 
     // stream.on needs to return ClientChannel (streamMock)
@@ -110,25 +101,31 @@ describe('Test SSH Client', () => {
 
   test('should emit error event', () => {
     const errMsg = { message: 'Error message' };
-    onMock.mockImplementation((eventName, fn) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    vi.mocked(Client.prototype.on).mockImplementation(function (this: Client, eventName: string, fn: Function): Client {
       if (eventName === 'error') {
         fn(errMsg);
       }
-      return client;
+      return this;
     });
 
+    const listener = vi.fn();
+    providerConnectionShellAccess.onErrorEmit.event(listener);
+
     providerConnectionShellAccess.open();
-    expect(providerConnectionShellAccess.onErrorEmit.fire).toHaveBeenCalledWith({ error: 'Error message' });
+
+    expect(listener).toHaveBeenCalledWith({ error: 'Error message' });
   });
 });
 
 describe('Test SSH Stream', () => {
   beforeEach(() => {
-    onMock.mockImplementation((eventName, fn) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    vi.mocked(Client.prototype.on).mockImplementation(function (this: Client, eventName: string, fn: Function): Client {
       if (eventName === 'ready') {
         fn();
       }
-      return client;
+      return this;
     });
   });
 
@@ -141,8 +138,12 @@ describe('Test SSH Stream', () => {
       return streamMock;
     });
 
+    const listener = vi.fn();
+    providerConnectionShellAccess.onDataEmit.event(listener);
+
     providerConnectionShellAccess.open();
-    expect(providerConnectionShellAccess.onDataEmit.fire).toHaveBeenCalledWith({ data: 'Some data' });
+
+    expect(listener).toHaveBeenCalledWith({ data: 'Some data' });
   });
 
   test('should handle ready event and end shell', async () => {
@@ -153,8 +154,11 @@ describe('Test SSH Stream', () => {
       return streamMock;
     });
 
+    const listener = vi.fn();
+    providerConnectionShellAccess.onEndEmit.event(listener);
+
     providerConnectionShellAccess.open();
-    expect(providerConnectionShellAccess.onEndEmit.fire).toHaveBeenCalled();
+    expect(listener).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Use vitest v4 compatible syntax for `podman-machine-stream.spec.ts`

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/pull/14898

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
