### PR TITLE
refactor(extension/podman): make podman-install.ts uses execPodman

### DIFF
--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -178,14 +178,15 @@ describe('update checks', () => {
   test('stopPodmanMachinesIfAnyBeforeUpdating with one machine running', async () => {
     await extensionObj.initInversify(extensionContext, mockTelemetryLogger);
 
-    vi.spyOn(utils, 'execPodman').mockResolvedValueOnce({
-      stdout: 'podman version 5.0.0',
-    } as extensionApi.RunResult);
-
     // return empty machine list
     vi.spyOn(utils, 'execPodman').mockResolvedValueOnce({
       stdout: JSON.stringify([{ Name: 'test', Running: true, VMType: 'libkrun' }]),
     } as unknown as extensionApi.RunResult);
+
+    // return podman version
+    vi.spyOn(utils, 'execPodman').mockResolvedValueOnce({
+      stdout: 'podman version 5.0.0',
+    } as extensionApi.RunResult);
 
     // mock user response
     vi.spyOn(extensionApi.window, 'showInformationMessage').mockResolvedValue('Yes');

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -178,7 +178,7 @@ describe('update checks', () => {
   test('stopPodmanMachinesIfAnyBeforeUpdating with one machine running', async () => {
     await extensionObj.initInversify(extensionContext, mockTelemetryLogger);
 
-    vi.spyOn(extensionApi.process, 'exec').mockResolvedValueOnce({
+    vi.spyOn(utils, 'execPodman').mockResolvedValueOnce({
       stdout: 'podman version 5.0.0',
     } as extensionApi.RunResult);
 
@@ -196,11 +196,7 @@ describe('update checks', () => {
     expect(extensionApi.window.showInformationMessage).toHaveBeenCalled();
 
     // check we called the stop command
-    expect(extensionApi.process.exec).toHaveBeenCalledWith(expect.stringContaining('podman'), [
-      'machine',
-      'stop',
-      'test',
-    ]);
+    expect(utils.execPodman).toHaveBeenCalledWith(['machine', 'stop', 'test']);
   });
 
   test('wipeAllDataBeforeUpdatingToV5 with podman 4.9 -> 5.0', async () => {

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2024 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,9 @@ import * as podman5JSON from '/@/podman5.json';
 import { MachineJSON } from '/@/types';
 import { InstalledPodman, PodmanBinary } from '/@/utils/podman-binary';
 import { getBundledPodmanVersion } from '/@/utils/podman-bundled';
-import { getPodmanCli } from '/@/utils/podman-cli';
 import type { PodmanInfo } from '/@/utils/podman-info';
 import { PodmanInfoImpl } from '/@/utils/podman-info';
+import { execPodman } from '/@/utils/util';
 
 import { Installer } from './installer';
 
@@ -169,7 +169,7 @@ export class PodmanInstall {
       if (answer === 'Yes') {
         for (const machine of machinesRunning) {
           try {
-            await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machine.Name]);
+            await execPodman(['machine', 'stop', machine.Name]);
           } catch (error) {
             console.error('Error while stopping machine', error);
           }


### PR DESCRIPTION
### What does this PR do?

In numerous place we directly use the `process.exec` method from the extension-api to call podman binary using `getPodmanCli()` but this make calling the podman binary inconsistent and rely on hardcoded path in the packages/main[^1]. When using the podman binary, we should use the `execPodman`.

[^1]: https://github.com/podman-desktop/podman-desktop/issues/15538

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15539

Required for
- https://github.com/podman-desktop/podman-desktop/issues/15538
### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing unit tests have been updated
