### PR TITLE
fix: rework updateimage error handling

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -35,7 +35,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ApiSenderType } from '/@/plugin/api.js';
 import type { Certificates } from '/@/plugin/certificates.js';
 import type { InternalContainerProvider } from '/@/plugin/container-registry.js';
-import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
+import { ContainerProviderRegistry, LatestImageError } from '/@/plugin/container-registry.js';
 import { ImageRegistry } from '/@/plugin/image-registry.js';
 import { KubePlayContext } from '/@/plugin/podman/kube.js';
 import type { Proxy } from '/@/plugin/proxy.js';
@@ -6241,9 +6241,7 @@ describe('updateImage', () => {
     vi.spyOn(containerRegistry, 'getMatchingEngine').mockReturnValue(engine as unknown as Dockerode);
     const deleteSpy = vi.spyOn(containerRegistry, 'deleteImage');
 
-    await expect(containerRegistry.updateImage('engine1', 'imageId', 'nginx:latest')).rejects.toThrowError(
-      'Image is already the latest version',
-    );
+    await expect(containerRegistry.updateImage('engine1', 'imageId', 'nginx:latest')).rejects.toThrow(LatestImageError);
     expect(getImageMock).toHaveBeenCalledTimes(2);
     expect(deleteSpy).not.toHaveBeenCalled();
   });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -107,6 +107,13 @@ interface JSONEvent {
   Type?: string;
 }
 
+export class LatestImageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LatestImageError';
+  }
+}
+
 @injectable()
 export class ContainerProviderRegistry {
   private readonly _onEvent = new Emitter<JSONEvent>();
@@ -1317,7 +1324,7 @@ export class ContainerProviderRegistry {
       const updatedImageInfo = await matchingEngine.getImage(tag).inspect();
 
       if (updatedImageInfo.Id === oldImageId) {
-        throw new Error('Image is already the latest version');
+        throw new LatestImageError('Image is already the latest version');
       }
 
       // Only delete the old image if it originally had a single tag

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -37,7 +37,7 @@ import type { TrayMenu } from '../tray-menu.js';
 import { ApiSenderType } from './api.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
-import { ContainerProviderRegistry } from './container-registry.js';
+import { ContainerProviderRegistry, LatestImageError } from './container-registry.js';
 import { DefaultConfiguration } from './default-configuration.js';
 import { Directories } from './directories.js';
 import { Emitter } from './events/emitter.js';
@@ -986,7 +986,7 @@ describe('updateImage handler', () => {
     const tag = 'alpine:latest';
 
     vi.spyOn(ContainerProviderRegistry.prototype, 'updateImage').mockRejectedValue(
-      new Error('Image is already the latest version'),
+      new LatestImageError('Image is already the latest version'),
     );
 
     const createTaskSpy = vi.spyOn(TaskManager.prototype, 'createTask');

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1242,7 +1242,14 @@ export class PluginSystem {
           await containerProviderRegistry.updateImage(engineId, imageId, tag);
           task.status = 'success';
         } catch (error: unknown) {
-          task.error = `Something went wrong while trying to update image: ${String(error)}`;
+          const errorMessage = String(error);
+          // "Image is already the latest version" is not a breaking error, treat as success
+          if (errorMessage.includes('Image is already the latest version')) {
+            task.name = `Image '${tag}' is already up to date`;
+            task.status = 'success';
+            return;
+          }
+          task.error = errorMessage;
           task.status = 'failure';
           throw error;
         }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -152,7 +152,7 @@ import { CommandRegistry } from './command-registry.js';
 import { CommandsInit } from './commands-init.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import { ConfirmationInit } from './confirmation-init.js';
-import { ContainerProviderRegistry } from './container-registry.js';
+import { ContainerProviderRegistry, LatestImageError } from './container-registry.js';
 import { Context } from './context/context.js';
 import { ContributionManager } from './contribution-manager.js';
 import { CustomPickRegistry } from './custompick/custompick-registry.js';
@@ -1242,14 +1242,13 @@ export class PluginSystem {
           await containerProviderRegistry.updateImage(engineId, imageId, tag);
           task.status = 'success';
         } catch (error: unknown) {
-          const errorMessage = String(error);
           // "Image is already the latest version" is not a breaking error, treat as success
-          if (errorMessage.includes('Image is already the latest version')) {
+          if (error instanceof LatestImageError) {
             task.name = `Image '${tag}' is already up to date`;
             task.status = 'success';
             return;
           }
-          task.error = errorMessage;
+          task.error = String(error);
           task.status = 'failure';
           throw error;
         }


### PR DESCRIPTION
Image already latest version was an error it should be a success

### What does this PR do?

Fixes a small backend issue as part of the update image feature (needed for ui)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/923

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
