### PR TITLE
refactor(svelte): extract provider action buttons to dedicate component

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -339,10 +339,6 @@ function hasAnyConfiguration(provider: ProviderInfo): boolean {
   );
 }
 
-function handleCreateNew(provider: ProviderInfo, displayName: string): Promise<void> {
-  return doCreateNew(provider, displayName);
-}
-
 function handleSetup(provider: ProviderInfo): void {
   if (globalContext && isOnboardingEnabled(provider, globalContext)) {
     router.goto(`/preferences/onboarding/${provider.extensionId}`);
@@ -482,7 +478,7 @@ $effect(() => {
               provider={provider}
               globalContext={globalContext}
               providerInstallationInProgress={providerInstallationInProgress.get(provider.name) ?? false}
-              onCreateNew={handleCreateNew}
+              onCreateNew={doCreateNew}
               onSetup={handleSetup}
               onUpdatePreflightChecks={handleUpdatePreflightChecks}
               isOnboardingEnabled={isOnboardingEnabled}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -339,14 +339,6 @@ function hasAnyConfiguration(provider: ProviderInfo): boolean {
   );
 }
 
-function handleSetup(provider: ProviderInfo): void {
-  if (globalContext && isOnboardingEnabled(provider, globalContext)) {
-    router.goto(`/preferences/onboarding/${provider.extensionId}`);
-  } else {
-    router.goto(`/preferences/default/preferences.${provider.extensionId}`);
-  }
-}
-
 function handleUpdatePreflightChecks(checks: CheckStatus[]): CheckStatus[] {
   preflightChecks = checks;
   return checks;
@@ -479,7 +471,6 @@ $effect(() => {
               globalContext={globalContext}
               providerInstallationInProgress={providerInstallationInProgress.get(provider.name) ?? false}
               onCreateNew={doCreateNew}
-              onSetup={handleSetup}
               onUpdatePreflightChecks={handleUpdatePreflightChecks}
               isOnboardingEnabled={isOnboardingEnabled}
               hasAnyConfiguration={hasAnyConfiguration} />

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { faCircleInfo, faGear, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { faCircleInfo, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import type { ContainerProviderConnection } from '@podman-desktop/api';
-import { Button, DropdownMenu, EmptyScreen, Tooltip } from '@podman-desktop/ui-svelte';
+import { DropdownMenu, EmptyScreen, Tooltip } from '@podman-desktop/ui-svelte';
 import { Buffer } from 'buffer';
 import { filesize } from 'filesize';
 import { onDestroy, onMount } from 'svelte';
@@ -25,7 +25,6 @@ import { providerInfos } from '../../stores/providers';
 import ContributionActions from '../actions/ContributionActions.svelte';
 import type { ContextUI } from '../context/context';
 import { ContextKeyExpr } from '../context/contextKey';
-import ProviderUpdateButton from '../dashboard/ProviderUpdateButton.svelte';
 import { normalizeOnboardingWhenClause } from '../onboarding/onboarding-utils';
 import ConnectionErrorInfoButton from '../ui/ConnectionErrorInfoButton.svelte';
 import ConnectionStatus from '../ui/ConnectionStatus.svelte';
@@ -37,6 +36,7 @@ import PreferencesConnectionActions from './PreferencesConnectionActions.svelte'
 import PreferencesConnectionsEmptyRendering from './PreferencesConnectionsEmptyRendering.svelte';
 import PreferencesProviderInstallationModal from './PreferencesProviderInstallationModal.svelte';
 import PreferencesResourcesRenderingCopyButton from './PreferencesResourcesRenderingCopyButton.svelte';
+import ProviderActionButtons from './ProviderActionButtons.svelte';
 import SettingsPage from './SettingsPage.svelte';
 import {
   getProviderConnectionName,
@@ -339,6 +339,23 @@ function hasAnyConfiguration(provider: ProviderInfo): boolean {
   );
 }
 
+function handleCreateNew(provider: ProviderInfo, displayName: string): Promise<void> {
+  return doCreateNew(provider, displayName);
+}
+
+function handleSetup(provider: ProviderInfo): void {
+  if (globalContext && isOnboardingEnabled(provider, globalContext)) {
+    router.goto(`/preferences/onboarding/${provider.extensionId}`);
+  } else {
+    router.goto(`/preferences/default/preferences.${provider.extensionId}`);
+  }
+}
+
+function handleUpdatePreflightChecks(checks: CheckStatus[]): CheckStatus[] {
+  preflightChecks = checks;
+  return checks;
+}
+
 interface Props {
   properties?: IConfigurationPropertyRecordedSchema[];
   focus: string | undefined;
@@ -461,64 +478,15 @@ $effect(() => {
               <span class="my-auto font-semibold text-[var(--pd-invert-content-card-header-text)] ml-3 break-words"
                 >{provider.name}</span>
             </div>
-            <div class="text-center mt-10">
-              <!-- Some providers have a status of 'unknown' so that they do not appear in the dashboard, this allows onboarding to still show. -->
-              {#if globalContext && isOnboardingEnabled(provider, globalContext) && (provider.status === 'not-installed' || provider.status === 'unknown')}
-                <Button
-                  aria-label="Setup {provider.name}"
-                  title="Setup {provider.name}"
-                  onclick={(): void => router.goto(`/preferences/onboarding/${provider.extensionId}`)}>
-                  Setup ...
-                </Button>
-              {:else}
-                <div class="flex flex-row justify-around flex-wrap gap-2">
-                  {#if provider.containerProviderConnectionCreation || provider.kubernetesProviderConnectionCreation || provider.vmProviderConnectionCreation}
-                    {@const providerDisplayName =
-                      (provider.containerProviderConnectionCreation
-                        ? (provider.containerProviderConnectionCreationDisplayName ?? undefined)
-                        : provider.kubernetesProviderConnectionCreation
-                          ? provider.kubernetesProviderConnectionCreationDisplayName
-                          : provider.vmProviderConnectionCreation
-                            ? provider.vmProviderConnectionCreationDisplayName
-                            : undefined) ?? provider.name}
-                    {@const buttonTitle =
-                      (provider.containerProviderConnectionCreation
-                        ? (provider.containerProviderConnectionCreationButtonTitle ?? undefined)
-                        : provider.kubernetesProviderConnectionCreation
-                          ? provider.kubernetesProviderConnectionCreationButtonTitle
-                          : provider.vmProviderConnectionCreation
-                            ? provider.vmProviderConnectionCreationButtonTitle
-                            : undefined) ?? 'Create new'}
-                    <!-- create new provider button -->
-                    <Tooltip bottom tip="Create new {providerDisplayName}">
-                      <Button
-                        aria-label="Create new {providerDisplayName}"
-                        inProgress={providerInstallationInProgress.get(provider.name)}
-                        onclick={(): Promise<void> => doCreateNew(provider, providerDisplayName)}>
-                        {buttonTitle} ...
-                      </Button>
-                    </Tooltip>
-                  {/if}
-                  {#if globalContext && (isOnboardingEnabled(provider, globalContext) || hasAnyConfiguration(provider))}
-                    <Button
-                      aria-label="Setup {provider.name}"
-                      title="Setup {provider.name}"
-                      onclick={(): void => {
-                        if (globalContext && isOnboardingEnabled(provider, globalContext)) {
-                          router.goto(`/preferences/onboarding/${provider.extensionId}`);
-                        } else {
-                          router.goto(`/preferences/default/preferences.${provider.extensionId}`);
-                        }
-                      }}>
-                      <Fa size="0.9x" icon={faGear} />
-                    </Button>
-                  {/if}
-                  {#if provider.updateInfo?.version && provider.version !== provider.updateInfo?.version}
-                    <ProviderUpdateButton onPreflightChecks={(checks): CheckStatus[] => (preflightChecks = checks)} provider={provider} />
-                  {/if}
-                </div>
-              {/if}
-            </div>
+            <ProviderActionButtons
+              provider={provider}
+              globalContext={globalContext}
+              providerInstallationInProgress={providerInstallationInProgress.get(provider.name) ?? false}
+              onCreateNew={handleCreateNew}
+              onSetup={handleSetup}
+              onUpdatePreflightChecks={handleUpdatePreflightChecks}
+              isOnboardingEnabled={isOnboardingEnabled}
+              hasAnyConfiguration={hasAnyConfiguration} />
           </div>
         </div>
         <!-- providers columns -->

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
@@ -29,11 +29,7 @@ import type { ProviderInfo } from '/@api/provider-info';
 
 import ProviderActionButtons from './ProviderActionButtons.svelte';
 
-vi.mock('tinro', () => ({
-  router: {
-    goto: vi.fn(),
-  },
-}));
+vi.mock(import('tinro'));
 
 vi.mock(import('/@/lib/dashboard/ProviderUpdateButton.svelte'));
 

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
@@ -20,15 +20,22 @@ import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { router } from 'tinro';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ContextUI } from '/@/lib/context/context';
+import ProviderUpdateButton from '/@/lib/dashboard/ProviderUpdateButton.svelte';
 import type { ProviderInfo } from '/@api/provider-info';
 
-import type { ContextUI } from '../context/context';
-import ProviderUpdateButton from '../dashboard/ProviderUpdateButton.svelte';
 import ProviderActionButtons from './ProviderActionButtons.svelte';
 
-vi.mock(import('../dashboard/ProviderUpdateButton.svelte'));
+vi.mock('tinro', () => ({
+  router: {
+    goto: vi.fn(),
+  },
+}));
+
+vi.mock(import('/@/lib/dashboard/ProviderUpdateButton.svelte'));
 
 const baseProviderInfo: ProviderInfo = {
   id: 'podman',
@@ -64,430 +71,439 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('shows only Setup button in onboarding mode when provider is not-installed', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    status: 'not-installed',
-  };
+describe('ProviderActionButtons', () => {
+  test('shows only Setup button in onboarding mode when provider is not-installed', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      status: 'not-installed',
+    };
 
-  const onSetup = vi.fn();
-  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
-  const hasAnyConfiguration = vi.fn().mockReturnValue(false);
+    const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+    const hasAnyConfiguration = vi.fn().mockReturnValue(false);
 
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup,
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled,
-    hasAnyConfiguration,
-  });
-
-  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
-  expect(setupButton).toBeInTheDocument();
-
-  const createButton = screen.queryByText(/Create new/i);
-  expect(createButton).not.toBeInTheDocument();
-});
-
-test('shows only Setup button in onboarding mode when provider is unknown', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    status: 'unknown',
-  };
-
-  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
-  const hasAnyConfiguration = vi.fn().mockReturnValue(false);
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled,
-    hasAnyConfiguration,
-  });
-
-  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
-  expect(setupButton).toBeInTheDocument();
-});
-
-test('calls onSetup callback when Setup button is clicked in onboarding mode', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    status: 'not-installed',
-  };
-
-  const onSetup = vi.fn();
-  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup,
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled,
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
-  await userEvent.click(setupButton);
-
-  expect(onSetup).toHaveBeenCalledWith(provider);
-});
-
-test('shows Create new button when containerProviderConnectionCreation is true', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    containerProviderConnectionCreation: true,
-    containerProviderConnectionCreationDisplayName: 'Podman Machine',
-  };
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  const createButton = screen.getByRole('button', {
-    name: `Create new ${provider.containerProviderConnectionCreationDisplayName}`,
-  });
-  expect(createButton).toBeInTheDocument();
-});
-
-test('shows Create new button with custom button title', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    containerProviderConnectionCreation: true,
-    containerProviderConnectionCreationButtonTitle: 'Initialize',
-    containerProviderConnectionCreationDisplayName: 'Podman Machine',
-  };
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  const createButton = screen.getByText('Initialize ...');
-  expect(createButton).toBeInTheDocument();
-});
-
-test('shows Create new button for kubernetesProviderConnectionCreation', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    kubernetesProviderConnectionCreation: true,
-    kubernetesProviderConnectionCreationDisplayName: 'Kind Cluster',
-  };
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  const createButton = screen.getByRole('button', {
-    name: `Create new ${provider.kubernetesProviderConnectionCreationDisplayName}`,
-  });
-  expect(createButton).toBeInTheDocument();
-});
-
-test('shows Create new button for vmProviderConnectionCreation', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    vmProviderConnectionCreation: true,
-    vmProviderConnectionCreationDisplayName: 'Lima VM',
-  };
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  const createButton = screen.getByRole('button', {
-    name: `Create new ${provider.vmProviderConnectionCreationDisplayName}`,
-  });
-  expect(createButton).toBeInTheDocument();
-});
-
-test('calls onCreateNew callback when Create new button is clicked', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    containerProviderConnectionCreation: true,
-    containerProviderConnectionCreationDisplayName: 'Podman Machine',
-  };
-
-  const onCreateNew = vi.fn();
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew,
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  const createButton = screen.getByRole('button', {
-    name: `Create new ${provider.containerProviderConnectionCreationDisplayName}`,
-  });
-  await userEvent.click(createButton);
-
-  expect(onCreateNew).toHaveBeenCalledWith(provider, provider.containerProviderConnectionCreationDisplayName);
-});
-
-test('shows Create new button in progress state', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    containerProviderConnectionCreation: true,
-  };
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: true,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
-  expect(createButton).toBeInTheDocument();
-});
-
-test('shows settings button when onboarding is enabled', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    containerProviderConnectionCreation: true,
-  };
-
-  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled,
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
-  expect(setupButton).toBeInTheDocument();
-});
-
-test('shows settings button when configuration is available', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    containerProviderConnectionCreation: true,
-  };
-
-  const hasAnyConfiguration = vi.fn().mockReturnValue(true);
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration,
-  });
-
-  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
-  expect(setupButton).toBeInTheDocument();
-});
-
-test('shows update button when update is available', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    version: '1.0.0',
-    updateInfo: {
-      version: '1.1.0',
-    },
-  };
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  expect(ProviderUpdateButton).toHaveBeenCalled();
-});
-
-test('does not show update button when no update is available', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    version: '1.0.0',
-    updateInfo: {
-      version: '1.0.0',
-    },
-  };
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  expect(ProviderUpdateButton).not.toHaveBeenCalled();
-});
-
-test('passes onUpdatePreflightChecks callback to ProviderUpdateButton', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    version: '1.0.0',
-    updateInfo: {
-      version: '1.1.0',
-    },
-  };
-
-  const onUpdatePreflightChecks = vi.fn();
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks,
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
-  });
-
-  expect(ProviderUpdateButton).toHaveBeenCalledWith(
-    expect.anything(),
-    expect.objectContaining({
-      onPreflightChecks: onUpdatePreflightChecks,
+    render(ProviderActionButtons, {
       provider,
-    }),
-  );
-});
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled,
+      hasAnyConfiguration,
+    });
 
