### PR TITLE
docs(settings): update to say %USERPROFILE% not %APPDATA%

### DIFF
--- a/website/docs/configuration/managed-configuration.md
+++ b/website/docs/configuration/managed-configuration.md
@@ -76,7 +76,7 @@ _Locked configuration_
 
 _User configuration_
 
-- Location: `%APPDATA%\podman-desktop\configuration\settings.json`
+- Location: `%USERPROFILE%\.local\share\containers\podman-desktop\configuration\settings.json`
 - Permissions: User read/write
 - Purpose: Normal user settings configured through the UI
 

--- a/website/docs/configuration/settings-reference.md
+++ b/website/docs/configuration/settings-reference.md
@@ -21,7 +21,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="windows" label="Windows">
 
 ```
-%APPDATA%\podman-desktop\configuration\settings.json
+%USERPROFILE%\.local\share\containers\podman-desktop\configuration\settings.json
 ```
 
 </TabItem>


### PR DESCRIPTION
docs(settings): update to say %USERPROFILE% not %APPDATA%

### What does this PR do?

Fixes the paths in the documentation. While writing the documentation
for settings, I had put down %APPDATA% for Windows, which was totally incorrect.

Should be `%USERPROFILE%` not `%APPADATA%` and resolves to:
`%USERPROFILE%\.local\share\containers\podman-desktop\configuration\settings.json`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

https://github.com/user-attachments/assets/7d08bfb2-f34a-4ce9-8e26-9a052d43ec91

Resolves to the correct path now :)


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/15204

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, docs

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
