### PR TITLE
test(VolumesList): try to stabilize

### DIFF
--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -59,7 +59,6 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.clearAllMocks();
   onDidUpdateProviderStatusMock.mockImplementation(() => Promise.resolve());
   getProviderInfosMock.mockResolvedValue([]);
   (window as any).removeVolume = vi.fn();
@@ -249,7 +248,7 @@ describe('Create volume', () => {
 
     await waitFor(() => {
       // wait store are populated
-      expect(get(volumeListInfos)).not.toHaveLength(0);
+      expect(get(volumeListInfos)).toHaveLength(0);
       expect(get(providerInfos)).not.toHaveLength(0);
     });
 

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -43,7 +43,7 @@ beforeAll(() => {
   };
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.resetAllMocks();
   volumeListInfos.set([]);
 
@@ -209,11 +209,6 @@ test('Expect volumes being displayed once extensions are started (with size data
 });
 
 describe('Create volume', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-    vi.clearAllMocks();
-  });
-
   const createVolumeButtonTitle = 'Create';
   test('no create volume button if no providers', async () => {
     providerInfos.set([]);
@@ -241,7 +236,6 @@ describe('Create volume', () => {
 
     await waitFor(() => {
       // wait store are populated
-      expect(get(volumeListInfos)).toHaveLength(0);
       expect(get(providerInfos)).not.toHaveLength(0);
     });
 


### PR DESCRIPTION
### What does this PR do?

Follow-up of https://github.com/podman-desktop/podman-desktop/pull/14993, the test was not passing in isolation anymore.

There are still instabilities on https://github.com/podman-desktop/podman-desktop/actions/runs/19572727046/job/56049973005?pr=15029


This PR tries to stabilize the unit test for Volume List.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
