### PR TITLE
test(stability): replace waitFor with waitUntil when boolean

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -806,7 +806,7 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   window.dispatchEvent(new CustomEvent('tray:update-provider'));
 
   // wait for the store to be cleared
-  await vi.waitFor(() => get(containersInfos).length === 0);
+  await vi.waitUntil(() => get(containersInfos).length === 0);
 
   // one single container and a container as part of a pod
   const mockedContainers = [
@@ -828,7 +828,7 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   window.dispatchEvent(new CustomEvent('tray:update-provider'));
 
   // wait until the store is populated
-  await vi.waitFor(() => get(containersInfos).length > 0);
+  await vi.waitUntil(() => get(containersInfos).length > 0);
 
   await waitRender({});
 
@@ -952,7 +952,7 @@ test('Ensuring the table and empty screen are not visible at the same time', asy
   window.dispatchEvent(new CustomEvent('tray:update-provider'));
 
   // wait until the stores are populated
-  await vi.waitFor(() => get(containersInfos).length === 1 && get(providerInfos).length === 0);
+  await vi.waitUntil(() => get(containersInfos).length === 1 && get(providerInfos).length === 0);
 
   const { getByRole, queryByRole } = await waitRender({});
 

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -692,7 +692,7 @@ test('Expect to see empty page and no table when no container engine is running'
   window.dispatchEvent(new CustomEvent('image-build'));
 
   // wait imageInfo store is populated
-  await vi.waitFor(() => get(imagesInfos).length > 0);
+  await vi.waitUntil(() => get(imagesInfos).length > 0);
 
   await waitRender({});
 

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -593,7 +593,7 @@ test('Expect to see empty page and no table when no container engine is running'
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
   // wait imageInfo store is populated
-  await vi.waitFor(() => get(podsInfos).length > 0);
+  await vi.waitUntil(() => get(podsInfos).length > 0);
 
   await waitRender({});
 

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -427,7 +427,7 @@ test('Expect to see empty page and no table when no container engine is running'
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
   // wait imageInfo store is populated
-  await vi.waitFor(() => get(volumeListInfos).length > 0);
+  await vi.waitUntil(() => get(volumeListInfos).length > 0);
 
   await waitRender({});
 


### PR DESCRIPTION
### What does this PR do?

This PR ensures waitFor in tests are only used when an exception in thrown.
In some case, and I will tag @axel7083 and @SoniaSandler for their attention because I am fixing some tests you wrote:

-> waitFor => needs an exception
-> waitUntil => needs a false 



### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

This PR tries so solves some CI instabilities.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
