### PR TITLE
fix(managed-by): fix macOS paths

### DIFF
--- a/packages/main/src/plugin/directories-legacy.spec.ts
+++ b/packages/main/src/plugin/directories-legacy.spec.ts
@@ -128,6 +128,18 @@ describe('LegacyDirectories', () => {
       expect(provider.getManagedDefaultsDirectory()).toBe(product.paths.managed.macOS);
     });
 
+    test('should use appId format for macOS managed folder path', () => {
+      vi.mocked(isMac).mockReturnValue(true);
+      vi.mocked(isWindows).mockReturnValue(false);
+      vi.mocked(isLinux).mockReturnValue(false);
+
+      provider = new LegacyDirectories();
+
+      // The macOS managed path folder should be the appId (macOS format is different vs Windows / Linux)
+      // so make sure we still have the correct format
+      expect(provider.getManagedDefaultsDirectory()).toBe(`/Library/Application Support/${product.appId}`);
+    });
+
     test('should map PROGRAMDATA into windows managed folder path', () => {
       vi.mocked(isMac).mockReturnValue(false);
       vi.mocked(isWindows).mockReturnValue(true);

--- a/product.json
+++ b/product.json
@@ -6,7 +6,7 @@
   "paths": {
     "config": "containers/podman-desktop",
     "managed": {
-      "macOS": "/Library/Application Support/Podman Desktop",
+      "macOS": "/Library/Application Support/io.podman_desktop.PodmanDesktop",
       "windows": "%PROGRAMDATA%\\Podman Desktop",
       "linux": "/usr/share/podman-desktop"
     }


### PR DESCRIPTION
fix(managed-by): fix macOS paths

### What does this PR do?

Uses `/Library/Application
Support/io.podman_desktop.PodmanDesktop/default-settings.json` and
`/Library/Application
Support/io.podman_desktop.PodmanDesktop/locked.json`

Instead of:
`/Library/Application Support/Podman Desktop/default-settings.json`
and
`/Library/Application Support/Podman Desktop/locked.json`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes https://github.com/podman-desktop/podman-desktop/issues/15276

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Boot PD on **macOS**
2. Confirm that the files are being loaded / checked in the correct
   location:

```sh
main ↪️ [Managed-by]: Loaded managed defaults from: /Library/Application Support/io.podman_desktop.PodmanDesktop/default-settings.json
main ↪️ [Managed-by]: Loaded managed locked from: /Library/Application Support/io.podman_desktop.PodmanDesktop/locked.json
```

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
