### PR TITLE
fix(download-remote-extension): exit code 1 in case of error

### DIFF
--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -284,7 +284,10 @@ export async function main(args: string[]): Promise<void> {
         extension,
       }),
     ),
-  ).catch(console.error);
+  ).catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
 }
 
 // do not start if we are in a VITEST env


### PR DESCRIPTION
### What does this PR do?
allow to have callers exiting the process

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/15273

### How to test this PR?

insert a fake oci image link (like quay.io/something-unknown/foo) and run `pnpm compile:current`
it should now abort the build

- [x] Tests are covering the bug fix or the new feature