-test('shows multiple buttons in regular mode', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    containerProviderConnectionCreation: true,
-    version: '1.0.0',
-    updateInfo: {
-      version: '1.1.0',
-    },
-  };
+    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    expect(setupButton).toBeInTheDocument();
 
-  const hasAnyConfiguration = vi.fn().mockReturnValue(true);
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration,
+    const createButton = screen.queryByText(/Create new/i);
+    expect(createButton).not.toBeInTheDocument();
   });
 
-  // Should show Create new button
-  const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
-  expect(createButton).toBeInTheDocument();
+  test('shows only Setup button in onboarding mode when provider is unknown', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      status: 'unknown',
+    };
 
-  // Should show Setup button
-  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
-  expect(setupButton).toBeInTheDocument();
+    const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+    const hasAnyConfiguration = vi.fn().mockReturnValue(false);
 
-  // Should show Update button
-  expect(ProviderUpdateButton).toHaveBeenCalled();
-});
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled,
+      hasAnyConfiguration,
+    });
 
-test('uses fallback display name when specific display name is not provided', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    name: 'Podman',
-    containerProviderConnectionCreation: true,
-  };
-
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: mockGlobalContext,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled: vi.fn().mockReturnValue(false),
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    expect(setupButton).toBeInTheDocument();
   });
 
