### PR TITLE
refactor(extension/podman): make podman-binary.ts uses execPodman

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-binary.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-binary.ts
@@ -15,10 +15,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { configuration as configurationAPI, Disposable, process as processAPI } from '@podman-desktop/api';
+import { configuration as configurationAPI, Disposable } from '@podman-desktop/api';
 import { injectable, postConstruct, preDestroy } from 'inversify';
 
-import { getPodmanCli } from '/@/utils/podman-cli';
+import { execPodman } from '/@/utils/util';
 
 export interface InstalledPodman {
   version: string;
@@ -32,8 +32,8 @@ export class PodmanBinary implements Disposable {
   /**
    * Given a path to a podman binary, return the version of podman
    */
-  protected async getPodmanVersion(path: string): Promise<string> {
-    const { stdout: versionOut } = await processAPI.exec(path, ['--version']);
+  protected async getPodmanVersion(): Promise<string> {
+    const { stdout: versionOut } = await execPodman(['--version']);
     const versionArr = versionOut.split(' ');
     return versionArr[versionArr.length - 1];
   }
@@ -49,9 +49,9 @@ export class PodmanBinary implements Disposable {
     if (this.#cli) {
       return this.#cli;
     }
-    const path = getPodmanCli();
+
     try {
-      const version = await this.getPodmanVersion(path);
+      const version = await this.getPodmanVersion();
       this.#cli = {
         version,
       };


### PR DESCRIPTION
### What does this PR do?

In numerous place we directly use the `process.exec` method from the extension-api to call podman binary using `getPodmanCli()` but this make calling the podman binary inconsistent and rely on hardcoded path in the packages/main[^1]. When using the podman binary, we should use the `execPodman`.

[^1]: https://github.com/podman-desktop/podman-desktop/issues/15538

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15539

Required for
- https://github.com/podman-desktop/podman-desktop/issues/15538
### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing unit tests have been updated
