### PR TITLE
chore: store catalog extension url in product.json

### DIFF
--- a/packages/main/src/plugin/extension/catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extension/catalog/extensions-catalog.ts
@@ -29,6 +29,7 @@ import type {
 } from '/@/plugin/extension/catalog/extensions-catalog-api.js';
 import { Proxy } from '/@/plugin/proxy.js';
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { ExtensionsCatalogSettings } from './extensions-catalog-settings.js';
 
@@ -37,7 +38,7 @@ import { ExtensionsCatalogSettings } from './extensions-catalog-settings.js';
  */
 @injectable()
 export class ExtensionsCatalog {
-  public static readonly DEFAULT_EXTENSIONS_URL = 'https://registry.podman-desktop.io/api/extensions.json';
+  public static readonly DEFAULT_EXTENSIONS_URL = product.catalog.default;
 
   private lastFetchTime = 0;
   private cachedCatalog: InternalCatalogJSON | undefined;

--- a/product.json
+++ b/product.json
@@ -6,6 +6,9 @@
   "telemetry": {
     "key": "Mhl7GXADk5M1vG6r9FXztbCqWRQY8XPy"
   },
+  "catalog": {
+    "default": "https://registry.podman-desktop.io/api/extensions.json"
+  },
   "extensions": {
     "remote": []
   }


### PR DESCRIPTION
### What does this PR do?
move extensions URL to product.json

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15043

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
