### PR TITLE
chore(test): update test framework to use alias path depedencies

### DIFF
--- a/tests/playwright/src/globalSetup/global-setup.ts
+++ b/tests/playwright/src/globalSetup/global-setup.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { removeFolderIfExists } from '../utility/cleanup';
+import { removeFolderIfExists } from '/@/utility/cleanup';
 
 let setupCalled = false;
 let teardownCalled = false;
@@ -30,7 +30,7 @@ export async function setup(): Promise<void> {
       await removeFolderIfExists('tests/output');
     } else {
       console.log(
-        `On CI, skipping before All tests/output cleanup, see https://github.com/containers/podman-desktop/issues/5460`,
+        'On CI, skipping before All tests/output cleanup, see https://github.com/containers/podman-desktop/issues/5460',
       );
     }
     setupCalled = true;

--- a/tests/playwright/src/model/core/platforms.ts
+++ b/tests/playwright/src/model/core/platforms.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const enum ArchitectureType {
+export enum ArchitectureType {
   Default = 'default',
   AMD64 = 'amd64',
   ARM64 = 'arm64',

--- a/tests/playwright/src/model/pages/compose-onboarding/compose-onboarding-page.ts
+++ b/tests/playwright/src/model/pages/compose-onboarding/compose-onboarding-page.ts
@@ -18,7 +18,7 @@
 
 import type { Locator, Page } from 'playwright';
 
-import { OnboardingPage } from '../onboarding-page';
+import { OnboardingPage } from '/@/model/pages/onboarding-page';
 
 export class ComposeOnboardingPage extends OnboardingPage {
   readonly heading: Locator;

--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -19,9 +19,9 @@
 import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
+import { ContainerState } from '/@/model/core/states';
 import { handleConfirmationDialog } from '/@/utility/operations';
 
-import { ContainerState } from '../core/states';
 import { BuildImagePage } from './build-image-page';
 import { ContainerDetailsPage } from './container-details-page';
 import { CreatePodsPage } from './create-pod-page';

--- a/tests/playwright/src/model/pages/forms/machine-creation-form.ts
+++ b/tests/playwright/src/model/pages/forms/machine-creation-form.ts
@@ -19,13 +19,12 @@
 import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
+import { DropdownComponent } from '/@/model/components/dropdown-component';
+import type { PodmanVirtualizationProviders } from '/@/model/core/types';
+import { matchesProviderVariant, PodmanVirtualizationProviderVariants } from '/@/model/core/types';
+import { BasePage } from '/@/model/pages/base-page';
 import { isWindows } from '/@/utility/platform';
 import { getDefaultVirtualizationProvider } from '/@/utility/provider';
-
-import { DropdownComponent } from '../../components/dropdown-component';
-import type { PodmanVirtualizationProviders } from '../../core/types';
-import { matchesProviderVariant, PodmanVirtualizationProviderVariants } from '../../core/types';
-import { BasePage } from '../base-page';
 
 export class MachineCreationForm extends BasePage {
   readonly podmanMachineConfiguration: Locator;

--- a/tests/playwright/src/model/pages/resource-details-page.ts
+++ b/tests/playwright/src/model/pages/resource-details-page.ts
@@ -18,8 +18,8 @@
 
 import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
-import type { ResourceElementActions } from '../core/operations';
-import { DetailsPage } from './details-page';
+import type { ResourceElementActions } from '/@/model/core/operations';
+import { DetailsPage } from '/@/model/pages/details-page';
 
 export class ResourceDetailsPage extends DetailsPage {
   readonly resourceStatus: Locator;
@@ -29,10 +29,7 @@ export class ResourceDetailsPage extends DetailsPage {
     this.resourceStatus = this.header.getByLabel('Connection Status Label');
   }
 
-  public async performConnectionActionDetails(
-    operation: ResourceElementActions,
-    timeout: number = 25_000,
-  ): Promise<void> {
+  public async performConnectionActionDetails(operation: ResourceElementActions, timeout = 25_000): Promise<void> {
     return test.step(`Perform connection action '${operation}' on resource element '${this.resourceName}' from details page`, async () => {
       const button = this.controlActions.getByRole('button', {
         name: operation,

--- a/tests/playwright/src/model/workbench/navigation.ts
+++ b/tests/playwright/src/model/workbench/navigation.ts
@@ -18,15 +18,15 @@
 
 import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
-import { ContainersPage } from '../pages/containers-page';
-import { DashboardPage } from '../pages/dashboard-page';
-import { ExtensionsPage } from '../pages/extensions-page';
-import { ImagesPage } from '../pages/images-page';
-import { KubernetesBar } from '../pages/kubernetes-bar';
-import { NetworksPage } from '../pages/networks-page';
-import { PodsPage } from '../pages/pods-page';
-import { SettingsBar } from '../pages/settings-bar';
-import { VolumesPage } from '../pages/volumes-page';
+import { ContainersPage } from '/@/model/pages/containers-page';
+import { DashboardPage } from '/@/model/pages/dashboard-page';
+import { ExtensionsPage } from '/@/model/pages/extensions-page';
+import { ImagesPage } from '/@/model/pages/images-page';
+import { KubernetesBar } from '/@/model/pages/kubernetes-bar';
+import { NetworksPage } from '/@/model/pages/networks-page';
+import { PodsPage } from '/@/model/pages/pods-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { VolumesPage } from '/@/model/pages/volumes-page';
 
 export class NavigationBar {
   readonly page: Page;

--- a/tests/playwright/src/model/workbench/status-bar.ts
+++ b/tests/playwright/src/model/workbench/status-bar.ts
@@ -18,9 +18,9 @@
 
 import { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
-import { handleConfirmationDialog } from '../../utility/operations';
-import { BasePage } from '../pages/base-page';
-import { TasksPage } from '../pages/tasks-page';
+import { BasePage } from '/@/model/pages/base-page';
+import { TasksPage } from '/@/model/pages/tasks-page';
+import { handleConfirmationDialog } from '/@/utility/operations';
 
 export class StatusBar extends BasePage {
   readonly content: Locator;

--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -24,8 +24,8 @@ import { _electron as electron, test } from '@playwright/test';
 import type { BrowserWindow } from 'electron';
 
 import { isLinux } from '/@/utility/platform';
+import { waitWhile } from '/@/utility/wait';
 
-import { waitWhile } from '../utility/wait';
 import { RunnerOptions } from './runner-options';
 
 type WindowState = {
@@ -131,17 +131,17 @@ export class Runner {
   public getPage(): Page {
     if (this._page) {
       return this._page;
-    } else {
-      throw Error('Application was not started yet');
     }
+
+    throw Error('Application was not started yet');
   }
 
   public getElectronApp(): ElectronApplication {
     if (this._app) {
       return this._app;
-    } else {
-      throw Error('Application was not started yet');
     }
+
+    throw Error('Application was not started yet');
   }
 
   public async getBrowserWindow(): Promise<JSHandle<BrowserWindow>> {
@@ -197,11 +197,11 @@ export class Runner {
       await video.saveAs(path);
       await video.delete();
     } else {
-      console.log(`Video file associated was not found`);
+      console.log('Video file associated was not found');
     }
   }
 
-  public async close(timeout: number = 30_000): Promise<void> {
+  public async close(timeout = 30_000): Promise<void> {
     // Stop playwright tracing
     await this.stopTracing();
 
@@ -219,7 +219,7 @@ export class Runner {
         ]);
       } catch (err: unknown) {
         console.log(`Caught exception in closing: ${err}`);
-        console.log(`Trying to kill the electron app process`);
+        console.log('Trying to kill the electron app process');
         if (pid) {
           console.log(`Killing the electron app process with PID: ${pid}`);
           try {

--- a/tests/playwright/src/setupFiles/setup-kind.ts
+++ b/tests/playwright/src/setupFiles/setup-kind.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { isLinux, isMac, isWindows } from '../utility/platform';
+import { isLinux, isMac, isWindows } from '/@/utility/platform';
 
 export function setupKind(): boolean[] {
   const rootfulMode = process.env.ROOTFUL_MODE === 'true'; // undefined or "false" => false

--- a/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
+++ b/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
@@ -19,9 +19,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { NavigationBar } from '../..';
-import { expect as playExpect, test } from '../../utility/fixtures';
-import { isCI, isLinux, isMac, isWindows } from '../../utility/platform';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { isCI, isLinux, isMac, isWindows } from '/@/utility/platform';
 
 test.skip(isLinux, 'Podman installation is not supported on Linux');
 

--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -23,12 +23,12 @@ import path from 'node:path';
 import type { Locator } from '@playwright/test';
 
 import { extensionsExternalList, podmanExtension } from '/@/model/core/extensions';
-
-import { ExtensionCardPage, ExtensionCatalogCardPage } from '../..';
-import type { StatusBar } from '../../model/workbench/status-bar';
-import { expect as playExpect, test } from '../../utility/fixtures';
-import { handleConfirmationDialog } from '../../utility/operations';
-import { isLinux, isMac, isWindows } from '../../utility/platform';
+import { ExtensionCardPage } from '/@/model/pages/extension-card-page';
+import { ExtensionCatalogCardPage } from '/@/model/pages/extension-catalog-card-page';
+import type { StatusBar } from '/@/model/workbench/status-bar';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { handleConfirmationDialog } from '/@/utility/operations';
+import { isLinux, isMac, isWindows } from '/@/utility/platform';
 
 const installExtensions = process.env.INSTALLATION_TYPE === 'custom-extensions' ? true : false;
 const activeExtensionStatus = 'ACTIVE';

--- a/tests/playwright/src/special-specs/podman-remote/podman-remote.spec.ts
+++ b/tests/playwright/src/special-specs/podman-remote/podman-remote.spec.ts
@@ -18,11 +18,10 @@
 
 import type { Locator } from '@playwright/test';
 
+import { PreferencesPage } from '/@/model/pages/preferences-page';
 import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
 import { ResourcesPage } from '/@/model/pages/resources-page';
-
-import { PreferencesPage } from '../../model/pages/preferences-page';
-import { expect as playExpect, test } from '../../utility/fixtures';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 
 // Image is pulled onto the podman machine before the test execution
 const IMAGE = 'ghcr.io/podmandesktop-ci/alpine-remote';

--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -15,9 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { expect as playExpect, test } from '../../utility/fixtures';
-import { isLinux } from '../../utility/platform';
-import { waitForPodmanMachineStartup } from '../../utility/wait';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { isLinux } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const numberOfObjects = Number(process.env.OBJECT_NUM) || 100;
 console.log(`numberOfObjects => ${numberOfObjects}`);

--- a/tests/playwright/src/specs/builtin-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/builtin-extension-smoke.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ExtensionState } from '../model/core/states';
-import type { DashboardPage } from '../model/pages/dashboard-page';
-import type { ExtensionDetailsPage } from '../model/pages/extension-details-page';
-import { NavigationBar } from '../model/workbench/navigation';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { ExtensionState } from '/@/model/core/states';
+import type { DashboardPage } from '/@/model/pages/dashboard-page';
+import type { ExtensionDetailsPage } from '/@/model/pages/extension-details-page';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 
 const extensionsToTest = [
   {

--- a/tests/playwright/src/specs/cancelable-task-smoke.spec.ts
+++ b/tests/playwright/src/specs/cancelable-task-smoke.spec.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { TaskState } from '../model/core/states';
-import { CommandPalette } from '../model/pages/command-palette';
-import { ExperimentalPage } from '../model/pages/experimental-page';
-import { TasksPage } from '../model/pages/tasks-page';
-import { StatusBar } from '../model/workbench/status-bar';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { TaskState } from '/@/model/core/states';
+import { CommandPalette } from '/@/model/pages/command-palette';
+import { ExperimentalPage } from '/@/model/pages/experimental-page';
+import { TasksPage } from '/@/model/pages/tasks-page';
+import { StatusBar } from '/@/model/workbench/status-bar';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const longRunningTaskName = 'quay.io/fbenoit/long-task-example:v1.0';
 const taskName = 'Dummy Long Task';

--- a/tests/playwright/src/specs/cli-tools-smoke.spec.ts
+++ b/tests/playwright/src/specs/cli-tools-smoke.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { CLIToolsPage } from '../model/pages/cli-tools-page';
-import type { SettingsBar } from '../model/pages/settings-bar';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { isLinux, isMac } from '../utility/platform';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { CLIToolsPage } from '/@/model/pages/cli-tools-page';
+import type { SettingsBar } from '/@/model/pages/settings-bar';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { isLinux, isMac } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 let settingsBar: SettingsBar;
 let cliToolsPage: CLIToolsPage;

--- a/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
@@ -18,17 +18,17 @@
 
 import type { Page } from '@playwright/test';
 
-import { CLIToolsPage } from '../model/pages/cli-tools-page';
-import { ComposeLocalInstallPage } from '../model/pages/compose-onboarding/compose-local-install-page';
-import { ComposeOnboardingPage } from '../model/pages/compose-onboarding/compose-onboarding-page';
-import { ComposeVersionPage } from '../model/pages/compose-onboarding/compose-version-page';
-import { ComposeWideInstallPage } from '../model/pages/compose-onboarding/compose-wide-install-page';
-import { ResourceCliCardPage } from '../model/pages/resource-cli-card-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import type { NavigationBar } from '../model/workbench/navigation';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { isCI, isLinux } from '../utility/platform';
+import { CLIToolsPage } from '/@/model/pages/cli-tools-page';
+import { ComposeLocalInstallPage } from '/@/model/pages/compose-onboarding/compose-local-install-page';
+import { ComposeOnboardingPage } from '/@/model/pages/compose-onboarding/compose-onboarding-page';
+import { ComposeVersionPage } from '/@/model/pages/compose-onboarding/compose-version-page';
+import { ComposeWideInstallPage } from '/@/model/pages/compose-onboarding/compose-wide-install-page';
+import { ResourceCliCardPage } from '/@/model/pages/resource-cli-card-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import type { NavigationBar } from '/@/model/workbench/navigation';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { isCI, isLinux } from '/@/utility/platform';
 
 const RESOURCE_NAME: string = 'Compose';
 let cliToolsPage: CLIToolsPage;

--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -16,15 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ContainerState, ImageState } from '../model/core/states';
-import type { ContainerInteractiveParams } from '../model/core/types';
-import { ContainersPage } from '../model/pages/containers-page';
-import { ImageDetailsPage } from '../model/pages/image-details-page';
-import type { ImagesPage } from '../model/pages/images-page';
-import { NavigationBar } from '../model/workbench/navigation';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deleteContainer, deleteImage } from '../utility/operations';
-import { waitForPodmanMachineStartup, waitWhile } from '../utility/wait';
+import { ContainerState, ImageState } from '/@/model/core/states';
+import type { ContainerInteractiveParams } from '/@/model/core/types';
+import { ContainersPage } from '/@/model/pages/containers-page';
+import { ImageDetailsPage } from '/@/model/pages/image-details-page';
+import type { ImagesPage } from '/@/model/pages/images-page';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteContainer, deleteImage } from '/@/utility/operations';
+import { waitForPodmanMachineStartup, waitWhile } from '/@/utility/wait';
 
 const imageToPull = 'ghcr.io/linuxcontainers/alpine';
 const imageTag = 'latest';

--- a/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
+++ b/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
@@ -16,15 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ResourceElementState } from '../model/core/states';
-import { DockerCompatibilityPage } from '../model/pages/docker-compatibility-page';
-import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { createPodmanMachineFromCLI, setDockerCompatibilityFeature } from '../utility/operations';
-import { isWindows } from '../utility/platform';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { ResourceElementState } from '/@/model/core/states';
+import { DockerCompatibilityPage } from '/@/model/pages/docker-compatibility-page';
+import { PodmanMachineDetails } from '/@/model/pages/podman-machine-details-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { createPodmanMachineFromCLI, setDockerCompatibilityFeature } from '/@/utility/operations';
+import { isWindows } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const defaultMachine = 'Podman Machine';
 

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -19,23 +19,22 @@
 import type { Locator, Page } from '@playwright/test';
 import { expect as playExpect, test } from '@playwright/test';
 
-import { isWindows } from '/@/utility/platform';
-
 import {
   bootcExtension,
   extensionsInstallationSmokeList,
   imageLayersExplorerExtension,
   openshiftDockerExtension,
   podmanQuadletExtension,
-} from '../model/core/extensions';
-import { ExtensionState } from '../model/core/states';
-import { ExtensionCatalogCardPage } from '../model/pages/extension-catalog-card-page';
-import { ExtensionsPage } from '../model/pages/extensions-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import { WelcomePage } from '../model/pages/welcome-page';
-import { NavigationBar } from '../model/workbench/navigation';
-import { Runner } from '../runner/podman-desktop-runner';
+} from '/@/model/core/extensions';
+import { ExtensionState } from '/@/model/core/states';
+import { ExtensionCatalogCardPage } from '/@/model/pages/extension-catalog-card-page';
+import { ExtensionsPage } from '/@/model/pages/extensions-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { WelcomePage } from '/@/model/pages/welcome-page';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { Runner } from '/@/runner/podman-desktop-runner';
+import { isWindows } from '/@/utility/platform';
 
 let pdRunner: Runner;
 let page: Page;

--- a/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { RunnerOptions } from '../runner/runner-options';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { isCI, isLinux } from '../utility/platform';
+import { RunnerOptions } from '/@/runner/runner-options';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { isCI, isLinux } from '/@/utility/platform';
 
 let rateLimitReachedFlag = false;
 

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -21,17 +21,17 @@ import { fileURLToPath } from 'node:url';
 
 import type { Page } from '@playwright/test';
 
-import { ArchitectureType } from '../model/core/platforms';
-import type { ImagesPage } from '../model/pages/images-page';
-import { RegistriesPage } from '../model/pages/registries-page';
-import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import { NavigationBar } from '../model/workbench/navigation';
-import { canTestRegistry, setupRegistry } from '../setupFiles/setup-registry';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { isWindows } from '../utility/platform';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { ArchitectureType } from '/@/model/core/platforms';
+import type { ImagesPage } from '/@/model/pages/images-page';
+import { RegistriesPage } from '/@/model/pages/registries-page';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { isWindows } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const architectures: string[] = [ArchitectureType.AMD64, ArchitectureType.ARM64];
 const imageNameSimple: string = 'manifest-test-simple';

--- a/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ImagesPage } from '../model/pages/images-page';
-import { RegistriesPage } from '../model/pages/registries-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import { canTestRegistry, setupRegistry } from '../setupFiles/setup-registry';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deleteImage, deleteRegistry } from '../utility/operations';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { ImagesPage } from '/@/model/pages/images-page';
+import { RegistriesPage } from '/@/model/pages/registries-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteImage, deleteRegistry } from '/@/utility/operations';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const helloContainer = 'quay.io/podman/hello';
 let registryUrl: string;

--- a/tests/playwright/src/specs/image-search.spec.ts
+++ b/tests/playwright/src/specs/image-search.spec.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect as playExpect, test } from '../utility/fixtures';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const imageToSearch = 'ghcr.io/linuxcontainers/alpine';
 const httpdImage = 'docker.io/httpd';

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -19,12 +19,12 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ArchitectureType } from '../model/core/platforms';
-import { ImageState } from '../model/core/states';
-import { ImageDetailsPage } from '../model/pages/image-details-page';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { untagImagesFromPodman } from '../utility/operations';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { ArchitectureType } from '/@/model/core/platforms';
+import { ImageState } from '/@/model/core/states';
+import { ImageDetailsPage } from '/@/model/pages/image-details-page';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { untagImagesFromPodman } from '/@/utility/operations';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const helloContainer = 'quay.io/podman/hello';
 const imageList = ['quay.io/podman/image1', 'quay.io/podman/image2'];

--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -19,12 +19,12 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ResourceElementActions } from '../model/core/operations';
-import { ContainerState, ExtensionState, ResourceElementState } from '../model/core/states';
-import type { ContainerInteractiveParams } from '../model/core/types';
-import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { canRunKindTests } from '../setupFiles/setup-kind';
+import { ResourceElementActions } from '/@/model/core/operations';
+import { ContainerState, ExtensionState, ResourceElementState } from '/@/model/core/states';
+import type { ContainerInteractiveParams } from '/@/model/core/types';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { canRunKindTests } from '/@/setupFiles/setup-kind';
 import {
   checkClusterResources,
   createKindCluster,
@@ -32,11 +32,11 @@ import {
   deleteClusterFromDetails,
   resourceConnectionAction,
   resourceConnectionActionDetails,
-} from '../utility/cluster-operations';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deployContainerToCluster } from '../utility/kubernetes';
-import { deleteContainer, deleteImage, ensureCliInstalled } from '../utility/operations';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+} from '/@/utility/cluster-operations';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deployContainerToCluster } from '/@/utility/kubernetes';
+import { deleteContainer, deleteImage, ensureCliInstalled } from '/@/utility/operations';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const RESOURCE_NAME: string = 'kind';
 const EXTENSION_LABEL: string = 'podman-desktop.kind';

--- a/tests/playwright/src/specs/kubernetes-context-smoke.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-context-smoke.spec.ts
@@ -20,9 +20,9 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { KubeContextPage } from '../model/pages/kubernetes-context-page';
-import { PreferencesPage } from '../model/pages/preferences-page';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { KubeContextPage } from '/@/model/pages/kubernetes-context-page';
+import { PreferencesPage } from '/@/model/pages/preferences-page';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 
 const testContexts = ['context-1', 'context-2', 'context-3'];
 

--- a/tests/playwright/src/specs/kubernetes-image-push.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-image-push.spec.ts
@@ -19,18 +19,18 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { KubernetesResourceState } from '../model/core/states';
-import { KubernetesResources } from '../model/core/types';
-import { canRunKindTests } from '../setupFiles/setup-kind';
-import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { KubernetesResourceState } from '/@/model/core/states';
+import { KubernetesResources } from '/@/model/core/types';
+import { canRunKindTests } from '/@/setupFiles/setup-kind';
+import { createKindCluster, deleteCluster } from '/@/utility/cluster-operations';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
   checkKubernetesResourceState,
   createKubernetesResource,
   deleteKubernetesResource,
-} from '../utility/kubernetes';
-import { ensureCliInstalled } from '../utility/operations';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+} from '/@/utility/kubernetes';
+import { ensureCliInstalled } from '/@/utility/operations';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;

--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -19,10 +19,10 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { KubernetesResourceState } from '../model/core/states';
-import { KubernetesResources } from '../model/core/types';
-import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { KubernetesResourceState } from '/@/model/core/states';
+import { KubernetesResources } from '/@/model/core/types';
+import { createKindCluster, deleteCluster } from '/@/utility/cluster-operations';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
   checkKubernetesResourceState,
   configurePortForwarding,
@@ -32,9 +32,9 @@ import {
   monitorPodStatusInClusterContainer,
   verifyLocalPortResponse,
   verifyPortForwardingConfiguration,
-} from '../utility/kubernetes';
-import { deleteContainer, deleteImage, ensureCliInstalled } from '../utility/operations';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+} from '/@/utility/kubernetes';
+import { deleteContainer, deleteImage, ensureCliInstalled } from '/@/utility/operations';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;
@@ -55,7 +55,7 @@ const INGRESS_CONTROLLER_COMMAND: string = 'kubectl get pods -n projectcontour';
 const REMOTE_PORT: number = 80;
 const LOCAL_PORT: number = 50000;
 const PORT_FORWARDING_ADDRESS: string = `http://localhost:${LOCAL_PORT}/`;
-const SERVICE_ADDRESS: string = `http://localhost:9090/`;
+const SERVICE_ADDRESS: string = 'http://localhost:9090/';
 const RESPONSE_MESSAGE: string = 'Welcome to nginx!';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -223,7 +223,7 @@ test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
       await playExpect.poll(async () => kubernetesPodsPage.getRowByName(POD_NAME), { timeout: 15_000 }).toBeTruthy();
       const podDetailPage = await kubernetesPodsPage.openResourceDetails(POD_NAME, KubernetesResources.Pods);
       await podDetailPage.activateTab('Summary');
-      const forwardButton = page.getByRole('button', { name: `Forward...` });
+      const forwardButton = page.getByRole('button', { name: 'Forward...' });
       await playExpect(forwardButton).toBeVisible();
     });
 

--- a/tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts
@@ -16,15 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ResourceElementState } from '../model/core/states';
-import { PodmanMachinePrivileges, PodmanVirtualizationProviders } from '../model/core/types';
-import { CreateMachinePage } from '../model/pages/create-machine-page';
-import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import { canRunKindTests } from '../setupFiles/setup-kind';
-import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { ResourceElementState } from '/@/model/core/states';
+import { PodmanMachinePrivileges, PodmanVirtualizationProviders } from '/@/model/core/types';
+import { CreateMachinePage } from '/@/model/pages/create-machine-page';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { canRunKindTests } from '/@/setupFiles/setup-kind';
+import { createKindCluster, deleteCluster } from '/@/utility/cluster-operations';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
   deletePodmanMachine,
   ensureCliInstalled,
@@ -32,10 +32,10 @@ import {
   setStatusBarProvidersFeature,
   verifyMachinePrivileges,
   verifyVirtualizationProvider,
-} from '../utility/operations';
-import { isLinux } from '../utility/platform';
-import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '../utility/provider';
-import { waitForPodmanMachineStartup, waitUntil } from '../utility/wait';
+} from '/@/utility/operations';
+import { isLinux } from '/@/utility/platform';
+import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '/@/utility/provider';
+import { waitForPodmanMachineStartup, waitUntil } from '/@/utility/wait';
 
 const podmanProviderName = 'Podman';
 const defaultMachine = 'podman-machine-default';

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -21,20 +21,20 @@ import { fileURLToPath } from 'node:url';
 
 import { expect as playExpect } from '@playwright/test';
 
-import { KubernetesResourceState } from '../model/core/states';
-import { KubernetesResources } from '../model/core/types';
-import { canRunKindTests } from '../setupFiles/setup-kind';
-import { createKindCluster, deleteCluster } from '../utility/cluster-operations';
-import { test } from '../utility/fixtures';
+import { KubernetesResourceState } from '/@/model/core/states';
+import { KubernetesResources } from '/@/model/core/types';
+import { canRunKindTests } from '/@/setupFiles/setup-kind';
+import { createKindCluster, deleteCluster } from '/@/utility/cluster-operations';
+import { test } from '/@/utility/fixtures';
 import {
   checkDeploymentReplicasInfo,
   checkKubernetesResourceState,
   createKubernetesResource,
   deleteKubernetesResource,
   editDeploymentYamlFile,
-} from '../utility/kubernetes';
-import { deletePod, ensureCliInstalled } from '../utility/operations';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+} from '/@/utility/kubernetes';
+import { deletePod, ensureCliInstalled } from '/@/utility/operations';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const CLUSTER_NAME: string = 'kind-cluster';
 const CLUSTER_CREATION_TIMEOUT: number = 300_000;

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -18,12 +18,12 @@
 
 import * as os from 'node:os';
 
-import { ContainerState, PodState } from '../model/core/states';
-import type { ContainerInteractiveParams } from '../model/core/types';
-import { PodsPage } from '../model/pages/pods-page';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deleteContainer, deleteImage, deletePod } from '../utility/operations';
-import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '../utility/wait';
+import { ContainerState, PodState } from '/@/model/core/states';
+import type { ContainerInteractiveParams } from '/@/model/core/types';
+import { PodsPage } from '/@/model/pages/pods-page';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteContainer, deleteImage, deletePod } from '/@/utility/operations';
+import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '/@/utility/wait';
 
 let backendPort: string;
 let frontendPort: string;

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -268,7 +268,7 @@ test.describe.serial('Verification of pod creation workflow', { tag: '@smoke' },
       // regex for div with number of visits
       const regex = /<div[^>]*>(\d+)<\/div>/i;
       const matches = RegExp(regex).exec(text);
-      playExpect(matches![1]).toEqual(i.toString());
+      playExpect(matches?.[1]).toEqual(i.toString());
       playExpect(matches).toBeDefined();
       playExpect(text).toContain('time(s)');
     }

