### PR TITLE
chore: migrated share feedback form to product.name

### DIFF
--- a/packages/api/src/feedback.ts
+++ b/packages/api/src/feedback.ts
@@ -34,3 +34,9 @@ export interface GitHubIssue {
   includeSystemInfo?: boolean;
   includeExtensionInfo?: boolean;
 }
+
+export interface FeedbackMessages {
+  experienceLabel: string;
+  thankYouMessage: string;
+  gitHubStarsMessage: string;
+}

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -90,9 +90,9 @@ function containSearchParams(url: string | undefined, params: Record<string, str
 }
 
 describe('getFeedbackMessages', () => {
-  test('should return feedback messages with default product name', () => {
+  test('should return feedback messages with default product name', async () => {
     const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
-    const messages = feedbackHandler.getFeedbackMessages();
+    const messages = await feedbackHandler.getFeedbackMessages();
 
     expect(messages.experienceLabel).toBe('How was your experience with Podman Desktop');
     expect(messages.thankYouMessage).toBe(
@@ -101,11 +101,11 @@ describe('getFeedbackMessages', () => {
     expect(messages.gitHubStarsMessage).toBe('Like Podman Desktop? Give us a star on GitHub');
   });
 
-  test('should return feedback messages with custom product name', () => {
+  test('should return feedback messages with custom product name', async () => {
     vi.mocked(productJSONFile).name = 'Custom Product';
 
     const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
-    const messages = feedbackHandler.getFeedbackMessages();
+    const messages = await feedbackHandler.getFeedbackMessages();
 
     expect(messages.experienceLabel).toBe('How was your experience with Custom Product');
     expect(messages.thankYouMessage).toBe(

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -90,9 +90,9 @@ function containSearchParams(url: string | undefined, params: Record<string, str
 }
 
 describe('getFeedbackMessages', () => {
-  test('should return feedback messages with default product name', async () => {
+  test('should return feedback messages with default product name', () => {
     const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
-    const messages = await feedbackHandler.getFeedbackMessages();
+    const messages = feedbackHandler.getFeedbackMessages();
 
     expect(messages.experienceLabel).toBe('How was your experience with Podman Desktop');
     expect(messages.thankYouMessage).toBe(
@@ -101,11 +101,11 @@ describe('getFeedbackMessages', () => {
     expect(messages.gitHubStarsMessage).toBe('Like Podman Desktop? Give us a star on GitHub');
   });
 
-  test('should return feedback messages with custom product name', async () => {
+  test('should return feedback messages with custom product name', () => {
     vi.mocked(productJSONFile).name = 'Custom Product';
 
     const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
-    const messages = await feedbackHandler.getFeedbackMessages();
+    const messages = feedbackHandler.getFeedbackMessages();
 
     expect(messages.experienceLabel).toBe('How was your experience with Custom Product');
     expect(messages.thankYouMessage).toBe(

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -37,7 +37,7 @@ export class FeedbackHandler {
     return productJSONFile ? productJSONFile.name : 'Podman Desktop';
   }
 
-  getFeedbackMessages(): FeedbackMessages {
+  async getFeedbackMessages(): Promise<FeedbackMessages> {
     const productName = this.getProductName();
     return {
       experienceLabel: `How was your experience with ${productName}`,

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -33,12 +33,8 @@ export class FeedbackHandler {
     this.#systemInfo = getSystemInfo();
   }
 
-  protected getProductName(): string {
-    return productJSONFile ? productJSONFile.name : 'Podman Desktop';
-  }
-
   getFeedbackMessages(): FeedbackMessages {
-    const productName = this.getProductName();
+    const productName = productJSONFile.name;
     return {
       experienceLabel: `How was your experience with ${productName}`,
       thankYouMessage: `Your input is valuable in helping us better understand and tailor ${productName}.`,

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -22,7 +22,8 @@ import { inject, injectable } from 'inversify';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { SystemInfo } from '/@/plugin/util/sys-info.js';
 import { getSystemInfo } from '/@/plugin/util/sys-info.js';
-import type { GitHubIssue } from '/@api/feedback.js';
+import type { FeedbackMessages, GitHubIssue } from '/@api/feedback.js';
+import productJSONFile from '/@product.json' with { type: 'json' };
 
 @injectable()
 export class FeedbackHandler {
@@ -30,6 +31,19 @@ export class FeedbackHandler {
 
   constructor(@inject(ExtensionLoader) protected extensionLoader: ExtensionLoader) {
     this.#systemInfo = getSystemInfo();
+  }
+
+  protected getProductName(): string {
+    return productJSONFile ? productJSONFile.name : 'Podman Desktop';
+  }
+
+  getFeedbackMessages(): FeedbackMessages {
+    const productName = this.getProductName();
+    return {
+      experienceLabel: `How was your experience with ${productName}`,
+      thankYouMessage: `Your input is valuable in helping us better understand and tailor ${productName}.`,
+      gitHubStarsMessage: `Like ${productName}? Give us a star on GitHub`,
+    };
   }
 
   async openGitHubIssue(issueProperties: GitHubIssue): Promise<void> {

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -37,7 +37,7 @@ export class FeedbackHandler {
     return productJSONFile ? productJSONFile.name : 'Podman Desktop';
   }
 
-  async getFeedbackMessages(): Promise<FeedbackMessages> {
+  getFeedbackMessages(): FeedbackMessages {
     const productName = this.getProductName();
     return {
       experienceLabel: `How was your experience with ${productName}`,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalo
 import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info.js';
 import type { ExtensionInfo } from '/@api/extension-info.js';
 import type { FeaturedExtension } from '/@api/featured/featured-api.js';
-import type { FeedbackProperties, GitHubIssue } from '/@api/feedback.js';
+import type { FeedbackMessages, FeedbackProperties, GitHubIssue } from '/@api/feedback.js';
 import type { HistoryInfo } from '/@api/history-info.js';
 import type { IconInfo } from '/@api/icon-info.js';
 import type { ImageCheckerInfo } from '/@api/image-checker-info.js';
@@ -3016,6 +3016,10 @@ export class PluginSystem {
 
     this.ipcHandle('feedback:GitHubPreview', async (_listener, properties: GitHubIssue): Promise<void> => {
       return feedback.openGitHubIssue(properties);
+    });
+
+    this.ipcHandle('feedback:getFeedbackMessages', async (): Promise<FeedbackMessages> => {
+      return feedback.getFeedbackMessages();
     });
 
     this.ipcHandle('cancellableTokenSource:create', async (): Promise<number> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalo
 import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info';
 import type { ExtensionInfo } from '/@api/extension-info';
 import type { FeaturedExtension } from '/@api/featured/featured-api';
-import type { FeedbackProperties, GitHubIssue } from '/@api/feedback';
+import type { FeedbackMessages, FeedbackProperties, GitHubIssue } from '/@api/feedback';
 import type { ItemInfo } from '/@api/help-menu';
 import type { HistoryInfo } from '/@api/history-info';
 import type { IconInfo } from '/@api/icon-info';
@@ -2416,6 +2416,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('previewOnGitHub', async (feedback: GitHubIssue): Promise<void> => {
     return ipcInvoke('feedback:GitHubPreview', feedback);
+  });
+
+  contextBridge.exposeInMainWorld('getFeedbackMessages', async (): Promise<FeedbackMessages> => {
+    return ipcInvoke('feedback:getFeedbackMessages');
   });
 
   contextBridge.exposeInMainWorld('telemetryTrack', async (event: string, eventProperties?: unknown): Promise<void> => {

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,18 +34,21 @@ beforeAll(() => {
   Object.defineProperty(window, 'sendFeedback', {
     value: vi.fn(),
   });
+  Object.defineProperty(window, 'getFeedbackMessages', {
+    value: vi.fn(),
+  });
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(window.getFeedbackMessages).mockResolvedValue({
+  vi.mocked(window.getFeedbackMessages).mockReturnValue({
     experienceLabel: 'How was your experience with Podman Desktop',
     thankYouMessage: 'Your input is valuable in helping us better understand and tailor Podman Desktop.',
     gitHubStarsMessage: 'Like Podman Desktop? Give us a star on GitHub',
   });
 });
 
-test('Expect that the button is disabled when loading the page', () => {
+test('Expect that the button is disabled when loading the page', async () => {
   render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
   const button = screen.getByRole('button', { name: 'Send feedback' });
   expect(button).toBeInTheDocument();

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -34,12 +34,6 @@ beforeAll(() => {
   Object.defineProperty(window, 'sendFeedback', {
     value: vi.fn(),
   });
-  Object.defineProperty(window, 'getFeedbackMessages', {
-    value: vi.fn(),
-  });
-  Object.defineProperty(window, 'showMessageBox', {
-    value: vi.fn(),
-  });
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -38,6 +38,11 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.getFeedbackMessages).mockResolvedValue({
+    experienceLabel: 'How was your experience with Podman Desktop',
+    thankYouMessage: 'Your input is valuable in helping us better understand and tailor Podman Desktop.',
+    gitHubStarsMessage: 'Like Podman Desktop? Give us a star on GitHub',
+  });
 });
 
 test('Expect that the button is disabled when loading the page', () => {

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -37,11 +37,14 @@ beforeAll(() => {
   Object.defineProperty(window, 'getFeedbackMessages', {
     value: vi.fn(),
   });
+  Object.defineProperty(window, 'showMessageBox', {
+    value: vi.fn(),
+  });
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(window.getFeedbackMessages).mockReturnValue({
+  vi.mocked(window.getFeedbackMessages).mockResolvedValue({
     experienceLabel: 'How was your experience with Podman Desktop',
     thankYouMessage: 'Your input is valuable in helping us better understand and tailor Podman Desktop.',
     gitHubStarsMessage: 'Like Podman Desktop? Give us a star on GitHub',
@@ -50,14 +53,14 @@ beforeEach(() => {
 
 test('Expect that the button is disabled when loading the page', async () => {
   render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
-  const button = screen.getByRole('button', { name: 'Send feedback' });
+  const button = await screen.findByRole('button', { name: 'Send feedback' });
   expect(button).toBeInTheDocument();
   expect(button).toBeDisabled();
 });
 
 test('Expect that the button is enabled after clicking on a smiley', async () => {
   render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
-  const button = screen.getByRole('button', { name: 'Send feedback' });
+  const button = await screen.findByRole('button', { name: 'Send feedback' });
 
   // expect to have indication why the button is disabled
   expect(screen.getByText('Please select an experience smiley')).toBeInTheDocument();
@@ -75,7 +78,7 @@ test('Expect that the button is enabled after clicking on a smiley', async () =>
 
 test('Expect very sad smiley errors without feedback', async () => {
   render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
-  const button = screen.getByRole('button', { name: 'Send feedback' });
+  const button = await screen.findByRole('button', { name: 'Send feedback' });
   expect(button).toBeDisabled();
 
   // expect to have indication why the button is disabled
@@ -103,7 +106,7 @@ test('Expect very sad smiley errors without feedback', async () => {
 
 test('Expect sad smiley warns without feedback', async () => {
   render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
-  const button = screen.getByRole('button', { name: 'Send feedback' });
+  const button = await screen.findByRole('button', { name: 'Send feedback' });
   expect(button).toBeDisabled();
 
   // expect to have indication why the button is disabled
@@ -129,34 +132,34 @@ test('Expect sad smiley warns without feedback', async () => {
 });
 
 test('Expect message for very-happy-smiley to use love', async () => {
-  const { getByRole, getByLabelText } = render(DirectFeedback, {
+  const { findByRole, findByLabelText } = render(DirectFeedback, {
     category: 'developers',
     contentChange: vi.fn(),
     onCloseForm: vi.fn(),
   });
 
   // click on a smiley
-  const smiley = getByRole('button', { name: 'very-happy-smiley' });
+  const smiley = await findByRole('button', { name: 'very-happy-smiley' });
   await fireEvent.click(smiley);
 
   // and the GitHub star text is visible
-  const region = getByLabelText('Like Podman Desktop? Give us a star on GitHub');
+  const region = await findByLabelText('Like Podman Desktop? Give us a star on GitHub');
   expect(region.textContent).toBe('Love It? Give us a on GitHub');
 });
 
 test('Expect message for happy-smiley to use like', async () => {
-  const { getByRole, getByLabelText } = render(DirectFeedback, {
+  const { findByRole, findByLabelText } = render(DirectFeedback, {
     category: 'developers',
     contentChange: vi.fn(),
     onCloseForm: vi.fn(),
   });
 
   // click on a smiley
-  const smiley = getByRole('button', { name: 'happy-smiley' });
+  const smiley = await findByRole('button', { name: 'happy-smiley' });
   await fireEvent.click(smiley);
 
   // and the GitHub star text is visible
-  const region = getByLabelText('Like Podman Desktop? Give us a star on GitHub');
+  const region = await findByLabelText('Like Podman Desktop? Give us a star on GitHub');
   expect(region.textContent).toBe('Like It? Give us a on GitHub');
 });
 
@@ -164,11 +167,11 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
   render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
 
   // click on a smiley
-  const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
+  const smiley = await screen.findByRole('button', { name: 'very-happy-smiley' });
   await fireEvent.click(smiley);
 
   // and the GitHub star text is visible
-  expect(screen.getByLabelText('Like Podman Desktop? Give us a star on GitHub')).toBeInTheDocument();
+  expect(await screen.findByLabelText('Like Podman Desktop? Give us a star on GitHub')).toBeInTheDocument();
 
   const link = screen.getByRole('link', { name: 'GitHub' });
   await fireEvent.click(link);
@@ -184,7 +187,7 @@ test('Expect category to be sent', async () => {
   render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: closeMock });
 
   // click on a smiley
-  const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
+  const smiley = await screen.findByRole('button', { name: 'very-happy-smiley' });
   await fireEvent.click(smiley);
 
   // click on submit button
@@ -217,7 +220,7 @@ test('Expect design category to be sent when design category is used', async () 
   render(DirectFeedback, { category: 'design', contentChange: vi.fn(), onCloseForm: closeMock });
 
   // click on a smiley
-  const smiley = screen.getByRole('button', { name: 'very-happy-smiley' });
+  const smiley = await screen.findByRole('button', { name: 'very-happy-smiley' });
   await fireEvent.click(smiley);
 
   // click on submit button

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -23,7 +23,6 @@ interface Props {
 
 // feedback of the user
 let smileyRating = $state(0);
-let feedbackMessagesPromise = $derived(window.getFeedbackMessages());
 let tellUsWhyFeedback = $state('');
 let contactInformation = $state('');
 let hasFeedback = $derived(
@@ -38,6 +37,8 @@ $effect(() => contentChange(Boolean(smileyRating || tellUsWhyFeedback || contact
 function selectSmiley(item: number): void {
   smileyRating = item;
 }
+
+let feedbackMessages = $derived(await window.getFeedbackMessages());
 
 async function sendFeedback(): Promise<void> {
   const properties: FeedbackProperties = {
@@ -62,7 +63,7 @@ async function sendFeedback(): Promise<void> {
   // 3. Display confirmation dialog
   await window.showMessageBox({
     title: 'Thanks for your feedback',
-    message: (await feedbackMessagesPromise).thankYouMessage,
+    message: feedbackMessages?.thankYouMessage ?? '',
     type: 'info',
     buttons: ['OK'],
   });
@@ -75,7 +76,6 @@ async function openGitHub(): Promise<void> {
 }
 </script>
 
-{#await feedbackMessagesPromise then feedbackMessages}
 <FeedbackForm>
   <svelte:fragment slot="content">
     <label for="smiley" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
@@ -161,4 +161,3 @@ async function openGitHub(): Promise<void> {
     >Send feedback</Button>
   </svelte:fragment>
 </FeedbackForm>
-{/await}

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -9,11 +9,12 @@ import {
   faStar,
 } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
 
 import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
-import type { DirectFeedbackCategory, FeedbackProperties } from '/@api/feedback';
+import type { DirectFeedbackCategory, FeedbackMessages, FeedbackProperties } from '/@api/feedback';
 
 interface Props {
   onCloseForm: (confirmation: boolean) => void;
@@ -23,6 +24,7 @@ interface Props {
 
 // feedback of the user
 let smileyRating = $state(0);
+let feedbackMessages = $state<FeedbackMessages | undefined>(undefined);
 let tellUsWhyFeedback = $state('');
 let contactInformation = $state('');
 let hasFeedback = $derived(
@@ -33,6 +35,10 @@ let hasFeedback = $derived(
 let { onCloseForm, contentChange, category }: Props = $props();
 
 $effect(() => contentChange(Boolean(smileyRating || tellUsWhyFeedback || contactInformation)));
+
+onMount(async () => {
+  feedbackMessages = await window.getFeedbackMessages();
+});
 
 function selectSmiley(item: number): void {
   smileyRating = item;
@@ -61,7 +67,7 @@ async function sendFeedback(): Promise<void> {
   // 3. Display confirmation dialog
   await window.showMessageBox({
     title: 'Thanks for your feedback',
-    message: 'Your input is valuable in helping us better understand and tailor Podman Desktop.',
+    message: feedbackMessages?.thankYouMessage ?? '',
     type: 'info',
     buttons: ['OK'],
   });
@@ -77,7 +83,7 @@ async function openGitHub(): Promise<void> {
 <FeedbackForm>
   <svelte:fragment slot="content">
     <label for="smiley" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
-      >How was your experience with Podman Desktop?</label>
+      >{feedbackMessages?.experienceLabel}</label>
     <div class="flex space-x-4">
       <button aria-label="very-sad-smiley" onclick={(): void => selectSmiley(1)}>
         <Fa
@@ -146,7 +152,7 @@ async function openGitHub(): Promise<void> {
     {:else if smileyRating > 2}
       <div class="text-[var(--pd-modal-text)] p-1 flex flex-row items-center text-xs">
         <Fa size="1.125x" class="cursor-pointer" icon={faQuestionCircle} />
-        <span aria-label="Like Podman Desktop? Give us a star on GitHub" class="flex items-center">
+        <span aria-label="{feedbackMessages?.gitHubStarsMessage}" class="flex items-center">
           <Fa class="px-1 text-[var(--pd-invert-content-info-icon)]" icon={faHeart} />{smileyRating === 3 ? 'Like' : 'Love'} It? Give us a <Fa
             class="px-1 text-[var(--pd-state-warning)]"
             icon={faStar} />on <Link aria-label="GitHub" on:click={openGitHub}>GitHub</Link>


### PR DESCRIPTION
### What does this PR do?
Migrates Podman Desktop label to product.name

### Screenshot / video of UI
N/A

### What issues does this PR fix or reference?
Closes #15406 
Similar to #15110

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
