### PR TITLE
fix: use custom token to trigger GH actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 Red Hat, Inc.
+# Copyright (C) 2022-2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
       - name: Generate tag utilities
         id: TAG_UTIL
         run: |


### PR DESCRIPTION
### What does this PR do?
by default, default token is not triggering GitHub actions

it means then, than pushing a tag is not starting the job to publish npmjs packages
using a PAT token will trigger jobs

https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/15279

### How to test this PR?


- [ ] Tests are covering the bug fix or the new feature
