### PR TITLE
chore: define executable name

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -239,6 +239,7 @@ const config = {
   linux: {
     category: 'Development',
     icon: './buildResources/icon-512x512.png',
+    executableName: product.artifactName,
     target: ['flatpak', { target: 'tar.gz', arch: ['x64', 'arm64'] }],
   },
   mac: {


### PR DESCRIPTION
### What does this PR do?
by default electron-builder is using the package.json name and not config.appName but only on Linux (not macOS or Windows...)

so at the end if we change some values in product.json it's not the one being applied leading to an error while we try to call an unexisting file
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/15326

### How to test this PR?

modify product.json name and run `./node_modules/.bin/electron-builder build --config .electron-builder.config.cjs --linux dir --arm64`

- [ ] Tests are covering the bug fix or the new feature
