### PR TITLE
fix(electron-builder): bundle extensions-extra in extraResources

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -169,11 +169,7 @@ const config = {
   afterPack: async context => {
     await addElectronFuses(context);
   },
-  files: [
-    'packages/**/dist/**',
-    'extensions/**/builtin/*.cdix/**',
-    'packages/main/src/assets/**',
-  ],
+  files: ['packages/**/dist/**', 'extensions/**/builtin/*.cdix/**', 'packages/main/src/assets/**'],
   portable: {
     artifactName: `${product.artifactName}${artifactNameSuffix}-\${version}-\${arch}.\${ext}`,
   },

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -73,7 +73,7 @@ async function addElectronFuses(context) {
  *
  * @remarks it should be called in the beforePack to populate the folder extensions-extra before electron builder pack them
  */
-async function packageRemoteExtensions() {
+async function packageRemoteExtensions(context) {
   const downloadScript = path.join('packages', 'main', 'dist', 'download-remote-extensions.cjs');
   if (!fs.existsSync(downloadScript)) {
     console.warn(`${downloadScript} not found, skipping remote extension download`);
@@ -82,7 +82,7 @@ async function packageRemoteExtensions() {
 
   const destination = path.resolve('./extensions-extra');
 
-  return new Promise((resolve, reject) => {
+  await new Promise((resolve, reject) => {
     execFile(
       'node',
       [downloadScript, `--output=${destination}`],
@@ -98,6 +98,7 @@ async function packageRemoteExtensions() {
       },
     );
   });
+  context.packager.config.extraResources.push('./extensions-extra/**');
 }
 
 /**
@@ -119,7 +120,7 @@ const config = {
     context.packager.config.extraResources = DEFAULT_ASSETS;
 
     // download & package remote extensions
-    await packageRemoteExtensions();
+    await packageRemoteExtensions(context);
 
     // include product.json
     context.packager.config.extraResources.push({
@@ -170,7 +171,6 @@ const config = {
   },
   files: [
     'packages/**/dist/**',
-    'extensions-extra/**',
     'extensions/**/builtin/*.cdix/**',
     'packages/main/src/assets/**',
   ],

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -333,6 +333,9 @@ const readdirMock = vi.mocked(
 /* eslint-disable @typescript-eslint/no-empty-function */
 beforeEach(() => {
   vi.resetAllMocks();
+  Object.defineProperty(process, 'resourcesPath', {
+    value: '/resources',
+  });
 
   extensionLoader = new TestExtensionLoader(
     commandRegistry,
@@ -402,7 +405,7 @@ describe('extensionLoader#start', () => {
 
     expect(readDevelopmentFoldersMock).toHaveBeenCalledOnce();
     const devFolder = readDevelopmentFoldersMock.mock.calls[0]?.[0];
-    expect(devFolder?.endsWith('extensions-extra')).toBeTruthy();
+    expect(devFolder).toEqual(path.join(process.resourcesPath, 'extensions-extra'));
   });
 
   test('error in one of analyzeExtension should not be dramatic', async () => {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -458,7 +458,7 @@ export class ExtensionLoader implements IAsyncDisposable {
       // in production mode, use the extensions & extensions-extra locally
       const promises = await Promise.all([
         this.readProductionFolders(path.join(__dirname, '../../../extensions')),
-        this.readDevelopmentFolders(path.join(__dirname, '../../../extensions-extra')),
+        this.readDevelopmentFolders(path.join(process.resourcesPath, 'extensions-extra')),
       ]);
 
       folders = promises.flat();


### PR DESCRIPTION
### What does this PR do?

The first implementation were adding the `extensions-extra in the `files`  property of electron builder, copying the content inside  the `app.asar` which seems to have some issues (See https://github.com/podman-desktop/podman-desktop/issues/15416#issuecomment-3714904956 for full details).

The solution provided in this PR is to move the `extensions-extra` folder into the `extraResources` which would make it appear next to the app.asar.

### Screenshot / video of UI

<img width="455" height="321" alt="image" src="https://github.com/user-attachments/assets/fbb6fa12-e228-4248-925c-33ce207b3bac" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15416

### How to test this PR?

**Testing manually**

⚠️ **The problem has been reported on Windows, the following steps will not work on non-windows as macadam need to be downloaded manually.**

1. Checkout this branch
2. Add the following extensions inside the `product.json`
```json
  [...]
  "extensions": {
    "remote": [{
      "name": "podman-desktop-extension-layers-explorer",
      "oci": "ghcr.io/podman-desktop/podman-desktop-extension-layers-explorer:dfb3d8ef35b852c758c8c7eba24db581f694a3fb"
    }, {
      "name": "podman-desktop-rhel-ext",
      "oci": "ghcr.io/redhat-developer/podman-desktop-rhel-ext:99acb52aad14d0a1fa7276805568a30f6987d1d9"
    }, {
      "name": "podman-desktop-redhat-account-ext",
      "oci": "ghcr.io/redhat-developer/podman-desktop-redhat-account-ext@sha256:9e7bbd86536ad9eef80d8e3168adc6ee01f3b6ae29e65c903d1e87449495e5ff"
    }]
  }
```
3. Run `pnpm compile:current`
4. Open the explorer and got inside the `dist` folder
5. Start `podman-desktop-1.25.0-next.exe`
6. Assert all bundled extensions are activated successfully
7. Create a new VM
<img width="191" height="140" alt="image" src="https://github.com/user-attachments/assets/f26f27a9-0262-414f-9310-8c394ca01679" />

8. Assert the VM is running as expected 🚀 
<img width="273" height="133" alt="image" src="https://github.com/user-attachments/assets/2abc122e-1ad3-4ced-a435-b63ad9b33382" />

