### PR TITLE
chore: move kube api from main package to api package so preload can import it as well

### DIFF
--- a/packages/api/src/kubernetes/kubernetes-generator-api.ts
+++ b/packages/api/src/kubernetes/kubernetes-generator-api.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,26 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
- ***********************************************************************/
-import type { KubernetesGeneratorSelector } from '../kubernetes/kube-generator-registry.js';
+ ********************************************************************/
 
 export interface KubernetesGeneratorInfo {
   id: string;
   name: string;
   types: KubernetesGeneratorSelector;
   default: boolean;
+}
+
+export type KubernetesGeneratorArgument = {
+  engineId: string;
+  containers?: string[];
+  pods?: string[];
+  compose?: string[];
+};
+
+export type KubernetesGeneratorSelector = KubernetesGeneratorType | ReadonlyArray<KubernetesGeneratorType>;
+
+export type KubernetesGeneratorType = 'Compose' | 'Pod' | 'Container';
+
+export interface GenerateKubeResult {
+  yaml: string;
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -49,15 +49,9 @@ import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import type { IpcMainInvokeEvent } from 'electron/main';
 import { Container } from 'inversify';
 
-import type { KubernetesGeneratorInfo } from '/@/plugin/api/KubernetesGeneratorInfo.js';
 import { ContainerfileParser } from '/@/plugin/containerfile-parser.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionWatcher } from '/@/plugin/extension/extension-watcher.js';
-import type {
-  GenerateKubeResult,
-  KubernetesGeneratorArgument,
-  KubernetesGeneratorSelector,
-} from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { LockedConfiguration } from '/@/plugin/locked-configuration.js';
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
@@ -101,6 +95,12 @@ import type { ImageFilesystemLayersUI } from '/@api/image-filesystem-layers.js';
 import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info.js';
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry.js';
+import type {
+  GenerateKubeResult,
+  KubernetesGeneratorArgument,
+  KubernetesGeneratorInfo,
+  KubernetesGeneratorSelector,
+} from '/@api/kubernetes/kubernetes-generator-api.js';
 import type { KubeContext } from '/@api/kubernetes-context.js';
 import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';

--- a/packages/main/src/plugin/kubernetes/kube-generator-registry.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kube-generator-registry.spec.ts
@@ -18,7 +18,8 @@
 
 import { expect, test, vi } from 'vitest';
 
-import type { KubernetesGeneratorSelector } from './kube-generator-registry.js';
+import type { KubernetesGeneratorSelector } from '/@api/kubernetes/kubernetes-generator-api.js';
+
 import { KubeGeneratorRegistry } from './kube-generator-registry.js';
 
 test('Creating KubeGeneratorRegistry and getting KubeGeneratorsInfos', async () => {

--- a/packages/main/src/plugin/kubernetes/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kubernetes/kube-generator-registry.ts
@@ -17,23 +17,14 @@
  ***********************************************************************/
 import { injectable } from 'inversify';
 
-import type { KubernetesGeneratorInfo } from '../api/KubernetesGeneratorInfo.js';
+import type {
+  GenerateKubeResult,
+  KubernetesGeneratorArgument,
+  KubernetesGeneratorInfo,
+  KubernetesGeneratorSelector,
+} from '/@api/kubernetes/kubernetes-generator-api.js';
+
 import { Disposable } from '../types/disposable.js';
-
-export type KubernetesGeneratorType = 'Compose' | 'Pod' | 'Container';
-
-export type KubernetesGeneratorSelector = KubernetesGeneratorType | ReadonlyArray<KubernetesGeneratorType>;
-
-export interface GenerateKubeResult {
-  yaml: string;
-}
-
-export type KubernetesGeneratorArgument = {
-  engineId: string;
-  containers?: string[];
-  pods?: string[];
-  compose?: string[];
-};
 
 export interface KubernetesGeneratorProvider {
   readonly name: string;

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -79,6 +79,12 @@ import type { ImageFilesystemLayersUI } from '/@api/image-filesystem-layers';
 import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info';
 import type { ImageInspectInfo } from '/@api/image-inspect-info';
 import type { ImageSearchOptions, ImageSearchResult, ImageTagsListOptions } from '/@api/image-registry';
+import type {
+  GenerateKubeResult,
+  KubernetesGeneratorArgument,
+  KubernetesGeneratorInfo,
+  KubernetesGeneratorSelector,
+} from '/@api/kubernetes/kubernetes-generator-api';
 import type { KubeContext } from '/@api/kubernetes-context';
 import type { ContextHealth } from '/@api/kubernetes-contexts-healths';
 import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
@@ -116,7 +122,6 @@ import type { WebviewInfo } from '/@api/webview-info';
 import type { ListOrganizerItem } from '../../api/src/list-organizer';
 import type { ApiSenderType } from '../../main/src/plugin/api';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
-import type { KubernetesGeneratorInfo } from '../../main/src/plugin/api/KubernetesGeneratorInfo';
 import type { AuthenticationProviderInfo } from '../../main/src/plugin/authentication';
 import type {
   ContainerCreateOptions as PodmanContainerCreateOptions,
@@ -124,11 +129,6 @@ import type {
 } from '../../main/src/plugin/dockerode/libpod-dockerode';
 import type { CatalogExtension } from '../../main/src/plugin/extension/catalog/extensions-catalog-api';
 import type { FeaturedExtension } from '../../main/src/plugin/featured/featured-api';
-import type {
-  GenerateKubeResult,
-  KubernetesGeneratorArgument,
-  KubernetesGeneratorSelector,
-} from '../../main/src/plugin/kubernetes/kube-generator-registry';
 import type { Guide } from '../../main/src/plugin/learning-center/learning-center-api';
 import type { ExtensionBanner, RecommendedRegistry } from '../../main/src/plugin/recommendations/recommendations-api';
 


### PR DESCRIPTION
### What does this PR do?
for now it was importing main using ../

but we should not import main from preload package

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/15485


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
