### PR TITLE
refactor(extension: podman): move createProvider logic to a dedicated class

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -24,7 +24,7 @@ import { arch } from 'node:os';
 import type { ServiceIdentifier } from '@inversifyjs/common/lib/esm';
 import type { Configuration, ContainerEngineInfo, ContainerProviderConnection } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
-import { Disposable, provider as apiProvider } from '@podman-desktop/api';
+import { Disposable } from '@podman-desktop/api';
 import type { Container as InversifyContainer } from 'inversify';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -107,17 +107,6 @@ const provider: extensionApi.Provider = {
   warnings: [],
   updateWarnings: updateWarningsMock,
   onDidUpdateDetectionChecks: vi.fn(),
-};
-
-// Use 'provider', but just replace status with 'ready'
-const providerWithReadyStatus = {
-  ...provider,
-  status: 'ready' as extensionApi.ProviderStatus,
-};
-
-const providerWithStoppedStatus = {
-  ...provider,
-  status: 'stopped' as extensionApi.ProviderStatus,
 };
 
 const machineInfo: MachineInfo = {
@@ -331,7 +320,6 @@ vi.mock(import('./utils/util'), async importOriginal => {
 beforeEach(() => {
   console.error = consoleErrorMock;
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue(config);
-  vi.mocked(extensionApi.provider.createProvider).mockReturnValue(provider);
   vi.mocked(extensionApi.env).isMac = false;
   vi.mocked(extensionApi.env).isLinux = false;
   vi.mocked(extensionApi.env).isWindows = false;
@@ -3324,12 +3312,6 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
     });
 
     vi.mock('./utils/warnings');
-
-    // Change the mock return value to return a provider with a ready status for testing,
-    // this uses the original provider, but just replaces the ready status
-    vi.spyOn(apiProvider, 'createProvider').mockReturnValue(
-      providerWithReadyStatus as unknown as extensionApi.Provider,
-    );
   });
 
   test('do not show any notifications / messages if the provider is stopped', async () => {
@@ -3337,11 +3319,6 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
     vi.mocked(extensionApi.env).isMac = true;
     vi.mocked(extensionApi.env).isWindows = false;
     vi.mocked(extensionApi.env).isLinux = false;
-
-    // Mock the provider to be "stopped"
-    vi.spyOn(apiProvider, 'createProvider').mockReturnValue(
-      providerWithStoppedStatus as unknown as extensionApi.Provider,
-    );
 
     const api = await extension.activate(contextMock);
     expect(api).toBeDefined();
@@ -3377,20 +3354,9 @@ describe('podman-mac-helper tests', () => {
         return '';
       },
     });
-
-    // Change the mock return value to return a provider with a ready status for testing,
-    // this uses the original provider, but just replaces the ready status
-    vi.spyOn(apiProvider, 'createProvider').mockReturnValue(
-      providerWithReadyStatus as unknown as extensionApi.Provider,
-    );
   });
 
   test('mock that the provider is "stopped" and make sure that the notification is NOT shown', async () => {
-    // Mock the provider to be "stopped"
-    vi.spyOn(apiProvider, 'createProvider').mockReturnValue(
-      providerWithStoppedStatus as unknown as extensionApi.Provider,
-    );
-
     // Activate
     const api = await extension.activate(contextMock);
     expect(api).toBeDefined();

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -39,6 +39,7 @@ import { MacOSInstaller } from '/@/installer/mac-os-installer';
 import { PodmanInstall } from '/@/installer/podman-install';
 import { WinInstaller } from '/@/installer/win-installer';
 import { WinPlatform } from '/@/platforms/win-platform';
+import { PodmanProvider } from '/@/providers/podman-provider';
 import { PodmanBinary } from '/@/utils/podman-binary';
 
 import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from './symbols';
@@ -75,6 +76,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(HyperVInstalledCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(UserAdminCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(PodmanDesktopElevatedCheck).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(PodmanProvider).toSelf().inSingletonScope();
 
     if (envAPI.isWindows) {
       this.#inversifyContainer.bind(Installer).to(WinInstaller).inSingletonScope();

--- a/extensions/podman/packages/extension/src/providers/podman-provider.spec.ts
+++ b/extensions/podman/packages/extension/src/providers/podman-provider.spec.ts
@@ -28,7 +28,9 @@ const PODMAN_BINARY: PodmanBinary = {
   getBinaryInfo: vi.fn(),
 } as unknown as PodmanBinary;
 
-const PROVIDER_MOCK: Provider = {} as unknown as Provider;
+const PROVIDER_MOCK: Provider = {
+  dispose: vi.fn(),
+} as unknown as Provider;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -97,4 +99,18 @@ describe('initialisation', () => {
       }),
     );
   });
+});
+
+test('dispose should make provider undefined', async () => {
+  const podmanProvider = new PodmanProvider(PODMAN_BINARY);
+  await podmanProvider.init();
+
+  expect(podmanProvider.provider).toBeDefined();
+
+  podmanProvider.dispose();
+
+  // expect error to be thrown
+  expect(() => {
+    return podmanProvider.provider;
+  }).toThrowError('Podman provider not initialized');
 });

