### PR TITLE
chore: abort build if Node.js engine is incorrect

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+engineStrict: true
 packages:
   - 'packages/*'
   - 'extensions/*'


### PR DESCRIPTION
### What does this PR do?
Ensure the Node.js version available is matching the requirement of the build.

For example if package.json says: Node.js >= 24, I can still use Node.js v22

But I see some
```
 WARN  Unsupported engine: wanted: {"node":">=24.0.0"} (current: {"node":"v22.21.1","pnpm":"10.20.0"})
```
traces

I noticed that during the test of the PR https://github.com/podman-desktop/podman-desktop/pull/15119

To be sure people will install/upgrade to the right Node.js version, and that all actions are using proper Node.js versions as well, ensure that during the build step

Then we got for example:

```
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your Node version is incompatible with "podman-desktop".

Expected version: >=24.0.0
Got: v22.21.1
```

https://pnpm.io/next/settings#enginestrict

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/15119

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
