### PR TITLE
chore: telemetry strings should come from product.json

### DIFF
--- a/packages/api/src/telemetry.ts
+++ b/packages/api/src/telemetry.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface TelemetryMessages {
+  acceptMessage: string;
+  infoLink?: string;
+  infoURL?: string;
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -134,6 +134,7 @@ import type { PullEvent } from '/@api/pull-event.js';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info.js';
 import type { StatusBarEntryDescriptor } from '/@api/status-bar.js';
 import type { PinOption } from '/@api/status-bar/pin-option.js';
+import type { TelemetryMessages } from '/@api/telemetry.js';
 import type { ViewInfoUI } from '/@api/view-info.js';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
@@ -3040,6 +3041,10 @@ export class PluginSystem {
       if (!tokenSource?.token.isCancellationRequested) {
         tokenSource?.dispose(true);
       }
+    });
+
+    this.ipcHandle('telemetry:getTelemetryMessages', async (): Promise<TelemetryMessages> => {
+      return telemetry.getTelemetryMessages();
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import { LockedConfiguration } from '/@/plugin/locked-configuration.js';
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import type { Event } from '/@api/event.js';
 import type { FeedbackProperties } from '/@api/feedback.js';
+import { TelemetryMessages } from '/@api/telemetry.js';
 import product from '/@product.json' with { type: 'json' };
 
 import telemetry from '../../../../../telemetry.json' with { type: 'json' };
@@ -108,14 +109,18 @@ export class Telemetry {
   }
 
   async init(): Promise<void> {
+    const telemetryMessages = this.getTelemetryMessages();
+    const telemetryLink =
+      telemetryMessages.infoLink && telemetryMessages.infoURL
+        ? ` [${telemetryMessages.infoLink}](${telemetryMessages.infoURL})`
+        : '';
     const telemetryConfigurationNode: IConfigurationNode = {
       id: 'preferences.telemetry',
       title: 'Telemetry',
       type: 'object',
       properties: {
         [TelemetrySettings.SectionName + '.' + TelemetrySettings.Enabled]: {
-          markdownDescription:
-            'Help improve Podman Desktop by allowing Red Hat to collect anonymous usage data. Read our [privacy statement](https://developers.redhat.com/article/tool-data-collection)',
+          markdownDescription: `${telemetryMessages.acceptMessage}${telemetryLink}`,
           type: 'boolean',
           default: true,
         },
@@ -174,6 +179,14 @@ export class Telemetry {
     const telemetryConfiguration = this.configurationRegistry.getConfiguration(TelemetrySettings.SectionName);
     const enabled = telemetryConfiguration.get<boolean>(TelemetrySettings.Enabled);
     return enabled === true;
+  }
+
+  getTelemetryMessages(): TelemetryMessages {
+    return {
+      acceptMessage: product.telemetry.acceptMessage,
+      infoLink: product.telemetry.infoLink,
+      infoURL: product.telemetry.infoURL,
+    } as TelemetryMessages;
   }
 
   protected createBuiltinTelemetrySender(extensionInfo: {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -120,6 +120,7 @@ import type { PullEvent } from '/@api/pull-event';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info';
 import type { StatusBarEntryDescriptor } from '/@api/status-bar';
 import type { PinOption } from '/@api/status-bar/pin-option';
+import type { TelemetryMessages } from '/@api/telemetry';
 import type { ViewInfoUI } from '/@api/view-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info';
 import type { WebviewInfo } from '/@api/webview-info';
@@ -2427,6 +2428,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('getFeedbackMessages', async (): Promise<FeedbackMessages> => {
     return ipcInvoke('feedback:getFeedbackMessages');
+  });
+
+  contextBridge.exposeInMainWorld('getTelemetryMessages', async (): Promise<TelemetryMessages> => {
+    return ipcInvoke('telemetry:getTelemetryMessages');
   });
 
   contextBridge.exposeInMainWorld('telemetryTrack', async (event: string, eventProperties?: unknown): Promise<void> => {

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -8,6 +8,7 @@ import DesktopIcon from '/@/lib/images/DesktopIcon.svelte';
 import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
 import type { OnboardingInfo } from '/@api/onboarding';
+import type { TelemetryMessages } from '/@api/telemetry';
 
 import bgImage from './background.png';
 import { WelcomeUtils } from './welcome-utils';
@@ -16,6 +17,7 @@ export let showWelcome = false;
 export let showTelemetry = false;
 
 let telemetry = true;
+let telemetryMessages: TelemetryMessages;
 
 const welcomeUtils = new WelcomeUtils();
 let podmanDesktopVersion: string;
@@ -58,6 +60,7 @@ onMount(async () => {
 
   const telemetryPrompt = await welcomeUtils.havePromptedForTelemetry();
   if (!telemetryPrompt) {
+    telemetryMessages = await window.getTelemetryMessages();
     showTelemetry = true;
   }
   podmanDesktopVersion = await window.getPodmanDesktopVersion();
@@ -161,11 +164,15 @@ function startOnboardingQueue(): void {
             class="text-lg px-2"
             title="Enable telemetry"><div class="text-base font-medium">Telemetry:</div></Checkbox>
           <div class="w-2/5 text-[var(--pd-content-card-text)]">
-            Help improve Podman Desktop by allowing Red Hat to collect anonymous usage data.
-            <Link
-              on:click={async (): Promise<void> => {
-                await window.openExternal('https://developers.redhat.com/article/tool-data-collection');
-              }}>Read our privacy statement</Link>
+            {#if telemetryMessages}
+              {telemetryMessages.acceptMessage}
+              {#if telemetryMessages?.infoLink && telemetryMessages?.infoURL}
+                <Link
+                  on:click={async (): Promise<void> => {
+                    await window.openExternal(telemetryMessages.infoURL ?? '');
+                  }}>{telemetryMessages?.infoLink}</Link>
+              {/if}
+            {/if}
           </div>
         </div>
         <div class="flex justify-center p-1 text-sm text-[var(--pd-content-card-text)]">

--- a/product.json
+++ b/product.json
@@ -12,7 +12,10 @@
     }
   },
   "telemetry": {
-    "key": "Mhl7GXADk5M1vG6r9FXztbCqWRQY8XPy"
+    "key": "Mhl7GXADk5M1vG6r9FXztbCqWRQY8XPy",
+    "acceptMessage": "Help improve Podman Desktop by allowing Red Hat to collect anonymous usage data.",
+    "infoLink": "Read our privacy statement",
+    "infoURL": "https://developers.redhat.com/article/tool-data-collection"
   },
   "catalog": {
     "default": "https://registry.podman-desktop.io/api/extensions.json"


### PR DESCRIPTION
### What does this PR do?

Adds telemetry messages to product.json and exposes them to the renderer package using the same pattern as #15536. The acceptMessage is required, product.json could omit the info link/url).

Uses the same message in both the Welcome page and telemetry preferences. This means there is a slight visual change in what's clickable in the preferences. (From "Read our [privacy statement]" to "[Read our privacy statement]", which matches the Welcome page)

If there's no link or url, the link is omitted from both the preferences and Welcome (issue #15379).

### Screenshot / video of UI

Just showing the link includes more text in the preferences, otherwise no visual change:
<img width="480" height="122" alt="Screenshot 2026-01-07 at 11 42 15 AM" src="https://github.com/user-attachments/assets/c38ff697-1543-486a-ae94-786d50a6686d" />

### What issues does this PR fix or reference?

Fixes #15350.
Fixes #15379.

### How to test this PR?

To test, remove welcome.version and telemetry.check from settings.json (being careful not to break json formatting) so that you can see the Welcome page again.

- [x] Tests are covering the bug fix or the new feature