### PR TITLE
fix: addressed sync value issue for containerconnectiondropdown

### DIFF
--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
@@ -125,3 +125,33 @@ test('expect binding to properly work', async () => {
   expect(alert).toBeDefined();
   expect(alert).toHaveTextContent(CONTAINER_CONNECTION_INFO.name);
 });
+
+test('expect dropdown value to be derived from value prop', () => {
+  // When a value prop is provided, the dropdown should display the correct selection
+  render(ContainerConnectionDropdown, {
+    connections: [CONTAINER_CONNECTION_INFO],
+    value: CONTAINER_CONNECTION_INFO,
+  });
+
+  expect(Dropdown).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      // The dropdown value should be the key derived from the connection
+      value: `${CONTAINER_CONNECTION_INFO.type}:${CONTAINER_CONNECTION_INFO.name}`,
+    }),
+  );
+});
+
+test('expect dropdown value to be undefined when value prop is undefined', () => {
+  render(ContainerConnectionDropdown, {
+    connections: [CONTAINER_CONNECTION_INFO],
+    value: undefined,
+  });
+
+  expect(Dropdown).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      value: undefined,
+    }),
+  );
+});

--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdown.svelte
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdown.svelte
@@ -23,22 +23,22 @@ let {
   disabled,
 }: Props = $props();
 
-let selected: string | undefined = $state<string>();
+/**
+ * Map of unique keys to connection objects.
+ * Key format: `${type}:${name}` ensures unique identification.
+ */
+let items = $derived(new Map(connections.map(c => [`${c.type}:${c.name}`, c])));
 
 /**
- * Internally this component generate a unique string for each connection provided
- * This ensure we have a unique identifier
+ * Derive the dropdown's selected key from the value prop.
+ * This ensures the dropdown displays the correct selection when value changes externally.
  */
-let items: Map<string, ProviderContainerConnectionInfo> = $derived(
-  new Map(connections.map(connection => [`${connection.type}:${connection.name}`, connection])),
-);
+let selected = $derived(value ? `${value.type}:${value.name}` : undefined);
 
 function handleChange(nValue: unknown): void {
   if (typeof nValue === 'string') {
-    selected = nValue;
     value = items.get(nValue);
   } else {
-    selected = undefined;
     value = undefined;
   }
 


### PR DESCRIPTION
while adding the advanced network tab I noticed switching tabs did not save the value of the container connection dropdown. The value prop never binded to the selected state.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/14797

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
