### PR TITLE
chore: align telemetry text

### DIFF
--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -115,7 +115,7 @@ export class Telemetry {
       properties: {
         [TelemetrySettings.SectionName + '.' + TelemetrySettings.Enabled]: {
           markdownDescription:
-            'Help improve Podman Desktop by allowing anonymous usage data to be sent to Red Hat. Read our [Privacy statement](https://developers.redhat.com/article/tool-data-collection)',
+            'Help improve Podman Desktop by allowing Red Hat to collect anonymous usage data. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection)',
           type: 'boolean',
           default: true,
         },

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -161,7 +161,7 @@ function startOnboardingQueue(): void {
             class="text-lg px-2"
             title="Enable telemetry"><div class="text-base font-medium">Telemetry:</div></Checkbox>
           <div class="w-2/5 text-[var(--pd-content-card-text)]">
-            Help Red Hat improve Podman Desktop by allowing anonymous usage data to be collected.
+            Help improve Podman Desktop by allowing Red Hat to collect anonymous usage data.
             <Link
               on:click={async (): Promise<void> => {
                 await window.openExternal('https://developers.redhat.com/article/tool-data-collection');


### PR DESCRIPTION
### What does this PR do?

I noticed the telemetry text on the Welcome page and preferences have diverged slightly. They should be the same, especially if we may allow it to be customized in the future (should be one string).

I could have copy/pasted in either direction, but instead I used the best parts of both, and confirmed with others that this is the most natural and readable version.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #15379.

### How to test this PR?

Verify text.