### PR TITLE
chore: define artifact name using product.name

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -240,6 +240,7 @@ const config = {
     category: 'Development',
     icon: './buildResources/icon-512x512.png',
     executableName: product.artifactName,
+    artifactName: `${product.artifactName}${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
     target: ['flatpak', { target: 'tar.gz', arch: ['x64', 'arm64'] }],
   },
   mac: {


### PR DESCRIPTION
### What does this PR do?
default was to take package.json name (except for flatpak)

also suffix by arch.

it'll require updates on the website for 1.25.0+


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/pull/15333

### How to test this PR?

run compile:current on linux or using --linux

- [ ] Tests are covering the bug fix or the new feature
