### PR TITLE
docs(managed-by): elaborate more on managed-by config settings

### DIFF
--- a/website/docs/configuration/managed-configuration-troubleshooting.md
+++ b/website/docs/configuration/managed-configuration-troubleshooting.md
@@ -36,8 +36,15 @@ To verify that your managed configuration is being loaded correctly:
 3. Look for messages in the console like:
    ```
    [Managed-by]: Loaded managed ...
+   [Managed-by]: Applied default settings for: setting.key1, setting.key2
    ```
 4. If you don't see these messages, the configuration files may not be in the correct location or may have syntax errors.
+
+:::note
+
+The "Applied default settings" message only appears when settings are copied from `default-settings.json` to the user's `settings.json`. This occurs once per setting when it doesn't already exist in the user's configuration.
+
+:::
 
 ## Verifying if a value is locked by the managed-by configuration
 

--- a/website/docs/configuration/managed-configuration.md
+++ b/website/docs/configuration/managed-configuration.md
@@ -21,6 +21,28 @@ Podman Desktop stores values for the following types of configuration in three s
 2. **Managed defaults configuration** - Read-only administrator-enforced default values that cannot be edited by the user.
 3. **Locked configuration** - Read-only administrator-enforced list of keys that must use managed values.
 
+### Default settings
+
+On startup, Podman Desktop checks `default-settings.json` and applies any settings that don't already exist in the user's `settings.json`. This is a one-time copy per setting:
+
+- Settings already in the user's `settings.json` are not overwritten
+- Settings that match the built-in schema default are not copied (to avoid unnecessary entries)
+- Only settings that differ from the schema default are persisted to `settings.json`
+
+This allows administrators to pre-configure settings for new users while respecting existing user preferences.
+
+### Locked settings
+
+Settings listed in `locked.json` are enforced on every read and cannot be changed by the user:
+
+- The value is always read from `default-settings.json`, ignoring the user's `settings.json`
+- The setting appears displays a lock icon in the UI
+- User changes to locked keys are ignored
+
+Use locked settings when you need to enforce compliance, such as proxy servers or telemetry policies.
+
+### Configuration priority
+
 When a configuration changes, Podman Desktop returns a value after checking the user configuration files in the following priority order:
 
 1. **Locked keys** - Return a value from the managed defaults configuration file, which is of highest priority


### PR DESCRIPTION
docs(managed-by): elaborate more on managed-by config settings

### What does this PR do?

Updates the documentation with more information with regards to more
eloration on how `default-settings.json` works, as well as `locked.json`
information.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/15198

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, it's docs!

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
