### PR TITLE
chore(preferences): add locked support to EnumItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
@@ -75,3 +75,19 @@ test('Expect dropdown to be disabled when record.readonly is true', async () => 
   expect(button).toBeInTheDocument();
   expect(button).toBeDisabled();
 });
+
+test('Expect dropdown to be disabled when record.locked is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    enum: ['hello', 'world'],
+    locked: true,
+  };
+
+  render(EnumItem, { record, value: 'hello' });
+  const button = screen.getByRole('button');
+  expect(button).toBeInTheDocument();
+  expect(button).toBeDisabled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -24,6 +24,6 @@ function onChangeHandler(newValue: unknown): void {
   bind:value={value}
   ariaInvalid={invalidEntry}
   ariaLabel={record.description}
-  disabled={!!record.readonly}
+  disabled={!!record.readonly || !!record.locked}
   options={record.enum?.map(recordEnum => ({label: recordEnum, value: recordEnum}))}>
 </Dropdown>


### PR DESCRIPTION
chore(preferences): add locked support to EnumItem component

### What does this PR do?

Disables the EnumItem dropdown when `record.locked` is true,
preventing edits to preferences / settings.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/15306

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Setup your managed configuration with the following values:

```sh
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "preferences.appearance": "dark"
}
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/locked.json
{
        "locked": ["preferences.appearance"]
}
~ $
```

2. Try to change the appearance dropdown selection

3. Unable to select / it's disabled

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
