### PR TITLE
chore(renderer/extensions): change built-in publisher display name

### DIFF
--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -107,7 +107,7 @@ export class ExtensionsUtils {
     let publisherDisplayName = matchingCatalogExtension?.publisherDisplayName ?? 'N/A';
 
     if (matchingInstalledExtension && !matchingInstalledExtension.removable) {
-      publisherDisplayName = 'Podman Desktop (built-in)';
+      publisherDisplayName = 'Pre-installed';
     }
 
     const categories: string[] = matchingCatalogExtension?.categories ?? [];


### PR DESCRIPTION
### What does this PR do?


This PR changes the built-in publisher display name in the extensions details page.

### Screenshot / video of UI

<img width="1138" height="1045" alt="Screenshot 2026-01-12 at 17 18 15" src="https://github.com/user-attachments/assets/52eecf90-acfe-48bd-b49f-3377f524a839" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix for https://github.com/podman-desktop/podman-desktop/issues/15407

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
