### PR TITLE
chore(docs): add codesign instructions for macOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,16 @@ This will create a binary according to your local system and output it to the `d
 
 > **_macOS NOTE:_** On macOS the `dist/` folder will contain folders for `arm64` and `universal` `.app` files. Ignore these and use the `.app` file in the `dist/mac/` folder for testing.
 
+> **_macOS CODE SIGNING:_** When testing the compiled binary on macOS, you must ad-hoc sign the application before launching it. Without signing, macOS will terminate the app with a `Code Signature Invalid` error. Run the following command after compiling: 
+>
+> ```sh
+> # Compile
+> pnpm compile:current
+> 
+> # Sign the binary
+> codesign --force --deep --sign - "dist/mac-arm64/Podman Desktop.app"
+> ```
+
 ## Submitting Pull Requests
 
 ### Process


### PR DESCRIPTION
chore(docs): add codesign instructions for macOS

### What does this PR do?

When testing a compiled binary on macOS, it is a special case as there
is validation against the Electron binary before launching.

If you are using `pnpm compile:current`, you should be able to run the
app after launch.

Unfortunatley this requires:

```sh
codesign --force --deep --sign - "dist/mac-arm64/Podman Desktop.app"
```

To be ran.

This adds those instructions to the documentation.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Be on macOS
2. `pnpm compile:current`
3. Try to launch the binary (`dist/mac-arm64/Podman Desktop.app`)
4. Get error. Close app.
5. `codesign --force --deep --sign - "dist/mac-arm64/Podman
   Desktop.app"`
6. No more error when launching.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
