### PR TITLE
chore(renderer/HelpMenu): update component to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/help/HelpMenu.svelte
+++ b/packages/renderer/src/lib/help/HelpMenu.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
-import { onDestroy, onMount } from 'svelte';
+import { onDestroy, onMount, type Snippet } from 'svelte';
 
-let dropDownHeight: number;
-let dropDownWidth: number;
-let dropDownElement: HTMLElement;
+interface Props {
+  children?: Snippet;
+}
+
+let { children }: Props = $props();
+
+let dropDownHeight = $state<number | undefined>();
+let dropDownWidth = $state<number | undefined>();
+let dropDownElement = $state<HTMLElement | undefined>();
 
 const STATUS_BAR_HEIGHT = 24;
 
 function updateMenuLocation(): void {
-  dropDownElement.style.top = `${window.innerHeight - dropDownHeight - STATUS_BAR_HEIGHT}px`;
-  dropDownElement.style.left = `${window.innerWidth - dropDownWidth - 1}px`;
+  if (dropDownElement && dropDownHeight !== undefined && dropDownWidth !== undefined) {
+    dropDownElement.style.top = `${window.innerHeight - dropDownHeight - STATUS_BAR_HEIGHT}px`;
+    dropDownElement.style.left = `${window.innerWidth - dropDownWidth - 1}px`;
+  }
 }
 
 onMount(() => {
@@ -29,6 +37,6 @@ onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
   <div
     title="Help Menu Items"
     class="z-10 m-1 rounded-md shadow-lg bg-[var(--pd-dropdown-bg)] ring-2 ring-[var(--pd-dropdown-ring)] hover:ring-[var(--pd-dropdown-hover-ring)] divide-y divide-[var(--pd-dropdown-divider)] focus:outline-hidden">
-    <slot />
+    {@render children?.()}
   </div>
 </div>


### PR DESCRIPTION
### What does this PR do?

This PR is a chore tu update the HelpMenu component to Svelte 5

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/15417

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Make sure that the help menu and the items still work here:

<img width="351" height="329" alt="Screenshot 2025-12-19 at 18 02 18" src="https://github.com/user-attachments/assets/d9a0d529-eee6-45d6-8a10-2b3a9ae2e725" />


<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
