### PR TITLE
feat(renderer): create empty experimental productized help menu

### DIFF
--- a/packages/renderer/src/lib/help/HelpActionsExperimental.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActionsExperimental.spec.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import HelpActionsExperimental from './HelpActionsExperimental.svelte';
+
+let toggleMenuCallback: () => void;
+
+describe('HelpActionsExperimental component', () => {
+  beforeAll(() => {
+    (window.events as unknown) = {
+      receive: vi.fn(),
+    };
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(window.events.receive).mockImplementation((channel: string, callback: () => void) => {
+      toggleMenuCallback = callback;
+      return {
+        dispose: (): void => {},
+      };
+    });
+  });
+
+  test('contains item with $title', async () => {
+    vi.mocked(window.events.receive).mockImplementation((channel: string, callback: () => void) => {
+      toggleMenuCallback = callback;
+      return {
+        dispose: (): void => {},
+      };
+    });
+    const { findByTitle } = render(HelpActionsExperimental);
+    toggleMenuCallback();
+    await vi.waitFor(async () => {
+      const items = await findByTitle('Help Menu Items');
+      expect(items).toBeVisible();
+    });
+  });
+});

--- a/packages/renderer/src/lib/help/HelpActionsExperimental.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActionsExperimental.spec.ts
@@ -43,12 +43,6 @@ describe('HelpActionsExperimental component', () => {
   });
 
   test('contains item with $title', async () => {
-    vi.mocked(window.events.receive).mockImplementation((channel: string, callback: () => void) => {
-      toggleMenuCallback = callback;
-      return {
-        dispose: (): void => {},
-      };
-    });
     const { findByTitle } = render(HelpActionsExperimental);
     toggleMenuCallback();
     await vi.waitFor(async () => {

--- a/packages/renderer/src/lib/help/HelpActionsExperimental.svelte
+++ b/packages/renderer/src/lib/help/HelpActionsExperimental.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+import HelpActionsItems from './HelpActionsItems.svelte';
+</script>
+
+<HelpActionsItems items={[]}/>


### PR DESCRIPTION
### What does this PR do?

This PR creates an empty experimental help menu that will be used to retrieve the items from the backend in other issues of the epic.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15421

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
