### PR TITLE
chore: add usage of env.appName in extension

### DIFF
--- a/extensions/compose/src/handler.ts
+++ b/extensions/compose/src/handler.ts
@@ -88,7 +88,7 @@ export async function installComposeBinary(
     }
   } else {
     await extensionApi.window.showErrorMessage(
-      `Podman Desktop was unable to locate the docker-compose binary in the ${extensionContext.storagePath}/bin folder. Please reinstall docker-compose to ${extensionContext.storagePath}/bin and try again.`,
+      `${extensionApi.env.appName} was unable to locate the docker-compose binary in the ${extensionContext.storagePath}/bin folder. Please reinstall docker-compose to ${extensionContext.storagePath}/bin and try again.`,
     );
   }
 }

--- a/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { CheckResult, TelemetryLogger } from '@podman-desktop/api';
+import { env } from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
 
 import { MemoizedBaseCheck } from '/@/checks/memoized-base-check';
@@ -24,7 +25,7 @@ import { getPowerShellClient } from '/@/utils/powershell';
 
 @injectable()
 export class PodmanDesktopElevatedCheck extends MemoizedBaseCheck {
-  title = 'Podman Desktop Elevated';
+  title = `${env.appName} Elevated`;
 
   constructor(
     @inject(TelemetryLoggerSymbol)
@@ -37,7 +38,7 @@ export class PodmanDesktopElevatedCheck extends MemoizedBaseCheck {
     const client = await getPowerShellClient(this.telemetryLogger);
     if (!(await client.isRunningElevated())) {
       return this.createFailureResult({
-        description: 'You must run Podman Desktop with administrative rights to run Hyper-V Podman machines.',
+        description: `You must run ${env.appName} with administrative rights to run Hyper-V Podman machines.`,
       });
     }
     return this.createSuccessfulResult();

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
@@ -122,7 +122,7 @@ export class RegistryConfigurationImpl implements RegistryConfiguration {
       // check if the file is mounted
       const result = await execPodman(commandLineArgs, machine.VMType);
       if (!result.stdout) {
-        const warningMessage = `The registries configuration file is not mounted in the Podman VM ${machine.Name} in /etc/containers/registries.conf.d/ folder. Cannot continue. Recreate the machine using Podman Desktop.`;
+        const warningMessage = `The registries configuration file is not mounted in the Podman VM ${machine.Name} in /etc/containers/registries.conf.d/ folder. Cannot continue. Recreate the machine using ${env.appName}.`;
         if (showWindowPopupError) {
           // display an error message if the link is not found
           // otherwise, log to console (for silent checks)


### PR DESCRIPTION
### What does this PR do?
replace some usage of Podman Desktop by `env.appName` in extensions

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to #15094

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
