### PR TITLE
chore(preferences): add locked support to BooleanItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
@@ -95,3 +95,19 @@ test('Expect to see checkbox not checked if default is false', async () => {
   expect(button).toBeInTheDocument();
   expect(button).not.toBeChecked();
 });
+
+test('Expect to see the checkbox disabled when locked is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema & { default: boolean } = {
+    title: 'my boolean property',
+    id: 'myid',
+    parentId: '',
+    type: 'boolean',
+    default: true,
+    locked: true,
+  };
+  render(BooleanItem, { record, checked: record.default });
+  const button = screen.getByRole('checkbox');
+  expect(button).toBeInTheDocument();
+  expect(button).toBeChecked();
+  expect(button).toBeDisabled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -21,8 +21,8 @@ function onChecked(state: boolean): void {
   left
   bind:checked={checked}
   on:checked={(event): void => onChecked(event.detail)}
-  readonly={!!record.readonly}
-  disabled={!!record.readonly}
+  readonly={!!record.readonly || !!record.locked}
+  disabled={!!record.readonly || !!record.locked}
   aria-invalid={invalidEntry}
   aria-label={record.description ?? record.markdownDescription}>
   <span class="text-xs">{checked ? 'Enabled' : 'Disabled'}</span>


### PR DESCRIPTION
chore(preferences): add locked support to BooleanItem component

### What does this PR do?

Disables the BooleanItem input when `record.locked` is true,
preventing edits to preferences / settings.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:

https://github.com/user-attachments/assets/7ef02a74-459e-4e1a-829e-a22835bca961


After:

https://github.com/user-attachments/assets/4e0a54bc-1c23-411a-8cf7-76ba7a1d029c


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/15306

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Setup your managed configuration with the following values:

```sh
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "telemetry.enabled": "false"
}
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/locked.json
{
	"locked": ["telemetry.enabled"]
}
~ $
```

2. Try to click on telemetry

3. Unable to click / it's disabled

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