-  const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
-  expect(createButton).toBeInTheDocument();
-});
+  test('navigates to onboarding page when Setup button is clicked in onboarding mode', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      status: 'not-installed',
+      extensionId: 'podman-extension',
+    };
 
-test('does not show onboarding setup when globalContext is undefined', async () => {
-  const provider: ProviderInfo = {
-    ...baseProviderInfo,
-    status: 'not-installed',
-  };
+    const isOnboardingEnabled = vi.fn().mockReturnValue(true);
 
-  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled,
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
 
-  render(ProviderActionButtons, {
-    provider,
-    globalContext: undefined,
-    providerInstallationInProgress: false,
-    onCreateNew: vi.fn(),
-    onSetup: vi.fn(),
-    onUpdatePreflightChecks: vi.fn(),
-    isOnboardingEnabled,
-    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    await userEvent.click(setupButton);
+
+    expect(router.goto).toHaveBeenCalledWith('/preferences/onboarding/podman-extension');
   });
 
-  // Should not show onboarding Setup button (because globalContext is undefined)
-  const setupButtons = screen.queryAllByRole('button', { name: `Setup ${provider.name}` });
-  // Should either not exist or be in regular mode (not onboarding mode)
-  // In this case, the component should show regular buttons mode
-  expect(setupButtons.length).toBeLessThanOrEqual(1);
+  test('navigates to settings page when Setup button is clicked in regular mode', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      containerProviderConnectionCreation: true,
+      extensionId: 'podman-extension',
+    };
+
+    const hasAnyConfiguration = vi.fn().mockReturnValue(true);
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration,
+    });
+
+    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    await userEvent.click(setupButton);
+
+    expect(router.goto).toHaveBeenCalledWith('/preferences/default/preferences.podman-extension');
+  });
+
+  test('shows Create new button when containerProviderConnectionCreation is true', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      containerProviderConnectionCreation: true,
+      containerProviderConnectionCreationDisplayName: 'Podman Machine',
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    const createButton = screen.getByRole('button', {
+      name: `Create new ${provider.containerProviderConnectionCreationDisplayName}`,
+    });
+    expect(createButton).toBeInTheDocument();
+  });
+
+  test('shows Create new button with custom button title', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      containerProviderConnectionCreation: true,
+      containerProviderConnectionCreationButtonTitle: 'Initialize',
+      containerProviderConnectionCreationDisplayName: 'Podman Machine',
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    const createButton = screen.getByText('Initialize ...');
+    expect(createButton).toBeInTheDocument();
+  });
+
+  test('shows Create new button for kubernetesProviderConnectionCreation', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      kubernetesProviderConnectionCreation: true,
+      kubernetesProviderConnectionCreationDisplayName: 'Kind Cluster',
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    const createButton = screen.getByRole('button', {
+      name: `Create new ${provider.kubernetesProviderConnectionCreationDisplayName}`,
+    });
+    expect(createButton).toBeInTheDocument();
+  });
+
+  test('shows Create new button for vmProviderConnectionCreation', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      vmProviderConnectionCreation: true,
+      vmProviderConnectionCreationDisplayName: 'Lima VM',
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    const createButton = screen.getByRole('button', {
+      name: `Create new ${provider.vmProviderConnectionCreationDisplayName}`,
+    });
+    expect(createButton).toBeInTheDocument();
+  });
+
+  test('calls onCreateNew callback when Create new button is clicked', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      containerProviderConnectionCreation: true,
+      containerProviderConnectionCreationDisplayName: 'Podman Machine',
+    };
+
+    const onCreateNew = vi.fn();
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew,
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    const createButton = screen.getByRole('button', {
+      name: `Create new ${provider.containerProviderConnectionCreationDisplayName}`,
+    });
+    await userEvent.click(createButton);
+
+    expect(onCreateNew).toHaveBeenCalledWith(provider, provider.containerProviderConnectionCreationDisplayName);
+  });
+
+  test('shows Create new button in progress state', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      containerProviderConnectionCreation: true,
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: true,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
+    expect(createButton).toBeInTheDocument();
+  });
+
+  test('shows settings button when onboarding is enabled', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      containerProviderConnectionCreation: true,
+    };
+
+    const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled,
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    expect(setupButton).toBeInTheDocument();
+  });
+
+  test('shows settings button when configuration is available', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      containerProviderConnectionCreation: true,
+    };
+
+    const hasAnyConfiguration = vi.fn().mockReturnValue(true);
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration,
+    });
+
+    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    expect(setupButton).toBeInTheDocument();
+  });
+
+  test('shows update button when update is available', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      version: '1.0.0',
+      updateInfo: {
+        version: '1.1.0',
+      },
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    expect(ProviderUpdateButton).toHaveBeenCalled();
+  });
+
+  test('does not show update button when no update is available', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      version: '1.0.0',
+      updateInfo: {
+        version: '1.0.0',
+      },
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    expect(ProviderUpdateButton).not.toHaveBeenCalled();
+  });
+
+  test('passes onUpdatePreflightChecks callback to ProviderUpdateButton', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      version: '1.0.0',
+      updateInfo: {
+        version: '1.1.0',
+      },
+    };
+
+    const onUpdatePreflightChecks = vi.fn();
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks,
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    expect(ProviderUpdateButton).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        onPreflightChecks: onUpdatePreflightChecks,
+        provider,
+      }),
+    );
+  });
+
+  test('shows multiple buttons in regular mode', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      containerProviderConnectionCreation: true,
+      version: '1.0.0',
+      updateInfo: {
+        version: '1.1.0',
+      },
+    };
+
+    const hasAnyConfiguration = vi.fn().mockReturnValue(true);
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration,
+    });
+
+    // Should show Create new button
+    const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
+    expect(createButton).toBeInTheDocument();
+
+    // Should show Setup button
+    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    expect(setupButton).toBeInTheDocument();
+
+    // Should show Update button
+    expect(ProviderUpdateButton).toHaveBeenCalled();
+  });
+
+  test('uses fallback display name when specific display name is not provided', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      name: 'Podman',
+      containerProviderConnectionCreation: true,
+    };
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: mockGlobalContext,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled: vi.fn().mockReturnValue(false),
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
+    expect(createButton).toBeInTheDocument();
+  });
+
+  test('does not show onboarding setup when globalContext is undefined', async () => {
+    const provider: ProviderInfo = {
+      ...baseProviderInfo,
+      status: 'not-installed',
+    };
+
+    const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+
+    render(ProviderActionButtons, {
+      provider,
+      globalContext: undefined,
+      providerInstallationInProgress: false,
+      onCreateNew: vi.fn(),
+      onUpdatePreflightChecks: vi.fn(),
+      isOnboardingEnabled,
+      hasAnyConfiguration: vi.fn().mockReturnValue(false),
+    });
+
+    // Should not show onboarding Setup button (because globalContext is undefined)
+    const setupButtons = screen.queryAllByRole('button', { name: `Setup ${provider.name}` });
+    // Should either not exist or be in regular mode (not onboarding mode)
+    // In this case, the component should show regular buttons mode
+    expect(setupButtons.length).toBeLessThanOrEqual(1);
+  });
 });

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
@@ -1,0 +1,493 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { ProviderInfo } from '/@api/provider-info';
+
+import type { ContextUI } from '../context/context';
+import ProviderUpdateButton from '../dashboard/ProviderUpdateButton.svelte';
+import ProviderActionButtons from './ProviderActionButtons.svelte';
+
+vi.mock(import('../dashboard/ProviderUpdateButton.svelte'));
+
+const baseProviderInfo: ProviderInfo = {
+  id: 'podman',
+  name: 'Podman',
+  images: {
+    icon: 'img',
+  },
+  status: 'ready',
+  warnings: [],
+  containerProviderConnectionCreation: false,
+  detectionChecks: [],
+  containerConnections: [],
+  installationSupport: false,
+  internalId: '0',
+  kubernetesConnections: [],
+  kubernetesProviderConnectionCreation: false,
+  links: [],
+  containerProviderConnectionInitialization: false,
+  kubernetesProviderConnectionInitialization: false,
+  extensionId: 'podman-extension',
+  cleanupSupport: false,
+  vmConnections: [],
+  vmProviderConnectionCreation: false,
+  vmProviderConnectionInitialization: false,
+  version: '1.0.0',
+};
+
+const mockGlobalContext: ContextUI = {
+  setValue: vi.fn(),
+} as unknown as ContextUI;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('shows only Setup button in onboarding mode when provider is not-installed', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    status: 'not-installed',
+  };
+
+  const onSetup = vi.fn();
+  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+  const hasAnyConfiguration = vi.fn().mockReturnValue(false);
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup,
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled,
+    hasAnyConfiguration,
+  });
+
+  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+  expect(setupButton).toBeInTheDocument();
+
+  const createButton = screen.queryByText(/Create new/i);
+  expect(createButton).not.toBeInTheDocument();
+});
+
+test('shows only Setup button in onboarding mode when provider is unknown', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    status: 'unknown',
+  };
+
+  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+  const hasAnyConfiguration = vi.fn().mockReturnValue(false);
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled,
+    hasAnyConfiguration,
+  });
+
+  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+  expect(setupButton).toBeInTheDocument();
+});
+
+test('calls onSetup callback when Setup button is clicked in onboarding mode', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    status: 'not-installed',
+  };
+
+  const onSetup = vi.fn();
+  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup,
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled,
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+  await userEvent.click(setupButton);
+
+  expect(onSetup).toHaveBeenCalledWith(provider);
+});
+
+test('shows Create new button when containerProviderConnectionCreation is true', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    containerProviderConnectionCreation: true,
+    containerProviderConnectionCreationDisplayName: 'Podman Machine',
+  };
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const createButton = screen.getByRole('button', {
+    name: `Create new ${provider.containerProviderConnectionCreationDisplayName}`,
+  });
+  expect(createButton).toBeInTheDocument();
+});
+
+test('shows Create new button with custom button title', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    containerProviderConnectionCreation: true,
+    containerProviderConnectionCreationButtonTitle: 'Initialize',
+    containerProviderConnectionCreationDisplayName: 'Podman Machine',
+  };
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const createButton = screen.getByText('Initialize ...');
+  expect(createButton).toBeInTheDocument();
+});
+
+test('shows Create new button for kubernetesProviderConnectionCreation', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    kubernetesProviderConnectionCreation: true,
+    kubernetesProviderConnectionCreationDisplayName: 'Kind Cluster',
+  };
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const createButton = screen.getByRole('button', {
+    name: `Create new ${provider.kubernetesProviderConnectionCreationDisplayName}`,
+  });
+  expect(createButton).toBeInTheDocument();
+});
+
+test('shows Create new button for vmProviderConnectionCreation', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    vmProviderConnectionCreation: true,
+    vmProviderConnectionCreationDisplayName: 'Lima VM',
+  };
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const createButton = screen.getByRole('button', {
+    name: `Create new ${provider.vmProviderConnectionCreationDisplayName}`,
+  });
+  expect(createButton).toBeInTheDocument();
+});
+
+test('calls onCreateNew callback when Create new button is clicked', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    containerProviderConnectionCreation: true,
+    containerProviderConnectionCreationDisplayName: 'Podman Machine',
+  };
+
+  const onCreateNew = vi.fn();
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew,
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const createButton = screen.getByRole('button', {
+    name: `Create new ${provider.containerProviderConnectionCreationDisplayName}`,
+  });
+  await userEvent.click(createButton);
+
+  expect(onCreateNew).toHaveBeenCalledWith(provider, provider.containerProviderConnectionCreationDisplayName);
+});
+
+test('shows Create new button in progress state', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    containerProviderConnectionCreation: true,
+  };
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: true,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
+  expect(createButton).toBeInTheDocument();
+});
+
+test('shows settings button when onboarding is enabled', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    containerProviderConnectionCreation: true,
+  };
+
+  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled,
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+  expect(setupButton).toBeInTheDocument();
+});
+
+test('shows settings button when configuration is available', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    containerProviderConnectionCreation: true,
+  };
+
+  const hasAnyConfiguration = vi.fn().mockReturnValue(true);
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration,
+  });
+
+  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+  expect(setupButton).toBeInTheDocument();
+});
+
+test('shows update button when update is available', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    version: '1.0.0',
+    updateInfo: {
+      version: '1.1.0',
+    },
+  };
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  expect(ProviderUpdateButton).toHaveBeenCalled();
+});
+
+test('does not show update button when no update is available', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    version: '1.0.0',
+    updateInfo: {
+      version: '1.0.0',
+    },
+  };
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  expect(ProviderUpdateButton).not.toHaveBeenCalled();
+});
+
+test('passes onUpdatePreflightChecks callback to ProviderUpdateButton', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    version: '1.0.0',
+    updateInfo: {
+      version: '1.1.0',
+    },
+  };
+
+  const onUpdatePreflightChecks = vi.fn();
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks,
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  expect(ProviderUpdateButton).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      onPreflightChecks: onUpdatePreflightChecks,
+      provider,
+    }),
+  );
+});
+
+test('shows multiple buttons in regular mode', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    containerProviderConnectionCreation: true,
+    version: '1.0.0',
+    updateInfo: {
+      version: '1.1.0',
+    },
+  };
+
+  const hasAnyConfiguration = vi.fn().mockReturnValue(true);
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration,
+  });
+
+  // Should show Create new button
+  const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
+  expect(createButton).toBeInTheDocument();
+
+  // Should show Setup button
+  const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+  expect(setupButton).toBeInTheDocument();
+
+  // Should show Update button
+  expect(ProviderUpdateButton).toHaveBeenCalled();
+});
+
+test('uses fallback display name when specific display name is not provided', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    name: 'Podman',
+    containerProviderConnectionCreation: true,
+  };
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: mockGlobalContext,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled: vi.fn().mockReturnValue(false),
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  const createButton = screen.getByRole('button', { name: `Create new ${provider.name}` });
+  expect(createButton).toBeInTheDocument();
+});
+
+test('does not show onboarding setup when globalContext is undefined', async () => {
+  const provider: ProviderInfo = {
+    ...baseProviderInfo,
+    status: 'not-installed',
+  };
+
+  const isOnboardingEnabled = vi.fn().mockReturnValue(true);
+
+  render(ProviderActionButtons, {
+    provider,
+    globalContext: undefined,
+    providerInstallationInProgress: false,
+    onCreateNew: vi.fn(),
+    onSetup: vi.fn(),
+    onUpdatePreflightChecks: vi.fn(),
+    isOnboardingEnabled,
+    hasAnyConfiguration: vi.fn().mockReturnValue(false),
+  });
+
+  // Should not show onboarding Setup button (because globalContext is undefined)
+  const setupButtons = screen.queryAllByRole('button', { name: `Setup ${provider.name}` });
+  // Should either not exist or be in regular mode (not onboarding mode)
+  // In this case, the component should show regular buttons mode
+  expect(setupButtons.length).toBeLessThanOrEqual(1);
+});

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
@@ -62,7 +62,9 @@ const showCreateNewButton = $derived(
     provider.vmProviderConnectionCreation,
 );
 
