### PR TITLE
chore(proxy-page): do not gray out setting titles

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -118,11 +118,9 @@ function validate(event: any): void {
     </div>
 
     <div class="space-y-2">
-      <label
-        for="httpProxy"
-        class="block font-semibold {proxyState === ProxyState.PROXY_MANUAL
-          ? 'text-[var(--pd-invert-content-card-text)]'
-          : 'text-[var(--pd-content-sub-header)]'}">Web Proxy (HTTP)</label>
+      <label for="httpProxy" class="block font-semibold text-[var(--pd-invert-content-card-text)]"
+        >Web Proxy (HTTP)</label
+      >
       <Input
         name="httpProxy"
         id="httpProxy"
@@ -140,11 +138,9 @@ function validate(event: any): void {
     </div>
 
     <div class="space-y-2">
-      <label
-        for="httpsProxy"
-        class="block font-semibold {proxyState === ProxyState.PROXY_MANUAL
-          ? 'text-[var(--pd-invert-content-card-text)]'
-          : 'text-[var(--pd-content-sub-header)]'}">Secure Web Proxy (HTTPS)</label>
+      <label for="httpsProxy" class="block font-semibold text-[var(--pd-invert-content-card-text)]"
+        >Secure Web Proxy (HTTPS)</label
+      >
       <Input
         name="httpsProxy"
         id="httpsProxy"
@@ -162,11 +158,9 @@ function validate(event: any): void {
     </div>
 
     <div class="space-y-2">
-      <label
-        for="noProxy"
-        class="block font-semibold {proxyState === ProxyState.PROXY_MANUAL
-          ? 'text-[var(--pd-invert-content-card-text)]'
-          : 'text-[var(--pd-content-sub-header)]'}">Bypass proxy settings for these hosts and domains</label>
+      <label for="noProxy" class="block font-semibold text-[var(--pd-invert-content-card-text)]"
+        >Bypass proxy settings for these hosts and domains</label
+      >
       <Input
         name="noProxy"
         id="noProxy"


### PR DESCRIPTION
chore(proxy-page): do not gray out setting titles

### What does this PR do?

Like our Preference page / other parts of Podman Desktop, we should not
be "disabling" the titles, only the input sections.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->



https://github.com/user-attachments/assets/d4ea6b6d-7753-4bd1-aa95-10b7f6f6f01c


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/15571

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Go to Proxy Page
2. Press System
3. See that the titles no longer gray out

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
