### PR TITLE
chore(test): fix strict mode violation in registry e2e tests

### DIFF
--- a/tests/playwright/src/specs/registry.spec.ts
+++ b/tests/playwright/src/specs/registry.spec.ts
@@ -74,7 +74,7 @@ test.describe.serial('Registries handling verification', { tag: '@smoke' }, () =
     await registryPage.cancelDialogButton.click();
 
     await registryPage.createRegistry(registryUrl, 'invalidName', 'invalidPswd');
-    const credsErrorMsg = page.getByLabel('Error Message Content');
+    const credsErrorMsg = page.getByRole('dialog', { name: 'Add Registry' }).getByLabel('Error Message Content');
     await playExpect(credsErrorMsg).toBeVisible({ timeout: 30_000 });
     await playExpect(credsErrorMsg).toContainText('Wrong Username or Password', { ignoreCase: true });
     await playExpect(registryPage.cancelDialogButton).toBeEnabled();
@@ -99,7 +99,7 @@ test.describe.serial('Registries handling verification', { tag: '@smoke' }, () =
         const registryPage = new RegistriesPage(page);
 
         await registryPage.editRegistry(registryName, 'invalidName', 'invalidPswd');
-        const errorMsg = page.getByLabel('Error Message Content');
+        const errorMsg = page.getByRole('dialog', { name: 'Edit Registry' }).getByLabel('Error Message Content');
         await playExpect(errorMsg).toBeVisible({ timeout: 30_000 });
         await playExpect(errorMsg).toContainText('Wrong Username or Password', { ignoreCase: true });
 


### PR DESCRIPTION
### What does this PR do?
Fixes strict mode violation in registry e2e tests where `getByLabel('Error Message Content')` was matching multiple elements.

**Changes:**
- Scoped error message locator to 'Add Registry' dialog
- Scoped error message locator to 'Edit Registry' dialog

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
