### PR TITLE
refactor(extension/podman): make compatibility-mode.ts uses execPodman

### DIFF
--- a/extensions/podman/packages/extension/src/utils/compatibility-mode.ts
+++ b/extensions/podman/packages/extension/src/utils/compatibility-mode.ts
@@ -22,8 +22,7 @@ import * as os from 'node:os';
 import * as extensionApi from '@podman-desktop/api';
 
 import { findRunningMachine } from '/@/extension';
-
-import { getPodmanCli } from './podman-cli';
+import { execPodman } from '/@/utils/util';
 
 const podmanSystemdSocket = 'podman.socket';
 
@@ -117,8 +116,8 @@ export class DarwinSocketCompatibility extends SocketCompatibility {
       );
       if (result === 'Yes') {
         // Await since we must wait for the machine to stop before starting it again
-        await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machine]);
-        await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machine]);
+        await execPodman(['machine', 'stop', machine]);
+        await execPodman(['machine', 'start', machine]);
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?

In numerous place we directly use the `process.exec` method from the extension-api to call podman binary using `getPodmanCli()` but this make calling the podman binary inconsistent and rely on hardcoded path in the packages/main[^1]. When using the podman binary, we should use the `execPodman`.

[^1]: https://github.com/podman-desktop/podman-desktop/issues/15538

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15539

Required for
- https://github.com/podman-desktop/podman-desktop/issues/15538
### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing unit tests have been updated
