### PR TITLE
chore(BuildImage): telemetry when user runs build of image on an intermediate (not final) target

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1484,6 +1484,7 @@ export class PluginSystem {
         }
         if (target) {
           titleArgs.push(`(${target})`);
+          telemetry.track('build-image-intermediate-target');
         }
 
         // create task


### PR DESCRIPTION
### What does this PR do?

When a user builds an multi-stage Containerfile image in Podman Desktop and selects a target which is not the default final one, this PR sends an event to telemetry.

### Screenshot / video of UI

In this screenshot, for example the user should be tracked only if they select stage1, stage2 or stage3.
<img width="1300" height="990" alt="dropdown-multi-target-containerfile-light" src="https://github.com/user-attachments/assets/8a2fb821-a7b1-4eb7-8cf1-0bf6e0b27e1b" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15048

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
