### PR TITLE
feat(podman): add default registry loader on startup

### DIFF
--- a/extensions/podman/packages/extension/src/configuration/default-registry-loader.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/default-registry-loader.spec.ts
@@ -1,0 +1,330 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration } from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry, UserDefaultRegistry, UserDefaultRegistryMirror } from './default-registry-loader';
+import { DefaultRegistryLoader } from './default-registry-loader';
+import type { RegistryConfigurationEntry } from './registry-configuration';
+
+let defaultRegistryLoader: DefaultRegistryLoader;
+let mockConfigurationRegistry: ConfigurationRegistry;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
+
+  mockConfigurationRegistry = {
+    getConfiguration: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue([]),
+    } as unknown as Configuration),
+  };
+
+  defaultRegistryLoader = new DefaultRegistryLoader(mockConfigurationRegistry);
+});
+
+describe('loadFromConfiguration', () => {
+  test('easy test that returns an empty array when no registries configured, to confirm it just loads', () => {
+    const result = defaultRegistryLoader.loadFromConfiguration();
+    expect(result).toEqual([]);
+  });
+
+  test('loads registries from configuration', () => {
+    // Test registries!
+    const userRegistry1: UserDefaultRegistry = {
+      registry: {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+      },
+    };
+    const userRegistry2: UserDefaultRegistry = {
+      registry: {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    };
+
+    // Set it all up
+    const getMock = vi.fn().mockReturnValue([userRegistry1, userRegistry2]);
+    mockConfigurationRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: getMock,
+      } as unknown as Configuration),
+    };
+    defaultRegistryLoader = new DefaultRegistryLoader(mockConfigurationRegistry);
+
+    // Make sure that both registries end up existing in the result
+    const result = defaultRegistryLoader.loadFromConfiguration();
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+      },
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    ]);
+  });
+
+  test('loads registries with mirrors from configuration', () => {
+    // Test registries with mirrors
+    // configured immediately after
+    const userRegistry1: UserDefaultRegistry = {
+      registry: {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+      },
+    };
+    const userRegistryMirror1: UserDefaultRegistryMirror = {
+      'registry.mirror': {
+        location: 'mirror1/foo',
+      },
+    };
+    const userRegistry2: UserDefaultRegistry = {
+      registry: {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    };
+    const userRegistryMirror2: UserDefaultRegistryMirror = {
+      'registry.mirror': {
+        location: 'mirror2/bar',
+        insecure: true,
+      },
+    };
+
+    // Setup
+    const getMock = vi.fn().mockReturnValue([userRegistry1, userRegistryMirror1, userRegistry2, userRegistryMirror2]);
+    mockConfigurationRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: getMock,
+      } as unknown as Configuration),
+    };
+    defaultRegistryLoader = new DefaultRegistryLoader(mockConfigurationRegistry);
+
+    // Make sure that both registries and their mirrors end up existing in the result
+    const result = defaultRegistryLoader.loadFromConfiguration();
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+        mirror: [
+          {
+            location: 'mirror2/bar',
+            insecure: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('ignores mirror if no registry precedes it', () => {
+    const userRegistryMirror: UserDefaultRegistryMirror = {
+      'registry.mirror': {
+        location: 'mirror1/foo',
+      },
+    };
+
+    const getMock = vi.fn().mockReturnValue([userRegistryMirror]);
+
+    mockConfigurationRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: getMock,
+      } as unknown as Configuration),
+    };
+
+    defaultRegistryLoader = new DefaultRegistryLoader(mockConfigurationRegistry);
+
+    // Ignore any mirrors that don't have the registry before them...
+    // this should equal blank (since registry.mirror without a preceding registry is ignored)
+    const result = defaultRegistryLoader.loadFromConfiguration();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('resolveConflicts', () => {
+  test('adds new registries to existing list', () => {
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    ];
+    const existingRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+      },
+    ];
+
+    // Should result in the same as just appending the new registry
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+      },
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+      },
+    ]);
+  });
+
+  test('merges mirrors when registry exists and properties match', () => {
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [
+          {
+            location: 'mirror1/bar',
+          },
+        ],
+      },
+    ];
+
+    const existingRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+    ];
+
+    // Make sure that the mirror is merged correctly / added to the existing registry
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+          {
+            location: 'mirror1/bar',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('does not duplicate existing mirrors', () => {
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+    ];
+
+    const existingRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+    ];
+
+    // Check that the mirror isn't duplicated when loaded
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        mirror: [
+          {
+            location: 'mirror1/foo',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('warns and does not merge when properties differ', () => {
+    const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const defaultRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: false,
+        insecure: true,
+      },
+    ];
+
+    const existingRegistries: RegistryConfigurationEntry[] = [
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        insecure: false,
+      },
+    ];
+
+    const result = defaultRegistryLoader.resolveConflicts(defaultRegistries, existingRegistries);
+
+    // We want to check that we get the correct warning about differing properties
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      'Default user registry registry1 already exists in registries.conf, but properties differ: blocked, insecure. User settings take precedence.',
+    );
+
+    // Existing registry remains unchanged
+    expect(result).toEqual([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        insecure: false,
+      },
+    ]);
+
+    consoleWarnMock.mockRestore();
+  });
+});

