### PR TITLE
fix: even spacing for separators in Resources page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -448,12 +448,12 @@ $effect(() => {
       <div
         id={provider.id}
         bind:this={providerElementMap[provider.id]}
-        class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 divide-x divide-[var(--pd-content-divider)] flex"
+        class="bg-[var(--pd-invert-content-card-bg)] mb-5 rounded-md p-3 flex"
         role="region"
         aria-label={provider.id}>
-        <div role="region" aria-label="Provider Setup">
+        <div role="region" aria-label="Provider Setup" class="border-r border-[var(--pd-content-divider)]">
           <!-- left col - provider icon/name + "create new" button -->
-          <div class="min-w-[170px] max-w-[200px]">
+          <div class="min-w-[170px] max-w-[200px] pr-5 py-2">
             <div class="flex">
               {#if provider.images.icon}
                 {#if typeof provider.images.icon === 'string'}
@@ -478,7 +478,7 @@ $effect(() => {
         </div>
         <!-- providers columns -->
         <div
-          class="grow flex flex-wrap divide-[var(--pd-content-divider)] ml-2 text-[var(--pd-invert-content-card-text)]"
+          class="grow flex flex-wrap text-[var(--pd-invert-content-card-text)]"
           role="region"
           aria-label="Provider Connections">
           <PreferencesConnectionsEmptyRendering
@@ -487,7 +487,7 @@ $effect(() => {
           {#each provider.containerConnections as container, index (index)}
             {@const peerProperties = new PeerProperties()}
             {@const rootfulInfo = getRootfulDisplayInfo(provider, container)}
-            <div class="px-5 py-2 w-[240px]" role="region" aria-label={container.name}>
+            <div class="px-5 py-2 w-[240px] border-r border-[var(--pd-content-divider)]" role="region" aria-label={container.name}>
               <div class="float-right">
                 <Tooltip bottom tip="{provider.name} details">
                   <button
@@ -607,7 +607,7 @@ $effect(() => {
             </div>
           {/each}
           {#each provider.kubernetesConnections as kubeConnection, index (index)}
-            <div class="px-5 py-2 w-[240px]" role="region" aria-label={kubeConnection.name}>
+            <div class="px-5 py-2 w-[240px] border-r border-[var(--pd-content-divider)]" role="region" aria-label={kubeConnection.name}>
               <div class="float-right">
                 <Tooltip bottom tip="{provider.name} details">
                   <button
@@ -645,7 +645,7 @@ $effect(() => {
             </div>
           {/each}
           {#each provider.vmConnections as vmConnection, index (index)}
-          <div class="px-5 py-2 w-[240px]" role="region" aria-label={vmConnection.name}>
+          <div class="px-5 py-2 w-[240px] border-r border-[var(--pd-content-divider)]" role="region" aria-label={vmConnection.name}>
             <div class="float-right">
               <Tooltip bottom tip="{provider.name} details">
                 <button


### PR DESCRIPTION
Signed-off-by: Dibyendu <dibyendusahoo03@gmail.com>

Closes: #15388 

### What does this PR do?
Enable even border spacing in each card of Resources Page
### Screenshot / video of UI
Before Edit
<img width="1316" height="1018" alt="528207945-ffb1483e-ac06-40fb-a1cd-401c83b644da" src="https://github.com/user-attachments/assets/bf20cdf8-c9d1-42af-bf51-26660c9b41fc" />

After Edit
<img width="1568" height="950" alt="Screenshot 2026-01-06 210523" src="https://github.com/user-attachments/assets/e137f9a6-c107-4e8e-9e8d-88eef952cf44" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

