### PR TITLE
feat: add kubernetesExperimentalMode in telemetry

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -270,6 +270,8 @@ export class KubernetesClient {
     const statesExperimental = this.experimentalConfigurationManager.isExperimentalConfigurationEnabled(
       'kubernetes.statesExperimental',
     );
+    this.telemetry.track('kubernetesExperimentalMode', { enabled: statesExperimental });
+
     if (statesExperimental) {
       const manager = new ContextsManagerExperimental();
       this.contextsState = manager;


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Adds a `kubernetesExperimentalMode` event to the telemetry, sent at every startup of Podman Desktop

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #15064 

### How to test this PR?

Check in telemetry that the event is received with the correct `enabled` field

- [ ] Tests are covering the bug fix or the new feature
