### PR TITLE
fix(podman): see if podman is installed for default registries

### DIFF
--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
@@ -303,7 +303,7 @@ test('when loadDefaultUserRegistries is called, make sure it calls all three fun
   expect(registryConfiguration.saveRegistriesConfContent).toBeCalled();
 });
 
-test('when loadDefaultUserRegistries is called and there are no default registries, it does not save', async () => {
+test('when loadDefaultUserRegistries is called and there are no default registries, it does not check podman machine VM or save', async () => {
   const mockDefaultRegistryLoader = {
     loadFromConfiguration: vi.fn().mockReturnValue([]),
     resolveConflicts: vi.fn(),
@@ -313,14 +313,45 @@ test('when loadDefaultUserRegistries is called and there are no default registri
 
   vi.spyOn(registryConfiguration, 'readRegistriesConfContent').mockResolvedValue({ registry: [] });
   vi.spyOn(registryConfiguration, 'saveRegistriesConfContent').mockResolvedValue();
-  vi.spyOn(registryConfiguration, 'checkRegistryConfFileExistsInVm').mockResolvedValue(true);
+  const checkVmSpy = vi.spyOn(registryConfiguration, 'checkRegistryConfFileExistsInVm').mockResolvedValue(true);
 
   vi.mocked(env).isMac = true;
 
   await registryConfiguration.loadDefaultUserRegistries();
 
-  // Make sure the only call is loadFromConfiguration! Resolve conflicts as well as saveRegistriesConfContent should NOT be called
+  // Only loadFromConfiguration should be called - VM check should be skipped when no registries configured
   expect(mockDefaultRegistryLoader.loadFromConfiguration).toBeCalled();
+  expect(checkVmSpy).not.toBeCalled();
   expect(mockDefaultRegistryLoader.resolveConflicts).not.toBeCalled();
   expect(registryConfiguration.saveRegistriesConfContent).not.toBeCalled();
+});
+
+test('when loadDefaultUserRegistries encounters an error (ex. podman not installed), it handles gracefully and does not block extension startup', async () => {
+  // Simulate podman not being installed by having checkRegistryConfFileExistsInVm throw
+  // an error of 'spawn podman ENOENT' (which is what happens when trying to run podman when it's not installed)
+  const mockDefaultRegistryLoader = {
+    loadFromConfiguration: vi.fn().mockReturnValue([{ prefix: 'registry1', location: '/registry1/foo' }]),
+    resolveConflicts: vi.fn(),
+  } as unknown as DefaultRegistryLoader;
+  registryConfiguration = new RegistryConfigurationImpl(mockDefaultRegistryLoader);
+  vi.spyOn(registryConfiguration, 'checkRegistryConfFileExistsInVm').mockRejectedValue(
+    new Error('spawn podman ENOENT'),
+  );
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  // Mock the environment to macOS to make sure we are doing the "VM" check (mac uses podman machine)
+  vi.mocked(env).isMac = true;
+
+  // Should not throw and is handled gracefully, as we cannot setup registries if podman if podman is not installed
+  // and we do not want to block extension startup in this case
+  await expect(registryConfiguration.loadDefaultUserRegistries()).resolves.toBeUndefined();
+
+  // Verify warning was logged on startup
+  expect(consoleWarnSpy).toHaveBeenCalledWith(
+    'Unable to load default user registries (podman may have not been installed):',
+    expect.any(Error),
+  );
+
+  // We expect the configuration to still attempt to load the default registries (since mockDefaultRegistryLoader is returning the registry values)
+  expect(mockDefaultRegistryLoader.loadFromConfiguration).toBeCalled();
 });

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
@@ -347,10 +347,7 @@ test('when loadDefaultUserRegistries encounters an error (ex. podman not install
   await expect(registryConfiguration.loadDefaultUserRegistries()).resolves.toBeUndefined();
 
   // Verify warning was logged on startup
-  expect(consoleWarnSpy).toHaveBeenCalledWith(
-    'Unable to load default user registries (podman may have not been installed):',
-    expect.any(Error),
-  );
+  expect(consoleWarnSpy).toHaveBeenCalledWith('Unable to load default user registries:', expect.any(Error));
 
   // We expect the configuration to still attempt to load the default registries (since mockDefaultRegistryLoader is returning the registry values)
   expect(mockDefaultRegistryLoader.loadFromConfiguration).toBeCalled();

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
@@ -159,11 +159,11 @@ export class RegistryConfigurationImpl implements RegistryConfiguration {
           return;
         }
       } catch (error: unknown) {
-        // Gracefully handle podman installation issues to avoid blocking extension activation.
-        // This typically occurs when podman is not installed (ENOENT error), while trying to check the VM.
-        // Note: If podman is installed but no machines exist or machines are stopped,
-        // the code returns early without error - this catch is specifically for binary issues.
-        console.warn('Unable to load default user registries (podman may have not been installed):', error);
+        // Gracefully handle errors to avoid blocking extension activation.
+        // This can occur for various reasons: podman not installed, VM connectivity issues,
+        // SSH failures, or other unexpected errors while checking the VM state. This would occur in the rare
+        // case where the user has configured registries, but the podman binary not accessible.
+        console.warn('Unable to load default user registries:', error);
         return;
       }
     }


### PR DESCRIPTION
fix(podman): see if podman is installed, check settings.json

### What does this PR do?

* Fixes the issue of podman extension not starting if podman is not
  installed when using the `loadDefaultUserRegistries()` function.
* Moves the settings.json registry check EARLIER so that we return earlier and do
  not check the VM / etc.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/15160

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Uninstall podman binary completely
2. `pnpm watch` this PR with PD
3. Open PD
4. Podman extension no longer fails when opening

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
