### PR TITLE
fix(website): make release notes shorter to fit in podman desktop

### DIFF
--- a/website/blog/2025-12-04-release-1.24.md
+++ b/website/blog/2025-12-04-release-1.24.md
@@ -18,9 +18,9 @@ Podman Desktop 1.24 is now available. [Click here to download it](/downloads)!
 
 This release brings exciting new features and improvements:
 
-- **Enterprise-managed default registries**: Allow administrators to preconfigure default container registries and optional mirrors for Podman Desktop deployments.
-- **Remote Podman connections visibility**: Resource lists now include the connection name, clearly indicating the remote container engine each resource is associated with.
-- **Select build targets in Containerfile**: Choose the specific build stage to build directly from the UI when working with multi-stage Containerfiles.
+- **Enterprise-managed default registries**: Allow administrators to preconfigure default container registries and mirrors.
+- **Remote Podman connections visibility**: Resource lists now include the connection name.
+- **Select build targets in Containerfile**: Choose a specific build stage when working with multi-stage Containerfiles.
 
 ## Release details
 


### PR DESCRIPTION
### What does this PR do?

Follow-up of https://github.com/podman-desktop/podman-desktop/pull/15365, the text does not fit in Podman Desktop dashboard, an attempt was tried here https://github.com/podman-desktop/podman-desktop/pull/15369 but I think we should reduce the number of words to make it fit.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
