### PR TITLE
chore(test): waiting for element attachment to DOM

### DIFF
--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -123,6 +123,7 @@ export async function waitForPodmanMachineStartup(page: Page, timeoutOut = 30_00
     await playExpect(dashboardPage.heading).toBeVisible();
 
     await playExpect(dashboardPage.podmanStatusLabel).toBeVisible({ timeout: timeoutOut });
+    await playExpect(dashboardPage.podmanStatusLabel).toBeAttached({ timeout: 10_000 });
     await dashboardPage.podmanStatusLabel.scrollIntoViewIfNeeded();
 
     try {


### PR DESCRIPTION
### What does this PR do?
Waits for element to be attached to DOM before scrolling.

### How to test this PR?
