### PR TITLE
chore: replace configuration constants by definition in product.json file

### DIFF
--- a/packages/main/src/plugin/directories-legacy.spec.ts
+++ b/packages/main/src/plugin/directories-legacy.spec.ts
@@ -22,10 +22,15 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { isLinux, isMac, isWindows } from '/@/util.js';
+import product from '/@product.json' with { type: 'json' };
+
 import type { Directories } from './directories.js';
 import { LegacyDirectories } from './directories-legacy.js';
 
 const originalProcessEnv = process.env;
+
+vi.mock(import('/@/util.js'));
 
 beforeEach(() => {
   // Reset environment variables to clean state
@@ -109,6 +114,65 @@ describe('LegacyDirectories', () => {
       provider = new LegacyDirectories();
 
       expect(mkdirSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('getManagedDefaultsDirectory', () => {
+    test('should return macOS managed folder path when running on macOS', () => {
+      vi.mocked(isMac).mockReturnValue(true);
+      vi.mocked(isWindows).mockReturnValue(false);
+      vi.mocked(isLinux).mockReturnValue(false);
+
+      provider = new LegacyDirectories();
+
+      expect(provider.getManagedDefaultsDirectory()).toBe(product.paths.managed.macOS);
+    });
+
+    test('should map PROGRAMDATA into windows managed folder path', () => {
+      vi.mocked(isMac).mockReturnValue(false);
+      vi.mocked(isWindows).mockReturnValue(true);
+      vi.mocked(isLinux).mockReturnValue(false);
+      const customProgramData = 'D:\\CorpData';
+      process.env['PROGRAMDATA'] = customProgramData;
+
+      provider = new LegacyDirectories();
+
+      expect(provider.getManagedDefaultsDirectory()).toBe(
+        product.paths.managed.windows.replace('%PROGRAMDATA%', customProgramData),
+      );
+    });
+
+    test('should default PROGRAMDATA when env variable is missing', () => {
+      vi.mocked(isMac).mockReturnValue(false);
+      vi.mocked(isWindows).mockReturnValue(true);
+      vi.mocked(isLinux).mockReturnValue(false);
+      delete process.env['PROGRAMDATA'];
+
+      provider = new LegacyDirectories();
+
+      expect(provider.getManagedDefaultsDirectory()).toBe(
+        product.paths.managed.windows.replace('%PROGRAMDATA%', 'C:\\ProgramData'),
+      );
+    });
+
+    test('should return linux managed folder path when running on Linux', () => {
+      vi.mocked(isMac).mockReturnValue(false);
+      vi.mocked(isWindows).mockReturnValue(false);
+      vi.mocked(isLinux).mockReturnValue(true);
+
+      provider = new LegacyDirectories();
+
+      expect(provider.getManagedDefaultsDirectory()).toBe(product.paths.managed.linux);
+    });
+
+    test('should fallback to linux managed folder path when platform is unknown', () => {
+      vi.mocked(isMac).mockReturnValue(false);
+      vi.mocked(isWindows).mockReturnValue(false);
+      vi.mocked(isLinux).mockReturnValue(false);
+
+      provider = new LegacyDirectories();
+
+      expect(provider.getManagedDefaultsDirectory()).toBe(product.paths.managed.linux);
     });
   });
 });

--- a/packages/main/src/plugin/directories-legacy.ts
+++ b/packages/main/src/plugin/directories-legacy.ts
@@ -22,13 +22,10 @@ import * as path from 'node:path';
 
 import { injectable } from 'inversify';
 
+import product from '/@product.json' with { type: 'json' };
+
 import { isLinux, isMac, isWindows } from '../util.js';
 import type { Directories } from './directories.js';
-import {
-  SYSTEM_DEFAULTS_FOLDER_LINUX,
-  SYSTEM_DEFAULTS_FOLDER_MACOS,
-  SYSTEM_DEFAULTS_FOLDER_WINDOWS,
-} from './managed-by-constants.js';
 
 /**
  * Directory provider that uses the traditional/legacy directory structure
@@ -37,7 +34,7 @@ import {
  */
 @injectable()
 export class LegacyDirectories implements Directories {
-  static readonly XDG_DATA_DIRECTORY = `.local${path.sep}share${path.sep}containers${path.sep}podman-desktop`;
+  static readonly XDG_DATA_DIRECTORY = `.local${path.sep}share${path.sep}${product.paths.config}`;
   static readonly PODMAN_DESKTOP_HOME_DIR = 'PODMAN_DESKTOP_HOME_DIR';
 
   private readonly configurationDirectory: string;
@@ -100,14 +97,15 @@ export class LegacyDirectories implements Directories {
 
   getManagedDefaultsDirectory(): string {
     if (isMac()) {
-      return SYSTEM_DEFAULTS_FOLDER_MACOS;
+      return product.paths.managed.macOS;
     } else if (isWindows()) {
       const programData = process.env['PROGRAMDATA'] ?? 'C:\\ProgramData';
-      return path.join(programData, SYSTEM_DEFAULTS_FOLDER_WINDOWS);
+      // replace %PROGRAMDATA% in the path
+      return product.paths.managed.windows.replace('%PROGRAMDATA%', programData);
     } else if (isLinux()) {
-      return SYSTEM_DEFAULTS_FOLDER_LINUX;
+      return product.paths.managed.linux;
     }
     // Fallback to Linux-style path
-    return SYSTEM_DEFAULTS_FOLDER_LINUX;
+    return product.paths.managed.linux;
   }
 }

--- a/packages/main/src/plugin/directories-linux-xdg.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.ts
@@ -21,8 +21,9 @@ import * as path from 'node:path';
 
 import { injectable } from 'inversify';
 
+import product from '/@product.json' with { type: 'json' };
+
 import type { Directories } from './directories.js';
-import { SYSTEM_DEFAULTS_FOLDER_LINUX } from './managed-by-constants.js';
 
 /**
  * Directory provider that follows XDG Base Directory Specification for Linux
@@ -42,12 +43,12 @@ export class LinuxXDGDirectories implements Directories {
     // XDG_CONFIG_HOME: user-specific configuration files
     // biome-ignore lint/complexity/useLiteralKeys: XDG_CONFIG_HOME comes from an index signature
     const xdgConfigHome = process.env['XDG_CONFIG_HOME'] ?? path.resolve(os.homedir(), '.config');
-    this.configurationDirectory = path.resolve(xdgConfigHome, 'containers', 'podman-desktop');
+    this.configurationDirectory = path.resolve(xdgConfigHome, product.paths.config);
 
     // XDG_DATA_HOME: user-specific data files (plugins, extensions data)
     // biome-ignore lint/complexity/useLiteralKeys: XDG_DATA_HOME comes from an index signature
     const xdgDataHome = process.env['XDG_DATA_HOME'] ?? path.resolve(os.homedir(), '.local', 'share');
-    this.dataDirectory = path.resolve(xdgDataHome, 'containers', 'podman-desktop');
+    this.dataDirectory = path.resolve(xdgDataHome, product.paths.config);
 
     // All data-related directories go under dataDirectory
     this.pluginsDirectory = path.resolve(this.dataDirectory, 'plugins');
@@ -86,6 +87,6 @@ export class LinuxXDGDirectories implements Directories {
   }
 
   getManagedDefaultsDirectory(): string {
-    return SYSTEM_DEFAULTS_FOLDER_LINUX;
+    return product.paths.managed.linux;
   }
 }

--- a/packages/main/src/plugin/managed-by-constants.ts
+++ b/packages/main/src/plugin/managed-by-constants.ts
@@ -25,8 +25,3 @@ export const SYSTEM_DEFAULTS_FILENAME = 'default-settings.json';
 
 // Filename for the managed locked file
 export const SYSTEM_LOCKED_FILENAME = 'locked.json';
-
-// Folders for managed defaults on different platforms
-export const SYSTEM_DEFAULTS_FOLDER_MACOS = '/Library/Application Support/io.podman_desktop.PodmanDesktop';
-export const SYSTEM_DEFAULTS_FOLDER_WINDOWS = 'Podman Desktop';
-export const SYSTEM_DEFAULTS_FOLDER_LINUX = '/usr/share/podman-desktop';

--- a/product.json
+++ b/product.json
@@ -3,6 +3,14 @@
   "appId": "io.podman_desktop.PodmanDesktop",
   "artifactName": "podman-desktop",
   "urlProtocol": "podman-desktop",
+  "paths": {
+    "config": "containers/podman-desktop",
+    "managed": {
+      "macOS": "/Library/Application Support/Podman Desktop",
+      "windows": "%PROGRAMDATA%\\Podman Desktop",
+      "linux": "/usr/share/podman-desktop"
+    }
+  },
   "telemetry": {
     "key": "Mhl7GXADk5M1vG6r9FXztbCqWRQY8XPy"
   },


### PR DESCRIPTION
### What does this PR do?
there are some hardcoded constants for folders of Podman Desktop
extract them into the product.json file

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#15043 

### How to test this PR?

Check that you're able to read the existing configuration file / managed configuration file

I added some tests as it looks like some stuff was not covered

- [x] Tests are covering the bug fix or the new feature
