### PR TITLE
feat: add terminal provider connection for Lima shell access

### DIFF
--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -40,6 +40,33 @@
           "default": "",
           "description": "Instance name (default is same name as type)"
         },
+        "lima.arch": {
+          "type": "arch",
+          "scope": "ContainerConnection",
+          "description": "Arch",
+          "readonly": true
+        },
+        "lima.cpus": {
+          "type": "number",
+          "format": "cpu",
+          "scope": "ContainerConnection",
+          "description": "CPUs",
+          "readonly": true
+        },
+        "lima.memory": {
+          "type": "number",
+          "format": "memory",
+          "scope": "ContainerConnection",
+          "description": "Memory",
+          "readonly": true
+        },
+        "lima.disk": {
+          "type": "number",
+          "format": "diskSize",
+          "scope": "ContainerConnection",
+          "description": "Disk",
+          "readonly": true
+        },
         "lima.socket": {
           "type": "string",
           "default": "",

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -9,7 +9,7 @@
   "engines": {
     "podman-desktop": "^0.0.1"
   },
-  "main": "./dist/extension.js",
+  "main": "./dist/extension.cjs",
   "contributes": {
     "configuration": {
       "title": "Lima",
@@ -96,9 +96,11 @@
     "watch": "vite build --watch"
   },
   "dependencies": {
-    "@podman-desktop/api": "workspace:*"
+    "@podman-desktop/api": "workspace:*",
+    "ssh2": "^1.17.0"
   },
   "devDependencies": {
+    "@types/ssh2": "^1.15.5",
     "adm-zip": "^0.5.16",
     "mkdirp": "^3.0.1",
     "vite": "^7.3.1",

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -24,7 +24,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { configuration, ProgressLocation } from '@podman-desktop/api';
 
 import { ImageHandler } from './image-handler';
-import { getLimactl } from './limactl';
+import { getLimactl, getLimaInstallation } from './limactl';
 
 type limaProviderType = 'docker' | 'podman' | 'kubernetes';
 
@@ -101,12 +101,16 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const socketPath = path.resolve(limaHome ?? '', instanceName + '/sock/' + socketName);
   const configPath = path.resolve(limaHome ?? '', instanceName + '/copied-from-guest/kubeconfig.yaml');
 
+  const installedLima = await getLimaInstallation();
+  const version: string | undefined = installedLima?.version;
+
   let provider;
   if (fs.existsSync(socketPath) || fs.existsSync(configPath)) {
     provider = extensionApi.provider.createProvider({
       name: 'Lima',
       id: 'lima',
       status: 'unknown',
+      version,
       images: {
         icon: './icon.png',
         logo: {

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -134,6 +134,12 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
           light: './logo-light.png',
         },
       },
+      links: [
+        {
+          title: 'Website',
+          url: 'https://lima-vm.io/',
+        },
+      ],
     });
     extensionContext.subscriptions.push(provider);
   }

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -24,7 +24,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { configuration, ProgressLocation } from '@podman-desktop/api';
 
 import { ImageHandler } from './image-handler';
-import { getLimactl, getLimaInstallation } from './limactl';
+import { getLimactl, getLimaInfo, getLimaInstallation } from './limactl';
 
 type limaProviderType = 'docker' | 'podman' | 'kubernetes';
 
@@ -42,13 +42,28 @@ function prettyInstanceName(instanceName: string): string {
   return name;
 }
 
-function registerProvider(
+async function updateContainerConfiguration(
+  containerProviderConnection: extensionApi.ContainerProviderConnection,
+  instanceName: string,
+): Promise<void> {
+  // get configuration for this connection
+  const containerConfiguration = extensionApi.configuration.getConfiguration('lima', containerProviderConnection);
+
+  const limaInfo = await getLimaInfo(instanceName);
+  containerProviderConnection.vmType = limaInfo?.vmType;
+  await containerConfiguration.update('arch', limaInfo?.arch);
+  await containerConfiguration.update('cpus', limaInfo?.cpus);
+  await containerConfiguration.update('memory', limaInfo?.memory);
+  await containerConfiguration.update('disk', limaInfo?.disk);
+}
+
+async function registerProvider(
   extensionContext: extensionApi.ExtensionContext,
   provider: extensionApi.Provider,
   providerType: limaProviderType,
   providerPath: string,
   instanceName: string,
-): void {
+): Promise<void> {
   let providerState: extensionApi.ProviderConnectionStatus = 'unknown';
   if (providerType === 'podman' || providerType === 'docker') {
     const connection: extensionApi.ContainerProviderConnection = {
@@ -59,6 +74,7 @@ function registerProvider(
         socketPath: providerPath,
       },
     };
+    await updateContainerConfiguration(connection, instanceName);
     providerState = 'started';
     const disposable = provider.registerContainerProviderConnection(connection);
     provider.updateStatus('started');
@@ -126,7 +142,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (socketName !== 'kubernetes.sock') {
     const providerType = engineType === 'kubernetes' ? 'docker' : (engineType as limaProviderType);
     if (fs.existsSync(socketPath) && provider) {
-      registerProvider(extensionContext, provider, providerType, socketPath, instanceName);
+      await registerProvider(extensionContext, provider, providerType, socketPath, instanceName);
     } else {
       console.debug(`Could not find socket at ${socketPath}`);
     }
@@ -135,7 +151,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   if (engineType === 'kubernetes') {
     const providerType = engineType as limaProviderType;
     if (fs.existsSync(configPath) && provider) {
-      registerProvider(extensionContext, provider, providerType, configPath, instanceName);
+      await registerProvider(extensionContext, provider, providerType, configPath, instanceName);
     } else {
       console.debug(`Could not find config at ${configPath}`);
     }

--- a/extensions/lima/src/lima-stream.ts
+++ b/extensions/lima/src/lima-stream.ts
@@ -97,7 +97,9 @@ export class ProviderConnectionShellAccessImpl implements ProviderConnectionShel
     this.#client = new Client();
     this.#client
       .on('ready', () => {
-        this.#client?.shell((err, stream) => {
+        const window = { term: 'xterm-256color' };
+        const options = { env: { COLORTERM: 'truecolor' } };
+        this.#client?.shell(window, options, (err, stream) => {
           if (err) {
             this.onErrorEmit.fire({ error: err.message });
             return;

--- a/extensions/lima/src/lima-stream.ts
+++ b/extensions/lima/src/lima-stream.ts
@@ -1,0 +1,136 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
+import type {
+  Disposable,
+  Event,
+  ProviderConnectionShellAccess,
+  ProviderConnectionShellAccessData,
+  ProviderConnectionShellAccessError,
+  ProviderConnectionShellAccessSession,
+  ProviderConnectionShellDimensions,
+} from '@podman-desktop/api';
+import { EventEmitter } from '@podman-desktop/api';
+import type { ClientChannel } from 'ssh2';
+import { Client } from 'ssh2';
+
+import type { LimaInfo } from './limactl';
+
+export class ProviderConnectionShellAccessImpl implements ProviderConnectionShellAccess, Disposable {
+  #host: string;
+  #port: number;
+  #username: string | undefined;
+  #privateKey: string | undefined;
+  #client: Client | undefined;
+  #stream: ClientChannel | undefined;
+
+  constructor(private readonly limaInfo: LimaInfo) {
+    this.#host = limaInfo.sshAddress;
+    this.#port = limaInfo.sshLocalPort;
+    this.#username = limaInfo.configUserName;
+    this.#privateKey = limaInfo.identityFile;
+  }
+
+  dispose(): void {
+    this.close();
+  }
+
+  onDataEmit = new EventEmitter<ProviderConnectionShellAccessData>();
+  onData: Event<ProviderConnectionShellAccessData> = this.onDataEmit.event;
+
+  onErrorEmit = new EventEmitter<ProviderConnectionShellAccessError>();
+  onError: Event<ProviderConnectionShellAccessError> = this.onErrorEmit.event;
+
+  onEndEmit = new EventEmitter<void>();
+  onEnd: Event<void> = this.onEndEmit.event;
+
+  write(data: string): void {
+    this.#stream?.write(data);
+  }
+
+  resize(dimensions: ProviderConnectionShellDimensions): void {
+    // rows and cols override width and height when rows and cols are non-zero.
+    this.#stream?.setWindow(dimensions.rows, dimensions.cols, 0, 0);
+  }
+
+  protected disposeListeners(): void {
+    this.onDataEmit.dispose();
+    this.onErrorEmit.dispose();
+    this.onEndEmit.dispose();
+  }
+
+  // Going to different tab => closing session + removing listeners
+  // Closes stream with client
+  close(): void {
+    this.closeStream();
+    this.disposeListeners();
+  }
+
+  // Closes stream with client
+  closeStream(): void {
+    this.#stream?.close();
+    this.#client?.end();
+    this.#client?.destroy();
+    this.#stream = undefined;
+    this.#client = undefined;
+  }
+
+  open(): ProviderConnectionShellAccessSession {
+    this.#client = new Client();
+    this.#client
+      .on('ready', () => {
+        this.#client?.shell((err, stream) => {
+          if (err) {
+            this.onErrorEmit.fire({ error: err.message });
+            return;
+          }
+          this.#stream = stream;
+
+          stream
+            .on('close', () => {
+              this.onEndEmit.fire();
+              this.closeStream();
+            })
+            .on('data', (data: string) => {
+              this.onDataEmit.fire({ data: data });
+            });
+        });
+      })
+      .on('error', err => {
+        this.onErrorEmit.fire({ error: err.message });
+      })
+      .connect({
+        host: this.#host,
+        port: this.#port,
+        username: this.#username ? this.#username : os.userInfo().username,
+        privateKey: this.#privateKey ? fs.readFileSync(this.#privateKey) : undefined,
+      });
+
+    return {
+      onData: this.onData,
+      onError: this.onError,
+      onEnd: this.onEnd,
+      write: this.write.bind(this),
+      resize: this.resize.bind(this),
+      close: this.close.bind(this),
+    };
+  }
+}

--- a/extensions/lima/src/limactl.ts
+++ b/extensions/lima/src/limactl.ts
@@ -80,6 +80,11 @@ export interface LimaInfo {
   memory: number; // bytes
   disk: number; // bytes
   dir: string;
+
+  sshAddress: string;
+  sshLocalPort: number;
+  configUserName?: string;
+  identityFile?: string;
 }
 
 export async function getLimaInfo(name: string): Promise<LimaInfo | undefined> {
@@ -94,7 +99,18 @@ export async function getLimaInfo(name: string): Promise<LimaInfo | undefined> {
       memory: limaInfo.memory,
       disk: limaInfo.disk,
       dir: limaInfo.dir,
+
+      sshAddress: limaInfo.sshAddress,
+      sshLocalPort: limaInfo.sshLocalPort,
+      configUserName: limaInfo.config?.user?.name,
+      identityFile: limaInfo?.IdentityFile,
     };
+    if (!instance.identityFile) {
+      // Starting with Lima 2.0, some host attributes have been deprecated in 'list'
+      const { stdout } = await extensionApi.process.exec(getLimactl(), ['info']);
+      const limaInfo = JSON.parse(stdout);
+      instance.identityFile = limaInfo.identityFile;
+    }
     return instance;
   } catch (err) {
     return undefined;

--- a/extensions/lima/src/limactl.ts
+++ b/extensions/lima/src/limactl.ts
@@ -66,3 +66,37 @@ export async function getLimaInstallation(): Promise<InstalledLima | undefined> 
     return undefined;
   }
 }
+
+/*
+NAME      STATUS     SSH            VMTYPE    ARCH      CPUS    MEMORY    DISK      DIR
+podman    Stopped    127.0.0.1:0    qemu      x86_64    4       4GiB      100GiB    ~/.lima/podman
+*/
+
+export interface LimaInfo {
+  name: string;
+  vmType: string;
+  arch: string;
+  cpus: number;
+  memory: number; // bytes
+  disk: number; // bytes
+  dir: string;
+}
+
+export async function getLimaInfo(name: string): Promise<LimaInfo | undefined> {
+  try {
+    const { stdout } = await extensionApi.process.exec(getLimactl(), ['list', '--json', name]);
+    const limaInfo = JSON.parse(stdout);
+    const instance: LimaInfo = {
+      name: limaInfo.name,
+      vmType: limaInfo.vmType,
+      arch: limaInfo.arch,
+      cpus: limaInfo.cpus,
+      memory: limaInfo.memory,
+      disk: limaInfo.disk,
+      dir: limaInfo.dir,
+    };
+    return instance;
+  } catch (err) {
+    return undefined;
+  }
+}

--- a/extensions/lima/src/limactl.ts
+++ b/extensions/lima/src/limactl.ts
@@ -50,3 +50,19 @@ export function getLimactl(): string {
 function getCustomBinaryPath(): string | undefined {
   return extensionApi.configuration.getConfiguration('lima').get('binary.path');
 }
+
+export interface InstalledLima {
+  version: string;
+}
+
+export async function getLimaInstallation(): Promise<InstalledLima | undefined> {
+  try {
+    const { stdout: versionOut } = await extensionApi.process.exec(getLimactl(), ['--version']);
+    const versionArr = versionOut.split(' ');
+    const version = versionArr[versionArr.length - 1];
+    return { version };
+  } catch (err) {
+    // no limactl binary
+    return undefined;
+  }
+}

--- a/extensions/lima/tsconfig.json
+++ b/extensions/lima/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "Node",
     "strict": true,
     "lib": ["ES2017", "webworker"],
     "sourceMap": true,

--- a/extensions/lima/vite.config.js
+++ b/extensions/lima/vite.config.js
@@ -45,9 +45,14 @@ const config = {
       formats: ['cjs'],
     },
     rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
+      external: [
+        '@podman-desktop/api',
+        'ssh2',
+        '@podman-desktop/podman-extension-api',
+        ...builtinModules.flatMap(p => [p, `node:${p}`]),
+      ],
       output: {
-        entryFileNames: '[name].js',
+        entryFileNames: '[name].cjs',
       },
     },
     emptyOutDir: true,


### PR DESCRIPTION
### What does this PR do?

* add Terminal to Lima provider (similar to `lima` command: `limactl shell`)

* enable color in the Lima shell (i.e. `TERM=xterm-256color`, `COLORTERM=true`)
  https://fedoraproject.org/wiki/Changes/Color_Bash_Prompt
  `sudo dnf install -y bash-color-prompt`

* username is optional for ssh (if undefined, use current user name)

* privateKey is optional for ssh (if undefined, use current user keys)

### Screenshot / video of UI

<img width="825" height="731" alt="pd-lima-color-shell" src="https://github.com/user-attachments/assets/5f4db5d5-5d3c-4b61-b6b5-3b299c427365" />

### What issues does this PR fix or reference?

* https://github.com/podman-desktop/podman-desktop/issues/15250

### How to test this PR?

Based on / requires PR #15125

SSH code copied from Podman

- [ ] Tests are covering the bug fix or the new feature
