### PR TITLE
feat(api): add engineid to networkcreateresult

### DIFF
--- a/packages/api/src/container-info.ts
+++ b/packages/api/src/container-info.ts
@@ -279,6 +279,7 @@ export type NetworkCreateOptions = Dockerode.NetworkCreateOptions;
 
 export interface NetworkCreateResult {
   Id: string;
+  engineId: string;
 }
 
 // Form state interface for creating networks in the UI

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3779,6 +3779,7 @@ declare module '@podman-desktop/api' {
 
   export interface NetworkCreateResult {
     Id: string;
+    engineId: string;
   }
 
   /**

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3432,7 +3432,8 @@ describe('attachToContainer', () => {
 });
 
 test('createNetwork', async () => {
-  server = setupServer(http.post('http://localhost/networks/create', () => new HttpResponse('', { status: 200 })));
+  const networkId = 'network123456';
+  server = setupServer(http.post('http://localhost/networks/create', () => HttpResponse.json({ Id: networkId })));
   server.listen({ onUnhandledRequest: 'error' });
 
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
@@ -3465,8 +3466,10 @@ test('createNetwork', async () => {
   // set provider
   containerRegistry.addInternalProvider('podman', internalContainerProvider);
 
-  // check that it's calling the right mock method
-  await containerRegistry.createNetwork(providerConnectionInfo, { Name: 'myNetwork' });
+  // check that it returns both Id and engineId
+  const result = await containerRegistry.createNetwork(providerConnectionInfo, { Name: 'myNetwork' });
+  expect(result.Id).toBe(networkId);
+  expect(result.engineId).toBe('podman1');
 });
 
 test('setupConnectionAPI with errors', async () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -790,9 +790,12 @@ export class ContainerProviderRegistry {
   ): Promise<NetworkCreateResult> {
     let telemetryOptions = {};
     try {
-      const matchingEngine = this.getMatchingEngineFromConnection(providerContainerConnectionInfo);
-      const network = await matchingEngine.createNetwork(options);
-      return { Id: network.id };
+      const matchingContainerProvider = this.getMatchingContainerProvider(providerContainerConnectionInfo);
+      if (!matchingContainerProvider?.api) {
+        throw new Error('no running provider for the matching container');
+      }
+      const network = await matchingContainerProvider.api.createNetwork(options);
+      return { Id: network.id, engineId: matchingContainerProvider.id };
     } catch (error) {
       telemetryOptions = { error: error };
       throw error;

--- a/packages/renderer/src/lib/network/CreateNetwork.spec.ts
+++ b/packages/renderer/src/lib/network/CreateNetwork.spec.ts
@@ -107,7 +107,7 @@ test('Expect all form fields to be present', async () => {
 });
 
 test('Expect createNetwork to be called with correct parameters', async () => {
-  vi.mocked(window.createNetwork).mockResolvedValue({ Id: 'network123' });
+  vi.mocked(window.createNetwork).mockResolvedValue({ Id: 'network123', engineId: 'test' });
   renderCreate();
 
   const networkName = screen.getByRole('textbox', { name: 'Name *' });
@@ -169,7 +169,7 @@ test('Expect empty screen when no providers available', async () => {
 });
 
 test('Expect createNetwork to be called with subnet when provided', async () => {
-  vi.mocked(window.createNetwork).mockResolvedValue({ Id: 'network123' });
+  vi.mocked(window.createNetwork).mockResolvedValue({ Id: 'network123', engineId: 'test' });
   renderCreate();
 
   const networkName = screen.getByRole('textbox', { name: 'Name *' });
@@ -208,7 +208,7 @@ test('Expect cancel button to navigate to networks page', async () => {
 
 test('Expect automatic routing after successful network creation when network appears in store', async () => {
   const networkId = 'network123';
-  vi.mocked(window.createNetwork).mockResolvedValue({ Id: networkId });
+  vi.mocked(window.createNetwork).mockResolvedValue({ Id: networkId, engineId: 'test' });
 
   renderCreate();
 


### PR DESCRIPTION
this is needed to identify what engine created the network in order to route to the network summary page

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

See https://github.com/podman-desktop/podman-desktop/pull/15209#discussion_r2591468279

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
