### PR TITLE
feat: set kubernetes experimental mode by default

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -247,6 +247,8 @@ export class KubernetesClient {
             githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/11424',
             image: kubernetesImage,
           },
+          // enabled by default
+          default: {},
         },
       },
     };


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Set kubernetes experimental mode by default. 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #15064 

### How to test this PR?

- Remove related configuration from `configuration/settings.json` file
- restart Podman Desktop
- Check in Settings > Experimental that `Kubernetes states Experimental` is a-enabled
 
- [ ] Tests are covering the bug fix or the new feature
