### PR TITLE
fix: remove kubernetesReadNamespacedPod.error telemetry

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -936,7 +936,6 @@ export class KubernetesClient {
       }
       return res;
     } catch (error) {
-      this.telemetry.track('kubernetesReadNamespacedPod.error', error);
       throw this.wrapK8sClientError(error);
     }
   }


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Removes the kubernetesReadNamespacedPod.error telemetry, which is sent too many times. 

I can see in the telemetry that in many cases it is due to 401 (unauthorized) errors, indaicating that the user tries to list the pods for a namespace on which he doesn't have the permission to do this. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #14751 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