--- a/tests/playwright/src/specs/podman-compose-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-compose-smoke.spec.ts
@@ -19,14 +19,14 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { CLIToolsPage } from '../model/pages/cli-tools-page';
-import { ResourceCliCardPage } from '../model/pages/resource-cli-card-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deleteContainer, deleteImage, runComposeUpFromCLI } from '../utility/operations';
-import { isCI, isLinux, isMac } from '../utility/platform';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { CLIToolsPage } from '/@/model/pages/cli-tools-page';
+import { ResourceCliCardPage } from '/@/model/pages/resource-cli-card-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteContainer, deleteImage, runComposeUpFromCLI } from '/@/utility/operations';
+import { isCI, isLinux, isMac } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const RESOURCE_NAME: string = 'Compose';
 const __filename = fileURLToPath(import.meta.url);

--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ExtensionState } from '../model/core/states';
-import type { DashboardPage } from '../model/pages/dashboard-page';
-import type { ExtensionDetailsPage } from '../model/pages/extension-details-page';
-import type { SettingsBar } from '../model/pages/settings-bar';
-import { NavigationBar } from '../model/workbench/navigation';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { ExtensionState } from '/@/model/core/states';
+import type { DashboardPage } from '/@/model/pages/dashboard-page';
+import type { ExtensionDetailsPage } from '/@/model/pages/extension-details-page';
+import type { SettingsBar } from '/@/model/pages/settings-bar';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 
 const extensionLabel = 'podman-desktop.podman';
 const extensionLabelName = 'podman';

