### PR TITLE
docs(managed-by): fix title of json for linux

### DIFF
--- a/website/docs/configuration/managed-configuration.md
+++ b/website/docs/configuration/managed-configuration.md
@@ -146,7 +146,7 @@ The administrator creates a managed defaults file with corporate settings:
 <Tabs groupId="operating-systems">
 <TabItem value="linux" label="Linux">
 
-```json title="/usr/share/containers/podman-desktop/default-settings.json"
+```json title="/usr/share/podman-desktop/default-settings.json"
 {
   "proxy.http": "http://corp-proxy.example.com:8080",
   "telemetry.enabled": false
@@ -183,7 +183,7 @@ The administrator creates a locked configuration file to enforce these settings:
 <Tabs groupId="operating-systems">
 <TabItem value="linux" label="Linux">
 
-```json title="/usr/share/containers/podman-desktop/locked.json"
+```json title="/usr/share/podman-desktop/locked.json"
 {
   "locked": ["proxy.http", "telemetry.enabled"]
 }


### PR DESCRIPTION
docs(managed-by): fix title of json for linux

### What does this PR do?

The titles were slightly incorrect (should be
`/usr/share/podman-desktop` not `/usr/share/containers/podman-desktop`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
