### PR TITLE
test(e2e): swap external extensions for internal ones

### DIFF
--- a/tests/playwright/src/model/core/extensions.ts
+++ b/tests/playwright/src/model/core/extensions.ts
@@ -189,9 +189,9 @@ export const extensionsExternalList = [
   openshiftLocalExtension,
 ];
 export const extensionsInstallationSmokeList = [
-  developerSandboxExtension,
-  openshiftLocalExtension,
-  openshiftCheckerExtension,
+  bootcExtension,
+  podmanQuadletExtension,
   openshiftDockerExtension,
+  imageLayersExplorerExtension,
 ];
 export const extensionsAllExternalList = [...extensionsExternalList, headlampExtension];

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -19,15 +19,16 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect as playExpect, test } from '@playwright/test';
 
+import { isWindows } from '/@/utility/platform';
+
 import {
-  developerSandboxExtension,
+  bootcExtension,
   extensionsInstallationSmokeList,
-  openshiftCheckerExtension,
+  imageLayersExplorerExtension,
   openshiftDockerExtension,
-  openshiftLocalExtension,
+  podmanQuadletExtension,
 } from '../model/core/extensions';
 import { ExtensionState } from '../model/core/states';
-import { DashboardPage } from '../model/pages/dashboard-page';
 import { ExtensionCatalogCardPage } from '../model/pages/extension-catalog-card-page';
 import { ExtensionsPage } from '../model/pages/extensions-page';
 import { ResourcesPage } from '../model/pages/resources-page';
@@ -35,13 +36,11 @@ import { SettingsBar } from '../model/pages/settings-bar';
 import { WelcomePage } from '../model/pages/welcome-page';
 import { NavigationBar } from '../model/workbench/navigation';
 import { Runner } from '../runner/podman-desktop-runner';
-import { isWindows } from '../utility/platform';
 
 let pdRunner: Runner;
 let page: Page;
 
-let extensionDashboardStatus: Locator | undefined;
-let extensionDashboardProvider: Locator | undefined;
+let extensionNavigationBarIcon: Locator | undefined;
 let resourceLabel: string | undefined;
 let ociImageUrl: string;
 
