### PR TITLE
fix(renderer/Label): text overflow

### DIFF
--- a/packages/renderer/src/lib/ui/Label.svelte
+++ b/packages/renderer/src/lib/ui/Label.svelte
@@ -13,12 +13,12 @@ interface Props {
 let { name = '', tip = '', role, capitalize = false, children }: Props = $props();
 </script>
 
-<Tooltip top tip={tip}>
+<Tooltip containerClass="w-full" top tip={tip}>
   <div
     role={role}
-    class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-sm text-[var(--pd-label-text)] gap-x-1">
+    class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-sm text-[var(--pd-label-text)] gap-x-1 w-full">
     {@render children?.()}
-    <span class:capitalize={capitalize}>
+    <span class:capitalize={capitalize} class="overflow-x-hidden text-ellipsis w-full">
       {name}
     </span>
   </div>


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/15028 we can now set the width of the component wrapping the Label.

> ⚠️ the weird sizing of the provider indicator (purple circle) will be fixed with https://github.com/podman-desktop/podman-desktop/pull/15054

### Screenshot / video of UI

**Before**

https://github.com/user-attachments/assets/2855eb6b-e9a8-4532-a881-e7db20e89d9c

**After**

https://github.com/user-attachments/assets/e1f493a9-b09d-42da-a3be-79a73a5a5bd0

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/pull/15027

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

You can check that everything is working as expected by opening the ContainersList and resizing it
