### PR TITLE
feat(managed-by): apply default settings on init

### DIFF
--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -442,6 +442,156 @@ test('should remove the object configuration if value is equal to default one', 
   );
 });
 
+// Tests for applyManagedDefaults method
+describe('applyManagedDefaults function tests', () => {
+  test('apply default-config.json values to undefined keys in config', async () => {
+    // "Default" user config
+    const managedDefaults = {
+      'setting.foo': 'defaultValue1',
+      'setting.bar': 'defaultValue2',
+    };
+
+    getContentMock.mockResolvedValue(managedDefaults);
+
+    // Create the test registry
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    // Setup the values
+    const configurationValues = (
+      testRegistry as unknown as { configurationValues: Map<string, { [key: string]: unknown }> }
+    ).configurationValues;
+    const userConfig = configurationValues.get('DEFAULT');
+
+    expect(userConfig?.['setting.foo']).toEqual('defaultValue1');
+    expect(userConfig?.['setting.bar']).toEqual('defaultValue2');
+  });
+
+  test('do not overwrite existing user settings with defaults', async () => {
+    const userSettings = {
+      'setting.foo': 'userValue',
+    };
+    const managedDefaults = {
+      'setting.foo': 'defaultValue1',
+      'setting.bar': 'defaultValue2',
+    };
+
+    // Mock fs.promises.readFile to return user settings.json
+    const readFileMock = vi.mocked(fs.promises.readFile);
+    readFileMock.mockResolvedValue(JSON.stringify(userSettings));
+
+    getContentMock.mockResolvedValue(managedDefaults);
+
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    const configurationValues = (
+      testRegistry as unknown as { configurationValues: Map<string, { [key: string]: unknown }> }
+    ).configurationValues;
+    const userConfig = configurationValues.get('DEFAULT');
+
+    // User's existing value should be preserved
+    expect(userConfig?.['setting.foo']).toEqual('userValue');
+    // Default should be applied for undefined key
+    expect(userConfig?.['setting.bar']).toEqual('defaultValue2');
+  });
+
+  test('make sure that the user config remains unchanged when defaults are empty', async () => {
+    getContentMock.mockResolvedValue({});
+
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    const configurationValues = (
+      testRegistry as unknown as { configurationValues: Map<string, { [key: string]: unknown }> }
+    ).configurationValues;
+    const userConfig = configurationValues.get('DEFAULT');
+
+    // Make sure it's still blank.. (nothing was added / changes, etc.)
+    expect(userConfig).toEqual({});
+  });
+
+  test('handle any nested values / make sure entire object is copied', async () => {
+    const managedDefaults = {
+      'nested.setting': {
+        nested: {
+          value: 'nested',
+        },
+        array: [1, 2, 3],
+      },
+    };
+    getContentMock.mockResolvedValue(managedDefaults);
+
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+    const configurationValues = (
+      testRegistry as unknown as { configurationValues: Map<string, { [key: string]: unknown }> }
+    ).configurationValues;
+    const userConfig = configurationValues.get('DEFAULT');
+
+    // Make sure it matches the managedDefaults config
+    expect(userConfig?.['nested.setting']).toEqual({
+      nested: {
+        value: 'nested',
+      },
+      array: [1, 2, 3],
+    });
+  });
+
+  test('logs are shown to console', async () => {
+    const managedDefaults = {
+      'setting.foo': 'defaultValue1',
+      'setting.bar': 'defaultValue2',
+    };
+
+    getContentMock.mockResolvedValue(managedDefaults);
+
+    const originalConsoleLog = console.log;
+    const mockedConsoleLog = vi.fn();
+    console.log = mockedConsoleLog;
+
+    // Make sure that the console log is called when the settings are applied on each run
+    try {
+      const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+      await testRegistry.init();
+
+      expect(mockedConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('[Managed-by]: Applied default settings for:'),
+      );
+      expect(mockedConsoleLog).toHaveBeenCalledWith(expect.stringContaining('setting.foo'));
+      expect(mockedConsoleLog).toHaveBeenCalledWith(expect.stringContaining('setting.bar'));
+    } finally {
+      console.log = originalConsoleLog;
+    }
+  });
+
+  test('check the applyManagedDefaults returns array of applied keys', async () => {
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    const configData: Record<string, unknown> = { existingKey: 'existingValue' };
+    const defaults: Record<string, unknown> = {
+      existingKey: 'defaultValue',
+      newKey1: 'newValue1',
+      newKey2: 'newValue2',
+    };
+
+    // Kindof hacky, but use applyManagedDefaults directly to test the return value, but gives
+    // you a good return of what keys were applied
+    const appliedKeys = (
+      testRegistry as unknown as {
+        applyManagedDefaults: (c: Record<string, unknown>, d: Record<string, unknown>) => string[];
+      }
+    ).applyManagedDefaults(configData, defaults);
+
+    // Make sure all the keys were applied correctly!
+    expect(appliedKeys).toEqual(['newKey1', 'newKey2']);
+    expect(configData['existingKey']).toEqual('existingValue');
+    expect(configData['newKey1']).toEqual('newValue1');
+    expect(configData['newKey2']).toEqual('newValue2');
+  });
+});
+
 // Tests for the new managed defaults functionality
 describe('Managed Defaults', () => {
   test('should load managed defaults configuration', async () => {

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -146,10 +146,15 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
 
     // Apply managed defaults to user config for any undefined keys
     // that have not been set yet in the local settings.json
-    this.applyManagedDefaults(configData, defaults);
+    const listOfAppliedKeys = this.applyManagedDefaults(configData, defaults);
 
-    // Set the updated configuration data
+    // Set the updated configuration data, this doesn't "save-to-disk" yet until we run saveDefault()...
     this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, configData);
+
+    // Note: saveDefault() will filter out any keys that match the schema default, so only non-default values will actually be persisted to settings.json
+    if (listOfAppliedKeys.length > 0) {
+      this.saveDefault();
+    }
 
     return notifications;
   }

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -135,7 +135,6 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
       });
       configData = {};
     }
