### PR TITLE
chore(main): import reflect-metadata explictly for inversify update

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "minimist": "^1.2.8",
     "moment": "^2.30.1",
     "os-locale": "^6.0.2",
+    "reflect-metadata": "^0.2.2",
     "semver": "^7.7.3",
     "stream-json": "^1.9.1",
     "sudo-prompt": "^9.2.1",

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -15,6 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import 'reflect-metadata';
+
 import type { App as ElectronApp, BrowserWindow } from 'electron';
 
 import type { AppPlugin } from '/@/plugin/app-ready/app-plugin.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       os-locale:
         specifier: ^6.0.2
         version: 6.0.2
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
       semver:
         specifier: ^7.7.3
         version: 7.7.3


### PR DESCRIPTION
### What does this PR do?

This PR tries to unblock the update of inversify to 7.10.5 by importing explicitly `reflect-metadata` in the main process.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related https://github.com/inversify/monorepo/issues/1370

Related https://github.com/podman-desktop/podman-desktop/pull/15182

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Rebase PR https://github.com/podman-desktop/podman-desktop/pull/15182

Run `pnpm install` and `pnpm watch`

See if the app now starts correctly.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
