### PR TITLE
feat: implement access to certificates from renderer process

### DIFF
--- a/packages/api/src/certificate-info.ts
+++ b/packages/api/src/certificate-info.ts
@@ -87,18 +87,7 @@ export interface CertificateInfo {
   keyUsage?: string[];
 
   /**
-   * The source/origin of the certificate.
-   * Indicates where the certificate was retrieved from.
-   */
-  source: CertificateSource;
-
-  /**
    * The raw PEM-encoded certificate string.
    */
   pem: string;
 }
-
-/**
- * Indicates the source from which a certificate was retrieved.
- */
-export type CertificateSource = 'system' | 'user' | 'bundled' | 'custom';

--- a/packages/api/src/certificate-info.ts
+++ b/packages/api/src/certificate-info.ts
@@ -1,0 +1,104 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Represents X.509 certificate information extracted from PEM-encoded certificates.
+ */
+export interface CertificateInfo {
+  /**
+   * The certificate subject's common name (CN).
+   */
+  subjectCommonName: string;
+
+  /**
+   * The full subject distinguished name (DN).
+   * Example: "CN=example.com,O=Example Inc,C=US"
+   */
+  subject: string;
+
+  /**
+   * The certificate issuer's common name (CN).
+   */
+  issuerCommonName: string;
+
+  /**
+   * The full issuer distinguished name (DN).
+   * Example: "CN=DigiCert Global Root CA,O=DigiCert Inc,C=US"
+   */
+  issuer: string;
+
+  /**
+   * The certificate serial number in hexadecimal format.
+   */
+  serialNumber: string;
+
+  /**
+   * The date from which the certificate is valid (notBefore).
+   * Undefined if the certificate could not be parsed.
+   */
+  validFrom?: Date;
+
+  /**
+   * The date until which the certificate is valid (notAfter).
+   * Undefined if the certificate could not be parsed.
+   */
+  validTo?: Date;
+
+  /**
+   * SHA-256 fingerprint of the certificate.
+   */
+  fingerprint256: string;
+
+  /**
+   * SHA-1 fingerprint of the certificate (legacy, for compatibility).
+   */
+  fingerprint: string;
+
+  /**
+   * Indicates whether this is a Certificate Authority (CA) certificate.
+   */
+  isCA: boolean;
+
+  /**
+   * Subject Alternative Names (SANs), if present.
+   * Example: "DNS:example.com, DNS:www.example.com, IP Address:192.168.1.1"
+   */
+  subjectAltName?: string;
+
+  /**
+   * Key usage extensions, if present.
+   * Example: ["digitalSignature", "keyEncipherment"]
+   */
+  keyUsage?: string[];
+
+  /**
+   * The source/origin of the certificate.
+   * Indicates where the certificate was retrieved from.
+   */
+  source: CertificateSource;
+
+  /**
+   * The raw PEM-encoded certificate string.
+   */
+  pem: string;
+}
+
+/**
+ * Indicates the source from which a certificate was retrieved.
+ */
+export type CertificateSource = 'system' | 'user' | 'bundled' | 'custom';

--- a/packages/api/src/certificate-info.ts
+++ b/packages/api/src/certificate-info.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -26,7 +26,7 @@ import { injectable } from 'inversify';
 import wincaAPI from 'win-ca/api';
 
 import { isLinux, isMac, isWindows } from '/@/util.js';
-import type { CertificateInfo, CertificateSource } from '/@api/certificate-info.js';
+import type { CertificateInfo } from '/@api/certificate-info.js';
 
 import { spawnWithPromise } from './util/spawn-promise.js';
 
