### PR TITLE
fix(website): handle -x64.tar.gz suffix for Linux AMD64 asset selection

### DIFF
--- a/website/src/plugins/github-service.ts
+++ b/website/src/plugins/github-service.ts
@@ -82,7 +82,7 @@ export class GitHubService {
             flatpak: findAssetOrThrow(a => a.name.endsWith('.flatpak'), 'Linux Flatpak'),
             arm64: findAssetOrThrow(a => a.name.endsWith('-arm64.tar.gz'), 'Linux ARM64 .tar.gz'),
             amd64: findAssetOrThrow(
-              a => a.name.endsWith('.tar.gz') && !a.name.includes('arm64'),
+              a => (a.name.endsWith('-x64.tar.gz') || a.name.endsWith('.tar.gz')) && !a.name.includes('arm64'),
               'Linux AMD64 .tar.gz',
             ),
           },


### PR DESCRIPTION
### What does this PR do?
with #15333 artifact for linux x64 may end with -x64.tar.gz

handle the case on the website

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#15333 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
