### PR TITLE
chore(packages/renderer): replace relative path in vi.mock calls

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretEmptyScreen.spec.ts
@@ -25,7 +25,7 @@ import { listenResourcePermitted } from '/@/lib/kube/resource-permission';
 
 import ConfigMapSecretEmptyScreen from './ConfigMapSecretEmptyScreen.svelte';
 
-vi.mock('../kube/resource-permission');
+vi.mock(import('/@/lib/kube/resource-permission'));
 
 test('Expect configmap empty screen', async () => {
   vi.mocked(listenResourcePermitted).mockImplementation(vi.fn((_, callback) => callback(true)));

--- a/packages/renderer/src/lib/deployments/DeploymentEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentEmptyScreen.spec.ts
@@ -25,7 +25,7 @@ import { listenResourcePermitted } from '/@/lib/kube/resource-permission';
 
 import DeploymentEmptyScreen from './DeploymentEmptyScreen.svelte';
 
-vi.mock('../kube/resource-permission');
+vi.mock(import('/@/lib/kube/resource-permission'));
 
 test('Expect deployment empty screen', async () => {
   vi.mocked(listenResourcePermitted).mockImplementation(vi.fn((_, callback) => callback(true)));

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -30,9 +30,9 @@ import type { IDisposable } from '/@api/disposable.js';
 
 import DeploymentsList from './DeploymentsList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
-vi.mock('/@/lib/kube/resources-listen');
-vi.mock('../kube/resource-permission');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
+vi.mock(import('/@/lib/kube/resources-listen'));
+vi.mock(import('/@/lib/kube/resource-permission'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteEmptyScreen.spec.ts
@@ -25,7 +25,7 @@ import { listenResourcePermitted } from '/@/lib/kube/resource-permission';
 
 import IngressRouteEmptyScreen from './IngressRouteEmptyScreen.svelte';
 
-vi.mock('../kube/resource-permission');
+vi.mock(import('/@/lib/kube/resource-permission'));
 
 test('Expect deployment empty screen', async () => {
   vi.mocked(listenResourcePermitted).mockImplementation(vi.fn((_, callback) => callback(true)));

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   EmbeddableCatalogExtensionList: vi.fn(),
 }));
 
-vi.mock('../extensions/EmbeddableCatalogExtensionList.svelte', () => ({
+vi.mock(import('/@/lib/extensions/EmbeddableCatalogExtensionList.svelte'), () => ({
   default: mocks.EmbeddableCatalogExtensionList,
 }));
 

--- a/packages/renderer/src/lib/kube/pods/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodEmptyScreen.spec.ts
@@ -25,7 +25,7 @@ import { listenResourcePermitted } from '/@/lib/kube/resource-permission';
 
 import PodEmptyScreen from './PodEmptyScreen.svelte';
 
-vi.mock('../resource-permission');
+vi.mock(import('/@/lib/kube/resource-permission'));
 
 test('Expect pod empty screen', async () => {
   vi.mocked(listenResourcePermitted).mockImplementation(vi.fn((_, callback) => callback(true)));

--- a/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
@@ -29,8 +29,8 @@ import type { IDisposable } from '/@api/disposable.js';
 
 import PodsList from './PodsList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
-vi.mock('../resources-listen');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
+vi.mock(import('/@/lib/kube/resources-listen'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/network/NetworkDetailsInspect.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkDetailsInspect.spec.ts
@@ -67,7 +67,7 @@ const network: NetworkInspectInfo = {
   },
 };
 
-vi.mock(import('../editor/MonacoEditor.svelte'));
+vi.mock(import('/@/lib/editor/MonacoEditor.svelte'));
 
 beforeEach(() => {
   vi.mocked(window.inspectNetwork).mockResolvedValue(network);

--- a/packages/renderer/src/lib/node/NodeEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/node/NodeEmptyScreen.spec.ts
@@ -30,8 +30,8 @@ const mocks = vi.hoisted(() => ({
   getCurrentKubeContextState: vi.fn(),
 }));
 
-vi.mock('../kube/resource-permission');
-vi.mock('../../stores/kubernetes-contexts-state', () => ({
+vi.mock(import('/@/lib/kube/resource-permission'));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), () => ({
   kubernetesCurrentContextState: {
     subscribe: mocks.subscribeMock,
   },

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -32,7 +32,7 @@ import type { V1Route } from '/@api/openshift-types';
 
 import DeployPodToKube from './DeployPodToKube.svelte';
 
-vi.mock(import('../editor/MonacoEditor.svelte'));
+vi.mock(import('/@/lib/editor/MonacoEditor.svelte'));
 
 // mock the router
 vi.mock('tinro', () => {

--- a/packages/renderer/src/lib/pvc/PVCEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCEmptyScreen.spec.ts
@@ -33,8 +33,8 @@ const mocks = vi.hoisted(() => ({
   eventsMocks: vi.fn(),
 }));
 
-vi.mock('../kube/resource-permission');
-vi.mock('../../stores/kubernetes-contexts-state', () => ({
+vi.mock(import('/@/lib/kube/resource-permission'));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), () => ({
   kubernetesCurrentContextState: {
     subscribe: mocks.subscribeMock,
   },

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -28,7 +28,7 @@ import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import { createNavigationKubernetesGroup } from './navigation-registry-kubernetes.svelte';
 
-vi.mock('../kubernetes-contexts-state', async () => {
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => {
   return {};
 });
 vi.mock('/@/stores/kubernetes-no-current-context');


### PR DESCRIPTION
### What does this PR do?
follow-up of https://github.com/podman-desktop/podman-desktop/pull/15483 reported by @axel7083 

https://github.com/podman-desktop/podman-desktop/pull/15483#discussion_r2648232602

replace relative path in vi.mock calls

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
