### PR TITLE
feat(podman kube play): support `replace` option

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6058,6 +6058,10 @@ describe('kube play', () => {
     ApiVersion: '1.41',
   } as unknown as Dockerode.DockerVersion;
 
+  const KUBE_PLAY_OPT = {
+    replace: true,
+  };
+
   beforeEach(() => {
     vi.resetAllMocks();
   });
@@ -6086,12 +6090,16 @@ describe('kube play', () => {
     // set provider
     containerRegistry.addInternalProvider('podman.podman', PODMAN_PROVIDER);
 
-    await containerRegistry.playKube('dummy-file', {
-      name: PODMAN_PROVIDER.name,
-      endpoint: PODMAN_PROVIDER.connection.endpoint,
-    } as unknown as ProviderContainerConnectionInfo);
+    await containerRegistry.playKube(
+      'dummy-file',
+      {
+        name: PODMAN_PROVIDER.name,
+        endpoint: PODMAN_PROVIDER.connection.endpoint,
+      } as unknown as ProviderContainerConnectionInfo,
+      KUBE_PLAY_OPT,
+    );
 
-    expect(PODMAN_PROVIDER.libpodApi.playKube).toHaveBeenCalledWith('dummy-file');
+    expect(PODMAN_PROVIDER.libpodApi.playKube).toHaveBeenCalledWith('dummy-file', KUBE_PLAY_OPT);
   });
 
   test('KubePlayContext returning zero build contexts should play kube with file', async () => {
@@ -6101,11 +6109,15 @@ describe('kube play', () => {
     // set provider
     containerRegistry.addInternalProvider('podman.podman', PODMAN_PROVIDER);
 
-    await containerRegistry.playKube('dummy-file', {
-      name: PODMAN_PROVIDER.name,
-      endpoint: PODMAN_PROVIDER.connection.endpoint,
-    } as unknown as ProviderContainerConnectionInfo);
+    await containerRegistry.playKube(
+      'dummy-file',
+      {
+        name: PODMAN_PROVIDER.name,
+        endpoint: PODMAN_PROVIDER.connection.endpoint,
+      } as unknown as ProviderContainerConnectionInfo,
+      KUBE_PLAY_OPT,
+    );
 
-    expect(PODMAN_PROVIDER.libpodApi.playKube).toHaveBeenCalledWith('dummy-file');
+    expect(PODMAN_PROVIDER.libpodApi.playKube).toHaveBeenCalledWith('dummy-file', KUBE_PLAY_OPT);
   });
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2530,9 +2530,13 @@ export class ContainerProviderRegistry {
     selectedProvider: ProviderContainerConnectionInfo,
     options?: {
       build?: boolean;
+      replace?: boolean;
     },
   ): Promise<PlayKubeInfo> {
-    const telemetryOptions: Record<string, unknown> = {};
+    const telemetryOptions: Record<string, unknown> = {
+      build: options?.build ?? false,
+      replace: options?.replace ?? false,
+    };
     try {
       const provider = this.getMatchingContainerProvider(selectedProvider);
       if (!provider?.libpodApi) {
@@ -2541,7 +2545,7 @@ export class ContainerProviderRegistry {
 
       // if we don't build, we use the file directory
       if (!options?.build) {
-        return provider.libpodApi.playKube(kubernetesYamlFilePath);
+        return provider.libpodApi.playKube(kubernetesYamlFilePath, options);
       }
 
       // ensure build support is true, otherwise let's throw a nice user friendly error
@@ -2556,12 +2560,10 @@ export class ContainerProviderRegistry {
 
       // if we have no context let's just use the the yaml
       if (kubePlay.getBuildContexts().length === 0) {
-        return provider.libpodApi.playKube(kubernetesYamlFilePath);
+        return provider.libpodApi.playKube(kubernetesYamlFilePath, options);
       }
 
-      return provider.libpodApi.playKube(kubePlay.build(), {
-        build: true,
-      });
+      return provider.libpodApi.playKube(kubePlay.build(), options);
     } catch (error: unknown) {
       telemetryOptions['error'] = error;
       throw error;

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -353,7 +353,10 @@ export interface LibPod {
   resolveShortnameImage(shortname: string): Promise<{ Names: string[] }>;
   restartPod(podId: string): Promise<void>;
   generateKube(names: string[]): Promise<string>;
-  playKube(file: string | NodeJS.ReadableStream, options?: { build?: boolean }): Promise<PlayKubeInfo>;
+  playKube(
+    file: string | NodeJS.ReadableStream,
+    options?: { build?: boolean; replace?: boolean },
+  ): Promise<PlayKubeInfo>;
   pruneAllImages(dangling: boolean): Promise<void>;
   podmanInfo(): Promise<Info>;
   getImages(options: GetImagesOptions): Promise<NodeJS.ReadableStream>;
@@ -802,10 +805,16 @@ export class LibpodDockerode {
     // add playKube
     prototypeOfDockerode.playKube = function (
       file: string | NodeJS.ReadableStream,
-      options?: { build?: boolean },
+      options?: { build?: boolean; replace?: boolean },
     ): Promise<PlayKubeInfo> {
+      const queries: string[] = [];
+      if (options?.replace === true) {
+        queries.push(`replace=true`);
+      }
+
       const optsf = {
-        path: '/v4.2.0/libpod/play/kube',
+        // N.B: last ? will be cut by the modem dial call
+        path: `/v4.2.0/libpod/play/kube?${queries.join('&')}?`,
         method: 'POST',
         file: file,
         statusCodes: {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1037,6 +1037,7 @@ export class PluginSystem {
         selectedProvider: ProviderContainerConnectionInfo,
         options?: {
           build?: boolean;
+          replace?: boolean;
         },
       ): Promise<PlayKubeInfo> => {
         return containerProviderRegistry.playKube(yamlFilePath, selectedProvider, options);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -403,6 +403,7 @@ export function initExposure(): void {
       selectedProvider: ProviderContainerConnectionInfo,
       options?: {
         build?: boolean;
+        replace?: boolean;
       },
     ): Promise<PlayKubeInfo> => {
       return ipcInvoke('container-provider-registry:playKube', relativeContainerfilePath, selectedProvider, options);

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -273,7 +273,7 @@ describe('Options', () => {
     setup();
     const { getByRole, getByLabelText } = render(KubePlayYAML, {});
 
-    // Enable build
+    // Enable replace
     const checkbox = getByRole('checkbox', { name: 'Replace' });
     await userEvent.click(checkbox);
 

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -220,13 +220,26 @@ test('expect workflow selection boxes have the correct selection borders', async
   expect(customOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border)]');
 });
 
-describe('Build options', () => {
-  test('checkbox should be disabled by default', async () => {
+describe('Options', () => {
+  test('build checkbox should be disabled by default', async () => {
     setup();
     const { getByRole } = render(KubePlayYAML, {});
 
     const checkbox = await vi.waitFor(() => {
       const element = getByRole('checkbox', { name: 'Enable build' });
+      expect(element).toBeInstanceOf(HTMLInputElement);
+      return element;
+    });
+
+    expect(checkbox).not.toBeChecked();
+  });
+
+  test('replace checkbox should be disabled by default', async () => {
+    setup();
+    const { getByRole } = render(KubePlayYAML, {});
+
+    const checkbox = await vi.waitFor(() => {
+      const element = getByRole('checkbox', { name: 'Replace' });
       expect(element).toBeInstanceOf(HTMLInputElement);
       return element;
     });
@@ -253,6 +266,28 @@ describe('Build options', () => {
       'Containerfile',
       expect.anything(),
       expect.objectContaining({ build: true }),
+    );
+  });
+
+  test('enabled replace option propagates to playKube call', async () => {
+    setup();
+    const { getByRole, getByLabelText } = render(KubePlayYAML, {});
+
+    // Enable build
+    const checkbox = getByRole('checkbox', { name: 'Replace' });
+    await userEvent.click(checkbox);
+
+    // Select file and play
+    const browseButton = getByLabelText('browse');
+    await userEvent.click(browseButton);
+
+    const playButton = screen.getByRole('button', { name: 'Play' });
+    await userEvent.click(playButton);
+
+    expect(window.playKube).toHaveBeenCalledWith(
+      'Containerfile',
+      expect.anything(),
+      expect.objectContaining({ replace: true }),
     );
   });
 });

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -21,6 +21,7 @@ let runStarted = $state(false);
 let runFinished = $state(false);
 let runError = $state('');
 let kubeBuild: boolean = $state(false);
+let kubeReplace: boolean = $state(false);
 let runWarning = $state('');
 let kubernetesYamlFilePath: string | undefined = $state(undefined);
 let customYamlContent: string = $state('');
@@ -96,8 +97,11 @@ async function playKubeFile(): Promise<void> {
     if (yamlFilePath && selectedProviderConnection) {
       try {
         const result = await window.playKube(yamlFilePath, $state.snapshot(selectedProviderConnection), {
-          build: kubeBuild,
+          build: $state.snapshot(kubeBuild),
+          replace: $state.snapshot(kubeReplace),
         });
+
+        console.log('window.playKube result', result);
 
         // remove the null values from the result
         playKubeResultRaw = JSON.stringify(removeEmptyOrNull(result), undefined, 2);
@@ -284,11 +288,16 @@ function toggle(choice: 'podman' | 'custom'): void {
         </div>
       {/if}
 
-      <div >
-        <div class="text-base font-bold text-[var(--pd-content-card-header-text)]">Build options</div>
-        <Checkbox class="mx-1 my-auto" title="Enable build" bind:checked={kubeBuild} >
-          <div>Enable build</div>
-        </Checkbox>
+      <div class="flex flex-col gap-y-2">
+        <div class="text-base font-bold text-[var(--pd-content-card-header-text)]">Options</div>
+        <div class="flex flex-row gap-x-2">
+          <Checkbox class="mx-1 my-auto" title="Enable build" bind:checked={kubeBuild} >
+            <div>Enable build</div>
+          </Checkbox>
+          <Checkbox class="mx-1 my-auto" title="Replace" bind:checked={kubeReplace} >
+            <div>Replace</div>
+          </Checkbox>
+        </div>
       </div>
 
       {#if !runFinished}

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -101,8 +101,6 @@ async function playKubeFile(): Promise<void> {
           replace: $state.snapshot(kubeReplace),
         });
 
-        console.log('window.playKube result', result);
-
         // remove the null values from the result
         playKubeResultRaw = JSON.stringify(removeEmptyOrNull(result), undefined, 2);
         playKubeResultJSON = JSON.parse(playKubeResultRaw);


### PR DESCRIPTION
### What does this PR do?

When applying a YAML for the [Podman Kube Play](https://docs.podman.io/en/v5.5.1/markdown/podman-kube-play.1.html) feature, you cannot re-applied a modified version if resources already exists. Through the cli this is solved by adding `--replace`. The libpodAPI do support this feature, so adding it.

### Screenshot / video of UI

<img width="690" height="484" alt="image" src="https://github.com/user-attachments/assets/1bf33e59-3988-423b-ac8e-13d9b9e24b77" />

https://github.com/user-attachments/assets/78ca0684-e4a3-4bd7-8815-89671de3d65f

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14632

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. Checkout branch
2. Go to `Pods > Podman Kube Play`
3. Select `Create file from scratch`
4. Paste the following content
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
    - name: nginx
      image: nginx
      ports:
        - containerPort: 80
```
5. Click on `Play Custom YAML`
6. Click on Done
7. Go back to the `Pods > Podman Kube Play`
8. Paste the content from step 4
9. Assert error ` name "nginx" is in use: pod already exists`
10. Select the `replace` checkbox
11. Click on `Play Custom YAML`
12. Assert it works as expected