### PR TITLE
fix: add get networkdrivers to index files and replace engineid

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6366,16 +6366,27 @@ describe('getNetworkDrivers', () => {
       info: infoMock,
     } as unknown as Dockerode;
 
+    const providerConnectionInfo: ProviderContainerConnectionInfo = {
+      name: 'engine1',
+      endpoint: {
+        socketPath: '/engine1.socket',
+      },
+    } as ProviderContainerConnectionInfo;
+
     containerRegistry.addInternalProvider('engine1', {
       name: 'engine1',
       id: 'engine1',
       connection: {
         type: 'podman',
+        name: 'engine1',
+        endpoint: {
+          socketPath: '/engine1.socket',
+        },
       },
       api: fakeDockerode,
     } as InternalContainerProvider);
 
-    const result = await containerRegistry.getNetworkDrivers('engine1');
+    const result = await containerRegistry.getNetworkDrivers(providerConnectionInfo);
 
     expect(result).toEqual(['bridge', 'macvlan', 'ipvlan']);
   });
@@ -6387,23 +6398,41 @@ describe('getNetworkDrivers', () => {
       info: infoMock,
     } as unknown as Dockerode;
 
+    const providerConnectionInfo: ProviderContainerConnectionInfo = {
+      name: 'engine2',
+      endpoint: {
+        socketPath: '/engine2.socket',
+      },
+    } as ProviderContainerConnectionInfo;
+
     containerRegistry.addInternalProvider('engine2', {
       name: 'engine2',
       id: 'engine2',
       connection: {
         type: 'docker',
+        name: 'engine2',
+        endpoint: {
+          socketPath: '/engine2.socket',
+        },
       },
       api: fakeDockerode,
     } as InternalContainerProvider);
 
-    const result = await containerRegistry.getNetworkDrivers('engine2');
+    const result = await containerRegistry.getNetworkDrivers(providerConnectionInfo);
 
     expect(result).toEqual([]);
   });
 
   test('throws error when engine not found', async () => {
-    await expect(containerRegistry.getNetworkDrivers('nonexistent')).rejects.toThrow(
-      'no engine matching this container',
+    const nonexistentConnectionInfo: ProviderContainerConnectionInfo = {
+      name: 'nonexistent',
+      endpoint: {
+        socketPath: '/nonexistent.socket',
+      },
+    } as ProviderContainerConnectionInfo;
+
+    await expect(containerRegistry.getNetworkDrivers(nonexistentConnectionInfo)).rejects.toThrow(
+      'no running provider for the matching container',
     );
   });
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2854,15 +2854,14 @@ export class ContainerProviderRegistry {
     return infos.filter((item): item is containerDesktopAPI.ContainerEngineInfo => !!item);
   }
 
-  async getNetworkDrivers(engineId: string): Promise<string[]> {
-    const provider = this.internalProviders.get(engineId);
-    if (!provider) {
-      throw new Error('no engine matching this container');
-    }
-    if (!provider.api) {
+  async getNetworkDrivers(
+    providerContainerConnectionInfo: ProviderContainerConnectionInfo | containerDesktopAPI.ContainerProviderConnection,
+  ): Promise<string[]> {
+    const matchingContainerProvider = this.getMatchingContainerProvider(providerContainerConnectionInfo);
+    if (!matchingContainerProvider?.api) {
       throw new Error('no running provider for the matching container');
     }
-    const info = await provider.api.info();
+    const info = await matchingContainerProvider.api.info();
     return info.Plugins?.Network ?? [];
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -885,6 +885,12 @@ export class PluginSystem {
       },
     );
     this.ipcHandle(
+      'container-provider-registry:getNetworkDrivers',
+      async (_listener, providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<string[]> => {
+        return containerProviderRegistry.getNetworkDrivers(providerContainerConnectionInfo);
+      },
+    );
+    this.ipcHandle(
       'container-provider-registry:listVolumes',
       async (_listener, fetchUsage: boolean): Promise<VolumeListInfo[]> => {
         return containerProviderRegistry.listVolumes(fetchUsage);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -337,6 +337,13 @@ export function initExposure(): void {
   );
 
   contextBridge.exposeInMainWorld(
+    'getNetworkDrivers',
+    async (providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<string[]> => {
+      return ipcInvoke('container-provider-registry:getNetworkDrivers', providerContainerConnectionInfo);
+    },
+  );
+
+  contextBridge.exposeInMainWorld(
     'replicatePodmanContainer',
     async (
       source: { engineId: string; id: string },


### PR DESCRIPTION
before the backend used engineid, like get info, but for network create we dont have access to this and must use providercontainerconnection instead

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Relates: https://github.com/podman-desktop/podman-desktop/pull/15364
Relates: https://github.com/podman-desktop/podman-desktop/issues/14797

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
