### PR TITLE
fix: fix visiblity of help menu

### DIFF
--- a/packages/renderer/src/lib/help/HelpMenu.svelte
+++ b/packages/renderer/src/lib/help/HelpMenu.svelte
@@ -24,7 +24,7 @@ onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
   bind:offsetHeight={dropDownHeight}
   bind:offsetWidth={dropDownWidth}
   bind:this={dropDownElement}
-  class="absolute"
+  class="absolute z-30"
   data-testid="help-menu">
   <div
     title="Help Menu Items"


### PR DESCRIPTION
### What does this PR do?

This PR fix the visibility of the Help Menu popup. For this, the implementation add Z-index value to the [Help Menu](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/help/HelpMenu.svelte) component.

### Screenshot / video of UI

<img width="1291" height="695" alt="Screenshot from 2025-12-19 11-10-11" src="https://github.com/user-attachments/assets/418b19b3-45a7-4108-a85b-6c1ba5192e62" />


### What issues does this PR fix or reference?

closes #15376 

### How to test this PR?

1. Open the Application.
2. In the bottom right section, you can find the help option.
3. Click on the help option. 
4. Now the Carousel button doesn't come over the Help Menu.

- [ ] Tests are covering the bug fix or the new feature
