### PR TITLE
chore: bump default buffer size of calling download script in electron-builder

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -83,15 +83,20 @@ async function packageRemoteExtensions() {
   const destination = path.resolve('./extensions-extra');
 
   return new Promise((resolve, reject) => {
-    execFile('node', [downloadScript, `--output=${destination}`], (error, stdout, stderr) => {
-      console.log(stdout);
-      console.log(stderr);
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
-    });
+    execFile(
+      'node',
+      [downloadScript, `--output=${destination}`],
+      { maxBuffer: 10 * 1024 * 1024 }, // use 10MB else default size is too small and we get stdout maxBuffer length exceeded
+      (error, stdout, stderr) => {
+        console.log(stdout);
+        console.log(stderr);
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      },
+    );
   });
 }
 


### PR DESCRIPTION
### What does this PR do?
it seems default may be too small (maybe 200kB or 1MB) bump it to 10MB to be safe on most logs


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/15352

### How to test this PR?

to test, duplicates remote extensions (taking one with multiple MB to download)
and having different names for them

then if you launch the pnpm compile:current script it should either fail (without the fix) or succeed (with the fix)

- [ ] Tests are covering the bug fix or the new feature
