### PR TITLE
refactor(extension: podman): creating dedicated check for libkrun podman min version

### DIFF
--- a/extensions/podman/packages/extension/src/checks/macos/libkrun-podman-version-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/macos/libkrun-podman-version-check.spec.ts
@@ -1,0 +1,70 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import type { CheckResult } from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { LibkrunPodmanVersionCheck } from '/@/checks/macos/libkrun-podman-version-check';
+import type { PodmanBinary } from '/@/utils/podman-binary';
+
+const PODMAN_BINARY_MOCK: PodmanBinary = {
+  getBinaryInfo: vi.fn(),
+} as unknown as PodmanBinary;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+interface TestCase {
+  name: string;
+  version: string;
+  expected: CheckResult;
+}
+
+test.each<TestCase>([
+  {
+    name: 'version bellow minimum should result in failure',
+    expected: {
+      successful: false,
+      description: 'Libkrun is only supported with podman version >= 5.2.0-rc1.',
+    },
+    version: '4.1.2',
+  },
+  {
+    name: 'version above minimum should result in a success',
+    expected: {
+      successful: true,
+    },
+    version: '5.3.0',
+  },
+])('$name', async ({ version, expected }) => {
+  vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version });
+
+  const check = new LibkrunPodmanVersionCheck(PODMAN_BINARY_MOCK);
+  const result = await check.execute();
+  expect(result).toStrictEqual(expected);
+});
+
+test('if podman is not installed the test should fail', async () => {
+  // mock no version of podman detected
+  vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue(undefined);
+
+  const check = new LibkrunPodmanVersionCheck(PODMAN_BINARY_MOCK);
+  const { successful } = await check.execute();
+  expect(successful).toBeFalsy();
+});

--- a/extensions/podman/packages/extension/src/checks/macos/libkrun-podman-version-check.ts
+++ b/extensions/podman/packages/extension/src/checks/macos/libkrun-podman-version-check.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { CheckResult } from '@podman-desktop/api';
+import { compareVersions } from 'compare-versions';
+import { inject, injectable } from 'inversify';
+
+import { PodmanBinary } from '/@/utils/podman-binary';
+
+import { BaseCheck } from '../base-check';
+
+@injectable()
+export class LibkrunPodmanVersionCheck extends BaseCheck {
+  title = 'Minimum Podman Version for Libkrun';
+  static readonly PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT = '5.2.0-rc1';
+
+  constructor(
+    @inject(PodmanBinary)
+    private readonly podmanBinary: PodmanBinary,
+  ) {
+    super();
+  }
+
+  async execute(): Promise<CheckResult> {
+    const isPodmanVersionSupported = await this.isPodmanVersionSupported();
+    if (!isPodmanVersionSupported) {
+      return this.createFailureResult({
+        description: `Libkrun is only supported with podman version >= ${LibkrunPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT}.`,
+      });
+    }
+    return this.createSuccessfulResult();
+  }
+
+  private async isPodmanVersionSupported(): Promise<boolean> {
+    const binaryInfo = await this.podmanBinary.getBinaryInfo();
+    if (!binaryInfo) return false;
+    return (
+      compareVersions(binaryInfo?.version, LibkrunPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT) >= 0
+    );
+  }
+}

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -46,6 +46,7 @@ import { PodmanBinaryLocationHelper } from '/@/helpers/podman-binary-location-he
 import { PodmanInfoHelper } from '/@/helpers/podman-info-helper';
 import { QemuHelper } from '/@/helpers/qemu-helper';
 import type { Installer } from '/@/installer/installer';
+import { MacOSPlatform } from '/@/platforms/macos-platform';
 import { WinPlatform } from '/@/platforms/win-platform';
 import { PodmanProvider } from '/@/providers/podman-provider';
 import type { ConnectionJSON, MachineInfo, MachineJSON } from '/@/types';
@@ -183,6 +184,9 @@ const WIN_PLATFORM_MOCK: WinPlatform = {
   isWSLEnabled: vi.fn(),
   isHyperVEnabled: vi.fn(),
 } as unknown as WinPlatform;
