### PR TITLE
Certificates preference page

### DIFF
--- a/packages/api/src/certificate-info.ts
+++ b/packages/api/src/certificate-info.ts
@@ -87,18 +87,7 @@ export interface CertificateInfo {
   keyUsage?: string[];
 
   /**
-   * The source/origin of the certificate.
-   * Indicates where the certificate was retrieved from.
-   */
-  source: CertificateSource;
-
-  /**
    * The raw PEM-encoded certificate string.
    */
   pem: string;
 }
-
-/**
- * Indicates the source from which a certificate was retrieved.
- */
-export type CertificateSource = 'system' | 'user' | 'bundled' | 'custom';

--- a/packages/api/src/certificate-info.ts
+++ b/packages/api/src/certificate-info.ts
@@ -1,0 +1,104 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Represents X.509 certificate information extracted from PEM-encoded certificates.
+ */
+export interface CertificateInfo {
+  /**
+   * The certificate subject's common name (CN).
+   */
+  subjectCommonName: string;
+
+  /**
+   * The full subject distinguished name (DN).
+   * Example: "CN=example.com,O=Example Inc,C=US"
+   */
+  subject: string;
+
+  /**
+   * The certificate issuer's common name (CN).
+   */
+  issuerCommonName: string;
+
+  /**
+   * The full issuer distinguished name (DN).
+   * Example: "CN=DigiCert Global Root CA,O=DigiCert Inc,C=US"
+   */
+  issuer: string;
+
+  /**
+   * The certificate serial number in hexadecimal format.
+   */
+  serialNumber: string;
+
+  /**
+   * The date from which the certificate is valid (notBefore).
+   * Undefined if the certificate could not be parsed.
+   */
+  validFrom?: Date;
+
+  /**
+   * The date until which the certificate is valid (notAfter).
+   * Undefined if the certificate could not be parsed.
+   */
+  validTo?: Date;
+
+  /**
+   * SHA-256 fingerprint of the certificate.
+   */
+  fingerprint256: string;
+
+  /**
+   * SHA-1 fingerprint of the certificate (legacy, for compatibility).
+   */
+  fingerprint: string;
+
+  /**
+   * Indicates whether this is a Certificate Authority (CA) certificate.
+   */
+  isCA: boolean;
+
+  /**
+   * Subject Alternative Names (SANs), if present.
+   * Example: "DNS:example.com, DNS:www.example.com, IP Address:192.168.1.1"
+   */
+  subjectAltName?: string;
+
+  /**
+   * Key usage extensions, if present.
+   * Example: ["digitalSignature", "keyEncipherment"]
+   */
+  keyUsage?: string[];
+
+  /**
+   * The source/origin of the certificate.
+   * Indicates where the certificate was retrieved from.
+   */
+  source: CertificateSource;
+
+  /**
+   * The raw PEM-encoded certificate string.
+   */
+  pem: string;
+}
+
+/**
+ * Indicates the source from which a certificate was retrieved.
+ */
+export type CertificateSource = 'system' | 'user' | 'bundled' | 'custom';

--- a/packages/api/src/certificate-info.ts
+++ b/packages/api/src/certificate-info.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -26,7 +26,7 @@ import { injectable } from 'inversify';
 import wincaAPI from 'win-ca/api';
 
 import { isLinux, isMac, isWindows } from '/@/util.js';
-import type { CertificateInfo, CertificateSource } from '/@api/certificate-info.js';
+import type { CertificateInfo } from '/@api/certificate-info.js';
 
 import { spawnWithPromise } from './util/spawn-promise.js';
 
