### PR TITLE
test(extension/podman): check telemetry sent when error on check disguised podman Mac

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -27,7 +27,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { Disposable } from '@podman-desktop/api';
 import type { Container as InversifyContainer } from 'inversify';
 import type { Mock } from 'vitest';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   CLEANUP_REQUIRED_MACHINE_KEY,
@@ -2498,6 +2498,37 @@ describe('registerOnboardingRemoveUnsupportedMachinesCommand', () => {
 
     // check called with true
     expect(extensionApi.context.setValue).toBeCalledWith('unsupportedMachineRemoved', 'ok', 'onboarding');
+  });
+});
+
+describe('socketCompatibilityMode command', () => {
+  test('check telemetry sent when error on check disguised podman Mac', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
+
+    await extension.activate(getContextMock());
+
+    const socketCommand = 'podman.socketCompatibilityMode';
+
+    // check command is called
+    expect(extensionApi.commands.registerCommand).toHaveBeenCalledWith(socketCommand, expect.any(Function));
+
+    const func = vi
+      .mocked(extensionApi.commands.registerCommand)
+      .mock.calls.find(([command]) => command === socketCommand)?.[1];
+
+    assert(func, `${socketCommand} should have been registered`);
+
+    const error = new Error('test error');
+
+    vi.mocked(isDisguisedPodman).mockRejectedValue(error);
+    // call the function
+    await func();
+
+    expect(isDisguisedPodman).toBeCalled();
+
+    expect(telemetryLogger.logError).toBeCalledWith('checkIfSocketDisguisedFailed', expect.objectContaining({ error }));
+    expect(telemetryLogger.logUsage).not.toBeCalled();
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2522,6 +2522,9 @@ describe('socketCompatibilityMode command', () => {
     const error = new Error('test error');
 
     vi.mocked(isDisguisedPodman).mockRejectedValue(error);
+
+    expect(isDisguisedPodman).not.toBeCalled();
+
     // call the function
     await func();
 


### PR DESCRIPTION
### What does this PR do?

test(extension/podman): check telemetry sent when error on check disguised podman Mac

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

closes https://github.com/podman-desktop/podman-desktop/issues/14384

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
