### PR TITLE
chore(preferences): add locked support to NumberItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -219,3 +219,28 @@ test('Expect input to be disabled when record.readonly is true', async () => {
   const incrementButton = screen.getByLabelText('increment');
   expect(incrementButton).toBeDisabled();
 });
+
+test('Expect input to be disabled when record.locked is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 1,
+    maximum: 34,
+    locked: true,
+  };
+  const value = 10;
+  render(NumberItem, { record, value });
+
+  const input = screen.getByRole('textbox', { name: 'record-description' });
+  expect(input).toBeInTheDocument();
+  expect(input).toBeDisabled();
+
+  const decrementButton = screen.getByLabelText('decrement');
+  expect(decrementButton).toBeDisabled();
+
+  const incrementButton = screen.getByLabelText('increment');
+  expect(incrementButton).toBeDisabled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -46,7 +46,7 @@ function onValidation(newValue: number, validationError?: string): void {
     step={record.step}
     type={record.type === 'integer' ? 'integer' : 'number'}
     maximum={record.maximum && typeof record.maximum === 'number' ? record.maximum : undefined}
-    disabled={!!record.readonly}
+    disabled={!!record.readonly || !!record.locked}
     showError={false}>
   </NumberInput>
 </Tooltip>


### PR DESCRIPTION
chore(preferences): add locked support to NumberItem component

### What does this PR do?

Disables the NumberItem input when `record.locked` is true,
preventing edits to preferences / settings.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/15306

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Setup your managed configuration with the following values:

```sh
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "editor.fontSize": 14
}
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/locked.json
{
        "locked": ["editor.fontSize"]
}
~ $
```

2. Try to edit the editor font size input field

3. Unable to type / it's disabled

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
