### PR TITLE
fix(renderer): introduce Kubernetes root component to fix side effect in router

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -26,7 +26,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
 
 import App from './App.svelte';
-import { lastPage, lastSubmenuPages } from './stores/breadcrumb';
+import { lastPage } from './stores/breadcrumb';
 import { navigationRegistry, type NavigationRegistryEntry } from './stores/navigation/navigation-registry';
 
 const mocks = vi.hoisted(() => ({
@@ -179,32 +179,6 @@ test('displays kubernetes empty screen if no current context, without Kubernetes
   expect(mocks.KubernetesDashboard).toHaveBeenCalled();
   expect(mocks.DeploymentsList).not.toHaveBeenCalled();
   expect(mocks.SubmenuNavigation).not.toHaveBeenCalled();
-});
-
-test('go to last kubernetes page when available', async () => {
-  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
-  lastSubmenuPages.set({ Kubernetes: '/kubernetes/deployments' });
-  render(App);
-  router.goto('/kubernetes');
-  await tick();
-  expect(mocks.DeploymentsList).toHaveBeenCalled();
-});
-
-test('go to dashboard page when last kubernetes page is /kubernetes', async () => {
-  lastSubmenuPages.set({ Kubernetes: '/kubernetes' });
-  render(App);
-  router.goto('/kubernetes');
-  await tick();
-
-  expect(mocks.KubernetesDashboard).toHaveBeenCalled();
-});
-
-test('go to dashboard page when last kubernetes page not available', async () => {
-  lastSubmenuPages.set({});
-  render(App);
-  router.goto('/kubernetes');
-  await tick();
-  expect(mocks.KubernetesDashboard).toHaveBeenCalled();
 });
 
 test('receive show-release-notes event from main', async () => {

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -6,6 +6,7 @@ import { tablePersistence } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import { parseExtensionListRequest } from '/@/lib/extensions/extension-list';
+import KubernetesRoot from '/@/lib/kube/KubernetesRoot.svelte';
 import PinActions from '/@/lib/statusbar/PinActions.svelte';
 import { handleNavigation } from '/@/navigation';
 import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
@@ -86,7 +87,6 @@ import Webview from './lib/webview/Webview.svelte';
 import WelcomePage from './lib/welcome/WelcomePage.svelte';
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import Route from './Route.svelte';
-import { lastSubmenuPages } from './stores/breadcrumb';
 import { navigationRegistry } from './stores/navigation/navigation-registry';
 import SubmenuNavigation from './SubmenuNavigation.svelte';
 
@@ -271,10 +271,8 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
             <KubernetesDashboard />
           </Route>
         {:else}
-          <!-- Redirect /kubernetes to dashboard if we end up on /kubernetes without a context error
-           we use router.goto to preserve the navbar remembering the navigation location. -->
-          <Route path="/kubernetes" breadcrumb="Kubernetes" navigationHint="root">
-            {router.goto($lastSubmenuPages['Kubernetes'] === '/kubernetes' ? '/kubernetes/dashboard' : ($lastSubmenuPages['Kubernetes'] ?? '/kubernetes/dashboard'))}
+         <Route path="/kubernetes" breadcrumb="Kubernetes" navigationHint="root">
+            <KubernetesRoot />
           </Route>
           <Route path="/kubernetes/dashboard" breadcrumb="Dashboard" navigationHint="root">
             <KubernetesDashboard />

--- a/packages/renderer/src/lib/kube/KubernetesRoot.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesRoot.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { lastSubmenuPages } from '/@/stores/breadcrumb';
+
+import KubernetesRoot from './KubernetesRoot.svelte';
+
+vi.mock(import('tinro'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('KubernetesRoot component', () => {
+  test('go to last kubernetes page when available', async () => {
+    lastSubmenuPages.set({ Kubernetes: '/kubernetes/deployments' });
+    render(KubernetesRoot);
+
+    expect(router.goto).toHaveBeenCalledWith('/kubernetes/deployments');
+  });
+
+  test('go to dashboard page when last kubernetes page is /kubernetes', async () => {
+    lastSubmenuPages.set({ Kubernetes: '/kubernetes' });
+    render(KubernetesRoot);
+
+    expect(router.goto).toHaveBeenCalledWith('/kubernetes/dashboard');
+  });
+
+  test('go to dashboard page when last kubernetes page not available', async () => {
+    lastSubmenuPages.set({});
+    render(KubernetesRoot);
+    expect(router.goto).toHaveBeenCalledWith('/kubernetes/dashboard');
+  });
+});

--- a/packages/renderer/src/lib/kube/KubernetesRoot.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesRoot.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+import { router } from 'tinro';
+
+import { lastSubmenuPages } from '/@/stores/breadcrumb';
+
+onMount(() => {
+  const value = $lastSubmenuPages['Kubernetes'];
+  //  Redirect /kubernetes to dashboard if we end up on /kubernetes without a context error
+  //  we use router.goto to preserve the navbar remembering the navigation location.
+  if (value && value !== '/kubernetes') {
+    router.goto(value);
+  } else {
+    router.goto('/kubernetes/dashboard');
+  }
+});
+</script>


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/pull/15506, I noticed an error in the tests of packages/renderer/src/App.spec.ts because the `router.goto` is called directly in the route definition and it leads to a problem where meta.url is not filled. To mitigate this issue, I introduce a new component that handles the redirect. This should not change the behaviour of the navigation.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Verify when you open the Kubernetes tab that you are on the dashboard tab, or on the last one you have opened when you come back.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
