### PR TITLE
feat(ui/Tooltip): support containerClass prop

### DIFF
--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -293,4 +293,9 @@ describe('Tooltip', () => {
       expect(slotElement).toHaveClass('my-[5px] mx-[10px]');
     });
   });
+
+  test('containerClass prop should replace the default class of the container', async () => {
+    const { container } = render(TooltipTestComponent, { containerClass: 'w-full' });
+    expect(container.childNodes[0]).toHaveClass('w-full');
+  });
 });

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -33,6 +33,7 @@ interface Props {
   bottomRight?: boolean;
   left?: boolean;
   class?: string;
+  containerClass?: string;
   tipSnippet?: Snippet;
   children?: Snippet;
   'aria-label'?: string;
@@ -49,6 +50,7 @@ let {
   bottomRight = false,
   left = false,
   class: className,
+  containerClass,
   tipSnippet,
   children,
   'aria-label': ariaLabel,
@@ -135,7 +137,7 @@ $effect((): (() => void) => {
 });
 </script>
 
-<div class="relative inline-block" aria-label={ariaLabel}>
+<div class={containerClass ?? 'relative inline-block'} aria-label={ariaLabel}>
   <span
     role="none"
     data-testid="tooltip-trigger"

--- a/packages/ui/src/lib/tooltip/TooltipTestComponent.svelte
+++ b/packages/ui/src/lib/tooltip/TooltipTestComponent.svelte
@@ -13,10 +13,23 @@ interface Props {
   bottomLeft?: boolean;
   bottomRight?: boolean;
   classStyle?: string;
+  containerClass?: string;
 }
 
-let { tip, tipSlot, top, bottom, left, right, topLeft, topRight, bottomLeft, bottomRight, classStyle }: Props =
-  $props();
+let {
+  tip,
+  tipSlot,
+  top,
+  bottom,
+  left,
+  right,
+  topLeft,
+  topRight,
+  bottomLeft,
+  bottomRight,
+  classStyle,
+  containerClass,
+}: Props = $props();
 </script>
 
 <Tooltip
@@ -29,6 +42,7 @@ let { tip, tipSlot, top, bottom, left, right, topLeft, topRight, bottomLeft, bot
   {topRight}
   {bottomLeft}
   {bottomRight}
+  {containerClass}
   class={classStyle}>
   {#snippet tipSnippet()}
     {#if tipSlot}


### PR DESCRIPTION
### What does this PR do?

The `class` property is already used for the content of the tooltip, so introducing `containerclass`. This is required as of today the default classes are `relative inline-block` which is pretty annoying because the `inline-block`  prevent us from sizing the children of the tooltip based on the parent component of the tooltip.

Specifically with the `inline-block` we cannot enforce the `text-ellipsis` as the `w-full` is not respecting the parent.

<img width="469" height="195" alt="image" src="https://github.com/user-attachments/assets/4f7e5b2b-fb41-4024-8837-266acbdccdd6" />

We cannot remove the inline-block as this is used in many places, and a lot of usage of the tooltip have built around this contraint, meaning we would break things otherwise.

<img width="153" height="96" alt="image" src="https://github.com/user-attachments/assets/bdeb6de1-5e03-4e90-8271-38971460b6ad" />

For https://github.com/podman-desktop/podman-desktop/pull/15027 if we want to overflow-x-hidden we need to be able to specify the width of our html container

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/15027

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
