### PR TITLE
chore(test): adjust test default timeout to account for image building

### DIFF
--- a/tests/playwright/src/specs/podman-kube-play-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-kube-play-smoke.spec.ts
@@ -105,6 +105,8 @@ test.describe.serial('Podman Kube Play Yaml - with Build flag', { tag: '@smoke' 
     }
   });
   test('Create pod and verify it is running', async ({ navigationBar }) => {
+    test.setTimeout(180_000);
+
     const podsPage = await navigationBar.openPods();
     await playExpect(podsPage.heading).toBeVisible();
     const podmanKubePlayPage = await podsPage.openPodmanKubePlay();


### PR DESCRIPTION
### What does this PR do?
Increases the test timeout from the default 60 seconds to account for how long it takes to build the image.

### What issues does this PR fix or reference?