--- a/extensions/podman/packages/extension/src/providers/podman-provider.spec.ts
+++ b/extensions/podman/packages/extension/src/providers/podman-provider.spec.ts
@@ -1,0 +1,100 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import type { Provider } from '@podman-desktop/api';
+import { configuration, provider } from '@podman-desktop/api';
+import { Container as InversifyContainer } from 'inversify';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PodmanProvider } from '/@/providers/podman-provider';
+import { PodmanBinary } from '/@/utils/podman-binary';
+
+const PODMAN_BINARY: PodmanBinary = {
+  getBinaryInfo: vi.fn(),
+} as unknown as PodmanBinary;
+
+const PROVIDER_MOCK: Provider = {} as unknown as Provider;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(provider.createProvider).mockReturnValue(PROVIDER_MOCK);
+  vi.mocked(configuration.getConfiguration).mockReturnValue({
+    get: vi.fn(),
+    has: vi.fn(),
+    update: vi.fn(),
+  });
+});
+
+describe('initialisation', () => {
+  test('PodmanProvider#provider should throw an error if not initialized', () => {
+    const podmanProvider = new PodmanProvider(PODMAN_BINARY);
+
+    // expect error to be thrown
+    expect(() => {
+      return podmanProvider.provider;
+    }).toThrowError('Podman provider not initialized');
+  });
+
+  test('PodmanProvider#provider should return the provider once initialized', async () => {
+    const podmanProvider = new PodmanProvider(PODMAN_BINARY);
+    await podmanProvider.init();
+
+    const provider = podmanProvider.provider;
+    expect(provider).toBe(PROVIDER_MOCK);
+  });
+
+  test('inversify should handle init through postConstructor decorator', async () => {
+    const inversify = new InversifyContainer();
+
+    inversify.bind(PodmanBinary).toConstantValue(PODMAN_BINARY);
+    inversify.bind(PodmanProvider).toSelf().inSingletonScope();
+
+    // be careful to use getAsync
+    const podmanProvider = await inversify.getAsync(PodmanProvider);
+
+    const provider = podmanProvider.provider;
+    expect(provider).toBe(PROVIDER_MOCK);
+  });
+
+  test('provider#createProvider should be called with the correct arguments', async () => {
+    const podmanProvider = new PodmanProvider(PODMAN_BINARY);
+    await podmanProvider.init();
+
+    expect(provider.createProvider).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        name: 'Podman',
+        id: 'podman',
+        status: 'not-installed',
+      }),
+    );
+  });
+
+  test('provider#createProvider should have status installed if version detected', async () => {
+    vi.mocked(PODMAN_BINARY.getBinaryInfo).mockResolvedValue({ version: '5.1.2' });
+
+    const podmanProvider = new PodmanProvider(PODMAN_BINARY);
+    await podmanProvider.init();
+
+    expect(provider.createProvider).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        status: 'installed',
+      }),
+    );
+  });
+});

