### PR TITLE
refactor: do not call a method when iterating elements, ensure it's computed before

### DIFF
--- a/packages/renderer/src/lib/kube/details/EventsTable.svelte
+++ b/packages/renderer/src/lib/kube/details/EventsTable.svelte
@@ -4,25 +4,29 @@ import moment from 'moment';
 
 import type { EventUI } from '../../events/EventUI';
 
+interface EventWithAge extends EventUI {
+  age: string;
+}
+
 interface Props {
   events: EventUI[];
 }
 
 let { events }: Props = $props();
 
-let sortedEvents: EventUI[] = $derived(
-  events.toSorted((ev1, ev2) => ((ev1.lastTimestamp ?? Date.now()) < (ev2.lastTimestamp ?? Date.now()) ? -1 : 1)),
+let sortedEvents: EventWithAge[] = $derived(
+  events
+    .toSorted((ev1, ev2) => ((ev1.lastTimestamp ?? Date.now()) < (ev2.lastTimestamp ?? Date.now()) ? -1 : 1))
+    .map(event => {
+      let age = `${humanizeDuration(moment().diff(event.lastTimestamp), { round: true, largest: 1 })}`;
+      if ((event.count ?? 0) > 1) {
+        age += ` (${event.count}x over ${humanizeDuration(moment().diff(event.firstTimestamp), { round: true, largest: 1 })})`;
+      }
+      return { ...event, age };
+    }),
 );
-
-function getAgeAndCount(event: EventUI): string {
-  let result = `${humanizeDuration(moment().diff(event.lastTimestamp), { round: true, largest: 1 })}`;
-  if ((event.count ?? 0) > 1) {
-    result += ` (${event.count}x over ${humanizeDuration(moment().diff(event.firstTimestamp), { round: true, largest: 1 })})`;
-  }
-  return result;
-}
 </script>
-    
+
 <tr>
   <td colspan="2">
     <table class="w-full ml-2.5" aria-label="events">
@@ -34,7 +38,7 @@ function getAgeAndCount(event: EventUI): string {
           <tr>
             <td>{event.type}</td>
             <td>{event.reason}</td>
-            <td>{getAgeAndCount(event)}</td>
+            <td>{event.age}</td>
             <td>{event.reportingComponent}</td>
             <td>{event.message}</td>
           </tr>
@@ -43,4 +47,3 @@ function getAgeAndCount(event: EventUI): string {
     </table>
   </td>
 </tr>
-  


### PR DESCRIPTION

### What does this PR do?
today there is an iterator and we're calling a method when displaying usually this pattern is throwing issue.
call the method when building the iteration

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/14865


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
