### PR TITLE
fix: handle sha in extension image links

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -394,14 +394,22 @@ export class ImageRegistry {
     }
 
     // Check if image is referenced by digest (@sha256:hash) instead of tag
+    // Format can be: name:tag, name@sha256:hash, or name:tag@sha256:hash
     let tag = 'latest';
     const atIndex = imageName.indexOf('@');
     const lastSlash = imageName.lastIndexOf('/');
 
     if (atIndex !== -1 && atIndex > lastSlash) {
-      // Image uses digest format: name@sha256:hash
+      // Image uses digest format: name@sha256:hash or name:tag@sha256:hash
+      // The digest is the authoritative reference
       tag = imageName.substring(atIndex + 1);
       imageName = imageName.substring(0, atIndex);
+
+      // Remove any tag that might be present before the @ (e.g., :0.11.0 in name:0.11.0@sha256:...)
+      const lastColon = imageName.lastIndexOf(':');
+      if (lastColon !== -1 && lastColon > lastSlash) {
+        imageName = imageName.substring(0, lastColon);
+      }
     } else {
       // Check for tag format: name:tag
       const lastColon = imageName.lastIndexOf(':');

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -393,13 +393,22 @@ export class ImageRegistry {
       throw new Error(`Invalid image name: ${imageName}`);
     }
 
-    // do we have a tag at the end with last
+    // Check if image is referenced by digest (@sha256:hash) instead of tag
     let tag = 'latest';
-    const lastColon = imageName.lastIndexOf(':');
+    const atIndex = imageName.indexOf('@');
     const lastSlash = imageName.lastIndexOf('/');
-    if (lastColon !== -1 && lastColon > lastSlash) {
-      tag = imageName.substring(lastColon + 1);
-      imageName = imageName.substring(0, lastColon);
+
+    if (atIndex !== -1 && atIndex > lastSlash) {
+      // Image uses digest format: name@sha256:hash
+      tag = imageName.substring(atIndex + 1);
+      imageName = imageName.substring(0, atIndex);
+    } else {
+      // Check for tag format: name:tag
+      const lastColon = imageName.lastIndexOf(':');
+      if (lastColon !== -1 && lastColon > lastSlash) {
+        tag = imageName.substring(lastColon + 1);
+        imageName = imageName.substring(0, lastColon);
+      }
     }
 
     let registry = '';


### PR DESCRIPTION
### What does this PR do?
using sha link was not working in "install custom extension..."

fixes it by implementing the support

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

~~fixes https://github.com/podman-desktop/podman-desktop/issues/15434~~
fixes https://github.com/podman-desktop/podman-desktop/issues/13720

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
