### PR TITLE
fix: fix bottom spacing in preferences page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -76,7 +76,7 @@ function updateSearchValue(event: any): void {
     {#snippet header()}
         <SearchInput  title="preferences" class="mt-4" oninput={updateSearchValue} />
       {/snippet}
-    <div class="flex flex-col space-y-5 text-[var(--pd-content-header)]">
+    <div class="flex flex-col space-y-5 text-[var(--pd-content-header)] pb-2">
       {#if matchingRecords.size === 0}
         <div>No Settings Found</div>
       {:else}


### PR DESCRIPTION
### What does this PR do?

This PR fix the spacing issue in the preference page by adding bottom padding to the Preferences component.

### Screenshot / video of UI

<img width="980" height="923" alt="image" src="https://github.com/user-attachments/assets/54631f6e-6ee3-4f6d-a5a2-5310e7bf4c8b" />

### What issues does this PR fix or reference?

closes #15395 

### How to test this PR?

1. Go to settings  > Preferences.
2. Scroll down to the bottom. Now the Bulk option is not squished against the bottom of the page.

- [ ] Tests are covering the bug fix or the new feature
