### PR TITLE
refactor(ExtensionUpdate): use extension api version instead of App#getVersion

### DIFF
--- a/packages/main/src/plugin/extension/updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/extension/updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { app } from 'electron';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
+import type { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { ExtensionInstaller } from '/@/plugin/install/extension-installer.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
@@ -28,12 +28,6 @@ import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalo
 import type { ExtensionInfo } from '/@api/extension-info.js';
 
 import { ExtensionsUpdater } from './extensions-updater.js';
-
-vi.mock('electron', () => ({
-  app: {
-    getVersion: vi.fn(),
-  },
-}));
 
 let extensionsUpdater: ExtensionsUpdater;
 
@@ -113,6 +107,10 @@ const telemetry = {
   }),
 } as unknown as Telemetry;
 
+const extensionApiVersion: ExtensionApiVersion = {
+  getApiVersion: vi.fn(),
+} as ExtensionApiVersion;
+
 const originalConsoleError = console.error;
 beforeEach(() => {
   console.error = vi.fn();
@@ -122,6 +120,7 @@ beforeEach(() => {
     configurationRegistry,
     extensionInstaller,
     telemetry,
+    extensionApiVersion,
   );
   vi.clearAllMocks();
 });
@@ -179,7 +178,7 @@ test('should check for updates if podman desktop version mistmatch and try to up
   } as ExtensionInfo;
 
   // mock current version being 1.0.0
-  vi.mocked(app.getVersion).mockReturnValue('1.0.0');
+  vi.mocked(extensionApiVersion.getApiVersion).mockReturnValue('1.0.0');
 
   if (!catalogExtension1.versions[0]) {
     throw new Error('No version');

--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -17,11 +17,11 @@
  ***********************************************************************/
 
 import { compareVersions } from 'compare-versions';
-import { app } from 'electron';
 import { inject, injectable } from 'inversify';
 import { coerce, satisfies } from 'semver';
 
 import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
+import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionsUpdaterSettings } from '/@/plugin/extension/updater/extensions-updater-settings.js';
 import { ExtensionInstaller } from '/@/plugin/install/extension-installer.js';
@@ -47,6 +47,8 @@ export class ExtensionsUpdater {
     private extensionInstaller: ExtensionInstaller,
     @inject(Telemetry)
     private telemetry: Telemetry,
+    @inject(ExtensionApiVersion)
+    private extensionApiVersion: ExtensionApiVersion,
   ) {}
 
   async init(): Promise<void> {
@@ -146,7 +148,7 @@ export class ExtensionsUpdater {
 
         // if found compare versions
         const installedVersion = installedExtension.version;
-        const appVersion = app.getVersion();
+        const appVersion = this.extensionApiVersion.getApiVersion();
 
         // coerce the podman desktop Version
         const currentPodmanDesktopVersion = coerce(appVersion);

--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What does this PR do?

Since https://github.com/podman-desktop/podman-desktop/pull/15586 the `ExtensionsUpdater` is injectable, we can then inject `ExtensionApiVersion`.

Finally we can replace the `Electron.app#getVersion` by the `ExtensionApiVersion#getApiVersion` introduced in https://github.com/podman-desktop/podman-desktop/pull/15563.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15373

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually for regression**

1. Checkout this branch
2. Start in dev mode using `pnpm watch`
3. Go to `Extensions > Catalog` download any extensions (E.g. quadlet :eagle: )
4. Once downloaded, close Podman Desktop
5. Open `~./.local/share/containers/podman-desktop/plugins/<extension-downloaded>/package.json`
6. Update the `version` field to anything bellow the current one (E.g. put `0.1.0` if the version is `0.11.1`)
7. Save the file
8. Start in dev mode Podman Desktop using `pnpm watch`
9. Assert in the logs you see
```
[...]
Analyzing image ghcr.io/podman-desktop/pd-extension-quadlet:0.11.1...
main ↪️ Downloading and extract layers...
[...]
main ↪️ Filtering image content...
main ↪️ Extension Successfully installed.
```
