### PR TITLE
chore: use product.name rather than Podman Desktop

### DIFF
--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -23,6 +23,7 @@ import { WindowPlugin } from '/@/plugin/app-ready/window-plugin.js';
 import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isLinux, isMac, isWindows } from '/@/util.js';
 import type { IDisposable } from '/@api/disposable.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { ProtocolLauncher } from './protocol-launcher.js';
 
@@ -69,7 +70,7 @@ export class Main implements IDisposable {
     try {
       this.init(additionalData);
     } catch (err: unknown) {
-      console.error('failed to init Podman Desktop', err);
+      console.error(`failed to init ${product.name}`, err);
     }
   }
 
@@ -79,7 +80,7 @@ export class Main implements IDisposable {
      */
     const isSingleInstance = this.app.requestSingleInstanceLock(additionalData);
     if (!isSingleInstance) {
-      console.warn('An instance of Podman Desktop is already running. Stopping');
+      console.warn(`An instance of ${product.name} is already running. Stopping`);
       this.app.quit();
       process.exit(0);
     }

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -20,6 +20,7 @@ import { inject, injectable } from 'inversify';
 
 import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { ProviderRegistry } from './provider-registry.js';
 import { Disposable } from './types/disposable.js';
@@ -53,7 +54,7 @@ export class AutostartEngine {
       },
       properties: {
         [`preferences.${extensionId}.engine.autostart`]: {
-          description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
+          description: `Autostart ${extensionDisplayName} engine when launching ${product.name}`,
           type: 'boolean',
           default: true,
           scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],

--- a/packages/main/src/plugin/open-devtools-init.ts
+++ b/packages/main/src/plugin/open-devtools-init.ts
@@ -19,6 +19,7 @@
 import { inject, injectable } from 'inversify';
 
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+import product from '/@product.json' with { type: 'json' };
 
 @injectable()
 export class OpenDevToolsInit {
@@ -32,7 +33,7 @@ export class OpenDevToolsInit {
       type: 'object',
       properties: {
         ['preferences.OpenDevTools']: {
-          description: 'Open DevTools when launching Podman Desktop in development mode.',
+          description: `Open DevTools when launching ${product.name} in development mode.`,
           type: 'string',
           enum: ['left', 'right', 'bottom', 'undocked', 'detach', 'none'],
           default: 'undocked',

--- a/packages/main/src/system/startup-install.ts
+++ b/packages/main/src/system/startup-install.ts
@@ -19,6 +19,7 @@
 import * as os from 'node:os';
 
 import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { MacosStartup } from './macos-startup.js';
 import { WindowsStartup } from './windows-startup.js';
@@ -68,7 +69,7 @@ export class StartupInstall {
       type: 'object',
       properties: {
         ['preferences.login.start']: {
-          description: 'Start Podman Desktop when you log in',
+          description: `Start ${product.name} when you log in`,
           type: 'boolean',
           default: true,
         },
@@ -80,7 +81,7 @@ export class StartupInstall {
       type: 'object',
       properties: {
         ['preferences.login.minimize']: {
-          description: 'Minimize Podman Desktop when you log in',
+          description: `Minimize ${product.name} when you log in`,
           type: 'boolean',
           default: false,
         },

--- a/packages/main/src/tray-animate-icon.ts
+++ b/packages/main/src/tray-animate-icon.ts
@@ -21,6 +21,8 @@ import * as path from 'node:path';
 import type { Tray } from 'electron';
 import { app, nativeTheme } from 'electron';
 
+import product from '/@product.json' with { type: 'json' };
+
 import { isLinux, isMac } from './util.js';
 
 export type TrayIconStatus = 'initialized' | 'updating' | 'error' | 'ready';
@@ -119,19 +121,19 @@ export class AnimatedTray {
     switch (this.status) {
       case 'initialized':
         this.tray.setImage(this.getIconPath('empty'));
-        this.tray.setToolTip('Podman Desktop is initialized');
+        this.tray.setToolTip(`${product.name} is initialized`);
         break;
       case 'error':
         this.tray.setImage(this.getIconPath('error'));
-        this.tray.setToolTip('Podman Desktop has an error');
+        this.tray.setToolTip(`${product.name} has an error`);
         break;
       case 'ready':
         this.tray.setImage(this.getIconPath('default'));
-        this.tray.setToolTip('Podman Desktop is ready');
+        this.tray.setToolTip(`${product.name} is ready`);
         break;
       case 'updating':
         this.animatedInterval = setInterval(this.animateTrayIcon.bind(this), 1000);
-        this.tray.setToolTip('Podman Desktop: resources are being updated');
+        this.tray.setToolTip(`${product.name}: resources are being updated`);
         break;
     }
   }

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -18,7 +18,8 @@
     "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src/*"]
+      "/@api/*": ["../api/src/*"],
+      "/@product.json": ["../../product.json"]
     }
   },
   "include": ["src/**/*.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -33,6 +33,7 @@ const config = {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
       '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
+      '/@product.json': `${join(PACKAGE_ROOT, '../../product.json')}`,
     },
   },
   build: {


### PR DESCRIPTION
### What does this PR do?
reuse definition of constants from product.json

first commit of the PR is adding path alias

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#15043 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
