### PR TITLE
refactor(extension-loader.spec.ts): improve test isolation

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -769,7 +769,7 @@ test('Verify extension do not add configuration to subscriptions', async () => {
 test('Verify disable extension updates configuration', async () => {
   const ids = ['extension.foo'];
 
-  configurationRegistryUpdateConfigurationMock.mockResolvedValue(Promise.resolve);
+  configurationRegistryUpdateConfigurationMock.mockResolvedValue(undefined);
   extensionLoader.setDisabledExtensionIds(ids);
 
   expect(configurationRegistryUpdateConfigurationMock).toHaveBeenCalledWith('extensions.disabled', ids);
@@ -783,14 +783,14 @@ test('Verify enable extension updates configuration', async () => {
   configurationRegistryGetConfigurationMock.mockReturnValue({
     get: () => before,
   });
-  configurationRegistryUpdateConfigurationMock.mockResolvedValue(Promise.resolve);
+  configurationRegistryUpdateConfigurationMock.mockResolvedValue(undefined);
   extensionLoader.ensureExtensionIsEnabled(id);
 
   expect(configurationRegistryUpdateConfigurationMock).toHaveBeenCalledWith('extensions.disabled', after);
 });
 
 test('Verify stopping extension disables it', async () => {
-  configurationRegistryUpdateConfigurationMock.mockResolvedValue(Promise.resolve);
+  configurationRegistryUpdateConfigurationMock.mockResolvedValue(undefined);
 
   const id = 'extension.no.foo';
   configurationRegistryGetConfigurationMock.mockReturnValue({
@@ -802,7 +802,7 @@ test('Verify stopping extension disables it', async () => {
 });
 
 test('Verify starting extension enables it', async () => {
-  configurationRegistryUpdateConfigurationMock.mockResolvedValue(Promise.resolve);
+  configurationRegistryUpdateConfigurationMock.mockResolvedValue(undefined);
 
   const id = 'extension.no.foo';
 

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -332,6 +332,8 @@ const readdirMock = vi.mocked(
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeEach(() => {
+  vi.resetAllMocks();
+
   extensionLoader = new TestExtensionLoader(
     commandRegistry,
     menuRegistry,
@@ -788,6 +790,8 @@ test('Verify enable extension updates configuration', async () => {
 });
 
 test('Verify stopping extension disables it', async () => {
+  configurationRegistryUpdateConfigurationMock.mockResolvedValue(Promise.resolve);
+
   const id = 'extension.no.foo';
   configurationRegistryGetConfigurationMock.mockReturnValue({
     get: () => [],
@@ -798,6 +802,8 @@ test('Verify stopping extension disables it', async () => {
 });
 
 test('Verify starting extension enables it', async () => {
+  configurationRegistryUpdateConfigurationMock.mockResolvedValue(Promise.resolve);
+
   const id = 'extension.no.foo';
 
   configurationRegistryGetConfigurationMock.mockReturnValue({


### PR DESCRIPTION
### What does this PR do?

Improve test isolation in `extension-loader.spec.ts` by calling `vi.resetAllMocks()` in `beforeEach`.

### What issues does this PR fix or reference?

Required for:
- https://github.com/podman-desktop/podman-desktop/pull/15563

### How to test this PR?

- [x] CI should be 🟢 
