### PR TITLE
feat: enable column configuration for network table

### DIFF
--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -158,7 +158,8 @@ function key(network: NetworkInfoUI): string {
         columns={columns}
         row={row}
         key={key}
-        defaultSortColumn="Name">
+        defaultSortColumn="Name"
+        enableLayoutConfiguration={true}>
       </Table>
     {/if}
   </div>


### PR DESCRIPTION
Signed-off-by: Dibyendu <dibyendusahoo03@gmail.com>

Closes: #15098 
### What does this PR do?
Enables column configuration for the network table by adding the `enableLayoutConfiguration` property. Users can now customize which columns are visible and reorder them in the Networks view, matching the functionality available in Containers, Images, Pods, and Volumes tables.
