### PR TITLE
chore(test): validate that input field is populated correctly

### DIFF
--- a/tests/playwright/src/model/pages/preferences-page.ts
+++ b/tests/playwright/src/model/pages/preferences-page.ts
@@ -40,7 +40,10 @@ export class PreferencesPage extends SettingsPage {
       }
       playExpect(this.kubePathInput).toBeDefined();
       await this.kubePathInput.clear();
+      await playExpect(this.kubePathInput).toHaveValue('');
+
       await this.kubePathInput.fill(pathToKube);
+      await playExpect(this.kubePathInput).toHaveValue(pathToKube);
     });
   }
 }

--- a/tests/playwright/src/specs/preferences.spec.ts
+++ b/tests/playwright/src/specs/preferences.spec.ts
@@ -32,8 +32,6 @@ test.afterAll(async ({ runner }) => {
 
 test.describe
   .serial('Preferences text persistence validation', () => {
-    test.describe.configure({ timeout: 60_000 });
-
     test('Check preferences text persistence', async ({ page, navigationBar }) => {
       //Open Settings/Preferences page
       const settingsBar = await navigationBar.openSettings();


### PR DESCRIPTION
### What does this PR do?
Checks that the path input field is populated correctly before moving on.

### What issues does this PR fix or reference?
