### PR TITLE
feat: stop deploy to kube on imagepullbackoff

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -564,11 +564,18 @@ test('ImagePullBackOff error should be reported', async () => {
   await vi.runAllTimersAsync();
 
   await waitFor(() => {
+    // The error is reported to the telemetry and to the user
     expect(window.telemetryTrack).toBeCalledWith('deployToKube', {
       errorMessage: 'ImagePullBackOff',
     });
     expect(screen.getByLabelText('Deploy Error Message')).toHaveTextContent(
       'ImagePullBackOff error, please check that the image is accessible from the Kubernetes cluster',
     );
+  });
+  await vi.waitFor(() => {
+    // The deploy button is displayed again, meaning that the deploy process has been aborted
+    const deployButton = screen.getByRole('button', { name: 'Deploy' });
+    expect(deployButton).toBeVisible();
+    expect(deployButton).toBeEnabled();
   });
 });

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { V1Pod } from '@kubernetes/client-node';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import * as jsYaml from 'js-yaml';
@@ -532,4 +533,42 @@ test('Done button should go back to previous page', async () => {
   lastPage.set({ name: 'perious page', path: '/last' });
   await fireEvent.click(doneButton);
   expect(router.goto).toHaveBeenCalledWith(`/last`);
+});
+
+test('ImagePullBackOff error should be reported', async () => {
+  await waitRender({});
+  const createButton = screen.getByRole('button', { name: 'Deploy' });
+  expect(createButton).toBeInTheDocument();
+  expect(createButton).toBeEnabled();
+
+  vi.mocked(window.kubernetesCreatePod).mockResolvedValue({
+    metadata: { name: 'my-pod', namespace: 'default' },
+  });
+  vi.mocked(window.kubernetesReadNamespacedPod).mockResolvedValue({
+    metadata: { name: 'my-pod', namespace: 'default' },
+    status: {
+      containerStatuses: [
+        {
+          state: {
+            waiting: {
+              reason: 'ImagePullBackOff',
+            },
+          },
+        },
+      ],
+    },
+  } as unknown as V1Pod);
+
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  await fireEvent.click(createButton);
+  await vi.runAllTimersAsync();
+
+  await waitFor(() => {
+    expect(window.telemetryTrack).toBeCalledWith('deployToKube', {
+      errorMessage: 'ImagePullBackOff',
+    });
+    expect(screen.getByLabelText('Deploy Error Message')).toHaveTextContent(
+      'ImagePullBackOff error, please check that the image is accessible from the Kubernetes cluster',
+    );
+  });
 });

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -128,6 +128,15 @@ async function updatePod(): Promise<void> {
       useServices: deployUsingServices,
       useRoutes: deployUsingRoutes,
     });
+  } else if (
+    createdPod?.status?.containerStatuses?.some(status => status.state?.waiting?.reason === 'ImagePullBackOff')
+  ) {
+    clearInterval(updatePodInterval);
+    await window.telemetryTrack('deployToKube', { errorMessage: 'ImagePullBackOff' });
+    deployError = 'ImagePullBackOff error, please check that the image is accessible from the Kubernetes cluster.';
+    deployStarted = false;
+    deployFinished = false;
+    return;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Stops the deploy process when the user deploys to Kubernetes a Podman pod, but the deployment fails with ImagePullBackOff

### Screenshot / video of UI

<img width="1050" height="697" alt="imagePullBackOff" src="https://github.com/user-attachments/assets/237a52fb-edac-49c7-9ce5-f9c42af5b660" />

### What issues does this PR fix or reference?

Fixes #15140

### How to test this PR?

- Deploy a Podman Pod with a local image, not accessible from your Kubernetes cluster
- "Deploy To Kube" the Podman Pod

- [x] Tests are covering the bug fix or the new feature
