### PR TITLE
chore(aria): add simple aria-labelledby attribute to preferences

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -84,9 +84,9 @@ function updateSearchValue(event: any): void {
           {@const records = matchingRecords.get(configSection)}
           {#if records}
             <div>
-              <div class="text-lg font-medium first-letter:uppercase">{records.at(0)?.title}</div>
+              <div role="heading" aria-level="2" class="text-lg font-medium first-letter:uppercase">{records.at(0)?.title}</div>
               {#each records as configItem (configItem.id)}
-                <div class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2">
+                <div class="bg-[var(--pd-invert-content-card-bg)] rounded-md mt-2 ml-2" aria-labelledby="{configItem.id}">
                   <PreferencesRenderingItem record={configItem} />
                 </div>
               {/each}


### PR DESCRIPTION
### What does this PR do?
Introduced two small improvements in aria functionality into preferences page to provide very basic structure where playwright can better search for particular section (ie. Appearance) and subsection (ie. zoom level) using prefenreces's record id. (ie `feedback.dialog`, `appearance.appearance`, etc.)
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#15163 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
In playwright tests something like this should be now possible:
```
const section = page.getByRole('heading', name: { 'Appearance' });
const zoomLevel= section.localtor('..').getByLabel('appearance.zoom-level') #something like this should work now
```
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
