### PR TITLE
feat(product/help-menu): add help menu items to product definition

### DIFF
--- a/packages/main/src/plugin/help-menu/help-menu.spec.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.spec.ts
@@ -66,5 +66,67 @@ test('should get the items', async () => {
   const helpMenu = new HelpMenu(configurationRegistryMock, ipcHandle);
   helpMenu.init();
 
-  expect(helpMenu.getItems()).toStrictEqual([]);
+  expect(helpMenu.getItems()).toStrictEqual([
+    {
+      action: {
+        kind: 'Link',
+        parameter: 'https://www.podman-desktop.io/docs/intro',
+      },
+      enabled: true,
+      icon: 'fas fa-external-link-alt',
+      title: 'Getting Started',
+    },
+    {
+      action: {
+        kind: 'Command',
+        parameter: 'troubleshooting',
+      },
+      enabled: true,
+      icon: 'fas fa-lightbulb',
+      title: 'Troubleshooting',
+    },
+    {
+      action: {
+        kind: 'Link',
+        parameter: 'https://github.com/podman-desktop/podman-desktop/issues/new/choose',
+      },
+      enabled: true,
+      icon: 'fas fa-exclamation-triangle',
+      title: 'Report a Bug',
+    },
+    {
+      action: {
+        kind: 'Command',
+        parameter: 'feedback',
+      },
+      enabled: true,
+      icon: 'far fa-comment',
+      title: 'Share Your Feedback',
+    },
+    {
+      enabled: false,
+      icon: 'fas fa-list-ul',
+      title: 'Community',
+    },
+    {
+      action: {
+        kind: 'Link',
+        parameter: 'https://discord.com/invite/x5GzFF6QH4',
+      },
+      enabled: true,
+      icon: 'fab fa-discord',
+      title: '#podman-desktop',
+      tooltip: 'Join Discord #podman-desktop channel',
+    },
+    {
+      action: {
+        kind: 'Link',
+        parameter: 'https://slack.k8s.io',
+      },
+      enabled: true,
+      icon: 'fab fa-slack',
+      title: '#podman-desktop',
+      tooltip: 'Join Slack #podman-desktop channel',
+    },
+  ]);
 });

--- a/packages/main/src/plugin/help-menu/help-menu.spec.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.spec.ts
@@ -15,6 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+
 import { expect, test, vi } from 'vitest';
 
 import type { IPCHandle } from '/@/plugin/api.js';
