### PR TITLE
fix(renderer): replace Terminal#reset by Terminal#clear

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -136,7 +136,7 @@ async function pullImage(): Promise<void> {
   lineNumberPerId.clear();
   lineIndex = 0;
   await tick();
-  logsPull?.reset();
+  logsPull?.clear();
 
   // reset error
   pullError = '';


### PR DESCRIPTION
### What does this PR do?

Very very subtle problem, we are using the `Terminal#reset` function when we want to _clear_ the terminal in the PullImage, but with the Terminal 6.0 this function seems to completely broke the terminal (might be the real reset), I tried running in debugger etc. can't understand the root cause (I spent hours...). But this makes some tests fails in https://github.com/podman-desktop/podman-desktop/pull/15454.

Replacing `Terminal#reset` by `Terminal#clear` seems to have no impact, we are achieving the same behaviour. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of 
- https://github.com/podman-desktop/podman-desktop/issues/15455

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests are ensuring no regression

You can try manually to go to `Images > Pull Image` and play around with it => everything works as expected 
