### PR TITLE
fix(main): download-remote-extensions support tmp dir on different device than output

### DIFF
--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -28,7 +28,6 @@ import product from '/@product.json' with { type: 'json' };
 
 import type { RemoteExtension } from './download-remote-extensions.js';
 import { downloadExtension, getRemoteExtensions, main } from './download-remote-extensions.js';
-import ErrnoException = NodeJS.ErrnoException;
 
 vi.mock(import('node:fs/promises'));
 vi.mock(import('node:fs'));
@@ -77,7 +76,7 @@ describe('downloadExtension', () => {
   test('if rename throw ErrnoException', async () => {
     vi.mocked(rename).mockRejectedValue({
       code: 'EXDEV',
-    } as ErrnoException);
+    } as NodeJS.ErrnoException);
 
     await downloadExtension(ABS_DEST_DIR, REMOTE_INFO_MOCK);
 

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -19,7 +19,7 @@
 import 'reflect-metadata';
 
 import { existsSync } from 'node:fs';
-import { mkdir, rename } from 'node:fs/promises';
+import { cp, mkdir, rename, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 
@@ -79,7 +79,30 @@ export async function downloadExtension(destination: string, info: RemoteExtensi
   await mkdir(destination, { recursive: true });
 
   // rename tmp to destination
-  await rename(join(tmpFolderPath, 'extension'), finalPath);
+  await moveSafely(join(tmpFolderPath, 'extension'), finalPath);
+}
+
+/**
+ * On a platform where the tmpdir is not on the same device as the destination
+ * the rename will fail
+ * @param src
+ * @param dest
+ */
+export async function moveSafely(src: string, dest: string): Promise<void> {
+  try {
+    await rename(src, dest);
+  } catch (error: unknown) {
+    if (!error || typeof error !== 'object' || !('code' in error)) {
+      throw error;
+    }
+
+    if (error.code !== 'EXDEV') {
+      throw error;
+    }
+
+    await cp(src, dest, { recursive: true });
+    await rm(src, { recursive: true });
+  }
 }
 
 export function getRemoteExtensions(): RemoteExtension[] {

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -85,8 +85,6 @@ export async function downloadExtension(destination: string, info: RemoteExtensi
 /**
  * On a platform where the tmpdir is not on the same device as the destination
  * the rename will fail
- * @param src
- * @param dest
  */
 export async function moveSafely(src: string, dest: string): Promise<void> {
   try {


### PR DESCRIPTION
### What does this PR do?

Very niche edge case where the rename would failed if the tmp dir is on a different device/fs than the output directory caught by @feloy 

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15188

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Checkout this branch
2. Add the following to the product.json
```json
{
  [...],
  "extensions": {
    "remote": [{
      "name": "podman-desktop-extension-layers-explorer",
      "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb"
    }]
  }
}
```
4. Run `pnpm build:main`
5. Run ` node .\packages\main\dist\download-remote-extensions.cjs --output="$pwd\\extensions-extra"`