### PR TITLE
feat(package: main): make ExtensionInstaller injectable

### DIFF
--- a/packages/main/src/plugin/api.ts
+++ b/packages/main/src/plugin/api.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IpcMainInvokeEvent } from 'electron';
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 
 import type { IDisposable } from '/@api/disposable.js';
 
@@ -31,4 +31,11 @@ export type IPCHandle = (
   channel: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   listener: (event: IpcMainInvokeEvent, ...args: any[]) => Promise<void> | any,
+) => void;
+
+export const IPCMainOn = Symbol.for('IPCMainOn');
+export type IPCMainOn = (
+  channel: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  listener: (event: IpcMainEvent, ...args: any[]) => void,
 ) => void;

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -20,7 +20,6 @@ import { rmSync } from 'node:fs';
 import * as path from 'node:path';
 
 import type { IpcMain, IpcMainEvent } from 'electron';
-import { ipcMain } from 'electron';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
@@ -82,12 +81,8 @@ const directories = {
 } as unknown as Directories;
 
 const contributionManager = {} as unknown as ContributionManager;
+const ipcMainOnMock = vi.fn();
 
-vi.mock(import('electron'), () => ({
-  ipcMain: {
-    on: vi.fn().mockReturnThis(),
-  } as unknown as IpcMain,
-}));
 vi.mock(import('node:fs'));
 vi.mock(import('./../docker-extension/docker-desktop-installer.js'));
 
@@ -105,6 +100,7 @@ beforeEach(() => {
     telemetryMock,
     directories,
     contributionManager,
+    ipcMainOnMock,
   );
 });
 
@@ -246,7 +242,7 @@ test('should report error', async () => {
   const spyInstaller = vi.spyOn(extensionInstaller, 'installFromImage');
   spyInstaller.mockRejectedValueOnce(new Error('fake error'));
 
-  vi.mocked(ipcMain.on).mockImplementation(
+  vi.mocked(ipcMainOnMock).mockImplementation(
     (_channel: string, listener: (event: IpcMainEvent, ...args: unknown[]) => void) => {
       // let's call the callback
       listener({ reply: replyMethodMock } as unknown as IpcMainEvent, imageToPull, 0);

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -22,31 +22,41 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import type { IpcMainEvent } from 'electron';
-import { ipcMain } from 'electron';
+import { inject, injectable } from 'inversify';
 import * as tarFs from 'tar-fs';
 
-import type { Directories } from '/@/plugin/directories.js';
-import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
+import { Directories } from '/@/plugin/directories.js';
+import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
-import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
+import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 
-import type { ApiSenderType } from '../api.js';
-import type { ContributionManager } from '../contribution-manager.js';
+import { ApiSenderType, IPCMainOn } from '../api.js';
+import { ContributionManager } from '../contribution-manager.js';
 import { DockerDesktopContribution, DockerDesktopInstaller } from '../docker-extension/docker-desktop-installer.js';
-import type { ImageRegistry } from '../image-registry.js';
-import type { Telemetry } from '../telemetry/telemetry.js';
+import { ImageRegistry } from '../image-registry.js';
+import { Telemetry } from '../telemetry/telemetry.js';
 
+@injectable()
 export class ExtensionInstaller {
   #dockerDesktopInstaller: DockerDesktopInstaller;
 
   constructor(
+    @inject(ApiSenderType)
     private apiSender: ApiSenderType,
+    @inject(ExtensionLoader)
     private extensionLoader: ExtensionLoader,
+    @inject(ImageRegistry)
     private imageRegistry: ImageRegistry,
+    @inject(ExtensionsCatalog)
     private extensionCatalog: ExtensionsCatalog,
+    @inject(Telemetry)
     private telemetry: Telemetry,
+    @inject(Directories)
     private directories: Directories,
+    @inject(ContributionManager)
     contributionManager: ContributionManager,
+    @inject(IPCMainOn)
+    private readonly ipcMainOn: IPCMainOn,
   ) {
     this.#dockerDesktopInstaller = new DockerDesktopInstaller(contributionManager);
   }
@@ -350,7 +360,7 @@ export class ExtensionInstaller {
   }
 
   async init(): Promise<void> {
-    ipcMain.on(
+    this.ipcMainOn(
       'extension-installer:install-from-image',
       (event: IpcMainEvent, imageName: string, logCallbackId: number, catalogExtensionId?: string): void => {
         const telemetryData: {


### PR DESCRIPTION
### What does this PR do?

Make `ExtensionInstaller` injectable to remove direct import dependency on electron package

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15117

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

You can confirm everything is working by doing the following

1. checkout
2. go to extension page
3. click on Install
4. type `ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb`
5. assert it correctly download with progress bar and install nicely
