### PR TITLE
fix: env. var. CI should be tested when in lowercase due to powershel…

### DIFF
--- a/tests/playwright/src/utility/platform.ts
+++ b/tests/playwright/src/utility/platform.ts
@@ -24,4 +24,4 @@ export const isWindows = os.platform() === 'win32';
 export const archType = os.arch();
 
 // powershell $true value is 'True', we need to make it a lowercase first
-export const isCI = process.env.CI ? process.env.CI.toLowerCase() === 'true' : false;
+export const isCI = String(process.env.CI).toLowerCase() === 'true';

--- a/tests/playwright/src/utility/platform.ts
+++ b/tests/playwright/src/utility/platform.ts
@@ -23,4 +23,5 @@ export const isMac = os.platform() === 'darwin';
 export const isWindows = os.platform() === 'win32';
 export const archType = os.arch();
 
-export const isCI = process.env.CI ? process.env.CI === 'true' : false;
+// powershell $true value is 'True', we need to make it a lowercase first
+export const isCI = process.env.CI ? process.env.CI.toLowerCase() === 'true' : false;


### PR DESCRIPTION
…l literal value for $true

### What does this PR do?
Powershell value for `$true` is `True`, thus isCI fails to evaluate properly when run from powershell.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#15065 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
