### PR TITLE
feat: added button history navigation

### DIFF
--- a/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
+++ b/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
@@ -25,41 +25,32 @@ import { goBack, goForward, navigationHistory } from '/@/stores/navigation-histo
 
 import NavigationButtons from './NavigationButtons.svelte';
 
-const goBackMock = vi.fn();
-const goForwardMock = vi.fn();
-
 vi.mock(import('/@/stores/navigation-history.svelte'));
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.useFakeTimers({ shouldAdvanceTime: true });
-
-  vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
-  vi.mocked(window.getOsPlatform).mockResolvedValue('linux');
 
   // Reset navigation history state
   vi.mocked(navigationHistory).stack = [];
   vi.mocked(navigationHistory).index = -1;
-  vi.mocked(goBack).mockImplementation(goBackMock);
-  vi.mocked(goForward).mockImplementation(goForwardMock);
 });
 
 describe('button states', () => {
-  test('back button should be disabled when no history', async () => {
+  test('back button should be disabled when no history', () => {
     render(NavigationButtons);
 
     const backButton = screen.getByTitle('Back (hold for history)');
     expect(backButton).toBeDisabled();
   });
 
-  test('forward button should be disabled when no history', async () => {
+  test('forward button should be disabled when no history', () => {
     render(NavigationButtons);
 
     const forwardButton = screen.getByTitle('Forward (hold for history)');
     expect(forwardButton).toBeDisabled();
   });
 
-  test('back button should be enabled when can go back', async () => {
+  test('back button should be enabled when can go back', () => {
     navigationHistory.stack = ['/containers', '/images'];
     navigationHistory.index = 1;
 
@@ -69,7 +60,7 @@ describe('button states', () => {
     expect(backButton).toBeEnabled();
   });
 
-  test('forward button should be enabled when can go forward', async () => {
+  test('forward button should be enabled when can go forward', () => {
     navigationHistory.stack = ['/containers', '/images'];
     navigationHistory.index = 0;
 
@@ -88,12 +79,9 @@ describe('click navigation', () => {
     render(NavigationButtons);
 
     const backButton = screen.getByTitle('Back (hold for history)');
+    await fireEvent.click(backButton);
 
-    // Simulate mousedown then mouseup (short click)
-    await fireEvent.mouseDown(backButton, { button: 0 });
-    await fireEvent.mouseUp(backButton);
-
-    expect(goBackMock).toHaveBeenCalled();
+    expect(goBack).toHaveBeenCalled();
   });
 
   test('clicking forward button should call goForward', async () => {
@@ -103,11 +91,8 @@ describe('click navigation', () => {
     render(NavigationButtons);
 
     const forwardButton = screen.getByTitle('Forward (hold for history)');
+    await fireEvent.click(forwardButton);
 
-    // Simulate mousedown then mouseup (short click)
-    await fireEvent.mouseDown(forwardButton, { button: 0 });
-    await fireEvent.mouseUp(forwardButton);
-
-    expect(goForwardMock).toHaveBeenCalled();
+    expect(goForward).toHaveBeenCalled();
   });
 });

--- a/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
+++ b/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
@@ -1,0 +1,113 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { goBack, goForward, navigationHistory } from '/@/stores/navigation-history.svelte';
+
+import NavigationButtons from './NavigationButtons.svelte';
+
+const goBackMock = vi.fn();
+const goForwardMock = vi.fn();
+
+vi.mock(import('/@/stores/navigation-history.svelte'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+
+  vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
+  vi.mocked(window.getOsPlatform).mockResolvedValue('linux');
+
+  // Reset navigation history state
+  vi.mocked(navigationHistory).stack = [];
+  vi.mocked(navigationHistory).index = -1;
+  vi.mocked(goBack).mockImplementation(goBackMock);
+  vi.mocked(goForward).mockImplementation(goForwardMock);
+});
+
+describe('button states', () => {
+  test('back button should be disabled when no history', async () => {
+    render(NavigationButtons);
+
+    const backButton = screen.getByTitle('Back (hold for history)');
+    expect(backButton).toBeDisabled();
+  });
+
+  test('forward button should be disabled when no history', async () => {
+    render(NavigationButtons);
+
+    const forwardButton = screen.getByTitle('Forward (hold for history)');
+    expect(forwardButton).toBeDisabled();
+  });
+
+  test('back button should be enabled when can go back', async () => {
+    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.index = 1;
+
+    render(NavigationButtons);
+
+    const backButton = screen.getByTitle('Back (hold for history)');
+    expect(backButton).toBeEnabled();
+  });
+
+  test('forward button should be enabled when can go forward', async () => {
+    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.index = 0;
+
+    render(NavigationButtons);
+
+    const forwardButton = screen.getByTitle('Forward (hold for history)');
+    expect(forwardButton).toBeEnabled();
+  });
+});
+
+describe('click navigation', () => {
+  test('clicking back button should call goBack', async () => {
+    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.index = 1;
+
+    render(NavigationButtons);
+
+    const backButton = screen.getByTitle('Back (hold for history)');
+
+    // Simulate mousedown then mouseup (short click)
+    await fireEvent.mouseDown(backButton, { button: 0 });
+    await fireEvent.mouseUp(backButton);
+
+    expect(goBackMock).toHaveBeenCalled();
+  });
+
+  test('clicking forward button should call goForward', async () => {
+    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.index = 0;
+
+    render(NavigationButtons);
+
+    const forwardButton = screen.getByTitle('Forward (hold for history)');
+
+    // Simulate mousedown then mouseup (short click)
+    await fireEvent.mouseDown(forwardButton, { button: 0 });
+    await fireEvent.mouseUp(forwardButton);
+
+    expect(goForwardMock).toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/ui/NavigationButtons.svelte
+++ b/packages/renderer/src/lib/ui/NavigationButtons.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import { goBack, goForward, navigationHistory } from '/@/stores/navigation-history.svelte';
+
+let canGoBack = $derived(navigationHistory.index > 0);
+let canGoForward = $derived(navigationHistory.index < navigationHistory.stack.length - 1);
+</script>
+
+<div
+    class="flex items-center gap-1 text-[color:var(--pd-global-nav-icon)]"
+    style="-webkit-app-region: none;">
+    <div class="relative">
+    <button
+        class="h-[25px] w-[25px] flex place-items-center justify-center hover:rounded hover:bg-[var(--pd-titlebar-hover-bg)] disabled:opacity-30 disabled:cursor-default disabled:hover:bg-transparent"
+        title="Back (hold for history)"
+        onclick={goBack}
+        disabled={!canGoBack}>
+        <Icon icon={faArrowLeft} />
+    </button>
+    </div>
+    <div class="relative">
+    <button
+        class="h-[25px] w-[25px] flex place-items-center justify-center hover:rounded hover:bg-[var(--pd-titlebar-hover-bg)] disabled:opacity-30 disabled:cursor-default disabled:hover:bg-transparent"
+        title="Forward (hold for history)"
+        onclick={goForward}
+        disabled={!canGoForward}>
+        <Icon icon={faArrowRight} />
+    </button>
+    </div>
+</div>

--- a/packages/renderer/src/lib/ui/NavigationButtons.svelte
+++ b/packages/renderer/src/lib/ui/NavigationButtons.svelte
@@ -4,12 +4,18 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import { goBack, goForward, navigationHistory } from '/@/stores/navigation-history.svelte';
 
+interface Props {
+  class: string;
+}
+
+let { class: className = '' }: Props = $props();
+
 let canGoBack = $derived(navigationHistory.index > 0);
 let canGoForward = $derived(navigationHistory.index < navigationHistory.stack.length - 1);
 </script>
 
 <div
-    class="flex items-center gap-1 text-[color:var(--pd-global-nav-icon)]"
+    class="flex items-center gap-1 text-[color:var(--pd-global-nav-icon)] {className}"
     style="-webkit-app-region: none;">
     <div class="relative">
     <button

--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -3,6 +3,7 @@ import { onMount } from 'svelte';
 
 import CommandPalette from '/@/lib/dialogs/CommandPalette.svelte';
 import DesktopIcon from '/@/lib/images/DesktopIcon.svelte';
+import NavigationButtons from '/@/lib/ui/NavigationButtons.svelte';
 import WindowControlButtons from '/@/lib/window-control-buttons/ControlButtons.svelte';
 
 import SearchButton from './SearchButton.svelte';
@@ -40,6 +41,7 @@ function closeCommandPalette(): void {
       {#if  platform === 'win32'}
         <div class="text-left text-base leading-3 text-[color:var(--pd-titlebar-text)]">{title}</div>
       {/if}
+      <NavigationButtons />
     </div>
 
     <!-- center -->

--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -41,7 +41,13 @@ function closeCommandPalette(): void {
       {#if  platform === 'win32'}
         <div class="text-left text-base leading-3 text-[color:var(--pd-titlebar-text)]">{title}</div>
       {/if}
-      <NavigationButtons />
+      {#if platform === 'darwin'}
+        <div class="pl-20">
+          <NavigationButtons />
+        </div>
+      {:else}
+        <NavigationButtons />
+      {/if}
     </div>
 
     <!-- center -->

--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -41,13 +41,7 @@ function closeCommandPalette(): void {
       {#if  platform === 'win32'}
         <div class="text-left text-base leading-3 text-[color:var(--pd-titlebar-text)]">{title}</div>
       {/if}
-      {#if platform === 'darwin'}
-        <div class="pl-20">
-          <NavigationButtons />
-        </div>
-      {:else}
-        <NavigationButtons />
-      {/if}
+      <NavigationButtons class={platform === 'darwin' ? 'pl-20' : ''}/>
     </div>
 
     <!-- center -->

--- a/packages/renderer/src/stores/navigation-history.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.spec.ts
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { router } from 'tinro';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { goBack, goForward, navigationHistory } from './navigation-history.svelte';
+
+vi.mock(import('tinro'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
+  // Reset navigation history state
+  navigationHistory.stack = [];
+  navigationHistory.index = -1;
+});
+
+describe('goBack', () => {
+  test('should not navigate when history is empty', () => {
+    goBack();
+
+    expect(router.goto).not.toHaveBeenCalled();
+    expect(window.telemetryTrack).not.toHaveBeenCalled();
+  });
+
+  test('should not navigate when at first entry', () => {
+    navigationHistory.stack = ['/containers'];
+    navigationHistory.index = 0;
+
+    goBack();
+
+    expect(router.goto).not.toHaveBeenCalled();
+    expect(window.telemetryTrack).not.toHaveBeenCalled();
+  });
+
+  test('should navigate to previous entry', () => {
+    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.index = 1;
+
+    goBack();
+
+    expect(navigationHistory.index).toBe(0);
+    expect(router.goto).toHaveBeenCalledWith('/containers');
+    expect(window.telemetryTrack).toHaveBeenCalledWith('navigation.back');
+  });
+});
+
+describe('goForward', () => {
+  test('should not navigate when history is empty', () => {
+    goForward();
+
+    expect(router.goto).not.toHaveBeenCalled();
+    expect(window.telemetryTrack).not.toHaveBeenCalled();
+  });
+
+  test('should not navigate when at last entry', () => {
+    navigationHistory.stack = ['/containers'];
+    navigationHistory.index = 0;
+
+    goForward();
+
+    expect(router.goto).not.toHaveBeenCalled();
+    expect(window.telemetryTrack).not.toHaveBeenCalled();
+  });
+
+  test('should navigate to next entry', () => {
+    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.index = 0;
+
+    goForward();
+
+    expect(navigationHistory.index).toBe(1);
+    expect(router.goto).toHaveBeenCalledWith('/images');
+    expect(window.telemetryTrack).toHaveBeenCalledWith('navigation.forward');
+  });
+});

--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -1,0 +1,84 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { router } from 'tinro';
+
+/**
+ * Navigation history store
+ *
+ * @property stack - An array of URLs
+ * @property index - The current index in the stack
+ */
+export const navigationHistory = $state<{
+  stack: string[];
+  index: number;
+}>({
+  stack: [],
+  index: -1,
+});
+
+let isNavigatingHistory = false;
+
+// Core navigation function
+function navigateToIndex(index: number): boolean {
+  if (index < 0 || index >= navigationHistory.stack.length || index === navigationHistory.index) {
+    return false;
+  }
+
+  isNavigatingHistory = true;
+  navigationHistory.index = index;
+  const url = navigationHistory.stack[index];
+  if (url) {
+    router.goto(url);
+  }
+  return true;
+}
+
+export function goBack(): void {
+  if (navigateToIndex(navigationHistory.index - 1)) {
+    window.telemetryTrack('navigation.back').catch(console.error);
+  }
+}
+
+export function goForward(): void {
+  if (navigateToIndex(navigationHistory.index + 1)) {
+    window.telemetryTrack('navigation.forward').catch(console.error);
+  }
+}
+
+// Initialize router subscription
+router.subscribe(navigation => {
+  if (navigation.url) {
+    if (isNavigatingHistory) {
+      isNavigatingHistory = false;
+      return;
+    }
+
+    // Truncate forward history if we're not at the end
+    if (navigationHistory.index < navigationHistory.stack.length - 1) {
+      navigationHistory.stack = navigationHistory.stack.slice(0, navigationHistory.index + 1);
+    }
+
+    // Only add if different from current
+    const currentUrl = navigationHistory.stack[navigationHistory.index];
+    if (currentUrl !== navigation.url) {
+      navigationHistory.stack = [...navigationHistory.stack, navigation.url];
+      navigationHistory.index = navigationHistory.stack.length - 1;
+    }
+  }
+});


### PR DESCRIPTION
### What does this PR do?
Adds basic history navigation - so far you can navigate only using buttons - no shortcuts or history

### Screenshot / video of UI


<img width="1157" height="772" alt="image" src="https://github.com/user-attachments/assets/bddef7d6-ab6c-4368-bcd1-085ad49dc5ef" />

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/15566

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
