### PR TITLE
feat: website last contributors section

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,23 +2,32 @@
 
 The current Maintainers Group for the Podman Desktop Project consists of:
 
-| Name | GitHub Username | Employer |
-| ---- | --------------- | -------- |
-| Axel Stefanini | @axel7083 | Red Hat|
-| Charlie Drage | @cdrage | Red Hat|
-| Denis Golovin | @dgolovin | Red Hat|
-| Emma Kidney | @ekidneyrh | Red Hat|
-| Evžen Gasta | @gastoner | Red Hat|
-| Florent Benoit | @benoitf | Red Hat|
-| Jeff MAURY | @jeffmaury | Red Hat|
-| Matthew Demyttenaere | @firewall | Red Hat|
-| Ondrej Dockal | @odockal | Red Hat|
-| Philippe Martin | @feloy | Red Hat|
-| Rujuta Shinde | @rujutashinde | Red Hat|
-| Shipra Singh | @shipsing | Red Hat|
-| Simon Rey | @simonrey1 | Red Hat|
-| Sonia Sandler | @SoniaSandler | Red Hat|
-| Stévan Le Meur | @slemeur | Red Hat|
-| Tim deBoer | @deboer-tim | Red Hat|
-| Vladimir Lazar | @cbr7 | Red Hat|
-| Vladyslav Zhukovskyi | @vzhukovs | Red Hat|
+| Name                 | GitHub Username | Employer |
+| -------------------- | --------------- | -------- |
+| Anton Misskii        | @amisskii       | Red Hat  |
+| Axel Stefanini       | @axel7083       | Red Hat  |
+| Brian Mahabirbu      | @bmahabirbu     | Red Hat  |
+| Daniel Villanueva    | @danivilla9     | Red Hat  |
+| Charlie Drage        | @cdrage         | Red Hat  |
+| Denis Golovin        | @dgolovin       | Red Hat  |
+| Emma Kidney          | @ekidneyrh      | Red Hat  |
+| Evžen Gasta          | @gastoner       | Red Hat  |
+| Florent Benoit       | @benoitf        | Red Hat  |
+| George Serban        | @serbangeorge-m | Red Hat  |
+| Jeff MAURY           | @jeffmaury      | Red Hat  |
+| Jiri Dostal          | @jiridostal     | Red Hat  |
+| Marcel Bertagnini    | @MarsKubeX      | Red Hat  |
+| Masha Lenova         | @MariaLeonova   | Red Hat  |
+| Matthew Demyttenaere | @firewall       | Red Hat  |
+| Ondrej Dockal        | @odockal        | Red Hat  |
+| Philippe Martin      | @feloy          | Red Hat  |
+| Rujuta Shinde        | @rujutashinde   | Red Hat  |
+| Shipra Singh         | @shipsing       | Red Hat  |
+| Simon Rey            | @simonrey1      | Red Hat  |
+| Sonia Sandler        | @SoniaSandler   | Red Hat  |
+| Stévan Le Meur       | @slemeur        | Red Hat  |
+| Tibor Dancs          | @ScrewTSW       | Red Hat  |
+| Tim deBoer           | @deboer-tim     | Red Hat  |
+| Václav Vančura       | @vancura        | Red Hat  |
+| Vladimir Lazar       | @cbr7           | Red Hat  |
+| Vladyslav Zhukovskyi | @vzhukovs       | Red Hat  |

