### PR TITLE
chore(main/image build): allow passing target when building image

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1439,6 +1439,7 @@ export class PluginSystem {
         cancellableTokenId?: number,
         buildargs?: { [key: string]: string },
         taskId?: number,
+        target?: string,
       ): Promise<unknown> => {
         // create task
         const task = taskManager.createTask({
@@ -1478,6 +1479,7 @@ export class PluginSystem {
               provider: selectedProvider,
               abortController,
               buildargs,
+              target,
             },
           )
           .then(result => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1301,6 +1301,7 @@ export function initExposure(): void {
       cancellableTokenId?: number,
       buildargs?: { [key: string]: string },
       taskId?: number,
+      target?: string,
     ): Promise<unknown> => {
       onDataCallbacksBuildImageId++;
       onDataCallbacksBuildImage.set(onDataCallbacksBuildImageId, eventCollect);
@@ -1316,6 +1317,7 @@ export function initExposure(): void {
         cancellableTokenId,
         buildargs,
         taskId,
+        target,
       );
     },
   );


### PR DESCRIPTION
### What does this PR do?

This PR adds a `target` argument when calling the build image from the frontend.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for: https://github.com/podman-desktop/podman-desktop/issues/14700

See full feature here: https://github.com/podman-desktop/podman-desktop/pull/14921 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
