### PR TITLE
feat(container-registry): expose abortSignal option

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6123,6 +6123,30 @@ describe('kube play', () => {
 
     expect(PODMAN_PROVIDER.libpodApi.playKube).toHaveBeenCalledWith('dummy-file', KUBE_PLAY_OPT);
   });
+
+  test('abortSignal should be passed down to libpod', async () => {
+    const ABORT_SIGNAL = new AbortController().signal;
+    vi.mocked(PODMAN_PROVIDER.api.version).mockResolvedValue(PODMAN_531_VERSION);
+    vi.mocked(KubePlayContext.prototype.getBuildContexts).mockReturnValue([]); // mock no contexts
+
+    // set provider
+    containerRegistry.addInternalProvider('podman.podman', PODMAN_PROVIDER);
+
+    await containerRegistry.playKube(
+      'dummy-file',
+      {
+        name: PODMAN_PROVIDER.name,
+        endpoint: PODMAN_PROVIDER.connection.endpoint,
+      } as unknown as ProviderContainerConnectionInfo,
+      {
+        abortSignal: ABORT_SIGNAL,
+      },
+    );
+
+    expect(PODMAN_PROVIDER.libpodApi.playKube).toHaveBeenCalledWith('dummy-file', {
+      abortSignal: ABORT_SIGNAL,
+    });
+  });
 });
 
 const originalConsoleWarn = console.warn;

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2610,6 +2610,7 @@ export class ContainerProviderRegistry {
     options?: {
       build?: boolean;
       replace?: boolean;
+      abortSignal?: AbortSignal;
     },
   ): Promise<PlayKubeInfo> {
     const telemetryOptions: Record<string, unknown> = {


### PR DESCRIPTION
### What does this PR do?

Cherry pick of https://github.com/podman-desktop/podman-desktop/commit/80455b3eb41737a82591f8951dda4c13c2c29f02 from https://github.com/podman-desktop/podman-desktop/pull/15464

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15462

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

Full feature can be tested in https://github.com/podman-desktop/podman-desktop/pull/15464
