### PR TITLE
feat(package: main): adding scripts/download-remote-extensions.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "@types/hosted-git-info": "^3.0.5",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22",
+    "@types/minimist": "^1.2.5",
     "@types/tar": "^6.1.13",
     "@types/tar-fs": "^2.0.4",
     "@types/validator": "^13.15.10",

--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -17,7 +17,7 @@
  ********************************************************************/
 
 import { existsSync } from 'node:fs';
-import { rename } from 'node:fs/promises';
+import { mkdir, rename } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -68,6 +68,14 @@ describe('downloadExtension', () => {
       join(TMP_DIR, REMOTE_INFO_MOCK.name, 'extension'),
       join(ABS_DEST_DIR, REMOTE_INFO_MOCK.name),
     );
+  });
+
+  test('should mkdir the destination directory', async () => {
+    await downloadExtension(ABS_DEST_DIR, REMOTE_INFO_MOCK);
+
+    expect(mkdir).toHaveBeenCalledExactlyOnceWith(ABS_DEST_DIR, {
+      recursive: true,
+    });
   });
 });
 

--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -47,7 +47,7 @@ beforeEach(() => {
 
   vi.mocked(tmpdir).mockReturnValue(TMP_DIR);
   vi.mocked(existsSync).mockReturnValue(true);
-  vi.mocked(product).remoteExtensions = [];
+  (vi.mocked(product).remoteExtensions as RemoteExtension[]) = [];
 });
 
 describe('downloadExtension', () => {
@@ -101,7 +101,7 @@ describe('main', () => {
   });
 
   test('--output argument should be used as destination', async () => {
-    vi.mocked(product).remoteExtensions = [REMOTE_INFO_MOCK];
+    (vi.mocked(product).remoteExtensions as RemoteExtension[]) = [REMOTE_INFO_MOCK];
 
     await main(['--output', ABS_DEST_DIR]);
 

--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -1,0 +1,99 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import { existsSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ImageRegistry } from '/@/plugin/image-registry.js';
+
+import product from '../../../product.json' with { type: 'json' };
+import type { RemoteExtension } from './download-remote-extensions.js';
+import { downloadExtension, main } from './download-remote-extensions.js';
+
+vi.mock(import('node:fs/promises'));
+vi.mock(import('node:fs'));
+vi.mock(import('node:os'));
+vi.mock(import('/@/plugin/image-registry.js'));
+vi.mock(import('../../../product.json'));
+
+const TMP_DIR = 'tmp-dir';
+const DEST_DIR = 'dest-dir';
+const REMOTE_INFO_MOCK: RemoteExtension = {
+  name: 'dummy-extension',
+  oci: 'localhost/dummy-extension:latest',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(tmpdir).mockReturnValue(TMP_DIR);
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(product).remoteExtensions = [];
+});
+
+describe('downloadExtension', () => {
+  test('should call ImageRegistry#downloadAndExtractImage with appropriate argument', async () => {
+    await downloadExtension(DEST_DIR, REMOTE_INFO_MOCK);
+
+    expect(ImageRegistry.prototype.downloadAndExtractImage).toHaveBeenCalledExactlyOnceWith(
+      REMOTE_INFO_MOCK.oci,
+      expect.stringContaining(TMP_DIR),
+      expect.any(Function),
+    );
+  });
+
+  test('should rename tmp directory to destination', async () => {
+    await downloadExtension(DEST_DIR, REMOTE_INFO_MOCK);
+
+    expect(rename).toHaveBeenCalledExactlyOnceWith(
+      join(TMP_DIR, REMOTE_INFO_MOCK.name, 'extension'),
+      join(DEST_DIR, REMOTE_INFO_MOCK.name),
+    );
+  });
+});
+
+describe('main', () => {
+  test('missing --output should throw an error', async () => {
+    await expect(async () => {
+      await main([]);
+    }).rejects.toThrowError('missing output argument');
+  });
+
+  test('empty remoteExtensions in product.json should not call any ImageRegistry#downloadAndExtractImage', async () => {
+    expect(ImageRegistry.prototype.downloadAndExtractImage).not.toHaveBeenCalled();
+
+    await main(['--output', DEST_DIR]);
+
+    expect(ImageRegistry.prototype.downloadAndExtractImage).not.toHaveBeenCalled();
+  });
+
+  test('--output argument should be used as destination', async () => {
+    vi.mocked(product).remoteExtensions = [REMOTE_INFO_MOCK];
+
+    await main(['--output', DEST_DIR]);
+
+    expect(rename).toHaveBeenCalledExactlyOnceWith(
+      join(TMP_DIR, REMOTE_INFO_MOCK.name, 'extension'),
+      join(DEST_DIR, REMOTE_INFO_MOCK.name),
+    );
+  });
+});

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -33,12 +33,17 @@ import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
 import product from '../../../product.json' with { type: 'json' };
 
-const apiSenderTypeMock = {} as unknown as ApiSenderType;
-const telemetryMock = {} as unknown as Telemetry;
-const certificateMock = {
+/**
+ * We create _dummy_ classes for the constructor of ImageRegistry
+ * We do not use those classes when calling ImageRegistry#downloadAndExtractImage as the internal logic
+ * uses different node_modules; those classes are needed for other things the class is doing
+ */
+const dummyApiSenderType = {} as unknown as ApiSenderType;
+const dummyTelemetry = {} as unknown as Telemetry;
+const dummyCertificate = {
   getAllCertificates: (): undefined => undefined,
 } as unknown as Certificates;
-const proxyMock = {
+const dummyProxy = {
   onDidUpdateProxy: (): void => {},
   onDidStateChange: (): void => {},
   isEnabled: (): boolean => false,
@@ -50,7 +55,7 @@ export interface RemoteExtension {
 }
 
 export async function downloadExtension(destination: string, info: RemoteExtension): Promise<void> {
-  const imageRegistry = new ImageRegistry(apiSenderTypeMock, telemetryMock, certificateMock, proxyMock);
+  const imageRegistry = new ImageRegistry(dummyApiSenderType, dummyTelemetry, dummyCertificate, dummyProxy);
 
   // tmp folder
   const tmpFolderPath = join(tmpdir(), info.name);

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -30,8 +30,7 @@ import type { Certificates } from '/@/plugin/certificates.js';
 import { ImageRegistry } from '/@/plugin/image-registry.js';
 import type { Proxy } from '/@/plugin/proxy.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-
-import product from '../../../product.json' with { type: 'json' };
+import product from '/@product.json' with { type: 'json' };
 
 /**
  * We create _dummy_ classes for the constructor of ImageRegistry
@@ -83,6 +82,14 @@ export async function downloadExtension(destination: string, info: RemoteExtensi
   await rename(join(tmpFolderPath, 'extension'), finalPath);
 }
 
+export function getRemoteExtensions(): RemoteExtension[] {
+  if (!product) return [];
+  if (!('extensions' in product) || !product.extensions || typeof product.extensions !== 'object') return [];
+  if (!('remote' in product.extensions) || !product.extensions.remote || !Array.isArray(product.extensions.remote))
+    return [];
+  return product.extensions.remote as RemoteExtension[];
+}
+
 export async function main(args: string[]): Promise<void> {
   const parsed = minimist(args);
 
@@ -91,9 +98,7 @@ export async function main(args: string[]): Promise<void> {
 
   if (!isAbsolute(output)) throw new Error('the output should be an absolute directory');
 
-  await Promise.all((product.remoteExtensions ?? []).map(downloadExtension.bind(undefined, output))).catch(
-    console.error,
-  );
+  await Promise.all(getRemoteExtensions().map(downloadExtension.bind(undefined, output))).catch(console.error);
 }
 
 // do not start if we are in a VITEST env

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -19,7 +19,7 @@
 import 'reflect-metadata';
 
 import { existsSync } from 'node:fs';
-import { rename } from 'node:fs/promises';
+import { mkdir, rename } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 
@@ -71,6 +71,10 @@ export async function downloadExtension(destination: string, info: RemoteExtensi
     );
   }
 
+  // ensure the destination directory exists
+  await mkdir(destination, { recursive: true });
+
+  // rename tmp to destination
   await rename(join(tmpFolderPath, 'extension'), finalPath);
 }
 

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -21,7 +21,7 @@ import 'reflect-metadata';
 import { existsSync } from 'node:fs';
 import { rename } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 
 import minimist from 'minimist';
 
@@ -79,6 +79,8 @@ export async function main(args: string[]): Promise<void> {
 
   const output: string | undefined = parsed['output'];
   if (!output) throw new Error('missing output argument');
+
+  if (!isAbsolute(output)) throw new Error('the output should be an absolute directory');
 
   await Promise.all((product.remoteExtensions ?? []).map(downloadExtension.bind(undefined, output))).catch(
     console.error,

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -1,0 +1,91 @@
+/*********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'reflect-metadata';
+
+import { existsSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import minimist from 'minimist';
+
+import type { ApiSenderType } from '/@/plugin/api.js';
+import type { Certificates } from '/@/plugin/certificates.js';
+import { ImageRegistry } from '/@/plugin/image-registry.js';
+import type { Proxy } from '/@/plugin/proxy.js';
+import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
+
+import product from '../../../product.json' with { type: 'json' };
+
+const apiSenderTypeMock = {} as unknown as ApiSenderType;
+const telemetryMock = {} as unknown as Telemetry;
+const certificateMock = {
+  getAllCertificates: (): undefined => undefined,
+} as unknown as Certificates;
+const proxyMock = {
+  onDidUpdateProxy: (): void => {},
+  onDidStateChange: (): void => {},
+  isEnabled: (): boolean => false,
+} as unknown as Proxy;
+
+export interface RemoteExtension {
+  name: string;
+  oci: string;
+}
+
+export async function downloadExtension(destination: string, info: RemoteExtension): Promise<void> {
+  const imageRegistry = new ImageRegistry(apiSenderTypeMock, telemetryMock, certificateMock, proxyMock);
+
+  // tmp folder
+  const tmpFolderPath = join(tmpdir(), info.name);
+
+  const finalPath = join(destination, info.name);
+
+  await imageRegistry.downloadAndExtractImage(info.oci, tmpFolderPath, console.log);
+
+  if (!existsSync(join(tmpFolderPath, 'extension'))) {
+    throw new Error(
+      `extension ${info.name} has malformed content: the OCI image should contains an "extension" folder`,
+    );
+  }
+
+  if (!existsSync(join(tmpFolderPath, 'extension', 'package.json'))) {
+    throw new Error(
+      `extension ${info.name} has malformed content: the OCI image should contains a "package.json" file in the extension folder`,
+    );
+  }
+
+  await rename(join(tmpFolderPath, 'extension'), finalPath);
+}
+
+export async function main(args: string[]): Promise<void> {
+  const parsed = minimist(args);
+
+  const output: string | undefined = parsed['output'];
+  if (!output) throw new Error('missing output argument');
+
+  await Promise.all((product.remoteExtensions ?? []).map(downloadExtension.bind(undefined, output))).catch(
+    console.error,
+  );
+}
+
+// do not start if we are in a VITEST env
+if (!process.env['VITEST']) {
+  main(process.argv.slice(2)).catch(console.error);
+}

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -22,5 +22,5 @@
       "/@product.json": ["../../product.json"]
     }
   },
-  "include": ["src/**/*.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]
 }

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -43,7 +43,7 @@ const config = {
     assetsDir: '.',
     minify: process.env.MODE === 'production' ? 'esbuild' : false,
     lib: {
-      entry: ['src/index.ts', 'scripts/download-extensions.ts'],
+      entry: ['src/index.ts', 'scripts/download-remote-extensions.ts'],
       formats: ['cjs'],
     },
     rollupOptions: {

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -43,7 +43,7 @@ const config = {
     assetsDir: '.',
     minify: process.env.MODE === 'production' ? 'esbuild' : false,
     lib: {
-      entry: 'src/index.ts',
+      entry: ['src/index.ts', 'scripts/download-extensions.ts'],
       formats: ['cjs'],
     },
     rollupOptions: {
@@ -67,7 +67,7 @@ const config = {
   test: {
     retry: 3, // Retries failing tests up to 3 times
     environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    include: ['{src,scripts}/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/minimist':
+        specifier: ^1.2.5
+        version: 1.2.5
       '@types/node':
         specifier: ^22
         version: 22.19.1
@@ -4308,6 +4311,9 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -16222,6 +16228,8 @@ snapshots:
   '@types/mdx@2.0.13': {}
 
   '@types/mime@1.3.5': {}
+
+  '@types/minimist@1.2.5': {}
 
   '@types/ms@2.1.0': {}
 

--- a/product.json
+++ b/product.json
@@ -3,5 +3,7 @@
   "appId": "io.podman_desktop.PodmanDesktop",
   "artifactName": "podman-desktop",
   "urlProtocol": "podman-desktop",
-  "remoteExtensions": []
+  "extensions": {
+    "remote": []
+  }
 }

--- a/product.json
+++ b/product.json
@@ -2,5 +2,6 @@
   "name": "Podman Desktop",
   "appId": "io.podman_desktop.PodmanDesktop",
   "artifactName": "podman-desktop",
-  "urlProtocol": "podman-desktop"
+  "urlProtocol": "podman-desktop",
+  "remoteExtensions": []
 }


### PR DESCRIPTION
### What does this PR do?

The `ImageRegistry` cannot be imported and used by `tsx` because of issue with inversify decorators and path aliases. I spent 2 hours trying to make it work, then got a genius idea 💡 

Instead of having a `scripts` folder at the root using classes from internal package, we should instead  have a scripts folder in the package next to the `src` and add a new entry in the vite config. It support multiple entries, so we can add our scripts to the vite entries, it will then be available in the `dist` folder.

This has a clear advantages => in packages/main vite is already nicely configured to build the code in it, and trying to make it works from the root directly is very hacky and annoying.

So let's don't do that, and use vite capabilities to build multiple targets :)

⚠️ the `minimalist` package is already used, but typecheck fails once properly configured it fails :( so we need to add the corresponding types

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15044

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

### Testing manually

1. checkout this branch
2. add the following to the `product.json` at the root directory

```json
{
  ...,
  "remoteExtensions": [{
    "name": "podman-desktop-extension-layers-explorer",
    "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb"
  }]
}
```

3. run `pnpm run build:main`
4. assert `.\packages\main\dist\download-remote-extensions.cjs` exists

<img width="1070" height="587" alt="image" src="https://github.com/user-attachments/assets/a94c220f-1f43-4762-a5eb-4c2cc012845f" />

6. run `node .\packages\main\dist\download-remote-extensions.cjs --output="$pwd\\extensions-extra"`
7. assert the folder `extensions-extra` has been populate with `podman-desktop-extension-layers-explorer` folder containing extension data
![Uploading image.png…]()

6. run `node .\packages\main\dist\download-remote-extensions.cjs --output="$pwd\\extensions-extra"`
7. assert the folder `extensions-extra` has been populate with `podman-desktop-extension-layers-explorer` folder containing extension data