### PR TITLE
feat(extension-loader): load extensions-extra in PROD mode

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -282,6 +282,7 @@ const extensionWatcher = {
   stop: vi.fn(),
   dispose: vi.fn(),
   reloadExtension: vi.fn(),
+  onNeedToReloadExtension: vi.fn(),
 } as unknown as ExtensionWatcher;
 
 const extensionDevelopmentFolder = {
@@ -378,6 +379,29 @@ vi.mock('node:fs');
 beforeEach(() => {
   telemetryTrackMock.mockImplementation(() => Promise.resolve());
   vi.clearAllMocks();
+
+  vi.mocked(extensionDevelopmentFolder).getDevelopmentFolders.mockReturnValue([]);
+});
+
+describe('extensionLoader#start', () => {
+  test('should load extensions & extensions-extra', async () => {
+    vi.stubEnv('PROD', true);
+
+    const readProductionFoldersMock = vi.spyOn(extensionLoader, 'readProductionFolders');
+    readProductionFoldersMock.mockResolvedValue([]);
+    const readDevelopmentFoldersMock = vi.spyOn(extensionLoader, 'readDevelopmentFolders');
+    readDevelopmentFoldersMock.mockResolvedValue([]);
+
+    await extensionLoader.start();
+
+    expect(readProductionFoldersMock).toHaveBeenCalledOnce();
+    const prodFolder = readProductionFoldersMock.mock.calls[0]?.[0];
+    expect(prodFolder?.endsWith('extensions')).toBeTruthy();
+
+    expect(readDevelopmentFoldersMock).toHaveBeenCalledOnce();
+    const devFolder = readDevelopmentFoldersMock.mock.calls[0]?.[0];
+    expect(devFolder?.endsWith('extensions-extra')).toBeTruthy();
+  });
 });
 
 test('Should watch for files and load them at startup', async () => {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -452,11 +452,16 @@ export class ExtensionLoader implements IAsyncDisposable {
       fs.mkdirSync(this.extensionsStorageDirectory);
     }
 
-    let folders;
+    let folders: string[];
     // scan all extensions that we can find from the extensions folder
     if (import.meta.env.PROD) {
-      // in production mode, use the extensions locally
-      folders = await this.readProductionFolders(path.join(__dirname, '../../../extensions'));
+      // in production mode, use the extensions & extensions-extra locally
+      const promises = await Promise.all([
+        this.readProductionFolders(path.join(__dirname, '../../../extensions')),
+        this.readDevelopmentFolders(path.join(__dirname, '../../../extensions-extra')),
+      ]);
+
+      folders = promises.flat();
     } else {
       // in development mode, use the extensions locally
       folders = await this.readDevelopmentFolders(path.join(__dirname, '../../../extensions'));


### PR DESCRIPTION
### What does this PR do?

Make the `ExtensionLoader` class loading the `extensions-extra` folder in production mode. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15044
Require rebase after
- https://github.com/podman-desktop/podman-desktop/pull/15158
Require for:
- https://github.com/podman-desktop/podman-desktop/pull/15165

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Checkout this PR
2. Ensure the .local\share\containers\podman-desktop\plugins does not contains the extension-layers plugin
3. Add the following inside the product.json
```json
{
  [...],
  "extensions": {
    "remote": [{
      "name": "podman-desktop-extension-layers-explorer",
      "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb"
    }]
  }
}
```
4. run `pnpm build:main`
5. run ` node .\packages\main\dist\download-remote-extensions.cjs --output="$pwd\\extensions-extra"` 
> The cmd is for windows, `--output` need to be abs path, pls adapt to your platform
6. Add `extensions-extra/**` to the following files in `.electron-builder.config.cjs`

https://github.com/podman-desktop/podman-desktop/blob/e1fca22fc15bb44bd19293fa9b2e3519b03c9824/.electron-builder.config.cjs#L133

7. Run `pnpm compile:current`
8. Start Podman Desktop from the dist folder
9. Go to `Extensions`
10. Assert the `Layer Explorer` extension is available, and marked as `builtin`