### PR TITLE
chore(preferences): add readonly support to EnumItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
@@ -59,3 +59,19 @@ test('Enum with default', async () => {
   expect(input).toBeInTheDocument();
   expect(input).toHaveTextContent('world');
 });
+
+test('Expect dropdown to be disabled when record.readonly is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    enum: ['hello', 'world'],
+    readonly: true,
+  };
+
+  render(EnumItem, { record, value: 'hello' });
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toBeDisabled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -24,5 +24,6 @@ function onChangeHandler(newValue: unknown): void {
   bind:value={value}
   ariaInvalid={invalidEntry}
   ariaLabel={record.description}
+  disabled={!!record.readonly}
   options={record.enum?.map(recordEnum => ({label: recordEnum, value: recordEnum}))}>
 </Dropdown>


### PR DESCRIPTION
chore(preferences): add readonly support to EnumItem component

### What does this PR do?

When record.readonly is true, the Dropdown is now disabled,
preventing user interaction with the dropdown selection.

### Screenshot / video of UI

N/A, no (current) user facing change as it's more of a chore / align
with how other preferences such as BooleanItem does it with disabled /
readonly.

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/14624

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
