### PR TITLE
feat: apply user default registries to Podman Desktop and Podman

### DIFF
--- a/extensions/podman/packages/extension/src/configuration/default-registry-loader.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/default-registry-loader.spec.ts
@@ -1,0 +1,351 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration, DefaultRegistry, DefaultRegistryMirror } from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { REGISTRY_MIRROR } from '/@/constants';
+
+import type { ConfigurationRegistry } from './default-registry-loader';
+import { DefaultRegistryLoader } from './default-registry-loader';
+import type { RegistryConfigurationEntry } from './registry-configuration';
+
+let defaultRegistryLoader: DefaultRegistryLoader;
+let mockConfigurationRegistry: ConfigurationRegistry;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+
+  mockConfigurationRegistry = {
+    getConfiguration: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue([]),
+    } as unknown as Configuration),
+  };
+
+  defaultRegistryLoader = new DefaultRegistryLoader(mockConfigurationRegistry);
+});
+
+describe('loadFromConfiguration', () => {
+  test('returns empty array when no registries configured', () => {
+    const result = defaultRegistryLoader.loadFromConfiguration();
+    expect(result).toEqual([]);
+  });
+
+  test('loads registries from configuration', () => {
+    const userRegistry1: DefaultRegistry = {
+      registry: {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+      },
+    };
+
+    const userRegistry2: DefaultRegistry = {
+      registry: {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    };
+
+    const getMock = vi.fn().mockReturnValue([userRegistry1, userRegistry2]);
+
+    mockConfigurationRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: getMock,
+      } as unknown as Configuration),
+    };
+
+    defaultRegistryLoader = new DefaultRegistryLoader(mockConfigurationRegistry);
+
+    const result = defaultRegistryLoader.loadFromConfiguration();
+
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+      },
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    ]);
+  });
+
+  test('loads registries with mirrors from configuration', () => {
+    const userRegistry1: DefaultRegistry = {
+      registry: {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+      },
+    };
+
+    const userRegistryMirror1: DefaultRegistryMirror = {
+      [REGISTRY_MIRROR]: {
+        location: 'mirror1/foo',
+      },
+    };
+
+    const userRegistry2: DefaultRegistry = {
+      registry: {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    };
+
+    const userRegistryMirror2: DefaultRegistryMirror = {
+      [REGISTRY_MIRROR]: {
+        location: 'mirror2/bar',
+        insecure: true,
+      },
+    };
+
+    const getMock = vi.fn().mockReturnValue([userRegistry1, userRegistryMirror1, userRegistry2, userRegistryMirror2]);
+
+    mockConfigurationRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: getMock,
+      } as unknown as Configuration),
+    };
+
+    defaultRegistryLoader = new DefaultRegistryLoader(mockConfigurationRegistry);
+
+    const result = defaultRegistryLoader.loadFromConfiguration();
+
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+        mirror: [
+          {
+            location: 'mirror2/bar',
+            insecure: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('ignores mirror if no registry precedes it', () => {
+    const userRegistryMirror: DefaultRegistryMirror = {
+      [REGISTRY_MIRROR]: {
+        location: 'mirror1/foo',
+      },
+    };
+
+    const getMock = vi.fn().mockReturnValue([userRegistryMirror]);
+
+    mockConfigurationRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: getMock,
+      } as unknown as Configuration),
+    };
+
+    defaultRegistryLoader = new DefaultRegistryLoader(mockConfigurationRegistry);
+
+    const result = defaultRegistryLoader.loadFromConfiguration();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('resolveConflicts', () => {
+  test('adds new registries to existing list', () => {
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+      },
+    ];
+
+    const existingRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    ];
+
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+
+    expect(result).toEqual([
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+      },
+    ]);
+  });
+
+  test('merges mirrors when registry exists and properties match', () => {
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [
+          {
+            location: 'mirror1/bar',
+          },
+        ],
+      },
+    ];
+
+    const existingRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+    ];
+
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+          {
+            location: 'mirror1/bar',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('does not duplicate existing mirrors', () => {
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+    ];
+
+    const existingRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+    ];
+
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('warns and does not merge when properties differ', () => {
+    const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: false,
+        insecure: true,
+      },
+    ];
+
+    const existingRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        insecure: false,
+      },
+    ];
+
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      'Default user registry registry1 already exists in the registries.conf.d file, but some of its properties do not match: blocked, insecure. Please update this registry',
+    );
+
+    // Existing registry remains unchanged
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        insecure: false,
+      },
+    ]);
+
+    consoleWarnMock.mockRestore();
+  });
+
+  test('handles registries without prefix', () => {
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        location: '/registry1/foo',
+      },
+    ];
+
+    const existingRegistries: RegistryConfigurationEntry[] = [];
+
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+
+    expect(result).toEqual([
+      {
+        location: '/registry1/foo',
+      },
+    ]);
+  });
+});

