### PR TITLE
docs(code-guideline): do not use code in Svelte templates

### DIFF
--- a/CODE-GUIDELINES.md
+++ b/CODE-GUIDELINES.md
@@ -19,6 +19,52 @@ import { WinPlatform } from './win-platform';
 import type { WSL2Check } from '../checks/windows/wsl2-check';
 ```
 
+### Svelte
+
+On templates of Svelte components, avoid using inline code and arrow functions. Instead, call a function defined in the script part of the component.
+
+✅ **Use this pattern:**
+
+```ts
+<script lang="ts">
+async function onButtonClicked(): Promise<void> {
+  // the code here
+}
+</script>
+
+<button on:click={onButtonClicked}>
+```
+
+🚫 **Instead of:**
+
+```ts
+<button on:click={(): Promise<void> => { /* the code here */ }}>
+```
+
+If values have to be passed from the template to the function, use the `bind` method on the function to pass the parameter.
+
+✅ **Use this pattern:**
+
+```ts
+<script lang="ts">
+async function onButtonClicked(object: Object): Promise<void> {
+  // the code here
+}
+</script>
+
+{#each objects as object (object.id)}
+  <button on:click={onButtonClicked.bind(undefined, object)}>
+{/each}
+```
+
+🚫 **Instead of:**
+
+```ts
+{#each objects as object (object.id)}
+  <button on:click={(): Promise<void> => onButtonClicked(object)}>
+{/each}
+```
+
 ## Unit tests code
 
 ### Use `vi.mocked`, not a generic `myFunctionMock`


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Add a code guideline to avoid using code in svelte templates, which could be badly supported by tooling (see https://github.com/podman-desktop/extension-kubernetes-contexts/issues/83)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
