### PR TITLE
fix: support  all characters in args of command passed to osascript

### DIFF
--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -342,7 +342,7 @@ describe('exec', () => {
 
   test('should run the command with privileges on macOS', async () => {
     const command = 'echo';
-    const args = ['Hello, World!'];
+    const args = ['Hello, "World"!'];
 
     (util.isMac as Mock).mockReturnValue(true);
 
@@ -368,7 +368,7 @@ describe('exec', () => {
       'osascript',
       expect.arrayContaining([
         '-e',
-        'do shell script "echo \\"Hello, World!\\"" with prompt "Podman Desktop requires admin privileges " with administrator privileges',
+        'do shell script "echo Hello,\\\\ \\\\\\"World\\\\\\"!" with prompt "Podman Desktop requires admin privileges " with administrator privileges',
       ]),
       expect.anything(),
     );

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -368,7 +368,7 @@ describe('exec', () => {
       'osascript',
       expect.arrayContaining([
         '-e',
-        'do shell script "echo Hello, World!" with prompt "Podman Desktop requires admin privileges " with administrator privileges',
+        'do shell script "echo \\"Hello, World!\\"" with prompt "Podman Desktop requires admin privileges " with administrator privileges',
       ]),
       expect.anything(),
     );

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -123,11 +123,11 @@ export class Exec {
           sudo.exec(sudoCommand, sudoOptions, callback);
         });
       } else if (isMac()) {
+        const quotedArgs = (args ?? []).map(arg => `\\"${arg}\\"`);
+        const shellScript = `${command} ${quotedArgs.join(' ')}`;
         args = [
           '-e',
-          `do shell script "${command} ${(args ?? []).join(
-            ' ',
-          )}" with prompt "Podman Desktop requires admin privileges " with administrator privileges`,
+          `do shell script "${shellScript}" with prompt "Podman Desktop requires admin privileges " with administrator privileges`,
         ];
         command = 'osascript';
       } else if (isLinux()) {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -123,11 +123,14 @@ export class Exec {
           sudo.exec(sudoCommand, sudoOptions, callback);
         });
       } else if (isMac()) {
-        const quotedArgs = (args ?? []).map(arg => `\\"${arg}\\"`);
-        const shellScript = `${command} ${quotedArgs.join(' ')}`;
+        const escapedArgs = (args ?? []).map(arg =>
+          arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/ /g, '\\ '),
+        );
+        const shellScript = `${command} ${escapedArgs.join(' ')}`;
+        const escapedShellScript = shellScript.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         args = [
           '-e',
-          `do shell script "${shellScript}" with prompt "Podman Desktop requires admin privileges " with administrator privileges`,
+          `do shell script "${escapedShellScript}" with prompt "Podman Desktop requires admin privileges " with administrator privileges`,
         ];
         command = 'osascript';
       } else if (isLinux()) {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Escape special characters in the args inside the AppleScript called by osascript

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #15582 

### How to test this PR?

- See steps to reproduce in #15582 
- try with other commands, in the extension, containing special characters (space, quote, backslash)

- [x] Tests are covering the bug fix or the new feature
