### PR TITLE
chore(vite): exclude @podman-desktop/api from dependency optimization

### DIFF
--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -40,7 +40,7 @@ export default defineConfig({
   },
   plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js', hot: !process.env.VITEST }), svelteTesting()],
   optimizeDeps: {
-    exclude: ['tinro'],
+    exclude: ['tinro', '@podman-desktop/api'],
   },
   test: {
     retry: 3, // Retries failing tests up to 3 times


### PR DESCRIPTION
### What does this PR do?

The following PR fixes vite dependency scanning error when importing types from `@podman-desktop/api` in renderer code.

The `@podman-desktop/api` package is a type-only package (only has `types` field in package.json, no `main` or `exports`). When vite performs dependency scanning during `pnpm watch`, it tries to resolve the package entry point and fails with:

```
...
rendering chunks (1)...(!) Failed to run dependency scan. Skipping dependency pre-bundling. Error:   Failed to scan for dependencies from entries:
  /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/packages/renderer/index.html                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                              
  ✘ [ERROR] Failed to resolve entry for package "@podman-desktop/api". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
...
```

Although the application works correctly (TypeScript removes type-only imports at compile time), this error clutters the console output during `pnpm watch`.

<details>
<summary>Log output before fix:</summary>

```
Vlad@MacBook-Pro-Vladyslav podman-desktop % pnpm watch

> podman-desktop@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop
> node scripts/watch.mjs

12:53:11 PM [vite-plugin-svelte] The following packages have a svelte field in their package.json but no exports condition for svelte.

tinro@0.6.12
svelte-steps@2.4.1

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
12:53:11 PM [vite-plugin-svelte] svelte 5 has hmr integrated in core. Please remove the vitePlugin.hot option and use compilerOptions.hmr instead
12:53:11 PM [vite] (client) Re-optimizing dependencies because vite config has changed
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/compose
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/docker/packages/extension
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kind
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kube-context
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kubectl-cli
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/lima
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/podman/packages/extension
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/podman-docker-context
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/registries
vite v7.2.7 building client environment for development...

watching for file changes...

build started...
vite v7.2.7 building client environment for development...

watching for file changes...

build started...
✓ 2 modules transformed.
vite v7.2.7 building client environment for development...

watching for file changes...

build started...
✓ 2 modules transformed.
dist/index.cjs  41.37 kB │ map: 22.99 kB
built in 2002ms.
dist/index.cjs  278.54 kB │ map: 148.17 kB
built in 4045ms.
transforming (1) src/index.ts
> compose@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/compose
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 97 modules transformed.
rendering chunks...
dist/extension.js  838.14 kB │ map: 453.31 kB
built in 333ms.
 { timestamp: true }

> kind@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kind
> vite build -w

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 1093 modules transformed.
rendering chunks...
dist/extension.js  25,396.10 kB │ map: 14,570.05 kB
built in 2331ms.
 { timestamp: true }

> podman@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/podman/packages/extension
> vite build -w

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 85 modules transformed.
rendering chunks...
dist/extension.cjs  1,599.58 kB │ map: 894.92 kB
built in 495ms.
 { timestamp: true }

> lima@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/lima
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 14 modules transformed.
rendering chunks...
dist/extension.js  117.33 kB │ map: 61.92 kB
built in 135ms.
 { timestamp: true }

> registries@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/registries
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 6 modules transformed.
rendering chunks...
dist/extension.js  92.07 kB │ map: 40.29 kB
built in 63ms.
 { timestamp: true }

> podman-docker-context@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/podman-docker-context
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 2 modules transformed.
rendering chunks...
dist/extension.js  13.91 kB │ map: 7.81 kB
built in 62ms.
 { timestamp: true }

> kube-context@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kube-context
> vite build -w

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 2 modules transformed.
rendering chunks...
dist/extension.js  418.81 kB │ map: 231.03 kB
built in 185ms.
 { timestamp: true }

> kubectl-cli@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kubectl-cli
> vite build -w

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 144 modules transformed.
rendering chunks...
dist/extension.js  947.02 kB │ map: 499.06 kB
built in 424ms.
 { timestamp: true }

> docker@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/docker/packages/extension
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 6 modules transformed.
rendering chunks...
dist/extension.js  60.84 kB │ map: 35.22 kB
built in 84ms.
 { timestamp: true }
12:53:15 PM [ui] d.ts type declaration files for the following files were likely not generated due to the following errors:
/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/packages/ui/src/lib/dropdownMenu/index.ts
  - Default export of the module has or is using private name 'Props'.
12:53:15 PM [ui] src/lib -> dist

Watching src/lib for changes...


vite v7.2.7 building client environment for development...

watching for file changes...                                                                                                                                                                                                                                                                                                  

build started...                                                                                                                                                                                                                                                                                                              
✓ 3 modules transformed.
dist/index.cjs  25.04 kB │ map: 14.21 kB
built in 5192ms.
✓ 2634 modules transformed.
node_modules/@protobufjs/inquire/index.js (12:18): Use of eval in "node_modules/@protobufjs/inquire/index.js" is strongly discouraged as it poses security risks and may cause issues with minification.
rendering chunks (1)...(!) Failed to run dependency scan. Skipping dependency pre-bundling. Error:   Failed to scan for dependencies from entries:
  /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/packages/renderer/index.html                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                              
  ✘ [ERROR] Failed to resolve entry for package "@podman-desktop/api". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]                                                                                                                                               

    node_modules/esbuild/lib/main.js:1217:21:
      1217 │         let result = await callback({
           ╵                      ^                                                                                                                                                                                                                                                                                           

    at packageEntryFailure (file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:32815:32)
    at resolvePackageEntry (file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:32812:2)
    at tryNodeResolve (file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:32715:70)
    at ResolveIdContext.handler (file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:32554:16)
    at EnvironmentPluginContainer.resolveId (file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:28716:56)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async resolve$4 (file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:31504:16)
    at async file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:31629:22
    at async requestCallbacks.on-resolve (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:1217:22)
    at async handleRequest (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:628:11)

  This error came from the "onResolve" callback registered here:

    node_modules/esbuild/lib/main.js:1141:20:
      1141 │       let promise = setup({
           ╵                     ^                                                                                                                                                                                                                                                                                            

    at setup (file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:31626:12)
    at handlePlugins (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:1141:21)
    at buildOrContextImpl (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:854:5)
    at Object.buildOrContext (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:680:5)
    at /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:2035:68
    at new Promise (<anonymous>)
    at Object.context (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:2035:27)
    at Object.context (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:1877:58)
    at prepareEsbuildScanner (file:///Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/vite/dist/node/chunks/config.js:31453:23)

  The plugin "vite:dep-scan" was triggered by this import

    script:/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte?id=0:346:7:
      346 │ import '@podman-desktop/api'
          ╵        ~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                                      


    at failureErrorWithLog (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:1467:15)
    at /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:926:25
    at runOnEndCallbacks (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:1307:45)
    at buildResponseToResult (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:924:7)
    at /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:936:9
    at new Promise (<anonymous>)
    at requestCallbacks.on-end (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:935:54)
    at handleRequest (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:628:17)
    at handleIncomingPacket (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:653:7)
    at Socket.readFromStdout (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/node_modules/esbuild/lib/main.js:581:7)
dist/download-remote-extensions.cjs     206.35 kB │ map:    116.10 kB
dist/image-registry-9aRBMnGI.cjs      9,370.18 kB │ map:  5,119.36 kB
dist/index.cjs                       40,977.51 kB │ map: 21,243.00 kB
built in 7741ms.
12:53:24 PM [main] (node:93766) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `Electron --trace-deprecation ...` to show where the warning was created)
12:53:24 PM [main] DevTools listening on ws://127.0.0.1:9223/devtools/browser/a3c335b1-4523-4597-b7f3-333f134af996
12:53:24 PM [main] [Managed-by]: No managed defaults file found at /Library/Application Support/io.podman_desktop.PodmanDesktop/default-settings.json
[Managed-by]: No managed locked file found at /Library/Application Support/io.podman_desktop.PodmanDesktop/locked.json

12:53:24 PM [main] Development mode, skipping startup install

12:53:25 PM [main] [93766:1210/125324.945272:ERROR:CONSOLE:1] "Request Autofill.enable failed. {"code":-32601,"message":"'Autofill.enable' wasn't found"}", source: devtools://devtools/bundled/core/protocol_client/protocol_client.js (1)
[93766:1210/125324.945304:ERROR:CONSOLE:1] "Request Autofill.setAddresses failed. {"code":-32601,"message":"'Autofill.setAddresses' wasn't found"}", source: devtools://devtools/bundled/core/protocol_client/protocol_client.js (1)
Kubeconfig path /Users/Vlad/.kube/config provided does not exist. Skipping.
12:53:25 PM [main] Starting http server to handle webviews on port 44000
System ready. Loading extensions...
Activating extension (podman-desktop.compose) with max activation time of 20 seconds
Fetched https://registry.podman-desktop.io/api/extensions.json in 180.41591700000004ms
[compose] Error trying to run the version on podman-compose. Binary might not be there RunErrorImpl: Failed to execute command: spawn podman-compose ENOENT
    at ChildProcess.<anonymous> (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/packages/main/dist/image-registry-9aRBMnGI.cjs:72011:27)
    at ChildProcess.emit (node:events:519:28)
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  exitCode: 1,
  command: 'podman-compose',
  stdout: '',
  stderr: '',
  cancelled: false,
  killed: false
}
Activating extension (podman-desktop.compose) ended in 233 milliseconds
Activating extension (podman-desktop.docker) with max activation time of 20 seconds
Activating extension (podman-desktop.docker) ended in 1 milliseconds
Activating extension (podman-desktop.kind) with max activation time of 20 seconds

12:53:25 PM [vite-plugin-svelte] packages/ui/dist/layouts/Page.svelte:50:21 This reference only captures the initial value of `breadcrumbLeftPart`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:25 PM [vite-plugin-svelte] packages/ui/dist/layouts/Page.svelte:50:43 This reference only captures the initial value of `breadcrumbRightPart`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:26 PM [vite-plugin-svelte] packages/renderer/src/lib/images/CronJobIcon.svelte:10:33 This reference only captures the initial value of `solid`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:26 PM [vite-plugin-svelte] packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte:36:30 This reference only captures the initial value of `category`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:26 PM [vite-plugin-svelte] packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte:37:36 This reference only captures the initial value of `category`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:26 PM [vite-plugin-svelte] packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte:39:2 This reference only captures the initial value of `category`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:26 PM [vite-plugin-svelte] packages/renderer/src/lib/images/JobIcon.svelte:10:33 This reference only captures the initial value of `solid`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:26 PM [vite-plugin-svelte] packages/renderer/src/lib/kube/pods/KubernetesTerminalBrowser.svelte:18:2 This reference only captures the initial value of `pod`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:26 PM [vite-plugin-svelte] packages/renderer/src/lib/kube/pods/PodDetailsLogs.svelte:38:0 This reference only captures the initial value of `pod`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:53:26 PM [main] [kind] kind extension is active
Activating extension (podman-desktop.kind) ended in 684 milliseconds
Activating extension (podman-desktop.kube-context) with max activation time of 20 seconds
[kube-context] starting extension kube-context
Activating extension (podman-desktop.kube-context) ended in 1 milliseconds
Activating extension (podman-desktop.kubectl-cli) with max activation time of 20 seconds
Activating extension (podman-desktop.kubectl-cli) ended in 120 milliseconds
Activating extension (podman-desktop.lima) with max activation time of 20 seconds
[lima] Could not find socket at /Users/Vlad/.lima/podman/sock/podman.sock
Activating extension (podman-desktop.lima) ended in 1 milliseconds
Activating extension (podman-desktop.podman) with max activation time of 20 seconds
Activating extension (podman-desktop.podman) ended in 80 milliseconds
Activating extension (podman-desktop.podman-docker-context) with max activation time of 20 seconds
Activating extension (podman-desktop.podman-docker-context) ended in 0 milliseconds
Activating extension (podman-desktop.registries) with max activation time of 20 seconds
Activating extension (podman-desktop.registries) ended in 0 milliseconds
```
</details>

<details>
<summary>Log output after fix:</summary>

```
Vlad@MacBook-Pro-Vladyslav podman-desktop % pnpm watch

> podman-desktop@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop
> node scripts/watch.mjs

12:54:52 PM [vite-plugin-svelte] The following packages have a svelte field in their package.json but no exports condition for svelte.

tinro@0.6.12
svelte-steps@2.4.1

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
12:54:52 PM [vite-plugin-svelte] svelte 5 has hmr integrated in core. Please remove the vitePlugin.hot option and use compilerOptions.hmr instead
12:54:52 PM [vite] (client) Re-optimizing dependencies because vite config has changed
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/compose
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/docker/packages/extension
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kind
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kube-context
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kubectl-cli
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/lima
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/podman/packages/extension
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/podman-docker-context
dirname is /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/registries
vite v7.2.7 building client environment for development...

watching for file changes...

build started...
vite v7.2.7 building client environment for development...

watching for file changes...

build started...
✓ 2 modules transformed.
vite v7.2.7 building client environment for development...

watching for file changes...
✓ 2 modules transformed.

build started...
dist/index.cjs  41.37 kB │ map: 22.99 kB
built in 1859ms.

> docker@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/docker/packages/extension
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 6 modules transformed.
rendering chunks...
dist/extension.js  60.84 kB │ map: 35.22 kB
built in 79ms.
 { timestamp: true }

> kind@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kind
> vite build -w

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 1093 modules transformed.
 { timestamp: true }

> lima@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/lima
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 14 modules transformed.
rendering chunks...
dist/extension.js  117.33 kB │ map: 61.92 kB
built in 141ms.
 { timestamp: true }

> podman@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/podman/packages/extension
> vite build -w

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 85 modules transformed.
rendering chunks...
dist/extension.cjs  1,599.58 kB │ map: 894.92 kB
built in 476ms.
 { timestamp: true }

> compose@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/compose
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 97 modules transformed.
rendering chunks...
dist/extension.js  838.14 kB │ map: 453.31 kB
built in 315ms.
 { timestamp: true }

> kube-context@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kube-context
> vite build -w

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 2 modules transformed.
rendering chunks...
dist/extension.js  418.81 kB │ map: 231.03 kB
built in 177ms.
 { timestamp: true }

> kubectl-cli@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/kubectl-cli
> vite build -w

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 144 modules transformed.
rendering chunks...
dist/extension.js  947.02 kB │ map: 499.06 kB
built in 393ms.
 { timestamp: true }

> registries@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/registries
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 6 modules transformed.
rendering chunks...
dist/extension.js  92.07 kB │ map: 40.29 kB
built in 54ms.
 { timestamp: true }

> podman-docker-context@1.25.0-next watch /Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/extensions/podman-docker-context
> vite build --watch

vite v7.2.7 building client environment for development...

watching for file changes...

build started...
transforming...
✓ 2 modules transformed.
rendering chunks...
dist/extension.js  13.91 kB │ map: 7.81 kB
built in 57ms.
 { timestamp: true }
12:54:54 PM [ui] d.ts type declaration files for the following files were likely not generated due to the following errors:
/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/packages/ui/src/lib/dropdownMenu/index.ts
  - Default export of the module has or is using private name 'Props'.
12:54:54 PM [ui] src/lib -> dist

Watching src/lib for changes...


dist/index.cjs  278.54 kB │ map: 148.17 kB
built in 3877ms.
rendering chunks...
dist/extension.js  25,396.10 kB │ map: 14,570.05 kB
built in 2244ms.
 { timestamp: true }
transforming (1) src/index.tsvite v7.2.7 building client environment for development...

watching for file changes...                                                                                                                                                                                                                                                                                                  

build started...                                                                                                                                                                                                                                                                                                              
✓ 3 modules transformed.
dist/index.cjs  25.04 kB │ map: 14.21 kB
built in 4952ms.
✓ 2634 modules transformed.
node_modules/@protobufjs/inquire/index.js (12:18): Use of eval in "node_modules/@protobufjs/inquire/index.js" is strongly discouraged as it poses security risks and may cause issues with minification.
dist/download-remote-extensions.cjs     206.35 kB │ map:    116.10 kB
dist/image-registry-9aRBMnGI.cjs      9,370.18 kB │ map:  5,119.36 kB
dist/index.cjs                       40,977.51 kB │ map: 21,243.00 kB
built in 7518ms.
12:55:05 PM [main] (node:94813) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `Electron --trace-deprecation ...` to show where the warning was created)
12:55:05 PM [main] DevTools listening on ws://127.0.0.1:9223/devtools/browser/17f6fc26-b71a-4666-a81f-d4b1739df0ef
12:55:05 PM [main] [Managed-by]: No managed defaults file found at /Library/Application Support/io.podman_desktop.PodmanDesktop/default-settings.json
[Managed-by]: No managed locked file found at /Library/Application Support/io.podman_desktop.PodmanDesktop/locked.json
Development mode, skipping startup install

12:55:06 PM [main] [94813:1210/125505.610166:ERROR:CONSOLE:1] "Request Autofill.enable failed. {"code":-32601,"message":"'Autofill.enable' wasn't found"}", source: devtools://devtools/bundled/core/protocol_client/protocol_client.js (1)
[94813:1210/125505.610206:ERROR:CONSOLE:1] "Request Autofill.setAddresses failed. {"code":-32601,"message":"'Autofill.setAddresses' wasn't found"}", source: devtools://devtools/bundled/core/protocol_client/protocol_client.js (1)
Kubeconfig path /Users/Vlad/.kube/config provided does not exist. Skipping.
12:55:06 PM [main] Starting http server to handle webviews on port 44000
System ready. Loading extensions...
Activating extension (podman-desktop.compose) with max activation time of 20 seconds
Fetched https://registry.podman-desktop.io/api/extensions.json in 127.372791ms
[compose] Error trying to run the version on podman-compose. Binary might not be there RunErrorImpl: Failed to execute command: spawn podman-compose ENOENT
    at ChildProcess.<anonymous> (/Users/Vlad/Workspace/RedHat/git/vzhukovs/podman-desktop/packages/main/dist/image-registry-9aRBMnGI.cjs:72011:27)
    at ChildProcess.emit (node:events:519:28)
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  exitCode: 1,
  command: 'podman-compose',
  stdout: '',
  stderr: '',
  cancelled: false,
  killed: false
}
Activating extension (podman-desktop.compose) ended in 218 milliseconds
Activating extension (podman-desktop.docker) with max activation time of 20 seconds
Activating extension (podman-desktop.docker) ended in 1 milliseconds

12:55:06 PM [vite-plugin-svelte] packages/ui/dist/layouts/Page.svelte:50:21 This reference only captures the initial value of `breadcrumbLeftPart`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:06 PM [vite-plugin-svelte] packages/ui/dist/layouts/Page.svelte:50:43 This reference only captures the initial value of `breadcrumbRightPart`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:06 PM [main] Activating extension (podman-desktop.kind) with max activation time of 20 seconds

12:55:06 PM [vite-plugin-svelte] packages/renderer/src/lib/images/CronJobIcon.svelte:10:33 This reference only captures the initial value of `solid`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:06 PM [vite-plugin-svelte] packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte:36:30 This reference only captures the initial value of `category`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:06 PM [vite-plugin-svelte] packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte:37:36 This reference only captures the initial value of `category`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:06 PM [vite-plugin-svelte] packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte:39:2 This reference only captures the initial value of `category`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:06 PM [vite-plugin-svelte] packages/renderer/src/lib/images/JobIcon.svelte:10:33 This reference only captures the initial value of `solid`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:06 PM [vite-plugin-svelte] packages/renderer/src/lib/kube/pods/KubernetesTerminalBrowser.svelte:18:2 This reference only captures the initial value of `pod`. Did you mean to reference it inside a derived instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:06 PM [vite-plugin-svelte] packages/renderer/src/lib/kube/pods/PodDetailsLogs.svelte:38:0 This reference only captures the initial value of `pod`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:07 PM [main] [kind] kind extension is active
Activating extension (podman-desktop.kind) ended in 702 milliseconds
Activating extension (podman-desktop.kube-context) with max activation time of 20 seconds
[kube-context] starting extension kube-context
Activating extension (podman-desktop.kube-context) ended in 1 milliseconds
Activating extension (podman-desktop.kubectl-cli) with max activation time of 20 seconds

12:55:07 PM [vite-plugin-svelte] packages/ui/dist/icons/Icon.svelte:18:22 This reference only captures the initial value of `icon`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:07 PM [vite-plugin-svelte] packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte:93:20 This reference only captures the initial value of `connectionInfo`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:07 PM [vite-plugin-svelte] packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte:94:23 This reference only captures the initial value of `connectionInfo`. Did you mean to reference it inside a closure instead?
https://svelte.dev/e/state_referenced_locally                                                                                                                                                                                                                                                                                 
12:55:07 PM [main] Activating extension (podman-desktop.kubectl-cli) ended in 173 milliseconds
Activating extension (podman-desktop.lima) with max activation time of 20 seconds
[lima] Could not find socket at /Users/Vlad/.lima/podman/sock/podman.sock
Activating extension (podman-desktop.lima) ended in 1 milliseconds
Activating extension (podman-desktop.podman) with max activation time of 20 seconds
Activating extension (podman-desktop.podman) ended in 81 milliseconds
Activating extension (podman-desktop.podman-docker-context) with max activation time of 20 seconds
Activating extension (podman-desktop.podman-docker-context) ended in 0 milliseconds
Activating extension (podman-desktop.registries) with max activation time of 20 seconds
Activating extension (podman-desktop.registries) ended in 0 milliseconds
```
</details>

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A found during running `pnpm watch` call.

### How to test this PR?

Run `pnpm watch` and verify that error:
>[ERROR] Failed to resolve entry for package "@podman-desktop/api". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-scan]
doesn't appear.

- [ ] Tests are covering the bug fix or the new feature
