### PR TITLE
docs: remove shell prompts from code blocks in website docs

### DIFF
--- a/website/blog/2024-01-29-run-webassembly-wasm-workloads-windows-and-macos.md
+++ b/website/blog/2024-01-29-run-webassembly-wasm-workloads-windows-and-macos.md
@@ -97,7 +97,7 @@ There is already an OCI image on quay.io
 To run the workload, we will use the following command:
 
 ```shell-shession
-$ podman run --platform wasi/wasm quay.io/podman-desktop-demo/wasm-rust-hello-world
+podman run --platform wasi/wasm quay.io/podman-desktop-demo/wasm-rust-hello-world
 ```
 
 When running the command, you will see a Podman Hello World that was compiled using a Rust project using the println function and compiled into Wasm using `--target wasm32-wasi` parameter at compilation time.

--- a/website/blog/2024-08-08-release-1.12.md
+++ b/website/blog/2024-08-08-release-1.12.md
@@ -51,7 +51,7 @@ This seamless setup can be enabled during Podman Machine creation by selecting t
 After enablement, you can test that the GPU has been supported by running a custom container with `--device /dev/dri` passed through:
 
 ```sh
-$ podman run --rm -it --device /dev/dri --name gpu-info quay.io/slopezpa/fedora-vgpu vulkaninfo | grep "GPU"
+podman run --rm -it --device /dev/dri --name gpu-info quay.io/slopezpa/fedora-vgpu vulkaninfo | grep "GPU"
 ```
 
 Which will output information regarding your GPU:

--- a/website/docs/compose/running-compose.md
+++ b/website/docs/compose/running-compose.md
@@ -19,7 +19,7 @@ With Podman Desktop, you can manage multi-container applications defined in a Co
 - Run the command in a terminal:
 
   ```shell-session
-  $ podman compose --file compose.yaml up --detach
+  podman compose --file compose.yaml up --detach
   ```
 
   <details>
@@ -32,7 +32,7 @@ With Podman Desktop, you can manage multi-container applications defined in a Co
   1. Run `docker-compose` rather than `podman compose`:
 
   ```shell-session
-  $ docker-compose --file compose.yaml up --detach
+  docker-compose --file compose.yaml up --detach
   ```
 
   </details>
@@ -45,7 +45,7 @@ With Podman Desktop, you can manage multi-container applications defined in a Co
   </summary>
 
   ```shell-session
-  $ podman compose --help
+  podman compose --help
   ```
 
   </details>

--- a/website/docs/compose/setting-up-compose.md
+++ b/website/docs/compose/setting-up-compose.md
@@ -20,13 +20,13 @@ Podman Desktop can install the Compose engine.
 1. The Compose reference implementation is in your `PATH`, therefore, you can display the Compose engine version in a terminal:
 
    ```shell-session
-   $ docker-compose version
+   docker-compose version
    ```
 
 1. Podman detects the same Compose version:
 
    ```shell-session
-   $ podman compose version
+   podman compose version
    ```
 
 #### Next steps

--- a/website/docs/containers/registries/index.md
+++ b/website/docs/containers/registries/index.md
@@ -90,7 +90,7 @@ If your registry has an insecure certificate, such as a self-signed certificate,
       - The configuration file is in the Podman machine: open a terminal in the Podman Machine.
 
       ```shell-session
-      $ podman machine ssh --username root [optional-machine-name]
+      podman machine ssh --username root [optional-machine-name]
       ```
 
       </TabItem>
@@ -98,7 +98,7 @@ If your registry has an insecure certificate, such as a self-signed certificate,
       - The configuration file is in the Podman machine: open a terminal in the Podman Machine.
 
       ```shell-session
-      $ podman machine ssh --username root [optional-machine-name]
+      podman machine ssh --username root [optional-machine-name]
       ```
 
       </TabItem>
@@ -106,7 +106,7 @@ If your registry has an insecure certificate, such as a self-signed certificate,
       - The configuration file is in your host: open a terminal with superuser privileges.
 
       ```shell-session
-      $ sudo su -
+      sudo su -
       ```
 
       </TabItem>
@@ -151,7 +151,7 @@ If your registry has an insecure certificate, such as a self-signed certificate,
    - Stop all Podman processes.
 
    ```shell-session
-   $ pkill podman
+   pkill podman
    ```
 
    </TabItem>
@@ -159,7 +159,7 @@ If your registry has an insecure certificate, such as a self-signed certificate,
    - Restart Podman.
 
    ```shell-session
-   $ sudo systemctl restart podman
+   sudo systemctl restart podman
    ```
 
    </TabItem>

--- a/website/docs/extensions/publish/index.md
+++ b/website/docs/extensions/publish/index.md
@@ -54,13 +54,13 @@ To enable users to install your extension from the catalog, push your extension 
 1. Build an image:
 
    ```shell-session
-   $ podman build -t quay.io/username/my-extension .
+   podman build -t quay.io/username/my-extension .
    ```
 
 1. Push the image and manifest to the OCI image registry:
 
    ```shell-session
-   $ podman push quay.io/username/my-extension
+   podman push quay.io/username/my-extension
    ```
 
 #### Adding platform-specific files

--- a/website/docs/installation/linux-install/index.md
+++ b/website/docs/installation/linux-install/index.md
@@ -28,13 +28,13 @@ Alternatively, you can install Podman Desktop from:
 1. Verify the Flathub repository is enabled, and add it if required:
 
    ```shell-session
-   $ flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
+   flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
    ```
 
 2. Install Podman Desktop from Flathub:
 
    ```shell-session
-   $ flatpak install --user flathub io.podman_desktop.PodmanDesktop
+   flatpak install --user flathub io.podman_desktop.PodmanDesktop
    ```
 
 #### Verification
@@ -42,7 +42,7 @@ Alternatively, you can install Podman Desktop from:
 - Open Podman Desktop from a terminal:
 
   ```shell-session
-  $ flatpak run io.podman_desktop.PodmanDesktop
+  flatpak run io.podman_desktop.PodmanDesktop
   ```
 
 #### Update
@@ -50,7 +50,7 @@ Alternatively, you can install Podman Desktop from:
 - Update Podman Desktop from Flathub:
 
   ```shell-session
-  $ flatpak update --user io.podman_desktop.PodmanDesktop
+  flatpak update --user io.podman_desktop.PodmanDesktop
   ```
 
 #### Additional resources

--- a/website/docs/installation/linux-install/install-on-rhel10.md
+++ b/website/docs/installation/linux-install/install-on-rhel10.md
@@ -20,13 +20,13 @@ You can use the subscription manager package to install Podman Desktop on a Red 
 1. Open a terminal, and enable the RHEL extensions repository:
 
    ```sh
-   $ sudo subscription-manager repos --enable rhel-10-for-$(arch)-extensions-rpms
+   sudo subscription-manager repos --enable rhel-10-for-$(arch)-extensions-rpms
    ```
 
 1. Enter your password when prompted.
 1. Install Podman Desktop:
    ```sh
-   $ sudo dnf install podman-desktop
+   sudo dnf install podman-desktop
    ```
 1. Enter `y` to confirm that the installed size is okay.
 1. Enter `y` to import the GPG key and complete the installation.

