### PR TITLE
feat(main/help-menu): new experimental option for working on help menu

### DIFF
--- a/packages/main/src/plugin/help-menu/help-menu.spec.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.spec.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2024-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+
+import { HelpMenu } from './help-menu.js';
+
+const registerConfigurationsMock = vi.fn();
+const configurationRegistryMock = {
+  registerConfigurations: registerConfigurationsMock,
+} as unknown as ConfigurationRegistry;
+
+const productConfigPropertyName = 'helpMenu.useProductConfig';
+test('should register a configuration', async () => {
+  vi.stubEnv('DEV', true);
+  const helpMenu = new HelpMenu(configurationRegistryMock);
+  helpMenu.init();
+
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
+  expect(configurationNode?.id).toBe('preferences.experimental.helpMenu');
+  expect(configurationNode?.title).toBe('Experimental (Help menu)');
+  expect(configurationNode?.properties).toBeDefined();
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+  expect(configurationNode?.properties?.[productConfigPropertyName]).toBeDefined();
+  expect(configurationNode?.properties?.[productConfigPropertyName]?.type).toBe('object');
+  expect(configurationNode?.properties?.[productConfigPropertyName]?.description).toBe(
+    'Replace help menu with the one defined in the product',
+  );
+
+  expect(configurationNode?.properties?.[productConfigPropertyName]?.experimental).toStrictEqual({});
+});
+
+test('Undefined should be default if not in dev env', () => {
+  vi.resetAllMocks();
+  vi.stubEnv('DEV', false);
+  const helpMenu = new HelpMenu(configurationRegistryMock);
+  helpMenu.init();
+
+  expect(configurationRegistryMock.registerConfigurations).toBeCalled();
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
+
+  expect(configurationNode?.properties?.[productConfigPropertyName]?.default).toBe(undefined);
+});

--- a/packages/main/src/plugin/help-menu/help-menu.spec.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2024-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+
+@injectable()
+export class HelpMenu {
+  constructor(@inject(IConfigurationRegistry) private configurationRegistry: IConfigurationRegistry) {}
+
+  init(): void {
+    const helpMenuConfiguration: IConfigurationNode = {
+      id: `preferences.experimental.helpMenu`,
+      title: 'Experimental (Help menu)',
+      type: 'object',
+      properties: {
+        [`helpMenu.useProductConfig`]: {
+          description: 'Replace help menu with the one defined in the product',
+          type: 'object',
+          default: import.meta.env.DEV ? {} : undefined,
+          experimental: {},
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([helpMenuConfiguration]);
+  }
+}

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -30,7 +30,7 @@ export class HelpMenu {
       title: 'Experimental (Help menu)',
       type: 'object',
       properties: {
-        ['helpMenu.useProductConfig']: {
+        'helpMenu.useProductConfig': {
           description: 'Replace help menu with the one defined in the product',
           type: 'object',
           default: import.meta.env.DEV ? {} : undefined,

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -26,7 +26,7 @@ export class HelpMenu {
 
   init(): void {
     const helpMenuConfiguration: IConfigurationNode = {
-      id: `preferences.experimental.helpMenu`,
+      id: 'preferences.experimental.helpMenu',
       title: 'Experimental (Help menu)',
       type: 'object',
       properties: {

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -30,7 +30,7 @@ export class HelpMenu {
       title: 'Experimental (Help menu)',
       type: 'object',
       properties: {
-        [`helpMenu.useProductConfig`]: {
+        ['helpMenu.useProductConfig']: {
           description: 'Replace help menu with the one defined in the product',
           type: 'object',
           default: import.meta.env.DEV ? {} : undefined,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -183,6 +183,7 @@ import { Featured } from './featured/featured.js';
 import type { FeaturedExtension } from './featured/featured-api.js';
 import { FeedbackHandler } from './feedback-handler.js';
 import { FilesystemMonitoring } from './filesystem-monitoring.js';
+import { HelpMenu } from './help-menu/help-menu.js';
 import { IconRegistry } from './icon-registry.js';
 import { ImageCheckerImpl } from './image-checker.js';
 import { ImageFilesRegistry } from './image-files-registry.js';
@@ -567,6 +568,10 @@ export class PluginSystem {
     container.bind<StatusbarProvidersInit>(StatusbarProvidersInit).toSelf().inSingletonScope();
     const statusbarProviders = container.get<StatusbarProvidersInit>(StatusbarProvidersInit);
     statusbarProviders.init();
+
+    container.bind<HelpMenu>(HelpMenu).toSelf().inSingletonScope();
+    const helpMenu = container.get<HelpMenu>(HelpMenu);
+    helpMenu.init();
 
     container.bind<MessageBox>(MessageBox).toSelf().inSingletonScope();
 


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new experimental option for the time we need to work on the epic of productization of the help menu.
<img width="1163" height="813" alt="Screenshot 2025-12-19 at 17 42 15" src="https://github.com/user-attachments/assets/463fcfea-778a-43f1-a2f6-9917ed241948" />

For now, this changes nothing.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15408

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
