### PR TITLE
feat(main): new class to expose product information

### DIFF
--- a/packages/main/src/plugin/product/product-api.ts
+++ b/packages/main/src/plugin/product/product-api.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Definition of interfaces shared by the renderer and the main process
+ */
+
+export interface ProductInfo {
+  name: string;
+}

--- a/packages/main/src/plugin/product/product.spec.ts
+++ b/packages/main/src/plugin/product/product.spec.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { Product } from './product.js';
+
+let product: Product;
+
+beforeAll(async () => {
+  product = new Product();
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('readFeaturedJson should be valid', async () => {
+  const info = await product.getProductInfo();
+  expect(info.name).toBe('Podman Desktop');
+});

--- a/packages/main/src/plugin/product/product.ts
+++ b/packages/main/src/plugin/product/product.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { injectable } from 'inversify';
+
+import { ProductInfo } from '/@/plugin/product/product-api.js';
+import product from '/@product.json' with { type: 'json' };
+
+@injectable()
+export class Product {
+  info: ProductInfo;
+
+  constructor() {
+    this.info = {
+      name: product.name,
+    };
+  }
+
+  async getProductInfo(): Promise<ProductInfo> {
+    return this.info;
+  }
+}


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new class `Product` that reads the product.json file in the `main` package and that will be used in further PRs to expose infos to the renderer. For now I only expose the name to gather some feedback but I will iterate on that after this is reviewed, approved and merged.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/15281

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
