### PR TITLE
test(renderer/ImageList): avoid error logs in test

### DIFF
--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -45,6 +45,7 @@ beforeEach(() => {
   vi.mocked(window.listViewsContributions).mockResolvedValue([]);
   vi.mocked(window.getConfigurationProperties).mockResolvedValue({});
   vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+  vi.mocked(window.onDidUpdateProviderStatus).mockResolvedValue(undefined);
 
   (window.events as unknown) = {
     receive: (_channel: string, func: () => void): void => {


### PR DESCRIPTION
### What does this PR do?

This PR removes the error logs when running the unit test

<img width="1446" height="976" alt="Screenshot 2025-11-19 at 10 47 49" src="https://github.com/user-attachments/assets/8aaa60c2-80e7-4c2c-8b3c-0aac037909fe" />

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?


To see the error logs on main branch, in renderer folder:

`pnpm test src/lib/image/ImagesList.spec.ts`

And compare with this PR.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
