### PR TITLE
feat(BuildImage): add target dropdown

### DIFF
--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -19,11 +19,11 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
-import { render, screen, waitFor } from '@testing-library/svelte';
+import { render, type RenderResult, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { tick } from 'svelte';
+import { type Component, tick } from 'svelte';
 import { get } from 'svelte/store';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import BuildImageFromContainerfile from '/@/lib/image/BuildImageFromContainerfile.svelte';
 import { buildImagesInfo, getNextTaskId } from '/@/stores/build-images';
@@ -44,11 +44,13 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-async function waitRender(): Promise<void> {
-  render(BuildImageFromContainerfile);
+async function waitRender(): Promise<RenderResult<Component>> {
+  const res = render(BuildImageFromContainerfile);
 
   // Wait 200ms for "cards" for platform render correctly
   await new Promise(resolve => setTimeout(resolve, 200));
+
+  return res;
 }
 
 // the build image page expects to have a valid provider connection, so let's mock one
@@ -201,6 +203,7 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
     expect.anything(),
     expect.anything(),
     expect.anything(),
+    undefined,
   );
 
   expect(window.buildImage).toHaveBeenCalledWith(
@@ -214,6 +217,7 @@ test('Select multiple platforms and expect pressing Build will do two buildImage
     expect.anything(),
     expect.anything(),
     expect.anything(),
+    undefined,
   );
 });
 
@@ -309,6 +313,7 @@ test('Selecting one platform only calls buildImage once with the selected platfo
     expect.anything(),
     expect.anything(),
     expect.anything(),
+    undefined,
   );
 });
 