-const showSetupButton = $derived(globalContext && (isOnboarding ?? hasAnyConfiguration(provider)));
+const showSetupButton = $derived(
+  globalContext && (isOnboardingEnabled(provider, globalContext) || hasAnyConfiguration(provider)),
+);
 
 const showUpdateButton = $derived(provider.updateInfo?.version && provider.version !== provider.updateInfo?.version);
 

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+import { faGear } from '@fortawesome/free-solid-svg-icons';
+import { Button, Tooltip } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
+
+import type { ContextUI } from '/@/lib/context/context';
+import ProviderUpdateButton from '/@/lib/dashboard/ProviderUpdateButton.svelte';
+import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
+
+interface Props {
+  provider: ProviderInfo;
+  globalContext: ContextUI | undefined;
+  providerInstallationInProgress: boolean;
+  onCreateNew: (provider: ProviderInfo, displayName: string) => Promise<void>;
+  onSetup: (provider: ProviderInfo) => void;
+  onUpdatePreflightChecks: (checks: CheckStatus[]) => void;
+  isOnboardingEnabled: (provider: ProviderInfo, context: ContextUI) => boolean;
+  hasAnyConfiguration: (provider: ProviderInfo) => boolean;
+  class?: string;
+}
+
+let {
+  provider,
+  globalContext,
+  providerInstallationInProgress,
+  onCreateNew,
+  onSetup,
+  onUpdatePreflightChecks,
+  isOnboardingEnabled,
+  hasAnyConfiguration,
+  class: className = '',
+}: Props = $props();
+
+const showOnboardingSetup = $derived(
+  globalContext &&
+    isOnboardingEnabled(provider, globalContext) &&
+    (provider.status === 'not-installed' || provider.status === 'unknown'),
+);
+
+const providerDisplayName = $derived(
+  (provider.containerProviderConnectionCreation
+    ? (provider.containerProviderConnectionCreationDisplayName ?? undefined)
+    : provider.kubernetesProviderConnectionCreation
+      ? provider.kubernetesProviderConnectionCreationDisplayName
+      : provider.vmProviderConnectionCreation
+        ? provider.vmProviderConnectionCreationDisplayName
+        : undefined) ?? provider.name,
+);
+
+const buttonTitle = $derived(
+  (provider.containerProviderConnectionCreation
+    ? (provider.containerProviderConnectionCreationButtonTitle ?? undefined)
+    : provider.kubernetesProviderConnectionCreation
+      ? provider.kubernetesProviderConnectionCreationButtonTitle
+      : provider.vmProviderConnectionCreation
+        ? provider.vmProviderConnectionCreationButtonTitle
+        : undefined) ?? 'Create new',
+);
+
+const showCreateNewButton = $derived(
+  provider.containerProviderConnectionCreation ||
+    provider.kubernetesProviderConnectionCreation ||
+    provider.vmProviderConnectionCreation,
+);
+
+const showSetupButton = $derived(
+  globalContext && (isOnboardingEnabled(provider, globalContext) || hasAnyConfiguration(provider)),
+);
+
+const showUpdateButton = $derived(provider.updateInfo?.version && provider.version !== provider.updateInfo?.version);
+
+function handleCreateNew(): Promise<void> {
+  return onCreateNew(provider, providerDisplayName);
+}
+
+function handleSetup(): void {
+  onSetup(provider);
+}
+</script>
+
+<div class="text-center mt-10 {className}">
+  {#if showOnboardingSetup}
+    <Button
+      aria-label="Setup {provider.name}"
+      title="Setup {provider.name}"
+      onclick={handleSetup}>
+      Setup ...
+    </Button>
+  {:else}
+    <div class="flex flex-row justify-around flex-wrap gap-2">
+      {#if showCreateNewButton}
+        <Tooltip bottom tip="Create new {providerDisplayName}">
+          <Button
+            aria-label="Create new {providerDisplayName}"
+            inProgress={providerInstallationInProgress}
+            onclick={handleCreateNew}>
+            {buttonTitle} ...
+          </Button>
+        </Tooltip>
+      {/if}
+
+      {#if showSetupButton}
+        <Button
+          aria-label="Setup {provider.name}"
+          title="Setup {provider.name}"
+          onclick={handleSetup}>
+          <Fa size="0.9x" icon={faGear} />
+        </Button>
+      {/if}
+
+      {#if showUpdateButton}
+        <ProviderUpdateButton
+          onPreflightChecks={onUpdatePreflightChecks}
+          provider={provider} />
+      {/if}
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
### What does this PR do?
Related changes request needed for https://github.com/podman-desktop/podman-desktop/pull/14773.

The main purpose is to extract provider action buttons to dedicate svelte component, to make it a bit simpler.

See discussion here: https://github.com/podman-desktop/podman-desktop/pull/14773#discussion_r2586101598

### Screenshot / video of UI

N/A no changes on the UI

### What issues does this PR fix or reference?

part of: https://github.com/podman-desktop/podman-desktop/issues/14145

### How to test this PR?

Make sure that provider action buttons on the create new resource page works as before.

- [x] Tests are covering the bug fix or the new feature
