### PR TITLE
fix: use info icon for internal navigation links

### DIFF
--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowUpRightFromSquare, faCheckCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
@@ -74,7 +74,7 @@ function openExtensionDetails(): void {
       <div class="flex flex-1 justify-end items-center">
         <Button
           type="link"
-          icon={faArrowUpRightFromSquare}
+          icon={faCircleInfo}
           aria-label="{catalogExtensionUI.displayName} details"
           on:click={openExtensionDetails}>More details</Button>
       </div>

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
@@ -19,7 +19,7 @@ function openDetailsExtension(): void {
   <button aria-label="{extension.name} extension details" type="button" on:click={openDetailsExtension}>
     <div class="flex flex-row items-center text-[var(--pd-content-header)]">
       {#if displayIcon}
-        <Fa icon={faArrowUpRightFromSquare} />
+        <Fa icon={faCircleInfo} />
       {/if}
       <div class="text-left before:{$$props.class}">
         {extension.displayName} extension

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import Fa from 'svelte-fa';
@@ -89,7 +89,7 @@ onMount(async () => {
           aria-label="{connectionInfo.provider.name} details"
           type="button"
           onclick={(): void => router.goto(connectionInfo.link)}>
-          <Fa icon={faArrowUpRightFromSquare} />
+          <Fa icon={faCircleInfo} />
         </button>
       </Tooltip>
     </div>


### PR DESCRIPTION
Replace `faArrowUpRightFromSquare` with `faCircleInfo` in:
- `ExtensionDetailsLink`
- `PreferencesDockerCompatibilitySocketMappingStatus`
- `CatalogExtension`

To follow the convention of using the external link icon only for external URLs.

### What does this PR do?

### Screenshot / video of UI

`ExtensionDetailsLink`:

BEFORE:

<img width="2138" height="1866" alt="CleanShot 2026-01-07 at 14 57 00@2x" src="https://github.com/user-attachments/assets/0a6e884f-9488-4573-9fe5-717f51e0e57e" />

AFTER:

<img width="2138" height="1866" alt="CleanShot 2026-01-07 at 13 24 34@2x" src="https://github.com/user-attachments/assets/e425fcf8-03b4-4f4d-8ec8-f5fced68c8e5" />

`CatalogExtension`:

BEFORE:

<img width="2138" height="1866" alt="CleanShot 2026-01-07 at 14 57 29@2x" src="https://github.com/user-attachments/assets/571c5a5e-65ff-42c6-8bbf-0acb63c2c525" />

AFTER:

<img width="2138" height="1866" alt="CleanShot 2026-01-07 at 13 31 26@2x" src="https://github.com/user-attachments/assets/aa9b7a63-7a2c-4303-b97f-bb2692806d52" />

`PreferencesDockerCompatibilitySocketMappingStatus`: For some reason, I don't get the icon in this Preferences panel, but the change is so small it's okay to not provide a screenshot, I hope.

### What issues does this PR fix or reference?

Fixes #14734

- [ ] Tests are covering the bug fix or the new feature (No test changes needed, this is just an icon change.
