### PR TITLE
feat(download-remote-extensions): support --oci & --name args

### DIFF
--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -21,7 +21,6 @@ import { cp, mkdir, rename, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { ParsedArgs } from 'minimist';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ImageRegistry } from '/@/plugin/image-registry.js';
@@ -30,11 +29,11 @@ import product from '/@product.json' with { type: 'json' };
 import type { RemoteExtension } from './download-remote-extensions.js';
 import {
   downloadExtension,
-  findRemoteExtensionFromArgs,
-  findRemoteExtensionFromProductJSON,
+  getRemoteExtensionFromProductJSON,
   main,
+  NAME_ARG,
   OCI_ARG,
-  sanitiseImageName,
+  parseArgs,
 } from './download-remote-extensions.js';
 
 vi.mock(import('node:fs/promises'));
@@ -134,94 +133,143 @@ describe('downloadExtension', () => {
   });
 });
 
-describe('findRemoteExtensionFromArgs', () => {
-  const PARSED_MOCK: ParsedArgs = {
-    _: [],
-  };
+describe('parseArgs', () => {
+  test.each<{
+    name: string;
+    args: unknown[];
+    error: string;
+  }>([
+    {
+      name: 'missing --output should throw an error',
+      args: [],
+      error: 'missing output argument',
+    },
+    {
+      name: 'non absolute --output should throw an error',
+      args: ['--output', './foo'],
+      error: 'the output should be an absolute directory',
+    },
+    // missing one arg
+    {
+      name: `having --${NAME_ARG} without --${OCI_ARG} should throw an error`,
+      args: ['--output', ABS_DEST_DIR, `--${NAME_ARG}`, 'foo'],
+      error: `when specifying --${OCI_ARG} or --${NAME_ARG}, both should be provided as valid string`,
+    },
+    {
+      name: `having --${OCI_ARG} without --${NAME_ARG} should throw an error`,
+      args: ['--output', ABS_DEST_DIR, `--${OCI_ARG}`, 'ghcr.io/org/my-user:latest'],
+      error: `when specifying --${OCI_ARG} or --${NAME_ARG}, both should be provided as valid string`,
+    },
+    // zero length args
+    {
+      name: `zero length --${NAME_ARG} should throw an error`,
+      args: ['--output', ABS_DEST_DIR, `--${NAME_ARG}`, '', `--${OCI_ARG}`, 'ghcr.io/org/foo:latest'],
+      error: `when specifying --${OCI_ARG} or --${NAME_ARG}, both should be provided as valid string`,
+    },
+    {
+      name: `zero length --${OCI_ARG} should throw an error`,
+      args: ['--output', ABS_DEST_DIR, `--${OCI_ARG}`, '', `--${NAME_ARG}`, 'foo'],
+      error: `when specifying --${OCI_ARG} or --${NAME_ARG}, both should be provided as valid string`,
+    },
+    // too many args
+    {
+      name: `multiple --${OCI_ARG} should throw an error`,
+      args: [
+        '--output',
+        ABS_DEST_DIR,
+        `--${OCI_ARG}`,
+        'ghcr.io/org/foo:latest',
+        `--${OCI_ARG}`,
+        'ghcr.io/org/bar:latest',
+        `--${NAME_ARG}`,
+        'foo',
+      ],
+      error: `when specifying --${OCI_ARG} and --${NAME_ARG}, only one is allowed`,
+    },
+    {
+      name: `multiple --${NAME_ARG} should throw an error`,
+      args: [
+        '--output',
+        ABS_DEST_DIR,
+        `--${OCI_ARG}`,
+        'ghcr.io/org/foo:latest',
+        `--${NAME_ARG}`,
+        'foo',
+        `--${NAME_ARG}`,
+        'bar',
+      ],
+      error: `when specifying --${OCI_ARG} and --${NAME_ARG}, only one is allowed`,
+    },
+    // wrong type args
+    {
+      name: `boolean --${NAME_ARG} should throw an error`,
+      args: ['--output', ABS_DEST_DIR, `--${NAME_ARG}`, true, `--${OCI_ARG}`, 'ghcr.io/org/foo:latest'],
+      error: `when specifying --${OCI_ARG} and --${NAME_ARG}, should be valid strings`,
+    },
+    {
+      name: `boolean --${OCI_ARG} should throw an error`,
+      args: ['--output', ABS_DEST_DIR, `--${NAME_ARG}`, 'foo', `--${OCI_ARG}`, true],
+      error: `when specifying --${OCI_ARG} and --${NAME_ARG}, should be valid strings`,
+    },
+  ])('$name', ({ args, error }) => {
+    expect(() => {
+      parseArgs(args as string[]);
+    }).toThrowError(error);
+  });
 
-  test('should handle undefined entry for --oci arg', () => {
-    expect(findRemoteExtensionFromArgs(PARSED_MOCK)).toHaveLength(0);
+  test(`should handle no --${NAME_ARG} & --${OCI_ARG} args`, () => {
+    expect(parseArgs(['--output', ABS_DEST_DIR])).toStrictEqual({
+      output: ABS_DEST_DIR,
+    });
   });
 
   test('should handle single string value for --oci arg', () => {
     expect(
-      findRemoteExtensionFromArgs({
-        ...PARSED_MOCK,
-        [OCI_ARG]: 'ghcr.io/org/my-user:latest',
-      }),
-    ).toStrictEqual([
-      {
+      parseArgs([
+        // output arg
+        '--output',
+        ABS_DEST_DIR,
+        // oci arg
+        `--${OCI_ARG}`,
+        'ghcr.io/org/my-user:latest',
+        // name arg
+        `--${NAME_ARG}`,
+        'my-user',
+      ]),
+    ).toStrictEqual({
+      output: ABS_DEST_DIR,
+      extension: {
         oci: 'ghcr.io/org/my-user:latest',
-        name: 'ghcrioorgmyuser',
+        name: 'my-user',
       },
-    ]);
-  });
-
-  test('should handle single multiple string values for --oci arg', () => {
-    expect(
-      findRemoteExtensionFromArgs({
-        ...PARSED_MOCK,
-        [OCI_ARG]: ['ghcr.io/org/foo-user:latest', 'ghcr.io/org/bar-user:latest'],
-      }),
-    ).toStrictEqual([
-      {
-        oci: 'ghcr.io/org/foo-user:latest',
-        name: 'ghcrioorgfoouser',
-      },
-      {
-        oci: 'ghcr.io/org/bar-user:latest',
-        name: 'ghcrioorgbaruser',
-      },
-    ]);
+    });
   });
 });
 
-describe('findRemoteExtensionFromProductJSON', () => {
+describe('getRemoteExtensionFromProductJSON', () => {
   test('expect to read product.json#extensions#remote', () => {
     (vi.mocked(product).extensions.remote as RemoteExtension[]) = [REMOTE_INFO_MOCK];
 
-    expect(findRemoteExtensionFromProductJSON()).toStrictEqual([REMOTE_INFO_MOCK]);
-  });
-});
-
-describe('sanitiseImageName', () => {
-  test.each<{ oci: string; expected: string }>([
-    // oci with a tag
-    {
-      oci: 'localhost/dummy-extension:latest',
-      expected: 'localhostdummyextension',
-    },
-    // oci without a tag
-    {
-      oci: 'localhost/dummy-extension',
-      expected: 'localhostdummyextension',
-    },
-  ])('$oci should be sanitized to $expected', ({ oci, expected }) => {
-    expect(sanitiseImageName(oci)).toBe(expected);
+    expect(getRemoteExtensionFromProductJSON()).toStrictEqual([REMOTE_INFO_MOCK]);
   });
 });
 
 describe('main', () => {
-  test('missing --output should throw an error', async () => {
-    await expect(async () => {
-      await main([]);
-    }).rejects.toThrowError('missing output argument');
-  });
-
-  test('non absolute --output should throw an error', async () => {
-    await expect(async () => {
-      await main(['--output', './foo']);
-    }).rejects.toThrowError('the output should be an absolute directory');
-  });
-
-  test(`--${OCI_ARG} should be preferred to product.json`, async () => {
+  test(`cli args should be preferred to product.json`, async () => {
     (vi.mocked(product).extensions.remote as RemoteExtension[]) = [REMOTE_INFO_MOCK];
 
-    await main(['--output', ABS_DEST_DIR, `--${OCI_ARG}`, 'localhost/dummy-extension:latest']);
+    await main([
+      '--output',
+      ABS_DEST_DIR,
+      `--${OCI_ARG}`,
+      'localhost/dummy-extension:latest',
+      `--${NAME_ARG}`,
+      'dummy-extension',
+    ]);
 
     expect(rename).toHaveBeenCalledExactlyOnceWith(
-      join(TMP_DIR, 'localhostdummyextension', 'extension'),
-      join(ABS_DEST_DIR, 'localhostdummyextension'),
+      join(TMP_DIR, 'dummy-extension', 'extension'),
+      join(ABS_DEST_DIR, 'dummy-extension'),
     );
   });
 

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -54,6 +54,7 @@ export interface RemoteExtension {
 }
 
 export const OCI_ARG = 'oci';
+export const NAME_ARG = 'name';
 
 export async function downloadExtension(destination: string, info: RemoteExtension): Promise<void> {
   const imageRegistry = new ImageRegistry(dummyApiSenderType, dummyTelemetry, dummyCertificate, dummyProxy);
@@ -105,13 +106,7 @@ export async function moveSafely(src: string, dest: string): Promise<void> {
   }
 }
 
-export function sanitiseImageName(name: string): string {
-  const sanitized = name?.split(':')?.[0]?.replace(/[^a-zA-Z0-9]/g, '');
-  if (!sanitized) throw new Error('invalid image name');
-  return sanitized;
-}
-
-export function findRemoteExtensionFromProductJSON(): RemoteExtension[] {
+export function getRemoteExtensionFromProductJSON(): RemoteExtension[] {
   if (!product) return [];
   if (!('extensions' in product) || !product.extensions || typeof product.extensions !== 'object') return [];
   if (!('remote' in product.extensions) || !product.extensions.remote || !Array.isArray(product.extensions.remote))
@@ -119,25 +114,12 @@ export function findRemoteExtensionFromProductJSON(): RemoteExtension[] {
   return product.extensions.remote as RemoteExtension[];
 }
 
-export function findRemoteExtensionFromArgs(args: minimist.ParsedArgs): RemoteExtension[] {
-  const raw = args[OCI_ARG];
-  if (!raw) return [];
-
-  let images: string[];
-  if (Array.isArray(raw) && raw.every(name => typeof name === 'string')) {
-    images = raw;
-  } else if (typeof raw === 'string') {
-    images = [raw];
-  } else {
-    throw new Error('invalid argument for --' + OCI_ARG + ', should be a string');
-  }
-  return images.map(image => ({
-    oci: image,
-    name: sanitiseImageName(image),
-  }));
-}
-
-export async function main(args: string[]): Promise<void> {
+/**
+ * Parsing the args provided
+ * the `--output` is mandatory and should be an absolute path
+ * the `--oci` and `--name` are optional but should be both defined if specified
+ */
+export function parseArgs(args: string[]): { output: string; extension?: RemoteExtension } {
   const parsed = minimist(args);
 
   const output: string | undefined = parsed['output'];
@@ -145,13 +127,44 @@ export async function main(args: string[]): Promise<void> {
 
   if (!isAbsolute(output)) throw new Error('the output should be an absolute directory');
 
-  // Get the extensions from the cli args or fallback to product.json
-  const extensions: RemoteExtension[] = findRemoteExtensionFromArgs(parsed);
-  if (extensions.length === 0) {
-    extensions.push(...findRemoteExtensionFromProductJSON());
+  const oci = parsed[OCI_ARG];
+  const name = parsed[NAME_ARG];
+
+  // if --oci and --name are not provided, return the output directory as the extension directory
+  if (!oci && !name) {
+    return { output };
   }
 
-  await Promise.all(extensions.map(downloadExtension.bind(undefined, output))).catch(console.error);
+  if (!oci || !name) {
+    throw new Error(`when specifying --${OCI_ARG} or --${NAME_ARG}, both should be provided as valid string`);
+  }
+
+  if (Array.isArray(oci) || Array.isArray(name)) {
+    throw new Error(`when specifying --${OCI_ARG} and --${NAME_ARG}, only one is allowed`);
+  }
+
+  if (typeof oci !== 'string' || typeof name !== 'string') {
+    throw new Error(`when specifying --${OCI_ARG} and --${NAME_ARG}, should be valid strings`);
+  }
+
+  return {
+    output,
+    extension: { oci, name },
+  };
+}
+
+export async function main(args: string[]): Promise<void> {
+  const { output, extension } = parseArgs(args);
+
+  // if an extension has been provided through CLI download it directly
+  if (extension) {
+    return downloadExtension(output, extension);
+  }
+
+  // otherwise fallback to bundled product.json
+  await Promise.all(getRemoteExtensionFromProductJSON().map(downloadExtension.bind(undefined, output))).catch(
+    console.error,
+  );
 }
 
 // do not start if we are in a VITEST env


### PR DESCRIPTION
### What does this PR do?

The `download-remote-extensions` script now support `--oci` & `--name` argument. If arguments are provided the content of the `product.json` is ignored.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15237

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

1. Checkout
2. Run `pnpm build:main`
3. Run the following cmd
```
# work for windows, pls adapt to your platform
$: node .\packages\main\dist\download-remote-extensions.cjs --output="$pwd\\extensions-extra" --oci="ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:f3c26a91bb1addce5c8280fe5b53ba25c720b48d" --name="podman-desktop-extension-layers-explorer"
```
4. Assert it downloaded the extension to `extensions-extra/podman-desktop-extension-layers-explorer`
5. Be happy in your life 🪄 