### PR TITLE
chore(podman-kube): Update form on kube play page

### DIFF
--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -283,12 +283,12 @@ test('expect workflow selection boxes have the correct selection borders', async
   setup();
   render(KubePlayYAML, {});
 
-  const customOption = screen.getByText('Create file from scratch');
+  const customOption = screen.getByText('Create a file from scratch');
   expect(customOption).toBeInTheDocument();
   expect(customOption.parentElement?.parentElement).not.toHaveClass('border-[var(--pd-content-card-border-selected)]');
   expect(customOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border)]');
 
-  // now switch selection to Create file from scratch
+  // now switch selection to Create a file from scratch
   await userEvent.click(customOption);
 
   expect(customOption.parentElement?.parentElement).toHaveClass('border-[var(--pd-content-card-border-selected)]');
@@ -373,28 +373,28 @@ describe('Custom YAML mode', () => {
     render(KubePlayYAML, {});
 
     // Initially, Monaco editor should not be visible
-    expect(screen.queryByLabelText('Custom Kubernetes YAML Content')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Custom Kubernetes YAML content')).not.toBeInTheDocument();
 
-    // Click on "Create file from scratch" option
-    const customOption = screen.getByText('Create file from scratch');
+    // Click on "Create a file from scratch" option
+    const customOption = screen.getByText('Create a file from scratch');
     await userEvent.click(customOption);
 
     // Now Monaco editor should be visible
-    expect(screen.getByText('Custom Kubernetes YAML Content')).toBeInTheDocument();
+    expect(screen.getByText('Custom Kubernetes YAML content')).toBeInTheDocument();
   });
 
   test('play button is disabled when no content provided', async () => {
     setup();
     render(KubePlayYAML, {});
 
-    const customOption = screen.getByText('Create file from scratch');
+    const customOption = screen.getByText('Create a file from scratch');
     await userEvent.click(customOption);
 
-    const playButton = screen.getByRole('button', { name: 'Play Custom YAML' });
+    const playButton = screen.getByRole('button', { name: 'Play custom YAML' });
     expect(playButton).toBeDisabled();
   });
 
-  test('button text changes to "Play Custom YAML"', async () => {
+  test('button text changes to "Play custom YAML"', async () => {
     setup();
     render(KubePlayYAML, {});
 
@@ -402,11 +402,11 @@ describe('Custom YAML mode', () => {
     expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
 
     // Switch to custom mode
-    const customOption = screen.getByText('Create file from scratch');
+    const customOption = screen.getByText('Create a file from scratch');
     await userEvent.click(customOption);
 
     // Button text should change
-    expect(screen.getByRole('button', { name: 'Play Custom YAML' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Play custom YAML' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Play' })).not.toBeInTheDocument();
   });
 
@@ -415,14 +415,14 @@ describe('Custom YAML mode', () => {
     render(KubePlayYAML, {});
 
     // Switch to custom mode
-    const customOption = screen.getByText('Create file from scratch');
+    const customOption = screen.getByText('Create a file from scratch');
     await userEvent.click(customOption);
 
     // Monaco editor should be visible
-    expect(screen.getByText('Custom Kubernetes YAML Content')).toBeInTheDocument();
+    expect(screen.getByText('Custom Kubernetes YAML content')).toBeInTheDocument();
 
     // Monaco editor should be hidden again
-    expect(screen.queryByLabelText('Custom Kubernetes YAML Content')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Custom Kubernetes YAML content')).not.toBeInTheDocument();
   });
 });
 
@@ -453,7 +453,7 @@ test('file mode: does not attempt temp file cleanup', async () => {
   expect(window.removeTempFile).not.toHaveBeenCalled();
 });
 
-test('custom YAML mode: button text changes to "Play Custom YAML"', async () => {
+test('custom YAML mode: button text changes to "Play custom YAML"', async () => {
   setup();
   render(KubePlayYAML, {});
 
@@ -461,11 +461,11 @@ test('custom YAML mode: button text changes to "Play Custom YAML"', async () => 
   expect(screen.getByRole('button', { name: 'Play' })).toBeInTheDocument();
 
   // Switch to custom mode
-  const customOption = screen.getByText('Create file from scratch');
+  const customOption = screen.getByText('Create a file from scratch');
   await userEvent.click(customOption);
 
   // Button text should change
-  expect(screen.getByRole('button', { name: 'Play Custom YAML' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Play custom YAML' })).toBeInTheDocument();
   expect(screen.queryByRole('button', { name: 'Play' })).not.toBeInTheDocument();
 });
 
@@ -474,14 +474,14 @@ test('switching between modes clears custom content', async () => {
   render(KubePlayYAML, {});
 
   // Switch to custom mode
-  const customOption = screen.getByText('Create file from scratch');
+  const customOption = screen.getByText('Create a file from scratch');
   await userEvent.click(customOption);
 
   // Monaco editor should be visible
-  expect(screen.getByText('Custom Kubernetes YAML Content')).toBeInTheDocument();
+  expect(screen.getByText('Custom Kubernetes YAML content')).toBeInTheDocument();
 
   // Monaco editor should be hidden again
-  expect(screen.queryByLabelText('Custom Kubernetes YAML Content')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Custom Kubernetes YAML content')).not.toBeInTheDocument();
 });
 
 test('validation: play button disabled when no file selected in file mode', async () => {

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -256,7 +256,7 @@ function toggle(choice: 'podman' | 'custom'): void {
 
         <button
           class="border-2 rounded-md p-5 cursor-pointer bg-[var(--pd-content-card-inset-bg)]"
-          aria-label="Create file from scratch"
+          aria-label="Create a file from scratch"
           aria-pressed={userChoice === 'custom' ? 'true' : 'false'}
           class:border-[var(--pd-content-card-border-selected)]={userChoice === 'custom'}
           class:border-[var(--pd-content-card-border)]={userChoice !== 'custom'}
@@ -272,7 +272,7 @@ function toggle(choice: 'podman' | 'custom'): void {
               class="pl-2"
               class:text-[var(--pd-content-card-text)]={userChoice === 'custom'}
               class:text-[var(--pd-input-field-disabled-text)]={userChoice !== 'custom'}>
-              Create file from scratch
+              Create a file from scratch
             </div>
           </div>
         </button>
@@ -282,7 +282,7 @@ function toggle(choice: 'podman' | 'custom'): void {
       {#if userChoice === 'custom'}
         <div class="space-y-3">
           <label for="custom-yaml-editor" class="block text-base font-bold text-[var(--pd-content-card-header-text)]">
-            Custom Kubernetes YAML Content
+            Custom Kubernetes YAML content
           </label>
           <div id="custom-yaml-editor" class="h-[400px] border">
             <MonacoEditor
@@ -315,7 +315,7 @@ function toggle(choice: 'podman' | 'custom'): void {
             class="w-full"
             inProgress={runStarted}
             icon={KubePlayIcon}>
-            {userChoice === 'custom' ? 'Play Custom YAML' : 'Play'}
+            {userChoice === 'custom' ? 'Play custom YAML' : 'Play'}
           </Button>
         {:else}
           <Button
@@ -328,7 +328,7 @@ function toggle(choice: 'podman' | 'custom'): void {
       {/if}
       {#if runStarted}
         <div class="text-[var(--pd-content-card-text)] text-sm">
-          Please wait during the Play Kube and do not change screen. This process may take a few minutes to complete...
+          Please do not change screens while Play Kube executes. This process may take a few minutes to complete...
         </div>
       {/if}
 

--- a/tests/playwright/src/model/pages/podman-kube-play-page.ts
+++ b/tests/playwright/src/model/pages/podman-kube-play-page.ts
@@ -43,7 +43,7 @@ export class PodmanKubePlayPage extends BasePage {
     this.selectYamlButton = page.getByRole('button', {
       name: 'Podman Container Engine Runtime',
     });
-    this.createYamlFromScratchButton = page.getByRole('button', { name: 'Create file from scratch' });
+    this.createYamlFromScratchButton = page.getByRole('button', { name: 'Create a file from scratch' });
     this.customYamlEditor = page.locator('#custom-yaml-editor');
     this.playButton = page.getByRole('button', { name: 'Play' });
     this.doneButton = page.getByRole('button', { name: 'Done' });


### PR DESCRIPTION
chore(podman-kube): Update form on kube play page

### What does this PR do?

Noticed a few minor things!

* Should be "Create a"
* Buttons typically aren't titled (So should be `Play custom YAML`
  instead of `Play Custom YAML`)
* Updates terminology when excuting / building a bit better

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A, found when reviewing

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
