### PR TITLE
feat: make kube play cancellable

### DIFF
--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -157,6 +157,86 @@ test('error: When pressing the Play button, expect us to show the errors to the 
   expect(error).toBeInTheDocument();
 });
 
+describe('cancel', () => {
+  test('expect cancel button not to be visible by default', async () => {
+    // Render the component
+    setup();
+    const { queryByRole } = render(KubePlayYAML, {});
+
+    const cancelBtn = queryByRole('button', { name: 'Cancel' });
+    expect(cancelBtn).toBeNull();
+  });
+
+  test('expect cancel button to be visible while playKube is running', async () => {
+    const { promise, resolve } = Promise.withResolvers<PlayKubeInfo>();
+    vi.mocked(window.playKube).mockReturnValue(promise);
+
+    // Render the component
+    setup();
+    const { getByRole, getByLabelText, queryByRole } = render(KubePlayYAML, {});
+
+    // Simulate selecting a file
+    const fileInput = getByRole('textbox', { name: 'Kubernetes YAML file' });
+    expect(fileInput).toBeInTheDocument();
+
+    const browseButton = getByLabelText('browse');
+    expect(browseButton).toBeInTheDocument();
+    await userEvent.click(browseButton);
+
+    // Simulate clicking the "Play" button
+    const playButton = getByRole('button', { name: 'Play' });
+    expect(playButton).toBeInTheDocument();
+    await userEvent.click(playButton);
+
+    const cancelBtn = await vi.waitFor(() => {
+      return getByRole('button', { name: 'Cancel' });
+    });
+    expect(cancelBtn).toBeInTheDocument();
+
+    // resolve window.playKube
+    resolve(mockedErroredPlayKubeInfo);
+
+    await vi.waitFor(() => {
+      const cancelBtn = queryByRole('button', { name: 'Cancel' });
+      expect(cancelBtn).toBeNull();
+    });
+  });
+
+  test('cancel action should call window#cancelToken', async () => {
+    const CANCELLABLE_TOKEN_ID: number = 55;
+    vi.mocked(window.getCancellableTokenSource).mockResolvedValue(CANCELLABLE_TOKEN_ID);
+
+    const { promise } = Promise.withResolvers<PlayKubeInfo>();
+    vi.mocked(window.playKube).mockReturnValue(promise);
+
+    // Render the component
+    setup();
+    const { getByRole, getByLabelText } = render(KubePlayYAML, {});
+
+    // Simulate selecting a file
+    const fileInput = getByRole('textbox', { name: 'Kubernetes YAML file' });
+    expect(fileInput).toBeInTheDocument();
+
+    const browseButton = getByLabelText('browse');
+    expect(browseButton).toBeInTheDocument();
+    await userEvent.click(browseButton);
+
+    // Simulate clicking the "Play" button
+    const playButton = getByRole('button', { name: 'Play' });
+    expect(playButton).toBeInTheDocument();
+    await userEvent.click(playButton);
+
+    const cancelBtn = await vi.waitFor(() => {
+      return getByRole('button', { name: 'Cancel' });
+    });
+    await userEvent.click(cancelBtn);
+
+    await vi.waitFor(() => {
+      expect(window.cancelToken).toHaveBeenCalledExactlyOnceWith(CANCELLABLE_TOKEN_ID);
+    });
+  });
+});
+
 test('expect done button is there at the end and redirects to pods', async () => {
   vi.mocked(window.playKube).mockResolvedValue({
     Pods: [],


### PR DESCRIPTION
### What does this PR do?

The Podman Kube Play feature can be pretty long, and the user may want to cancel, this PR is adding this ability, through the Podman Kube Play form (Through a Cancel button) and in the Task added in https://github.com/podman-desktop/podman-desktop/issues/15173)

### Screenshot / video of UI

<img width="1163" height="1078" alt="image" src="https://github.com/user-attachments/assets/a5505bd4-3e0b-4a22-9e50-48a45c72e23f" />

https://github.com/user-attachments/assets/2ce71243-bcac-4ce3-ba6b-dbe6fdad1916

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15462

Require rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/15465
- https://github.com/podman-desktop/podman-desktop/pull/15487
- https://github.com/podman-desktop/podman-desktop/pull/15489

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Checkout this PR
2. Go to `Pods > Podman Kube Play`
3. Select `Create file from scratch`
4. Paste the following (The `ghcr.io/ggml-org/llama.cpp:full-cuda` is several GB, making it ideal to give you enough time to click on `Cancel`)
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: llamacpp
spec:
  containers:
    - name: llamacpp
      image: ghcr.io/ggml-org/llama.cpp:full-cuda
```
5. Assert the `Cancel` button is visible
6. Click on `Cancel`
7. Assert message `The operation was aborted`