### PR TITLE
chore(preferences): add locked support to SliderItem component

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -64,3 +64,21 @@ test('Expect slider to be disabled when record.readonly is true', async () => {
   expect(input).toBeInTheDocument();
   expect(input).toBeDisabled();
 });
+
+test('Expect slider to be disabled when record.locked is true', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 4,
+    maximum: 34,
+    locked: true,
+  };
+
+  render(SliderItem, { record, value: 15 });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toBeInTheDocument();
+  expect(input).toBeDisabled();
+});

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -23,5 +23,5 @@ async function onInput(event: Event): Promise<void> {
   value={value}
   aria-label={record.description}
   on:input={onInput}
-  disabled={!!record.readonly}
+  disabled={!!record.readonly || !!record.locked}
   class="w-full h-1 bg-[var(--pd-input-toggle-on-bg)] rounded-lg appearance-none accent-[var(--pd-input-toggle-on-bg)] cursor-pointer range-xs mt-2" />


### PR DESCRIPTION
chore(preferences): add locked support to SliderItem component

### What does this PR do?

Disables the SliderItem input when `record.locked` is true,
preventing edits to preferences / settings.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Part of https://github.com/podman-desktop/podman-desktop/issues/15306

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Setup your managed configuration with the following values:

```sh
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/default-settings.json
{
  "preferences.zoomLevel": 0
}
~ $ cat /Library/Application\ Support/io.podman_desktop.PodmanDesktop/locked.json
{
        "locked": ["preferences.zoomLevel"]
}
~ $
```

2. Try to move the zoom level slider

3. Unable to slide / it's disabled

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
