### PR TITLE
docs: fix broken argo ci link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ Kubernetes questions & development:
 [![Mastodon](https://img.shields.io/badge/mastodon-6364ff?style=for-the-badge&logo=mastodon&logoColor=white)](https://fosstodon.org/@podmandesktop)
 [![Bluesky](https://img.shields.io/badge/bluesky-1283FE.svg?style=for-the-badge&logo=Bluesky&logoColor=white)](https://bsky.app/profile/podman-desktop.io)
 
-
 ### Adopters
 
 Check out the [list of companies](./ADOPTERS.md) already using Podman Desktop.
@@ -142,7 +141,7 @@ This project uses the [Containers Community Code of Conduct](https://github.com/
 
 ## Testing
 
-[![Covered by Argos Visual Testing](https://argos-ci.com/badge-large.svg)](https://app.argos-ci.com/containers/podman-desktop/reference)
+[![Covered by Argos Visual Testing](https://argos-ci.com/badge-large.svg)](https://app.argos-ci.com/containers/podman-desktop-website)
 
 ## License
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes the broken link of Argos CI provided in the [README.md](https://github.com/podman-desktop/podman-desktop/blob/main/README.md). For this, the implementation changes the link from  [broken link](https://app.argos-ci.com/containers/podman-desktop/reference) to this [valid link](https://app.argos-ci.com/containers/podman-desktop-website).

### Screenshot / video of UI

[Screencast from 2025-12-18 19-51-20.webm](https://github.com/user-attachments/assets/134ce95d-e5b0-4ad5-850e-1e70ba8859a2)

### What issues does this PR fix or reference?

closes #15374 

### How to test this PR?

 1. Go to the project's README.md 
 2. Click on **Covered by Argos**  banner under **Testing** section

- [ ] Tests are covering the bug fix or the new feature
