### PR TITLE
feat(download-extension-remote): auth support through `--registry-user`  & `--registry-secret`

### DIFF
--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -37,8 +37,12 @@ import product from '/@product.json' with { type: 'json' };
  * We do not use those classes when calling ImageRegistry#downloadAndExtractImage as the internal logic
  * uses different node_modules; those classes are needed for other things the class is doing
  */
-const dummyApiSenderType = {} as unknown as ApiSenderType;
-const dummyTelemetry = {} as unknown as Telemetry;
+const dummyApiSenderType = {
+  send: (): void => {},
+} as unknown as ApiSenderType;
+const dummyTelemetry = {
+  track: (): void => {},
+} as unknown as Telemetry;
 const dummyCertificate = {
   getAllCertificates: (): undefined => undefined,
 } as unknown as Certificates;
@@ -55,8 +59,21 @@ export interface RemoteExtension {
 
 export const OCI_ARG = 'oci';
 export const NAME_ARG = 'name';
+export const REGISTRY_USER_ARG = 'registry-user';
+export const REGISTRY_SECRET_ARG = 'registry-secret';
 
 export const DIGEST_FILENAME = '.digest';
+
+export interface RegistryAuth {
+  username: string;
+  secret: string;
+}
+
+export interface DownloadOptions {
+  destination: string;
+  extension: RemoteExtension;
+  auth?: RegistryAuth;
+}
 
 async function findExtensionDigest(extension: string): Promise<string | undefined> {
   try {
@@ -66,23 +83,37 @@ async function findExtensionDigest(extension: string): Promise<string | undefine
   }
 }
 
-export async function downloadExtension(destination: string, info: RemoteExtension): Promise<void> {
+export async function downloadExtension(options: DownloadOptions): Promise<void> {
   const imageRegistry = new ImageRegistry(dummyApiSenderType, dummyTelemetry, dummyCertificate, dummyProxy);
 
+  if (options.auth) {
+    const registry = imageRegistry.extractRegistryServerFromImage(options.extension.oci);
+    if (!registry) throw new Error(`cannot determine registry for image ${options.extension.oci}`);
+
+    console.debug(`Configuring registry ${registry}`);
+
+    imageRegistry.registerRegistry({
+      source: 'scripts',
+      serverUrl: registry,
+      username: options.auth.username,
+      secret: options.auth.secret,
+    });
+  }
+
   // tmp folder
-  const tmpFolderPath = join(tmpdir(), info.name);
+  const tmpFolderPath = join(tmpdir(), options.extension.name);
 
-  const finalPath = join(destination, info.name);
+  const finalPath = join(options.destination, options.extension.name);
 
-  const { config } = await imageRegistry.getManifestFromImageName(info.oci);
+  const { config } = await imageRegistry.getManifestFromImageName(options.extension.oci);
   if (!config) {
     throw new Error(
-      `extension ${info.name} has malformed content: the OCI image manifest should contains a "config" field`,
+      `extension ${options.extension.name} has malformed content: the OCI image manifest should contains a "config" field`,
     );
   }
   if (!config.digest) {
     throw new Error(
-      `extension ${info.name} has malformed content: the OCI image manifest should contains a "config.digest" field`,
+      `extension ${options.extension.name} has malformed content: the OCI image manifest should contains a "config.digest" field`,
     );
   }
 
@@ -90,24 +121,24 @@ export async function downloadExtension(destination: string, info: RemoteExtensi
   if (existsSync(finalPath)) {
     const existingDigest = await findExtensionDigest(finalPath);
     if (existingDigest === config.digest) {
-      console.log(`cache hit for ${info.name} ${config.digest.substring(0, 18)}`);
+      console.log(`cache hit for ${options.extension.name} ${config.digest.substring(0, 18)}`);
       return;
     } else {
-      console.log(`invalid digest for ${info.name}, cleanup ${finalPath}`);
+      console.log(`invalid digest for ${options.extension.name}, cleanup ${finalPath}`);
       await rm(finalPath, { recursive: true });
     }
   }
 
-  await imageRegistry.downloadAndExtractImage(info.oci, tmpFolderPath, console.log);
+  await imageRegistry.downloadAndExtractImage(options.extension.oci, tmpFolderPath, console.log);
 
   if (!existsSync(join(tmpFolderPath, 'extension', 'package.json'))) {
     throw new Error(
-      `extension ${info.name} has malformed content: the OCI image should contains a "package.json" file in the extension folder`,
+      `extension ${options.extension.name} has malformed content: the OCI image should contains a "package.json" file in the extension folder`,
     );
   }
 
   // ensure the destination directory exists
-  await mkdir(destination, { recursive: true });
+  await mkdir(options.destination, { recursive: true });
 
   // rename tmp to destination
   await moveSafely(join(tmpFolderPath, 'extension'), finalPath);
@@ -148,7 +179,7 @@ export function getRemoteExtensionFromProductJSON(): RemoteExtension[] {
  * the `--output` is mandatory and should be an absolute path
  * the `--oci` and `--name` are optional but should be both defined if specified
  */
-export function parseArgs(args: string[]): { output: string; extension?: RemoteExtension } {
+export function parseArgs(args: string[]): { output: string; extension?: RemoteExtension; auth?: RegistryAuth } {
   const parsed = minimist(args);
 
   const output: string | undefined = parsed['output'];
@@ -156,44 +187,79 @@ export function parseArgs(args: string[]): { output: string; extension?: RemoteE
 
   if (!isAbsolute(output)) throw new Error('the output should be an absolute directory');
 
+  // Access the --oci & --name properties
   const oci = parsed[OCI_ARG];
   const name = parsed[NAME_ARG];
 
-  // if --oci and --name are not provided, return the output directory as the extension directory
-  if (!oci && !name) {
-    return { output };
+  // Parse the --oci & --name args if provided
+  let extension: RemoteExtension | undefined;
+  if (oci || name) {
+    if (!oci || !name) {
+      throw new Error(`when specifying --${OCI_ARG} or --${NAME_ARG}, both should be provided as valid string`);
+    }
+
+    if (Array.isArray(oci) || Array.isArray(name)) {
+      throw new Error(`when specifying --${OCI_ARG} and --${NAME_ARG}, only one is allowed`);
+    }
+
+    if (typeof oci !== 'string' || typeof name !== 'string') {
+      throw new Error(`when specifying --${OCI_ARG} and --${NAME_ARG}, should be valid strings`);
+    }
+    extension = { oci, name };
   }
 
-  if (!oci || !name) {
-    throw new Error(`when specifying --${OCI_ARG} or --${NAME_ARG}, both should be provided as valid string`);
-  }
+  // access the --registry-user & --registry-secret args
+  const user = parsed[REGISTRY_USER_ARG];
+  const secret = parsed[REGISTRY_SECRET_ARG];
 
-  if (Array.isArray(oci) || Array.isArray(name)) {
-    throw new Error(`when specifying --${OCI_ARG} and --${NAME_ARG}, only one is allowed`);
-  }
+  let auth: RegistryAuth | undefined;
+  if (user || secret) {
+    if (!user || !secret) {
+      throw new Error(
+        `when specifying --${REGISTRY_USER_ARG} or --${REGISTRY_SECRET_ARG}, both should be provided as valid string`,
+      );
+    }
 
-  if (typeof oci !== 'string' || typeof name !== 'string') {
-    throw new Error(`when specifying --${OCI_ARG} and --${NAME_ARG}, should be valid strings`);
+    if (Array.isArray(user) || Array.isArray(secret)) {
+      throw new Error(`when specifying --${REGISTRY_USER_ARG} and --${REGISTRY_SECRET_ARG}, only one is allowed`);
+    }
+
+    if (typeof user !== 'string' || typeof secret !== 'string') {
+      throw new Error(`when specifying --${REGISTRY_USER_ARG} and --${REGISTRY_SECRET_ARG}, should be valid strings`);
+    }
+
+    auth = { username: user, secret: secret };
   }
 
   return {
     output,
-    extension: { oci, name },
+    extension: extension,
+    auth: auth,
   };
 }
 
 export async function main(args: string[]): Promise<void> {
-  const { output, extension } = parseArgs(args);
+  const { output, auth, extension } = parseArgs(args);
 
   // if an extension has been provided through CLI download it directly
   if (extension) {
-    return downloadExtension(output, extension);
+    return downloadExtension({
+      destination: output,
+      auth,
+      extension,
+    });
   }
 
   // otherwise fallback to bundled product.json
-  await Promise.all(getRemoteExtensionFromProductJSON().map(downloadExtension.bind(undefined, output))).catch(
-    console.error,
-  );
+  await Promise.all(
+    getRemoteExtensionFromProductJSON().map(extension =>
+      downloadExtension({
+        destination: output,
+        auth,
+        extension,
+      }),
+    ),
+  ).catch(console.error);
 }
 
 // do not start if we are in a VITEST env


### PR DESCRIPTION
### What does this PR do?

Reading from the `auth.json` is kinda complicated, as the code doing this is stored in the [extensions/podman/packages/extension/src/utils/registry-setup.ts](https://github.com/podman-desktop/podman-desktop/blob/e06f9a29d31ce8ae7085cf6f6146e1add51cedb1/extensions/podman/packages/extension/src/utils/registry-setup.ts#L49-L50). As the script only has access to code from the main package, we could either duplicate the code or find another way.

💡 The solution is to let the caller of the script provide the user & password through the CLI args. We could also define some ENV if we want to support it through the electron builder

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15197

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature


** Testing manually **

> You are gonna love those steps

1. Go to `quay.io` and create a private repository, let's call it `demo-private`
2. Go to `Account Settings > Robot Account > Create new Robot Account`
3. Once created, go to `repositories` column 
4. Give **write** permission to the Robot Account you created
5. Click on your Robot Account Name to open details
6. Select `podman login`
<img width="997" height="244" alt="image" src="https://github.com/user-attachments/assets/9f311c92-2bcf-4b68-a8b8-29a4771791a6" />

7. Copy the command and run it in your terminal
```
$: podman login [...]
Login Succeeded!
```
8. Let's copy and push the extension-layer extensions to our private repo
```
$: podman pull ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb
$: podman tag ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb quay.io/<user>/demo-private:extension-layers
```
9. Checkout this branch
10. Run `pnpm build:main`
11. Run the following command and replace the placeholder 
```
$:  node .\packages\main\dist\download-remote-extensions.cjs --output="$pwd\\extensions-extra" --name="podman-desktop-extension-layers-explorer" --oci="quay.io/<user>/demo-private:extension-layers" --registry-user="<user>" --registry-secret="<secret>"
```
12. assert it download the extension as expected