### PR TITLE
feat(managed-config): add visual indicators for proxy locked values

### DIFF
--- a/packages/api/src/proxy.ts
+++ b/packages/api/src/proxy.ts
@@ -21,3 +21,12 @@ export enum ProxyState {
   PROXY_MANUAL = 1,
   PROXY_DISABLED = 2,
 }
+
+// Easier to remember constants for our proxy configuration keys
+// now can refer to PROXY_CONFIG_KEYS.ENABLED instead of 'proxy.enabled'
+export const PROXY_CONFIG_KEYS = {
+  ENABLED: 'proxy.enabled',
+  HTTP: 'proxy.http',
+  HTTPS: 'proxy.https',
+  NO_PROXY: 'proxy.no',
+} as const;

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -22,7 +22,7 @@ import { Agent, ProxyAgent } from 'undici';
 
 import { Certificates } from '/@/plugin/certificates.js';
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { ProxyState } from '/@api/proxy.js';
+import { PROXY_CONFIG_KEYS, ProxyState } from '/@api/proxy.js';
 
 import { Emitter } from './events/emitter.js';
 import { getProxyUrl } from './proxy-resolver.js';
@@ -79,25 +79,25 @@ export class Proxy {
       title: 'Proxy',
       type: 'object',
       properties: {
-        ['proxy.http']: {
+        [PROXY_CONFIG_KEYS.HTTP]: {
           description: 'Proxy (HTTP)',
           type: 'string',
           default: '',
           hidden: true,
         },
-        ['proxy.https']: {
+        [PROXY_CONFIG_KEYS.HTTPS]: {
           description: 'Proxy (HTTPS)',
           type: 'string',
           default: '',
           hidden: true,
         },
-        ['proxy.no']: {
+        [PROXY_CONFIG_KEYS.NO_PROXY]: {
           description: 'Pattern for not using a proxy',
           type: 'string',
           default: '',
           hidden: true,
         },
-        ['proxy.enabled']: {
+        [PROXY_CONFIG_KEYS.ENABLED]: {
           description: 'Configure proxy',
           type: 'number',
           maximum: 2,

--- a/packages/renderer/src/lib/preferences/PreferencesManagedInput.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesManagedInput.spec.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+
+import PreferencesManagedInput from '/@/lib/preferences/PreferencesManagedInput.svelte';
+
+test('should display the managed by organization text after rendering', async () => {
+  const { getByText } = render(PreferencesManagedInput);
+
+  await vi.waitFor(() => {
+    const element = getByText('Managed by your organization');
+    expect(element).toBeInTheDocument();
+  });
+});
+
+test('should render the lock icon', async () => {
+  const { container } = render(PreferencesManagedInput);
+
+  await vi.waitFor(() => {
+    const svgElement = container.querySelector('svg');
+    expect(svgElement).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesManagedInput.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesManagedInput.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+import { faLock } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+</script>
+
+<div class="flex flex-row space-x-1 items-center text-sm">
+  <Icon icon={faLock} size="xs"/>
+  <span>Managed by your organization</span>
+</div>

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -4,8 +4,9 @@ import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte
 import { onMount } from 'svelte';
 
 import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
-import { ProxyState } from '/@api/proxy';
+import { PROXY_CONFIG_KEYS, ProxyState } from '/@api/proxy';
 
+import PreferencesManagedInput from './PreferencesManagedInput.svelte';
 import SettingsPage from './SettingsPage.svelte';
 import { validateProxyAddress } from './Util';
 
@@ -15,6 +16,10 @@ let noProxy = '';
 let proxyState: ProxyState;
 let httpProxyError: string | undefined;
 let httpsProxyError: string | undefined;
+let httpProxyLocked = false;
+let httpsProxyLocked = false;
+let noProxyLocked = false;
+let proxyEnabledLocked = false;
 
 onMount(async () => {
   const proxySettings = await window.getProxySettings();
@@ -22,6 +27,26 @@ onMount(async () => {
   httpsProxy = proxySettings?.httpsProxy ?? '';
   noProxy = proxySettings?.noProxy ?? '';
   proxyState = await window.getProxyState();
+
+  // Check if proxy settings are locked by managed configuration
+  const configProperties = await window.getConfigurationProperties();
+  proxyEnabledLocked = configProperties[PROXY_CONFIG_KEYS.ENABLED]?.locked ?? false;
+  httpProxyLocked = configProperties[PROXY_CONFIG_KEYS.HTTP]?.locked ?? false;
+  httpsProxyLocked = configProperties[PROXY_CONFIG_KEYS.HTTPS]?.locked ?? false;
+  noProxyLocked = configProperties[PROXY_CONFIG_KEYS.NO_PROXY]?.locked ?? false;
+
+  // If locked, ensure we display the managed configuration values
+  // we "retrieve" these values instead of from the proxy settings fetched earlier, as those
+  // do not reflect managed configuration overrides
+  if (httpProxyLocked) {
+    httpProxy = (await window.getConfigurationValue<string>(PROXY_CONFIG_KEYS.HTTP)) ?? httpProxy;
+  }
+  if (httpsProxyLocked) {
+    httpsProxy = (await window.getConfigurationValue<string>(PROXY_CONFIG_KEYS.HTTPS)) ?? httpsProxy;
+  }
+  if (noProxyLocked) {
+    noProxy = (await window.getConfigurationValue<string>(PROXY_CONFIG_KEYS.NO_PROXY)) ?? noProxy;
+  }
 });
 
 function onProxyStateChange(key: unknown): void {
@@ -79,6 +104,7 @@ function validate(event: any): void {
         >Proxy configuration</label>
       <Dropdown
         id="toggle-proxy"
+        disabled={proxyEnabledLocked}
         onChange={onProxyStateChange}
         value={PROXY_LABELS.get(proxyState)}
         options={Array.from(PROXY_LABELS.values()).map((label) => ({
@@ -86,6 +112,9 @@ function validate(event: any): void {
           label: label,
         }))}>
       </Dropdown>
+      {#if proxyEnabledLocked}
+        <PreferencesManagedInput />
+      {/if}
     </div>
 
     <div class="space-y-2">
@@ -97,11 +126,14 @@ function validate(event: any): void {
       <Input
         name="httpProxy"
         id="httpProxy"
-        disabled={proxyState !== ProxyState.PROXY_MANUAL}
+        disabled={proxyState !== ProxyState.PROXY_MANUAL || httpProxyLocked}
         bind:value={httpProxy}
         placeholder="URL of the proxy for http: URLs (eg http://myproxy.domain.com:8080)"
         required
         on:input={validate} />
+      {#if httpProxyLocked}
+        <PreferencesManagedInput />
+      {/if}
       {#if httpProxyError}
         <ErrorMessage error={httpProxyError} />
       {/if}
@@ -116,11 +148,14 @@ function validate(event: any): void {
       <Input
         name="httpsProxy"
         id="httpsProxy"
-        disabled={proxyState !== ProxyState.PROXY_MANUAL}
+        disabled={proxyState !== ProxyState.PROXY_MANUAL || httpsProxyLocked}
         bind:value={httpsProxy}
         placeholder="URL of the proxy for https: URLs (eg http://myproxy.domain.com:8080)"
         required
         on:input={validate} />
+      {#if httpsProxyLocked}
+        <PreferencesManagedInput />
+      {/if}
       {#if httpsProxyError}
         <ErrorMessage error={httpsProxyError} />
       {/if}
@@ -135,10 +170,13 @@ function validate(event: any): void {
       <Input
         name="noProxy"
         id="noProxy"
-        disabled={proxyState !== ProxyState.PROXY_MANUAL}
+        disabled={proxyState !== ProxyState.PROXY_MANUAL || noProxyLocked}
         bind:value={noProxy}
         placeholder="Example: *.domain.com, 192.168.*.*"
         required />
+      {#if noProxyLocked}
+        <PreferencesManagedInput />
+      {/if}
     </div>
 
     <div class="pt-2">


### PR DESCRIPTION
feat(managed-config): add visual indicators for proxy locked values

### What does this PR do?

In this PR we are adding visual indicators of when we are using locked
values for the following values:

```
  "proxy.no": "localhost",
  "proxy.http": "http://foobar.com",
  "proxy.https": "https://foobar.com",
  "proxy.enabled": 1
```

When we have these in `locked.json`:

```
{
	"locked": ["telemetry.enabled", "proxy.https", "proxy.http", "proxy.no"]
}
```

They will then show in the UI that they are managed by your
organization.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="950" height="406" alt="Screenshot 2025-12-16 at 4 31 31 PM" src="https://github.com/user-attachments/assets/eb446388-9639-4e91-9f0d-f2242ee09e84" />
<img width="950" height="406" alt="Screenshot 2025-12-16 at 4 31 45 PM" src="https://github.com/user-attachments/assets/429a9f4c-beec-48bd-ba91-0ce76de99088" />


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/15206

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Setup your managed configuration with the following values:

```
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "proxy.no": "localhost",
  "proxy.http": "http://foobar.com",
  "proxy.https": "https://foobar.com",
  "proxy.enabled": 2
}
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/locked.json
{
	"locked": ["proxy.no", "proxy.https", "proxy.http", "proxy.enabled"]
}
~ $
```

2. Start PD

3. Go to **Preferences > Proxy**

4. See that the values are now disabled as well as the Managed
   configuration indicators showing.

- [X] Tests are covering the bug fix or the new feature
