### PR TITLE
fix(libpod#kubeplay): invalid content-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,8 @@
       "cheerio>undici": "^7.18.2"
     },
     "patchedDependencies": {
-      "dmg-builder": "patches/dmg-builder.patch"
+      "dmg-builder": "patches/dmg-builder.patch",
+      "docker-modem": "patches/docker-modem.patch"
     }
   },
   "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -519,4 +519,32 @@ describe('kube play', () => {
       return playKubePromise;
     }).rejects.toThrowError('The operation was aborted');
   });
+
+  test('default content-type should application/yaml', async () => {
+    await libPod.playKube(file, { build: false });
+
+    expect(postHandler).toHaveBeenCalledOnce();
+    const request = vi.mocked(postHandler).mock.calls[0]?.[0]?.request;
+    assert(request);
+
+    expect(request.headers.get('Content-Type')).toBe('application/yaml');
+  });
+
+  test('previous call should not affect Content-Type', async () => {
+    await libPod.playKube(file, { build: true });
+
+    expect(postHandler).toHaveBeenCalledOnce();
+    const request = vi.mocked(postHandler).mock.calls[0]?.[0]?.request;
+    assert(request);
+
+    expect(request.headers.get('Content-Type')).toBe('application/x-tar');
+
+    await libPod.playKube(file, { build: false });
+
+    expect(postHandler).toHaveBeenCalledTimes(2);
+    const second = vi.mocked(postHandler).mock.calls[1]?.[0]?.request;
+    assert(second);
+
+    expect(second.headers.get('Content-Type')).toBe('application/yaml');
+  });
 });

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -520,7 +520,7 @@ describe('kube play', () => {
     }).rejects.toThrowError('The operation was aborted');
   });
 
-  test('default content-type should application/yaml', async () => {
+  test('default content-type should be application/yaml', async () => {
     await libPod.playKube(file, { build: false });
 
     expect(postHandler).toHaveBeenCalledOnce();

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -721,30 +721,12 @@ export class LibpodDockerode {
           204: true,
           500: 'server error',
         },
+        headers: {
+          // if we don't build - we should send Content-Type application/yaml
+          // application/tar is not supported
+          'Content-Type': options?.build ? 'application/x-tar' : 'application/yaml',
+        },
         options: {},
-      };
-
-      // if we don't build - we should send Content-Type application/yaml
-      // application/tar is not supported
-      const contentType = options?.build ? 'application/x-tar' : 'application/yaml';
-
-      // patch the modem to not send x-tar header as content-type
-      const originalBuildRequest = this.modem.buildRequest;
-      this.modem.buildRequest = function (
-        options: RequestOptions,
-        context: DialOptions,
-        data?: string | Buffer | NodeJS.ReadableStream,
-        callback?: DockerModem.RequestCallback,
-      ): void {
-        // in case of kube play, docker-modem will send the header application/tar while it's basically the content of the file so it should be application/yaml
-        if (context && typeof context === 'object' && 'path' in context) {
-          if (String(context.path).includes('/libpod/play/kube')) {
-            if (options && typeof options === 'object' && 'headers' in options) {
-              options.headers = { 'Content-Type': contentType };
-            }
-          }
-        }
-        originalBuildRequest.call(this, options, context, data, callback);
       };
 
       return new Promise((resolve, reject) => {

--- a/patches/docker-modem.patch
+++ b/patches/docker-modem.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/modem.js b/lib/modem.js
+index 3a91cd716895085c1dccef23fef3e9630dc9cf05..e4c14a37031bd77aa262c118c6c830c4a4926f85 100644
+--- a/lib/modem.js
++++ b/lib/modem.js
+@@ -203,14 +203,14 @@ Modem.prototype.dial = function (options, callback) {
+     } else {
+       data = options.file;
+     }
+-    optionsf.headers['Content-Type'] = 'application/tar';
++    optionsf.headers['Content-Type'] = optionsf.headers['Content-Type'] ?? 'application/tar';
+   } else if (opts && options.method === 'POST') {
+     data = JSON.stringify(opts._body || opts);
+     if (options.allowEmpty) {
+-      optionsf.headers['Content-Type'] = 'application/json';
++      optionsf.headers['Content-Type'] = optionsf.headers['Content-Type'] ?? 'application/json';
+     } else {
+       if (data !== '{}' && data !== '""') {
+-        optionsf.headers['Content-Type'] = 'application/json';
++        optionsf.headers['Content-Type'] = optionsf.headers['Content-Type'] ?? 'application/json';
+       } else {
+         data = undefined;
+       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,11 @@ patchedDependencies:
     hash: b1937a6dd1c958dfabaa5fd32cb2ede7972c4d6143ccb1e7fe5963e19e34cc3d
     path: patches/dmg-builder.patch
 
+patchedDependencies:
+  docker-modem:
+    hash: 5c70d772609f3932e49bceba1d646d56a515d449a1304c39c12df33f16066a9e
+    path: patches/docker-modem.patch
+
 importers:
 
   .:
@@ -19013,7 +19018,7 @@ snapshots:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
-  docker-modem@5.0.6:
+  docker-modem@5.0.6(patch_hash=5c70d772609f3932e49bceba1d646d56a515d449a1304c39c12df33f16066a9e):
     dependencies:
       debug: 4.4.3
       readable-stream: 3.6.2
@@ -19027,7 +19032,7 @@ snapshots:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.0
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.6
+      docker-modem: 5.0.6(patch_hash=5c70d772609f3932e49bceba1d646d56a515d449a1304c39c12df33f16066a9e)
       protobufjs: 7.5.4
       tar-fs: 2.1.4
       uuid: 10.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,6 @@ patchedDependencies:
   dmg-builder:
     hash: b1937a6dd1c958dfabaa5fd32cb2ede7972c4d6143ccb1e7fe5963e19e34cc3d
     path: patches/dmg-builder.patch
-
-patchedDependencies:
   docker-modem:
     hash: 5c70d772609f3932e49bceba1d646d56a515d449a1304c39c12df33f16066a9e
     path: patches/docker-modem.patch


### PR DESCRIPTION
### What does this PR do?

https://github.com/apocas/docker-modem/pull/189 has been merged, however they have not published a new release yet, so having a patch until this is available.

Full explanation of the issue in https://github.com/podman-desktop/podman-desktop/issues/14273#issuecomment-3724833868

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/14273

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Checkout this branch
2. Run `pnpm install`
3. In `Pods > Podman Kube Play` Try to play a Kubernetes resource **with** the `--build` flag.  
   - For testing, use this file: [tests/playwright/resources/podman-kube-play/podman-kube-play-build-test.yaml](https://github.com/podman-desktop/podman-desktop/blob/main/tests/playwright/resources/podman-kube-play/podman-kube-play-build-test.yaml)
:warning: You should select the file from within the repository, as we want to build the file, we need the full folder, **do not** copy paste the content in `Create file from scratch`.
4. Assert works as expected
5. Go back to the **Podman kube play** page and try to play another Kubernetes resource **without** the `--build` flag.  
   - You can try [nginx-pod.yaml](https://gist.github.com/larrycai/7acb05c9c8594d7030a5469d0ea15a95) 
6. Assert everything is working as expected
