### PR TITLE
feat(renderer): adding env column to podman pods

### DIFF
--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -284,6 +284,9 @@ test('Expect single podman pod being displayed', async () => {
     name: `${pod1.Name}`,
   });
   expect(pod1Row).toBeInTheDocument();
+
+  const env = screen.getByRole('cell', { name: 'Provider info circle podman' });
+  expect(env).toBeInTheDocument();
 });
 
 test('Expect 2 podman pods being displayed', async () => {

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -12,7 +12,6 @@ import {
 } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
-import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 import ContainerEngineEnvironmentColumn from '/@/lib/table/columns/ContainerEngineEnvironmentColumn.svelte';
 import type { PodInfo } from '/@api/pod-info';
 
@@ -132,7 +131,7 @@ let nameColumn = new TableColumn<PodInfoUI>('Name', {
   comparator: (a, b): number => a.name.localeCompare(b.name),
 });
 
-let envColumn = new TableColumn<ImageInfoUI>('Environment', {
+let envColumn = new TableColumn<PodInfoUI>('Environment', {
   renderer: ContainerEngineEnvironmentColumn,
   comparator: (a, b): number => a.engineName.localeCompare(b.engineName),
 });

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -12,6 +12,8 @@ import {
 } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
+import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
+import ContainerEngineEnvironmentColumn from '/@/lib/table/columns/ContainerEngineEnvironmentColumn.svelte';
 import type { PodInfo } from '/@api/pod-info';
 
 import { filtered, podsInfos, searchPattern } from '../../stores/pods';
@@ -130,6 +132,11 @@ let nameColumn = new TableColumn<PodInfoUI>('Name', {
   comparator: (a, b): number => a.name.localeCompare(b.name),
 });
 
+let envColumn = new TableColumn<ImageInfoUI>('Environment', {
+  renderer: ContainerEngineEnvironmentColumn,
+  comparator: (a, b): number => a.engineName.localeCompare(b.engineName),
+});
+
 let containersColumn = new TableColumn<PodInfoUI>('Containers', {
   renderer: PodColumnContainers,
   comparator: (a, b): number => a.containers.length - b.containers.length,
@@ -148,6 +155,7 @@ let ageColumn = new TableColumn<PodInfoUI, Date | undefined>('Age', {
 const columns = [
   statusColumn,
   nameColumn,
+  envColumn,
   containersColumn,
   ageColumn,
   new TableColumn<PodInfoUI>('Actions', { align: 'right', width: '150px', renderer: PodColumnActions, overflow: true }),


### PR DESCRIPTION
### What does this PR do?

Adding missing environment column to Podman Pods. With https://github.com/podman-desktop/podman-desktop/pull/15027 the column will display the connection name if the user has multiple connections.

### Screenshot / video of UI

<img width="898" height="898" alt="Screenshot From 2025-12-03 14-23-36" src="https://github.com/user-attachments/assets/ec411fbd-f870-4188-9b0b-78bef2658b95" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15052

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
