### PR TITLE
feat(main): create a task for podman kube play action

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1051,7 +1051,18 @@ export class PluginSystem {
           replace?: boolean;
         },
       ): Promise<PlayKubeInfo> => {
-        return containerProviderRegistry.playKube(yamlFilePath, selectedProvider, options);
+        const task = taskManager.createTask({
+          title: `Podman Play Kube`,
+        });
+        try {
+          const result = await containerProviderRegistry.playKube(yamlFilePath, selectedProvider, options);
+          task.status = 'success';
+          return result;
+        } catch (error: unknown) {
+          task.error = String(error);
+          task.status = 'failure';
+          throw error;
+        }
       },
     );
 


### PR DESCRIPTION
### What does this PR do?

Using the `Pods > Podman Kube Play` feature were lacking a task. Currently the task do not have cancellation nor action to go back to the page, but this might be follow-up PR.

### Screenshot / video of UI

<img width="1051" height="703" alt="Screenshot From 2025-12-23 15-36-54" src="https://github.com/user-attachments/assets/db91909d-6b23-4be8-aa7d-0806a8fd46c5" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15173

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Checkout branch
2. Go to `Pods > Podman Kube Play`
3. Select `Create file from scratch`
4. Paste the following
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
    - name: nginx
      image: nginx
      ports:
        - containerPort: 80

```
5. Click on `Play`
6. assert a task has been created and is visible