### PR TITLE
feat: show more info about the Lima provider and connections

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -40,6 +40,33 @@
           "default": "",
           "description": "Instance name (default is same name as type)"
         },
+        "lima.arch": {
+          "type": "arch",
+          "scope": "ContainerConnection",
+          "description": "Arch",
+          "readonly": true
+        },
+        "lima.cpus": {
+          "type": "number",
+          "format": "cpu",
+          "scope": "ContainerConnection",
+          "description": "CPUs",
+          "readonly": true
+        },
+        "lima.memory": {
+          "type": "number",
+          "format": "memory",
+          "scope": "ContainerConnection",
+          "description": "Memory",
+          "readonly": true
+        },
+        "lima.disk": {
+          "type": "number",
+          "format": "diskSize",
+          "scope": "ContainerConnection",
+          "description": "Disk",
+          "readonly": true
+        },
         "lima.socket": {
           "type": "string",
           "default": "",

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -24,7 +24,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { configuration, ProgressLocation } from '@podman-desktop/api';
 
 import { ImageHandler } from './image-handler';
-import { getLimactl } from './limactl';
+import { getLimactl, getLimaInstallation } from './limactl';
 
 type limaProviderType = 'docker' | 'podman' | 'kubernetes';
 
@@ -101,12 +101,16 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const socketPath = path.resolve(limaHome ?? '', instanceName + '/sock/' + socketName);
   const configPath = path.resolve(limaHome ?? '', instanceName + '/copied-from-guest/kubeconfig.yaml');
 
+  const installedLima = await getLimaInstallation();
+  const version: string | undefined = installedLima?.version;
+
   let provider;
   if (fs.existsSync(socketPath) || fs.existsSync(configPath)) {
     provider = extensionApi.provider.createProvider({
       name: 'Lima',
       id: 'lima',
       status: 'unknown',
+      version,
       images: {
         icon: './icon.png',
         logo: {

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -134,6 +134,12 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
           light: './logo-light.png',
         },
       },
+      links: [
+        {
+          title: 'Website',
+          url: 'https://lima-vm.io/',
+        },
+      ],
     });
     extensionContext.subscriptions.push(provider);
   }

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -24,7 +24,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { configuration, ProgressLocation } from '@podman-desktop/api';
 
 import { ImageHandler } from './image-handler';
-import { getLimactl, getLimaInstallation } from './limactl';
+import { getLimactl, getLimaInfo, getLimaInstallation } from './limactl';
 
 type limaProviderType = 'docker' | 'podman' | 'kubernetes';
 
@@ -42,13 +42,28 @@ function prettyInstanceName(instanceName: string): string {
   return name;
 }
 
-function registerProvider(
+async function updateContainerConfiguration(
+  containerProviderConnection: extensionApi.ContainerProviderConnection,
+  instanceName: string,
+): Promise<void> {
+  // get configuration for this connection
+  const containerConfiguration = extensionApi.configuration.getConfiguration('lima', containerProviderConnection);
+
+  const limaInfo = await getLimaInfo(instanceName);
+  containerProviderConnection.vmType = limaInfo?.vmType;
+  await containerConfiguration.update('arch', limaInfo?.arch);
+  await containerConfiguration.update('cpus', limaInfo?.cpus);
+  await containerConfiguration.update('memory', limaInfo?.memory);
+  await containerConfiguration.update('disk', limaInfo?.disk);
+}
+
+async function registerProvider(
   extensionContext: extensionApi.ExtensionContext,
   provider: extensionApi.Provider,
   providerType: limaProviderType,
   providerPath: string,
   instanceName: string,
-): void {
+): Promise<void> {
   let providerState: extensionApi.ProviderConnectionStatus = 'unknown';
   if (providerType === 'podman' || providerType === 'docker') {
     const connection: extensionApi.ContainerProviderConnection = {
@@ -59,6 +74,7 @@ function registerProvider(
         socketPath: providerPath,
       },
     };
+    await updateContainerConfiguration(connection, instanceName);
     providerState = 'started';
     const disposable = provider.registerContainerProviderConnection(connection);
     provider.updateStatus('started');
@@ -126,7 +142,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (socketName !== 'kubernetes.sock') {
     const providerType = engineType === 'kubernetes' ? 'docker' : (engineType as limaProviderType);
     if (fs.existsSync(socketPath) && provider) {
-      registerProvider(extensionContext, provider, providerType, socketPath, instanceName);
+      await registerProvider(extensionContext, provider, providerType, socketPath, instanceName);
     } else {
       console.debug(`Could not find socket at ${socketPath}`);
     }
@@ -135,7 +151,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (engineType === 'kubernetes') {
     const providerType = engineType as limaProviderType;
     if (fs.existsSync(configPath) && provider) {
-      registerProvider(extensionContext, provider, providerType, configPath, instanceName);
+      await registerProvider(extensionContext, provider, providerType, configPath, instanceName);
     } else {
       console.debug(`Could not find config at ${configPath}`);
     }

--- a/extensions/lima/src/limactl.ts
+++ b/extensions/lima/src/limactl.ts
@@ -66,3 +66,37 @@ export async function getLimaInstallation(): Promise<InstalledLima | undefined> 
     return undefined;
   }
 }
+
+/*
+NAME      STATUS     SSH            VMTYPE    ARCH      CPUS    MEMORY    DISK      DIR
+podman    Stopped    127.0.0.1:0    qemu      x86_64    4       4GiB      100GiB    ~/.lima/podman
+*/
+
+export interface LimaInfo {
+  name: string;
+  vmType: string;
+  arch: string;
+  cpus: number;
+  memory: number; // bytes
+  disk: number; // bytes
+  dir: string;
+}
+
+export async function getLimaInfo(name: string): Promise<LimaInfo | undefined> {
+  try {
+    const { stdout } = await extensionApi.process.exec(getLimactl(), ['list', '--json', name]);
+    const limaInfo = JSON.parse(stdout);
+    const instance: LimaInfo = {
+      name: limaInfo.name,
+      vmType: limaInfo.vmType,
+      arch: limaInfo.arch,
+      cpus: limaInfo.cpus,
+      memory: limaInfo.memory,
+      disk: limaInfo.disk,
+      dir: limaInfo.dir,
+    };
+    return instance;
+  } catch (err) {
+    return undefined;
+  }
+}

--- a/extensions/lima/src/limactl.ts
+++ b/extensions/lima/src/limactl.ts
@@ -50,3 +50,19 @@ export function getLimactl(): string {
 function getCustomBinaryPath(): string | undefined {
   return extensionApi.configuration.getConfiguration('lima').get('binary.path');
 }
+
+export interface InstalledLima {
+  version: string;
+}
+
+export async function getLimaInstallation(): Promise<InstalledLima | undefined> {
+  try {
+    const { stdout: versionOut } = await extensionApi.process.exec(getLimactl(), ['--version']);
+    const versionArr = versionOut.split(' ');
+    const version = versionArr[versionArr.length - 1];
+    return { version };
+  } catch (err) {
+    // no limactl binary
+    return undefined;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

* show the Lima provider version
  `limactl --version`

  https://lima-vm.io/


* show the Lima connection info
  `limactl list`

  - vmType
  - arch
  - cpus
  - memory
  - disk

### Screenshot / video of UI

<img width="282" height="102" alt="image" src="https://github.com/user-attachments/assets/8a995dc1-9471-4902-9f68-e65dc556cfe0" />

This will look better, once "arch" and "version" is fixed...

i.e. moving arch from configuration to connection
and moving version from connection to provider

```console
$ limactl --version
limactl version 2.0.1
$ limactl list podman
NAME      STATUS     SSH                VMTYPE    ARCH      CPUS    MEMORY    DISK      DIR
podman    Running    127.0.0.1:34813    qemu      x86_64    2       2GiB      100GiB    ~/.lima/podman
```

<img width="1171" height="128" alt="image" src="https://github.com/user-attachments/assets/f83b3693-a63a-4931-bff7-64d0a8ef6f31" />

```console
$ podman.lima version
Client:       Podman Engine
Version:      4.9.3
API Version:  4.9.3
Go Version:   go1.21.7
Git Commit:   8d2b55ddde1bc81f43d018dfc1ac027c06b26a7f
Built:        Fri Feb 16 11:30:23 2024
OS/Arch:      linux/amd64

Server:       Podman Engine
Version:      5.6.2
API Version:  5.6.2
Go Version:   go1.25.1 X:nodwarf5
Git Commit:   9dd5e1ed33830612bc200d7a13db00af6ab865a4
Built:        Tue Sep 30 02:00:00 2025
OS/Arch:      linux/amd64
```

### What issues does this PR fix or reference?

* https://github.com/podman-desktop/podman-desktop/issues/15250

* ~~#3748~~

* ~~#2916~~

### How to test this PR?

Based on/requires PR #16818

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

https://podman-desktop.io/docs/lima

```shell
brew install lima podman
```

```shell
limactl start template:podman
```