### PR TITLE
chore(preferences): add locked support to FileItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -175,3 +175,20 @@ test('If FileItem has readonly = true, then expect readonly to show in the eleme
   expect(input).toBeInTheDocument();
   expect((input as HTMLInputElement).readOnly).toBe(true);
 });
+
+test('If FileItem has locked = true, then expect readonly to show in the element', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    format: 'file',
+    locked: true,
+  };
+
+  render(FileItem, { record, value: '' });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect((input as HTMLInputElement).readOnly).toBe(true);
+});

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -29,7 +29,7 @@ function onChangeFileInput(value: string): void {
     name={record.id}
     bind:value={value}
     onChange={onChangeFileInput}
-    readonly={record.readonly ?? false}
+    readonly={record.readonly ?? record.locked ?? false}
     clearable={true}
     placeholder={record.placeholder}
     options={dialogOptions}


### PR DESCRIPTION
chore(preferences): add locked support to FileItem component

### What does this PR do?

Disables the FileItem input when `record.locked` is true,
preventing edits to preferences / settings.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/15306

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Setup your managed configuration with the following values:

```sh
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "kubernetes.Kubeconfig": "~/.kube/config"
}
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/locked.json
{
        "locked": ["kubernetes.Kubeconfig"]
}
~ $
```

2. Try to change the file path

3. Unable to browse / it's disabled

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
