### PR TITLE
chore(ci): delete the tag and release of testing-builds if on of the …

### DIFF
--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -112,7 +112,7 @@ jobs:
       ELECTRON_ENABLE_INSPECT: true
       GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-24.04, windows-2025, macos-15]
     timeout-minutes: 60
@@ -157,9 +157,12 @@ jobs:
     if: github.event.repository.fork == false
     steps:
       - name: id
-        run: echo the release id is ${{ needs.tag.outputs.releaseId }}
+        run: | 
+          echo the release id is ${{ needs.tag.outputs.releaseId }}
+          echo "The result of the build jobs: ${{ needs.build.result }}"
 
       - name: Publish release
+        if: ${{ needs.build.result == 'success' }}
         uses: StuYarrow/publish-release@01f2a1365bacd77bad861873a7fdf274ab49eefd # v1.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
@@ -167,3 +170,22 @@ jobs:
           id: ${{ needs.tag.outputs.releaseId }}
           repo: testing-prereleases
           owner: podman-desktop
+      
+      - name: Delete release
+        if: ${{ needs.build.result != 'success' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+        run: |
+          echo "Build failed, deleting release with id: ${{ needs.tag.outputs.releaseId }}"
+          set -e
+          curl -L -f -X DELETE -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/podman-desktop/testing-prereleases/releases/${{ needs.tag.outputs.releaseId }}"
+          echo "Release deleted..."
+          echo "Delete tag: ${{ needs.tag.outputs.githubTag }}"
+          curl -L -f -X DELETE -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/podman-desktop/testing-prereleases/git/refs/tags/${{ needs.tag.outputs.githubTag }}"
+          echo "Tag deleted..."


### PR DESCRIPTION
…builds fails

### What does this PR do?
If delete the remote release and tag if one the daily testing-builds workflow builds failed.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/15144
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
