### PR TITLE
feat(main/BuilImage): add target name if any to the task title

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1447,9 +1447,12 @@ export class PluginSystem {
         taskId?: number,
         target?: string,
       ): Promise<unknown> => {
+        const targetDisplay = target ? `(${target})` : '';
+
         // create task
         const task = taskManager.createTask({
-          title: `Building image ${imageName ?? ''}`,
+          title: `Building image ${imageName ?? ''} ${targetDisplay}`,
+
           action: {
             name: 'Go to task >',
             execute: () => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1447,12 +1447,17 @@ export class PluginSystem {
         taskId?: number,
         target?: string,
       ): Promise<unknown> => {
-        const targetDisplay = target ? ` (${target})` : '';
+        const array = ['Building image'];
+        if (imageName) {
+          array.push(imageName);
+        }
+        if (target) {
+          array.push(`(${target})`);
+        }
 
         // create task
         const task = taskManager.createTask({
-          title: `Building image ${imageName ?? ''}${targetDisplay}`,
-
+          title: array.join(' '),
           action: {
             name: 'Go to task >',
             execute: () => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1447,17 +1447,17 @@ export class PluginSystem {
         taskId?: number,
         target?: string,
       ): Promise<unknown> => {
-        const array = ['Building image'];
+        const titleArgs = ['Building image'];
         if (imageName) {
-          array.push(imageName);
+          titleArgs.push(imageName);
         }
         if (target) {
-          array.push(`(${target})`);
+          titleArgs.push(`(${target})`);
         }
 
         // create task
         const task = taskManager.createTask({
-          title: array.join(' '),
+          title: titleArgs.join(' '),
           action: {
             name: 'Go to task >',
             execute: () => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1447,11 +1447,11 @@ export class PluginSystem {
         taskId?: number,
         target?: string,
       ): Promise<unknown> => {
-        const targetDisplay = target ? `(${target})` : '';
+        const targetDisplay = target ? ` (${target})` : '';
 
         // create task
         const task = taskManager.createTask({
-          title: `Building image ${imageName ?? ''} ${targetDisplay}`,
+          title: `Building image ${imageName ?? ''}${targetDisplay}`,
 
           action: {
             name: 'Go to task >',


### PR DESCRIPTION
### What does this PR do?

feat(main/BuilImage): add target name if any to the task title

When building an image, if a target is specified, it will be displayed in the task title between parenthesis.

### Screenshot / video of UI

<img width="1569" height="908" alt="Screenshot 2025-11-21 at 13 53 22" src="https://github.com/user-attachments/assets/446ee66a-3dbe-4f1f-8e04-5ffe32b4703e" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix of #14700 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Go to Image build, use a file like:


```Containerfile
FROM golang:1.24 AS build
WORKDIR /src
COPY <<EOF /src/main.go
package main

import "fmt"

func main() {
  fmt.Println("hello, world")
}
EOF
RUN go build -o /bin/hello ./main.go


FROM build AS stage1

RUN echo stage1


FROM build AS stage2

RUN echo stage2

FROM build AS stage33

RUN echo stage33

FROM scratch
COPY --from=build /bin/hello /bin/hello
CMD ["/bin/hello"]


```

Select target from dropdown, check the tasks title includes the target name.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->


I did not add unit test because I could not find any that checked this task.

- [ ] Tests are covering the bug fix or the new feature