--- a/website/src/components/LatestContributors.tsx
+++ b/website/src/components/LatestContributors.tsx
@@ -37,11 +37,11 @@ function ContributorCard({ contributor }: ContributorCardProps): JSX.Element {
       <img
         src={contributor.avatarUrl}
         alt={`${contributor.login}'s avatar`}
-        className="w-15 h-15 rounded-full border border-white group-hover:opacity-90 transition-opacity"
+        className="w-15 h-15 rounded-full border border-charcoal-300 dark:border-white group-hover:opacity-90 transition-opacity"
       />
       <div className="flex flex-col">
         <span className="text-sky-500 font-semibold">{contributor.login}</span>
-        <span className="text-white">
+        <span className="text-charcoal-300 dark:text-white">
           {contributor.commitCount} {contributor.commitCount === 1 ? 'commit' : 'commits'}
         </span>
       </div>

--- a/website/src/components/LatestContributors.tsx
+++ b/website/src/components/LatestContributors.tsx
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { usePluginData } from '@docusaurus/useGlobalData';
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { Contributor, GitHubMetadata } from '@site/src/plugins/github-metadata';
+
+import GradientButton from './GradientButton';
+
+interface ContributorCardProps {
+  readonly contributor: Contributor;
+}
+
+function ContributorCard({ contributor }: ContributorCardProps): JSX.Element {
+  return (
+    <a
+      href={contributor.profileUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex flex-row items-center gap-3 no-underline hover:no-underline group">
+      <img
+        src={contributor.avatarUrl}
+        alt={`${contributor.login}'s avatar`}
+        className="w-15 h-15 rounded-full border border-white group-hover:opacity-90 transition-opacity"
+      />
+      <div className="flex flex-col">
+        <span className="text-sky-500 font-semibold">{contributor.login}</span>
+        <span className="text-white">
+          {contributor.commitCount} {contributor.commitCount === 1 ? 'commit' : 'commits'}
+        </span>
+      </div>
+    </a>
+  );
+}
+
+export default function LatestContributors(): JSX.Element | null {
+  const { latestContributors } = usePluginData('docusaurus-plugin-github-metadata') as GitHubMetadata;
+
+  // Don't render the section if there are no contributors
+  if (!latestContributors || latestContributors.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      {/* Contributors grid */}
+      <div className="flex flex-wrap justify-center gap-8 mb-10">
+        {latestContributors.map((contributor: Contributor) => (
+          <ContributorCard key={contributor.login} contributor={contributor} />
+        ))}
+      </div>
+
+      {/* View all contributors button */}
+      <div className="flex justify-center">
+        <GradientButton href="https://github.com/podman-desktop/podman-desktop/graphs/contributors">
+          <FontAwesomeIcon icon={faGithub} className="mr-2" />
+          View all contributors
+        </GradientButton>
+      </div>
+    </div>
+  );
+}

--- a/website/src/pages/community/index.tsx
+++ b/website/src/pages/community/index.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import CommunityBanner from '@site/src/components/CommunityBanner';
 import GradientButton from '@site/src/components/GradientButton';
 import GradientIcon from '@site/src/components/GradientIcon';
+import LatestContributors from '@site/src/components/LatestContributors';
 import TailWindThemeSelector from '@site/src/components/TailWindThemeSelector';
 import Layout from '@theme/Layout';
 import React from 'react';
@@ -147,6 +148,11 @@ export default function Home(): JSX.Element {
               </p>
             </div>
           </div>
+        </section>
+
+        <section className="mb-16 text-center">
+          <h2 className="text-3xl font-bold mb-6">Latest Contributors</h2>
+          <LatestContributors />
         </section>
 
         <section id="community-events" className="mb-16 text-center">

--- a/website/src/plugins/github-metadata-plugin.ts
+++ b/website/src/plugins/github-metadata-plugin.ts
@@ -40,8 +40,17 @@ export default async function githubMetadataPlugin(): Promise<Plugin<GitHubMetad
       const metadata = await githubService.getMetadata();
 
       // Read and parse MAINTAINERS.md to get excluded usernames
-      const maintainersContent = readFileSync(MAINTAINERS_FILE_PATH, 'utf-8');
-      const excludedUsernames = parseMaintainersFromMarkdown(maintainersContent);
+      let excludedUsernames: Set<string>;
+      try {
+        const maintainersContent = readFileSync(MAINTAINERS_FILE_PATH, 'utf-8');
+        excludedUsernames = parseMaintainersFromMarkdown(maintainersContent);
+      } catch (err) {
+        throw new Error(
+          `Failed to read MAINTAINERS.md at ${MAINTAINERS_FILE_PATH}.
+            This file is required to filter out maintainers from the contributors list.
+            Error: ${err instanceof Error ? err.message : err}`,
+        );
+      }
 
       // Fetch latest contributors, excluding maintainers
       // Parameters: excludedUsernames, contributorLimit (5), pagesToFetch (5 = 500 commits)

--- a/website/src/plugins/github-service.ts
+++ b/website/src/plugins/github-service.ts
@@ -141,11 +141,20 @@ export class GitHubService {
     }
   }
 
+  /**
+   * Fetches the latest contributors from the repository.
+   * @param excludeUsernames - Set of usernames to exclude (case-insensitive; usernames will be normalized internally)
+   * @param contributorLimit - Maximum number of contributors to return
+   * @param pagesToFetch - Number of pages of commits to fetch (default: 5)
+   * @returns Array of contributors sorted by commit count
+   */
   public async getLatestContributors(
     excludeUsernames: Set<string>,
     contributorLimit: number,
     pagesToFetch = 5,
   ): Promise<Contributor[]> {
+    // Normalize exclude set to lowercase for case-insensitive comparison
+    const normalizedExcludeUsernames = new Set([...excludeUsernames].map(username => username.toLowerCase()));
     // GitHub API limits to 100 per page, so we fetch multiple pages
     const allCommits: Awaited<ReturnType<typeof this.octokit.rest.repos.listCommits>>['data'] = [];
 
@@ -172,7 +181,7 @@ export class GitHubService {
 
     for (const commit of allCommits) {
       const author = commit.author;
-      if (!author || excludeUsernames.has(author.login.toLowerCase()) || isBot(author.login)) {
+      if (!author?.login || normalizedExcludeUsernames.has(author.login.toLowerCase()) || isBot(author.login)) {
         continue;
       }
 

--- a/website/src/plugins/maintainers-parser.ts
+++ b/website/src/plugins/maintainers-parser.ts
@@ -16,37 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface Contributor {
-  login: string;
-  avatarUrl: string;
-  profileUrl: string;
-  commitCount: number;
-}
+/**
+ * Parses MAINTAINERS.md to extract GitHub usernames.
+ * Expected format: | Name | @username | Employer |
+ */
 
-export interface GitHubMetadata {
-  stargazersCount: number;
-  latestContributors?: Contributor[];
-  latestRelease: {
-    version: string;
-    linux: {
-      flatpak: string;
-      amd64: string;
-      arm64: string;
-    };
-    macos: {
-      universal: string;
-      x64: string;
-      arm64: string;
-      airgapsetupX64: string;
-      airgapsetupArm64: string;
-    };
-    windows: {
-      binaryX64: string;
-      binaryArm64: string;
-      setupX64: string;
-      setupArm64: string;
-      airgapsetupX64: string;
-      airgapsetupArm64: string;
-    };
-  };
+export function parseMaintainersFromMarkdown(content: string): Set<string> {
+  const maintainers = new Set<string>();
+
+  // Match GitHub usernames in format @username
+  const usernamePattern = /@([a-zA-Z0-9_-]+)/g;
+  const matches = content.matchAll(usernamePattern);
+
+  for (const match of matches) {
+    maintainers.add(match[1].toLowerCase());
+  }
+
+  return maintainers;
 }


### PR DESCRIPTION
### What does this PR do?
This PR add the "Last contributors section" in the website. For this, the implementation get the last 500 commits of the repo and filter the authors with the MAINTAINERS.md file (updated in this PR) so it can get the contributors.

### Screenshot / video of UI

<img width="2886" height="1856" alt="image" src="https://github.com/user-attachments/assets/659d97b1-d03b-46fd-920c-d17bad53ab91" />

### What issues does this PR fix or reference?
Not merge until [#15402](https://github.com/podman-desktop/podman-desktop/pull/15402) is merged
closes #13748 

### How to test this PR?

1. Run the website in local (pnpm run website:dev).
2. Once the app is up, go to "Community" section in the main menu.
3. Under de "Community" section check that "Last Contributors" section is being displayed

- [ ] Tests are covering the bug fix or the new feature
