### PR TITLE
refactor(renderer): move matchMedia logic setup vitest

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -45,8 +45,8 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.0",
     "vitest": "^4.0.10",
-    "@xterm/xterm": "^5.5.0",
-    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^6.0.0",
+    "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "vitest-canvas-mock": "^1.1.3",
     "yaml": "^2.8.2"

--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -39,13 +39,6 @@ vi.mock('./appearance-util', () => {
 
 beforeAll(() => {
   Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
-  Object.defineProperty(window, 'matchMedia', {
-    value: vi.fn().mockReturnValue({
-      matches: false,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    }),
-  });
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -42,11 +42,6 @@ beforeAll(() => {
       func();
     },
   };
-  Object.defineProperty(window, 'matchMedia', {
-    value: () => ({
-      addListener: vi.fn(),
-    }),
-  });
   mockBreadcrumb();
 });
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -20,7 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { containerTerminals } from '/@/stores/container-terminal-store';
 
@@ -28,10 +28,6 @@ import ContainerDetailsTerminal from './ContainerDetailsTerminal.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
 let shellInContainerMock = vi.fn();
-
-beforeAll(() => {
-  Object.defineProperty(window, 'matchMedia', { value: vi.fn() });
-});
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -42,10 +38,6 @@ beforeEach(() => {
     return undefined;
   });
   shellInContainerMock = vi.mocked(window.shellInContainer);
-  vi.mocked(window.matchMedia).mockReturnValue({
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-  } as unknown as MediaQueryList);
 
   // reset terminals
   containerTerminals.set([]);

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.spec.ts
@@ -37,13 +37,6 @@ beforeAll(() => {
   Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
   Object.defineProperty(window, 'attachContainer', { value: attachContainerMock });
   Object.defineProperty(window, 'attachContainerSend', { value: vi.fn() });
-
-  Object.defineProperty(window, 'matchMedia', {
-    value: vi.fn().mockReturnValue({
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-    }),
-  });
 });
 
 test('expect being able to attach terminal ', async () => {

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -129,15 +129,6 @@ beforeEach(() => {
     return undefined;
   });
   window.HTMLElement.prototype.scrollIntoView = vi.fn();
-  Object.defineProperty(window, 'matchMedia', {
-    value: () => {
-      return {
-        matches: false,
-        addListener: (): void => {},
-        removeListener: (): void => {},
-      };
-    },
-  });
 
   providerInfos.set([providerInfo]);
 });

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -39,15 +39,6 @@ beforeAll(() => {
   };
 
   vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
-  Object.defineProperty(window, 'matchMedia', {
-    value: () => {
-      return {
-        matches: false,
-        addListener: (): void => {},
-        removeListener: (): void => {},
-      };
-    },
-  });
 });
 
 const CONTAINER_CONNECTION_MOCK: ProviderContainerConnectionInfo = {

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -89,11 +89,6 @@ beforeAll(() => {
 beforeEach(() => {
   vi.resetAllMocks();
 
-  vi.mocked(window.matchMedia).mockReturnValue({
-    matches: false,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  } as unknown as MediaQueryList);
   vi.mocked(window.openDialog).mockResolvedValue(['Containerfile']);
   vi.mocked(window.telemetryPage).mockResolvedValue(undefined);
   vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);

--- a/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.spec.ts
@@ -43,13 +43,6 @@ beforeAll(() => {
   Object.defineProperty(window, 'kubernetesExec', { value: kubernetesExecMock });
   Object.defineProperty(window, 'kubernetesExecResize', { value: kubernetesExecResizeMock });
   Object.defineProperty(window, 'kubernetesExecSend', { value: vi.fn().mockResolvedValue(undefined) });
-
-  Object.defineProperty(window, 'matchMedia', {
-    value: vi.fn().mockReturnValue({
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-    }),
-  });
 });
 
 test('Test should render the terminal and being able to reconnect', async () => {

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
@@ -79,16 +79,6 @@ beforeAll(() => {
   Object.defineProperty(window, 'getCancellableTokenSource', { value: vi.fn() });
   Object.defineProperty(window, 'auditConnectionParameters', { value: vi.fn() });
   Object.defineProperty(window, 'telemetryTrack', { value: vi.fn() });
-
-  Object.defineProperty(window, 'matchMedia', {
-    value: () => {
-      return {
-        matches: false,
-        addListener: (): void => {},
-        removeListener: (): void => {},
-      };
-    },
-  });
 });
 
 test('Expect to find PreferencesConnectionCreationRendering component if step includes "create" component', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -76,16 +76,6 @@ beforeAll(() => {
   (window as any).auditConnectionParameters = vi.fn();
   (window as any).telemetryTrack = vi.fn();
   (window as any).openDialog = vi.fn();
-
-  Object.defineProperty(window, 'matchMedia', {
-    value: () => {
-      return {
-        matches: false,
-        addListener: (): void => {},
-        removeListener: (): void => {},
-      };
-    },
-  });
 });
 
 function mockCallback(

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
@@ -61,12 +61,6 @@ beforeEach(() => {
     receiveEndCallback: {
       value: receiveEndCallbackMock,
     },
-    matchMedia: {
-      value: () => ({
-        addListener: (): void => {},
-        removeListener: (): void => {},
-      }),
-    },
   });
 });
 

--- a/packages/renderer/src/stores/kubernetes-terminal-state-store.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-terminal-state-store.spec.ts
@@ -34,13 +34,6 @@ beforeAll(() => {
   });
   Object.defineProperty(window, 'kubernetesExec', { value: kubernetesExecMock });
   Object.defineProperty(window, 'kubernetesExecResize', { value: vi.fn() });
-
-  Object.defineProperty(window, 'matchMedia', {
-    value: vi.fn().mockReturnValue({
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-    }),
-  });
 });
 
 test('Test should check saved terminal state after destroying terminal window', async () => {

--- a/packages/renderer/vite.tests.setup.js
+++ b/packages/renderer/vite.tests.setup.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,23 @@ import { readFileSync } from 'node:fs';
 import 'vitest-canvas-mock';
 import typescript from 'typescript';
 import { EventStore } from './src/stores/event-store';
+import { vi } from 'vitest';
 
-global.window.matchMedia = vi.fn();
+/**
+ * Mock matchMedia
+ * @param query {string} the media query to match
+ * @returns {MediaQueryList} the media query list
+ */
+global.window.matchMedia = query => ({
+  matches: false,
+  media: query,
+  onchange: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+});
 
 // read the given path and extract the method names from the Window interface
 function extractWindowMethods(filePath) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,8 +684,8 @@ importers:
         specifier: ^8.50.1
         version: 8.50.1(@typescript-eslint/parser@8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@xterm/addon-fit':
-        specifier: ^0.10.0
-        version: 0.10.0(@xterm/xterm@5.5.0)
+        specifier: ^0.11.0
+        version: 0.11.0
       '@xterm/addon-search':
         specifier: ^0.16.0
         version: 0.16.0
@@ -693,8 +693,8 @@ importers:
         specifier: ^0.14.0
         version: 0.14.0
       '@xterm/xterm':
-        specifier: ^5.5.0
-        version: 5.5.0
+        specifier: ^6.0.0
+        version: 6.0.0
       eslint-plugin-svelte:
         specifier: ^3.13.1
         version: 3.13.1(eslint@9.39.2(jiti@2.6.1))(svelte@5.46.1)
@@ -4713,10 +4713,8 @@ packages:
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
 
-  '@xterm/addon-fit@0.10.0':
-    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
-    peerDependencies:
-      '@xterm/xterm': ^5.0.0
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
   '@xterm/addon-search@0.16.0':
     resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
@@ -4724,8 +4722,8 @@ packages:
   '@xterm/addon-serialize@0.14.0':
     resolution: {integrity: sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==}
 
-  '@xterm/xterm@5.5.0':
-    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -16771,15 +16769,13 @@ snapshots:
 
   '@xmldom/xmldom@0.8.10': {}
 
-  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
-    dependencies:
-      '@xterm/xterm': 5.5.0
+  '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-search@0.16.0': {}
 
   '@xterm/addon-serialize@0.14.0': {}
 
-  '@xterm/xterm@5.5.0': {}
+  '@xterm/xterm@6.0.0': {}
 
   '@xtuc/ieee754@1.2.0': {}
 


### PR DESCRIPTION
Based on https://github.com/podman-desktop/podman-desktop/pull/15454

Trying to address the problem with xterm upgrade to v6

The fix does not work without the lib bump, so they have to be done at the same time

Fixes https://github.com/podman-desktop/podman-desktop/issues/15455