### PR TITLE
fix: allow to fetch extension from OCI registries with long segments

### DIFF
--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -338,6 +338,42 @@ describe('extractImageDataFromImageName', () => {
   test('invalid empty', async () => {
     expect(() => imageRegistry.extractImageDataFromImageName('')).toThrow('Image name is empty');
   });
+
+  test('OCI image with three path segments', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('quay.io/foo/bar/my-ext');
+    expect(nameAndTag.registry).toBe('quay.io');
+    expect(nameAndTag.registryURL).toBe('https://quay.io/v2');
+    expect(nameAndTag.tag).toBe('latest');
+    expect(nameAndTag.name).toBe('foo/bar/my-ext');
+  });
+
+  test('OCI image with three path segments and tag', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName('quay.io/foo/bar/my-ext:v1.2.3');
+    expect(nameAndTag.registry).toBe('quay.io');
+    expect(nameAndTag.registryURL).toBe('https://quay.io/v2');
+    expect(nameAndTag.tag).toBe('v1.2.3');
+    expect(nameAndTag.name).toBe('foo/bar/my-ext');
+  });
+
+  test('OCI image with four path segments', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName(
+      'registry.example.com/org/team/project/image:v1.0.0',
+    );
+    expect(nameAndTag.registry).toBe('registry.example.com');
+    expect(nameAndTag.registryURL).toBe('https://registry.example.com/v2');
+    expect(nameAndTag.tag).toBe('v1.0.0');
+    expect(nameAndTag.name).toBe('org/team/project/image');
+  });
+
+  test('OCI image with five path segments', () => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName(
+      'myregistry.io/level1/level2/level3/level4/myimage:latest',
+    );
+    expect(nameAndTag.registry).toBe('myregistry.io');
+    expect(nameAndTag.registryURL).toBe('https://myregistry.io/v2');
+    expect(nameAndTag.tag).toBe('latest');
+    expect(nameAndTag.name).toBe('level1/level2/level3/level4/myimage');
+  });
 });
 
 test('expect getImageConfigLabels works', async () => {

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -422,7 +422,8 @@ export class ImageRegistry {
       valid = true;
     } else if (slashes.length > 2 && slashes[0]) {
       registry = slashes[0];
-      name = `${slashes[1]}/${slashes[2]}`;
+      // join all remaining parts as the image name
+      name = slashes.slice(1).join('/');
       valid = true;
     }
     if (!valid) {


### PR DESCRIPTION
### What does this PR do?
if a registry is allowing multiple segments like my-registry/my-org/my-sub-org/my-image (rather than the classical my-registry/my-org/my-image) then it's failing to fetch properly the image in case of authentication


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/15176

### How to test this PR?

I've added a test, fix also look like straightforward to keep all the segments

- [x] Tests are covering the bug fix or the new feature
