### PR TITLE
chore(main/extension-loader): ensure path exist before readdir

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -632,6 +632,9 @@ export class ExtensionLoader implements IAsyncDisposable {
   }
 
   async readDevelopmentFolders(folderPath: string): Promise<string[]> {
+    // only readdir on existing folder
+    if (!fs.existsSync(folderPath)) return [];
+
     const entries = await fs.promises.readdir(folderPath, { withFileTypes: true });
     // filter only directories ignoring node_modules directory
     return entries
@@ -660,6 +663,9 @@ export class ExtensionLoader implements IAsyncDisposable {
   }
 
   async readProductionFolders(folderPath: string): Promise<string[]> {
+    // only readdir on existing folder
+    if (!fs.existsSync(folderPath)) return [];
+
     const entries = await fs.promises.readdir(folderPath, { withFileTypes: true });
     return entries
       .filter(entry => entry.isDirectory() && entry.name !== 'node_modules')


### PR DESCRIPTION
### What does this PR do?

Adding a guard check on the folder, trying to `readdir` on a non-existing folder throw an error that freeze the init of Podman Desktop, making it unusable.

This is not a bug currently as this scenario never happen. However this may happen with the `extensions-extra` packaging that will be introduced in https://github.com/podman-desktop/podman-desktop/pull/15147

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/pull/15147

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
