### PR TITLE
refactor(renderer/Label): migrate to Svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/Label.svelte
+++ b/packages/renderer/src/lib/ui/Label.svelte
@@ -10,7 +10,7 @@ interface Props {
   children?: Snippet;
 }
 
-let { name = '', tip = '', role, capitalize, children }: Props = $props();
+let { name = '', tip = '', role, capitalize = false, children }: Props = $props();
 </script>
 
 <Tooltip top tip={tip}>

--- a/packages/renderer/src/lib/ui/Label.svelte
+++ b/packages/renderer/src/lib/ui/Label.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
 import { Tooltip } from '@podman-desktop/ui-svelte';
+import type { Snippet } from 'svelte';
 
-export let name = '';
-export let tip = '';
-export let role: string | undefined = undefined;
-export let capitalize: boolean = false;
+interface Props {
+  name?: string;
+  tip?: string;
+  role?: string;
+  capitalize?: boolean;
+  children?: Snippet;
+}
+
+let { name = '', tip = '', role, capitalize, children }: Props = $props();
 </script>
 
 <Tooltip top tip={tip}>
   <div
     role={role}
     class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-sm text-[var(--pd-label-text)] gap-x-1">
-    <slot></slot>
+    {@render children?.()}
     <span class:capitalize={capitalize}>
       {name}
     </span>


### PR DESCRIPTION
### What does this PR do?

Migrate Label to Svelte5

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/pull/15027

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure it works in Svelte4 (LabelSpec.svelte is written in Svelte4).