@@ -66,67 +67,23 @@ test('should get the items', async () => {
   const helpMenu = new HelpMenu(configurationRegistryMock, ipcHandle);
   helpMenu.init();
 
-  expect(helpMenu.getItems()).toStrictEqual([
-    {
-      action: {
-        kind: 'Link',
-        parameter: 'https://www.podman-desktop.io/docs/intro',
-      },
-      enabled: true,
-      icon: 'fas fa-external-link-alt',
-      title: 'Getting Started',
-    },
-    {
-      action: {
-        kind: 'Command',
-        parameter: 'troubleshooting',
-      },
-      enabled: true,
-      icon: 'fas fa-lightbulb',
-      title: 'Troubleshooting',
-    },
-    {
-      action: {
-        kind: 'Link',
-        parameter: 'https://github.com/podman-desktop/podman-desktop/issues/new/choose',
-      },
-      enabled: true,
-      icon: 'fas fa-exclamation-triangle',
-      title: 'Report a Bug',
-    },
-    {
-      action: {
-        kind: 'Command',
-        parameter: 'feedback',
-      },
-      enabled: true,
-      icon: 'far fa-comment',
-      title: 'Share Your Feedback',
-    },
-    {
-      enabled: false,
-      icon: 'fas fa-list-ul',
-      title: 'Community',
-    },
-    {
-      action: {
-        kind: 'Link',
-        parameter: 'https://discord.com/invite/x5GzFF6QH4',
-      },
-      enabled: true,
-      icon: 'fab fa-discord',
-      title: '#podman-desktop',
-      tooltip: 'Join Discord #podman-desktop channel',
-    },
-    {
-      action: {
-        kind: 'Link',
-        parameter: 'https://slack.k8s.io',
-      },
-      enabled: true,
-      icon: 'fab fa-slack',
-      title: '#podman-desktop',
-      tooltip: 'Join Slack #podman-desktop channel',
-    },
-  ]);
+  const items = helpMenu.getItems();
+
+  expect(items).not.toHaveLength(0);
+
+  items.forEach(item => {
+    expect(item.enabled).toBeDefined();
+    expect(item.enabled).toBeTypeOf('boolean');
+    if (item.action) {
+      expect(item.action.kind).toBeDefined();
+      expect(item.action.kind).toBeTypeOf('number');
+
+      expect(item.action.parameter).toBeDefined();
+      expect(item.action.parameter).toBeTypeOf('string');
+    }
+    expect(item.icon).toBeDefined();
+    expect(item.icon).toBeTypeOf('string');
+    expect(item.title).toBeDefined();
+    expect(item.title).toBeTypeOf('string');
+  });
 });

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -55,20 +55,27 @@ export class HelpMenu {
 
   getItems(): ItemInfo[] {
     return product.helpMenu.items.map(item => {
-      const { action, ...tempItem } = item;
-      const itemInfo: ItemInfo = tempItem;
-      if (action?.command) {
-        itemInfo.action = {
-          kind: ActionKind.COMMAND,
-          parameter: action.command,
+      const baseItem = { icon: item.icon, title: item.title, tooltip: item.tooltip };
+      if (item.command) {
+        return {
+          ...baseItem,
+          action: {
+            kind: ActionKind.COMMAND,
+            parameter: item.command,
+          },
+          enabled: true,
         };
-      } else if (action?.link) {
-        itemInfo.action = {
-          kind: ActionKind.LINK,
-          parameter: action.link,
+      } else if (item.link) {
+        return {
+          ...baseItem,
+          action: {
+            kind: ActionKind.LINK,
+            parameter: item.link,
+          },
+          enabled: true,
         };
       }
-      return itemInfo;
+      return { ...baseItem, enabled: false };
     });
   }
 }

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -20,7 +20,8 @@ import { inject, injectable } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { ItemInfo } from '/@api/help-menu.js';
+import { ActionKind, ItemInfo } from '/@api/help-menu.js';
+import product from '/@product.json' with { type: 'json' };
 
 @injectable()
 export class HelpMenu {
@@ -53,6 +54,21 @@ export class HelpMenu {
   }
 
   getItems(): ItemInfo[] {
-    return [];
+    return product.helpMenu.items.map(item => {
+      const { action, ...tempItem } = item;
+      const itemInfo: ItemInfo = tempItem;
+      if (action?.command) {
+        itemInfo.action = {
+          kind: ActionKind.COMMAND,
+          parameter: action.command,
+        };
+      } else if (action?.link) {
+        itemInfo.action = {
+          kind: ActionKind.LINK,
+          parameter: action.link,
+        };
+      }
+      return itemInfo;
+    });
   }
 }

--- a/product.json
+++ b/product.json
@@ -19,5 +19,64 @@
   },
   "extensions": {
     "remote": []
+  },
+  "helpMenu": {
+    "items": [
+      {
+        "title": "Getting Started",
+        "icon": "fas fa-external-link-alt",
+        "enabled": true,
+        "action": {
+          "link": "https://www.podman-desktop.io/docs/intro"
+        }
+      },
+      {
+        "title": "Troubleshooting",
+        "icon": "fas fa-lightbulb",
+        "enabled": true,
+        "action": {
+          "command": "troubleshooting"
+        }
+      },
+      {
+        "title": "Report a Bug",
+        "icon": "fas fa-exclamation-triangle",
+        "enabled": true,
+        "action": {
+          "link": "https://github.com/podman-desktop/podman-desktop/issues/new/choose"
+        }
+      },
+      {
+        "title": "Share Your Feedback",
+        "icon": "far fa-comment",
+        "enabled": true,
+        "action": {
+          "command": "feedback"
+        }
+      },
+      {
+        "title": "Community",
+        "icon": "fas fa-list-ul",
+        "enabled": false
+      },
+      {
+        "title": "#podman-desktop",
+        "tooltip": "Join Discord #podman-desktop channel",
+        "icon": "fab fa-discord",
+        "enabled": true,
+        "action": {
+          "link": "https://discord.com/invite/x5GzFF6QH4"
+        }
+      },
+      {
+        "title": "#podman-desktop",
+        "tooltip": "Join Slack #podman-desktop channel",
+        "icon": "fab fa-slack",
+        "enabled": true,
+        "action": {
+          "link": "https://slack.k8s.io"
+        }
+      }
+    ]
   }
 }

--- a/product.json
+++ b/product.json
@@ -25,57 +25,38 @@
       {
         "title": "Getting Started",
         "icon": "fas fa-external-link-alt",
-        "enabled": true,
-        "action": {
-          "link": "https://www.podman-desktop.io/docs/intro"
-        }
+        "link": "https://www.podman-desktop.io/docs/intro"
       },
       {
         "title": "Troubleshooting",
         "icon": "fas fa-lightbulb",
-        "enabled": true,
-        "action": {
-          "command": "troubleshooting"
-        }
+        "command": "troubleshooting"
       },
       {
         "title": "Report a Bug",
         "icon": "fas fa-exclamation-triangle",
-        "enabled": true,
-        "action": {
-          "link": "https://github.com/podman-desktop/podman-desktop/issues/new/choose"
-        }
+        "link": "https://github.com/podman-desktop/podman-desktop/issues/new/choose"
       },
       {
         "title": "Share Your Feedback",
         "icon": "far fa-comment",
-        "enabled": true,
-        "action": {
-          "command": "feedback"
-        }
+        "command": "feedback"
       },
       {
         "title": "Community",
-        "icon": "fas fa-list-ul",
-        "enabled": false
+        "icon": "fas fa-list-ul"
       },
       {
         "title": "#podman-desktop",
         "tooltip": "Join Discord #podman-desktop channel",
         "icon": "fab fa-discord",
-        "enabled": true,
-        "action": {
-          "link": "https://discord.com/invite/x5GzFF6QH4"
-        }
+        "link": "https://discord.com/invite/x5GzFF6QH4"
       },
       {
         "title": "#podman-desktop",
         "tooltip": "Join Slack #podman-desktop channel",
         "icon": "fab fa-slack",
-        "enabled": true,
-        "action": {
-          "link": "https://slack.k8s.io"
-        }
+        "link": "https://slack.k8s.io"
       }
     ]
   }


### PR DESCRIPTION
### What does this PR do?

This PR adds help menu items to the product definition (product.json):
- ~it completes the zod schema of the product with an additional property helpMenu > items~
- it adds the help menu items to the product.json file
- first solution was to use a zod schema but Florent told us that for now we should not use Enums values in product.json, but instead he said we should have a format in product.json with ItemAction being either "link: string" or "command: string" and map it to the interface "ItemAction" in the main package (see issue https://github.com/podman-desktop/podman-desktop/issues/15527)


Needs a rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/15528 is merged

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15412

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

The experimental productized help menu is not displayed yet, so for now you can call:

```js
await helpMenuGetItems()
```

<img width="556" height="170" alt="Screenshot 2026-01-02 at 12 03 43" src="https://github.com/user-attachments/assets/2868ac60-3701-4945-8d14-29434c3863e5" />


<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
