### PR TITLE
feat(electron-builder): download & bundle extensions-extra from product.json

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -72,7 +72,6 @@ async function addElectronFuses(context) {
  * to the extensions-extra folder
  *
  * @remarks it should be called in the beforePack to populate the folder extensions-extra before electron builder pack them
- * @return {Promise<void>}
  */
 async function packageRemoteExtensions() {
   const downloadScript = path.join('packages', 'main', 'dist', 'download-remote-extensions.cjs');

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -83,18 +83,15 @@ async function packageRemoteExtensions() {
   const destination = path.resolve('./extensions-extra');
 
   return new Promise((resolve, reject) => {
-    execFile(
-      'node',
-      [downloadScript, `--output=${destination}`],
-      (error, stdout, stderr) => {
-        console.log(stdout);
-        console.log(stderr);
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
+    execFile('node', [downloadScript, `--output=${destination}`], (error, stdout, stderr) => {
+      console.log(stdout);
+      console.log(stderr);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
   });
 }
 

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -111,6 +111,9 @@ const config = {
     const PODMAN_EXTENSION_ASSETS = 'extensions/podman/packages/extension/assets';
     context.packager.config.extraResources = DEFAULT_ASSETS;
 
+    // download & package remote extensions
+    await packageRemoteExtensions();
+
     // include product.json
     context.packager.config.extraResources.push({
       from: 'product.json',
@@ -154,9 +157,6 @@ const config = {
         context.packager.config.extraResources.push(`${PODMAN_EXTENSION_ASSETS}/podman-image-arm64.zst`);
       }
     }
-
-    // download & package extensions
-    await packageRemoteExtensions();
   },
   afterPack: async context => {
     await addElectronFuses(context);

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-const exec = require('child_process').exec;
+const { exec, execFile } = require('child_process');
 const Arch = require('builder-util').Arch;
 const path = require('path');
 const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
@@ -83,7 +83,10 @@ async function packageRemoteExtensions() {
   const destination = path.resolve('./extensions-extra');
 
   return new Promise((resolve, reject) => {
-    exec(`node ${downloadScript} --output=${destination}`, (error, stdout, stderr) => {
+    execFile('node', [
+      downloadScript,
+      `--output=${destination}`,
+    ], (error, stdout, stderr) => {
       if(error) {
         reject(error);
       } else {

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -83,13 +83,18 @@ async function packageRemoteExtensions() {
   const destination = path.resolve('./extensions-extra');
 
   return new Promise((resolve, reject) => {
-    execFile('node', [downloadScript, `--output=${destination}`], (error, stdout, stderr) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
-    });
+    execFile(
+      'node',
+      [downloadScript, `--output=${destination}`],
+      (error, stdout, stderr) => {
+        console.log(stdout);
+        console.log(stderr);
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
   });
 }
 

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -75,7 +75,7 @@ async function addElectronFuses(context) {
  */
 async function packageRemoteExtensions() {
   const downloadScript = path.join('packages', 'main', 'dist', 'download-remote-extensions.cjs');
-  if(!fs.existsSync(downloadScript)) {
+  if (!fs.existsSync(downloadScript)) {
     console.warn(`${downloadScript} not found, skipping remote extension download`);
     return;
   }
@@ -83,11 +83,8 @@ async function packageRemoteExtensions() {
   const destination = path.resolve('./extensions-extra');
 
   return new Promise((resolve, reject) => {
-    execFile('node', [
-      downloadScript,
-      `--output=${destination}`,
-    ], (error, stdout, stderr) => {
-      if(error) {
+    execFile('node', [downloadScript, `--output=${destination}`], (error, stdout, stderr) => {
+      if (error) {
         reject(error);
       } else {
         resolve();
@@ -164,7 +161,12 @@ const config = {
   afterPack: async context => {
     await addElectronFuses(context);
   },
-  files: ['packages/**/dist/**', 'extensions-extra/**', 'extensions/**/builtin/*.cdix/**', 'packages/main/src/assets/**'],
+  files: [
+    'packages/**/dist/**',
+    'extensions-extra/**',
+    'extensions/**/builtin/*.cdix/**',
+    'packages/main/src/assets/**',
+  ],
   portable: {
     artifactName: `${product.artifactName}${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
   },


### PR DESCRIPTION
### What does this PR do?

Allow remote extensions to be bundled in the Podman Desktop binaries; This PR is the last step of the first version of loading remote extensions in the assembly.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15044
Require rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/15164
- https://github.com/podman-desktop/podman-desktop/pull/15158

Fixes https://github.com/podman-desktop/podman-desktop/issues/15166
Fixes https://github.com/podman-desktop/podman-desktop/issues/15170

### How to test this PR?

**Testing manually**

To test this PR, we will try to bundle the https://github.com/podman-desktop/extension-layers-explorer extension to the build of Podman Desktop

1. Checkout this PR
2. Ensure the `.local\share\containers\podman-desktop\plugins` does not contains the extension-layers plugin
3. Add the following inside the `product.json`

```json
{
  [...],
  "extensions": {
    "remote": [{
      "name": "podman-desktop-extension-layers-explorer",
      "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb"
    }]
  }
}
```

4. Run `pnpm compile:current`
5. Start / install Podman Desktop from the `./dist` folder
6. Go to `Extensions > Installed`
7. Assert you can see the Extension Layer extension
8. Open Details
9. Assert `(built-in)` in Published section