### PR TITLE
chore(test): set XDG_SESSION_TYPE=x11 when e2e tests are run on linux

### DIFF
--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -23,6 +23,8 @@ import type { ElectronApplication, JSHandle, Page } from '@playwright/test';
 import { _electron as electron, test } from '@playwright/test';
 import type { BrowserWindow } from 'electron';
 
+import { isLinux } from '/@/utility/platform';
+
 import { waitWhile } from '../utility/wait';
 import { RunnerOptions } from './runner-options';
 
@@ -323,6 +325,11 @@ export class Runner {
     const dir = join(this._customFolder);
     console.log(`podman desktop custom config will be written to: ${dir}`);
     env.PODMAN_DESKTOP_HOME_DIR = dir;
+
+    // required to get dashboard opened, https://github.com/podman-desktop/podman-desktop/issues/15220
+    if (isLinux) {
+      env.XDG_SESSION_TYPE = 'x11';
+    }
 
     // add a custom config file by disabling OpenDevTools
     const settingsFile = resolve(dir, 'configuration', 'settings.json');


### PR DESCRIPTION
### What does this PR do?
Tests are now run on linux with dashboard opened.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#15220 and patch shows it can help with https://github.com/podman-desktop/podman-desktop/issues/14387
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
all tests are passing, any failure causing video/traces to be produced should be watchable, no error saving video.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