--- a/extensions/podman/packages/extension/src/configuration/default-registry-loader.ts
+++ b/extensions/podman/packages/extension/src/configuration/default-registry-loader.ts
@@ -1,0 +1,116 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration, ConfigurationScope, DefaultRegistry, DefaultRegistryMirror } from '@podman-desktop/api';
+import { configuration as apiConfiguration } from '@podman-desktop/api';
+
+import { REGISTRY_MIRROR } from '/@/constants';
+
+import type { RegistryConfigurationEntry } from './registry-configuration';
+
+export interface ConfigurationRegistry {
+  getConfiguration(section?: string, scope?: ConfigurationScope): Configuration;
+}
+
+// Handles loading and merging user default registries from podman desktop configuration (settings.json)
+export class DefaultRegistryLoader {
+  #configurationRegistry: ConfigurationRegistry;
+
+  constructor(configurationRegistry: ConfigurationRegistry = apiConfiguration) {
+    this.#configurationRegistry = configurationRegistry;
+  }
+
+  // Get the registry entries from the config
+  loadFromConfiguration(): RegistryConfigurationEntry[] {
+    const defaultRegistries: RegistryConfigurationEntry[] = [];
+    const userDefaultRegistries = this.#configurationRegistry.getConfiguration('registries').get('defaults') as (
+      | DefaultRegistry
+      | DefaultRegistryMirror
+    )[];
+
+    userDefaultRegistries?.forEach(registry => {
+      if ('registry' in registry) {
+        defaultRegistries.push({ ...registry.registry });
+      } else if (defaultRegistries.length > 0) {
+        // mirror registries come after the registry to which they belong
+        defaultRegistries[defaultRegistries.length - 1].mirror ??= [];
+        defaultRegistries[defaultRegistries.length - 1].mirror?.push({ ...registry[REGISTRY_MIRROR] });
+      }
+    });
+
+    return defaultRegistries;
+  }
+
+  // Resolve any conflicts between the default registries and existing registries
+  resolveConflicts(
+    defaultRegistries: RegistryConfigurationEntry[],
+    existingRegistries: RegistryConfigurationEntry[],
+  ): RegistryConfigurationEntry[] {
+    defaultRegistries.forEach(defaultRegistry => {
+      const duplicateRegistry = existingRegistries.find(
+        existingRegistry => existingRegistry.prefix === defaultRegistry.prefix,
+      );
+      if (defaultRegistry.prefix && duplicateRegistry) {
+        const hasDiff = this.checkForDifference(duplicateRegistry, defaultRegistry);
+        if (!hasDiff) {
+          defaultRegistry.mirror?.forEach(mirror => {
+            duplicateRegistry.mirror ??= [];
+            if (!duplicateRegistry.mirror?.map(dupMirror => dupMirror.location).includes(mirror.location)) {
+              duplicateRegistry.mirror.push(mirror);
+            }
+          });
+        }
+      } else {
+        existingRegistries.push(defaultRegistry);
+      }
+    });
+    return existingRegistries;
+  }
+
+  // Check all the nested differences between two registry entries
+  private checkForDifference(
+    duplicateRegistry: RegistryConfigurationEntry,
+    defaultRegistry: RegistryConfigurationEntry,
+  ): boolean {
+    if (
+      duplicateRegistry.blocked !== defaultRegistry.blocked ||
+      duplicateRegistry.insecure !== defaultRegistry.insecure ||
+      duplicateRegistry.location !== defaultRegistry.location
+    ) {
+      const diff = [];
+      if (duplicateRegistry.blocked !== defaultRegistry.blocked) {
+        diff.push('blocked');
+      }
+
+      if (duplicateRegistry.insecure !== defaultRegistry.insecure) {
+        diff.push('insecure');
+      }
+
+      if (duplicateRegistry.location !== defaultRegistry.location) {
+        diff.push('location');
+      }
+
+      console.warn(
+        `Default user registry ${defaultRegistry.prefix} already exists in the registries.conf.d file, but some of its properties do not match: ${diff.join(', ')}. Please update this registry`,
+      );
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/extensions/podman/packages/extension/src/constants.ts
+++ b/extensions/podman/packages/extension/src/constants.ts
@@ -31,3 +31,4 @@ export const PODMAN_MACHINE_EDIT_CPU = 'podman.podmanMachineEditCPUSupported';
 export const PODMAN_MACHINE_EDIT_MEMORY = 'podman.podmanMachineEditMemorySupported';
 export const PODMAN_MACHINE_EDIT_DISK_SIZE = 'podman.podmanMachineEditDiskSizeSupported';
 export const PODMAN_MACHINE_EDIT_ROOTFUL = 'podman.podmanMachineEditRootfulSupported';
+export const REGISTRY_MIRROR = 'registry.mirror';

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -173,6 +173,12 @@ vi.mock('./compatibility-mode', async () => {
   };
 });
 
+vi.mock(import('./configuration/registry-configuration'), async () => {
+  const RegistryConfigurationImpl = vi.fn();
+  RegistryConfigurationImpl.prototype.init = vi.fn(() => []);
+  return { RegistryConfigurationImpl };
+});
+
 const PODMAN_INSTALL_MOCK: PodmanInstall = {
   getUpdatePreflightChecks: vi.fn(),
   isAbleToInstall: vi.fn(),

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -1149,6 +1149,22 @@ declare module '@podman-desktop/api' {
     export const onDidStateChange: Event<boolean>;
   }
 
+  export interface DefaultRegistry {
+    registry: {
+      prefix: string;
+      insecure?: boolean;
+      blocked?: boolean;
+      location: string;
+    };
+  }
+
+  export interface DefaultRegistryMirror {
+    'registry.mirror': {
+      location: string;
+      insecure?: boolean;
+    };
+  }
+
   // An interface for "Default" registries that include the name, URL as well as an icon
   // This allows an extension to "suggest" a registry to the user that you may
   // login via a username & password.
@@ -1158,6 +1174,8 @@ declare module '@podman-desktop/api' {
 
     // Optional base64 PNG image (for transparency / non vector icons)
     icon?: string | { light: string; dark: string };
+    insecure?: boolean;
+    blocked?: boolean;
   }
 
   export interface Registry extends RegistryCreateOptions {

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -446,7 +446,13 @@ beforeEach(() => {
     isEnabled: vi.fn(),
   } as unknown as Proxy;
 
-  const imageRegistry = new ImageRegistry({} as ApiSenderType, telemetry, certificates, proxy);
+  const imageRegistry = new ImageRegistry(
+    {} as ApiSenderType,
+    telemetry,
+    certificates,
+    proxy,
+    {} as ConfigurationRegistry,
+  );
   containerRegistry = new TestContainerProviderRegistry(apiSender, configurationRegistry, imageRegistry, telemetry);
 });
 

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -976,7 +976,7 @@ export class ExtensionLoader implements IAsyncDisposable {
       },
 
       suggestRegistry: (registry: containerDesktopAPI.RegistrySuggestedProvider): Disposable => {
-        return imageRegistry.suggestRegistry(registry);
+        return imageRegistry.suggestRegistry({ registry, isUserDefaultRegistry: false });
       },
 
       unregisterRegistry: (registry: containerDesktopAPI.Registry): void => {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -23,7 +23,13 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import type { Registry } from '@podman-desktop/api';
+import type {
+  Configuration,
+  DefaultRegistry,
+  DefaultRegistryMirror,
+  Registry,
+  RegistrySuggestedProvider,
+} from '@podman-desktop/api';
 import * as fzstd from 'fzstd';
 import { http, HttpResponse } from 'msw';
 import { setupServer, type SetupServerApi } from 'msw/node';
@@ -44,6 +50,7 @@ import imageRegistryManifestMultiArchJson from '../../tests/resources/data/plugi
 };
 import type { ApiSenderType } from './api.js';
 import type { Certificates } from './certificates.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
 import { ImageRegistry } from './image-registry.js';
 import type { Proxy } from './proxy.js';
 import type { EventType, Telemetry } from './telemetry/telemetry.js';
@@ -75,8 +82,12 @@ const apiSender: ApiSenderType = {
   send(_channel: string, _data?: any): void {},
 } as ApiSenderType;
 
+const configurationRegistry: ConfigurationRegistry = {
+  getConfiguration: vi.fn(),
+} as unknown as ConfigurationRegistry;
+
 beforeAll(async () => {
-  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
+  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy, configurationRegistry);
 });
 
 beforeEach(() => {
@@ -1012,7 +1023,7 @@ test('getOptions uses proxy settings', () => {
     httpsProxy: 'http://192.168.1.1:3128',
     noProxy: '',
   });
-  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
+  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy, configurationRegistry);
   const options = imageRegistry.getOptions();
   expect(options.agent).toBeDefined();
   expect(options.agent?.http).toBeDefined();
@@ -1027,7 +1038,7 @@ test('searchImages with proxy', async () => {
 
     noProxy: '',
   });
-  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
+  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy, configurationRegistry);
 
   const handlers = [
     http.get('https://index.docker.io/v1/search', () => {
@@ -1126,4 +1137,114 @@ test('listImageTags', async () => {
 
   const result = await imageRegistry.listImageTags({ image: 'an-image' });
   expect(result).toEqual(['1', '2', '3']);
+});
+
+const userRegistry1: DefaultRegistry = {
+  registry: {
+    prefix: 'registry1',
+    location: '/registry1/foo',
+    blocked: true,
+  },
+};
+
+const userRegistryMirror1: DefaultRegistryMirror = {
+  'registry.mirror': {
+    location: 'mirror1/foo',
+  },
+};
+
+const userRegistry2: DefaultRegistry = {
+  registry: {
+    prefix: 'registry2',
+    location: '/registry2/foo',
+    blocked: true,
+  },
+};
+
+const userRegistryMirror2: DefaultRegistryMirror = {
+  'registry.mirror': {
+    location: 'mirror2/foo',
+  },
+};
+
+const userRegistry3: DefaultRegistry = {
+  registry: {
+    prefix: 'registry3',
+    location: '/registry3/foo',
+  },
+};
+
+test('loadUserDefaultRegistryConfig', () => {
+  const getMock = vi.fn().mockReturnValue([userRegistry1, userRegistryMirror1, userRegistry2, userRegistryMirror2]);
+
+  vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+    get: getMock,
+  } as unknown as Configuration);
+
+  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy, configurationRegistry);
+
+  imageRegistry.loadUserDefaultRegistryConfig();
+
+  expect(configurationRegistry.getConfiguration).toHaveBeenCalledWith('registries');
+  expect(getMock).toHaveBeenCalledWith('defaults', []);
+
+  const suggestedRegistries = imageRegistry.getSuggestedRegistries();
+  expect(suggestedRegistries).toStrictEqual([
+    { name: 'registry1', url: '/registry1/foo', blocked: true, insecure: undefined },
+    { name: 'registry2', url: '/registry2/foo', blocked: true, insecure: undefined },
+  ]);
+});
+
+test('Handle conflicts with existing suggested registries and user default registries', async () => {
+  const consoleDebugMock = vi.spyOn(console, 'debug');
+
+  const consoleWarnMock = vi.spyOn(console, 'warn');
+
+  const getMock = vi
+    .fn()
+    .mockReturnValue([userRegistry1, userRegistryMirror1, userRegistry2, userRegistryMirror2, userRegistry3]);
+
+  vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
+    get: getMock,
+  } as unknown as Configuration);
+
+  const suggestedRegistry1: RegistrySuggestedProvider = {
+    name: 'Suggested registry 1',
+    url: '/registry1/foo',
+  };
+
+  const suggestedRegistry2: RegistrySuggestedProvider = {
+    name: 'Suggested registry 2',
+    url: '/registry2/foo',
+    blocked: true,
+  };
+
+  const suggestedRegistry3: RegistrySuggestedProvider = {
+    name: 'Suggested registry 3',
+    url: '/registry3/bar',
+  };
+
+  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy, configurationRegistry);
+
+  imageRegistry.suggestRegistry({ registry: suggestedRegistry1, isUserDefaultRegistry: false });
+  imageRegistry.suggestRegistry({ registry: suggestedRegistry2, isUserDefaultRegistry: false });
+  imageRegistry.suggestRegistry({ registry: suggestedRegistry3, isUserDefaultRegistry: false });
+
+  imageRegistry.loadUserDefaultRegistryConfig();
+
+  expect(configurationRegistry.getConfiguration).toHaveBeenCalledWith('registries');
+  expect(getMock).toHaveBeenCalledWith('defaults', []);
+
+  expect(consoleWarnMock).toHaveBeenCalledWith(
+    'User default registry is already registered and the blocked status adjusted to: /registry1/foo',
+  );
+  expect(consoleDebugMock).toHaveBeenCalledWith('Registry is already registered: /registry2/foo');
+
+  const suggestedRegistries = imageRegistry.getSuggestedRegistries();
+  expect(suggestedRegistries).toStrictEqual([
+    { ...suggestedRegistry1, blocked: true },
+    suggestedRegistry2,
+    suggestedRegistry3,
+    { name: 'registry3', url: '/registry3/foo', blocked: undefined, insecure: undefined },
+  ]);
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -786,6 +786,8 @@ export class PluginSystem {
     const imageRegistry = container.get<ImageRegistry>(ImageRegistry);
     const tempFileService = container.get<TempFileService>(TempFileService);
 
+    imageRegistry.loadUserDefaultRegistryConfig();
+
     container.bind<ExperimentalFeatureFeedbackHandler>(ExperimentalFeatureFeedbackHandler).toSelf().inSingletonScope();
     const experimentalFeatureFeedbackHandler = container.get<ExperimentalFeatureFeedbackHandler>(
       ExperimentalFeatureFeedbackHandler,


### PR DESCRIPTION
### What does this PR do?

Uses the `registries.defaults` configuration value from `settings.json` to get the user defaults registries and apply them to Podman Desktop and Podman machines.

In the Podman extension, the user default registries are added to the `registries.conf.d` file with conflict resolution focusing on registries with the same prefix => different blocked/insecure/location value will show a warning in the console and will not add the newest registry. If all the value are the same, the newer registry's mirrors will be added to the ones of the existing registry.

### Screenshot / video of UI

N/A

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/13902

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Add to `settings.json` `"registries.defaults": []`
2. Inside the array, add different registry entry following:
```
{
  "registry": {
    "prefix": string,
    "location": string,
    "blocked": boolean | undefined,
    "insecure": boolean | undefined
  }
}
```
or 
```
{
  "registry.mirror": {
    "location": string,
    "insecure": boolean | undefined,
  }
}
```
Each mirror for a registry has to come right after the registry entry.

**EDIT BY CHARLIE:**
For a complete example of `settings.json`:

```json
{
  "registries.defaults": [
    {
      "registry": {
        "prefix": "quay.io",
        "location": "quay.io"
      }
    },
    {
      "registry.mirror": {
        "location": "mirror.example.com"
      }
    }
  ]
}
```

3. Upon Podman Desktop start, check that the correct warning/logs are outputted in case of conflicts
4. Check that in the `$HOME/.config/containers/registries.conf` file, the registries have been added correctly and that conflicts have been resolved as expected:

Example:
```
~ $ cat .config/containers/registries.conf
[[registry]]
prefix = "quay.io"
location = "quay.io"

[[registry.mirror]]
location = "mirror.example.com"⏎
```

- [x] Tests are covering the bug fix or the new feature
