### PR TITLE
chore(managed-by): do not show reset icon on locked preference items

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -113,3 +113,26 @@ test('locked record should display managed-by label', async () => {
 
   await vi.waitFor(() => getByText('Managed'));
 });
+
+test('locked record should not show reset to default button', async () => {
+  const lockedRecord: IConfigurationPropertyRecordedSchema = {
+    id: 'proxy.http',
+    title: 'Proxy',
+    parentId: 'proxy',
+    description: 'HTTP proxy configuration',
+    type: 'string',
+    locked: true,
+    default: 'default-value',
+  };
+
+  const { queryByRole, getByText } = render(PreferencesRenderingItem, {
+    record: lockedRecord,
+  });
+
+  // Verify managed label is shown
+  await vi.waitFor(() => getByText('Managed'));
+
+  // Verify reset button is not present
+  const resetButton = queryByRole('button', { name: 'Reset to default value' });
+  expect(resetButton).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -73,6 +73,7 @@ function updateResetButtonVisibility(recordValue: unknown): void {
 }
 
 function doResetToDefault(): void {
+  if (record.locked) return;
   resetToDefault = true;
 }
 
@@ -106,7 +107,7 @@ async function openGitHubDiscussion(): Promise<void> {
             </Label>
           {/if}
         </div>
-        {#if showResetButton}
+        {#if showResetButton && !record.locked}
           <div class="ml-2">
             <RefreshButton label="Reset to default value" onclick={doResetToDefault} />
           </div>


### PR DESCRIPTION
chore(managed-by): do not show reset icon on locked preference items

### What does this PR do?

Do not show the "reset to default" button when a preference item is
locked, since it's... locked anyways and you are unable to change it.

### Screenshot / video of UI

Before:
<img width="944" height="132" alt="Screenshot 2026-01-07 at 4 37 19 PM" src="https://github.com/user-attachments/assets/37636489-3b61-4c27-9440-04b5ec2ca937" />



After:
<img width="944" height="132" alt="Screenshot 2026-01-07 at 4 28 28 PM" src="https://github.com/user-attachments/assets/f838d34e-c177-495c-a3f6-c758dee0ca05" />




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/15305

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature

1. Setup your managed configuration with the following values:

```sh
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "telemetry.enabled": "false"
}
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/locked.json
{
	"locked": ["telemetry.enabled"]
}
~ $
```

2. Go to Preferences.

3. See that the "reset" icon / button does not appear anymore for locked
   a locked value.
   
   <img width="944" height="132" alt="Screenshot 2026-01-07 at 4 28 28 PM" src="https://github.com/user-attachments/assets/f838d34e-c177-495c-a3f6-c758dee0ca05" />

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
