### PR TITLE
fix(cli-tool-registry): trigger on update and uninstall

### DIFF
--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -485,6 +485,48 @@ suite('cli module', () => {
       // the onDidCliToolsChange should have been fired twice (creation, deletion)
       expect(cliToolsUpdateNumbers).equals(2);
     });
+
+    test('onDidCliToolsChange should be fired when version is updated', async () => {
+      const cliToolsChangeListener = vi.fn();
+      cliToolRegistry.onDidCliToolsChange(cliToolsChangeListener);
+
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      // should have fired once for creation
+      expect(cliToolsChangeListener).toHaveBeenCalledOnce();
+
+      (newCliTool as CliToolImpl).updateVersion({ version: '1.2.3' });
+
+      // should have fired again for update
+      expect(cliToolsChangeListener).toHaveBeenCalledTimes(2);
+      expect(apiSender.send).toBeCalledWith('cli-tool-change', newCliTool.id);
+    });
+
+    test('onDidCliToolsChange should be fired when tool is uninstalled', async () => {
+      const cliToolsChangeListener = vi.fn();
+      cliToolRegistry.onDidCliToolsChange(cliToolsChangeListener);
+
+      const options: CliToolOptions = {
+        name: 'tool-name',
+        displayName: 'tool-display-name',
+        markdownDescription: 'markdown description',
+        images: {},
+      };
+      const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
+      // should have fired once for creation
+      expect(cliToolsChangeListener).toHaveBeenCalledOnce();
+
+      (newCliTool as CliToolImpl).uninstall();
+
+      // should have fired again for uninstall
+      expect(cliToolsChangeListener).toHaveBeenCalledTimes(2);
+      expect(apiSender.send).toBeCalledWith('cli-tool-change', newCliTool.id);
+    });
   });
 
   test('check conversion from cliTool to cliToolInfo is performed well', async () => {

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -51,8 +51,14 @@ export class CliToolRegistry {
     this.cliTools.set(cliTool.id, cliTool);
     this.apiSender.send('cli-tool-create');
     this._onDidCliToolsChange.fire();
-    cliTool.onDidUpdateVersion(() => this.apiSender.send('cli-tool-change', cliTool.id));
-    cliTool.onDidUninstall(() => this.apiSender.send('cli-tool-change', cliTool.id));
+    cliTool.onDidUpdateVersion(() => {
+      this._onDidCliToolsChange.fire();
+      this.apiSender.send('cli-tool-change', cliTool.id);
+    });
+    cliTool.onDidUninstall(() => {
+      this._onDidCliToolsChange.fire();
+      this.apiSender.send('cli-tool-change', cliTool.id);
+    });
     return cliTool;
   }
 


### PR DESCRIPTION
### What does this PR do?

Currently and according to the documentation of the extension-api on cli namespace, the onDidChange is suppose to be triggered when **installed** and **unisntalled** but it is only when registered and unregistered, which are not the same idea. An extension could uninstall a binary, and any listneers would not be notified. 

https://github.com/podman-desktop/podman-desktop/blob/0294cfae423825bc1d5dfc802870a72a71733884/packages/extension-api/src/extension-api.d.ts#L4815-L4819

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/13926

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
