### PR TITLE
docs(settings): settings reference fix dir location linux

### DIFF
--- a/website/docs/configuration/settings-reference.md
+++ b/website/docs/configuration/settings-reference.md
@@ -35,7 +35,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="linux" label="Linux">
 
 ```
-~/.local/share/podman-desktop/configuration/settings.json
+~/.local/share/containers/podman-desktop/configuration/settings.json
 ```
 
 </TabItem>


### PR DESCRIPTION
docs(settings): settings reference fix dir location linux

### What does this PR do?

It is: `~/.local/share/containers/podman-desktop/configuration/settings.json` on Linux / same as macOS.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A, caught this while clicking the tabs between the two!

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

N/A, minor doc change

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