--- a/extensions/podman/packages/extension/src/providers/podman-provider.ts
+++ b/extensions/podman/packages/extension/src/providers/podman-provider.ts
@@ -1,0 +1,127 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+import {
+  Disposable,
+  Provider,
+  provider,
+  ProviderDetectionCheck,
+  ProviderOptions,
+  ProviderStatus,
+} from '@podman-desktop/api';
+import { inject, injectable, postConstruct, preDestroy } from 'inversify';
+
+import { getDetectionChecks } from '/@/checks/detection-checks';
+import { PodmanBinary } from '/@/utils/podman-binary';
+
+@injectable()
+export class PodmanProvider implements Disposable {
+  #provider: Provider | undefined;
+
+  constructor(
+    @inject(PodmanBinary)
+    private readonly podmanBinary: PodmanBinary,
+  ) {}
+
+  @preDestroy()
+  dispose(): void {
+    this.#provider?.dispose();
+    this.#provider = undefined;
+  }
+
+  get provider(): Provider {
+    if (!this.#provider) throw new Error('Podman provider not initialized');
+    return this.#provider;
+  }
+
+  @postConstruct()
+  async init(): Promise<void> {
+    const installedPodman = await this.podmanBinary.getBinaryInfo();
+    const version: string | undefined = installedPodman?.version;
+
+    const detectionChecks: ProviderDetectionCheck[] = [];
+    let status: ProviderStatus = 'not-installed';
+    if (version) {
+      status = 'installed';
+    }
+
+    // update detection checks
+    detectionChecks.push(...getDetectionChecks(installedPodman));
+
+    const providerOptions: ProviderOptions = {
+      name: 'Podman',
+      id: 'podman',
+      detectionChecks,
+      status,
+      version,
+    };
+
+    // add images
+    providerOptions.images = {
+      icon: './icon.png',
+      logo: './logo.png',
+    };
+
+    // Empty connection descriptive message
+    providerOptions.emptyConnectionMarkdownDescription =
+      'Podman is a lightweight, open-source container runtime and image management tool that enables users to run and manage containers without the need for a separate daemon.\n\nMore information: [podman.io](https://podman.io/)';
+
+    const corePodmanEngineLinkGroup = 'Core Podman Engine';
+
+    // add links
+    providerOptions.links = [
+      {
+        title: 'Website',
+        url: 'https://podman.io/',
+      },
+      {
+        title: 'Installation guide',
+        url: 'https://podman.io/getting-started/installation',
+      },
+      {
+        title: 'Docker compatibility guide',
+        url: 'https://podman-desktop.io/docs/migrating-from-docker/managing-docker-compatibility',
+      },
+      {
+        title: 'Join the community',
+        url: 'https://podman.io/community/',
+      },
+      {
+        title: 'Getting started with containers',
+        url: 'https://podman.io/getting-started/',
+        group: corePodmanEngineLinkGroup,
+      },
+      {
+        title: 'View podman commands',
+        url: 'https://docs.podman.io/en/latest/Commands.html',
+        group: corePodmanEngineLinkGroup,
+      },
+      {
+        title: 'Set up podman',
+        url: 'https://podman.io/getting-started/installation',
+        group: corePodmanEngineLinkGroup,
+      },
+      {
+        title: 'View all tutorials',
+        url: 'https://docs.podman.io/en/latest/Tutorials.html',
+        group: corePodmanEngineLinkGroup,
+      },
+    ];
+
+    this.#provider = provider.createProvider(providerOptions);
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Currently the Podman Provider, is created inside the `extensions/podman/packages/extension/src/extension.ts`, then the provider object is passed down many functions and this makes pretty hard to move other functions, as they require the provider.

Creating a dedicated class creating the Podman Provider allow us to make it injectable through inversify, and later could be injected to class that requires the provider;

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/10327

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

The createProvider logic was not tested, I added some basic tests to cover the logic.