### PR TITLE
chore(test): use koji repo for latest Podman and run e2e tests on Fedora 43

### DIFF
--- a/.github/workflows/e2e-main-tf.yaml
+++ b/.github/workflows/e2e-main-tf.yaml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fedora-version: ['Fedora-41', 'Fedora-42']
+        fedora-version: ['Fedora-42', 'Fedora-43']
     steps:
       - name: Set the default env. variables
         env:


### PR DESCRIPTION
Signed-off-by: Anton Misskii <amisskii@redhat.com>

### What does this PR do?

This PR fixes the TF e2e tests. It updates the configuration to use the Koji npm repository for the latest Podman, enables the tests to run on Fedora 43, and removes support for Fedora 41 since it does not support the new Podman 5.7.0 version.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/e2e/issues/520
https://github.com/podman-desktop/e2e/issues/525

