### PR TITLE
feat: added back/forward commands to command palette 

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -735,6 +735,7 @@ export class PluginSystem {
     commandsInit.init();
 
     const navigationManager = container.get<NavigationManager>(NavigationManager);
+    navigationManager.init();
     navigationManager.registerRoute({ routeId: 'kubernetes', commandId: 'kubernetes-navigation' });
 
     container.bind<ExtensionAnalyzer>(ExtensionAnalyzer).toSelf().inSingletonScope();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -735,7 +735,6 @@ export class PluginSystem {
     commandsInit.init();
 
     const navigationManager = container.get<NavigationManager>(NavigationManager);
-    navigationManager.init();
     navigationManager.registerRoute({ routeId: 'kubernetes', commandId: 'kubernetes-navigation' });
 
     container.bind<ExtensionAnalyzer>(ExtensionAnalyzer).toSelf().inSingletonScope();

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -65,6 +65,8 @@ const webviewRegistry = {
 const commandRegistry: CommandRegistry = {
   hasCommand: vi.fn(),
   executeCommand: vi.fn(),
+  registerCommand: vi.fn(),
+  registerCommandPalette: vi.fn(),
 } as unknown as CommandRegistry;
 
 const onboardingRegistry: OnboardingRegistry = {
@@ -302,5 +304,26 @@ test('check navigateToExtensionsCatalog', async () => {
     parameters: {
       searchTerm: 'not:installed category:foo keyword:bar',
     },
+  });
+});
+
+describe('register navigation commands', () => {
+  beforeEach(() => {
+    navigationManager.init();
+  });
+
+  test('should register the navigation.goBack command', () => {
+    expect(commandRegistry.registerCommand).toBeCalledWith('navigation.goBack', expect.anything());
+  });
+
+  test('should register the navigation.goForward command', () => {
+    expect(commandRegistry.registerCommand).toBeCalledWith('navigation.goForward', expect.anything());
+  });
+
+  test('should register navigation commands in command palette', () => {
+    expect(commandRegistry.registerCommandPalette).toBeCalledWith(
+      expect.objectContaining({ command: 'navigation.goBack', title: 'Go Back', category: 'Navigation' }),
+      expect.objectContaining({ command: 'navigation.goForward', title: 'Go Forward', category: 'Navigation' }),
+    );
   });
 });

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -24,6 +24,7 @@ import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
 import { ContributionManager } from '/@/plugin/contribution-manager.js';
 import { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import { IDisposable } from '/@api/disposable.js';
 import { NavigationPage } from '/@api/navigation-page.js';
 import type { NavigationRequest } from '/@api/navigation-request.js';
 
@@ -39,6 +40,7 @@ export interface NavigationRoute {
 @injectable()
 export class NavigationManager {
   #registry: Map<string, NavigationRoute>;
+  #disposables: IDisposable[] = [];
 
   constructor(
     @inject(ApiSenderType)
@@ -57,6 +59,39 @@ export class NavigationManager {
     private onboardingRegistry: OnboardingRegistry,
   ) {
     this.#registry = new Map();
+  }
+
+  init(): void {
+    this.#disposables.push(
+      this.commandRegistry.registerCommand('navigation.goBack', () => {
+        this.apiSender.send('navigation-go-back', '');
+      }),
+    );
+
+    this.#disposables.push(
+      this.commandRegistry.registerCommand('navigation.goForward', () => {
+        this.apiSender.send('navigation-go-forward', '');
+      }),
+    );
+
+    this.#disposables.push(
+      this.commandRegistry.registerCommandPalette(
+        {
+          command: 'navigation.goBack',
+          title: 'Go Back',
+          category: 'Navigation',
+        },
+        {
+          command: 'navigation.goForward',
+          title: 'Go Forward',
+          category: 'Navigation',
+        },
+      ),
+    );
+  }
+
+  dispose(): void {
+    this.#disposables.forEach(disposable => disposable.dispose());
   }
 
   navigateTo<T extends NavigationPage>(navigateRequest: NavigationRequest<T>): void {

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { NavigateToExtensionsCatalogOptions, ProviderContainerConnection } from '@podman-desktop/api';
-import { inject, injectable, preDestroy } from 'inversify';
+import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 
 import { CommandRegistry } from '/@/plugin/command-registry.js';
 import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
@@ -61,6 +61,7 @@ export class NavigationManager {
     this.#registry = new Map();
   }
 
+  @postConstruct()
   init(): void {
     this.#disposables.push(
       this.commandRegistry.registerCommand('navigation.goBack', () => {

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { NavigateToExtensionsCatalogOptions, ProviderContainerConnection } from '@podman-desktop/api';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, preDestroy } from 'inversify';
 
 import { CommandRegistry } from '/@/plugin/command-registry.js';
 import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
@@ -90,6 +90,7 @@ export class NavigationManager {
     );
   }
 
+  @preDestroy()
   dispose(): void {
     this.#disposables.forEach(disposable => disposable.dispose());
   }

--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -101,3 +101,12 @@ router.subscribe(navigation => {
     }
   }
 });
+
+// Listen for navigation commands from command palette
+window.events?.receive('navigation-go-back', () => {
+  goBack();
+});
+
+window.events?.receive('navigation-go-forward', () => {
+  goForward();
+});


### PR DESCRIPTION
### What does this PR do?
Adds back/forward commands to command pallete

### Screenshot / video of UI


<img width="1158" height="771" alt="image" src="https://github.com/user-attachments/assets/c3bc9e5a-df37-4e39-9e9a-08fe3a250952" />


### What issues does this PR fix or reference?
Closes #15604 

### How to test this PR?
Move around the app and try to navigate forward/back using go back and go forward commands in command pallete

- [x] Tests are covering the bug fix or the new feature
