### PR TITLE
refactor(package: main): use object for analyzeExtension function parameters

### DIFF
--- a/packages/main/src/plugin/extension/extension-analyzer.spec.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.spec.ts
@@ -58,7 +58,10 @@ describe('analyze extension and main', () => {
     const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
     loadManifestMock.mockResolvedValue(fakeManifest);
 
-    const extension = await extensionAnalyzer.analyzeExtension(path.resolve('/', 'fake', 'path'), false, false);
+    const extension = await extensionAnalyzer.analyzeExtension({
+      extensionPath: path.resolve('/', 'fake', 'path'),
+      removable: false,
+    });
 
     expect(extension).toBeDefined();
     expect(extension?.error).toBeDefined();
@@ -91,7 +94,10 @@ describe('analyze extension and main', () => {
     const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
     loadManifestMock.mockResolvedValue(fakeManifest);
 
-    const extension = await extensionAnalyzer.analyzeExtension(path.resolve('/', 'linked', 'path'), false, false);
+    const extension = await extensionAnalyzer.analyzeExtension({
+      extensionPath: path.resolve('/', 'linked', 'path'),
+      removable: false,
+    });
 
     expect(extension).toBeDefined();
     expect(extension?.error).toBeDefined();
@@ -120,7 +126,10 @@ describe('analyze extension and main', () => {
     const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
     loadManifestMock.mockResolvedValue(fakeManifest);
 
-    const extension = await extensionAnalyzer.analyzeExtension('/fake/path', false, false);
+    const extension = await extensionAnalyzer.analyzeExtension({
+      extensionPath: '/fake/path',
+      removable: false,
+    });
 
     expect(extension).toBeDefined();
     expect(extension?.error).toBeDefined();
@@ -149,7 +158,11 @@ describe('analyze extension and main', () => {
     const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
     loadManifestMock.mockResolvedValue(fakeManifest);
 
-    const extension = await extensionAnalyzer.analyzeExtension('/fake/path', false, true);
+    const extension = await extensionAnalyzer.analyzeExtension({
+      extensionPath: '/fake/path',
+      removable: false,
+      devMode: true,
+    });
 
     expect(extension?.id).toBe('fooPublisher.fooName');
     expect(extension?.devMode).toBeTruthy();

--- a/packages/main/src/plugin/extension/extension-analyzer.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.ts
@@ -56,9 +56,15 @@ export interface AnalyzedExtension {
   dispose(): void;
 }
 
+export interface ExtensionAnalyzerOptions {
+  extensionPath: string;
+  removable: boolean;
+  devMode?: boolean;
+}
+
 @injectable()
 export class ExtensionAnalyzer {
-  async analyzeExtension(extensionPath: string, removable: boolean, devMode: boolean): Promise<AnalyzedExtension> {
+  async analyzeExtension({ extensionPath, removable, devMode }: ExtensionAnalyzerOptions): Promise<AnalyzedExtension> {
     const resolvedExtensionPath = await realpath(extensionPath);
     // do nothing if there is no package.json file
     let error = undefined;
@@ -72,8 +78,8 @@ export class ExtensionAnalyzer {
         manifest: undefined,
         readme: '',
         api: <typeof containerDesktopAPI>{},
-        removable,
-        devMode,
+        removable: removable,
+        devMode: devMode ?? false,
         subscriptions: [],
         dispose(): void {},
         error,
@@ -105,7 +111,7 @@ export class ExtensionAnalyzer {
       mainPath: manifest.main ? path.resolve(resolvedExtensionPath, manifest.main) : undefined,
       readme,
       removable,
-      devMode,
+      devMode: devMode ?? false,
       subscriptions: disposables,
       dispose(): void {
         for (const disposable of disposables) {

--- a/packages/main/src/plugin/extension/extension-development-folders.ts
+++ b/packages/main/src/plugin/extension/extension-development-folders.ts
@@ -129,7 +129,11 @@ export class ExtensionDevelopmentFolders {
     }
 
     // before adding the path, check it's a valid extension path
-    const analyzedExtension = await this.#extensionAnalyzer.analyzeExtension(path, false, true);
+    const analyzedExtension = await this.#extensionAnalyzer.analyzeExtension({
+      extensionPath: path,
+      removable: false,
+      devMode: true,
+    });
     // if there is an error, abort
     if (analyzedExtension.error) {
       throw new Error(analyzedExtension.error);

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -2586,7 +2586,10 @@ test('reload extensions', async () => {
   await extensionLoader.reloadExtension(extension, false);
 
   expect(deactivateSpy).toBeCalledWith(extension.id);
-  expect(analyzeExtensionSpy).toBeCalledWith(extension.path, false);
+  expect(analyzeExtensionSpy).toBeCalledWith({
+    extensionPath: extension.path,
+    removable: false,
+  });
   expect(loadExtensionSpy).toBeCalledWith(analyzedExtension, true);
 
   expect(vi.mocked(notificationRegistry.addNotification)).toBeCalledWith({

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -90,7 +90,7 @@ import { Uri } from '../types/uri.js';
 import { Exec } from '../util/exec.js';
 import { getFreePort } from '../util/port.js';
 import { ViewRegistry } from '../view-registry.js';
-import { type AnalyzedExtension, ExtensionAnalyzer } from './extension-analyzer.js';
+import { type AnalyzedExtension, ExtensionAnalyzer, ExtensionAnalyzerOptions } from './extension-analyzer.js';
 import { ExtensionDevelopmentFolders } from './extension-development-folders.js';
 import { ExtensionWatcher } from './extension-watcher.js';
 
@@ -312,7 +312,10 @@ export class ExtensionLoader implements IAsyncDisposable {
     // eslint-disable-next-line sonarjs/no-unsafe-unzip
     admZip.extractAllTo(unpackedDirectory, true);
 
-    const extension = await this.analyzeExtension(unpackedDirectory, true);
+    const extension = await this.analyzeExtension({
+      extensionPath: unpackedDirectory,
+      removable: true,
+    });
     if (!extension.error) {
       await this.loadExtension(extension);
       this.apiSender.send('extension-started', {});
@@ -462,12 +465,27 @@ export class ExtensionLoader implements IAsyncDisposable {
     const analyzedExtensions: AnalyzedExtension[] = [];
 
     const analyzedFoldersExtension = (
-      await Promise.all(folders.map(folder => this.analyzeExtension(folder, false)))
+      await Promise.all(
+        folders.map(folder =>
+          this.analyzeExtension({
+            extensionPath: folder,
+            removable: false,
+          }),
+        ),
+      )
     ).filter(extension => !extension.error);
     analyzedExtensions.push(...analyzedFoldersExtension);
 
     const analyzedExternalExtensions = (
-      await Promise.all(externalExtensions.map(folder => this.analyzeExtension(folder, false, true)))
+      await Promise.all(
+        externalExtensions.map(folder =>
+          this.analyzeExtension({
+            extensionPath: folder,
+            removable: false,
+            devMode: true,
+          }),
+        ),
+      )
     ).filter(extension => !extension.error);
     analyzedExtensions.push(...analyzedExternalExtensions);
 
@@ -481,7 +499,14 @@ export class ExtensionLoader implements IAsyncDisposable {
 
       // collect all extensions from the pluginDirectory folders
       const analyzedPluginsDirectoryExtensions: AnalyzedExtension[] = (
-        await Promise.all(pluginDirectories.map(folder => this.analyzeExtension(folder, true)))
+        await Promise.all(
+          pluginDirectories.map(folder =>
+            this.analyzeExtension({
+              extensionPath: folder,
+              removable: true,
+            }),
+          ),
+        )
       ).filter(extension => !extension.error);
       analyzedExtensions.push(...analyzedPluginsDirectoryExtensions);
     }
@@ -503,7 +528,11 @@ export class ExtensionLoader implements IAsyncDisposable {
   protected async loadDevelopmentFolderExtensions(analyzedExtensions: AnalyzedExtension[]): Promise<void> {
     for (const folder of this.extensionDevelopmentFolder.getDevelopmentFolders()) {
       if (fs.existsSync(folder.path)) {
-        const analyzedExtension = await this.analyzeExtension(folder.path, false, true);
+        const analyzedExtension = await this.analyzeExtension({
+          extensionPath: folder.path,
+          removable: false,
+          devMode: true,
+        });
         if (!analyzedExtension.error) {
           analyzedExtensions.push(analyzedExtension);
         } else {
@@ -686,7 +715,10 @@ export class ExtensionLoader implements IAsyncDisposable {
 
     // reload the extension
     try {
-      const updatedExtension = await this.analyzeExtension(extension.path, removable);
+      const updatedExtension = await this.analyzeExtension({
+        extensionPath: extension.path,
+        removable,
+      });
 
       if (!updatedExtension.error) {
         await this.loadExtension(updatedExtension, true);
@@ -814,12 +846,8 @@ export class ExtensionLoader implements IAsyncDisposable {
     }
   }
 
-  async analyzeExtension(
-    extensionPath: string,
-    removable: boolean,
-    devMode: boolean = false,
-  ): Promise<AnalyzedExtensionWithApi> {
-    const analyzedExtension = await this.extensionAnalyzer.analyzeExtension(extensionPath, removable, devMode);
+  async analyzeExtension(options: ExtensionAnalyzerOptions): Promise<AnalyzedExtensionWithApi> {
+    const analyzedExtension = await this.extensionAnalyzer.analyzeExtension(options);
 
     const api = this.createApi(analyzedExtension);
 
@@ -1826,7 +1854,11 @@ export class ExtensionLoader implements IAsyncDisposable {
 
     const extension = this.analyzedExtensions.get(extensionId);
     if (extension) {
-      const analyzedExtension = await this.analyzeExtension(extension.path, extension.removable, extension.devMode);
+      const analyzedExtension = await this.analyzeExtension({
+        extensionPath: extension.path,
+        removable: extension.removable,
+        devMode: extension.devMode,
+      });
 
       if (!analyzedExtension.error) {
         await this.loadExtension(analyzedExtension, true);

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -718,6 +718,7 @@ export class ExtensionLoader implements IAsyncDisposable {
       const updatedExtension = await this.analyzeExtension({
         extensionPath: extension.path,
         removable,
+        devMode: extension.devMode,
       });
 
       if (!updatedExtension.error) {

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -219,7 +219,10 @@ export class ExtensionInstaller {
     if (isPDExtension) {
       let analyzedExtension: AnalyzedExtension | undefined;
       try {
-        analyzedExtension = await this.extensionLoader.analyzeExtension(finalFolderPath, true);
+        analyzedExtension = await this.extensionLoader.analyzeExtension({
+          extensionPath: finalFolderPath,
+          removable: true,
+        });
       } catch (error) {
         sendError('Error while analyzing extension: ' + error);
       }


### PR DESCRIPTION
### What does this PR do?

For https://github.com/podman-desktop/podman-desktop/issues/15044, we will have 3 kind of extensions
- build-in (E.g. podman, kind)
- plugins (E.g. installed from catalog Quadlet)
- dev (E.g. from `--extension-folder` arg)
- extra (E.g. extensions specified in the product.json )

But they have different properties each

| kind | removable | devMode | updatable |
| --- | --- | --- | --- |
| `built-in` | 🔴 | 🔴  | 🔴 |
| `plugins` | 🟢 | 🔴  | 🟢 |
| `dev` | 🔴| 🟢 | 🔴 |
| `extra` | 🔴 | 🔴  | 🟢 |

The logic will be for extra extension, we load the extensions from the `app.asar` the same way we load `build-in` extensions, but we can overwrite them with new version inside the `plugins`.

When starting Podman Desktop, it will analyse all extensions, and if duplicate it will take the latest version and ignore previous.

This PR is just refactoring the params of the `analyzeExtension` function, we wil be able to easily add `updatable` then 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/15044

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
