### PR TITLE
fix(renderer): use min-w and min-h for dimension in ProviderInfoCircle

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.spec.ts
@@ -70,3 +70,11 @@ test('Expect missing is gray', async () => {
   expect(circle).toBeInTheDocument();
   expect(circle).toHaveClass('bg-gray-900');
 });
+
+test('Expect appropriate dimension', async () => {
+  const { getByLabelText } = render(ProviderInfoCircle);
+  const circle = getByLabelText('Provider info circle');
+  expect(circle).toBeInTheDocument();
+  expect(circle).toHaveClass('min-w-2');
+  expect(circle).toHaveClass('min-h-2');
+});

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.svelte
@@ -8,4 +8,4 @@ let { type }: Props = $props();
 let color = $derived(providerColors[type ?? 'unknown']);
 </script>
 
-<div aria-label="Provider info circle" class="w-2 h-2 {color} rounded-full"></div>
+<div aria-label="Provider info circle" class="min-w-2 min-h-2 {color} rounded-full"></div>


### PR DESCRIPTION
### What does this PR do?

In some very specific scenario the `ProviderInfoCircle` is disappearing when the size of the screen get too small; to prevent resizing, we can use the `min-width` & `min-height`

### Screenshot / video of UI

**Before**

https://github.com/user-attachments/assets/7eeab148-ad38-414b-97b8-5249c9e24e05 

**After**

https://github.com/user-attachments/assets/0885e395-4f40-4313-b9ef-e9a13c5cca78

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/pull/15027

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
