### PR TITLE
chore(e2e): fix traces not appearing on k8s test case

### DIFF
--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -136,7 +136,7 @@ test.describe.serial('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () =
           KubernetesResources.Deployments,
           DEPLOYMENT_NAME,
           KubernetesResourceState.Running,
-          80_000,
+          360_000,
         );
       });
       test.describe(() => {

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -139,15 +139,18 @@ test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
           80_000,
         );
       });
-      test('Create and verify a running Kubernetes service', async ({ page }) => {
-        await createKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME, SERVICE_YAML_PATH);
-        await checkKubernetesResourceState(
-          page,
-          KubernetesResources.Services,
-          SERVICE_NAME,
-          KubernetesResourceState.Running,
-          10_000,
-        );
+      test.describe(() => {
+        test.describe.configure({ retries: 1 });
+        test('Create and verify a running Kubernetes service', async ({ page }) => {
+          await createKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME, SERVICE_YAML_PATH);
+          await checkKubernetesResourceState(
+            page,
+            KubernetesResources.Services,
+            SERVICE_NAME,
+            KubernetesResourceState.Running,
+            10_000,
+          );
+        });
       });
       test('Create and verify a running Kubernetes ingress', async ({ page }) => {
         await createKubernetesResource(page, KubernetesResources.IngeressesRoutes, INGRESS_NAME, INGRESS_YAML_PATH);

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -129,27 +129,25 @@ test.describe.serial('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () =
       });
 
       test('Create and verify a running Kubernetes deployment', async ({ page }) => {
-        test.setTimeout(360_000);
+        test.setTimeout(80_000);
         await createKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, DEPLOYMENT_YAML_PATH);
         await checkKubernetesResourceState(
           page,
           KubernetesResources.Deployments,
           DEPLOYMENT_NAME,
           KubernetesResourceState.Running,
-          360_000,
+          80_000,
         );
       });
-      test.describe(() => {
-        test('Create and verify a running Kubernetes service', async ({ page }) => {
-          await createKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME, SERVICE_YAML_PATH);
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Services,
-            SERVICE_NAME,
-            KubernetesResourceState.Running,
-            10_000,
-          );
-        });
+      test('Create and verify a running Kubernetes service', async ({ page }) => {
+        await createKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME, SERVICE_YAML_PATH);
+        await checkKubernetesResourceState(
+          page,
+          KubernetesResources.Services,
+          SERVICE_NAME,
+          KubernetesResourceState.Running,
+          10_000,
+        );
       });
       test('Create and verify a running Kubernetes ingress', async ({ page }) => {
         await createKubernetesResource(page, KubernetesResources.IngeressesRoutes, INGRESS_NAME, INGRESS_YAML_PATH);

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -129,7 +129,7 @@ test.describe.serial('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () =
       });
 
       test('Create and verify a running Kubernetes deployment', async ({ page }) => {
-        test.setTimeout(80_000);
+        test.setTimeout(360_000);
         await createKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, DEPLOYMENT_YAML_PATH);
         await checkKubernetesResourceState(
           page,

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -120,7 +120,7 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
+test.describe.serial('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
   test.describe
     .serial('Ingress routing workflow verification', () => {
       test('Check Ingress controller pods status', async ({ page }) => {
@@ -140,7 +140,6 @@ test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
         );
       });
       test.describe(() => {
-        test.describe.configure({ retries: 1 });
         test('Create and verify a running Kubernetes service', async ({ page }) => {
           await createKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME, SERVICE_YAML_PATH);
           await checkKubernetesResourceState(


### PR DESCRIPTION
### What does this PR do?
Fixes the traces not appearing on  kubernetes-networking.spec.ts by adding a missing 'serial' 
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#14825
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
