### PR TITLE
fix(extension-loader): avoid cascade failure when an extension cannot be loaded

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -18,8 +18,6 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { Buffer } from 'node:buffer';
-import type { Dirent } from 'node:fs';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -426,7 +424,9 @@ describe('extensionLoader#start', () => {
     const loadExtensionsMock = vi.spyOn(extensionLoader, 'loadExtensions');
     loadExtensionsMock.mockResolvedValue(undefined);
 
-    vi.mocked(fs.promises.readdir).mockImplementation(async path => {
+    vi.mocked(
+      fs.promises.readdir as (path: string, options?: { withFileTypes: true }) => Promise<fs.Dirent[]>,
+    ).mockImplementation(async path => {
       switch (path) {
         case directories.getPluginsDirectory():
           return [
@@ -434,12 +434,12 @@ describe('extensionLoader#start', () => {
               name: 'foo',
               isFile: () => false,
               isDirectory: () => true,
-            } as unknown as Dirent<Buffer<ArrayBuffer>>,
+            } as unknown as fs.Dirent,
             {
               name: 'bar',
               isFile: () => false,
               isDirectory: () => true,
-            } as unknown as Dirent<Buffer<ArrayBuffer>>,
+            } as unknown as fs.Dirent,
           ];
         default:
           return [];

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -225,10 +225,10 @@ const safeStorageRegistry: SafeStorageRegistry = {
 } as unknown as SafeStorageRegistry;
 
 const directories = {
-  getPluginsDirectory: () => '/fake-plugins-directory',
-  getPluginsScanDirectory: () => '/fake-plugins-scanning-directory',
-  getExtensionsStorageDirectory: () => '/fake-extensions-storage-directory',
-  getSafeStorageDirectory: () => '/fake-safe-storage-directory',
+  getPluginsDirectory: () => path.resolve('/fake-plugins-directory'),
+  getPluginsScanDirectory: () => path.resolve('/fake-plugins-scanning-directory'),
+  getExtensionsStorageDirectory: () => path.resolve('/fake-extensions-storage-directory'),
+  getSafeStorageDirectory: () => path.resolve('/fake-safe-storage-directory'),
 } as unknown as Directories;
 
 const exec = new Exec(proxy);

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -514,8 +514,10 @@ export class ExtensionLoader implements IAsyncDisposable {
           ),
         )
       ).reduce((accumulator, result) => {
-        if (result.status === 'fulfilled' && !result.value.error) {
+        if (result.status === 'fulfilled') {
           accumulator.push(result.value);
+        } else {
+          console.error('Something went wrong while trying to analyse an extension:', result.reason);
         }
         return accumulator;
       }, [] as AnalyzedExtensionWithApi[]);

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -501,7 +501,7 @@ export class ExtensionLoader implements IAsyncDisposable {
       // filter only directories ignoring node_modules directory
       const pluginDirectories = pluginDirEntries
         .filter(entry => entry.isDirectory())
-        .map(directory => this.pluginsDirectory + '/' + directory.name);
+        .map(directory => path.join(this.pluginsDirectory, directory.name));
 
       // collect all extensions from the pluginDirectory folders
       const analyzedPluginsDirectoryExtensions: AnalyzedExtension[] = (


### PR DESCRIPTION
### What does this PR do?

When the extension loader fails to analyses an extension because of malformed content, this will cascade and prevent any extensions to be loaded.

This can be clearly tested by creating an empty folder in the `~/.local/share/containers/podman-desktop/plugins`. This is because the loading of each extensions is done through an `Promise.all` meaning if one fail, everything fails. This PR changes this to Promise.allSettle and filter out the failed extensions.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14999

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature


**Testing manually**

1. Checkout this PR
2. Create an empty folder in  `~/.local/share/containers/podman-desktop/plugins`
3. Start Podman Desktop
4. Assert everything is working as expected