### PR TITLE
chore: extract constants to product.json

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -20,7 +20,7 @@ const exec = require('child_process').exec;
 const Arch = require('builder-util').Arch;
 const path = require('path');
 const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
-
+const product = require('./product.json');
 if (process.env.VITE_APP_VERSION === undefined) {
   const now = new Date();
   process.env.VITE_APP_VERSION = `${now.getUTCFullYear() - 2000}.${now.getUTCMonth() + 1}.${now.getUTCDate()}-${
@@ -70,8 +70,8 @@ async function addElectronFuses(context) {
  * @see https://www.electron.build/configuration/configuration
  */
 const config = {
-  productName: 'Podman Desktop',
-  appId: 'io.podman_desktop.PodmanDesktop',
+  productName: product.name,
+  appId: product.appId,
   directories: {
     output: 'dist',
     buildResources: 'buildResources',
@@ -126,10 +126,10 @@ const config = {
   },
   files: ['packages/**/dist/**', 'extensions/**/builtin/*.cdix/**', 'packages/main/src/assets/**'],
   portable: {
-    artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
+    artifactName: `${product.artifactName}${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
   },
   nsis: {
-    artifactName: `podman-desktop${artifactNameSuffix}-\${version}-setup-\${arch}.\${ext}`,
+    artifactName: `${product.artifactName}${artifactNameSuffix}-\${version}-setup-\${arch}.\${ext}`,
     oneClick: false,
     include: 'buildResources/installer.nsh',
   },
@@ -184,7 +184,7 @@ const config = {
       '--env=XDG_SESSION_TYPE=x11',
     ],
     useWaylandFlags: 'false',
-    artifactName: 'podman-desktop-${version}.${ext}',
+    artifactName: `${product.artifactName}-\${version}.\${ext}`,
     runtimeVersion: '25.08',
     branch: 'main',
     files: [
@@ -198,7 +198,7 @@ const config = {
     target: ['flatpak', { target: 'tar.gz', arch: ['x64', 'arm64'] }],
   },
   mac: {
-    artifactName: `podman-desktop${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
+    artifactName: `${product.artifactName}${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
     hardenedRuntime: true,
     entitlements: './node_modules/electron-builder-notarize/entitlements.mac.inherit.plist',
     target: {
@@ -227,8 +227,8 @@ const config = {
     ],
   },
   protocols: {
-    name: 'Podman Desktop',
-    schemes: ['podman-desktop'],
+    name: product.name,
+    schemes: [product.urlProtocol],
     role: 'Editor',
   },
   publish: {

--- a/product.json
+++ b/product.json
@@ -1,0 +1,6 @@
+{
+  "name": "Podman Desktop",
+  "appId": "io.podman_desktop.PodmanDesktop",
+  "artifactName": "podman-desktop",
+  "urlProtocol": "podman-desktop"
+}


### PR DESCRIPTION
### What does this PR do?
instead of duplicating constants, use a file

first step, as other constants could come there


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15043


### How to test this PR?

Change the value in the .json file and see the output in `dist/` folder for example after running `compile:current` script
(and run of the assembly)

- [ ] Tests are covering the bug fix or the new feature