@@ -167,10 +167,9 @@ export class Certificates {
   /**
    * Parse a PEM-encoded certificate and extract its information.
    * @param pem The PEM-encoded certificate string.
-   * @param source The source from which the certificate was retrieved.
    * @returns The parsed certificate information.
    */
-  parseCertificate(pem: string, source: CertificateSource = 'system'): CertificateInfo {
+  parseCertificate(pem: string): CertificateInfo {
     try {
       const cert = new crypto.X509Certificate(pem);
 
@@ -221,7 +220,6 @@ export class Certificates {
         isCA: cert.ca,
         subjectAltName: cert.subjectAltName,
         keyUsage: cert.keyUsage,
-        source,
         pem,
       };
     } catch (error) {
@@ -237,7 +235,6 @@ export class Certificates {
         fingerprint256: '',
         fingerprint: '',
         isCA: false,
-        source,
         pem,
       };
     }
@@ -248,17 +245,6 @@ export class Certificates {
    * @returns An array of parsed certificate information.
    */
   getAllCertificateInfos(): CertificateInfo[] {
-    const source = this.getCurrentPlatformSource();
-    return this.allCertificates.map(pem => this.parseCertificate(pem, source));
-  }
-
-  /**
-   * Determine the certificate source based on the current platform.
-   */
-  private getCurrentPlatformSource(): CertificateSource {
-    if (isMac() || isWindows() || isLinux()) {
-      return 'system';
-    }
-    return 'bundled';
+    return this.allCertificates.map(pem => this.parseCertificate(pem));
   }
 }

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,9 @@ import * as tls from 'node:tls';
 import { injectable } from 'inversify';
 import wincaAPI from 'win-ca/api';
 
-import type { CertificateInfo, CertificateSource } from '../../../api/src/certificate-info.js';
-import { isLinux, isMac, isWindows } from '../util.js';
+import { isLinux, isMac, isWindows } from '/@/util.js';
+import type { CertificateInfo, CertificateSource } from '/@api/certificate-info.js';
+
 import { spawnWithPromise } from './util/spawn-promise.js';
 
 /**

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -63,6 +63,7 @@ import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Uri } from '/@/plugin/types/uri.js';
 import { Updater } from '/@/plugin/updater.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { CertificateInfo } from '/@api/certificate-info.js';
 import type { CliToolInfo } from '/@api/cli-tool-info.js';
 import type { ColorInfo } from '/@api/color-info.js';
 import type { CommandInfo } from '/@api/command-info.js';
@@ -139,7 +140,6 @@ import type { ViewInfoUI } from '/@api/view-info.js';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
 
-import type { CertificateInfo } from '../../../api/src/certificate-info.js';
 import type { ListOrganizerItem } from '../../../api/src/list-organizer.js';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import { TrayMenu } from '../tray-menu.js';

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -139,6 +139,7 @@ import type { ViewInfoUI } from '/@api/view-info.js';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
 
+import type { CertificateInfo } from '../../../api/src/certificate-info.js';
 import type { ListOrganizerItem } from '../../../api/src/list-organizer.js';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import { TrayMenu } from '../tray-menu.js';
@@ -2417,6 +2418,10 @@ export class PluginSystem {
 
     this.ipcHandle('proxy:getState', async (): Promise<ProxyState> => {
       return proxy.getState();
+    });
+
+    this.ipcHandle('certificates:listCertificates', async (): Promise<CertificateInfo[]> => {
+      return certificates.getAllCertificateInfos();
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -44,6 +44,7 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import { contextBridge, ipcRenderer } from 'electron';
 
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type';
+import type { CertificateInfo } from '/@api/certificate-info';
 import type { CliToolInfo } from '/@api/cli-tool-info';
 import type { ColorInfo } from '/@api/color-info';
 import type { CommandInfo } from '/@api/command-info';
@@ -2695,6 +2696,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('unpinStatusBar', async (optionId: string): Promise<void> => {
     return ipcInvoke('statusbar:unpin', optionId);
+  });
+
+  contextBridge.exposeInMainWorld('listCertificates', async (): Promise<CertificateInfo[]> => {
+    return ipcInvoke('certificates:listCertificates');
   });
 }
 

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -12,6 +12,7 @@ import PreferencesIcon from '/@/lib/images/PreferencesIcon.svelte';
 import ProxyIcon from '/@/lib/images/ProxyIcon.svelte';
 import RegistriesIcon from '/@/lib/images/RegistriesIcon.svelte';
 import ResourcesIcon from '/@/lib/images/ResourcesIcon.svelte';
+import CertificateIcon from '/@/lib/preferences/certificate/CertificateIcon.svelte';
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
 import { DockerCompatibilitySettings } from '/@api/docker-compatibility-info';
 
@@ -53,6 +54,7 @@ let settingsNavigationItems = $derived<SettingsNavItemConfig[]>([
   { title: 'Authentication', href: '/preferences/authentication-providers', visible: true, icon: AuthenticationIcon },
   { title: 'CLI Tools', href: '/preferences/cli-tools', visible: true, icon: CLIToolsIcon },
   { title: 'Kubernetes', href: '/preferences/kubernetes-contexts', visible: true, icon: KubernetesIcon },
+  { title: 'Certificates', href: '/preferences/certificates', visible: true, icon: CertificateIcon },
 ]);
 
 function updateDockerCompatibility(): void {

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -8,6 +8,7 @@ import Route from '/@/Route.svelte';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
+import CertificateList from './certificate/CertificateList.svelte';
 import PreferencesDockerCompatibilityRendering from './docker-compat/PreferencesDockerCompatibilityRendering.svelte';
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
 import PreferencesCliToolsRendering from './PreferencesCliToolsRendering.svelte';
@@ -84,6 +85,9 @@ onMount(async () => {
   </Route>
   <Route path="/proxies" breadcrumb="Proxy">
     <PreferencesProxiesRendering />
+  </Route>
+  <Route path="/certificates" breadcrumb="Certificates">
+    <CertificateList />
   </Route>
 
   <Route path="/onboarding/:extensionId" breadcrumb="Extension Onboarding" let:meta navigationHint="details">

--- a/packages/renderer/src/lib/preferences/certificate/CertificateColumnSimple.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateColumnSimple.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+interface Props {
+  object: string;
+}
+
+let { object }: Props = $props();
+</script>
+
+<div class="text-[var(--pd-table-body-text-highlight) overflow-hidden text-ellipsis">
+  {object}
+</div>
+

--- a/packages/renderer/src/lib/preferences/certificate/CertificateColumnSimple.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateColumnSimple.svelte
@@ -6,7 +6,7 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<div class="text-[var(--pd-table-body-text-highlight) overflow-hidden text-ellipsis">
+<div title={object} class="text-[var(--pd-table-body-text-highlight) overflow-hidden text-ellipsis">
   {object}
 </div>
 

--- a/packages/renderer/src/lib/preferences/certificate/CertificateColumnSimple.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateColumnSimple.svelte
@@ -6,7 +6,7 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<div title={object} class="text-[var(--pd-table-body-text-highlight) overflow-hidden text-ellipsis">
+<div title={object} class="text-(--pd-table-body-text-highlight) overflow-hidden text-ellipsis">
   {object}
 </div>
 

--- a/packages/renderer/src/lib/preferences/certificate/CertificateEmptyScreen.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateEmptyScreen.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+
+import CertificateIcon from './CertificateIcon.svelte';
+</script>
+
+<EmptyScreen
+  icon={CertificateIcon}
+  title="No certificates found"
+  message="System certificates will be loaded automatically when the application starts." />
+

--- a/packages/renderer/src/lib/preferences/certificate/CertificateIcon.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateIcon.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+interface Props {
+  size?: string | number;
+  class?: string;
+  style?: string;
+}
+
+let { size = '14', class: className = '', style: styleName = '' }: Props = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  class={className}
+  style={styleName}
+  viewBox="0 0 24 24"
+  fill="none"
+  aria-label="Certificates"
+  xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M12 1L3 5V11C3 16.55 6.84 21.74 12 23C17.16 21.74 21 16.55 21 11V5L12 1ZM12 11.99H19C18.47 16.11 15.72 19.78 12 20.93V12H5V6.3L12 3.19V11.99Z"
+    fill="currentColor" />
+</svg>
+

--- a/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
@@ -72,23 +72,23 @@ function formatExpirationDate(date: Date | undefined): string {
 
 let nameColumn = new TableColumn<CertificateInfoUI, string>('Certificate Name', {
   width: '2fr',
-  renderMapping: (cert): string => cert.issuer || 'Unknown',
+  renderMapping: (cert): string => cert.issuer ?? 'Unknown',
   renderer: CertificateColumnSimple,
   comparator: (a, b): number => getDisplayName(a).localeCompare(getDisplayName(b)),
 });
 
 let issuerColumn = new TableColumn<CertificateInfoUI, string>('Issuer', {
   width: '2fr',
-  renderMapping: (cert): string => cert.issuer || 'Unknown',
+  renderMapping: (cert): string => cert.issuer ?? 'Unknown',
   renderer: CertificateColumnSimple,
   comparator: (a, b): number => getIssuerDisplayName(a).localeCompare(getIssuerDisplayName(b)),
 });
 
 let serialColumn = new TableColumn<CertificateInfoUI, string>('Serial Number', {
   width: '1fr',
-  renderMapping: (cert): string => cert.serialNumber || 'Unknown',
+  renderMapping: (cert): string => cert.serialNumber ?? 'Unknown',
   renderer: CertificateColumnSimple,
-  comparator: (a, b): number => (a.serialNumber || '').localeCompare(b.serialNumber || ''),
+  comparator: (a, b): number => (a.serialNumber ?? '').localeCompare(b.serialNumber ?? ''),
 });
 
 let expiresColumn = new TableColumn<CertificateInfoUI, string>('Expires On', {

--- a/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
@@ -72,7 +72,7 @@ function formatExpirationDate(date: Date | undefined): string {
 
 let nameColumn = new TableColumn<CertificateInfoUI, string>('Certificate Name', {
   width: '2fr',
-  renderMapping: (cert): string => cert.issuer ?? 'Unknown',
+  renderMapping: (cert): string => cert.subject ?? 'Unknown',
   renderer: CertificateColumnSimple,
   comparator: (a, b): number => getDisplayName(a).localeCompare(getDisplayName(b)),
 });

--- a/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-import { FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+import { Button, FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
+import SlideToggle from '/@/lib/ui/SlideToggle.svelte';
 import { certificatesInfos, filtered, searchPattern } from '/@/stores/certificates';
 import type { CertificateInfo } from '/@api/certificate-info';
 
@@ -19,6 +20,7 @@ interface Props {
 }
 
 let { searchTerm = $bindable('') }: Props = $props();
+let checked = $state(true);
 $effect(() => {
   searchPattern.set(searchTerm);
 });
@@ -119,32 +121,67 @@ function key(item: CertificateInfoUI): string {
 function label(item: CertificateInfoUI): string {
   return getDisplayName(item);
 }
+
+function onChecked(state: boolean): void {
+  checked = state;
+}
 </script>
 
 <NavPage bind:searchTerm={searchTerm} title="Certificates">
+  {#snippet additionalActions()}
+    <Button class="mr-5">Synchronize into podman-machine-default</Button>
+  {/snippet}
   {#snippet content()}
-    <div class="flex min-w-full h-full">
-      {#if $certificatesInfos.length === 0}
-        <CertificateEmptyScreen />
-      {:else if certificates.length === 0}
-        {#if searchTerm}
-          <FilteredEmptyScreen icon={CertificateIcon} kind="certificates" bind:searchTerm={searchTerm} />
-        {:else}
+    <div class="flex flex-col px-2 py-2 w-full">
+      <div class="bg-(--pd-invert-content-card-bg) rounded-md mx-5"> 
+        <div class="flex flex-col px-2 py-2 w-full text-(--pd-invert-content-card-text) space-y-4">
+          <dif class="flex flex-row justify-between">
+            <div class="flex flex-col">
+              <div class="flex flex-row text-(--pd-invert-content-card-text)">
+                <div class="flex flex-row space-x-2 items-center">
+                  <span class="font-semibold">Synchronize Certificates</span>
+                </div>
+              </div>
+              <div class="pt-1 text-(--pd-invert-content-card-text) text-sm pr-2">Automatically synchronize certificates to all Podman machines.</div>        
+            </div>
+            <SlideToggle
+              id="sync-all-certificates"
+              name="Automatic Synchronize"
+              left
+              bind:checked={checked}
+              on:checked={(event): void => onChecked(event.detail)}
+              aria-label="Automatic Ceritficates Synchronization">
+              <span class="text-xs">{checked ? 'Enabled' : 'Disabled'}</span>
+            </SlideToggle>
+          </dif>
+        </div>
+      </div>
+      <div class="self-start text-(--pd-invert-content-card-text) mx-5 my-5">
+        Manage host-based certificates in Podman Desktop with automatic synchronization to your Podman Machine.
+      </div>
+      <div class="flex min-w-full h-full">
+        {#if $certificatesInfos.length === 0}
           <CertificateEmptyScreen />
+        {:else if certificates.length === 0}
+          {#if searchTerm}
+            <FilteredEmptyScreen icon={CertificateIcon} kind="certificates" bind:searchTerm={searchTerm} />
+          {:else}
+            <CertificateEmptyScreen />
+          {/if}
+        {:else}
+          <Table
+            kind="certificate"
+            data={certificates}
+            columns={columns}
+            row={row}
+            defaultSortColumn="Certificate Name"
+            key={key}
+            label={label}
+            enableLayoutConfiguration={true}
+            on:update={(): CertificateInfoUI[] => (certificates = certificates)}>
+          </Table>
         {/if}
-      {:else}
-        <Table
-          kind="certificate"
-          data={certificates}
-          columns={columns}
-          row={row}
-          defaultSortColumn="Certificate Name"
-          key={key}
-          label={label}
-          enableLayoutConfiguration={true}
-          on:update={(): CertificateInfoUI[] => (certificates = certificates)}>
-        </Table>
-      {/if}
+      </div>
     </div>
   {/snippet}
 </NavPage>

--- a/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+import { FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+import { onDestroy, onMount } from 'svelte';
+import type { Unsubscriber } from 'svelte/store';
+
+import { certificatesInfos, filtered, searchPattern } from '/@/stores/certificates';
+import type { CertificateInfo } from '/@api/certificate-info';
+
+import CertificateColumnSimple from './CertificateColumnSimple.svelte';
+import CertificateEmptyScreen from './CertificateEmptyScreen.svelte';
+import CertificateIcon from './CertificateIcon.svelte';
+
+interface CertificateInfoUI extends CertificateInfo {
+  name: string;
+}
+
+interface Props {
+  searchTerm?: string;
+}
+
+let { searchTerm = $bindable('') }: Props = $props();
+$effect(() => {
+  searchPattern.set(searchTerm);
+});
+
+let certificates: CertificateInfoUI[] = $state([]);
+
+let certificatesUnsubscribe: Unsubscriber;
+
+onMount(async () => {
+  certificatesUnsubscribe = filtered.subscribe(value => {
+    certificates = value.map(cert => ({
+      ...cert,
+      name: getDisplayName(cert),
+    }));
+  });
+});
+
+onDestroy(() => {
+  if (certificatesUnsubscribe) {
+    certificatesUnsubscribe();
+  }
+});
+
+/**
+ * Get display name for certificate (Subject: CN → Full DN → 'Unknown')
+ */
+function getDisplayName(cert: CertificateInfo): string {
+  return cert.subjectCommonName || cert.subject || 'Unknown';
+}
+
+/**
+ * Get issuer display name (Issuer: CN → Full DN → 'Unknown')
+ */
+function getIssuerDisplayName(cert: CertificateInfo): string {
+  return cert.issuerCommonName || cert.issuer || 'Unknown';
+}
+
+/**
+ * Format a date for display, returning 'Unknown' if undefined
+ */
+function formatExpirationDate(date: Date | undefined): string {
+  if (!date) {
+    return 'Unknown';
+  }
+  return new Date(date).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+let nameColumn = new TableColumn<CertificateInfoUI, string>('Certificate Name', {
+  width: '2fr',
+  renderMapping: (cert): string => cert.issuer || 'Unknown',
+  renderer: CertificateColumnSimple,
+  comparator: (a, b): number => getDisplayName(a).localeCompare(getDisplayName(b)),
+});
+
+let issuerColumn = new TableColumn<CertificateInfoUI, string>('Issuer', {
+  width: '2fr',
+  renderMapping: (cert): string => cert.issuer || 'Unknown',
+  renderer: CertificateColumnSimple,
+  comparator: (a, b): number => getIssuerDisplayName(a).localeCompare(getIssuerDisplayName(b)),
+});
+
+let serialColumn = new TableColumn<CertificateInfoUI, string>('Serial Number', {
+  width: '1fr',
+  renderMapping: (cert): string => cert.serialNumber || 'Unknown',
+  renderer: CertificateColumnSimple,
+  comparator: (a, b): number => (a.serialNumber || '').localeCompare(b.serialNumber || ''),
+});
+
+let expiresColumn = new TableColumn<CertificateInfoUI, string>('Expires On', {
+  width: '1fr',
+  renderMapping: (cert): string => formatExpirationDate(cert.validTo),
+  renderer: CertificateColumnSimple,
+  comparator: (a, b): number => {
+    const dateA = a.validTo ? new Date(a.validTo).getTime() : 0;
+    const dateB = b.validTo ? new Date(b.validTo).getTime() : 0;
+    return dateA - dateB;
+  },
+});
+
+const columns = [nameColumn, issuerColumn, serialColumn, expiresColumn];
+
+const row = new TableRow<CertificateInfoUI>({});
+
+/**
+ * Utility function for the Table to get the key to use for each item
+ */
+function key(item: CertificateInfoUI): string {
+  return `${item.fingerprint256 || item.serialNumber || item.subjectCommonName}`;
+}
+
+/**
+ * Utility function for the Table to get the label to use for each item
+ */
+function label(item: CertificateInfoUI): string {
+  return getDisplayName(item);
+}
+</script>
+
+<NavPage bind:searchTerm={searchTerm} title="Certificates">
+  {#snippet content()}
+    <div class="flex min-w-full h-full">
+      {#if $certificatesInfos.length === 0}
+        <CertificateEmptyScreen />
+      {:else if certificates.length === 0}
+        {#if searchTerm}
+          <FilteredEmptyScreen icon={CertificateIcon} kind="certificates" bind:searchTerm={searchTerm} />
+        {:else}
+          <CertificateEmptyScreen />
+        {/if}
+      {:else}
+        <Table
+          kind="certificate"
+          data={certificates}
+          columns={columns}
+          row={row}
+          defaultSortColumn="Certificate Name"
+          key={key}
+          label={label}
+          enableLayoutConfiguration={true}
+          on:update={(): CertificateInfoUI[] => (certificates = certificates)}>
+        </Table>
+      {/if}
+    </div>
+  {/snippet}
+</NavPage>
+

--- a/packages/renderer/src/stores/certificates.ts
+++ b/packages/renderer/src/stores/certificates.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
+
+import type { CertificateInfo } from '/@api/certificate-info';
+
+import { EventStore } from './event-store';
+import { findMatchInLeaves } from './search-util';
+
+const windowEvents = ['extensions-started'];
+const windowListeners = ['system-ready'];
+
+export async function checkForUpdate(_eventName: string): Promise<boolean> {
+  return true;
+}
+
+export const certificatesInfos: Writable<CertificateInfo[]> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const listCertificates = (): Promise<CertificateInfo[]> => {
+  return window.listCertificates();
+};
+
+export const certificatesEventStore = new EventStore<CertificateInfo[]>(
+  'certificates',
+  certificatesInfos,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  listCertificates,
+);
+certificatesEventStore.setupWithDebounce();
+
+export const searchPattern = writable('');
+
+export const filtered = derived([searchPattern, certificatesInfos], ([$searchPattern, $certificatesInfos]) =>
+  $certificatesInfos.filter(certificateInfo => findMatchInLeaves(certificateInfo, $searchPattern.toLowerCase())),
+);


### PR DESCRIPTION
### What does this PR do?

This PR adds `Certificates` Preference page to show certificates available on localhost.

### Screenshot / video of UI

<img width="1311" height="974" alt="image" src="https://github.com/user-attachments/assets/d928854e-3041-4b62-9ebd-7cbdbf813ef2" />

<img width="1311" height="974" alt="image" src="https://github.com/user-attachments/assets/441322a6-0a53-4fc9-9c1d-091ada6bf576" />


### What issues does this PR fix or reference?

Related to #14729.

### How to test this PR?

1. Checkout the PR's branch 
2. Run `pnpm watch`
3. Open `Preferences\Certificates` page

- [ ] Tests are covering the bug fix or the new feature
