### PR TITLE
chore(guidelines): add example difference between waitFor and waitUntil

### DIFF
--- a/CODE-GUIDELINES.md
+++ b/CODE-GUIDELINES.md
@@ -187,6 +187,20 @@ const text = getByText('text in the page');
 expect(text).toHaveStyle({ color: '#FFFFF'});
 ```
 
+### `waitFor` vs `waitUntil`
+
+Use `waitFor` to retry an assertion until it passes, and `waitUntil` to wait for a function to return a truthy value.
+
+**Example:**
+
+```typescript
+// Use waitUntil with a boolean value
+await vi.waitUntil(() => get(imagesInfos).length > 0);
+
+// Use waitFor with an assertion
+await waitFor(() => expect(get(providerInfos)).not.toHaveLength(0));
+```
+
 ### Mocking a sub-component
 
 To test a component in isolation without testing its sub-components, you have the possibility to mock

--- a/CODE-GUIDELINES.md
+++ b/CODE-GUIDELINES.md
@@ -189,18 +189,20 @@ expect(text).toHaveStyle({ color: '#FFFFF'});
 
 ### `waitFor` vs `waitUntil`
 
-Use `waitFor` to retry an assertion until it passes, and `waitUntil` to wait for a function to return a truthy value.
+Use `waitFor` (https://vitest.dev/api/vi.html#vi-waitfor) to retry an assertion until it passes, and `waitUntil` (https://vitest.dev/api/vi.html#vi-waituntil) to wait for a function to return a truthy value.
 
-`waitFor` in tests are only used when an exception in thrown.
+→ `waitFor` → needs an exception
+
+→ `waitUntil` → needs a boolean
 
 **Example:**
 
 ```typescript
-// Use waitUntil with a boolean value
-await vi.waitUntil(() => get(imagesInfos).length > 0);
-
 // Use waitFor with an assertion
 await waitFor(() => expect(get(providerInfos)).not.toHaveLength(0));
+
+// Use waitUntil with a boolean value
+await vi.waitUntil(() => get(imagesInfos).length > 0);
 ```
 
 ### Mocking a sub-component

--- a/CODE-GUIDELINES.md
+++ b/CODE-GUIDELINES.md
@@ -191,6 +191,8 @@ expect(text).toHaveStyle({ color: '#FFFFF'});
 
 Use `waitFor` to retry an assertion until it passes, and `waitUntil` to wait for a function to return a truthy value.
 
+`waitFor` in tests are only used when an exception in thrown.
+
 **Example:**
 
 ```typescript


### PR DESCRIPTION
### What does this PR do?

chore(guidelines): add example difference between waitFor and waitUntil

Follow up of PR https://github.com/podman-desktop/podman-desktop/pull/14974

### Screenshot / video of UI

<img width="866" height="300" alt="Screenshot 2025-11-20 at 11 26 54" src="https://github.com/user-attachments/assets/1955ebc3-06c3-40c8-8aaf-f94f282c9772" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
