### PR TITLE
fix: move provider version to provider

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -465,8 +465,10 @@ $effect(() => {
               {/if}
               <span class="my-auto font-semibold text-[var(--pd-invert-content-card-header-text)] ml-3 break-words"
                 >{provider.name}</span>
-              <span class="my-auto text-[var(--pd-invert-content-card-header-text)] ml-3 break-words"
-                  >{provider.version ? `v${provider.version}` : ''}</span>
+              {#if provider.version}
+                <span class="my-auto text-[var(--pd-content-sub-header)] ml-3 break-words"
+                  >v{provider.version}</span>
+              {/if}
             </div>
             <ProviderActionButtons
               provider={provider}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -465,6 +465,8 @@ $effect(() => {
               {/if}
               <span class="my-auto font-semibold text-[var(--pd-invert-content-card-header-text)] ml-3 break-words"
                 >{provider.name}</span>
+              <span class="my-auto text-[var(--pd-invert-content-card-header-text)] ml-3 break-words"
+                  >{provider.version ? `v${provider.version}` : ''}</span>
             </div>
             <ProviderActionButtons
               provider={provider}
@@ -598,10 +600,6 @@ $effect(() => {
                 {/snippet}
               </PreferencesConnectionActions>
               <div class="mt-1.5 text-[var(--pd-content-sub-header)] text-[9px] flex justify-between">
-                <div aria-label="Connection Version">
-                  {provider.name}
-                  {provider.version ? `v${provider.version}` : ''}
-                </div>
                 <div aria-label="Connection Type">{container.vmType ? capitalize(container.vmType.name) : ''}</div>
               </div>
             </div>


### PR DESCRIPTION
### What does this PR do?

Currently the provider version is shown as connection version, which is misleading. That needs to come from each connection.

Better to show the provider version with the provider name, and the connection version with the connection name (later)?

### Screenshot / video of UI

<img width="523" height="649" alt="pd-resources" src="https://github.com/user-attachments/assets/1c5315c6-8aef-40a2-99b7-52e822404eb4" />

### What issues does this PR fix or reference?

Fixes #4215

* #4215

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
