### PR TITLE
refactor(TitleBar): remove absolute classes in favor of flex and grids

### DIFF
--- a/packages/renderer/src/lib/ui/SearchButton.svelte
+++ b/packages/renderer/src/lib/ui/SearchButton.svelte
@@ -9,6 +9,6 @@ interface Props {
 let { onclick = (): void => {} }: Props = $props();
 </script>
 
-<button id="Search button" title="Search" class="absolute top-1/2 left-1/2 text-[color:var(--pd-global-nav-icon)] transform -translate-x-1/2 -translate-y-1/2 flex justify-center items-center gap-1" style="-webkit-app-region: none;" {onclick}>
+<button id="Search button" title="Search" class="text-[color:var(--pd-global-nav-icon)] flex justify-center items-center gap-1" style="-webkit-app-region: none;" {onclick}>
     <Icon icon={faMagnifyingGlass} />Search
 </button>

--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -27,32 +27,33 @@ function closeCommandPalette(): void {
 
 <header
   id="navbar"
-  class="bg-[var(--pd-titlebar-bg)] body-font z-999 relative {platform === 'win32'
+  class="bg-[var(--pd-titlebar-bg)] body-font relative {platform === 'win32'
     ? 'min-h-[32px]'
     : 'min-h-[38px]'} border-[var(--pd-global-nav-bg-border)] border-b-[1px]"
   style="-webkit-app-region: drag;">
-  <div class="flex select-none">
-    <!-- On Linux, title is centered and we have control buttons in the title bar-->
-    {#if platform === 'linux'}
-      <div class="flex mx-auto flex-row pt-[7px] pb-[6px] items-center">
-        <div class="absolute left-[10px] top-[10px]">
-          <DesktopIcon size="18" />
-        </div>
-        <SearchButton onclick={openCommandPalette}/>
-        <WindowControlButtons platform={platform} />
-      </div>
-    {:else if platform === 'win32'}
-      <div class="flex flex-row pt-[10px] pb-[10px] items-center">
-        <div class="absolute left-[7px] top-[7px]">
-          <DesktopIcon size="20" />
-        </div>
-        <SearchButton onclick={openCommandPalette}/>
-        <div class="ml-[35px] text-left text-base leading-3 text-[color:var(--pd-titlebar-text)]">{title}</div>
-        <WindowControlButtons platform={platform} />
-      </div>
-    {:else if platform === 'darwin'}
+  <div class="select-none grid grid-cols-3 items-center h-full w-full">
+    <!-- left -->
+    <div class="flex flex-row grow pl-[7px] items-center gap-x-2">
+      {#if platform !== 'darwin'}
+        <DesktopIcon size={platform === 'win32' ? '20' : '18'} />
+      {/if}
+      {#if  platform === 'win32'}
+        <div class="text-left text-base leading-3 text-[color:var(--pd-titlebar-text)]">{title}</div>
+      {/if}
+    </div>
+
+    <!-- center -->
+    <div class="flex flex-row grow items-center justify-center w-full">
       <SearchButton onclick={openCommandPalette}/>
-    {/if}
-    <CommandPalette display={commandPaletteVisible} onclose={closeCommandPalette}/>
+    </div>
+
+    <!-- right -->
+    <div class="flex flex-row grow justify-end">
+      {#if platform !== 'darwin'}
+        <WindowControlButtons platform={platform} />
+      {/if}
+    </div>
   </div>
 </header>
+
+<CommandPalette display={commandPaletteVisible} onclose={closeCommandPalette}/>

--- a/packages/renderer/src/lib/window-control-buttons/ControlButtons.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButtons.svelte
@@ -18,7 +18,7 @@ async function close(): Promise<void> {
 
 <!-- Display the min, max and close buttons and avoid drag & drop on this region-->
 <div
-  class="{platform === 'linux' ? 'top-[7px] right-3' : ''} {platform === 'win32' ? 'top-0 right-0' : ''}"
+  class="{platform === 'linux' ? 'pr-3' : ''}"
   style="-webkit-app-region: none;">
   <div class="flex flex-row {platform === 'linux' ? 'space-x-2' : 'space-x-[1px]'}">
     <WindowControlButton platform={platform} name="Minimize" action={minimize} />

--- a/packages/renderer/src/lib/window-control-buttons/ControlButtons.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButtons.svelte
@@ -18,7 +18,7 @@ async function close(): Promise<void> {
 
 <!-- Display the min, max and close buttons and avoid drag & drop on this region-->
 <div
-  class="absolute {platform === 'linux' ? 'top-[7px] right-3' : ''} {platform === 'win32' ? 'top-0 right-0' : ''}"
+  class="{platform === 'linux' ? 'top-[7px] right-3' : ''} {platform === 'win32' ? 'top-0 right-0' : ''}"
   style="-webkit-app-region: none;">
   <div class="flex flex-row {platform === 'linux' ? 'space-x-2' : 'space-x-[1px]'}">
     <WindowControlButton platform={platform} name="Minimize" action={minimize} />


### PR DESCRIPTION
### What does this PR do?

In https://github.com/podman-desktop/podman-desktop/pull/15600 a problem with spacing and hardcoding spacing occured, the root cause it that the TitleBar is using absolute classes and hardcoded transform position => kinda problematic as it requires to find the correct amount of pixel to move something to make it display properly.

This is fixed by using flex & grids.

### Screenshot / video of UI

#### Windows

**On Windows BEFORE**

<img width="958" height="69" alt="image" src="https://github.com/user-attachments/assets/b1d5a5f5-52cc-4961-864c-97c64bc31006" />

**On Windows AFTER**

<img width="961" height="76" alt="image" src="https://github.com/user-attachments/assets/9ad6f458-36f3-4dc6-bdaf-a8886db6a6bc" />

**On Linux BEFORE**

<img width="1209" height="93" alt="image" src="https://github.com/user-attachments/assets/5d20997b-e898-4d23-86df-38d8b5531560" />

**On Linux AFTER**

<img width="1209" height="93" alt="image" src="https://github.com/user-attachments/assets/b5a8684a-381e-4b3e-ab02-19126fb00273" />

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

We should ensure that we don't introduce regression on ALL platforms before mergin this PR

- [x] Windows (Done by @axel7083 )
- [x] Linux (Fedora)  (Done by @axel7083 )
- [x] MacOS (Done in https://github.com/podman-desktop/podman-desktop/pull/15607#pullrequestreview-3638945875 by @simonrey1 )

**Unit testing**

- [x] Tests in [packages/renderer/src/lib/ui/TitleBar.spec.ts](https://github.com/podman-desktop/podman-desktop/blob/52c68bb83da8fcf40a359ea81f1403574631f2f9/packages/renderer/src/lib/ui/TitleBar.spec.ts) ensure no regressions
