### PR TITLE
chore(preferences): add locked support to StringItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
@@ -98,3 +98,19 @@ test('Ensure that after typing into the input, that onChange is called each time
   await userEvent.type(input, 'foobar');
   expect(onChange).toHaveBeenCalledTimes(6);
 });
+
+test('Ensure HTMLInputElement readonly when locked', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    locked: true,
+  };
+
+  render(StringItem, { record, value: '' });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect((input as HTMLInputElement).readOnly).toBeTruthy();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -23,7 +23,7 @@ function onInput(event: Event): void {
   name={record.id}
   placeholder={record.placeholder}
   value={value}
-  readonly={!!record.readonly}
+  readonly={!!record.readonly || !!record.locked}
   id="input-standard-{record.id}"
   aria-invalid={invalidEntry}
   aria-label={record.description} />


### PR DESCRIPTION
chore(preferences): add locked support to StringItem component

### What does this PR do?

Disables the StringItem input when `record.locked` is true,
preventing edits to preferences / settings.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/15306

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Setup your managed configuration with the following values:

```sh
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "proxy.http": "http://proxy.example.com:8080"
}
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/locked.json
{
        "locked": ["proxy.http"]
}
~ $
```

2. Try to edit the HTTP proxy input field

3. Unable to type / it's disabled

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