--- a/extensions/podman/packages/extension/src/configuration/default-registry-loader.ts
+++ b/extensions/podman/packages/extension/src/configuration/default-registry-loader.ts
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration, ConfigurationScope } from '@podman-desktop/api';
+import { configuration as apiConfiguration } from '@podman-desktop/api';
+
+import type { RegistryConfigurationEntry } from './registry-configuration';
+
+export interface ConfigurationRegistry {
+  getConfiguration(section?: string, scope?: ConfigurationScope): Configuration;
+}
+
+// Internal types for reading user default registries from settings.json
+// These mirror the containers-registries.conf format but are internal to the Podman extension
+// see: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#example
+export interface UserDefaultRegistry {
+  registry: {
+    prefix: string;
+    insecure?: boolean;
+    blocked?: boolean;
+    location: string;
+  };
+}
+export interface UserDefaultRegistryMirror {
+  'registry.mirror': {
+    location: string;
+    insecure?: boolean;
+  };
+}
+
+// Handles loading and merging user default registries from podman desktop configuration (settings.json)
+export class DefaultRegistryLoader {
+  #configurationRegistry: ConfigurationRegistry;
+
+  constructor(configurationRegistry: ConfigurationRegistry = apiConfiguration) {
+    this.#configurationRegistry = configurationRegistry;
+  }
+
+  // Load registry entries from settings.json configuration.
+  // The format intentionally mirrors registries.conf where mirrors must immediately
+  // follow their parent registry (ex. [[registry]] followed by [[registry.mirror]]).
+  // Orphan mirrors (those without a preceding registry) are ignored as they do not have context / do not make sense vs the spec.
+  // See: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md
+  loadFromConfiguration(): RegistryConfigurationEntry[] {
+    const userDefaultRegistries = this.#configurationRegistry.getConfiguration('registries').get('defaults') as (
+      | UserDefaultRegistry
+      | UserDefaultRegistryMirror
+    )[];
+
+    return (userDefaultRegistries ?? []).reduce<RegistryConfigurationEntry[]>((entries, item) => {
+      if ('registry' in item) {
+        entries.push({ ...item.registry });
+      } else if (entries.length > 0) {
+        // Attach mirror to the preceding registry (mimics registries.conf format)
+        const lastEntry = entries[entries.length - 1];
+        lastEntry.mirror ??= [];
+        // It will always be 'registry.mirror' (check podman registries.conf link above)
+        lastEntry.mirror.push({ ...item['registry.mirror'] });
+      }
+      return entries;
+    }, []);
+  }
+
+  // Merge default registries into existing registries, resolving conflicts
+  // Some private helpers for resolveConflicts are used try and make understanding a bit easier
+  // since the logic in the podman spec is more complex, and must adhere to strict rules such as the mirror
+  // always preceding the reigistry it belongs to.
+  resolveConflicts(
+    defaultRegistries: RegistryConfigurationEntry[],
+    existingRegistries: RegistryConfigurationEntry[],
+  ): RegistryConfigurationEntry[] {
+    for (const defaultRegistry of defaultRegistries) {
+      const existing = this.findByPrefix(existingRegistries, defaultRegistry.prefix);
+
+      if (!existing) {
+        existingRegistries.push(defaultRegistry);
+        continue;
+      }
+
+      // Skip merging if properties differ (user settings take precedence)
+      if (this.hasPropertyDifference(existing, defaultRegistry)) {
+        continue;
+      }
+
+      this.mergeMirrors(existing, defaultRegistry.mirror ?? []);
+    }
+    return existingRegistries;
+  }
+
+  // Helper method to find the corresponding registry by prefix
+  private findByPrefix(
+    registries: RegistryConfigurationEntry[],
+    prefix: string | undefined,
+  ): RegistryConfigurationEntry | undefined {
+    if (!prefix) return undefined;
+    return registries.find(r => r.prefix === prefix);
+  }
+
+  // Helper method to merge mirrors into a target registry entry
+  private mergeMirrors(target: RegistryConfigurationEntry, mirrors: RegistryConfigurationEntry['mirror']): void {
+    if (!mirrors?.length) return;
+
+    target.mirror ??= [];
+    const existingLocations = new Set(target.mirror.map(m => m.location));
+
+    for (const mirror of mirrors) {
+      if (!existingLocations.has(mirror.location)) {
+        target.mirror.push(mirror);
+      }
+    }
+  }
+
+  // Returns true if properties differ between existing and default registry (warns user)
+  // we only compare the main properties, not mirrors, as those are merged separately
+  // specifically we make sure to compare blocked, insecure, and location (hence the 3 if statements..)
+  private hasPropertyDifference(
+    existing: RegistryConfigurationEntry,
+    defaultRegistry: RegistryConfigurationEntry,
+  ): boolean {
+    const diff: string[] = [];
+
+    if (existing.blocked !== defaultRegistry.blocked) diff.push('blocked');
+    if (existing.insecure !== defaultRegistry.insecure) diff.push('insecure');
+    if (existing.location !== defaultRegistry.location) diff.push('location');
+
+    if (diff.length > 0) {
+      console.warn(
+        `Default user registry ${defaultRegistry.prefix} already exists in registries.conf, but properties differ: ${diff.join(', ')}. User settings take precedence.`,
+      );
+      return true;
+    }
+    return false;
+  }
+}

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
@@ -24,6 +24,7 @@ import * as os from 'node:os';
 import { commands, env, window } from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { DefaultRegistryLoader } from './default-registry-loader';
 import type { RegistryConfigurationFile } from './registry-configuration';
 import { ActionEnum, RegistryConfigurationImpl } from './registry-configuration';
 
