### PR TITLE
feat(ipc): expose cancellableTokenId in window#playKube

### DIFF
--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -404,6 +404,7 @@ export function initExposure(): void {
       options?: {
         build?: boolean;
         replace?: boolean;
+        cancellableTokenId?: number;
       },
     ): Promise<PlayKubeInfo> => {
       return ipcInvoke('container-provider-registry:playKube', relativeContainerfilePath, selectedProvider, options);


### PR DESCRIPTION
### What does this PR do?

Cherry pick of https://github.com/podman-desktop/podman-desktop/commit/73f0c77312f374ab1e7fc502c9998ac1792d54c8 from https://github.com/podman-desktop/podman-desktop/pull/15464

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15462

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

Full feature can be tested in https://github.com/podman-desktop/podman-desktop/pull/15464
