### PR TITLE
refactor(help-menu): expose interfaces in api to be used by backend

### DIFF
--- a/packages/api/src/help-menu.ts
+++ b/packages/api/src/help-menu.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export enum ActionKind {
+  LINK,
+  COMMAND,
+}
+
+export interface ItemAction {
+  kind: ActionKind;
+  parameter: string;
+}
+
+export interface ItemInfo {
+  title: string;
+  tooltip?: string;
+  icon: string;
+  enabled: boolean;
+  action?: ItemAction;
+}

--- a/packages/renderer/src/lib/help/HelpActionsItems.svelte
+++ b/packages/renderer/src/lib/help/HelpActionsItems.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
 
-import { ActionKind, type ItemAction, type ItemInfo } from './HelpItems';
+import { ActionKind, type ItemAction, type ItemInfo } from '/@api/help-menu';
+
 import HelpMenu from './HelpMenu.svelte';
 
 interface Props {

--- a/packages/renderer/src/lib/help/HelpItems.ts
+++ b/packages/renderer/src/lib/help/HelpItems.ts
@@ -16,25 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ActionKind, type ItemInfo } from '/@api/help-menu';
+
 import { homepage, repository } from '../../../../../package.json';
-
-export enum ActionKind {
-  LINK,
-  COMMAND,
-}
-
-export interface ItemAction {
-  kind: ActionKind;
-  parameter: string;
-}
-
-export interface ItemInfo {
-  title: string;
-  tooltip?: string;
-  icon: string;
-  enabled: boolean;
-  action?: ItemAction;
-}
 
 export const Items: readonly ItemInfo[] = [
   {


### PR DESCRIPTION
### What does this PR do?

Interface definitions ItemAction and ItemInfo (and enum ActionKind) are only available in the renderer. This PR consists of moving them to the api package, so they can be reused my the main package to expose the help menu items with the correct types.


Needs a rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/15513 is merged

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #15508

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
