### PR TITLE
feat(download-remote-extensions): support caching

### DIFF
--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -17,7 +17,7 @@
  ********************************************************************/
 
 import { existsSync } from 'node:fs';
-import { cp, mkdir, readFile, rename, rm } from 'node:fs/promises';
+import { cp, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -155,6 +155,14 @@ describe('downloadExtension', () => {
 
     expect(cp).not.toHaveBeenCalled();
     expect(rm).not.toHaveBeenCalled();
+  });
+
+  test('should write digest file to destination', async () => {
+    await downloadExtension(ABS_DEST_DIR, REMOTE_INFO_MOCK);
+
+    expect(writeFile).toHaveBeenCalledExactlyOnceWith(FINAL_EXTENSION_DIGEST_FILE, MANIFEST_MOCK.config.digest, {
+      encoding: 'utf-8',
+    });
   });
 
   test('if rename throw ErrnoException', async () => {

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -90,7 +90,7 @@ export async function downloadExtension(destination: string, info: RemoteExtensi
   if (existsSync(finalPath)) {
     const existingDigest = await findExtensionDigest(finalPath);
     if (existingDigest === config.digest) {
-      console.log(`cache hit for ${info.name}`);
+      console.log(`cache hit for ${info.name} ${config.digest.substring(0, 18)}`);
       return;
     } else {
       console.log(`invalid digest for ${info.name}, cleanup ${finalPath}`);

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -19,7 +19,7 @@
 import 'reflect-metadata';
 
 import { existsSync } from 'node:fs';
-import { cp, mkdir, rename, rm } from 'node:fs/promises';
+import { cp, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 
@@ -56,6 +56,16 @@ export interface RemoteExtension {
 export const OCI_ARG = 'oci';
 export const NAME_ARG = 'name';
 
+export const DIGEST_FILENAME = '.digest';
+
+async function findExtensionDigest(extension: string): Promise<string | undefined> {
+  try {
+    return await readFile(join(extension, DIGEST_FILENAME), { encoding: 'utf-8' });
+  } catch (_: unknown) {
+    return undefined;
+  }
+}
+
 export async function downloadExtension(destination: string, info: RemoteExtension): Promise<void> {
   const imageRegistry = new ImageRegistry(dummyApiSenderType, dummyTelemetry, dummyCertificate, dummyProxy);
 
@@ -64,13 +74,31 @@ export async function downloadExtension(destination: string, info: RemoteExtensi
 
   const finalPath = join(destination, info.name);
 
-  await imageRegistry.downloadAndExtractImage(info.oci, tmpFolderPath, console.log);
-
-  if (!existsSync(join(tmpFolderPath, 'extension'))) {
+  const { config } = await imageRegistry.getManifestFromImageName(info.oci);
+  if (!config) {
     throw new Error(
-      `extension ${info.name} has malformed content: the OCI image should contains an "extension" folder`,
+      `extension ${info.name} has malformed content: the OCI image manifest should contains a "config" field`,
     );
   }
+  if (!config.digest) {
+    throw new Error(
+      `extension ${info.name} has malformed content: the OCI image manifest should contains a "config.digest" field`,
+    );
+  }
+
+  // check if the extension is already downloaded
+  if (existsSync(finalPath)) {
+    const existingDigest = await findExtensionDigest(finalPath);
+    if (existingDigest === config.digest) {
+      console.log(`cache hit for ${info.name}`);
+      return;
+    } else {
+      console.log(`invalid digest for ${info.name}, cleanup ${finalPath}`);
+      await rm(finalPath, { recursive: true });
+    }
+  }
+
+  await imageRegistry.downloadAndExtractImage(info.oci, tmpFolderPath, console.log);
 
   if (!existsSync(join(tmpFolderPath, 'extension', 'package.json'))) {
     throw new Error(
@@ -83,6 +111,7 @@ export async function downloadExtension(destination: string, info: RemoteExtensi
 
   // rename tmp to destination
   await moveSafely(join(tmpFolderPath, 'extension'), finalPath);
+  await writeFile(join(finalPath, DIGEST_FILENAME), config.digest, { encoding: 'utf-8' });
 }
 
 /**

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -438,6 +438,21 @@ export class ImageRegistry {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getManifestFromImageName(imageName: string): Promise<any> {
+    const imageData = this.extractImageDataFromImageName(imageName);
+
+    // grab auth info from the registry
+    const authInfo = await this.getAuthInfo(imageData.registry);
+    const token = await this.getToken(authInfo, imageData);
+    if (authInfo.scheme.toLowerCase() !== 'bearer') {
+      throw new Error(`Unsupported auth scheme: ${authInfo.scheme}`);
+    }
+
+    // now, grab manifest for the given image URL
+    return await this.getManifest(imageData, token);
+  }
+
   // Fetch the image Labels from the registry for a given image URL
   async getImageConfigLabels(imageName: string): Promise<{ [key: string]: unknown }> {
     const imageData = this.extractImageDataFromImageName(imageName);


### PR DESCRIPTION
### What does this PR do?

To avoid re-downloading extensions configured in the `product.json`, we can use the digest from the image manifest. We create a `.digest` file in each downloaded extensions, and when we call `download-extension-remote` we check first those files, if they match the corresponding digest of the OCI image configured, we skip.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15171

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Manually**


1. Checkout this PR
2. Add the following inside the `product.json`

```json
{
  [...],
  "extensions": {
    "remote": [{
      "name": "podman-desktop-extension-layers-explorer",
      "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb"
    }]
  }
}
```

3. Run `pnpm build:main`
4. Run `node ./packages/main/dist/download-remote-extensions.cjs --output="$pwd\\extensions-extra"`
> This command is windows specific, use "$PWD/extension-extra" on linux
5. Assert it downloaded the extension in `extensions-extra`
6. Assert `extensions-extra/podman-desktop-extension-layers-explorer/.digest` exists
7. Run again step number 4, and assert the log `cache hit`
8. Update the `product.json` with another OCI image 
```diff
{
  [...],
  "extensions": {
    "remote": [{
      "name": "podman-desktop-extension-layers-explorer",
-      "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb"
+      "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:f3c26a91bb1addce5c8280fe5b53ba25c720b48d"
    }]
  }
}
```
9. ⚠️ Run `pnpm build:main` again
10. Run  `node ./packages/main/dist/download-remote-extensions.cjs --output="$pwd\\extensions-extra"`
11. It downloaded the package