### PR TITLE
fix(renderer): remove default w-full on label

### DIFF
--- a/packages/renderer/src/lib/ui/Label.svelte
+++ b/packages/renderer/src/lib/ui/Label.svelte
@@ -8,12 +8,13 @@ interface Props {
   role?: string;
   capitalize?: boolean;
   children?: Snippet;
+  containerClass?: string;
 }
 
-let { name = '', tip = '', role, capitalize = false, children }: Props = $props();
+let { name = '', tip = '', role, capitalize = false, containerClass, children }: Props = $props();
 </script>
 
-<Tooltip containerClass="w-full" top tip={tip}>
+<Tooltip containerClass={containerClass} top tip={tip}>
   <div
     role={role}
     class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-sm text-[var(--pd-label-text)] gap-x-1 w-full">

--- a/packages/renderer/src/lib/ui/ProviderInfo.svelte
+++ b/packages/renderer/src/lib/ui/ProviderInfo.svelte
@@ -30,6 +30,6 @@ function getProviderName(providerName: string): ProviderNameType {
 }
 </script>
 
-<Label tip={provider === 'Kubernetes' ? context : ''} name={provider} capitalize>
+<Label containerClass="w-full" tip={provider === 'Kubernetes' ? context : ''} name={provider} capitalize>
   <ProviderInfoCircle type={providerName} />
 </Label>


### PR DESCRIPTION
### What does this PR do?

https://github.com/podman-desktop/podman-desktop/pull/15028 introduced  new `containerClass` on the `ToolTip` component. 

https://github.com/podman-desktop/podman-desktop/pull/15055 set the `containerClass` in the `Label` component, but as this component is used in several places, it had unfortunate consequences.

This is not a revert of https://github.com/podman-desktop/podman-desktop/pull/15055 as another solution is to propagate the `containerClass` to the props of the Label, and use it only when needed rather than by default.

### Screenshot / video of UI

We keep the fix for the provider info :+1: 

<img width="452" height="273" alt="image" src="https://github.com/user-attachments/assets/1eceea7d-f1f3-41e8-a11c-e32076d20b0c" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15175

### How to test this PR?

- Check the `Settings > Experimental`: assert nothing weird
