### PR TITLE
fix: default proxy setting to disabled for better out-of-box experience

### DIFF
--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -103,7 +103,7 @@ export class Proxy {
           maximum: 2,
           minimum: 0,
           placeholder: 'System(0)/Manual(1)/Disabled(2)',
-          default: 0,
+          default: 2,
           hidden: true,
         },
       },


### PR DESCRIPTION
fix: default proxy setting to disabled for better out-of-box experience

### What does this PR do?

Change the default proxy setting from System (0) to Disabled (2) to prevent initialization failures caused by proxy configuration requirements when installing Podman via Podman Desktop, and improve user experience to achieve out-of-the-box usability.

### What issues does this PR fix or reference?

When first-time users install Podman via Podman Desktop, they can initialize it successfully without configuring a proxy. 
Fixes #15471

**Problem:**
- Default proxy setting is `System (0)`
- Podman Desktop initialization fails when the system proxy is configured but unavailable, or when no proxy is configured at all.
- Poor out-of-box experience for new users,

### How to test this PR?

#### Test Scenarios:

1. **Fresh install with no proxy configuration**
   - Install Podman Desktop with this change
   - Initialization should succeed immediately
   - No network configuration required

2. **Users who need proxy**
   - After installation, go to Settings → Proxy
   - Verify user can still choose:
     - `System (0)` - Use system proxy
     - `Manual (1)` - Configure custom proxy
     - `Disabled (2)` - No proxy (new default)

3. **Existing users with saved proxy settings**
   - Upgrade Podman Desktop with existing proxy configuration
   - Verify existing settings are preserved
   - No regression in functionality

### Code Changes:
- **File:** `packages/main/src/plugin/proxy.ts`
- **Line 71:** Changed `default: 0` to `default: 2`
- **Impact:** Only affects default value for new installations

### Impact Analysis:
| Aspect | Impact |
|--------|--------|
| New Users | ✅ Better out-of-box experience |
| Existing Users | ⚠️ No change (settings preserved) |
| Enterprise Users | ✅ Can still configure proxy |
| Backward Compatibility | ✅ Fully compatible |
| Performance | ⚠️ No impact |