### PR TITLE
feat(download-extension-remote): stronger validation of product.json

### DIFF
--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -534,7 +534,7 @@ describe('getRemoteExtensionFromProductJSON', () => {
   });
 
   test('missing oci property in an item in extension.remote should throw an error', () => {
-    vi.mocked(product).extensions.remote = [
+    (vi.mocked(product).extensions.remote as RemoteExtension[]) = [
       {
         occci: '',
         name: 'foo',
@@ -547,7 +547,7 @@ describe('getRemoteExtensionFromProductJSON', () => {
   });
 
   test('missing name property in an item in extension.remote should throw an error', () => {
-    vi.mocked(product).extensions.remote = [
+    (vi.mocked(product).extensions.remote as RemoteExtension[]) = [
       {
         oci: 'foo',
         Name: 'bar',
@@ -560,7 +560,7 @@ describe('getRemoteExtensionFromProductJSON', () => {
   });
 
   test('undefined item in extension.remote should throw an error', () => {
-    vi.mocked(product).extensions.remote = [undefined as unknown as RemoteExtension];
+    (vi.mocked(product).extensions.remote as RemoteExtension[]) = [undefined as unknown as RemoteExtension];
 
     expect(() => {
       getRemoteExtensionFromProductJSON();

--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -70,7 +70,9 @@ beforeEach(() => {
   vi.unstubAllEnvs();
 
   vi.mocked(tmpdir).mockReturnValue(TMP_DIR);
-  (vi.mocked(product).extensions.remote as RemoteExtension[]) = [];
+  vi.mocked(product).extensions = {
+    remote: [],
+  };
 
   vi.mocked(ImageRegistry.prototype.getManifestFromImageName).mockResolvedValue(MANIFEST_MOCK);
   vi.mocked(ImageRegistry.prototype.extractRegistryServerFromImage).mockReturnValue('quay.io');
@@ -499,6 +501,70 @@ describe('getRemoteExtensionFromProductJSON', () => {
     (vi.mocked(product).extensions.remote as RemoteExtension[]) = [REMOTE_INFO_MOCK];
 
     expect(getRemoteExtensionFromProductJSON()).toStrictEqual([REMOTE_INFO_MOCK]);
+  });
+
+  test('malformed extensions in product.json should throw an error', () => {
+    (vi.mocked(product).extensions as unknown) = undefined;
+
+    expect(() => {
+      getRemoteExtensionFromProductJSON();
+    }).toThrowError('malformed product.json: extensions property is not an object');
+  });
+
+  test('array for extension property should throw an error', () => {
+    (vi.mocked(product).extensions as unknown) = [];
+
+    expect(() => {
+      getRemoteExtensionFromProductJSON();
+    }).toThrowError('malformed product.json: object extensions do not have a valid remote array');
+  });
+
+  test('non-array for extension.remote should throw an error', () => {
+    (vi.mocked(product).extensions.remote as unknown) = {};
+
+    expect(() => {
+      getRemoteExtensionFromProductJSON();
+    }).toThrowError('malformed product.json: object extensions do not have a valid remote array');
+  });
+
+  test('empty array in extensions.remote should return itself', () => {
+    vi.mocked(product).extensions.remote = [];
+
+    expect(getRemoteExtensionFromProductJSON()).toHaveLength(0);
+  });
+
+  test('missing oci property in an item in extension.remote should throw an error', () => {
+    vi.mocked(product).extensions.remote = [
+      {
+        occci: '',
+        name: 'foo',
+      } as unknown as RemoteExtension,
+    ];
+
+    expect(() => {
+      getRemoteExtensionFromProductJSON();
+    }).toThrowError('malformed product.json: extension at index 0 must have oci property as a valid string');
+  });
+
+  test('missing name property in an item in extension.remote should throw an error', () => {
+    vi.mocked(product).extensions.remote = [
+      {
+        oci: 'foo',
+        Name: 'bar',
+      } as unknown as RemoteExtension,
+    ];
+
+    expect(() => {
+      getRemoteExtensionFromProductJSON();
+    }).toThrowError('malformed product.json: extension at index 0 must have name property as a valid string');
+  });
+
+  test('undefined item in extension.remote should throw an error', () => {
+    vi.mocked(product).extensions.remote = [undefined as unknown as RemoteExtension];
+
+    expect(() => {
+      getRemoteExtensionFromProductJSON();
+    }).toThrowError('malformed product.json: extension at index 0 is invalid');
   });
 });
 

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -193,9 +193,28 @@ export async function moveSafely(src: string, dest: string): Promise<void> {
 
 export function getRemoteExtensionFromProductJSON(): RemoteExtension[] {
   if (!product) return [];
-  if (!('extensions' in product) || !product.extensions || typeof product.extensions !== 'object') return [];
-  if (!('remote' in product.extensions) || !product.extensions.remote || !Array.isArray(product.extensions.remote))
-    return [];
+  if (!('extensions' in product) || !product.extensions || typeof product.extensions !== 'object') {
+    throw new Error(`malformed product.json: extensions property is not an object`);
+  }
+  if (!('remote' in product.extensions) || !product.extensions.remote || !Array.isArray(product.extensions.remote)) {
+    throw new Error(`malformed product.json: object extensions do not have a valid remote array`);
+  }
+
+  // validate each items
+  product.extensions.remote.forEach((extension, index) => {
+    if (!extension) {
+      throw new Error(`malformed product.json: extension at index ${index} is invalid`);
+    }
+
+    if (!('name' in extension) || typeof extension.name !== 'string') {
+      throw new Error(`malformed product.json: extension at index ${index} must have name property as a valid string`);
+    }
+
+    if (!('oci' in extension) || typeof extension.oci !== 'string') {
+      throw new Error(`malformed product.json: extension at index ${index} must have oci property as a valid string`);
+    }
+  });
+
   return product.extensions.remote as RemoteExtension[];
 }
 

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -192,16 +192,19 @@ export async function moveSafely(src: string, dest: string): Promise<void> {
 }
 
 export function getRemoteExtensionFromProductJSON(): RemoteExtension[] {
-  if (!product) return [];
-  if (!('extensions' in product) || !product.extensions || typeof product.extensions !== 'object') {
+  const raw = product as unknown;
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`malformed product.json: content is not object`);
+  }
+  if (!('extensions' in raw) || !raw.extensions || typeof raw.extensions !== 'object') {
     throw new Error(`malformed product.json: extensions property is not an object`);
   }
-  if (!('remote' in product.extensions) || !product.extensions.remote || !Array.isArray(product.extensions.remote)) {
+  if (!('remote' in raw.extensions) || !raw.extensions.remote || !Array.isArray(raw.extensions.remote)) {
     throw new Error(`malformed product.json: object extensions do not have a valid remote array`);
   }
 
   // validate each items
-  product.extensions.remote.forEach((extension, index) => {
+  raw.extensions.remote.forEach((extension, index) => {
     if (!extension) {
       throw new Error(`malformed product.json: extension at index ${index} is invalid`);
     }
@@ -215,7 +218,7 @@ export function getRemoteExtensionFromProductJSON(): RemoteExtension[] {
     }
   });
 
-  return product.extensions.remote as RemoteExtension[];
+  return raw.extensions.remote as RemoteExtension[];
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Raised in https://github.com/podman-desktop/podman-desktop/pull/15270#issuecomment-3627834153 the validation of the product.json was pretty low, let's raise it

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related https://github.com/podman-desktop/podman-desktop/issues/15197

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
