### PR TITLE
refactor: updateImage to latest build backend

### DIFF
--- a/packages/api/src/image-registry.ts
+++ b/packages/api/src/image-registry.ts
@@ -31,3 +31,32 @@ export interface ImageSearchResult {
 export interface ImageTagsListOptions {
   image: string;
 }
+
+/**
+ * Result of checking if an image can be updated from a remote registry.
+ */
+export interface ImageUpdateStatus {
+  /**
+   * The status of the check operation.
+   * - 'normal': Check completed successfully
+   * - 'error': Check failed due to an error (registry errors, authentication failures, etc.)
+   * - 'skipped': Check skipped due to the image being local or dangling
+   */
+  status: 'normal' | 'error' | 'skipped';
+
+  /**
+   * Whether an update is available from the remote registry.
+   */
+  updateAvailable: boolean;
+
+  /**
+   * The remote digest if an update is available.
+   * Can be used for verification after pulling.
+   */
+  remoteDigest?: string;
+
+  /**
+   * Human-readable message describing the result.
+   */
+  message: string;
+}

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -107,13 +107,6 @@ interface JSONEvent {
   Type?: string;
 }
 
-export class LatestImageError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'LatestImageError';
-  }
-}
-
 @injectable()
 export class ContainerProviderRegistry {
   private readonly _onEvent = new Emitter<JSONEvent>();
@@ -1273,75 +1266,6 @@ export class ContainerProviderRegistry {
 
   getImageHash(imageName: string): string {
     return crypto.createHash('sha512').update(imageName).digest('hex');
-  }
-
-  async updateImage(engineId: string, imageId: string, tag: string): Promise<void> {
-    let telemetryOptions = {};
-    try {
-      // get image info to validate the image can be updated
-      const imageInfo = await this.getMatchingImage(engineId, imageId).inspect();
-
-      // validate the image has tags
-      const repoTags = imageInfo.RepoTags;
-      if (!repoTags?.length) {
-        throw new Error('Image has no tags and cannot be updated');
-      }
-
-      // validate the provided tag exists on this image
-      if (!repoTags.includes(tag)) {
-        throw new Error(`Tag '${tag}' not found on this image`);
-      }
-
-      // check if image has a remote registry source (RepoDigests is populated when pulled from a registry)
-      if (!imageInfo.RepoDigests?.length) {
-        throw new Error('Image has no remote registry source and cannot be updated');
-      }
-
-      // store whether the image originally had a single tag
-      const hadSingleTag = repoTags.length === 1;
-
-      // check if this is an immutable tag (contains a SHA digest)
-      if (tag.includes('@sha256:')) {
-        throw new Error('Image with digest-based tag is immutable and cannot be updated');
-      }
-
-      // store the current image ID to compare after pull
-      const oldImageId = imageInfo.Id;
-
-      // pull the latest build of the image
-      const authconfig = this.imageRegistry.getAuthconfigForImage(tag);
-      const matchingEngine = this.getMatchingEngine(engineId);
-      const pullStream = await matchingEngine.pull(tag, { authconfig });
-
-      await new Promise<void>((resolve, reject) => {
-        matchingEngine.modem.followProgress(pullStream, (err: Error | null) => {
-          if (err) return reject(err);
-          resolve();
-        });
-      });
-
-      // check if the image was actually updated
-      const updatedImageInfo = await matchingEngine.getImage(tag).inspect();
-
-      if (updatedImageInfo.Id === oldImageId) {
-        throw new LatestImageError('Image is already the latest version');
-      }
-
-      // Only delete the old image if it originally had a single tag
-      if (hadSingleTag) {
-        try {
-          await this.deleteImage(engineId, oldImageId);
-        } catch (error: unknown) {
-          console.warn(`Could not delete old image ${oldImageId}: ${error}`);
-          // Don't fail the update if we can't delete the old image
-        }
-      }
-    } catch (error: unknown) {
-      telemetryOptions = { error: error };
-      throw error;
-    } finally {
-      this.telemetryService.track('updateImage', { imageName: this.getImageHash(imageId), ...telemetryOptions });
-    }
   }
 
   async pingContainerEngine(providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<unknown> {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -1334,17 +1334,30 @@ test('listImageTags', async () => {
 });
 
 describe('getDigestFromImageName', () => {
-  test('should return digest from getManifestFromURL response', async () => {
-    const expectedDigest = 'sha256:abc123def456';
+  test('single-arch image: should return platform digest with no listDigest', async () => {
     vi.spyOn(imageRegistry, 'getAuthInfo').mockResolvedValue({ authUrl: 'https://auth.example.com', scheme: 'bearer' });
     vi.spyOn(imageRegistry, 'getToken').mockResolvedValue('test-token');
     vi.spyOn(
       imageRegistry as unknown as { getManifestFromURL: () => Promise<unknown> },
       'getManifestFromURL',
-    ).mockResolvedValue({ manifest: {}, digest: expectedDigest });
+    ).mockResolvedValue({ manifest: {}, digest: 'sha256:abc123' });
 
-    const digest = await imageRegistry.getDigestFromImageName('nginx:latest');
-    expect(digest).toBe(expectedDigest);
+    const result = await imageRegistry.getDigestFromImageName('nginx:latest');
+    expect(result.digest).toBe('sha256:abc123');
+    expect(result.listDigest).toBeUndefined();
+  });
+
+  test('multi-arch image: should return both platform digest and listDigest', async () => {
+    vi.spyOn(imageRegistry, 'getAuthInfo').mockResolvedValue({ authUrl: 'https://auth.example.com', scheme: 'bearer' });
+    vi.spyOn(imageRegistry, 'getToken').mockResolvedValue('test-token');
+    vi.spyOn(
+      imageRegistry as unknown as { getManifestFromURL: () => Promise<unknown> },
+      'getManifestFromURL',
+    ).mockResolvedValue({ manifest: {}, digest: 'sha256:platform', listDigest: 'sha256:list' });
+
+    const result = await imageRegistry.getDigestFromImageName('nginx:latest');
+    expect(result.digest).toBe('sha256:platform');
+    expect(result.listDigest).toBe('sha256:list');
   });
 
   test('should throw when digest is missing from response', async () => {
@@ -1408,7 +1421,7 @@ describe('checkImageUpdateStatus', () => {
 
   test('should return update available when remote digest differs', async () => {
     const remoteDigest = 'sha256:newdigest';
-    vi.spyOn(imageRegistry, 'getDigestFromImageName').mockResolvedValue(remoteDigest);
+    vi.spyOn(imageRegistry, 'getDigestFromImageName').mockResolvedValue({ digest: remoteDigest });
 
     const result = await imageRegistry.checkImageUpdateStatus('nginx:latest', 'latest', ['nginx@sha256:olddigest']);
 
@@ -1420,13 +1433,53 @@ describe('checkImageUpdateStatus', () => {
 
   test('should return no update available when already latest version', async () => {
     const remoteDigest = 'sha256:samedigest';
-    vi.spyOn(imageRegistry, 'getDigestFromImageName').mockResolvedValue(remoteDigest);
+    vi.spyOn(imageRegistry, 'getDigestFromImageName').mockResolvedValue({ digest: remoteDigest });
 
     const result = await imageRegistry.checkImageUpdateStatus('nginx:latest', 'latest', ['nginx@sha256:samedigest']);
 
     expect(result.status).toBe('normal');
     expect(result.updateAvailable).toBe(false);
     expect(result.message).toContain('already the latest');
+  });
+
+  // Multi-arch image tests: Docker and Podman both store manifest list digest in RepoDigests
+  test('multi-arch image: should match using list digest (Docker/Podman store list digest)', async () => {
+    vi.spyOn(imageRegistry, 'getDigestFromImageName').mockResolvedValue({
+      digest: 'sha256:platformdigest',
+      listDigest: 'sha256:listdigest',
+    });
+
+    // localDigests contains the list digest (as stored by Docker/Podman for multi-arch)
+    const result = await imageRegistry.checkImageUpdateStatus('nginx:latest', 'latest', ['nginx@sha256:listdigest']);
+
+    expect(result.updateAvailable).toBe(false);
+  });
+
+  // Single-arch image tests: Both runtimes store platform digest only
+  test('single-arch image: should match using platform digest (no listDigest)', async () => {
+    vi.spyOn(imageRegistry, 'getDigestFromImageName').mockResolvedValue({
+      digest: 'sha256:platformdigest',
+      listDigest: undefined,
+    });
+
+    // localDigests contains the platform digest (single-arch image)
+    const result = await imageRegistry.checkImageUpdateStatus('nginx:latest', 'latest', [
+      'nginx@sha256:platformdigest',
+    ]);
+
+    expect(result.updateAvailable).toBe(false);
+  });
+
+  test('should return update available when digest does not match', async () => {
+    vi.spyOn(imageRegistry, 'getDigestFromImageName').mockResolvedValue({
+      digest: 'sha256:newplatform',
+      listDigest: 'sha256:newlist',
+    });
+
+    // localDigests has an old digest that doesn't match either remote digest
+    const result = await imageRegistry.checkImageUpdateStatus('nginx:latest', 'latest', ['nginx@sha256:olddigest']);
+
+    expect(result.updateAvailable).toBe(true);
   });
 
   test('should detect local image with localhost: prefix', async () => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -102,7 +102,12 @@ import type { ImageFilesInfo } from '/@api/image-files-info.js';
 import type { ImageFilesystemLayersUI } from '/@api/image-filesystem-layers.js';
 import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info.js';
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
-import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry.js';
+import type {
+  ImageSearchOptions,
+  ImageSearchResult,
+  ImageTagsListOptions,
+  ImageUpdateStatus,
+} from '/@api/image-registry.js';
 import type {
   GenerateKubeResult,
   KubernetesGeneratorArgument,
@@ -162,7 +167,7 @@ import { CommandRegistry } from './command-registry.js';
 import { CommandsInit } from './commands-init.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import { ConfirmationInit } from './confirmation-init.js';
-import { ContainerProviderRegistry, LatestImageError } from './container-registry.js';
+import { ContainerProviderRegistry } from './container-registry.js';
 import { Context } from './context/context.js';
 import { ContributionManager } from './contribution-manager.js';
 import { CustomPickRegistry } from './custompick/custompick-registry.js';
@@ -1277,25 +1282,14 @@ export class PluginSystem {
     );
 
     this.ipcHandle(
-      'container-provider-registry:updateImage',
-      async (_listener, engineId: string, imageId: string, tag: string): Promise<void> => {
-        const task = taskManager.createTask({
-          title: `Updating image '${tag}'`,
-        });
-        try {
-          await containerProviderRegistry.updateImage(engineId, imageId, tag);
-          task.status = 'success';
-        } catch (error: unknown) {
-          // "Image is already the latest version" is not a breaking error, treat as success
-          if (error instanceof LatestImageError) {
-            task.name = `Image '${tag}' is already up to date`;
-            task.status = 'success';
-            return;
-          }
-          task.error = String(error);
-          task.status = 'failure';
-          throw error;
-        }
+      'image-registry:checkImageUpdateStatus',
+      async (
+        _listener,
+        imageReference: string,
+        imageTag: string,
+        localDigests: string[],
+      ): Promise<ImageUpdateStatus> => {
+        return imageRegistry.checkImageUpdateStatus(imageReference, imageTag, localDigests);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -85,7 +85,12 @@ import type { ImageFilesInfo } from '/@api/image-files-info';
 import type { ImageFilesystemLayersUI } from '/@api/image-filesystem-layers';
 import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
-import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry';
+import type {
+  ImageSearchOptions,
+  ImageSearchResult,
+  ImageTagsListOptions,
+  ImageUpdateStatus,
+} from '/@api/image-registry';
 import type {
   GenerateKubeResult,
   KubernetesGeneratorArgument,
@@ -585,9 +590,9 @@ export function initExposure(): void {
   });
 
   contextBridge.exposeInMainWorld(
-    'updateImage',
-    async (engineId: string, imageId: string, tag: string): Promise<void> => {
-      return ipcInvoke('container-provider-registry:updateImage', engineId, imageId, tag);
+    'checkImageUpdateStatus',
+    async (imageReference: string, imageTag: string, localDigests: string[]): Promise<ImageUpdateStatus> => {
+      return ipcInvoke('image-registry:checkImageUpdateStatus', imageReference, imageTag, localDigests);
     },
   );
 


### PR DESCRIPTION
now update image will retrieve the digest from the image name.
Check if its a different digest than local then update if its
clear to do so. Also removed update image error class as well
since its not needed. Cursor helped with tests

### What does this PR do?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/15730

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
