### PR TITLE
feat: added prioritization of registries

### DIFF
--- a/packages/api/src/prefered-registries-info.ts
+++ b/packages/api/src/prefered-registries-info.ts
@@ -1,0 +1,22 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum PreferredRegistriesSettings {
+  SectionName = 'registries',
+  Preferred = 'preferred',
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -200,6 +200,7 @@ import { OpenDevToolsInit } from './open-devtools-init.js';
 import { ProviderRegistry } from './provider-registry.js';
 import { Proxy } from './proxy.js';
 import { RecommendationsRegistry } from './recommendations/recommendations-registry.js';
+import { RegistryInit } from './registry-init.js';
 import { ReleaseNotesBannerInit } from './release-notes-banner-init.js';
 import { SafeStorageRegistry } from './safe-storage/safe-storage-registry.js';
 import { PinRegistry } from './statusbar/pin-registry.js';
@@ -675,6 +676,11 @@ export class PluginSystem {
     container.bind<EditorInit>(EditorInit).toSelf().inSingletonScope();
     const editorInit = container.get<EditorInit>(EditorInit);
     editorInit.init();
+
+    // init registry configuration
+    container.bind<RegistryInit>(RegistryInit).toSelf().inSingletonScope();
+    const registryInit = container.get<RegistryInit>(RegistryInit);
+    registryInit.init();
 
     // init welcome configuration
     container.bind<WelcomeInit>(WelcomeInit).toSelf().inSingletonScope();

--- a/packages/main/src/plugin/registry-init.spec.ts
+++ b/packages/main/src/plugin/registry-init.spec.ts
@@ -16,37 +16,29 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { ApiSenderType } from './api.js';
-import { ConfigurationRegistry } from './configuration-registry.js';
-import type { DefaultConfiguration } from './default-configuration.js';
-import type { Directories } from './directories.js';
-import type { LockedConfiguration } from './locked-configuration.js';
+import type { ConfigurationRegistry } from './configuration-registry.js';
 import { RegistryInit } from './registry-init.js';
 
-let configurationRegistry: ConfigurationRegistry;
+const configurationRegistryMock: ConfigurationRegistry = {
+  registerConfigurations: vi.fn(),
+  deregisterConfigurations: vi.fn(),
+} as unknown as ConfigurationRegistry;
 
-beforeAll(() => {
-  configurationRegistry = new ConfigurationRegistry(
-    {} as ApiSenderType,
-    {} as Directories,
-    {} as DefaultConfiguration,
-    {} as LockedConfiguration,
-  );
-  configurationRegistry.registerConfigurations = vi.fn();
-  configurationRegistry.deregisterConfigurations = vi.fn();
+beforeEach(() => {
+  vi.resetAllMocks();
 });
 
 test('should register a configuration', () => {
-  const registryInit = new RegistryInit(configurationRegistry);
+  const registryInit = new RegistryInit(configurationRegistryMock);
   registryInit.init();
 
-  expect(configurationRegistry.registerConfigurations).toBeCalled();
-  const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
   expect(configurationNode?.id).toBe('preferences.registries');
   expect(configurationNode?.title).toBe('Registries');
   expect(configurationNode?.type).toBe('object');
   expect(configurationNode?.properties).toBeDefined();
-  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+  expect(Object.keys(configurationNode?.properties ?? {})).toHaveLength(1);
 });

--- a/packages/main/src/plugin/registry-init.spec.ts
+++ b/packages/main/src/plugin/registry-init.spec.ts
@@ -1,0 +1,52 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, expect, test, vi } from 'vitest';
+
+import type { ApiSenderType } from './api.js';
+import { ConfigurationRegistry } from './configuration-registry.js';
+import type { DefaultConfiguration } from './default-configuration.js';
+import type { Directories } from './directories.js';
+import type { LockedConfiguration } from './locked-configuration.js';
+import { RegistryInit } from './registry-init.js';
+
+let configurationRegistry: ConfigurationRegistry;
+
+beforeAll(() => {
+  configurationRegistry = new ConfigurationRegistry(
+    {} as ApiSenderType,
+    {} as Directories,
+    {} as DefaultConfiguration,
+    {} as LockedConfiguration,
+  );
+  configurationRegistry.registerConfigurations = vi.fn();
+  configurationRegistry.deregisterConfigurations = vi.fn();
+});
+
+test('should register a configuration', () => {
+  const registryInit = new RegistryInit(configurationRegistry);
+  registryInit.init();
+
+  expect(configurationRegistry.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistry.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.registries');
+  expect(configurationNode?.title).toBe('Registries');
+  expect(configurationNode?.type).toBe('object');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+});

--- a/packages/main/src/plugin/registry-init.ts
+++ b/packages/main/src/plugin/registry-init.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
+const SectionName = 'registries';
+const PreferredRegistries = 'preferredRegistries';
+
+@injectable()
+export class RegistryInit {
+  constructor(@inject(IConfigurationRegistry) private configurationRegistry: IConfigurationRegistry) {}
+
+  init(): void {
+    const registryConfiguration: IConfigurationNode = {
+      id: 'preferences.registries',
+      title: 'Registries',
+      type: 'object',
+      properties: {
+        [`${SectionName}.${PreferredRegistries}`]: {
+          markdownDescription:
+            'String of preferred registries for pulling images. Registries are used in the order specified. Use registry URLs without `https://` prefix (e.g., `docker.io`, `quay.io`, `ghcr.io`). Separate multiple registries with commas.',
+          type: 'string',
+          default: 'docker.io',
+          placeholder: 'quay.io, ghcr.io',
+          hidden: true,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([registryConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/registry-init.ts
+++ b/packages/main/src/plugin/registry-init.ts
@@ -19,9 +19,7 @@
 import { inject, injectable } from 'inversify';
 
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-
-const SectionName = 'registries';
-const PreferredRegistries = 'preferredRegistries';
+import { PreferredRegistriesSettings } from '/@api/prefered-registries-info.js';
 
 @injectable()
 export class RegistryInit {
@@ -33,7 +31,7 @@ export class RegistryInit {
       title: 'Registries',
       type: 'object',
       properties: {
-        [`${SectionName}.${PreferredRegistries}`]: {
+        [`${PreferredRegistriesSettings.SectionName}.${PreferredRegistriesSettings.Preferred}`]: {
           markdownDescription:
             'String of preferred registries for pulling images. Registries are used in the order specified. Use registry URLs without `https://` prefix (e.g., `docker.io`, `quay.io`, `ghcr.io`). Separate multiple registries with commas.',
           type: 'string',

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -22,7 +22,7 @@ import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { get } from 'svelte/store';
-import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 import { recommendedRegistries } from '/@/stores/recommendedRegistries';
@@ -72,19 +72,29 @@ const PROVIDER_INFO_MOCK: ProviderInfo = {
   kubernetesProviderConnectionInitialization: false,
 } as unknown as ProviderInfo;
 
+const originalConsoleError = console.error;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
     if (key === 'terminal.integrated.scrollback') {
       return 1000;
     }
+    if (key === 'registries.preferredRegistries') {
+      return 'docker.io';
+    }
     return undefined;
   });
+  console.error = vi.fn();
   vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
   vi.mocked(window.pullImage).mockResolvedValue(undefined);
   vi.mocked(window.listImageTagsInRegistry).mockResolvedValue(['latest', 'other']);
 
   providerInfos.set([PROVIDER_INFO_MOCK]);
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
 });
 
 const buttonText = 'Pull image';
@@ -471,6 +481,161 @@ describe('container connections', () => {
 
     await vi.waitFor(() => {
       expect(window.pullImage).toHaveBeenCalledWith(connectionTarget, 'test1', expect.any(Function));
+    });
+  });
+});
+
+describe('Preferred Registries', () => {
+  beforeEach(() => {
+    vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+      if (key === 'terminal.integrated.scrollback') {
+        return 1000;
+      }
+      if (key === 'registries.preferredRegistries') {
+        return 'quay.io, ghcr.io, docker.io';
+      }
+      return undefined;
+    });
+  });
+
+  test('should load preferred registries from configuration on mount', async () => {
+    render(PullImage);
+
+    await vi.waitFor(() => {
+      expect(window.getConfigurationValue).toHaveBeenCalledWith('registries.preferredRegistries');
+    });
+  });
+
+  test('should search all preferred registries when no registry prefix specified', async () => {
+    vi.mocked(window.searchImageInRegistry).mockImplementation(async options => {
+      if (options.registry === 'quay.io') {
+        return [
+          { name: 'nginx', description: '', star_count: 0, is_official: false },
+          { name: 'redis', description: '', star_count: 0, is_official: false },
+        ];
+      }
+      if (options.registry === 'ghcr.io') {
+        return [
+          { name: 'nginx', description: '', star_count: 0, is_official: false },
+          { name: 'postgres', description: '', star_count: 0, is_official: false },
+        ];
+      }
+      if (options.registry === 'docker.io') {
+        return [
+          { name: 'nginx', description: '', star_count: 0, is_official: false },
+          { name: 'mysql', description: '', star_count: 0, is_official: false },
+        ];
+      }
+      return [];
+    });
+
+    render(PullImage);
+    await tick();
+
+    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    await userEvent.click(textbox);
+    await userEvent.paste('ngin');
+
+    await vi.waitFor(() => {
+      expect(window.searchImageInRegistry).toHaveBeenCalledWith(
+        expect.objectContaining({ registry: 'quay.io', query: 'ngin' }),
+      );
+      expect(window.searchImageInRegistry).toHaveBeenCalledWith(
+        expect.objectContaining({ registry: 'ghcr.io', query: 'ngin' }),
+      );
+      expect(window.searchImageInRegistry).toHaveBeenCalledWith(
+        expect.objectContaining({ registry: 'docker.io', query: 'ngin' }),
+      );
+    });
+  });
+
+  test('should deduplicate exact same image names from search results', async () => {
+    vi.mocked(window.searchImageInRegistry).mockImplementation(async () => {
+      // Both registries return the same image
+      return [
+        { name: 'nginx', description: '', star_count: 0, is_official: false },
+        { name: 'nginx', description: '', star_count: 0, is_official: false },
+      ]; // duplicate from API
+    });
+
+    render(PullImage);
+    await tick();
+
+    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    await userEvent.click(textbox);
+    await userEvent.paste('nginx');
+
+    await tick();
+
+    // Verify deduplication happens (exact implementation depends on how results are displayed)
+    // This test verifies the searchImages function is called
+    await vi.waitFor(() => {
+      expect(window.searchImageInRegistry).toHaveBeenCalled();
+    });
+  });
+
+  test('should show images from different registries as separate entries', async () => {
+    vi.mocked(window.searchImageInRegistry).mockImplementation(async () => {
+      // Same image name but from different registries
+      return [{ name: 'nginx', description: '', star_count: 0, is_official: false }];
+    });
+
+    render(PullImage);
+    await tick();
+
+    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    await userEvent.click(textbox);
+    await userEvent.paste('nginx');
+
+    await vi.waitFor(() => {
+      // Both quay.io and docker.io should be searched
+      expect(window.searchImageInRegistry).toHaveBeenCalledWith(expect.objectContaining({ registry: 'quay.io' }));
+      expect(window.searchImageInRegistry).toHaveBeenCalledWith(expect.objectContaining({ registry: 'docker.io' }));
+    });
+  });
+
+  test('should handle registry search failures gracefully', async () => {
+    vi.mocked(window.searchImageInRegistry).mockImplementation(async options => {
+      if (options.registry === 'quay.io') {
+        throw new Error('Registry unavailable');
+      }
+      return [{ name: 'nginx', description: '', star_count: 0, is_official: false }];
+    });
+
+    render(PullImage);
+    await tick();
+
+    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    await userEvent.click(textbox);
+    await userEvent.paste('nginx');
+
+    await vi.waitFor(() => {
+      // Should continue with other registries despite quay.io failing
+      expect(window.searchImageInRegistry).toHaveBeenCalledWith(expect.objectContaining({ registry: 'ghcr.io' }));
+      expect(window.searchImageInRegistry).toHaveBeenCalledWith(expect.objectContaining({ registry: 'docker.io' }));
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Failed to search registry quay.io'));
+    });
+  });
+
+  test('should use default docker.io if no preferred registries configured', async () => {
+    vi.mocked(window.getConfigurationValue).mockImplementation(async (key: string) => {
+      if (key === 'terminal.integrated.scrollback') {
+        return 1000;
+      }
+      // Don't return a value for registries.preferredRegistries
+      return undefined;
+    });
+
+    render(PullImage);
+    await tick();
+
+    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    await userEvent.click(textbox);
+    await userEvent.paste('nginx');
+
+    await vi.waitFor(() => {
+      // Should fall back to docker.io
+      expect(window.searchImageInRegistry).toHaveBeenCalledWith(expect.objectContaining({ registry: 'docker.io' }));
     });
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -2,12 +2,12 @@
 import { faPlusCircle, faTrash, faUser, faUserPen } from '@fortawesome/free-solid-svg-icons';
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { Button, DropdownMenu, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
-import { onDestroy, onMount } from 'svelte';
-import type { Unsubscriber } from 'svelte/store';
+import { onMount } from 'svelte';
 
 import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 import { configurationProperties } from '/@/stores/configurationProperties';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
+import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+import { PreferredRegistriesSettings } from '/@api/prefered-registries-info';
 
 import { registriesInfos, registriesSuggestedInfos } from '../../stores/registries';
 import IconImage from '../appearance/IconImage.svelte';
@@ -50,23 +50,17 @@ const newRegistryRequest = $state<containerDesktopAPI.Registry>({
 });
 
 // Preferred registries configuration property
-let preferredRegistriesProperty = $state<IConfigurationPropertyRecordedSchema | undefined>();
-let propertiesUnsubscribe: Unsubscriber;
+let preferredRegistriesProperty: IConfigurationPropertyRecordedSchema | undefined = $derived(
+  $configurationProperties.find(
+    prop => prop.id === `${PreferredRegistriesSettings.SectionName}.${PreferredRegistriesSettings.Preferred}`,
+  ),
+);
 
 onMount(async () => {
   let providerSourceNames = await window.getImageRegistryProviderNames();
   if (providerSourceNames && providerSourceNames.length > 0) {
     defaultProviderSourceName = providerSourceNames[0];
   }
-
-  // Subscribe to configuration properties to get the preferred registries property
-  propertiesUnsubscribe = configurationProperties.subscribe(properties => {
-    preferredRegistriesProperty = properties.find(prop => prop.id === 'registries.preferredRegistries');
-  });
-});
-
-onDestroy(() => {
-  propertiesUnsubscribe?.();
 });
 
 function markRegistryAsModified(registry: containerDesktopAPI.Registry): void {


### PR DESCRIPTION
### What does this PR do?
Adds prioritization of registries, but keeps the docker.io as last option (now it is default/ only one)

### Screenshot / video of UI


[Screencast_20251201_115144.webm](https://github.com/user-attachments/assets/bcd5e951-539d-4662-810a-5a770e976e85)



### What issues does this PR fix or reference?
Closes #14332 

### How to test this PR?
Go to registries
Set some registries e.g. `quay.io`
Try to pull image - don't add prefix
PD should give you `quay.io` preferred results 

- [x] Tests are covering the bug fix or the new feature
