### PR TITLE
refactor(electron-builder): package extensions-extra

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -21,6 +21,8 @@ const Arch = require('builder-util').Arch;
 const path = require('path');
 const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
 const product = require('./product.json');
+const fs = require('node:fs');
+
 if (process.env.VITE_APP_VERSION === undefined) {
   const now = new Date();
   process.env.VITE_APP_VERSION = `${now.getUTCFullYear() - 2000}.${now.getUTCMonth() + 1}.${now.getUTCDate()}-${
@@ -62,6 +64,26 @@ async function addElectronFuses(context) {
     [FuseV1Options.RunAsNode]: false,
     [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
     [FuseV1Options.EnableNodeCliInspectArguments]: electronEnableInspect,
+  });
+}
+
+async function packageRemoteExtensions() {
+  const downloadScript = path.join('packages', 'main', 'dist', 'download-remote-extensions.cjs');
+  if(!fs.existsSync(downloadScript)) {
+    console.warn(`${downloadScript} not found, skipping remote extension download`);
+    return;
+  }
+
+  const destination = path.resolve('./extensions-extra');
+
+  return new Promise((resolve, reject) => {
+    exec(`node ${downloadScript} --output=${destination}`, (error, stdout, stderr) => {
+      if(error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
   });
 }
 
@@ -126,11 +148,14 @@ const config = {
         context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-arm64.zst`);
       }
     }
+
+    // download & package extensions
+    await packageRemoteExtensions();
   },
   afterPack: async context => {
     await addElectronFuses(context);
   },
-  files: ['packages/**/dist/**', 'extensions/**/builtin/*.cdix/**', 'packages/main/src/assets/**'],
+  files: ['packages/**/dist/**', 'extensions-extra/**', 'extensions/**/builtin/*.cdix/**', 'packages/main/src/assets/**'],
   portable: {
     artifactName: `${product.artifactName}${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
   },

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 /storybook/storybook-static/
 yarn.lock
 extensions/podman/assets/
+extensions-extra/**

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -451,11 +451,14 @@ export class ExtensionLoader implements IAsyncDisposable {
       fs.mkdirSync(this.extensionsStorageDirectory);
     }
 
-    let folders;
+    let folders: string[] = [];
     // scan all extensions that we can find from the extensions folder
     if (import.meta.env.PROD) {
       // in production mode, use the extensions locally
-      folders = await this.readProductionFolders(path.join(__dirname, '../../../extensions'));
+      folders = [
+        ...(await this.readProductionFolders(path.join(__dirname, '../../../extensions'))),
+        ...(await this.readDevelopmentFolders(path.join(__dirname, '../../../extensions-extra'))),
+      ];
     } else {
       // in development mode, use the extensions locally
       folders = await this.readDevelopmentFolders(path.join(__dirname, '../../../extensions'));
@@ -632,6 +635,8 @@ export class ExtensionLoader implements IAsyncDisposable {
   }
 
   async readDevelopmentFolders(folderPath: string): Promise<string[]> {
+    if (!fs.existsSync(folderPath)) return [];
+
     const entries = await fs.promises.readdir(folderPath, { withFileTypes: true });
     // filter only directories ignoring node_modules directory
     return entries


### PR DESCRIPTION
### What does this PR do?

Adding the logic inside the `packages/main` & `.electron-builder.config.cjs` to launch the script `download-remote-extensions.cjs` (Added in https://github.com/podman-desktop/podman-desktop/pull/15121)

### Screenshot / video of UI

Here is the result of the steps bellow (See `How to test this PR?`)

<img width="1046" height="469" alt="image" src="https://github.com/user-attachments/assets/65483c36-0f09-46f7-b8ef-70c5181f543a" />

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15044

### How to test this PR?

**Testing manually**

To test this PR, we will try to bundle the https://github.com/podman-desktop/extension-layers-explorer extension to the build of Podman Desktop

1. Checkout this PR
2. Ensure the `.local\share\containers\podman-desktop\plugins` does not contains the extension-layers plugin
3. Add the following inside the `product.json`

```json
{
  [...],
  "extensions": {
    "remote": [{
      "name": "podman-desktop-extension-layers-explorer",
      "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb"
    }]
  }
}
```

4. Run `pnpm compile:current`
5. Start / install Podman Desktop from the `./dist` folder
6. Go to `Extensions > Installed`
7. Assert you can see the Extension Layer extension
8. Open Details
9. Assert `(built-in)` in Published section