### PR TITLE
chore(preferences): add readonly support to NumberItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -194,3 +194,28 @@ test('Expect onChange is not triggered in case of error on validation', async ()
   // then we should have the onChange call to be 1
   await vi.waitFor(() => expect(onChange).toHaveBeenCalledWith('record', 1));
 });
+
+test('Expect input to be disabled when record.readonly is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+    readonly: true,
+  };
+  const value = 10;
+  render(NumberItem, { record, value });
+
+  const input = screen.getByRole('textbox', { name: 'record-description' });
+  expect(input).toBeInTheDocument();
+  expect(input).toBeDisabled();
+
+  const decrementButton = screen.getByLabelText('decrement');
+  expect(decrementButton).toBeDisabled();
+
+  const incrementButton = screen.getByLabelText('increment');
+  expect(incrementButton).toBeDisabled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -46,6 +46,7 @@ function onValidation(newValue: number, validationError?: string): void {
     step={record.step}
     type={record.type === 'integer' ? 'integer' : 'number'}
     maximum={record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}
+    disabled={!!record.readonly}
     showError={false}>
   </NumberInput>
 </Tooltip>


### PR DESCRIPTION
chore(preferences): add readonly support to NumberItem component

### What does this PR do?

When record.readonly is true, the NumberInput is now disabled, preventing user interaction with the input field and increment/decrement buttons.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A, no (current) user facing change as it's more of a chore / align
with how other preferences such as BooleanItem does it with disabled /
readonly.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/14624

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