@@ -120,6 +121,7 @@ describe('init', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(registryConfiguration, 'registerSetupRegistryCommand').mockReturnValue(fakeDisposable);
+    vi.spyOn(registryConfiguration, 'loadDefaultUserRegistries').mockResolvedValue(undefined);
   });
 
   test('check command is registered', async () => {
@@ -264,4 +266,61 @@ describe('displayRegistryQuickPick', () => {
       ],
     });
   });
+});
+
+test('when loadDefaultUserRegistries is called, make sure it calls all three functions for configuring the registry', async () => {
+  const mockDefaultRegistryLoader = {
+    loadFromConfiguration: vi.fn().mockReturnValue([
+      {
+        prefix: 'registry1',
+        location: '/registry1/foo',
+        blocked: true,
+        mirror: [{ location: 'mirror1/foo' }],
+      },
+      {
+        prefix: 'registry2',
+        location: '/registry2/foo',
+        blocked: true,
+      },
+    ]),
+    resolveConflicts: vi.fn().mockImplementation((defaultRegs, existingRegs) => [...existingRegs, ...defaultRegs]),
+  } as unknown as DefaultRegistryLoader;
+
+  registryConfiguration = new RegistryConfigurationImpl(mockDefaultRegistryLoader);
+
+  vi.spyOn(registryConfiguration, 'readRegistriesConfContent').mockResolvedValue({ registry: [] });
+  vi.spyOn(registryConfiguration, 'saveRegistriesConfContent').mockResolvedValue();
+  vi.spyOn(registryConfiguration, 'checkRegistryConfFileExistsInVm').mockResolvedValue(true);
+
+  vi.mocked(env).isMac = true;
+
+  // Time to call the method!
+  await registryConfiguration.loadDefaultUserRegistries();
+
+  // We make sure that ALL the methods are called as expected (since we are merging)
+  expect(mockDefaultRegistryLoader.loadFromConfiguration).toBeCalled();
+  expect(mockDefaultRegistryLoader.resolveConflicts).toBeCalled();
+  expect(registryConfiguration.saveRegistriesConfContent).toBeCalled();
+});
+
+test('when loadDefaultUserRegistries is called and there are no default registries, it does not save', async () => {
+  const mockDefaultRegistryLoader = {
+    loadFromConfiguration: vi.fn().mockReturnValue([]),
+    resolveConflicts: vi.fn(),
+  } as unknown as DefaultRegistryLoader;
+
+  registryConfiguration = new RegistryConfigurationImpl(mockDefaultRegistryLoader);
+
+  vi.spyOn(registryConfiguration, 'readRegistriesConfContent').mockResolvedValue({ registry: [] });
+  vi.spyOn(registryConfiguration, 'saveRegistriesConfContent').mockResolvedValue();
+  vi.spyOn(registryConfiguration, 'checkRegistryConfFileExistsInVm').mockResolvedValue(true);
+
+  vi.mocked(env).isMac = true;
+
+  await registryConfiguration.loadDefaultUserRegistries();
+
+  // Make sure the only call is loadFromConfiguration! Resolve conflicts as well as saveRegistriesConfContent should NOT be called
+  expect(mockDefaultRegistryLoader.loadFromConfiguration).toBeCalled();
+  expect(mockDefaultRegistryLoader.resolveConflicts).not.toBeCalled();
+  expect(registryConfiguration.saveRegistriesConfContent).not.toBeCalled();
 });

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -173,6 +173,12 @@ vi.mock('./compatibility-mode', async () => {
   };
 });
 
