### PR TITLE
chore(preferences input): if disabled, placeholder should be disabled font colour

### DIFF
--- a/packages/ui/src/lib/inputs/Input.spec.ts
+++ b/packages/ui/src/lib/inputs/Input.spec.ts
@@ -56,6 +56,7 @@ test('Expect basic styling', async () => {
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-[var(--pd-input-field-bg)]');
   expect(element).toHaveClass('text-[color:var(--pd-input-field-focused-text)]');
+  expect(element).toHaveClass('placeholder:text-[color:var(--pd-input-field-placeholder-text)]');
 
   expect(element).toHaveClass('group-hover:bg-[var(--pd-input-field-hover-bg)]');
   expect(element).toHaveClass('group-focus-within:bg-[var(--pd-input-field-hover-bg)]');
@@ -108,10 +109,12 @@ test('Expect basic disabled styling', async () => {
   expect(element).toHaveClass('outline-0');
   expect(element).toHaveClass('bg-[var(--pd-input-field-bg)]');
   expect(element).toHaveClass('text-[color:var(--pd-input-field-disabled-text)]');
+  expect(element).toHaveClass('placeholder:text-[color:var(--pd-input-field-disabled-text)]');
 
   expect(element).not.toHaveClass('group-hover:bg-[var(--pd-input-field-hover-bg)]');
   expect(element).not.toHaveClass('group-focus-within:bg-[var(--pd-input-field-hover-bg)]');
   expect(element).not.toHaveClass('group-hover-placeholder:text-[color:var(--pd-input-field-placeholder-text)]');
+  expect(element).not.toHaveClass('placeholder:text-[color:var(--pd-input-field-placeholder-text)]');
 
   expect(element.parentElement).toBeInTheDocument();
   expect(element.parentElement).toHaveClass('bg-[var(--pd-input-field-bg)]');

--- a/packages/ui/src/lib/inputs/Input.svelte
+++ b/packages/ui/src/lib/inputs/Input.svelte
@@ -90,7 +90,9 @@ async function onClear(): Promise<void> {
       bind:this={element}
       oninput={oninput}
       onkeypress={onkeypress}
-      class="w-full px-0.5 outline-0 bg-[var(--pd-input-field-bg)] placeholder:text-[color:var(--pd-input-field-placeholder-text)] overflow-hidden {inputClass}"
+      class="w-full px-0.5 outline-0 bg-[var(--pd-input-field-bg)] overflow-hidden {inputClass}"
+      class:placeholder:text-[color:var(--pd-input-field-placeholder-text)]={!disabled}
+      class:placeholder:text-[color:var(--pd-input-field-disabled-text)]={disabled}
       class:text-[color:var(--pd-input-field-focused-text)]={!disabled}
       class:text-[color:var(--pd-input-field-disabled-text)]={disabled}
       class:group-hover:bg-[var(--pd-input-field-hover-bg)]={enabled}


### PR DESCRIPTION
chore(preferences input): if disabled, placeholder should should be disable font

### What does this PR do?

When an input is disabled, the placeholder text now uses the disabled
text colour instead of the regular colour.

This makes it easier to distinguish that it is in fact.. a component
that cannot add any input.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:
<img width="1205" height="827" alt="Screenshot 2026-01-06 at 11 54 54 AM" src="https://github.com/user-attachments/assets/e8fd8c20-2dbf-4cd3-a73f-de9ce916d2aa" />



After:
<img width="1200" height="832" alt="Screenshot 2026-01-06 at 11 53 15 AM" src="https://github.com/user-attachments/assets/bf5f7c0e-53f0-47f2-9ec1-cd0f8c230444" />



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/15573

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Go to Proxy page
2. Press System
3. See that the placeholder text is the same colour across all three
   (HTTPS / HTTP + input on bottom)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
