### PR TITLE
fix(packages/renderer): display transient pods state + svelte 5 migrate [WIP]

### DIFF
--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -19,6 +19,7 @@
 import humanizeDuration from 'humanize-duration';
 import moment from 'moment';
 
+import { podsInfoUiOverrides } from '/@/states/pods-info-ui-overrides.svelte';
 import type { PodInfo } from '/@api/pod-info';
 
 import type { PodInfoUI } from './PodInfoUI';
@@ -72,6 +73,7 @@ export class PodUtils {
       selected: false,
       node: podinfo.node,
       namespace: podinfo.Namespace,
+      ...podsInfoUiOverrides.value[podinfo.Id],
     };
   }
 

--- a/packages/renderer/src/states/pods-info-ui-overrides.svelte.ts
+++ b/packages/renderer/src/states/pods-info-ui-overrides.svelte.ts
@@ -1,0 +1,6 @@
+import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
+
+export type TransientStatus = 'STARTING' | 'STOPPING' | 'RESTARTING' | 'DELETING' | 'ERROR';
+export type PodInfoOverride = Partial<PodInfoUI & { status: TransientStatus }>;
+
+export const podsInfoUiOverrides = $state<{ value: Record<string, PodInfoOverride> }>({ value: {} });

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -18,6 +18,7 @@
 
 import { derived, type Writable, writable } from 'svelte/store';
 
+import { podsInfoUiOverrides } from '/@/states/pods-info-ui-overrides.svelte';
 import type { PodInfo } from '/@api/pod-info';
 
 import PodIcon from '../lib/images/PodIcon.svelte';
@@ -80,6 +81,7 @@ export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $i
 });
 
 const listPods = (): Promise<PodInfo[]> => {
+  podsInfoUiOverrides.value = {};
   return window.listPods();
 };
 


### PR DESCRIPTION
### What does this PR do?

This PR is a demo of the handling of state management for Pods when they are "starting" or "stopping" (called transient states here).
It is a WIP to demonstrate one of the options that is blocking https://github.com/podman-desktop/podman-desktop/pull/14587

### Screenshot / video of UI

https://github.com/user-attachments/assets/23babf6a-7496-4dda-859e-f70554c6367c


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
