### PR TITLE
chore: move guide API from main to api packages so renderer/preload can use it

### DIFF
--- a/packages/api/src/learning-center/guide.ts
+++ b/packages/api/src/learning-center/guide.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/learning-center/learning-center.ts
+++ b/packages/main/src/plugin/learning-center/learning-center.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { Guide } from '/@api/learning-center/guide.js';
+
 import guidesJson from './guides.json' with { type: 'json' };
-import type { Guide } from './learning-center-api.js';
 
 export function downloadGuideList(): Guide[] {
   return guidesJson.guides;

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -93,6 +93,7 @@ import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forwar
 import type { ResourceCount } from '/@api/kubernetes-resource-count';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources';
 import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting';
+import type { Guide } from '/@api/learning-center/guide';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { Menu } from '/@api/menu.js';
 import { NavigationPage } from '/@api/navigation-page';
@@ -129,7 +130,6 @@ import type {
 } from '../../main/src/plugin/dockerode/libpod-dockerode';
 import type { CatalogExtension } from '../../main/src/plugin/extension/catalog/extensions-catalog-api';
 import type { FeaturedExtension } from '../../main/src/plugin/featured/featured-api';
-import type { Guide } from '../../main/src/plugin/learning-center/learning-center-api';
 import type { ExtensionBanner, RecommendedRegistry } from '../../main/src/plugin/recommendations/recommendations-api';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;

--- a/packages/renderer/src/lib/learning-center/GuideCard.svelte
+++ b/packages/renderer/src/lib/learning-center/GuideCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { Button } from '@podman-desktop/ui-svelte';
 
-import type { Guide } from '../../../../main/src/plugin/learning-center/learning-center-api';
+import type { Guide } from '/@api/learning-center/guide';
 
 interface Props {
   guide: Guide;

--- a/packages/renderer/src/lib/learning-center/LearningCenter.svelte
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.svelte
@@ -3,8 +3,8 @@ import { Carousel, Expandable } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
+import type { Guide } from '/@api/learning-center/guide';
 
-import type { Guide } from '../../../../main/src/plugin/learning-center/learning-center-api';
 import GuideCard from './GuideCard.svelte';
 
 let guides: Guide[] = $state([]);


### PR DESCRIPTION
### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361
and https://github.com/podman-desktop/podman-desktop/pull/15485 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
