### PR TITLE
feat(renderer): link experimental help menu to preference feature 

### DIFF
--- a/packages/renderer/src/lib/help/HelpActions.svelte
+++ b/packages/renderer/src/lib/help/HelpActions.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
+import HelpActionsExperimental from '/@/lib/help/HelpActionsExperimental.svelte';
 import { Items } from '/@/lib/help/HelpItems';
 
 import HelpActionsItems from './HelpActionsItems.svelte';
+
+const isExperimentalHelpEnabled = $derived(
+  await window.isExperimentalConfigurationEnabled('helpMenu.useProductConfig'),
+);
 </script>
 
-<HelpActionsItems items={Items}/>
+{#if isExperimentalHelpEnabled}
+  <HelpActionsExperimental />
+{:else}
+  <HelpActionsItems items={Items}/>
+{/if}


### PR DESCRIPTION
### What does this PR do?

This PR links the preference feature that enables the productized help menu to display it.

### Screenshot / video of UI

No change expected here:
<img width="300" height="340" alt="Screenshot 2026-01-07 at 16 18 02" src="https://github.com/user-attachments/assets/bb9b56cc-7fab-4c52-bba3-25065a4066f4" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15409

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<img width="1159" height="712" alt="Screenshot 2025-12-29 at 12 19 41" src="https://github.com/user-attachments/assets/c56db642-474c-4545-90d1-d0fe8a9b79b9" />

Refresh Podman Desktop and when you open the help menu.

✔️  Check that there is no change with the current help menu

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
