### PR TITLE
feat(renderer): show container connection display name in environment column

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -318,7 +318,7 @@ let nameColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Name',
 
 let envColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Environment', {
   renderer: ContainerEngineEnvironmentColumn,
-  comparator: (a, b): number => (a.engineName ?? '').localeCompare(b.engineName ?? ''),
+  comparator: (a, b): number => (a.engineId ?? '').localeCompare(b.engineId ?? ''),
 });
 
 let imageColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Image', {

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -318,7 +318,7 @@ let nameColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Name',
 
 let envColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Environment', {
   renderer: ContainerEngineEnvironmentColumn,
-  comparator: (a, b): number => (a.engineId ?? '').localeCompare(b.engineId ?? ''),
+  comparator: (a, b): number => (a.engineName ?? '').localeCompare(b.engineName ?? ''),
 });
 
 let imageColumn = new TableColumn<ContainerInfoUI | ContainerGroupInfoUI>('Image', {

--- a/packages/renderer/src/lib/table/columns/ContainerEngineEnvironmentColumn.svelte
+++ b/packages/renderer/src/lib/table/columns/ContainerEngineEnvironmentColumn.svelte
@@ -1,14 +1,25 @@
 <script lang="ts">
-import ProviderInfo from '/@/lib/ui/ProviderInfo.svelte';
+import Label from '/@/lib/ui/Label.svelte';
+import ProviderInfoCircle from '/@/lib/ui/ProviderInfoCircle.svelte';
+import { providerInfos } from '/@/stores/providers';
 
 interface Props {
   object: {
     engineId: string;
-    engineName: string;
   };
 }
 
 let { object }: Props = $props();
+
+const [providerId, connectionName] = $derived(object.engineId.split('.'));
+
+const connection = $derived(
+  $providerInfos
+    .find(provider => provider.id === providerId)
+    ?.containerConnections?.find(({ name }) => name === connectionName),
+);
 </script>
 
-<ProviderInfo provider={object.engineName} context={object.engineId} />
+<Label tip={connection?.endpoint.socketPath} name={connection?.displayName}>
+  <ProviderInfoCircle type="podman" />
+</Label>

--- a/packages/renderer/src/lib/table/columns/ContainerEngineEnvironmentColumn.svelte
+++ b/packages/renderer/src/lib/table/columns/ContainerEngineEnvironmentColumn.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Label from '/@/lib/ui/Label.svelte';
 import ProviderInfoCircle from '/@/lib/ui/ProviderInfoCircle.svelte';
-import { providerInfos } from '/@/stores/providers';
+import { containerConnectionCount, providerInfos } from '/@/stores/providers';
 
 interface Props {
   object: {
@@ -18,8 +18,16 @@ const connection = $derived(
     .find(provider => provider.id === providerId)
     ?.containerConnections?.find(({ name }) => name === connectionName),
 );
+
+const displayName = $derived.by(() => {
+  if (!connection) return object.engineId;
+
+  if ($containerConnectionCount[connection.type] > 1) return connection.displayName;
+
+  return connection.type;
+});
 </script>
 
-<Label tip={connection?.endpoint.socketPath} name={connection?.displayName}>
-  <ProviderInfoCircle type="podman" />
+<Label tip={connection?.endpoint?.socketPath} name={displayName}>
+  <ProviderInfoCircle type={connection?.type} />
 </Label>


### PR DESCRIPTION
### What does this PR do?

⚠️ change is only visible if you have more than one connection per type (E.g. multiple podman machine / connections)

For user dealing with several connections (multiple podman connections) the UI does not today offer a way to differentiate resources per connection.

We have the `Environment` column that allow us to differentiate docker / podman container engines, but this is not enough when dealing with several podman connections.

ℹ️ As discussed with @Firewall when we only have one connection per type, we use the connection type, if more, we use the connection name

### Screenshot / video of UI

<img width="1459" height="622" alt="image" src="https://github.com/user-attachments/assets/77fc353f-462a-4cf0-b61e-be5dac8d337a" />

Some changes are required to support the `text-ellipsis` and have the label nicely displayed when the window is pretty small

<img width="605" height="162" alt="image" src="https://github.com/user-attachments/assets/a78d92f1-c223-4f36-a7f6-00582b00b336" />

### What issues does this PR fix or reference?

Partially address
- https://github.com/podman-desktop/podman-desktop/issues/15000
- https://github.com/podman-desktop/podman-desktop/issues/12501

Require rebase after
- https://github.com/podman-desktop/podman-desktop/pull/15024
- https://github.com/podman-desktop/podman-desktop/pull/15023
- https://github.com/podman-desktop/podman-desktop/pull/15028
- https://github.com/podman-desktop/podman-desktop/pull/15029
- https://github.com/podman-desktop/podman-desktop/pull/15054

### How to test this PR?

- [x] unit tests have been added
