### PR TITLE
fix(storybook): add text-base (12px) to html

### DIFF
--- a/storybook/.storybook/main.css
+++ b/storybook/.storybook/main.css
@@ -1,2 +1,6 @@
 @import 'tailwindcss';
 @config '../tailwind.config.js';
+
+html {
+  @apply text-base;
+}


### PR DESCRIPTION
As outlined in #14651, Storybook components were rendering approximately 25% larger than in the main application due to a mismatch in font size configuration.

Fixes #14651

- [ ] Tests are covering the bug fix or the new feature

(No tests needed)