### PR TITLE
feat(renderer/help-menu): get items from backend for experimental 

### DIFF
--- a/packages/renderer/src/lib/help/HelpActionsExperimental.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActionsExperimental.spec.ts
@@ -34,6 +34,7 @@ describe('HelpActionsExperimental component', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(window.helpMenuGetItems).mockResolvedValue([]);
     vi.mocked(window.events.receive).mockImplementation((channel: string, callback: () => void) => {
       toggleMenuCallback = callback;
       return {
@@ -44,6 +45,7 @@ describe('HelpActionsExperimental component', () => {
 
   test('contains item with $title', async () => {
     const { findByTitle } = render(HelpActionsExperimental);
+    await vi.waitFor(() => expect(toggleMenuCallback).toBeDefined());
     toggleMenuCallback();
     await vi.waitFor(async () => {
       const items = await findByTitle('Help Menu Items');

--- a/packages/renderer/src/lib/help/HelpActionsExperimental.svelte
+++ b/packages/renderer/src/lib/help/HelpActionsExperimental.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import HelpActionsItems from './HelpActionsItems.svelte';
+
+const items = $derived(await window.helpMenuGetItems());
 </script>
 
-<HelpActionsItems items={[]}/>
+<HelpActionsItems items={items}/>


### PR DESCRIPTION
### What does this PR do?

This PR reads the items provided by the backend for the help menu in its experimental productized version. For now the items list is empty and the experimental menu is not displayed.

Needs a rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/15514 is merged

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15411

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