--- a/tests/playwright/src/specs/podman-kube-play-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-kube-play-smoke.spec.ts
@@ -19,12 +19,12 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ImageState, PodState } from '../model/core/states';
-import { PodmanKubePlayOptions } from '../model/core/types';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deleteImage, deletePod } from '../utility/operations';
-import { isCI, isLinux } from '../utility/platform';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { ImageState, PodState } from '/@/model/core/states';
+import { PodmanKubePlayOptions } from '/@/model/core/types';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteImage, deletePod } from '/@/utility/operations';
+import { isCI, isLinux } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const POD_NAME_FROM_SCRATCH: string = 'podman-kube-play-test';
 const POD_NAME_BUILD_OPTION: string = 'podman-kube-play-build-test';

--- a/tests/playwright/src/specs/preferences.spec.ts
+++ b/tests/playwright/src/specs/preferences.spec.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { PreferencesPage } from '../model/pages/preferences-page';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { PreferencesPage } from '/@/model/pages/preferences-page';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 
 const preferencesTestString = 'this text should persist through page change';
 

--- a/tests/playwright/src/specs/proxy-smoke.spec.ts
+++ b/tests/playwright/src/specs/proxy-smoke.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ProxyTypes } from '../model/core/types';
-import { ProxyPage } from '../model/pages/proxy-page';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { ProxyTypes } from '/@/model/core/types';
+import { ProxyPage } from '/@/model/pages/proxy-page';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 
 const invalidProxyUrl = 'invalid-proxy-url';
 const httpProxyUrl = 'http://http.proxy:8080';

