### PR TITLE
chore: add position properties to label tooltip

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesManagedLabel.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesManagedLabel.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 import { expect, test, vi } from 'vitest';
 
 import PreferencesManagedLabel from '/@/lib/preferences/PreferencesManagedLabel.svelte';
@@ -38,5 +38,17 @@ test('simple test to see if the svg (icon) renders', async () => {
   await vi.waitFor(() => {
     const svgElement = container.querySelector('svg');
     expect(svgElement).toBeInTheDocument();
+  });
+});
+
+test('should have This setting is managed by your organization tooltip', async () => {
+  const { getByText, getByTestId } = render(PreferencesManagedLabel);
+
+  await vi.waitFor(async () => {
+    const tooltipTrigger = getByTestId('tooltip-trigger');
+    await fireEvent.mouseEnter(tooltipTrigger);
+
+    const element = getByText('This setting is managed by your organization.');
+    expect(element).toBeInTheDocument();
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesManagedLabel.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesManagedLabel.svelte
@@ -1,16 +1,13 @@
 <script lang="ts">
 import { faLock } from '@fortawesome/free-solid-svg-icons';
-import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import Label from '/@/lib/ui/Label.svelte';
 </script>
 
-<Tooltip tip="This setting is managed by your organization." right>
-  <Label>
-    <div class="flex flex-row space-x-1 items-center">
-      <Icon icon={faLock} size="xs"/>
-      <span>Managed</span>
-    </div>
-  </Label>
-</Tooltip>
+<Label tip="This setting is managed by your organization." right>
+  <div class="flex flex-row space-x-1 items-center">
+    <Icon icon={faLock} size="xs"/>
+    <span>Managed</span>
+  </div>
+</Label>

--- a/packages/renderer/src/lib/ui/Label.spec.ts
+++ b/packages/renderer/src/lib/ui/Label.spec.ts
@@ -18,8 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import * as uiPackage from '@podman-desktop/ui-svelte';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import LabelSpec from './LabelSpec.svelte';
 
@@ -81,4 +82,27 @@ test('Expect capitalization', async () => {
   const label = screen.getByText('label');
   expect(label).toBeInTheDocument();
   expect(label).toHaveClass('capitalize');
+});
+
+test.each([
+  { top: true },
+  { bottom: true },
+  { right: true },
+  { left: true },
+  { topLeft: true },
+  { topRight: true },
+  { bottomLeft: true },
+  { bottomRight: true },
+])('Expect tooltip to have custom position %s', async position => {
+  const tooltipSpy = vi.spyOn(uiPackage, 'Tooltip');
+  render(LabelSpec, {
+    name: 'label',
+    tip: 'tooltip 1',
+    ...position,
+  });
+
+  expect(tooltipSpy).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({ tip: 'tooltip 1', ...position }),
+  );
 });

--- a/packages/renderer/src/lib/ui/Label.svelte
+++ b/packages/renderer/src/lib/ui/Label.svelte
@@ -5,16 +5,46 @@ import type { Snippet } from 'svelte';
 interface Props {
   name?: string;
   tip?: string;
+  top?: boolean;
+  bottom?: boolean;
+  left?: boolean;
+  right?: boolean;
+  topLeft?: boolean;
+  topRight?: boolean;
+  bottomLeft?: boolean;
+  bottomRight?: boolean;
   role?: string;
   capitalize?: boolean;
   children?: Snippet;
   containerClass?: string;
 }
 
-let { name = '', tip = '', role, capitalize = false, containerClass, children }: Props = $props();
+let {
+  name = '',
+  tip = '',
+  top,
+  bottom,
+  left,
+  right,
+  topLeft,
+  topRight,
+  bottomLeft,
+  bottomRight,
+  role,
+  capitalize = false,
+  containerClass,
+  children,
+}: Props = $props();
 </script>
 
-<Tooltip containerClass={containerClass} top tip={tip}>
+<Tooltip containerClass={containerClass} {top}
+  {bottom}
+  {left}
+  {right}
+  {topLeft}
+  {topRight}
+  {bottomLeft}
+  {bottomRight} tip={tip}>
   <div
     role={role}
     class="flex items-center bg-[var(--pd-label-bg)] p-1 rounded-md text-sm text-[var(--pd-label-text)] gap-x-1 w-full">

--- a/packages/renderer/src/lib/ui/LabelSpec.svelte
+++ b/packages/renderer/src/lib/ui/LabelSpec.svelte
@@ -6,6 +6,22 @@ export let tip = '';
 export let slot = '';
 export let role: string | undefined = undefined;
 export let capitalize: boolean = false;
+export let top: boolean | undefined = undefined;
+export let bottom: boolean | undefined = undefined;
+export let left: boolean | undefined = undefined;
+export let right: boolean | undefined = undefined;
+export let topLeft: boolean | undefined = undefined;
+export let topRight: boolean | undefined = undefined;
+export let bottomLeft: boolean | undefined = undefined;
+export let bottomRight: boolean | undefined = undefined;
 </script>
 
-<Label tip={tip} role={role} name={name} capitalize={capitalize}>{slot}</Label>
+<Label tip={tip} role={role} name={name} capitalize={capitalize}
+{top}
+  {bottom}
+  {left}
+  {right}
+  {topLeft}
+  {topRight}
+  {bottomLeft}
+  {bottomRight}>{slot}</Label>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds custom position props for the tooltip of the label component and removes the double use of tooltip in the `PreferencesManagedLabel` component

### Screenshot / video of UI
No UI changes

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/15056

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
