### PR TITLE
chore: replace deprecated sudo-prompt with @expo/sudo-prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "os-locale": "^6.0.2",
     "semver": "^7.7.3",
     "stream-json": "^1.9.1",
-    "sudo-prompt": "^9.2.1",
+    "@expo/sudo-prompt": "^9.3.2",
     "tar": "^7.5.2",
     "tar-fs": "^3.1.1",
     "tar-stream": "^3.1.7",

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -20,7 +20,7 @@ import type { ChildProcess, ChildProcessWithoutNullStreams } from 'node:child_pr
 import { spawn } from 'node:child_process';
 import type { Readable } from 'node:stream';
 
-import * as sudo from 'sudo-prompt';
+import * as sudo from '@expo/sudo-prompt';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -29,7 +29,7 @@ import type { Proxy } from '../proxy.js';
 import { Exec, getInstallationPath, macosExtraPath } from './exec.js';
 
 // Mock sudo-prompt exec to resolve everytime.
-vi.mock('sudo-prompt', async () => {
+vi.mock(import('@expo/sudo-prompt'), async () => {
   return {
     exec: vi.fn(),
   };

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -19,8 +19,8 @@
 import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { spawn } from 'node:child_process';
 
+import * as sudo from '@expo/sudo-prompt';
 import type { RunError, RunOptions, RunResult } from '@podman-desktop/api';
-import * as sudo from 'sudo-prompt';
 
 import { isLinux, isMac, isWindows } from '../../util.js';
 import type { Proxy } from '../proxy.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         specifier: 0.4.2
         version: 0.4.2
       '@expo/sudo-prompt':
-        specifier: 9.3.2
+        specifier: ^9.3.2
         version: 9.3.2
       '@kubernetes/client-node':
         specifier: ^1.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@docker/extension-api-client-types':
         specifier: 0.4.2
         version: 0.4.2
+      '@expo/sudo-prompt':
+        specifier: 9.3.2
+        version: 9.3.2
       '@kubernetes/client-node':
         specifier: ^1.4.0
         version: 1.4.0(encoding@0.1.13)
@@ -103,9 +106,6 @@ importers:
       stream-json:
         specifier: ^1.9.1
         version: 1.9.1
-      sudo-prompt:
-        specifier: ^9.2.1
-        version: 9.2.1
       tar:
         specifier: ^7.5.2
         version: 7.5.2
@@ -2746,6 +2746,9 @@ packages:
     peerDependenciesMeta:
       '@exodus/crypto':
         optional: true
+
+  '@expo/sudo-prompt@9.3.2':
+    resolution: {integrity: sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==}
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -10830,10 +10833,6 @@ packages:
   stylis@4.3.6:
     resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
 
-  sudo-prompt@9.2.1:
-    resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -14496,6 +14495,8 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.7.0': {}
+
+  '@expo/sudo-prompt@9.3.2': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -24094,8 +24095,6 @@ snapshots:
       postcss-selector-parser: 6.1.2
 
   stylis@4.3.6: {}
-
-  sudo-prompt@9.2.1: {}
 
   sumchecker@3.0.1:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

The `sudo-prompt` is deprecated and have some issues on Node 24, making https://github.com/podman-desktop/podman-desktop/issues/15067 not working.

As suggested in https://github.com/podman-desktop/podman-desktop/issues/15548#issuecomment-3710935740 we can replace it with `@expo/sudo-prompt` which include the removal of deprecated APIs

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15548#issuecomment-3710935740

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