@@ -605,4 +610,50 @@ test('Expect error to be displayed if uppercase character in image name', async 
   const buildButton = getByRole('button', { name: 'Build' });
   expect(buildButton).toBeInTheDocument();
   expect(buildButton).toBeDisabled();
+});
+
+describe('Build image that has an intermediate target', () => {
+  test.each([
+    { target: 'custom-target', expected: 'custom-target' },
+    { target: 'none', expected: undefined },
+  ])('should build with target $target', async ({ target, expected }) => {
+    vi.mocked(window.containerfileGetInfo).mockResolvedValue({
+      targets: ['custom-target'],
+    });
+    vi.mocked(window.getOsArch).mockResolvedValue('amd64');
+    setup();
+
+    const { getByRole } = await waitRender();
+
+    vi.mocked(window.pathRelative).mockResolvedValue('containerfile');
+    const containerFilePath = getByRole('textbox', { name: 'Containerfile path' });
+    await userEvent.type(containerFilePath, '/somepath/containerfile');
+
+    const imageName = getByRole('textbox', { name: 'Image name' });
+    await userEvent.type(imageName, 'foobar');
+
+    const targetDropdown = getByRole('button', { name: 'Target' });
+    await userEvent.click(targetDropdown);
+
+    await userEvent.click(getByRole('button', { name: target }));
+
+    const buildButton = getByRole('button', { name: 'Build' });
+    expect(buildButton).toBeEnabled();
+    await userEvent.click(buildButton);
+
+    expect(window.buildImage).toHaveBeenCalledTimes(1);
+    expect(window.buildImage).toHaveBeenCalledWith(
+      '/somepath',
+      'containerfile',
+      'foobar',
+      'linux/amd64',
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      {},
+      expect.anything(),
+      expected,
+    );
+  });
 });

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -615,7 +615,7 @@ test('Expect error to be displayed if uppercase character in image name', async 
 describe('Build image that has an intermediate target', () => {
   test.each([
     { target: 'custom-target', expected: 'custom-target' },
-    { target: 'none', expected: undefined },
+    { target: 'default (no target)', expected: undefined },
   ])('should build with target $target', async ({ target, expected }) => {
     vi.mocked(window.containerfileGetInfo).mockResolvedValue({
       targets: ['custom-target'],

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -26,6 +26,7 @@ import EngineFormPage from '../ui/EngineFormPage.svelte';
 import TerminalWindow from '../ui/TerminalWindow.svelte';
 import { type BuildImageCallback, disconnectUI, eventCollect, reconnectUI, startBuild } from './build-image-task';
 import BuildImageFromContainerfileCards from './BuildImageFromContainerfileCards.svelte';
+import BuildTargetDropdown from './BuildTargetDropdown.svelte';
 import RecommendedRegistry from './RecommendedRegistry.svelte';
 
 interface Props {
@@ -143,6 +144,7 @@ async function buildSinglePlatformImage(): Promise<void> {
       buildImageInfo.cancellableTokenId,
       formattedBuildArgs,
       buildImageInfo.taskId,
+      buildImageInfo.target,
     );
   } catch (error) {
     eventCollect(buildImageInfo.buildImageKey, 'error', String(error));
@@ -205,6 +207,7 @@ async function buildMultiplePlatformImagesAndCreateManifest(): Promise<void> {
         buildImageInfo.cancellableTokenId,
         formattedBuildArgs,
         buildImageInfo.taskId,
+        buildImageInfo.target,
       )) as BuildOutput;
 
       // Extract and store the build ID as this is required for creating the manifest, only if it is available.
@@ -385,6 +388,12 @@ let hasInvalidFields = $derived(
           error={errorContainerImageName}
           class="w-full" />
       </div>
+
+      {#if buildImageInfo.containerFilePath}
+        <div hidden={buildImageInfo.buildRunning}>
+            <BuildTargetDropdown bind:target={buildImageInfo.target} containerFilePath={buildImageInfo.containerFilePath} />
+        </div>
+      {/if}
 
       {#if providerConnections.length > 1}
         <div hidden={buildImageInfo.buildRunning}>

--- a/packages/renderer/src/lib/image/BuildTargetDropdown.spec.ts
+++ b/packages/renderer/src/lib/image/BuildTargetDropdown.spec.ts
@@ -39,7 +39,7 @@ test('Expect Target dropdown to be visible with targets and select a target', as
 
   const targetDropdown = await findByRole('button', { name: 'Target' });
 
-  expect(getByText('none')).toBeInTheDocument();
+  expect(getByText('default (no target)')).toBeInTheDocument();
 
   await userEvent.click(targetDropdown);
 
@@ -73,9 +73,9 @@ test('Expect selecting "none" to set target to undefined', async () => {
 
   await userEvent.click(targetDropdown);
 
-  const noneOption = getByRole('button', { name: 'none' });
+  const noneOption = getByRole('button', { name: 'default (no target)' });
   expect(noneOption).toBeInTheDocument();
   await userEvent.click(noneOption);
 
-  expect(getByText('none')).toBeInTheDocument();
+  expect(getByText('default (no target)')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/image/BuildTargetDropdown.spec.ts
+++ b/packages/renderer/src/lib/image/BuildTargetDropdown.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import BuildTargetDropdown from './BuildTargetDropdown.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect Target dropdown to be visible with targets and select a target', async () => {
+  vi.mocked(window.containerfileGetInfo).mockResolvedValue({
+    targets: ['target1', 'target2', 'custom-target'],
+  });
+
+  const { findByRole, getByText, getByRole } = render(BuildTargetDropdown, {
+    props: { containerFilePath: '/somepath/Containerfile', target: undefined },
+  });
+
+  const targetDropdown = await findByRole('button', { name: 'Target' });
+
+  expect(getByText('none')).toBeInTheDocument();
+
+  await userEvent.click(targetDropdown);
+
+  const target1Option = getByRole('button', { name: 'target1' });
+  expect(target1Option).toBeInTheDocument();
+  await userEvent.click(target1Option);
+
+  expect(getByText('target1')).toBeInTheDocument();
+
+  await userEvent.click(targetDropdown);
+
+  const customTargetOption = getByRole('button', { name: 'custom-target' });
+  await userEvent.click(customTargetOption);
+
+  expect(getByText('custom-target')).toBeInTheDocument();
+});
+
+test('Expect selecting "none" to set target to undefined', async () => {
+  vi.mocked(window.containerfileGetInfo).mockResolvedValue({
+    targets: ['target1', 'target2'],
+  });
+
+  const { findByRole, getByText, getByRole } = render(BuildTargetDropdown, {
+    props: { containerFilePath: '/somepath/Containerfile', target: 'target1' },
+  });
+
+  const targetDropdown = await findByRole('button', { name: 'Target' });
+  expect(targetDropdown).toBeInTheDocument();
+
+  expect(getByText('target1')).toBeInTheDocument();
+
+  await userEvent.click(targetDropdown);
+
+  const noneOption = getByRole('button', { name: 'none' });
+  expect(noneOption).toBeInTheDocument();
+  await userEvent.click(noneOption);
+
+  expect(getByText('none')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/image/BuildTargetDropdown.svelte
+++ b/packages/renderer/src/lib/image/BuildTargetDropdown.svelte
@@ -26,7 +26,7 @@ const infoPromise = $derived(window.containerfileGetInfo(containerFilePath));
           onChange={onChange}
           name="target"
           id="target"
-          options={info.targets.map(target => ({ label: target, value: target })).concat({ label: 'none', value: DEFAULT })}
+          options={info.targets.map(target => ({ label: target, value: target })).concat({ label: 'default (no target)', value: DEFAULT })}
           class="w-full" />
       </div>
     {/if}

--- a/packages/renderer/src/lib/image/BuildTargetDropdown.svelte
+++ b/packages/renderer/src/lib/image/BuildTargetDropdown.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { Dropdown } from '@podman-desktop/ui-svelte';
+
+let { target = $bindable(), containerFilePath }: { target: string | undefined; containerFilePath: string } = $props();
+
+const DEFAULT = '<none>';
+
+function onChange(val: string): void {
+  if (val === DEFAULT) {
+    target = undefined;
+  } else {
+    target = val;
+  }
+}
+
+const infoPromise = $derived(window.containerfileGetInfo(containerFilePath));
+</script>
+
+<svelte:boundary>
+  {#await infoPromise then info}
+    {#if info?.targets.length > 0}
+      <div class="space-y-2">
+        <label for="target" class="block mb-2 font-semibold text-(--pd-content-card-header-text)">Target</label>
+        <Dropdown
+          value={target ?? DEFAULT}
+          onChange={onChange}
+          name="target"
+          id="target"
+          options={info.targets.map(target => ({ label: target, value: target })).concat({ label: 'none', value: DEFAULT })}
+          class="w-full" />
+      </div>
+    {/if}
+  {/await}
+</svelte:boundary>

--- a/packages/renderer/src/stores/build-images.ts
+++ b/packages/renderer/src/stores/build-images.ts
@@ -42,6 +42,7 @@ export interface BuildImageInfo {
   selectedProvider?: ProviderContainerConnectionInfo;
   logsTerminal?: Terminal;
   taskId: number;
+  target?: string;
 }
 
 let taskCounter = 0;
@@ -74,6 +75,7 @@ export function createDefaultBuildImageInfo(): BuildImageInfo {
     containerBuildContextDirectory: '',
     containerBuildPlatform: '',
     buildArgs: [{ key: '', value: '' }],
+    target: undefined,
   };
 }
 


### PR DESCRIPTION
### What does this PR do?

For the Dev Week, my proposition was to add the target dropdown when building an image.

This PR adds the frontend target dropdown.

It needs a rebase after:
- #14980 is merged




https://github.com/user-attachments/assets/dffb1eb2-b657-459f-9930-4d5cf9b47f1e



Example used:

```Containerfile
FROM golang:1.24 AS build
WORKDIR /src
COPY <<EOF /src/main.go
package main

import "fmt"

func main() {
  fmt.Println("hello, world")
}
EOF
RUN go build -o /bin/hello ./main.go


FROM build AS stage1

RUN echo stage1


FROM build AS stage2

RUN echo stage2

FROM build AS stage33

RUN echo stage33

FROM scratch
COPY --from=build /bin/hello /bin/hello
CMD ["/bin/hello"]


```

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix of #14700 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