@@ -167,10 +167,9 @@ export class Certificates {
   /**
    * Parse a PEM-encoded certificate and extract its information.
    * @param pem The PEM-encoded certificate string.
-   * @param source The source from which the certificate was retrieved.
    * @returns The parsed certificate information.
    */
-  parseCertificate(pem: string, source: CertificateSource = 'system'): CertificateInfo {
+  parseCertificate(pem: string): CertificateInfo {
     try {
       const cert = new crypto.X509Certificate(pem);
 
@@ -221,7 +220,6 @@ export class Certificates {
         isCA: cert.ca,
         subjectAltName: cert.subjectAltName,
         keyUsage: cert.keyUsage,
-        source,
         pem,
       };
     } catch (error) {
@@ -237,7 +235,6 @@ export class Certificates {
         fingerprint256: '',
         fingerprint: '',
         isCA: false,
-        source,
         pem,
       };
     }
@@ -248,17 +245,6 @@ export class Certificates {
    * @returns An array of parsed certificate information.
    */
   getAllCertificateInfos(): CertificateInfo[] {
-    const source = this.getCurrentPlatformSource();
-    return this.allCertificates.map(pem => this.parseCertificate(pem, source));
-  }
-
-  /**
-   * Determine the certificate source based on the current platform.
-   */
-  private getCurrentPlatformSource(): CertificateSource {
-    if (isMac() || isWindows() || isLinux()) {
-      return 'system';
-    }
-    return 'bundled';
+    return this.allCertificates.map(pem => this.parseCertificate(pem));
   }
 }

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,9 @@ import * as tls from 'node:tls';
 import { injectable } from 'inversify';
 import wincaAPI from 'win-ca/api';
 
-import type { CertificateInfo, CertificateSource } from '../../../api/src/certificate-info.js';
-import { isLinux, isMac, isWindows } from '../util.js';
+import { isLinux, isMac, isWindows } from '/@/util.js';
+import type { CertificateInfo, CertificateSource } from '/@api/certificate-info.js';
+
 import { spawnWithPromise } from './util/spawn-promise.js';
 
 /**

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -63,6 +63,7 @@ import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Uri } from '/@/plugin/types/uri.js';
 import { Updater } from '/@/plugin/updater.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { CertificateInfo } from '/@api/certificate-info.js';
 import type { CliToolInfo } from '/@api/cli-tool-info.js';
 import type { ColorInfo } from '/@api/color-info.js';
 import type { CommandInfo } from '/@api/command-info.js';
@@ -139,7 +140,6 @@ import type { ViewInfoUI } from '/@api/view-info.js';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
 
-import type { CertificateInfo } from '../../../api/src/certificate-info.js';
 import type { ListOrganizerItem } from '../../../api/src/list-organizer.js';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import { TrayMenu } from '../tray-menu.js';

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -139,6 +139,7 @@ import type { ViewInfoUI } from '/@api/view-info.js';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
 
+import type { CertificateInfo } from '../../../api/src/certificate-info.js';
 import type { ListOrganizerItem } from '../../../api/src/list-organizer.js';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import { TrayMenu } from '../tray-menu.js';
@@ -2417,6 +2418,10 @@ export class PluginSystem {
 
     this.ipcHandle('proxy:getState', async (): Promise<ProxyState> => {
       return proxy.getState();
+    });
+
+    this.ipcHandle('certificates:listCertificates', async (): Promise<CertificateInfo[]> => {
+      return certificates.getAllCertificateInfos();
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -44,6 +44,7 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import { contextBridge, ipcRenderer } from 'electron';
 
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type';
+import type { CertificateInfo } from '/@api/certificate-info';
 import type { CliToolInfo } from '/@api/cli-tool-info';
 import type { ColorInfo } from '/@api/color-info';
 import type { CommandInfo } from '/@api/command-info';
@@ -2695,6 +2696,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('unpinStatusBar', async (optionId: string): Promise<void> => {
     return ipcInvoke('statusbar:unpin', optionId);
+  });
+
+  contextBridge.exposeInMainWorld('listCertificates', async (): Promise<CertificateInfo[]> => {
+    return ipcInvoke('certificates:listCertificates');
   });
 }
 

--- a/packages/renderer/src/stores/certificates.ts
+++ b/packages/renderer/src/stores/certificates.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
+
+import type { CertificateInfo } from '/@api/certificate-info';
+
+import { EventStore } from './event-store';
+import { findMatchInLeaves } from './search-util';
+
+const windowEvents = ['extensions-started'];
+const windowListeners = ['system-ready'];
+
+export async function checkForUpdate(_eventName: string): Promise<boolean> {
+  return true;
+}
+
+export const certificatesInfos: Writable<CertificateInfo[]> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const listCertificates = (): Promise<CertificateInfo[]> => {
+  return window.listCertificates();
+};
+
+export const certificatesEventStore = new EventStore<CertificateInfo[]>(
+  'certificates',
+  certificatesInfos,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  listCertificates,
+);
+certificatesEventStore.setupWithDebounce();
+
+export const searchPattern = writable('');
+
+export const filtered = derived([searchPattern, certificatesInfos], ([$searchPattern, $certificatesInfos]) =>
+  $certificatesInfos.filter(certificateInfo => findMatchInLeaves(certificateInfo, $searchPattern.toLowerCase())),
+);


### PR DESCRIPTION
### What does this PR do?

PR adds store, window.listSertificates mehotd, sertificate parsing implementation. It provides base for creating Certificates Preference page on renderer side.

### Screenshot / video of UI

See (TBD)

### What issues does this PR fix or reference?

Related to #14729.

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