-    this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, configData);
 
     // Load managed defaults
     const defaults = await this.defaultConfiguration.getContent();
@@ -145,7 +144,42 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     const locked = await this.lockedConfiguration.getContent();
     this.configurationValues.set(CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE, locked);
 
+    // Apply managed defaults to user config for any undefined keys
+    // that have not been set yet in the local settings.json
+    this.applyManagedDefaults(configData, defaults);
+
+    // Set the updated configuration data
+    this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, configData);
+
     return notifications;
+  }
+
+  /**
+   * Apply default settings from default-settings.json (object) to user config (settings.json) (also an object being passed in),
+   * and mutably update the object.
+   * @returns array of keys that were applied to configData (useful for testing and debugging purposes)
+   */
+  protected applyManagedDefaults(configData: Record<string, unknown>, defaults: Record<string, unknown>): string[] {
+    const appliedKeys: string[] = [];
+
+    // Keeping it simple here by iterating over the default keys
+    // and applying it to any undefined keys in the user config.
+    // we do NOT do any deep merging of objects here, as we are only interested if there is a
+    // top-level key that is undefined in the user config, and then copy over the configuration default.
+    for (const key of Object.keys(defaults)) {
+      if (configData[key] === undefined) {
+        configData[key] = defaults[key];
+        appliedKeys.push(key);
+      }
+    }
+
+    // We concatenate the applied keys into one console.log so we don't spam the console,
+    // this is only shown once when initialized / copy over the keys, but does not subsequently log
+    // after each startup.
+    if (appliedKeys.length > 0) {
+      console.log(`[Managed-by]: Applied default settings for: ${appliedKeys.join(', ')}`);
+    }
+    return appliedKeys;
   }
 
   /**


### PR DESCRIPTION
feat(managed-by): apply default settings on init

### What does this PR do?

When a setting exists in your `default-settings.json`, but does not
exist in your user `settings.json`. The setting will then be set in your `settings.json` if it does not exist.

This "applies" the `default-settings.json` to your `settings.json` on
first boot to any values that aren't there yet.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, no UI change

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/15087

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Add the following setting to your default-settings.json configuration
   (different on Linux and Windows, see: https://podman-desktop.io/docs/configuration/managed-configuration):

```
cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "telemetry.enabled": false
}
```

2. Check that the value does NOT exist yet in your local
   `settings.json`:

```
cat ~/.local/share/containers/podman-desktop/configuration/settings.json
{
  "window.bounds": {
    "x": 1959,
    "y": 242,
    "width": 1255,
    "height": 1064
  }
}
```

3. Boot up Podman Desktop (with this PR)

4. Check the console logs have: `[Managed-by]: Applied default settings
   for: ...`

5. Check that the value was added to settings.json:

```
cat ~/.local/share/containers/podman-desktop/configuration/settings.json
{
  "window.bounds": {
    "x": 1959,
    "y": 242,
    "width": 1255,
    "height": 1064
  },
  "telemetry.enabled": false
}
```

On subsequent startups, the value won't be overriden (it checks if the
value exists before doing anything to `settings.json`).

You can also check the reverse, have the `telemetry.enabled` setting
already in your `settings.json` and check to see if the
`default-settings.json` had overridden the setting.

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
