### PR TITLE
chore(preferences): add readonly support to SliderItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -46,3 +46,21 @@ test('Ensure HTMLInputElement', async () => {
 
   expect(input instanceof HTMLInputElement).toBe(true);
 });
+
+test('Expect slider to be disabled when record.readonly is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 4,
+    maximum: 34,
+    readonly: true,
+  };
+
+  render(SliderItem, { record, value: 15 });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input).toBeDisabled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -23,4 +23,5 @@ async function onInput(event: Event): Promise<void> {
   value={value}
   aria-label={record.description}
   on:input={onInput}
+  disabled={!!record.readonly}
   class="w-full h-1 bg-[var(--pd-input-toggle-on-bg)] rounded-lg appearance-none accent-[var(--pd-input-toggle-on-bg)] cursor-pointer range-xs mt-2" />


### PR DESCRIPTION
chore(preferences): add readonly support to SliderItem component

### What does this PR do?

When record.readonly is true, the range slider input is now disabled,
preventing user interaction with the slider.

### Screenshot / video of UI

N/A, no (current) user facing change as it's more of a chore / align
with how other preferences such as BooleanItem does it with disabled /
readonly.

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/14624

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
