### PR TITLE
chore(git ignore): adding `extensions-extra` entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 /storybook/storybook-static/
 yarn.lock
 extensions/podman/assets/
+extensions-extra/


### PR DESCRIPTION
### What does this PR do?

As suggested in https://github.com/podman-desktop/podman-desktop/pull/15165#pullrequestreview-3550660917, we should add the `extensions-extra` to the `.gitignore`

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/15044

### How to test this PR?

N/A