+vi.mock(import('./configuration/registry-configuration'), async () => {
+  const RegistryConfigurationImpl = vi.fn();
+  RegistryConfigurationImpl.prototype.init = vi.fn(() => []);
+  return { RegistryConfigurationImpl };
+});
+
 const PODMAN_INSTALL_MOCK: PodmanInstall = {
   getUpdatePreflightChecks: vi.fn(),
   isAbleToInstall: vi.fn(),


### PR DESCRIPTION
feat(podman): add default registry loader on startup

### What does this PR do?

At the moment, there is not a way to configure your local
`~/.config/containers/registries.conf` on startup.

This PR adds the ability to add the following to your local
`~/.local/share/containers/podman-desktop/configuration/settings.json`:

```json
  {
  "registries.defaults": [
    {
      "registry": {
        "prefix": "example.com",
        "location": "example.com",
        "blocked": false,
        "insecure": true
      }
    },
    {
      "registry.mirror": {
        "location": "mirror.example.com"
      }
    }
  ]
}
```

And it will then be added to your `registries.conf` on boot:

```sh
cat ~/.config/containers/registries.conf
[[registry]]
prefix = "example.com"
location = "example.com"
blocked = false
insecure = true

[[registry.mirror]]
location = "mirror.example.com"
```

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, this is done internally / no GUI changes.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/13902

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Add to your local `settings.json`, the following, please **note that
   the mirror has to be right after the registry, which is the podman
   registry format**:

```json
{
  "registries.defaults": [
    {
      "registry": {
        "prefix": "example.com",
        "location": "example.com"
      }
    },
    {
      "registry.mirror": {
        "location": "mirror.example.com"
      }
    }
  ]
}
```

3. Upon Podman Desktop start, check that the correct warning/logs are outputted in case of conflicts
4. Check that in the `$HOME/.config/containers/registries.conf` file, the registries have been added correctly and that conflicts have been resolved as expected:

Example:

```
~ $ cat .config/containers/registries.conf
[[registry]]
prefix = "example.com"
location = "example.com"
blocked = false
insecure = true

[[registry.mirror]]
location = "mirror.example.com"
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
