### PR TITLE
feat(extension/podman): introduce PodmanWindowsLegacyInstaller

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -44,6 +44,10 @@
       {
         "command": "podman.setupRegistry",
         "title": "Podman: Setup registry"
+      },
+      {
+        "command": "podman.uninstallLegacyPodmanInstaller",
+        "title": "Podman: Uninstall legacy podman installer"
       }
     ],
     "configuration": {
@@ -446,7 +450,8 @@
     "mustache": "^4.2.0",
     "ps-list": "^9.0.0",
     "smol-toml": "1.6.0",
-    "ssh2": "^1.17.0"
+    "ssh2": "^1.17.0",
+    "winreg": "^1.2.5"
   },
   "devDependencies": {
     "@types/mustache": "^4.2.6",

--- a/extensions/podman/packages/extension/src/constants.ts
+++ b/extensions/podman/packages/extension/src/constants.ts
@@ -31,3 +31,7 @@ export const PODMAN_MACHINE_EDIT_CPU = 'podman.podmanMachineEditCPUSupported';
 export const PODMAN_MACHINE_EDIT_MEMORY = 'podman.podmanMachineEditMemorySupported';
 export const PODMAN_MACHINE_EDIT_DISK_SIZE = 'podman.podmanMachineEditDiskSizeSupported';
 export const PODMAN_MACHINE_EDIT_ROOTFUL = 'podman.podmanMachineEditRootfulSupported';
+/**
+ * Command ID to uninstall a version of podman installed with non-msi installer
+ */
+export const UNINSTALL_LEGACY_INSTALLER_COMMAND = 'podman.uninstallLegacyPodmanInstaller';

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -41,6 +41,7 @@ import { WinInstaller } from '/@/installer/win-installer';
 import { WinPlatform } from '/@/platforms/win-platform';
 import { PodmanProvider } from '/@/providers/podman-provider';
 import { PodmanBinary } from '/@/utils/podman-binary';
+import { PodmanWindowsLegacyInstaller } from '/@/utils/podman-windows-legacy-installer';
 
 import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from './symbols';
 
@@ -75,6 +76,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(HyperVRunningCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(HyperVInstalledCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(UserAdminCheck).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(PodmanWindowsLegacyInstaller).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(PodmanDesktopElevatedCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(PodmanProvider).toSelf().inSingletonScope();
 

--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -23,6 +23,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { WinPlatform } from '/@/platforms/win-platform';
+import type { PodmanWindowsLegacyInstaller } from '/@/utils/podman-windows-legacy-installer';
 import { getAssetsFolder } from '/@/utils/util';
 
 import { WinInstaller } from './win-installer';
@@ -40,6 +41,7 @@ const progress = {
 
 const mockTelemetryLogger = {} as TelemetryLogger;
 const mockWinPlatform = {} as WinPlatform;
+const legacyInstaller = {} as PodmanWindowsLegacyInstaller;
 
 vi.mock(import('/@/utils/util'), () => ({
   getAssetsFolder: vi.fn(),
@@ -48,7 +50,7 @@ vi.mock(import('/@/utils/util'), () => ({
 let installer: WinInstaller;
 
 beforeEach(() => {
-  installer = new WinInstaller(extensionContext, mockTelemetryLogger, mockWinPlatform);
+  installer = new WinInstaller(extensionContext, mockTelemetryLogger, mockWinPlatform, legacyInstaller);
   vi.resetAllMocks();
   // reset array of subscriptions
   extensionContext.subscriptions.length = 0;

--- a/extensions/podman/packages/extension/src/installer/win-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.ts
@@ -34,6 +34,7 @@ import { inject, injectable } from 'inversify';
 import { ExtensionContextSymbol, TelemetryLoggerSymbol } from '/@/inject/symbols';
 import { WinPlatform } from '/@/platforms/win-platform';
 import podman5Json from '/@/podman5.json';
+import { PodmanWindowsLegacyInstaller } from '/@/utils/podman-windows-legacy-installer';
 import { getAssetsFolder } from '/@/utils/util';
 
 import { BaseInstaller } from './base-installer';
@@ -47,6 +48,8 @@ export class WinInstaller extends BaseInstaller {
     readonly telemetryLogger: TelemetryLogger,
     @inject(WinPlatform)
     readonly winPlatform: WinPlatform,
+    @inject(PodmanWindowsLegacyInstaller)
+    readonly legacyPodmanInstaller: PodmanWindowsLegacyInstaller,
   ) {
     super();
   }

--- a/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.spec.ts
@@ -1,0 +1,238 @@
+/*********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import * as extensionApi from '@podman-desktop/api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Registry, RegistryItem } from 'winreg';
+import WinReg from 'winreg';
+
+import { UNINSTALL_LEGACY_INSTALLER_COMMAND } from '/@/constants';
+import {
+  LEGACY_PODMAN_REGISTRY_ITEM_NAME,
+  LEGACY_PODMAN_REGISTRY_KEY,
+  PodmanWindowsLegacyInstaller,
+  UNINSTALL_REGISTRY_DISPLAY_NAME_KEY,
+  UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY,
+} from '/@/utils/podman-windows-legacy-installer';
+
+vi.mock(import('winreg'));
+vi.mock(
+  import('@podman-desktop/api'),
+  () =>
+    ({
+      window: {
+        withProgress: vi.fn(),
+      },
+      commands: {
+        registerCommand: vi.fn(),
+      },
+      process: {
+        exec: vi.fn(),
+      },
+      ProgressLocation: {
+        TASK_WIDGET: 2,
+      },
+    }) as unknown as typeof extensionApi,
+);
+
+const TELEMETRY_LOGGER_MOCK = {
+  logUsage: vi.fn(),
+} as unknown as extensionApi.TelemetryLogger;
+const CANCELLATION_TOKEN_MOCK: extensionApi.CancellationToken = {
+  isCancellationRequested: false,
+  onCancellationRequested: vi.fn(),
+};
+
+let podmanWindowsLegacyInstaller: PodmanWindowsLegacyInstaller;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  podmanWindowsLegacyInstaller = new PodmanWindowsLegacyInstaller(TELEMETRY_LOGGER_MOCK);
+
+  vi.mocked(extensionApi.window.withProgress).mockImplementation(
+    (
+      _: extensionApi.ProgressOptions,
+      task: (
+        progress: extensionApi.Progress<{ message?: string; increment?: number }>,
+        token: extensionApi.CancellationToken,
+      ) => Promise<unknown>,
+    ) => {
+      return task({ report: vi.fn() }, CANCELLATION_TOKEN_MOCK);
+    },
+  );
+});
+
+describe('init', () => {
+  test('expect uninstall command to be registered', async () => {
+    podmanWindowsLegacyInstaller.init();
+
+    expect(extensionApi.commands.registerCommand).toHaveBeenCalledExactlyOnceWith(
+      UNINSTALL_LEGACY_INSTALLER_COMMAND,
+      expect.any(Function),
+    );
+  });
+});
+
+describe('dispose', () => {
+  test('expect register command disposable to be disposed', async () => {
+    const disposable: extensionApi.Disposable = {
+      dispose: vi.fn(),
+    };
+    vi.mocked(extensionApi.commands.registerCommand).mockReturnValue(disposable);
+
+    podmanWindowsLegacyInstaller.init();
+    podmanWindowsLegacyInstaller.dispose();
+
+    expect(disposable.dispose).toHaveBeenCalledOnce();
+  });
+});
+
+describe('isInstalled', () => {
+  test('expect true if ', async () => {
+    vi.mocked(WinReg.prototype.valueExists).mockImplementation(function (
+      this: Registry,
+      _: string,
+      cb: (err: Error | undefined, exists: boolean) => void,
+    ): Registry {
+      cb(undefined, true);
+      return this;
+    });
+
+    const result = await podmanWindowsLegacyInstaller.isInstalled();
+    expect(result).toBeTruthy();
+
+    expect(WinReg).toHaveBeenCalledExactlyOnceWith({
+      hive: WinReg.HKLM,
+      key: LEGACY_PODMAN_REGISTRY_KEY,
+    });
+    expect(WinReg.prototype.valueExists).toHaveBeenCalledExactlyOnceWith(
+      LEGACY_PODMAN_REGISTRY_ITEM_NAME,
+      expect.any(Function),
+    );
+  });
+
+  test('should return failure if legacy podman installer detected', async () => {
+    vi.mocked(WinReg.prototype.valueExists).mockImplementation(function (
+      this: Registry,
+      _: string,
+      cb: (err: Error | undefined, exists: boolean) => void,
+    ): Registry {
+      cb(undefined, false);
+      return this;
+    });
+
+    const result = await podmanWindowsLegacyInstaller.isInstalled();
+    expect(result).toBeFalsy();
+  });
+});
+
+describe('uninstall', () => {
+  const UNINSTALL_CMD_MOCK = 'uninstall.exe /a /b /c';
+
+  const PODMAN_UNINSTALL_REGISTRY: Registry = {
+    valueExists: vi.fn(),
+    get: vi.fn(),
+  } as unknown as Registry;
+
+  beforeEach(() => {
+    vi.mocked(WinReg.prototype.keys).mockImplementation(function (
+      this: Registry,
+      cb: (err: Error | undefined, result: Registry[]) => void,
+    ): Registry {
+      cb(undefined, [PODMAN_UNINSTALL_REGISTRY]);
+      return this;
+    });
+
+    vi.mocked(PODMAN_UNINSTALL_REGISTRY.valueExists).mockImplementation(function (
+      this: Registry,
+      name: string,
+      cb: (err: Error, exists: boolean) => void,
+    ): Registry {
+      cb(undefined as unknown as Error, true);
+      return this;
+    });
+
+    vi.mocked(PODMAN_UNINSTALL_REGISTRY.get).mockImplementation(function (
+      this: Registry,
+      name: string,
+      cb: (err: Error, result: RegistryItem) => void,
+    ): Registry {
+      switch (name) {
+        case UNINSTALL_REGISTRY_DISPLAY_NAME_KEY:
+          cb(
+            undefined as unknown as Error,
+            {
+              value: 'podman',
+            } as RegistryItem,
+          );
+          break;
+        case UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY:
+          cb(
+            undefined as unknown as Error,
+            {
+              value: UNINSTALL_CMD_MOCK,
+            } as RegistryItem,
+          );
+          break;
+        default:
+          throw new Error(`unknown key ${name}`);
+      }
+      return this;
+    });
+  });
+
+  test('should execute expected uninstall cmd in shell', async () => {
+    await podmanWindowsLegacyInstaller.uninstall();
+
+    expect(extensionApi.process.exec).toHaveBeenCalledWith('cmd.exe', ['/s', '/c', `"${UNINSTALL_CMD_MOCK}"`], {
+      isAdmin: true,
+      logger: expect.anything(),
+    });
+  });
+
+  test('expect telemetry usage to be provided for uninstall legacy', async () => {
+    await podmanWindowsLegacyInstaller.uninstall();
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith('podman.uninstallLegacy', {
+      duration: expect.any(Number),
+    });
+  });
+
+  test('expect error raised during uninstall to be logged in telemetry', async () => {
+    const error = new Error('Dummy Foo Bar');
+    vi.mocked(WinReg.prototype.keys).mockImplementation(function (
+      this: Registry,
+      cb: (err: Error | undefined, result: Registry[]) => void,
+    ): Registry {
+      cb(error, []);
+      return this;
+    });
+
+    await expect(async () => {
+      return await podmanWindowsLegacyInstaller.uninstall();
+    }).rejects.toThrowError(error);
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      'podman.uninstallLegacy',
+      expect.objectContaining({
+        error: error,
+      }),
+    );
+  });
+});

--- a/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.spec.ts
@@ -27,7 +27,7 @@ import {
   LEGACY_PODMAN_REGISTRY_KEY,
   PodmanWindowsLegacyInstaller,
   UNINSTALL_REGISTRY_DISPLAY_NAME_KEY,
-  UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY,
+  UNINSTALL_REGISTRY_QUIET_UNINSTALL_STRING_KEY,
 } from '/@/utils/podman-windows-legacy-installer';
 
 vi.mock(import('winreg'));
@@ -104,7 +104,7 @@ describe('dispose', () => {
 });
 
 describe('isInstalled', () => {
-  test('expect true if ', async () => {
+  test('expect true if legacy podman installer is detected', async () => {
     vi.mocked(WinReg.prototype.valueExists).mockImplementation(function (
       this: Registry,
       _: string,
@@ -127,7 +127,7 @@ describe('isInstalled', () => {
     );
   });
 
-  test('should return failure if legacy podman installer detected', async () => {
+  test('expect false if legacy podman installer is not detected', async () => {
     vi.mocked(WinReg.prototype.valueExists).mockImplementation(function (
       this: Registry,
       _: string,
@@ -182,7 +182,7 @@ describe('uninstall', () => {
             } as RegistryItem,
           );
           break;
-        case UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY:
+        case UNINSTALL_REGISTRY_QUIET_UNINSTALL_STRING_KEY:
           cb(
             undefined as unknown as Error,
             {

--- a/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.ts
@@ -39,7 +39,7 @@ export const LEGACY_PODMAN_REGISTRY_ITEM_NAME = 'InstallDir';
 // Uninstall
 export const UNINSTALL_REGISTRY_PATH = '\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall';
 export const UNINSTALL_REGISTRY_DISPLAY_NAME_KEY = 'DisplayName';
-export const UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY = 'QuietUninstallString';
+export const UNINSTALL_REGISTRY_QUIET_UNINSTALL_STRING_KEY = 'QuietUninstallString';
 
 /**
  * On Windows Podman migrated from a system-wide installer requiring admin privilege to
@@ -134,7 +134,7 @@ export class PodmanWindowsLegacyInstaller implements Disposable {
 
     if (item.value.trim().toLowerCase() !== 'podman') return false;
 
-    return valueExists(UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY);
+    return valueExists(UNINSTALL_REGISTRY_QUIET_UNINSTALL_STRING_KEY);
   }
 
   /**
@@ -154,7 +154,7 @@ export class PodmanWindowsLegacyInstaller implements Disposable {
     for (const registry of registries) {
       if (await this.isPodmanUninstallRegistry(registry)) {
         const uninstallItem = await promisify(registry.get).bind(registry)(
-          UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY,
+          UNINSTALL_REGISTRY_QUIET_UNINSTALL_STRING_KEY,
         );
         return uninstallItem.value;
       }

--- a/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.ts
@@ -1,0 +1,137 @@
+/*********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+import { promisify } from 'node:util';
+
+import {
+  commands,
+  type Disposable,
+  process as processAPI,
+  ProgressLocation,
+  TelemetryLogger,
+  window,
+} from '@podman-desktop/api';
+import { inject, injectable, postConstruct, preDestroy } from 'inversify';
+import type { Registry } from 'winreg';
+import WinReg from 'winreg';
+
+import { UNINSTALL_LEGACY_INSTALLER_COMMAND } from '/@/constants';
+import { TelemetryLoggerSymbol } from '/@/inject/symbols';
+
+// Registry key / item used by the legacy installer
+export const LEGACY_PODMAN_REGISTRY_KEY = '\\SOFTWARE\\Red Hat\\Podman';
+export const LEGACY_PODMAN_REGISTRY_ITEM_NAME = 'InstallDir';
+
+// Uninstall
+export const UNINSTALL_REGISTRY_PATH = '\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall';
+export const UNINSTALL_REGISTRY_DISPLAY_NAME_KEY = 'DisplayName';
+export const UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY = 'QuietUninstallString';
+
+@injectable()
+export class PodmanWindowsLegacyInstaller implements Disposable {
+  #disposables: Disposable[] = [];
+
+  constructor(
+    @inject(TelemetryLoggerSymbol)
+    readonly telemetryLogger: TelemetryLogger,
+  ) {}
+
+  @preDestroy()
+  dispose(): void {
+    this.#disposables.forEach(disposable => disposable.dispose());
+  }
+
+  @postConstruct()
+  init(): void {
+    this.#disposables.push(commands.registerCommand(UNINSTALL_LEGACY_INSTALLER_COMMAND, this.uninstall.bind(this)));
+  }
+
+  async isInstalled(): Promise<boolean> {
+    const legacyRegistry: Registry = new WinReg({
+      hive: WinReg.HKLM,
+      key: LEGACY_PODMAN_REGISTRY_KEY,
+    });
+
+    return await promisify(legacyRegistry.valueExists).bind(legacyRegistry)(LEGACY_PODMAN_REGISTRY_ITEM_NAME);
+  }
+
+  public async uninstall(): Promise<void> {
+    return window.withProgress(
+      {
+        location: ProgressLocation.TASK_WIDGET,
+        title: 'Uninstalling legacy Podman Installer',
+      },
+      async ({ report }) => {
+        report({ message: 'Uninstalling legacy Podman Installer' });
+
+        const start = performance.now();
+        const telemetry: Record<string, unknown> = {};
+
+        try {
+          const uninstallString = await this.getUninstallCMD();
+
+          await processAPI.exec('cmd.exe', ['/s', '/c', `"${uninstallString}"`], {
+            logger: {
+              error: console.error,
+              log: console.log,
+              warn: console.warn,
+            },
+            isAdmin: true,
+          });
+        } catch (err: unknown) {
+          console.error('Something went wrong while trying to uninstall legacy Podman Installer', err);
+          telemetry['error'] = err;
+          throw err;
+        } finally {
+          telemetry['duration'] = performance.now() - start;
+          this.telemetryLogger.logUsage('podman.uninstallLegacy', telemetry);
+        }
+      },
+    );
+  }
+
+  protected async isPodmanUninstallRegistry(registry: Registry): Promise<boolean> {
+    const valueExists = promisify(registry.valueExists).bind(registry);
+    const exists = await valueExists(UNINSTALL_REGISTRY_DISPLAY_NAME_KEY);
+    if (!exists) return false;
+
+    const item = await promisify(registry.get).bind(registry)(UNINSTALL_REGISTRY_DISPLAY_NAME_KEY);
+
+    if (item.value.trim().toLowerCase() !== 'podman') return false;
+
+    return valueExists(UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY);
+  }
+
+  protected async getUninstallCMD(): Promise<string> {
+    const uninstallRegistry: Registry = new WinReg({
+      hive: WinReg.HKLM,
+      key: UNINSTALL_REGISTRY_PATH,
+    });
+
+    const registries: Registry[] = await promisify(uninstallRegistry.keys).bind(uninstallRegistry)();
+    for (const registry of registries) {
+      if (await this.isPodmanUninstallRegistry(registry)) {
+        const uninstallItem = await promisify(registry.get).bind(registry)(
+          UNINSTALL_REGISTRY_QUIT_UNINSTALL_STRING_KEY,
+        );
+        return uninstallItem.value;
+      }
+    }
+
+    throw new Error('cannot find the uninstall command for the Podman legacy installer');
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
       ssh2:
         specifier: ^1.17.0
         version: 1.17.0
+      winreg:
+        specifier: ^1.2.5
+        version: 1.2.5
     devDependencies:
       '@types/mustache':
         specifier: ^4.2.6


### PR DESCRIPTION
### What does this PR do?

To simplify https://github.com/podman-desktop/podman-desktop/pull/15441, making a dedicated PR for the new `feat(extension/podman): introduce PodmanWindowsLegacyInstaller`.

The registries read do not require admin privileges, as they are READ for all users (See https://flylib.com/books/en/1.271.1.84/1/)

💡 I added a `'podman.legacyInstallerCheck'` telemetry event for errors. We will be able to monitore this new logic

⚠️ There is a new command, but currently it is not available, as nobody is consuming `PodmanWindowsLegacyInstaller `, you can try it in https://github.com/podman-desktop/podman-desktop/pull/15441

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for
- https://github.com/podman-desktop/podman-desktop/pull/15441/

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

We can only test the uninstall part of the legacy installer, **this is not about updating podman**.

1. Assert you have a version of Podman installed with the legacy installer (E.g. [podman-5.7.0-setup.exe](https://github.com/containers/podman/releases/download/v5.7.0/podman-5.7.0-setup.exe))
2. Checkout this PR
3. Start Podman Desktop in watch
4. Open the Command Palette 
5. Search `Uninstall`
<img width="757" height="178" alt="image" src="https://github.com/user-attachments/assets/ccd5335f-511a-42df-b280-0ef8c3ad17f8" />

6. Select the `Podman: uninstall legacy installer`
7. Assert success

<img width="903" height="92" alt="image" src="https://github.com/user-attachments/assets/6f5f26cb-8208-4d10-9e97-648449365429" />

8. Go to your terminal 
9. Assert `podman --version` is not recognised