+const MAC_OS_PLATFORM_MOCK: MacOSPlatform = {
+  isLibkrunSupported: vi.fn(),
+} as unknown as MacOSPlatform;
 const PODMAN_BINARY_MOCK: PodmanBinary = {
   getBinaryInfo: vi.fn(),
   invalidate: vi.fn(),
@@ -261,6 +265,8 @@ beforeEach(async () => {
         return PODMAN_BINARY_MOCK;
       case PodmanProvider:
         return PODMAN_PROVIDER_MOCK;
+      case MacOSPlatform:
+        return MAC_OS_PLATFORM_MOCK;
     }
     throw new Error(`Unknown identifier ${String(identifier)}`);
   }
@@ -1456,6 +1462,7 @@ test('ensure showNotification is not called during update', async () => {
     {} as unknown as Installer,
     {} as unknown as extensionApi.ProviderCleanup,
     PODMAN_BINARY_MOCK,
+    MAC_OS_PLATFORM_MOCK,
   );
   vi.spyOn(podmanInstall, 'checkForUpdate').mockImplementation((_installedPodman: InstalledPodman | undefined) => {
     return Promise.resolve({
@@ -1513,6 +1520,7 @@ test('should not register update when there are multiple Podman installations', 
     {} as unknown as Installer,
     undefined,
     PODMAN_BINARY_MOCK,
+    MAC_OS_PLATFORM_MOCK,
   );
   const findPodmanInstallationsMock = vi.spyOn(podmanCli, 'findPodmanInstallations');
 
@@ -1547,6 +1555,7 @@ test('should register update when there is single Podman installation', async ()
     {} as unknown as Installer,
     undefined,
     PODMAN_BINARY_MOCK,
+    MAC_OS_PLATFORM_MOCK,
   );
   const findPodmanInstallationsMock = vi.spyOn(podmanCli, 'findPodmanInstallations');
 
@@ -1577,6 +1586,7 @@ test('should register update when there are multiple Podman installations but cu
     {} as unknown as Installer,
     undefined,
     PODMAN_BINARY_MOCK,
+    MAC_OS_PLATFORM_MOCK,
   );
   const findPodmanInstallationsMock = vi.spyOn(podmanCli, 'findPodmanInstallations');
   vi.spyOn(podmanCli, 'getCustomBinaryPath').mockReturnValue('/custom/path/podman');
@@ -1612,6 +1622,7 @@ test('update should be wrapped with withProgress to create a visible task', asyn
     {} as unknown as Installer,
     undefined,
     PODMAN_BINARY_MOCK,
+    MAC_OS_PLATFORM_MOCK,
   );
 
   vi.spyOn(podmanCli, 'findPodmanInstallations').mockResolvedValue(['/usr/local/bin/podman']);
@@ -2559,6 +2570,7 @@ test('checkForUpdate func should be called if there is no podman installed', asy
     {} as unknown as Installer,
     {} as unknown as extensionApi.ProviderCleanup,
     PODMAN_BINARY_MOCK,
+    MAC_OS_PLATFORM_MOCK,
   );
 
   vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
@@ -2569,34 +2581,6 @@ test('checkForUpdate func should be called if there is no podman installed', asy
 
   await extension.initCheckAndRegisterUpdate(provider, podmanInstall);
   expect(podmanInstall.checkForUpdate).toBeCalledWith(undefined);
-});
-
-test('isLibkrunSupported should return false with 5.3.0 on intel', async () => {
-  vi.mocked(extensionApi.env).isMac = true;
-  vi.mocked(arch).mockReturnValue('x64');
-  const enabled = extension.isLibkrunSupported('5.3.0');
-  expect(enabled).toBeFalsy();
-});
-
-test('isLibkrunSupported should return true with prelease older than rc1', async () => {
-  vi.mocked(arch).mockReturnValue('arm64');
-  vi.mocked(extensionApi.env).isMac = true;
-  const enabled = extension.isLibkrunSupported('5.2.0-rc2');
-  expect(enabled).toBeTruthy();
-});
-
-test('isLibkrunSupported should return true with 5.2.0 version', async () => {
-  vi.mocked(arch).mockReturnValue('arm64');
-  vi.mocked(extensionApi.env).isMac = true;
-  const enabled = extension.isLibkrunSupported('5.2.0');
-  expect(enabled).toBeTruthy();
-});
-
-test('isLibkrunSupported should return false with previous 5.1.2 version', async () => {
-  vi.mocked(arch).mockReturnValue('arm64');
-  vi.mocked(extensionApi.env).isMac = true;
-  const enabled = extension.isLibkrunSupported('5.1.2');
-  expect(enabled).toBeFalsy();
 });
 
 describe('isPlaybookMachineInitSupported', () => {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -44,6 +44,7 @@ import {
   USER_MODE_NETWORKING_SUPPORTED_KEY,
   WSL_HYPERV_ENABLED_KEY,
 } from '/@/constants';
+import { MacOSPlatform } from '/@/platforms/macos-platform';
 import { WinPlatform } from '/@/platforms/win-platform';
 import { PodmanProvider } from '/@/providers/podman-provider';
 import type { ConnectionJSON, MachineInfo, MachineJSON, MachineJSONListOutput, MachineListOutput } from '/@/types';
@@ -114,6 +115,7 @@ const containerProviderConnections = new Map<string, extensionApi.ContainerProvi
 let telemetryLogger: extensionApi.TelemetryLogger;
 
 let winPlatform: WinPlatform;
+let macOSPlatform: MacOSPlatform;
 let podmanBinary: PodmanBinary;
 
 let certificateDetectionService: CertificateDetectionService | undefined;
@@ -1262,6 +1264,7 @@ export async function initInversify(
 
   const podmanInstall = inversifyContainer.get(PodmanInstall);
   winPlatform = inversifyContainer.get(WinPlatform);
+  macOSPlatform = inversifyContainer.get(MacOSPlatform);
   podmanBinary = inversifyContainer.get(PodmanBinary);
   const podmanProvider = await inversifyContainer.getAsync(PodmanProvider);
 
@@ -1290,7 +1293,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     extensionApi.context.setValue(ROOTFUL_MACHINE_INIT_SUPPORTED_KEY, isRootfulMachineInitSupported(version));
     extensionApi.context.setValue(START_NOW_MACHINE_INIT_SUPPORTED_KEY, isStartNowAtMachineInitSupported(version));
     extensionApi.context.setValue(USER_MODE_NETWORKING_SUPPORTED_KEY, isUserModeNetworkingSupported(version));
-    extensionApi.context.setValue(PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY, isLibkrunSupported(version));
+    extensionApi.context.setValue(PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY, macOSPlatform.isLibkrunSupported());
     isMovedPodmanSocket = isPodmanSocketLocationMoved(version);
   }
 
@@ -1760,11 +1763,10 @@ async function stopAutoStartedMachine(): Promise<void> {
 }
 
 export async function getJSONMachineList(): Promise<MachineJSONListOutput> {
-  const installedPodman = await podmanBinary.getBinaryInfo();
-
   const containerMachineProviders: (string | undefined)[] = [];
+  const libkrunSupported = await macOSPlatform.isLibkrunSupported();
   // if libkrun is supported we want to show both applehv and libkrun machines
-  if (installedPodman && isLibkrunSupported(installedPodman.version)) {
+  if (libkrunSupported) {
     containerMachineProviders.push(...['applehv', 'libkrun']);
   }
 
@@ -1862,17 +1864,6 @@ const PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING = '4.6.0';
 export function isUserModeNetworkingSupported(podmanVersion: string): boolean {
   return (
     extensionApi.env.isWindows && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING) >= 0
-  );
-}
-
-const PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT = '5.2.0-rc1';
-
-// Checks if libkrun is supported. Only Mac/silicon platform allows this parameter to be tuned
-export function isLibkrunSupported(podmanVersion: string): boolean {
-  return (
-    extensionApi.env.isMac &&
-    os.arch() === 'arm64' &&
-    compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT) >= 0
   );
 }
 

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -20,6 +20,7 @@ import type { ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
 import { env as envAPI } from '@podman-desktop/api';
 import { Container as InversifyContainer } from 'inversify';
 
+import { LibkrunPodmanVersionCheck } from '/@/checks/macos/libkrun-podman-version-check';
 import { HyperVCheck } from '/@/checks/windows/hyper-v-check';
 import { HyperVInstalledCheck } from '/@/checks/windows/hyper-v-installed-check';
 import { HyperVPodmanVersionCheck } from '/@/checks/windows/hyper-v-podman-version-check';
@@ -38,6 +39,7 @@ import { Installer } from '/@/installer/installer';
 import { MacOSInstaller } from '/@/installer/mac-os-installer';
 import { PodmanInstall } from '/@/installer/podman-install';
 import { WinInstaller } from '/@/installer/win-installer';
+import { MacOSPlatform } from '/@/platforms/macos-platform';
 import { WinPlatform } from '/@/platforms/win-platform';
 import { PodmanProvider } from '/@/providers/podman-provider';
 import { PodmanBinary } from '/@/utils/podman-binary';
@@ -62,8 +64,13 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(TelemetryLoggerSymbol).toConstantValue(this.#telemetryLogger);
     this.#inversifyContainer.bind(PodmanInstall).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WinPlatform).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(MacOSPlatform).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(PodmanBinary).toSelf().inSingletonScope();
 
+    // MacOS checks
+    this.#inversifyContainer.bind(LibkrunPodmanVersionCheck).toSelf().inSingletonScope();
+
+    // Windows check
     this.#inversifyContainer.bind(WinBitCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WinVersionCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WinMemoryCheck).toSelf().inSingletonScope();
@@ -76,6 +83,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(HyperVInstalledCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(UserAdminCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(PodmanDesktopElevatedCheck).toSelf().inSingletonScope();
+
     this.#inversifyContainer.bind(PodmanProvider).toSelf().inSingletonScope();
 
     if (envAPI.isWindows) {

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -21,6 +21,7 @@ import * as fs from 'node:fs';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { MacOSPlatform } from '/@/platforms/macos-platform';
 import type { InstalledPodman, PodmanBinary } from '/@/utils/podman-binary';
 
 import * as extensionObj from '../extension';
@@ -77,6 +78,9 @@ const PROVIDER_CLEANUP_MOCK = {
 const PODMAN_BINARY_MOCK: PodmanBinary = {
   getBinaryInfo: vi.fn(),
 } as unknown as PodmanBinary;
+const MAC_OS_PLATFORM_MOCK = {
+  isLibkrunSupported: vi.fn(),
+} as unknown as MacOSPlatform;
 
 // mock filesystem
 vi.mock('node:fs');
@@ -123,6 +127,7 @@ beforeEach(() => {
     INSTALLER_MOCK,
     PROVIDER_CLEANUP_MOCK,
     PODMAN_BINARY_MOCK,
+    MAC_OS_PLATFORM_MOCK,
   );
   // reset array of subscriptions
   extensionContext.subscriptions.length = 0;

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -30,6 +30,7 @@ import {
   USER_MODE_NETWORKING_SUPPORTED_KEY,
 } from '/@/constants';
 import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
+import { MacOSPlatform } from '/@/platforms/macos-platform';
 import { MachineJSON } from '/@/types';
 import { InstalledPodman, PodmanBinary } from '/@/utils/podman-binary';
 
@@ -37,7 +38,6 @@ import { getDetectionChecks } from '../checks/detection-checks';
 import {
   calcPodmanMachineSetting,
   getJSONMachineList,
-  isLibkrunSupported,
   isRootfulMachineInitSupported,
   isStartNowAtMachineInitSupported,
   isUserModeNetworkingSupported,
@@ -74,6 +74,8 @@ export class PodmanInstall {
     readonly providerCleanup: extensionApi.ProviderCleanup | undefined,
     @inject(PodmanBinary)
     readonly podmanBinary: PodmanBinary,
+    @inject(MacOSPlatform)
+    readonly macosPlatform: MacOSPlatform,
   ) {
     this.storagePath = extensionContext.storagePath;
   }
@@ -106,10 +108,7 @@ export class PodmanInstall {
           START_NOW_MACHINE_INIT_SUPPORTED_KEY,
           isStartNowAtMachineInitSupported(newInstalledPodman.version),
         );
-        extensionApi.context.setValue(
-          PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
-          isLibkrunSupported(newInstalledPodman.version),
-        );
+        extensionApi.context.setValue(PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY, this.macosPlatform.isLibkrunSupported());
         await calcPodmanMachineSetting();
       }
       // update detections checks
@@ -315,10 +314,7 @@ export class PodmanInstall {
             START_NOW_MACHINE_INIT_SUPPORTED_KEY,
             isStartNowAtMachineInitSupported(updateInfo.bundledVersion),
           );
-          extensionApi.context.setValue(
-            PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
-            isLibkrunSupported(updateInfo.bundledVersion),
-          );
+          extensionApi.context.setValue(PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY, this.macosPlatform.isLibkrunSupported());
         } else if (answer === 'Ignore') {
           this.podmanInfo.ignoreVersionUpdate = updateInfo.bundledVersion;
         } else if (answer === 'Open release notes') {

--- a/extensions/podman/packages/extension/src/platforms/macos-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/macos-platform.spec.ts
@@ -1,0 +1,67 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import { arch } from 'node:os';
+
+import * as extensionApi from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { LibkrunPodmanVersionCheck } from '/@/checks/macos/libkrun-podman-version-check';
+import { MacOSPlatform } from '/@/platforms/macos-platform';
+
+vi.mock(import('node:os'));
+
+const LIBKRUN_PODMAN_VERSION_CHECK_MOCK = {
+  execute: vi.fn(),
+} as unknown as LibkrunPodmanVersionCheck;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(LIBKRUN_PODMAN_VERSION_CHECK_MOCK.execute).mockResolvedValue({
+    successful: true,
+  });
+});
+
+test('MacOSPlatform#isLibkrunSupported should return false on non-ios platform', async () => {
+  vi.mocked(extensionApi.env).isMac = false;
+  const platform = new MacOSPlatform(LIBKRUN_PODMAN_VERSION_CHECK_MOCK);
+
+  const enabled = await platform.isLibkrunSupported();
+  expect(enabled).toBeFalsy();
+});
+
+test('MacOSPlatform#isLibkrunSupported should return false on non-arm64 platform', async () => {
+  vi.mocked(extensionApi.env).isMac = true;
+  vi.mocked(arch).mockReturnValue('x64');
+
+  const platform = new MacOSPlatform(LIBKRUN_PODMAN_VERSION_CHECK_MOCK);
+
+  const enabled = await platform.isLibkrunSupported();
+  expect(enabled).toBeFalsy();
+});
+
+test('MacOSPlatform#isLibkrunSupported should return LibkrunPodmanVersionCheck results on macOS arm64', async () => {
+  vi.mocked(extensionApi.env).isMac = true;
+  vi.mocked(arch).mockReturnValue('arm64');
+
+  const platform = new MacOSPlatform(LIBKRUN_PODMAN_VERSION_CHECK_MOCK);
+
+  const enabled = await platform.isLibkrunSupported();
+  expect(enabled).toBeTruthy();
+});

--- a/extensions/podman/packages/extension/src/platforms/macos-platform.ts
+++ b/extensions/podman/packages/extension/src/platforms/macos-platform.ts
@@ -15,7 +15,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import os from 'node:os';
+
+import extensionApi from '@podman-desktop/api';
+import { inject } from 'inversify';
+
+import { LibkrunPodmanVersionCheck } from '/@/checks/macos/libkrun-podman-version-check';
 
 export class MacOSPlatform {
   readonly type = 'macOS';
+
+  constructor(
+    @inject(LibkrunPodmanVersionCheck)
+    private readonly libbkrunPodmanVersionCheck: LibkrunPodmanVersionCheck,
+  ) {}
+
+  async isLibkrunSupported(): Promise<boolean> {
+    if (!extensionApi.env.isMac || os.arch() !== 'arm64') {
+      return false;
+    }
+
+    const result = await this.libbkrunPodmanVersionCheck.execute();
+    return result.successful;
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Goal : remove the global function `isLibkrunSupported`

1. create a `LibkrunPodmanVersionCheck` class checking the minimum version of podman supported
> This class is kinda similar to `HyperVPodmanVersionCheck`
2. make `LibkrunPodmanVersionCheck` injectable
3. inject `LibkrunPodmanVersionCheck` in the `MacOSPlatform`
4. expose `isLibkrunEnabled` in MacOSPlatform`
5. replace all usage of `extension.isLibkrunSupported` with `MacOSPlatform#isLibkrunSupported`
6. move related tests

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/10327

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
