### PR TITLE
fix: switch to span for string icons

### DIFF
--- a/packages/ui/src/lib/icons/Icon.spec.ts
+++ b/packages/ui/src/lib/icons/Icon.spec.ts
@@ -81,6 +81,7 @@ describe('class icon', () => {
     const img = screen.getByRole('img', { hidden: true });
     expect(img).toBeInTheDocument();
     expect(img).toHaveClass('fas fa-icon');
+    expect(img.nodeName).toBe('SPAN');
   });
 
   test('icon should reflect prefered fa-{number}x size', () => {

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -27,7 +27,7 @@ const IconComponent = icon;
     <!-- fas fa- and far fa- and fab fa- for Font awesome icons -->
     <!-- -icon for extension icons e.g. 'kind-icon' -->
     {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.startsWith('fab fa-') || icon.endsWith('-icon')}
-        <i class={`${icon} ${size} ${className}`} {role} {title}></i>
+        <span class={`${icon} ${size} ${className}`} {role} {title}></span>
     {:else if icon.startsWith('data:image/')}
         <img src={icon} alt={title ?? ''} {title} {role} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
     {/if}


### PR DESCRIPTION
### What does this PR do?

I haven't tracked down the direct cause, but at some point last year the path to display string icons changed to using the i (italic) HTML component. This is completely fine for FontAwesome icons, but for icons loaded from other sources like product contributions it made them italicized.

This switches to use span instead. It's three extra characters :), but it is more technically correct and we are already using it in other places (e.g. status bar).

We still use i to display icons in 20 other places (15 files), but I've verified that these are all FontAwesome.

### Screenshot / video of UI

<img width="250" height="459" alt="Screenshot 2026-01-05 at 12 14 52 PM" src="https://github.com/user-attachments/assets/0d4ba6f9-ca5c-4fe5-9c6c-03ae79f3f6bc" />

### What issues does this PR fix or reference?

Fixes #15217. (and https://github.com/podman-desktop/extension-bootc/issues/2196)

### How to test this PR?

Confirm the icon is fixed (may have to stop Podman machine to see it) and no obvious regressions elsewhere (e.g. buttons at top-right of Images page).

- [x] Tests are covering the bug fix or the new feature