### PR TITLE
feat(ui): allow FontAwesome brands in Icon component

### DIFF
--- a/packages/ui/src/lib/icons/Icon.spec.ts
+++ b/packages/ui/src/lib/icons/Icon.spec.ts
@@ -107,6 +107,14 @@ describe('class icon', () => {
     const img = getByTitle('test title');
     expect(img).toBeInTheDocument();
   });
+
+  test('brand icon should be created', () => {
+    render(Icon, { icon: 'fab fa-discord' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('fab fa-discord');
+  });
 });
 
 describe('component icon', () => {

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -24,9 +24,9 @@ const IconComponent = icon;
         <Fa {icon} {size} class={className} {title}/>
     {/if}
 {:else if typeof icon === 'string'}
-    <!-- fas fa- and far fa- for Font awesome icons -->
+    <!-- fas fa- and far fa- and fab fa- for Font awesome icons -->
     <!-- -icon for extension icons e.g. 'kind-icon' -->
-    {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.endsWith('-icon')}
+    {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.startsWith('fab fa-') || icon.endsWith('-icon')}
         <i class={`${icon} ${size} ${className}`} {role} {title}></i>
     {:else if icon.startsWith('data:image/')}
         <img src={icon} alt={title ?? ''} {title} {role} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />


### PR DESCRIPTION
### What does this PR do?

When displaying a Font Awesome icon, it is not possible right now to display a brand icon. The only prefix allowed are fas and far, and not fab.

For the productized help menu, we need to declare the Discord and other brand icons in the product.json file, so this PR adds this prefix to the list.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15510

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
