### PR TITLE
chore(preferences): add readonly support to FloatNumberItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.spec.ts
@@ -135,3 +135,22 @@ test('Expect only one dot is added to input', async () => {
 
   expect(onChange).toBeCalledWith('record', 2.2);
 });
+
+test('Expect input to be disabled when record.readonly is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+    readonly: true,
+  };
+  const value = 2;
+  render(FloatNumberItem, { record, value });
+
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input).toBeDisabled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -80,6 +80,7 @@ function assertNumericValueIsValid(value: number): boolean {
       bind:value={recordValue}
       on:keypress={onNumberInputKeyPress}
       on:input={onInput}
+      disabled={!!record.readonly}
       aria-label={record.description} />
   </Tooltip>
 </div>


### PR DESCRIPTION
chore(preferences): add readonly support to FloatNumberItem component

### What does this PR do?

When record.readonly is true, the text input is now disabled,
preventing user interaction with the float number input field.

### Screenshot / video of UI

N/A, no (current) user facing change as it's more of a chore / align
with how other preferences such as BooleanItem does it with disabled /
readonly.

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/14624

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
