### PR TITLE
refactor(extension: podman): move calcWinPipeName function to WinPlatform class

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -309,7 +309,7 @@ async function doUpdateMachines(
         } else if (extensionApi.env.isLinux) {
           socketPath = calcLinuxSocketPath(machineName);
         } else if (extensionApi.env.isWindows) {
-          socketPath = calcWinPipeName(machineName);
+          socketPath = winPlatform.calcPipeName(machineName);
         }
       }
       const podmanMachineInfo = podmanMachinesInfo.get(machineName);
@@ -536,11 +536,6 @@ function calcLinuxSocketPath(machineName: string): string {
     socketPath = path.resolve(podmanMachineSocketsDirectory, 'qemu', 'podman.sock');
   }
   return socketPath;
-}
-
-function calcWinPipeName(machineName: string): string {
-  const name = machineName.startsWith('podman') ? machineName : 'podman-' + machineName;
-  return `//./pipe/${name}`;
 }
 
 function getLinuxSocketPath(): string {

--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -18,7 +18,7 @@
 
 import type { CheckResult, ExtensionContext, TelemetryLogger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { HyperVCheck } from '/@/checks/windows/hyper-v-check';
 import type { HyperVPodmanVersionCheck } from '/@/checks/windows/hyper-v-podman-version-check';
@@ -123,4 +123,27 @@ test('isWSLEnabled should return true if all WSL checks succeed', async () => {
   const wslEnabled = await winPlatform.isWSLEnabled();
 
   expect(wslEnabled).toBeTruthy();
+});
+
+describe('calcPipeName', () => {
+  test('calcPipeName should prepend "podman-" if machine name does not start with "podman"', () => {
+    const machineName = 'my-machine';
+    const expectedPipeName = '//./pipe/podman-my-machine';
+    const result = winPlatform.calcPipeName(machineName);
+    expect(result).toBe(expectedPipeName);
+  });
+
+  test('calcPipeName should not prepend "podman-" if machine name already starts with "podman"', () => {
+    const machineName = 'podman-machine';
+    const expectedPipeName = '//./pipe/podman-machine';
+    const result = winPlatform.calcPipeName(machineName);
+    expect(result).toBe(expectedPipeName);
+  });
+
+  test('calcPipeName should handle machine name that is just "podman"', () => {
+    const machineName = 'podman';
+    const expectedPipeName = '//./pipe/podman';
+    const result = winPlatform.calcPipeName(machineName);
+    expect(result).toBe(expectedPipeName);
+  });
 });

--- a/extensions/podman/packages/extension/src/platforms/win-platform.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.ts
@@ -91,4 +91,9 @@ export class WinPlatform {
     const hyperVCheckResult = await this.hyperVSequenceCheck.execute();
     return hyperVCheckResult.successful;
   }
+
+  calcPipeName(machineName: string): string {
+    const name = machineName.startsWith('podman') ? machineName : 'podman-' + machineName;
+    return `//./pipe/${name}`;
+  }
 }


### PR DESCRIPTION
### What does this PR do?

refactor(extension: podman): move calcWinPipeName function to WinPlatform class

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes [#14291](https://github.com/podman-desktop/podman-desktop/issues/14291)

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