--- a/website/docs/installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle.md
+++ b/website/docs/installation/linux-install/installing-podman-desktop-from-a-flatpak-bundle.md
@@ -28,7 +28,7 @@ Consider installing a Flatpak bundle rather than [from Flathub](/docs/installati
 2. Install Podman Desktop from the downloaded Flatpak bundle:
 
    ```shell-session
-   $ flatpak install --user $HOME/Downloads/podman-desktop-<version>.flatpak
+   flatpak install --user $HOME/Downloads/podman-desktop-<version>.flatpak
    ```
 
 #### Verification
@@ -36,7 +36,7 @@ Consider installing a Flatpak bundle rather than [from Flathub](/docs/installati
 - Open Podman Desktop from a terminal:
 
   ```shell-session
-  $ flatpak run io.podman_desktop.PodmanDesktop
+  flatpak run io.podman_desktop.PodmanDesktop
   ```
 
 #### Additional resources

--- a/website/docs/kind/configuring-podman-for-kind-on-windows.md
+++ b/website/docs/kind/configuring-podman-for-kind-on-windows.md
@@ -21,17 +21,17 @@ Therefore, set the Podman machine to rootful mode.
 1. Stop the Podman machine:
 
    ```shell-session
-   $ podman machine stop
+   podman machine stop
    ```
 
 2. Set the Podman machine in rootful mode:
 
    ```shell-session
-   $ podman machine set --rootful
+   podman machine set --rootful
    ```
 
 3. Start the Podman machine:
 
    ```shell-session
-   $ podman machine start
+   podman machine start
    ```

--- a/website/docs/kind/installing.md
+++ b/website/docs/kind/installing.md
@@ -21,5 +21,5 @@ tags: [installing-the-kind-CLI, kind]
 1. You can run the `kind` CLI:
 
    ```shell-session
-   $ kind get clusters
+   kind get clusters
    ```

--- a/website/docs/kind/working-with-your-local-kind-cluster.md
+++ b/website/docs/kind/working-with-your-local-kind-cluster.md
@@ -32,5 +32,5 @@ Alternatively, use the status bar or the Podman Desktop **Settings** to set your
 - The Kubernetes CLI reports that the current context is your cluster with the `kind` suffix:
 
   ```shell-session
-  $ kubectl config current-context
+  kubectl config current-context
   ```

--- a/website/docs/kubernetes/existing-kubernetes/index.md
+++ b/website/docs/kubernetes/existing-kubernetes/index.md
@@ -26,7 +26,7 @@ You can also use the Kubernetes CLI to configure access to your Kubernetes clust
 1. Register your _`<my_kubernetes>`_ Kubernetes cluster:
 
    ```shell-session
-   $ kubectl config set-cluster <my_kubernetes> --server=<my_kubernetes_url>
+   kubectl config set-cluster <my_kubernetes> --server=<my_kubernetes_url>
    ```
 
 #### Verification

--- a/website/docs/lima/creating-a-kubernetes-instance.md
+++ b/website/docs/lima/creating-a-kubernetes-instance.md
@@ -27,13 +27,13 @@ Consider creating a custom Lima instance to:
    - To create a single-node Kubernetes cluster running [k3s](https://k3s.io/):
 
      ```shell-session
-     $ limactl start template://k3s
+     limactl start template://k3s
      ```
 
    - To create a single-node Kubernetes cluster running [k8s](https://k8s.io/):
 
      ```shell-session
-     $ limactl start template://k8s
+     limactl start template://k8s
      ```
 
    - To select the number of CPUs, the memory, and the disk size, add the options to the `limactl start` command:
@@ -64,5 +64,5 @@ Consider creating a custom Lima instance to:
 1. Use the `kubectl.lima` wrapper script to connect to the cluster:
 
    ```shell-session
-   $ kubectl.lima version
+   kubectl.lima version
    ```

--- a/website/docs/lima/creating-a-lima-instance.md
+++ b/website/docs/lima/creating-a-lima-instance.md
@@ -27,25 +27,25 @@ Consider creating a custom Lima instance to:
    - To create a Lima instance with rootless Podman, use the `podman` template:
 
      ```shell-session
-     $ limactl start --name=podman template://podman
+     limactl start --name=podman template://podman
      ```
 
    - To create a Lima instance with rootful Podman, use the `podman-rootful` template:
 
      ```shell-session
-     $ limactl start --name=podman template://podman-rootful
+     limactl start --name=podman template://podman-rootful
      ```
 
    - To create an Lima instance with rootless Docker, use the `docker` template:
 
      ```shell-session
-     $ limactl start --name=docker template://docker
+     limactl start --name=docker template://docker
      ```
 
    - To create an Lima instance with rootful Docker, use the `docker-rootful` template:
 
      ```shell-session
-     $ limactl start --name=docker template://docker-rootful
+     limactl start --name=docker template://docker-rootful
      ```
 
    - To select the number of CPUs, the memory, and the disk size, add the options to the `limactl start` command:
@@ -83,11 +83,11 @@ Consider creating a custom Lima instance to:
 - To verify the connection to a running "podman" instance:
 
   ```shell-session
-  $ podman.lima version
+  podman.lima version
   ```
 
 - To verify the connection to a running "docker" instance:
 
   ```shell-session
-  $ docker.lima version
+  docker.lima version
   ```

--- a/website/docs/lima/customizing.md
+++ b/website/docs/lima/customizing.md
@@ -17,13 +17,13 @@ For more information on yq, see the yq [documentation](https://mikefarah.gitbook
 - To create a new instance:
 
   ```shell-session
-  $ limactl create <instance>
+  limactl create <instance>
   ```
 
 - To edit an existing instance:
 
   ```shell-session
-  $ limactl edit <instance>
+  limactl edit <instance>
   ```
 
 Some of the things you can edit:

--- a/website/docs/lima/installing.md
+++ b/website/docs/lima/installing.md
@@ -14,7 +14,7 @@ tags: [migrating-to-kubernetes, lima]
   See [Installing Lima](https://lima-vm.io/docs/installation/).
 
   ```shell-session
-  $ brew install lima
+  brew install lima
   ```
 
 #### Verification
@@ -22,13 +22,13 @@ tags: [migrating-to-kubernetes, lima]
 1. You can run the `limactl` CLI:
 
    ```shell-session
-   $ limactl list
+   limactl list
    ```
 
 1. (Optionally) To open a shell:
 
    ```shell-session
-   $ # requires a running instance
-   $ export LIMA_INSTANCE=<instance>
-   $ lima
+   # requires a running instance
+   export LIMA_INSTANCE=<instance>
+   lima
    ```

--- a/website/docs/lima/pushing-an-image-to-lima.md
+++ b/website/docs/lima/pushing-an-image-to-lima.md
@@ -29,7 +29,7 @@ With Podman Desktop, you can push an image to your local Lima-powered Kubernetes
 Lima enables you to list loaded images:
 
 ```shell-session
-$ LIMA_INSTANCE=<name> lima sudo crictl images
+LIMA_INSTANCE=<name> lima sudo crictl images
 ```
 
 You can also create a pod that uses the loaded image:

--- a/website/docs/migrating-from-docker/customizing-docker-compatibility.md
+++ b/website/docs/migrating-from-docker/customizing-docker-compatibility.md
@@ -64,7 +64,7 @@ Perform any of the following steps:
 - Run the following command to check the output returns the Podman version rather than the Docker version:
 
   ```shell-session
-  $ docker info --format=json | jq -r .ServerVersion
+  docker info --format=json | jq -r .ServerVersion
   ```
 
 - Run the `docker context list` command to check that the Docker CLI context is set to the default value `npipe:////./pipe/docker_engine`.
@@ -94,7 +94,7 @@ Perform any of the following steps:
 - Check whether the Docker socket is a symbolic link for the Podman socket:
 
   ```shell-session
-  $ ls -la /var/run/docker.sock
+  ls -la /var/run/docker.sock
   ```
 
   The output points to a `podman.sock` file, as shown below:
@@ -106,7 +106,7 @@ Perform any of the following steps:
 - Run the following command to check the output returns the Podman version rather than the Docker version:
 
   ```shell-session
-  $ curl -s --unix-socket /var/run/docker.sock "http://v1.41/info"  | jq -r .ServerVersion
+  curl -s --unix-socket /var/run/docker.sock "http://v1.41/info"  | jq -r .ServerVersion
   ```
 
 - Run the `docker context list` command to check that the Docker CLI context is set to `unix:///var/run/docker.sock`.
@@ -127,7 +127,7 @@ Perform any of the following steps:
 - Run the following command to check the output returns the Podman version rather than the Docker version:
 
   ```shell-session
-  $ docker info --format=json | jq -r .ServerVersion
+  docker info --format=json | jq -r .ServerVersion
   ```
 
 - Run the `docker context list` command to check that the Docker CLI context is set to the default value `unix:///var/run/docker.sock`.
@@ -155,7 +155,7 @@ Perform any of the following steps:
 - Run the following command to check the output returns the Docker version rather than the Podman version:
 
   ```shell-session
-  $ docker info --format=json | jq -r .ServerVersion
+  docker info --format=json | jq -r .ServerVersion
   ```
 
 </TabItem>
@@ -178,7 +178,7 @@ Perform any of the following steps:
 - Check that the Docker socket is not a symbolic link for the Podman socket:
 
   ```shell-session
-  $ ls -la /var/run/docker.sock
+  ls -la /var/run/docker.sock
   ```
 
   The output returns the following:
@@ -190,7 +190,7 @@ Perform any of the following steps:
 - Run the following command to check the output returns the Docker version rather than the Podman version:
 
   ```shell-session
-  $ curl -s --unix-socket /var/run/docker.sock "http://v1.41/info"  | jq -r .ServerVersion
+  curl -s --unix-socket /var/run/docker.sock "http://v1.41/info"  | jq -r .ServerVersion
   ```
 
 </TabItem>
@@ -207,7 +207,7 @@ Perform any of the following steps:
 - Run the following command to check the output returns the Docker version rather than the Podman version:
 
   ```shell-session
-  $ docker info --format=json | jq -r .ServerVersion
+  docker info --format=json | jq -r .ServerVersion
   ```
 
 </TabItem>

--- a/website/docs/migrating-from-docker/importing-saved-containers.md
+++ b/website/docs/migrating-from-docker/importing-saved-containers.md
@@ -23,14 +23,14 @@ Consider importing saved containers to continue using familiar containers.
     <TabItem value="podman" label="Podman">
 
   ```shell-session
-  $ podman save <your_container> > <your_container_archive>.tar
+  podman save <your_container> > <your_container_archive>.tar
   ```
 
     </TabItem>
     <TabItem value="docker" label="Docker">
 
   ```shell-session
-  $ docker export <your_container> -o <your_container_archive>.tar
+  docker export <your_container> -o <your_container_archive>.tar
   ```
 
     </TabItem>
@@ -42,7 +42,7 @@ Consider importing saved containers to continue using familiar containers.
   Run the command for each container archive:
 
   ```shell-session
-  $ podman import <your_container_archive>.tar
+  podman import <your_container_archive>.tar
   ```
 
 #### Verification

--- a/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
+++ b/website/docs/migrating-from-docker/using-the-docker_host-environment-variable.md
@@ -45,7 +45,7 @@ Then, you can run the `docker context use podman` command to switch to that cont
 1. Identify the location of your Podman pipe <!-- markdownlint-disable MD029 -->
 
 ```shell-session
-$ podman machine inspect --format '{{.ConnectionInfo.PodmanPipe.Path}}'
+ podman machine inspect --format '{{.ConnectionInfo.PodmanPipe.Path}}'
 ```
 
 2. Set the `DOCKER_HOST` environment variable to your Podman pipe location. You'll need to replace back slashes with forward slashes and add the `npipe://` scheme to the path retrieved previously: <!-- markdownlint-disable MD029 -->
@@ -92,13 +92,13 @@ Setting the `DOCKER_HOST` environment variable isn't necessary on Windows becaus
 1. Identify the location of your Podman socket.
 
 ```shell-session
-$ podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
+podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'
 ```
 
 2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
 
 ```shell-session
-$ export DOCKER_HOST=unix://<your_podman_socket_location>
+export DOCKER_HOST=unix://<your_podman_socket_location>
 ```
 
 </TabItem>
@@ -107,13 +107,13 @@ $ export DOCKER_HOST=unix://<your_podman_socket_location>
 1. Identify the location of your Podman socket.
 
 ```shell-session
-$ podman info --format '{{.Host.RemoteSocket.Path}}'
+podman info --format '{{.Host.RemoteSocket.Path}}'
 ```
 
 2. Set the `DOCKER_HOST` environment variable to your Podman socket location. Be sure to add the `unix://` scheme to the path retrieved previously:
 
 ```shell-session
-$ export DOCKER_HOST=unix://<your_podman_socket_location>
+export DOCKER_HOST=unix://<your_podman_socket_location>
 ```
 
    </TabItem>

--- a/website/docs/minikube/configuring-podman-for-minikube-on-windows.md
+++ b/website/docs/minikube/configuring-podman-for-minikube-on-windows.md
@@ -21,17 +21,17 @@ Therefore, set the Podman machine to rootful mode.
 1. Stop the Podman machine:
 
    ```shell-session
-   $ podman machine stop
+   podman machine stop
    ```
 
 2. Set the Podman machine in rooful mode:
 
    ```shell-session
-   $ podman machine set --rootful
+   podman machine set --rootful
    ```
 
 3. Start the Podman machine:
 
    ```shell-session
-   $ podman machine start
+   podman machine start
    ```

--- a/website/docs/minikube/installing.md
+++ b/website/docs/minikube/installing.md
@@ -21,5 +21,5 @@ tags: [installing-the-minikube-CLI, minikube]
 1. You can run the `minikube` CLI:
 
    ```shell-session
-   $ minikube profile list
+   minikube profile list
    ```

--- a/website/docs/minikube/pushing-an-image-to-minikube.md
+++ b/website/docs/minikube/pushing-an-image-to-minikube.md
@@ -29,7 +29,7 @@ With Podman Desktop, you can push an image to your local Minikube-powered Kubern
 Minikube enables you to list loaded images:
 
 ```command
-$ minikube image list
+minikube image list
 ```
 
 You can also create a pod that uses the loaded image:

--- a/website/docs/minikube/working-with-your-local-minikube-cluster.md
+++ b/website/docs/minikube/working-with-your-local-minikube-cluster.md
@@ -31,5 +31,5 @@ Alternatively, use the status bar or the Podman Desktop **Settings** to set your
 - The Kubernetes CLI reports that the current context is your cluster with the `minikube` name:
 
   ```shell-session
-  $ kubectl config current-context
+  kubectl config current-context
   ```

--- a/website/docs/openshift/openshift-local/index.md
+++ b/website/docs/openshift/openshift-local/index.md
@@ -50,7 +50,7 @@ With Podman Desktop and the OpenShift Local extension, you can manage your OpenS
    1. To configure your system, run the command:
 
    ```shell-session
-   $ crc setup
+   crc setup
    ```
 
    1. Exit and restart Podman Desktop.

--- a/website/docs/podman/accessing-podman-from-another-wsl-instance.md
+++ b/website/docs/podman/accessing-podman-from-another-wsl-instance.md
@@ -27,7 +27,7 @@ In foldable details, you can find alternative steps for least common contexts:
 1. Start a session in your WSL distribution:
 
    ```shell-session
-   > wsl --distribution your-distribution-name
+   wsl --distribution your-distribution-name
    ```
 
 1. To communicate with the remote Podman Machine, you need a Podman client.
@@ -43,15 +43,15 @@ In foldable details, you can find alternative steps for least common contexts:
    Download and unpack the binary:
 
    ```shell-session
-   $ wget https://github.com/containers/podman/releases/download/v4.9.1/podman-remote-static-linux_amd64.tar.gz
-   $ sudo tar -C /usr/local -xzf podman-remote-static-linux_amd64.tar.gz
+   wget https://github.com/containers/podman/releases/download/v4.9.1/podman-remote-static-linux_amd64.tar.gz
+   sudo tar -C /usr/local -xzf podman-remote-static-linux_amd64.tar.gz
    ```
 
    Make this executable as `podman` with the following addition to `.bashrc`:
 
    ```shell-session
-   $ export PATH="$PATH:/usr/local/bin"
-   $ alias podman='podman-remote-static-linux_amd64'
+   export PATH="$PATH:/usr/local/bin"
+   alias podman='podman-remote-static-linux_amd64'
    ```
 
 1. Configure the Podman client in your WSL distribution to communicate with the remote Podman machine defined by Podman Desktop.
@@ -61,7 +61,7 @@ In foldable details, you can find alternative steps for least common contexts:
    Set the default Podman system connection to your Podman Machine (assuming Podman Desktop is configured with the default of Podman Machine enabled with root privileges):
 
    ```shell-session
-   $ podman system connection add --default podman-machine-default-root unix:///mnt/wsl/podman-sockets/podman-machine-default/podman-root.sock
+   podman system connection add --default podman-machine-default-root unix:///mnt/wsl/podman-sockets/podman-machine-default/podman-root.sock
    ```
 
    <details>
@@ -84,7 +84,7 @@ In foldable details, you can find alternative steps for least common contexts:
    In your WSL session, list the available sockets:
 
    ```shell-session
-   $ find /mnt/wsl/podman-sockets/ -name '*.sock'
+   find /mnt/wsl/podman-sockets/ -name '*.sock'
    ```
 
    Each Podman Machine has a socket for:
@@ -108,7 +108,7 @@ In foldable details, you can find alternative steps for least common contexts:
       Open a new Command Prompt, and list your Podman system connections:
 
       ```shell-session
-      > podman system connection list
+      podman system connection list
       ```
 
       The default connection line ends with `true`.
@@ -142,8 +142,8 @@ In foldable details, you can find alternative steps for least common contexts:
    To give access to the remote Podman machine to your user: create the group if necessary, assign group membership, and exit your session on the WSL distribution to apply the new group membership:
 
    ```shell-session
-   $ sudo usermod --append --groups 10 $(whoami)
-   $ exit
+   sudo usermod --append --groups 10 $(whoami)
+   exit
    ```
 
 ## Testing the connection
@@ -153,13 +153,13 @@ Verify that, on your WSL distribution, the Podman CLI communicates with your Pod
 1. Start a session in your WSL distribution:
 
    ```shell-session
-   > wsl
+   wsl
    ```
 
 1. Verify that your user is member of the group delivering access to the remote Podman Machine socket:
 
    ```shell-session
-   $ groups
+   groups
    ```
 
    On the default Ubuntu WSL, the list contains the `uucp` group.
@@ -187,13 +187,13 @@ Verify that, on your WSL distribution, the Podman CLI communicates with your Pod
    - Rootful Podman:
 
      ```shell-session
-     $ getent group 10
+     getent group 10
      ```
 
    - Rootless Podman:
 
      ```shell-session
-     $ getent group 1000
+     getent group 1000
      ```
 
    </div>
@@ -202,13 +202,13 @@ Verify that, on your WSL distribution, the Podman CLI communicates with your Pod
 1. Verify that Podman default system connections is set to your remote Podman machine:
 
    ```shell-session
-   $ podman system connection list
+   podman system connection list
    ```
 
 1. Verify that Podman has a `Server` version corresponding to your Podman Machine version:
 
    ```shell-session
-   $ podman version
+   podman version
    ```
 
    Sample output:
@@ -240,8 +240,8 @@ Verify that, on your WSL distribution, the Podman CLI communicates with your Pod
    On your WSL distribution, start a container such as `quay.io/podman/hello`, and list the name of the last running container:
 
    ```shell-session
-   $ podman run quay.io/podman/hello
-   $ podman ps -a --no-trunc --last 1
+   podman run quay.io/podman/hello
+   podman ps -a --no-trunc --last 1
    ```
 
    On **Podman Desktop > Containers**, the output lists the same container (same name, same image).
@@ -256,26 +256,26 @@ To change the active connection:
    - To set the connection to rootless:
 
      ```shell-session
-     $ podman machine set --rootful=false
+     podman machine set --rootful=false
      ```
 
    - To set the connection to rootful:
 
      ```shell-session
-     $ podman machine set --rootful=true
+     podman machine set --rootful=true
      ```
 
 1. In your WSL session, Change the Podman system connection configuration:
    - To set the connection to rootless:
 
      ```shell-session
-     $ podman system connection add --default podman-machine-default-user unix:///mnt/wsl/podman-sockets/podman-machine-default/podman-user.sock
+     podman system connection add --default podman-machine-default-user unix:///mnt/wsl/podman-sockets/podman-machine-default/podman-user.sock
      ```
 
    - To set the connection to rootful:
 
      ```shell-session
-     $ podman system connection add --default podman-machine-default-root unix:///mnt/wsl/podman-sockets/podman-machine-default/podman-root.sock
+     podman system connection add --default podman-machine-default-root unix:///mnt/wsl/podman-sockets/podman-machine-default/podman-root.sock
      ```
 
 ## Next steps

--- a/website/docs/podman/adding-certificates-to-a-podman-machine.md
+++ b/website/docs/podman/adding-certificates-to-a-podman-machine.md
@@ -29,19 +29,19 @@ On Windows, the Podman commands use the CAs from the certificate store. For exam
 1. Start an interactive session with the default Podman machine:
 
 ```sh
-$ podman machine ssh <machine_name>
+podman machine ssh <machine_name>
 ```
 
 2. Optional: Switch to a root shell only if Podman runs in the default rootless mode:
 
 ```sh
-$ sudo su -
+sudo su -
 ```
 
 3. Change to the directory where the certificates must be placed:
 
 ```sh
-$ cd /etc/pki/ca-trust/source/anchors
+cd /etc/pki/ca-trust/source/anchors
 ```
 
 4. Perform one of the following steps:
@@ -49,7 +49,7 @@ $ cd /etc/pki/ca-trust/source/anchors
 - Use the `curl` command to download a certificate:
 
   ```sh
-  $ curl [-k] -o <my-certificate> https://<my-server.com/my-certificate>
+  curl [-k] -o <my-certificate> https://<my-server.com/my-certificate>
   ```
 
 - Use any editor, such as Notepad or Vim to create a certificate file with .crt, .cer, or .pem extension.
@@ -63,13 +63,13 @@ $ cd /etc/pki/ca-trust/source/anchors
 5. Add the certificate to the list of trusted certificates:
 
 ```sh
-$ update-ca-trust
+update-ca-trust
 ```
 
 6. Optional: Run the `exit` command to exit the root shell.
 
 ```sh
-$ exit
+exit
 ```
 
 7. Run the `exit` command to exit the Podman machine.
@@ -77,6 +77,6 @@ $ exit
 8. Optional: Reboot the Podman machine.
 
 ```sh
-$ podman machine stop <machine_name>
-$ podman machine start <machine_name>
+podman machine stop <machine_name>
+podman machine start <machine_name>
 ```

--- a/website/docs/podman/gpu.md
+++ b/website/docs/podman/gpu.md
@@ -36,13 +36,13 @@ This can be installed by following the [official NVIDIA guide](https://docs.nvid
 SSH into the Podman Machine:
 
 ```sh
-$ podman machine ssh
+podman machine ssh
 ```
 
 Run the following commands **on the Podman Machine, not the host system**:
 
 ```sh
-$ curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | \
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | \
  tee /etc/yum.repos.d/nvidia-container-toolkit.repo && \
  yum install -y nvidia-container-toolkit && \
  nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml && \
@@ -62,7 +62,7 @@ To verify that containers created can access the GPU, you can use `nvidia-smi` f
 Run the following official NVIDIA container on your host machine:
 
 ```sh
-$ podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
+podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
 ```
 
 Example output:
@@ -161,13 +161,13 @@ RUN dnf -y install dnf-plugins-core && \
 3. Verify you can see the GPU by running a test container:
 
 ```sh
-$  podman run --rm -it --device /dev/dri --name gpu-info <gpu-container-image>  vulkaninfo | grep "GPU"
+ podman run --rm -it --device /dev/dri --name gpu-info <gpu-container-image>  vulkaninfo | grep "GPU"
 ```
 
 Example output:
 
 ```sh
-$  podman run --rm -it --device /dev/dri --name gpu-info quay.io/slopezpa/fedora-vgpu vulkaninfo | grep "GPU"
+ podman run --rm -it --device /dev/dri --name gpu-info quay.io/slopezpa/fedora-vgpu vulkaninfo | grep "GPU"
   GPU id = 0 (Virtio-GPU Venus (Apple M1 Pro))
   GPU id = 1 (llvmpipe (LLVM 17.0.6, 128 bits))
 GPU0:
@@ -203,13 +203,13 @@ Important note that the virtualized GPU (Virtio-GPU Venus (Apple M1 Pro)) only s
    Generate the CDI file:
 
    ```sh
-   $ nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+   nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
    ```
 
    Check the list of generated devices:
 
    ```sh
-   $ nvidia-ctk cdi list
+   nvidia-ctk cdi list
    ```
 
    More information as well as troubleshooting tips can be found [on the official NVIDIA CDI guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html).
@@ -221,14 +221,14 @@ Important note that the virtualized GPU (Virtio-GPU Venus (Apple M1 Pro)) only s
    Check whether SELinux is installed and enabled:
 
    ```sh
-   $ getenforce
+   getenforce
    ```
 
    - If `getenforce` is not found or its output is `Permissive` or `Disabled`, no action is needed.
    - If the output is `Enforcing`, configure SELinux to enable device access for containers:
 
      ```sh
-     $ sudo setsebool -P container_use_devices true
+     sudo setsebool -P container_use_devices true
      ```
 
 #### Verification
@@ -238,7 +238,7 @@ To verify that containers created can access the GPU, you can use `nvidia-smi` f
 Run the following official NVIDIA container on your host machine:
 
 ```sh
-$ podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
+podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
 ```
 
 #### Additional resources

--- a/website/docs/podman/podman-remote.md
+++ b/website/docs/podman/podman-remote.md
@@ -36,7 +36,7 @@ If you have not added a remote podman connection yet, you can follow the [offici
 1. Generate a local ed25519 key:
 
 ```sh
-$ ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
+ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
 ```
 
 2. Copy your **public** ed25519 key to the server:
@@ -48,7 +48,7 @@ Your public SSH key needs to be copied to the `~/.ssh/authorized_keys` file on t
 <TabItem value="win" label="Windows">
 
 ```sh
-$ type ~\.ssh\id_ed25519.pub | ssh user@my-server-ip "cat >> .ssh/authorized_keys"
+type ~\.ssh\id_ed25519.pub | ssh user@my-server-ip "cat >> .ssh/authorized_keys"
 ```
 
 </TabItem>
@@ -56,7 +56,7 @@ $ type ~\.ssh\id_ed25519.pub | ssh user@my-server-ip "cat >> .ssh/authorized_key
 <TabItem value="linux-macos" label="Linux & MacOS">
 
 ```sh
-$ ssh-copy-id -i ~/.ssh/id_ed25519.pub user@my-server-ip
+ssh-copy-id -i ~/.ssh/id_ed25519.pub user@my-server-ip
 ```
 
 </TabItem>
@@ -67,14 +67,14 @@ $ ssh-copy-id -i ~/.ssh/id_ed25519.pub user@my-server-ip
 By default, the podman.socket is **disabled** in Podman installations. Enabling the systemd socket allows remote clients to control Podman.
 
 ```sh
-$ systemctl enable podman.socket
-$ systemctl start podman.socket
+systemctl enable podman.socket
+systemctl start podman.socket
 ```
 
 Confirm that the socket is enabled by checking the status:
 
 ```sh
-$ systemctl status --user podman.socket
+systemctl status --user podman.socket
 ```
 
 4. Add the connection to `podman system connection ls`:
@@ -84,14 +84,14 @@ It's important to know which socket path you are using, as this varies between r
 Use `podman info` to determine the correct socket path:
 
 ```sh
-$ ssh user@my-server-ip podman info | grep sock
+ssh user@my-server-ip podman info | grep sock
    path: /run/user/1000/podman/podman.sock
 ```
 
 If you are using root, it may appear as:
 
 ```sh
-$ ssh root@my-server-ip podman info | grep sock
+ssh root@my-server-ip podman info | grep sock
    path: /run/podman/podman.sock
 ```
 
@@ -99,10 +99,10 @@ Now you are ready to add the connection. Add it with a distinct name to the Podm
 
 ```sh
 # non-root
-$ podman system connection add my-remote-machine --identity ~/.ssh/id_ed25519 ssh://myuser@my-server-ip/run/user/1000/podman/podman.sock
+podman system connection add my-remote-machine --identity ~/.ssh/id_ed25519 ssh://myuser@my-server-ip/run/user/1000/podman/podman.sock
 
 # root
-$ podman system connection add my-remote-machine --identity ~/.ssh/id_ed25519 ssh://root@my-server-ip/run/podman/podman.sock
+podman system connection add my-remote-machine --identity ~/.ssh/id_ed25519 ssh://root@my-server-ip/run/podman/podman.sock
 ```
 
 :::warning
@@ -120,7 +120,7 @@ On Windows, you need to use an absolute path for the identities; a path with ~ w
 1. Run a helloworld container on the remote machine:
 
 ```sh
-$ ssh user@my-server-ip podman run -d quay.io/podman/hello
+ssh user@my-server-ip podman run -d quay.io/podman/hello
 ```
 
 2. Within Podman Desktop, check that your container appears in the **Containers** section.
@@ -130,13 +130,13 @@ $ ssh user@my-server-ip podman run -d quay.io/podman/hello
 1. Set your remote connection as the default:
 
 ```sh
-$ podman system connection default my-remote-machine
+podman system connection default my-remote-machine
 ```
 
 2. Verify that the container appears in the CLI:
 
 ```sh
-$ podman ps
+podman ps
 ```
 
 :::note

--- a/website/docs/podman/setting-podman-machine-default-connection.md
+++ b/website/docs/podman/setting-podman-machine-default-connection.md
@@ -22,26 +22,26 @@ After an event that might have changed the default Podman machine connection, su
 1. List Podman machine connections, in a terminal:
 
    ```shell-session
-   $ podman system connection ls
+   podman system connection ls
    ```
 
 1. Set the Podman machine default connection to your desired connection, such as `podman-machine-default-root`, in a terminal:
 
    ```shell-session
-   $ podman system connection default podman-machine-default-root
+   podman system connection default podman-machine-default-root
    ```
 
 1. List Podman machine connections, to verify which is the default, in a terminal:
 
    ```shell-session
-   $ podman system connection ls
+   podman system connection ls
    ```
 
 1. Restart the Podman machine that has the default connection:
 
    ```shell-session
-   $ podman machine stop
-   $ podman machine start
+   podman machine stop
+   podman machine start
    ```
 
 1. Refresh Podman Desktop connection to Podman: click the **<Icon icon="fa-solid fa-lightbulb" size="lg" />** icon to open the **Troubleshooting** page, and click the **Reconnect providers** button.

--- a/website/docs/proxy/index.md
+++ b/website/docs/proxy/index.md
@@ -168,20 +168,20 @@ Requirements:
    2. Copy the certificate to the Podman machine:
 
    ```shell-session
-   $ cat proxy_ca.pem | podman machine ssh podman-machine-default "cat > proxy_ca.pem"
+   cat proxy_ca.pem | podman machine ssh podman-machine-default "cat > proxy_ca.pem"
    ```
 
    3. Open a shell prompt on the Podman machine:
 
       ```shell-session
-      $ podman machine ssh
+      podman machine ssh
       ```
 
    4. Add the custom Certificate Authorities (CA) for your proxy:
 
       ```shell-session
-      $ sudo cp <proxy_ca.pem> /etc/pki/ca-trust/source/anchors/
-      $ sudo update-ca-trust
+      sudo cp <proxy_ca.pem> /etc/pki/ca-trust/source/anchors/
+      sudo update-ca-trust
       ```
 
    </div>
@@ -197,7 +197,7 @@ Requirements:
    1. Open a shell prompt on the Podman machine:
 
    ```shell-session
-   $ podman machine ssh
+   podman machine ssh
    ```
 
    2. Edit the `containers.conf` file to pass the proxy environment variables to Podman CLI.
@@ -242,20 +242,20 @@ Requirements:
    2. Copy the certificate to the Podman machine:
 
    ```shell-session
-   $ cat proxy_ca.pem | podman machine ssh podman-machine-default "cat > proxy_ca.pem"
+   cat proxy_ca.pem | podman machine ssh podman-machine-default "cat > proxy_ca.pem"
    ```
 
    3. Open a shell prompt on the Podman machine:
 
       ```shell-session
-      $ podman machine ssh
+      podman machine ssh
       ```
 
    4. Add the custom Certificate Authorities (CA) for your proxy:
 
       ```shell-session
-      $ sudo cp <proxy_ca.pem> /etc/pki/ca-trust/source/anchors/
-      $ sudo update-ca-trust
+      sudo cp <proxy_ca.pem> /etc/pki/ca-trust/source/anchors/
+      sudo update-ca-trust
       ```
 
    </div>
@@ -271,7 +271,7 @@ Requirements:
    1. Open a shell prompt on the Podman machine:
 
    ```shell-session
-   $ podman machine ssh
+   podman machine ssh
    ```
 
    2. Edit the `containers.conf` file to pass the proxy environment variables to Podman CLI.
@@ -318,14 +318,14 @@ Configure Podman:
 1. Add the custom Certificate Authorities (CA) for your proxy:
 
    ```shell-session
-   $ sudo cp <proxy_ca.pem> /etc/pki/ca-trust/source/anchors/
-   $ sudo update-ca-trust
+   sudo cp <proxy_ca.pem> /etc/pki/ca-trust/source/anchors/
+   sudo update-ca-trust
    ```
 
 1. Restart all `podman` processes.
 
    ```shell-session
-   $ pkill podman
+   pkill podman
    ```
 
 </TabItem>

--- a/website/docs/troubleshooting/troubleshooting-extension-issues.md
+++ b/website/docs/troubleshooting/troubleshooting-extension-issues.md
@@ -19,7 +19,7 @@ You might get this error message `Failed to create minikube cluster. E0125 05:58
 1. Run the following command to delete the Minikube cluster.
 
    ```shell-session
-   $ minikube delete
+   minikube delete
    ```
 
 2. Create a new [Minikube cluster](/docs/minikube/installing-extension) using the Podman Desktop UI.

--- a/website/docs/troubleshooting/troubleshooting-openshift-local.md
+++ b/website/docs/troubleshooting/troubleshooting-openshift-local.md
@@ -13,7 +13,7 @@ You can find here troubleshooting help for issues specific to OpenShift Local.
 2. To verify that the host is ready to run OpenShift Local, in a terminal, run this command and verify the output has no errors:
 
    ```shell-session
-   $ crc setup --check-only
+   crc setup --check-only
    ```
 
    Sample output:
@@ -29,5 +29,5 @@ You can find here troubleshooting help for issues specific to OpenShift Local.
 3. To verify the configured preset, in a terminal, run:
 
    ```shell-session
-   $ crc config get preset
+   crc config get preset
    ```

--- a/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
@@ -96,8 +96,8 @@ Then run a terminal in native mode (default) and install Podman machine `brew in
 Finally clean the Podman machine VMs that had been previously created, and create new ones.
 
 ```shell-session
-$ podman machine rm podman-machine-default
-$ podman machine init
+podman machine rm podman-machine-default
+podman machine init
 ```
 
 You should be a happy camper from here.
@@ -111,7 +111,7 @@ After a failed start, the Podman machine might be unable to start because a QEMU
 1. Kill the remaining QEMU process and stop the Podman machine:
 
    ```shell-session
-   $ ps -edf | grep qemu-system | grep -v grep | awk '{print $2}' | xargs -I{} kill -9 {}; podman machine stop
+   ps -edf | grep qemu-system | grep -v grep | awk '{print $2}' | xargs -I{} kill -9 {}; podman machine stop
    ```
 
 2. Start the Podman machine.
@@ -137,15 +137,15 @@ Keep your brew-based installation and apply one of these workarounds:
 - Rollback the QEMU brew package to v8.0.3.
 
   ```shell-session
-  $ brew uninstall qemu
-  $ curl -OSL https://raw.githubusercontent.com/Homebrew/homebrew-core/dc0669eca9479e9eeb495397ba3a7480aaa45c2e/Formula/qemu.rb
-  $ brew install ./qemu.rb
+  brew uninstall qemu
+  curl -OSL https://raw.githubusercontent.com/Homebrew/homebrew-core/dc0669eca9479e9eeb495397ba3a7480aaa45c2e/Formula/qemu.rb
+  brew install ./qemu.rb
   ```
 
 - Alternatively, sign the QEMU brew binary locally:
 
   ```shell-session
-  $ cat >entitlements.xml <<EOF
+  cat >entitlements.xml <<EOF
   <?xml version="1.0" encoding="UTF-8"?>
   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
   <plist version="1.0">
@@ -155,7 +155,7 @@ Keep your brew-based installation and apply one of these workarounds:
   </dict>
   </plist>
   EOF
-  $ codesign --sign - --entitlements entitlements.xml --force /usr/local/bin/qemu-system-$(uname -m | sed -e s/arm64/aarch64/)
+  codesign --sign - --entitlements entitlements.xml --force /usr/local/bin/qemu-system-$(uname -m | sed -e s/arm64/aarch64/)
   ```
 
 #### Additional resources
@@ -181,42 +181,42 @@ For M3 processors:
    1. Remove eventual installation from podman/podman desktop installer:
 
       ```shell-session
-      $ sudo rm -rf opt/podman
+      sudo rm -rf opt/podman
       ```
 
    1. Remove brew installations:
 
       ```shell-session
-      $ brew uninstall podman-desktop
-      $ brew uninstall podman
-      $ brew uninstall qemu
+      brew uninstall podman-desktop
+      brew uninstall podman
+      brew uninstall qemu
       ```
 
    1. Remove Podman files:
 
       ```shell-session
-      $ rm -rf ~/.ssh/podman-machine-default
-      $ rm -rf ~/.ssh/podman-machine-default.pub
-      $ rm -rf ~/.local/share/containers
-      $ rm -rf ~/.config/containers
+      rm -rf ~/.ssh/podman-machine-default
+      rm -rf ~/.ssh/podman-machine-default.pub
+      rm -rf ~/.local/share/containers
+      rm -rf ~/.config/containers
       ```
 
 1. Reinstall Podman using brew:
 
    ```shell-session
-   $ brew install podman
+   brew install podman
    ```
 
 1. Install bunzip2:
 
    ```shell-session
-   $ brew install bzip2
+   brew install bzip2
    ```
 
 1. Install QEMU 8.2.0 to `/opt/homebrew/Cellar/qemu/8.2.0`:
 
    ```shell-session
-   $ curl -sL https://github.com/AkihiroSuda/qemu/raw/704f7cad5105246822686f65765ab92045f71a3b/pc-bios/edk2-aarch64-code.fd.bz2 | bunzip2 > /opt/homebrew/Cellar/qemu/8.2.0/share/qemu/edk2-aarch64-code.fd
+   curl -sL https://github.com/AkihiroSuda/qemu/raw/704f7cad5105246822686f65765ab92045f71a3b/pc-bios/edk2-aarch64-code.fd.bz2 | bunzip2 > /opt/homebrew/Cellar/qemu/8.2.0/share/qemu/edk2-aarch64-code.fd
    ```
 
 1. Install patched EDK2.
@@ -227,14 +227,14 @@ For M3 processors:
 1. Find QEMU configuration directory to define _`qemu-config-directory`_ in next step:
 
    ```shell-session
-   $ podman machine info | grep MachineConfigDir
+   podman machine info | grep MachineConfigDir
 
    ```
 
 1. Update podman machine config json:
 
    ```shell-session
-   $ sed -i 's@file=.\*edk2-aarch64-code.fd@file=/path/to/downloaded/edk2-aarch64-code.fd@g' qemu-config-directory/podman-machine-default.json
+   sed -i 's@file=.\*edk2-aarch64-code.fd@file=/path/to/downloaded/edk2-aarch64-code.fd@g' qemu-config-directory/podman-machine-default.json
    ```
 
 1. Start Podman machine.
@@ -250,14 +250,14 @@ When you create a Podman machine with the `GPU enabled (LibKrun)` provider type,
 **_Podman machine is not listed_**
 
 ```shell-session
-$ podman machine list
+podman machine list
 NAME        VM TYPE     CREATED     LAST UP     CPUS        MEMORY      DISK SIZE
 ```
 
 **_Error: interacting with the default Podman machine_**
 
 ```shell-session
-$ podman machine ssh
+podman machine ssh
 Error: vm podman-machine-default not found: podman-machine-default: VM does not exist
 ```
 
@@ -282,18 +282,18 @@ With Podman Desktop 1.16, the log files are automatically cleaned at the restart
 Check the size of the Podman Desktop log files to troubleshoot:
 
 ```sh
-$ ls -la ~/Library/Logs/Podman\ Desktop/*.log
+ls -la ~/Library/Logs/Podman\ Desktop/*.log
 ```
 
 With Podman Desktop 1.16.0 or later versions, your computer might require a restart to truncate the Podman Desktop log files.
 To avoid restarting your computer, run these commands one by one:
 
 ```shell-session
-$ launchctl unload  ~/Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist
+launchctl unload  ~/Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist
 ```
 
 ```shell-session
-$ launchctl load  ~/Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist
+launchctl load  ~/Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist
 ```
 
 ## Unable to upgrade Podman Desktop to the latest version using Homebrew
@@ -305,7 +305,7 @@ When you use Homebrew to upgrade to the latest version of Podman Desktop, you mi
 To resolve the error, use the `--greedy` flag with the `upgrade` command:
 
 ```sh
-$ brew upgrade --greedy podman-desktop
+brew upgrade --greedy podman-desktop
 ```
 
 The `--greedy` flag instructs Homebrew to check and upgrade casks marked with `:latest` versions. This ensures self-updating applications, such as Podman Desktop, are included in the upgrade process if a newer cask version exists.

--- a/website/docs/troubleshooting/troubleshooting-podman-on-windows.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-windows.md
@@ -15,7 +15,7 @@ You can find here troubleshooting help for issues specific to Windows.
 1. You are not able to stop your Podman Machine.
 
    ```shell-session
-   $ podman machine stop
+   podman machine stop
    ```
 
 2. The Logs contain this error:
@@ -29,7 +29,7 @@ You can find here troubleshooting help for issues specific to Windows.
 1. To display the active Windows Subsystem for Linux (WSL) distribution list: in the terminal, run:
 
    ```shell-session
-   $ wsl --list
+   wsl --list
    ```
 
 1. The command returns the list of active WSL distributions. Identify your Podman Machine in the list, such as `podman-machine-default`.
@@ -37,7 +37,7 @@ You can find here troubleshooting help for issues specific to Windows.
 1. To stop, and uninstall your Podman Machine: in the terminal, replace `podman-machine-default` by your Podman machine name, and run:
 
    ```shell-session
-   $ wsl --unregister podman-machine-default
+   wsl --unregister podman-machine-default
    ```
 
 #### Additional resources

--- a/website/docs/troubleshooting/troubleshooting-podman.md
+++ b/website/docs/troubleshooting/troubleshooting-podman.md
@@ -30,7 +30,7 @@ After each step, quit and restart Podman Desktop to ensure that it can detect yo
 1. In a terminal, verify you can access the Podman CLI, and verify the version.
 
    ```shell-session
-   $ podman version
+   podman version
    ```
 
 1. Update Podman to the latest stable version by using your installation method.
@@ -51,7 +51,7 @@ Podman Desktop might fail creating a Podman machine.
 1. In a terminal, create the Podman machine with the Podman CLI:
 
    ```shell-session
-   $ podman machine init
+   podman machine init
    ```
 
 1. If the creation fails, read the logs carefully to continue troubleshooting.
@@ -67,7 +67,7 @@ Podman Desktop might fail starting a Podman machine. On the **Settings > Resourc
 1. In a terminal, start the Podman machine with the Podman CLI:
 
    ```shell-session
-   $ podman machine start
+   podman machine start
    ```
 
 1. If the start fails, read the logs carefully to continue troubleshooting.
@@ -87,13 +87,13 @@ Podman Desktop might fail listing images or container.
 1. On Windows and macOS: In a terminal, verify that at least one Podman machine is running:
 
    ```shell-session
-   $ podman machine list
+   podman machine list
    ```
 
 1. To verify that you can connect using the CLI, open a terminal and run the `hello` container:
 
    ```shell-session
-   $ podman run quay.io/podman/hello
+   podman run quay.io/podman/hello
    ```
 
 ## Podman Desktop fails listing containers
@@ -110,23 +110,23 @@ Podman Desktop might display "No containers" on the Containers page, even if act
 1. In a terminal, restart the Podman machine:
 
    ```shell-session
-   $ podman machine stop
-   $ podman machine start
+   podman machine stop
+   podman machine start
    ```
 
 1. If the previous step did not work for you, delete your Podman machine, and create a new one:
 
    ```shell-session
-   $ podman machine rm
-   $ podman machine init
+   podman machine rm
+   podman machine init
    ```
 
 1. If the previous steps did not work for you, delete your Podman configuration files, and create a new Podman machine:
 
    ```shell-session
-   $ rm -rf ~/.local/share/containers/podman
-   $ rm -rf ~/.config/containers/
-   $ podman machine init
+   rm -rf ~/.local/share/containers/podman
+   rm -rf ~/.config/containers/
+   podman machine init
    ```
 
 ## Podman Desktop is failing to display the images or containers from a rootful Podman machine
@@ -140,7 +140,7 @@ Podman Desktop might then reconnect in rootless mode, and fail to display the im
 1. Verify that the Podman default connection is the rootful connection to your Podman machine:
 
    ```shell-session
-   $ podman system connection ls
+   podman system connection ls
    ```
 
    The default connection has `true` at the end of the line.
@@ -168,20 +168,20 @@ Podman Desktop might then reconnect in rootless mode, and fail to display the im
 1. Set the Podman machine in rootful mode:
 
    ```shell-session
-   $ podman machine set --rootful
+   podman machine set --rootful
    ```
 
 1. Restart the Podman machine:
 
    ```shell-session
-   $ podman machine stop
-   $ podman machine start
+   podman machine stop
+   podman machine start
    ```
 
 1. Verify that Podman default connection points to the rootful connection:
 
    ```shell-session
-   $ podman system connection ls
+   podman system connection ls
    ```
 
    Continue with the next steps only if the default connection is not the rootful connection to your Podman machine.
@@ -189,14 +189,14 @@ Podman Desktop might then reconnect in rootless mode, and fail to display the im
 1. Set the Podman machine, such as `podman-machine-default` in rootful mode:
 
    ```shell-session
-   $ podman system connection default podman-machine-default-root
+   podman system connection default podman-machine-default-root
    ```
 
 1. Restart the Podman machine:
 
    ```shell-session
-   $ podman machine stop
-   $ podman machine start
+   podman machine stop
+   podman machine start
    ```
 
 #### Verification
@@ -204,7 +204,7 @@ Podman Desktop might then reconnect in rootless mode, and fail to display the im
 1. The Podman default connection is the rootful connection to your Podman machine:
 
    ```shell-session
-   $ podman system connection ls
+   podman system connection ls
    ```
 
 ## Warning about Docker compatibility mode
@@ -228,7 +228,7 @@ This might appear when either:
 2. On macOS, Run the `podman-mac-helper` binary:
 
    ```shell-session
-   $ sudo podman-mac-helper install
+   sudo podman-mac-helper install
    ```
 
 3. Restart the Podman machine to recreate and activate the default Docker socket path.

--- a/website/docs/uninstall/index.md
+++ b/website/docs/uninstall/index.md
@@ -37,7 +37,7 @@ You can delete all pods, containers, and images by removing the Podman machine.
 
 1. Remove all Podman machines:
    ```sh
-   $ podman machine reset -f
+   podman machine reset -f
    ```
 1. Uninstall Podman from the Start menu, Settings, or Control Panel. For more details, see the [resource](https://support.microsoft.com/en-us/windows/uninstall-or-remove-apps-and-programs-in-windows-4b55f974-2cc6-2d2b-d092-5905080eaf98).
 1. Remove Podman files and configurations:
@@ -52,27 +52,27 @@ You can delete all pods, containers, and images by removing the Podman machine.
 
 1. Remove all Podman machines:
    ```sh
-   $ podman machine reset -f
+   podman machine reset -f
    ```
 1. Perform one of the following steps based on your installation:
    - If you have installed Podman using `brew`, run the following command:
      ```sh
-     $ brew uninstall podman
+     brew uninstall podman
      ```
    - If you have installed Podman using the Podman Desktop setup, run the following commands one by one:
      ```sh
-     $ sudo /opt/podman/bin/podman-mac-helper uninstall
-     $ sudo rm /etc/paths.d/podman-pkg
-     $ sudo rm -rfv /opt/podman
+     sudo /opt/podman/bin/podman-mac-helper uninstall
+     sudo rm /etc/paths.d/podman-pkg
+     sudo rm -rfv /opt/podman
      ```
 1. Remove the Podman files and configurations:
    ```sh
-   $ rm -rf ~/.local/share/containers/podman
-   $ rm -rf ~/.config/containers/podman
+   rm -rf ~/.local/share/containers/podman
+   rm -rf ~/.config/containers/podman
    ```
 1. Optional: Delete storage configuration:
    ```sh
-   $ rm -rf ~/.local/share/containers/storage
+   rm -rf ~/.local/share/containers/storage
    ```
 
 </TabItem>
@@ -132,12 +132,12 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
 
 1. Remove the Podman Desktop configuration files:
    ```powershell
-   $ rm -Recurse -Force ~/.local/share/containers/podman-desktop/
-   $ rm -Recurse -Force ~/AppData/Roaming/Podman Desktop
+   rm -Recurse -Force ~/.local/share/containers/podman-desktop/
+   rm -Recurse -Force ~/AppData/Roaming/Podman Desktop
    ```
 1. Remove temporary files, caches, and blobs:
    ```powershell
-   $ rm -Recurse -Force ~/AppData/Roaming/Podman Desktop
+   rm -Recurse -Force ~/AppData/Roaming/Podman Desktop
    ```
 
 </TabItem>
@@ -146,7 +146,7 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
 1. Perform one of the following steps based on your installation:
    - If you have installed Podman Desktop using `brew`, run the following command:
      ```sh
-     $ brew uninstall podman-desktop
+     brew uninstall podman-desktop
      ```
    - If you have installed Podman Desktop using the `.dmg` file, perform the following steps:
      1. Locate the Podman Desktop `.dmg` file.
@@ -154,7 +154,7 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
 
 1. Remove the Podman Desktop configuration files:
    ```sh
-   $ rm -rf ~/.local/share/containers/podman-desktop
+   rm -rf ~/.local/share/containers/podman-desktop
    ```
 
 </TabItem>
@@ -163,12 +163,12 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
 1. Uninstall Podman Desktop using flatpak or flathub:
 
    ```sh
-   $ flatpak uninstall io.podman_desktop.PodmanDesktop
+   flatpak uninstall io.podman_desktop.PodmanDesktop
    ```
 
 1. Remove the Podman Desktop configuration folder:
    ```sh
-   $ rm -rf ~/.local/share/containers/podman-desktop
+   rm -rf ~/.local/share/containers/podman-desktop
    ```
 
 </TabItem>

--- a/website/tutorial/testcontainers-with-podman.md
+++ b/website/tutorial/testcontainers-with-podman.md
@@ -27,7 +27,7 @@ Thanks to the container technology, you can obtain fresh, clean instances withou
 Before we start, you need to have installed [Podman](https://podman.io/) and run it in socket listening:
 
 ```shell
-$ podman system service --time=0 &
+ podman system service --time=0 &
 ```
 
 Set Testcontainers runtime to Podman by using one of the following options:
@@ -44,7 +44,7 @@ Set Testcontainers runtime to Podman by using one of the following options:
     Run the following command after configuration:
 
     ```bash
-    $ export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
+    export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
     ```
 
   - Linux:
@@ -62,7 +62,7 @@ Set Testcontainers runtime to Podman by using one of the following options:
 > **_OPTIONAL:_** If you are running Podman in rootless mode, you must disable Ryuk by defining this environment variable:
 >
 > ```bash
-> $ export TESTCONTAINERS_RYUK_DISABLED=true
+> export TESTCONTAINERS_RYUK_DISABLED=true
 > ```
 
 ## Creating a project
@@ -72,13 +72,13 @@ This example uses the Redis service and Redis module from Testcontainers. You ca
 1. Initialize a project.
 
    ```bash
-   $ npm init -y
+   npm init -y
    ```
 
 2. Installing dependencies.
 
    ```bash
-   $ npm install testcontainers vitest @testcontainers/redis redis typescript --save-dev
+   npm install testcontainers vitest @testcontainers/redis redis typescript --save-dev
    ```
 
 3. Update `package.json` file.
@@ -204,7 +204,7 @@ This example uses the Redis service and Redis module from Testcontainers. You ca
 When running Testcontainers for the first time, ensure that you run your tests in `DEBUG` mode by using this command:
 
 ```bash
-$ DEBUG=testcontainers* npm test
+DEBUG=testcontainers* npm test
 ```
 
 Then, you should be able to see lines similar to the ones below:


### PR DESCRIPTION
### What does this PR do?

This PR removes the shell prompts from the code blocks in the Markdown doc files.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

I didn't open an issue for this as it's very minor (but please let me know if I should), but the reasoning for this is that leaving the shell prompts in the Markdown code blocks means that when the code block is rendered on the docs site, and you use the built-in copy button, it will copy the shell prompt to your clipboard along with the command, which is undesirable. This PR fixes that by removing the hard-coded shell prompt from the Markdown code blocks in our docs.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
