### PR TITLE
test(renderer): remove duplicated mock already in beforeEach

### DIFF
--- a/packages/renderer/src/lib/help/HelpActions.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActions.spec.ts
@@ -44,12 +44,6 @@ describe('HelpActions component', () => {
   });
 
   test.each(Items)('contains item with $title', async ({ title, tooltip }) => {
-    vi.mocked(window.events.receive).mockImplementation((channel: string, callback: () => void) => {
-      toggleMenuCallback = callback;
-      return {
-        dispose: (): void => {},
-      };
-    });
     const ha = render(HelpActions);
     toggleMenuCallback();
     await vi.waitFor(async () => {

--- a/packages/renderer/src/lib/help/HelpActionsItems.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActionsItems.spec.ts
@@ -50,12 +50,6 @@ describe('HelpActionsItems component', () => {
   });
 
   test('simulate clicking outside the menu closes it', async () => {
-    vi.mocked(window.events.receive).mockImplementation((channel: string, callback: () => void) => {
-      toggleMenuCallback = callback;
-      return {
-        dispose: (): void => {},
-      };
-    });
     const ha = render(HelpActionsItems, { items: Items });
 
     toggleMenuCallback();
@@ -97,12 +91,6 @@ describe('HelpActionsItems component', () => {
   });
 
   test.each(Items)('contains item with $title', async ({ title, tooltip }) => {
-    vi.mocked(window.events.receive).mockImplementation((channel: string, callback: () => void) => {
-      toggleMenuCallback = callback;
-      return {
-        dispose: (): void => {},
-      };
-    });
     const ha = render(HelpActionsItems, { items: Items });
     toggleMenuCallback();
     await vi.waitFor(async () => {


### PR DESCRIPTION
### What does this PR do?

This PR changes a bit two tests that have the mock twice: in the beforeEach, and at the beginning of the test.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

This was noticed while working on https://github.com/podman-desktop/podman-desktop/issues/15281

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
