### PR TITLE
chore: switched to Icon component instead of Fa

### DIFF
--- a/packages/renderer/src/lib/ui/LoadingIcon.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIcon.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
-import { Fa, type IconSize } from 'svelte-fa';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+import type { Component } from 'svelte';
+import type { IconSize } from 'svelte-fa';
 
 interface Props {
-  icon: IconDefinition;
+  icon: IconDefinition | Component | string;
   loadingWidthClass?: string;
   loadingHeightClass?: string;
   loading?: boolean;
   iconSize?: IconSize;
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 7e7363962a7 (chore: fixed linter)
 let {
   icon,
   loadingWidthClass = 'w-6',
@@ -21,16 +19,10 @@ let {
   loading = false,
   iconSize = undefined,
 }: Props = $props();
-<<<<<<< HEAD
-=======
-let { icon, loadingWidthClass = 'w-6', loadingHeightClass = 'h-6', loading = false, iconSize = undefined }: Props = $props();
->>>>>>> 3d6f8e545dc (refactor: migrated LoadingIcon component to svelte5)
-=======
->>>>>>> 7e7363962a7 (chore: fixed linter)
 </script>
 
 <div>
-  <Fa size={iconSize} icon={icon} />
+  <Icon size={iconSize} icon={icon} />
   <div
     aria-label="spinner"
     class="{loading

--- a/packages/renderer/src/lib/ui/LoadingIcon.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIcon.svelte
@@ -11,6 +11,9 @@ interface Props {
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 7e7363962a7 (chore: fixed linter)
 let {
   icon,
   loadingWidthClass = 'w-6',
@@ -18,9 +21,12 @@ let {
   loading = false,
   iconSize = undefined,
 }: Props = $props();
+<<<<<<< HEAD
 =======
 let { icon, loadingWidthClass = 'w-6', loadingHeightClass = 'h-6', loading = false, iconSize = undefined }: Props = $props();
 >>>>>>> 3d6f8e545dc (refactor: migrated LoadingIcon component to svelte5)
+=======
+>>>>>>> 7e7363962a7 (chore: fixed linter)
 </script>
 
 <div>

--- a/packages/renderer/src/lib/ui/LoadingIcon.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIcon.svelte
@@ -10,6 +10,7 @@ interface Props {
   iconSize?: IconSize;
 }
 
+<<<<<<< HEAD
 let {
   icon,
   loadingWidthClass = 'w-6',
@@ -17,6 +18,9 @@ let {
   loading = false,
   iconSize = undefined,
 }: Props = $props();
+=======
+let { icon, loadingWidthClass = 'w-6', loadingHeightClass = 'h-6', loading = false, iconSize = undefined }: Props = $props();
+>>>>>>> 3d6f8e545dc (refactor: migrated LoadingIcon component to svelte5)
 </script>
 
 <div>


### PR DESCRIPTION
### What does this PR do?
Migrates to Icon component instead of Fa component

### Screenshot / video of UI
N/A

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/15425

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