--- a/tests/playwright/src/specs/registry-image.spec.ts
+++ b/tests/playwright/src/specs/registry-image.spec.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { RegistriesPage } from '../model/pages/registries-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import { canTestRegistry, setupRegistry } from '../setupFiles/setup-registry';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deleteImage, deleteRegistry } from '../utility/operations';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { RegistriesPage } from '/@/model/pages/registries-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteImage, deleteRegistry } from '/@/utility/operations';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 let registryUrl: string;
 let registryUsername: string;

--- a/tests/playwright/src/specs/registry.spec.ts
+++ b/tests/playwright/src/specs/registry.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { RegistriesPage } from '../model/pages/registries-page';
-import { canTestRegistry, setupRegistry } from '../setupFiles/setup-registry';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { RegistriesPage } from '/@/model/pages/registries-page';
+import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 let registryUrl: string;
 let registryUsername: string;

--- a/tests/playwright/src/specs/troubleshooting-smoke.spec.ts
+++ b/tests/playwright/src/specs/troubleshooting-smoke.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { TroubleshootingPage } from '../model/pages/troubleshooting-page';
-import { StatusBar } from '../model/workbench/status-bar';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { TroubleshootingPage } from '/@/model/pages/troubleshooting-page';
+import { StatusBar } from '/@/model/workbench/status-bar';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 
 test.beforeAll(async ({ runner, welcomePage }) => {
   runner.setVideoAndTraceName('troubleshooting-e2e');

--- a/tests/playwright/src/specs/troubleshooting-smoke.spec.ts
+++ b/tests/playwright/src/specs/troubleshooting-smoke.spec.ts
@@ -53,7 +53,7 @@ test.describe.serial('Troubleshooting page verification', { tag: '@smoke' }, () 
   test('Content of the application Log', async () => {
     await troubleshootingPage.openLogs();
     const logs = await troubleshootingPage.getLogs();
-    for (const logEntry in [
+    for (const logEntry of [
       /System ready. Loading extensions/,
       /PluginSystem: received dom-ready event from the UI/,
       /Delayed startup, flushing/,

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ContainerState, VolumeState } from '../model/core/states';
-import type { ContainerInteractiveParams } from '../model/core/types';
-import { ContainerDetailsPage } from '../model/pages/container-details-page';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deleteContainer, deleteImage, readFileInVolumeFromCLI } from '../utility/operations';
-import { isWindows } from '../utility/platform';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { ContainerState, VolumeState } from '/@/model/core/states';
+import type { ContainerInteractiveParams } from '/@/model/core/types';
+import { ContainerDetailsPage } from '/@/model/pages/container-details-page';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteContainer, deleteImage, readFileInVolumeFromCLI } from '/@/utility/operations';
+import { isWindows } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const imageToPull = 'quay.io/centos-bootc/bootc-image-builder';
 const imageTag = 'latest';

--- a/tests/playwright/src/specs/welcome-page-smoke.spec.ts
+++ b/tests/playwright/src/specs/welcome-page-smoke.spec.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { RunnerOptions } from '../runner/runner-options';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { RunnerOptions } from '/@/runner/runner-options';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 
 test.use({ runnerOptions: new RunnerOptions({ customFolder: 'welcome-podman-desktop' }) });
 test.beforeAll(async ({ runner }) => {

--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -19,11 +19,11 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ImageState } from '../model/core/states';
-import { PodmanKubePlayOptions } from '../model/core/types';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { deleteImage, deletePod } from '../utility/operations';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { ImageState } from '/@/model/core/states';
+import { PodmanKubePlayOptions } from '/@/model/core/types';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteImage, deletePod } from '/@/utility/operations';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const podAppName = 'primary-podify-demo';
 const podName = 'podify-demo-pod';

--- a/tests/playwright/src/specs/z-podman-machine-dashboard-onboarding.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-dashboard-onboarding.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ResourceElementState } from '../model/core/states';
-import { expect as playExpect, test } from '../utility/fixtures';
-import { createPodmanMachineFromCLI, deletePodmanMachine, resetPodmanMachinesFromCLI } from '../utility/operations';
-import { isLinux } from '../utility/platform';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+import { ResourceElementState } from '/@/model/core/states';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { createPodmanMachineFromCLI, deletePodmanMachine, resetPodmanMachinesFromCLI } from '/@/utility/operations';
+import { isLinux } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const PODMAN_MACHINE_NAME: string = 'podman-machine-default';
 

--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -18,13 +18,13 @@
 
 import type { Locator, Page } from '@playwright/test';
 
-import { ResourceElementActions } from '../model/core/operations';
-import { ResourceElementState } from '../model/core/states';
-import { PodmanMachinePrivileges, PodmanVirtualizationProviders } from '../model/core/types';
-import { CreateMachinePage } from '../model/pages/create-machine-page';
-import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { ResourceElementActions } from '/@/model/core/operations';
+import { ResourceElementState } from '/@/model/core/states';
+import { PodmanMachinePrivileges, PodmanVirtualizationProviders } from '/@/model/core/types';
+import { CreateMachinePage } from '/@/model/pages/create-machine-page';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
   createPodmanMachineFromCLI,
   deletePodmanMachine,
@@ -32,10 +32,10 @@ import {
   resetPodmanMachinesFromCLI,
   verifyMachinePrivileges,
   verifyVirtualizationProvider,
-} from '../utility/operations';
-import { isLinux, isWindows } from '../utility/platform';
-import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '../utility/provider';
-import { waitForPodmanMachineStartup, waitUntil } from '../utility/wait';
+} from '/@/utility/operations';
+import { isLinux, isWindows } from '/@/utility/platform';
+import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '/@/utility/provider';
+import { waitForPodmanMachineStartup, waitUntil } from '/@/utility/wait';
 
 const DEFAULT_PODMAN_MACHINE_NAME = 'podman-machine-default';
 const RESOURCE_NAME = 'podman';

--- a/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
@@ -18,14 +18,14 @@
 
 import type { Locator, Page } from '@playwright/test';
 
-import { ResourceElementState } from '../model/core/states';
-import { PodmanMachinePrivileges } from '../model/core/types';
-import { PodmanMachineDetails } from '../model/pages/podman-machine-details-page';
-import { PodmanOnboardingPage } from '../model/pages/podman-onboarding-page';
-import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import type { NavigationBar } from '../model/workbench/navigation';
-import { expect as playExpect, test } from '../utility/fixtures';
+import { ResourceElementState } from '/@/model/core/states';
+import { PodmanMachinePrivileges } from '/@/model/core/types';
+import { PodmanMachineDetails } from '/@/model/pages/podman-machine-details-page';
+import { PodmanOnboardingPage } from '/@/model/pages/podman-onboarding-page';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import type { NavigationBar } from '/@/model/workbench/navigation';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
   createPodmanMachineFromCLI,
   deletePodmanMachine,
@@ -33,10 +33,10 @@ import {
   resetPodmanMachinesFromCLI,
   verifyMachinePrivileges,
   verifyVirtualizationProvider,
-} from '../utility/operations';
-import { isLinux } from '../utility/platform';
-import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '../utility/provider';
-import { waitForPodmanMachineStartup } from '../utility/wait';
+} from '/@/utility/operations';
+import { isLinux } from '/@/utility/platform';
+import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '/@/utility/provider';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const DEFAULT_PODMAN_MACHINE = 'Podman Machine';
 const DEFAULT_PODMAN_MACHINE_VISIBLE = 'podman-machine-default';

--- a/tests/playwright/src/utility/auth-utils.ts
+++ b/tests/playwright/src/utility/auth-utils.ts
@@ -55,7 +55,7 @@ export async function performBrowserLogin(
     screenshotsPath: string | undefined;
   } = { screenshotsPath: '' },
 ): Promise<void> {
-  console.log(`Performing browser login...`);
+  console.log('Performing browser login...');
   const path = options.screenshotsPath;
   if (path) {
     await page.screenshot({ path: join(path, 'screenshots', 'initial_page.png'), type: 'png', fullPage: true });

--- a/tests/playwright/src/utility/cleanup.ts
+++ b/tests/playwright/src/utility/cleanup.ts
@@ -26,7 +26,7 @@ export async function removeFolderIfExists(path: string): Promise<void> {
   console.log(`Cleaning up folder: ${path}`);
 
   if (existsSync(path)) {
-    console.log(`Folder found, removing...`);
+    console.log('Folder found, removing...');
     rmSync(path, { recursive: true, force: true, maxRetries: 5 });
   }
 }

--- a/tests/playwright/src/utility/cluster-operations.ts
+++ b/tests/playwright/src/utility/cluster-operations.ts
@@ -19,22 +19,22 @@
 import type { Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
-import { ResourceElementActions } from '../model/core/operations';
-import { ContainerState, ResourceElementState } from '../model/core/states';
-import type { KindClusterOptions } from '../model/core/types';
-import { CreateKindClusterPage } from '../model/pages/create-kind-cluster-page';
-import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
-import { ResourceDetailsPage } from '../model/pages/resource-details-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { VolumesPage } from '../model/pages/volumes-page';
-import { NavigationBar } from '../model/workbench/navigation';
-import { StatusBar } from '../model/workbench/status-bar';
-import { getVolumeNameForContainer } from './operations';
+import { ResourceElementActions } from '/@/model/core/operations';
+import { ContainerState, ResourceElementState } from '/@/model/core/states';
+import type { KindClusterOptions } from '/@/model/core/types';
+import { CreateKindClusterPage } from '/@/model/pages/create-kind-cluster-page';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourceDetailsPage } from '/@/model/pages/resource-details-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { VolumesPage } from '/@/model/pages/volumes-page';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { StatusBar } from '/@/model/workbench/status-bar';
+import { getVolumeNameForContainer } from '/@/utility/operations';
 
 export async function createKindCluster(
   page: Page,
   clusterName: string,
-  timeout: number = 300_000,
+  timeout = 300_000,
   { configFilePath, providerType, httpPort, httpsPort, useIngressController, containerImage }: KindClusterOptions = {},
 ): Promise<void> {
   return test.step(`Create Kind cluster with settings: configFilePath=${configFilePath}, 
@@ -84,10 +84,10 @@ export async function createKindCluster(
 
 export async function deleteCluster(
   page: Page,
-  resourceName: string = 'kind',
-  containerName: string = 'kind-cluster-control-plane',
-  clusterName: string = 'kind-cluster',
-  timeout: number = 50_000,
+  resourceName = 'kind',
+  containerName = 'kind-cluster-control-plane',
+  clusterName = 'kind-cluster',
+  timeout = 50_000,
 ): Promise<void> {
   return test.step(`Delete ${resourceName} cluster`, async () => {
     const volumeName = await getVolumeNameForContainer(page, containerName);
@@ -137,7 +137,7 @@ export async function resourceConnectionAction(
   resourceCard: ResourceConnectionCardPage,
   resourceConnectionAction: ResourceElementActions,
   expectedResourceState: ResourceElementState,
-  timeout: number = 30_000,
+  timeout = 30_000,
 ): Promise<void> {
   return test.step(`Performs "${resourceConnectionAction}" action, expects "${expectedResourceState}" state.`, async () => {
     const navigationBar = new NavigationBar(page);
@@ -162,7 +162,7 @@ export async function resourceConnectionActionDetails(
   resourceName: string,
   resourceConnectionAction: ResourceElementActions,
   expectedResourceState: ResourceElementState,
-  timeout: number = 30_000,
+  timeout = 30_000,
 ): Promise<void> {
   return test.step(`Performs a connection action '${resourceConnectionAction}' on the resource from the details page, verifies the expected resource state '${expectedResourceState}'`, async () => {
     const navigationBar = new NavigationBar(page);
@@ -194,10 +194,10 @@ export async function resourceConnectionActionDetails(
 
 export async function deleteClusterFromDetails(
   page: Page,
-  resourceName: string = 'kind',
-  containerName: string = 'kind-cluster-control-plane',
-  clusterName: string = 'kind-cluster',
-  timeout: number = 30_000,
+  resourceName = 'kind',
+  containerName = 'kind-cluster-control-plane',
+  clusterName = 'kind-cluster',
+  timeout = 30_000,
 ): Promise<void> {
   return test.step(`Deletes the '${clusterName}' cluster from the details page`, async () => {
     const navigationBar = new NavigationBar(page);
@@ -231,7 +231,7 @@ export async function validateClusterResourcesDeletion(
   clusterName: string,
   containerName: string,
   volumeName: string,
-  timeout: number = 20_000,
+  timeout = 20_000,
 ): Promise<void> {
   return test.step(`Validates that resources associated with the deleted '${clusterName}' cluster are removed`, async () => {
     const navigationBar = new NavigationBar(page);

--- a/tests/playwright/src/utility/fixtures.ts
+++ b/tests/playwright/src/utility/fixtures.ts
@@ -19,11 +19,11 @@
 import type { Page } from '@playwright/test';
 import { test as base } from '@playwright/test';
 
-import { WelcomePage } from '../model/pages/welcome-page';
-import { NavigationBar } from '../model/workbench/navigation';
-import { StatusBar } from '../model/workbench/status-bar';
-import { Runner } from '../runner/podman-desktop-runner';
-import { RunnerOptions } from '../runner/runner-options';
+import { WelcomePage } from '/@/model/pages/welcome-page';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { StatusBar } from '/@/model/workbench/status-bar';
+import { Runner } from '/@/runner/podman-desktop-runner';
+import { RunnerOptions } from '/@/runner/runner-options';
 
 export type TestFixtures = {
   runner: Runner;

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -21,11 +21,11 @@ import { execSync } from 'node:child_process';
 import type { Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
-import type { KubernetesResourceState } from '../model/core/states';
-import { KubernetesResources } from '../model/core/types';
-import { ContainerDetailsPage } from '../model/pages/container-details-page';
-import { NavigationBar } from '../model/workbench/navigation';
-import { handleConfirmationDialog } from './operations';
+import type { KubernetesResourceState } from '/@/model/core/states';
+import { KubernetesResources } from '/@/model/core/types';
+import { ContainerDetailsPage } from '/@/model/pages/container-details-page';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { handleConfirmationDialog } from '/@/utility/operations';
 
 export async function deployContainerToCluster(
   page: Page,

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -22,21 +22,21 @@ import * as os from 'node:os';
 import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
-import { ResourceElementActions } from '../model/core/operations';
-import { ResourceElementState } from '../model/core/states';
-import type { PodmanVirtualizationProviders } from '../model/core/types';
-import { matchesProviderVariant, PodmanMachinePrivileges } from '../model/core/types';
-import { CLIToolsPage } from '../model/pages/cli-tools-page';
-import { ExperimentalPage } from '../model/pages/experimental-page';
-import { PreferencesPage } from '../model/pages/preferences-page';
-import { RegistriesPage } from '../model/pages/registries-page';
-import { ResourceConnectionCardPage } from '../model/pages/resource-connection-card-page';
-import { ResourcesPage } from '../model/pages/resources-page';
-import { SettingsBar } from '../model/pages/settings-bar';
-import { VolumeDetailsPage } from '../model/pages/volume-details-page';
-import { NavigationBar } from '../model/workbench/navigation';
-import { isLinux, isMac, isWindows } from './platform';
-import { waitUntil, waitWhile } from './wait';
+import { ResourceElementActions } from '/@/model/core/operations';
+import { ResourceElementState } from '/@/model/core/states';
+import type { PodmanVirtualizationProviders } from '/@/model/core/types';
+import { matchesProviderVariant, PodmanMachinePrivileges } from '/@/model/core/types';
+import { CLIToolsPage } from '/@/model/pages/cli-tools-page';
+import { ExperimentalPage } from '/@/model/pages/experimental-page';
+import { PreferencesPage } from '/@/model/pages/preferences-page';
+import { RegistriesPage } from '/@/model/pages/registries-page';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { SettingsBar } from '/@/model/pages/settings-bar';
+import { VolumeDetailsPage } from '/@/model/pages/volume-details-page';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { isLinux, isMac, isWindows } from '/@/utility/platform';
+import { waitUntil, waitWhile } from '/@/utility/wait';
 
 /**
  * Stop and delete container defined by its name

--- a/tests/playwright/src/utility/provider.ts
+++ b/tests/playwright/src/utility/provider.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { PodmanVirtualizationProviders } from '../model/core/types';
-import { isMac, isWindows } from './platform';
+import { PodmanVirtualizationProviders } from '/@/model/core/types';
+import { isMac, isWindows } from '/@/utility/platform';
 
 export const envProvider = process.env.CONTAINERS_MACHINE_PROVIDER;
 

--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -19,8 +19,8 @@
 import type { Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
-import { NavigationBar } from '../model/workbench/navigation';
-import { createPodmanMachineFromCLI, resetPodmanMachinesFromCLI } from './operations';
+import { NavigationBar } from '/@/model/workbench/navigation';
+import { createPodmanMachineFromCLI, resetPodmanMachinesFromCLI } from '/@/utility/operations';
 
 export async function wait(
   waitFunction: () => Promise<boolean>,


### PR DESCRIPTION
### What does this PR do?
Update dependencies style in the PD test framework to conform with new coding guidelines.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/15241
