### PR TITLE
chore(test): fix edit registry locator

### DIFF
--- a/tests/playwright/src/specs/registry.spec.ts
+++ b/tests/playwright/src/specs/registry.spec.ts
@@ -99,7 +99,7 @@ test.describe.serial('Registries handling verification', { tag: '@smoke' }, () =
         const registryPage = new RegistriesPage(page);
 
         await registryPage.editRegistry(registryName, 'invalidName', 'invalidPswd');
-        const errorMsg = page.getByRole('dialog', { name: 'Edit Registry' }).getByLabel('Error Message Content');
+        const errorMsg = page.getByLabel('Error Message Content');
         await playExpect(errorMsg).toBeVisible({ timeout: 30_000 });
         await playExpect(errorMsg).toContainText('Wrong Username or Password', { ignoreCase: true });
 


### PR DESCRIPTION
### What does this PR do?
revert locator for edit registry, only add registry test/locator should have been updated in [15236](https://github.com/podman-desktop/podman-desktop/pull/15236)
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
