### PR TITLE
ci: delete target before mv command

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: setup telemetry key for production
         run: |
-          jq --arg key "${{ secrets.SEGMENT_WRITE_KEY }}" '.telemetry.key = $key' product.json > product.json.tmp && mv product.json.tmp product.json
+          jq --arg key "${{ secrets.SEGMENT_WRITE_KEY }}" '.telemetry.key = $key' product.json > product.json.tmp && rm product.json && mv product.json.tmp product.json
 
       - name: Execute pnpm
         run: pnpm install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,7 +165,7 @@ jobs:
 
       - name: setup telemetry key for production
         run: |
-          jq --arg key "${{ secrets.SEGMENT_WRITE_KEY }}" '.telemetry.key = $key' product.json > product.json.tmp && mv product.json.tmp product.json
+          jq --arg key "${{ secrets.SEGMENT_WRITE_KEY }}" '.telemetry.key = $key' product.json > product.json.tmp && rm product.json && mv product.json.tmp product.json
 
       - name: Execute pnpm
         run: pnpm install


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Delete the target file before executing the `mv` command, as it will fail on Windows if the target file exists. We cannot use `rm -f ` as it is not supported on Windows, but it is not necessary as the produect.json file is expected to exist (or the previous `jq` command would fail)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #15265 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
