### PR TITLE
feat(main/help-menu): expose a method to get the items (empty for now) 

### DIFF
--- a/packages/main/src/plugin/help-menu/help-menu.spec.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.spec.ts
@@ -22,7 +22,7 @@ import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js'
 
 import { HelpMenu } from './help-menu.js';
 
-const ipcHandle = vi.fn() as IPCHandle;
+const ipcHandle: IPCHandle = vi.fn();
 
 const registerConfigurationsMock = vi.fn();
 const configurationRegistryMock = {

--- a/packages/main/src/plugin/help-menu/help-menu.spec.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.spec.ts
@@ -17,9 +17,12 @@
  ***********************************************************************/
 import { expect, test, vi } from 'vitest';
 
+import type { IPCHandle } from '/@/plugin/api.js';
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 
 import { HelpMenu } from './help-menu.js';
+
+const ipcHandle = vi.fn() as IPCHandle;
 
 const registerConfigurationsMock = vi.fn();
 const configurationRegistryMock = {
@@ -29,7 +32,7 @@ const configurationRegistryMock = {
 const productConfigPropertyName = 'helpMenu.useProductConfig';
 test('should register a configuration', async () => {
   vi.stubEnv('DEV', true);
-  const helpMenu = new HelpMenu(configurationRegistryMock);
+  const helpMenu = new HelpMenu(configurationRegistryMock, ipcHandle);
   helpMenu.init();
 
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
@@ -50,11 +53,18 @@ test('should register a configuration', async () => {
 test('Undefined should be default if not in dev env', () => {
   vi.resetAllMocks();
   vi.stubEnv('DEV', false);
-  const helpMenu = new HelpMenu(configurationRegistryMock);
+  const helpMenu = new HelpMenu(configurationRegistryMock, ipcHandle);
   helpMenu.init();
 
   expect(configurationRegistryMock.registerConfigurations).toBeCalled();
   const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0][0];
 
   expect(configurationNode?.properties?.[productConfigPropertyName]?.default).toBe(undefined);
+});
+
+test('should get the items', async () => {
+  const helpMenu = new HelpMenu(configurationRegistryMock, ipcHandle);
+  helpMenu.init();
+
+  expect(helpMenu.getItems()).toStrictEqual([]);
 });

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -18,11 +18,17 @@
 
 import { inject, injectable } from 'inversify';
 
+import { IPCHandle } from '/@/plugin/api.js';
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+import { ItemInfo } from '/@api/help-menu.js';
 
 @injectable()
 export class HelpMenu {
-  constructor(@inject(IConfigurationRegistry) private configurationRegistry: IConfigurationRegistry) {}
+  constructor(
+    @inject(IConfigurationRegistry) private configurationRegistry: IConfigurationRegistry,
+    @inject(IPCHandle)
+    private readonly ipcHandle: IPCHandle,
+  ) {}
 
   init(): void {
     const helpMenuConfiguration: IConfigurationNode = {
@@ -40,5 +46,13 @@ export class HelpMenu {
     };
 
     this.configurationRegistry.registerConfigurations([helpMenuConfiguration]);
+
+    this.ipcHandle('help-menu:getItems', async (): Promise<ItemInfo[]> => {
+      return this.getItems();
+    });
+  }
+
+  getItems(): ItemInfo[] {
+    return [];
   }
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -74,6 +74,7 @@ import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development
 import type { ExtensionInfo } from '/@api/extension-info';
 import type { FeaturedExtension } from '/@api/featured/featured-api';
 import type { FeedbackProperties, GitHubIssue } from '/@api/feedback';
+import type { ItemInfo } from '/@api/help-menu';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
 import type { ImageCheckerInfo } from '/@api/image-checker-info';
@@ -2625,6 +2626,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('containerfileGetInfo', async (path: string): Promise<ContainerfileInfo> => {
     return ipcInvoke('containerfile:getInfo', path);
+  });
+
+  contextBridge.exposeInMainWorld('helpMenuGetItems', async (): Promise<ItemInfo[]> => {
+    return ipcInvoke('help-menu:getItems');
   });
 
   contextBridge.exposeInMainWorld('contextCollectAllValues', async (): Promise<Record<string, unknown>> => {


### PR DESCRIPTION
### What does this PR do?

This PR exposes a new method to get the items of the help menu in the renderer. For now it returns an empty list but in another issue it will be populated with `product.json` content.

Needs a rebase after:

- https://github.com/podman-desktop/podman-desktop/pull/15509 is merged 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15410

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
