### PR TITLE
docs: fix path and typo in managed config docs

### DIFF
--- a/website/docs/configuration/managed-configuration.md
+++ b/website/docs/configuration/managed-configuration.md
@@ -36,7 +36,7 @@ This allows administrators to pre-configure settings for new users while respect
 Settings listed in `locked.json` are enforced on every read and cannot be changed by the user:
 
 - The value is always read from `default-settings.json`, ignoring the user's `settings.json`
-- The setting appears displays a lock icon in the UI
+- The setting displays a lock icon in the UI
 - User changes to locked keys are ignored
 
 Use locked settings when you need to enforce compliance, such as proxy servers or telemetry policies.

--- a/website/docs/configuration/settings-reference.md
+++ b/website/docs/configuration/settings-reference.md
@@ -28,7 +28,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="mac" label="macOS">
 
 ```
-~/.local/share/podman-desktop/configuration/settings.json
+~/.local/share/containers/podman-desktop/configuration/settings.json
 ```
 
 </TabItem>


### PR DESCRIPTION
### What does this PR do?

Fixes a path in the docs and removes an extra word

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A
### How to test this PR?

N/A