@@ -80,10 +79,7 @@ for (const {
     });
 
     test('Install extension through Extensions Catalog', async () => {
-      test.skip(
-        extensionName === openshiftCheckerExtension.extensionName ||
-          extensionName === openshiftDockerExtension.extensionName,
-      );
+      test.skip(extensionName !== imageLayersExplorerExtension.extensionName);
       test.setTimeout(200_000);
 
       const extensionsPage = new ExtensionsPage(page);
@@ -101,10 +97,7 @@ for (const {
     });
 
     test('Install extension from OCI Image', async () => {
-      test.skip(
-        extensionName !== openshiftCheckerExtension.extensionName &&
-          extensionName !== openshiftDockerExtension.extensionName,
-      );
+      test.skip(extensionName === imageLayersExplorerExtension.extensionName);
       test.setTimeout(200_000);
 
       const extensionsPage = new ExtensionsPage(page);
@@ -162,7 +155,7 @@ for (const {
               'OpenShift Docker extension cannot be disabled',
             );
 
-            test('Disable extension and verify Dashboard and Resources components if present', async () => {
+            test('Disable extension and verify Navbar and Resources components if present', async () => {
               const extensionsPage = await navigationBar.openExtensions();
               const extensionPage = await extensionsPage.openExtensionDetails(
                 extensionLabel,
@@ -173,14 +166,17 @@ for (const {
               await extensionPage.disableExtension();
               await playExpect(extensionPage.status).toHaveText(ExtensionState.Disabled);
 
-              // check that dashboard card provider is hidden/shown
-              if (extensionDashboardProvider && extensionDashboardStatus) {
-                await goToDashboard();
-                await playExpect(extensionDashboardProvider).toBeHidden();
+              // check that extension navbar icon is hidden/shown
+              if (extensionNavigationBarIcon) {
+                await playExpect(extensionNavigationBarIcon).toBeHidden();
               }
 
-              // check that the provider card is on Resources Page
-              if (resourceLabel) {
+              // check that the provider card is on Resources Page -> bootc require binary installation, docker doesn't have
+              if (
+                resourceLabel &&
+                extensionName !== openshiftDockerExtension.extensionName &&
+                extensionName !== bootcExtension.extensionName
+              ) {
                 const settingsBar = await goToSettings();
                 const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
                 const extensionResourceBox = resourcesPage.featuredProviderResources.getByRole('region', {
@@ -190,7 +186,7 @@ for (const {
               }
             });
 
-            test('Enable extension and verify Dashboard and Resources components', async () => {
+            test('Enable extension and verify Navbar and Resources components', async () => {
               const extensionsPage = await navigationBar.openExtensions();
               const extensionPage = await extensionsPage.openExtensionDetails(
                 extensionLabel,
@@ -201,20 +197,17 @@ for (const {
               await extensionPage.enableExtension();
               await playExpect(extensionPage.status).toHaveText(ExtensionState.Active, { timeout: 10_000 });
 
-              // check that dashboard card provider is hidden/shown
-              if (extensionDashboardProvider && extensionDashboardStatus) {
-                await goToDashboard();
-                await playExpect(extensionDashboardProvider).toBeVisible();
-                await playExpect(extensionDashboardStatus).toBeVisible();
-                if (extensionName === developerSandboxExtension.extensionName) {
-                  await playExpect(extensionDashboardStatus).toHaveText(ExtensionState.Running);
-                } else {
-                  await playExpect(extensionDashboardStatus).toHaveText(ExtensionState.NotInstalled);
-                }
+              // check that extension navbar icon is hidden/shown
+              if (extensionNavigationBarIcon) {
+                await playExpect(extensionNavigationBarIcon).toBeVisible();
               }
 
-              // check that the provider card is on Resources Page
-              if (resourceLabel) {
+              // check that the provider card is on Resources Page -> bootc requires binary installation
+              if (
+                resourceLabel &&
+                extensionName !== openshiftDockerExtension.extensionName &&
+                extensionName !== bootcExtension.extensionName
+              ) {
                 const settingsBar = await goToSettings();
                 const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
                 const extensionResourceBox = resourcesPage.featuredProviderResources.getByRole('region', {
@@ -236,7 +229,6 @@ for (const {
             extensionFullLabel,
             extensionFullName,
           );
-
           if (extensionName !== openshiftDockerExtension.extensionName) {
             await extensionDetails.disableExtension();
           }
@@ -261,34 +253,36 @@ for (const {
 }
 
 function initializeLocators(extensionName: string): void {
-  const dashboardPage = new DashboardPage(page);
+  const navigationBar = new NavigationBar(page);
   switch (extensionName) {
-    case developerSandboxExtension.extensionName: {
-      extensionDashboardStatus = dashboardPage.devSandboxStatusLabel;
-      extensionDashboardProvider = dashboardPage.devSandboxProvider;
-      resourceLabel = 'redhat.sandbox';
-      ociImageUrl = '';
+    case bootcExtension.extensionName: {
+      extensionNavigationBarIcon = navigationBar.navigationLocator.getByRole('link', {
+        name: 'Bootable Containers',
+        exact: true,
+      });
+      resourceLabel = 'bootc';
+      ociImageUrl = 'ghcr.io/containers/podman-desktop-extension-bootc';
       break;
     }
-    case openshiftLocalExtension.extensionName: {
-      extensionDashboardStatus = dashboardPage.openshiftLocalStatusLabel;
-      extensionDashboardProvider = dashboardPage.openshiftLocalProvider;
-      resourceLabel = 'crc';
-      ociImageUrl = '';
-      break;
-    }
-    case openshiftCheckerExtension.extensionName: {
-      extensionDashboardStatus = undefined;
-      extensionDashboardProvider = undefined;
+    case podmanQuadletExtension.extensionName: {
+      extensionNavigationBarIcon = navigationBar.navigationLocator.getByRole('link', { name: 'Quadlets', exact: true });
       resourceLabel = undefined;
-      ociImageUrl = 'ghcr.io/redhat-developer/podman-desktop-image-checker-openshift-ext:0.1.5';
+      ociImageUrl = 'ghcr.io/podman-desktop/pd-extension-quadlet:latest';
       break;
     }
     case openshiftDockerExtension.extensionName: {
-      extensionDashboardStatus = undefined;
-      extensionDashboardProvider = undefined;
+      extensionNavigationBarIcon = navigationBar.navigationLocator.getByRole('link', {
+        name: 'OpenShift',
+        exact: true,
+      });
       resourceLabel = undefined;
       ociImageUrl = 'redhatdeveloper/openshift-dd-ext:0.0.1-100';
+      break;
+    }
+    case imageLayersExplorerExtension.extensionName: {
+      extensionNavigationBarIcon = undefined;
+      resourceLabel = undefined;
+      ociImageUrl = '';
       break;
     }
   }


### PR DESCRIPTION
### What does this PR do?
Closes #12742
Clarification: In the previous version there were some checks on the dashboard cards, but given that there are no internal extensions with cards in the dashboard, those checks have been changed for ones that verify the navbar icons.
Worked locally, but I ran the tests on CI here to make sure: https://github.com/podman-desktop/e2e/actions/runs/19506685836

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#12742

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
`pnpm test:e2e`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
