### PR TITLE
refactor(ui): updated ui lib icon types to to reflect actual types

### DIFF
--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import type { Snippet } from 'svelte';
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import type { Component, Snippet } from 'svelte';
 import { createEventDispatcher } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
@@ -11,8 +12,7 @@ interface Props {
   inProgress?: boolean;
   disabled?: boolean;
   type?: ButtonType;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  icon?: any;
+  icon?: IconDefinition | Component | string;
   selected?: boolean;
   padding?: string;
   class?: string;
@@ -98,7 +98,9 @@ let classes = $derived.by(() => {
       {#if inProgress}
         <Spinner size="1em" />
       {:else}
-        <Icon icon={icon}/>
+        {#if icon}
+          <Icon icon={icon}/>
+        {/if}
       {/if}
       {#if children}
         <span>{@render children()}</span>

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -97,10 +97,8 @@ let classes = $derived.by(() => {
       class:py-[3px]={!children}>
       {#if inProgress}
         <Spinner size="1em" />
-      {:else}
-        {#if icon}
-          <Icon icon={icon}/>
-        {/if}
+      {:else if icon}
+        <Icon icon={icon}/>
       {/if}
       {#if children}
         <span>{@render children()}</span>

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
+import type { Component } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
 
 interface Props {
   title: string;
   tooltip?: string;
-  icon: IconDefinition | string;
+  icon: IconDefinition | Component | string;
   enabled?: boolean;
   hidden?: boolean;
   onClick?: () => void;

--- a/packages/ui/src/lib/dropdownMenu/DropdownMenu.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropdownMenu.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
-import type { Snippet } from 'svelte';
+import type { Component, Snippet } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
 import DropDownMenuItems from './DropDownMenuItems.svelte';
 
 interface Props {
   onBeforeToggle?: () => void;
-  icon?: IconDefinition;
+  icon?: IconDefinition | Component | string;
   shownAsMenuActionItem?: boolean;
   hidden?: boolean;
   title?: string;

--- a/packages/ui/src/lib/link/Link.svelte
+++ b/packages/ui/src/lib/link/Link.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/free-regular-svg-icons';
-import { createEventDispatcher, type Snippet } from 'svelte';
+import { type Component, createEventDispatcher, type Snippet } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
 
 const dispatch = createEventDispatcher<{ click: undefined }>();
 
 interface Props {
-  icon?: IconDefinition;
+  icon?: IconDefinition | Component | string;
   class?: string;
   children: Snippet;
   onclick?: () => void;

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
-import { faPaste } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher, onMount, type Snippet } from 'svelte';
+import { faPaste, type IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { type Component, createEventDispatcher, onMount, type Snippet } from 'svelte';
 
 import Button from '../button/Button.svelte';
 import Icon from '../icons/Icon.svelte';
 import { isFontAwesomeIcon } from '../utils/icon-utils';
 
 interface Props {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  icon: any;
+  icon: IconDefinition | Component | string | undefined;
   title?: string;
   message?: string;
   detail?: string;
@@ -68,7 +67,7 @@ let copyTextDivElement = $state<HTMLDivElement>();
   aria-label={ariaLabel}>
   <div class="flex flex-col h-full justify-center text-center space-y-3">
     <div class="flex justify-center text-[var(--pd-details-empty-icon)] py-2">
-      {#if processed}
+      {#if processed && icon}
         {#if fontAwesomeIcon}
           <Icon icon={icon} size='4x'/>
         {:else}

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -7,7 +7,7 @@ import Icon from '../icons/Icon.svelte';
 import { isFontAwesomeIcon } from '../utils/icon-utils';
 
 interface Props {
-  icon: IconDefinition | Component | string | undefined;
+  icon?: IconDefinition | Component | string;
   title?: string;
   message?: string;
   detail?: string;
@@ -22,7 +22,7 @@ interface Props {
 }
 
 let {
-  icon = undefined,
+  icon,
   title = 'No title',
   message = '',
   detail = '',

--- a/packages/ui/src/lib/screen/FilteredEmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/FilteredEmptyScreen.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { createEventDispatcher } from 'svelte';
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { type Component, createEventDispatcher } from 'svelte';
 
 import Button from '../button/Button.svelte';
 import EmptyScreen from './EmptyScreen.svelte';
@@ -12,8 +13,7 @@ const defaultOnResetFilter = (): void => {
   }
 };
 interface Props {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  icon: any;
+  icon?: IconDefinition | Component | string;
   kind: string;
   searchTerm: string;
   onResetFilter?: () => void;

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -11,7 +11,7 @@ interface Props {
   expanded?: boolean;
   child?: boolean;
   selected?: boolean;
-  icon?: IconDefinition | Component;
+  icon?: IconDefinition | Component | string;
   iconPosition?: 'left' | 'right';
   onClick?: () => void;
 }

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -34,10 +34,8 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
     title={status}>
     {#if status === 'DELETING' || status === 'UPDATING'}
       <Spinner size="1.4em" />
-    {:else}
-      {#if icon}
-        <Icon icon={icon} size={size} />
-      {/if}
+    {:else if icon}
+      <Icon icon={icon} size={size} />
     {/if}
   </div>
   {#if status === 'CREATED'}

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import type { Component } from 'svelte';
+
 import Icon from '../icons/Icon.svelte';
 import StarIcon from '../icons/StarIcon.svelte';
 import Spinner from '../progress/Spinner.svelte';
@@ -7,8 +10,7 @@ interface Props {
   // status: one of RUNNING, STARTING, USED, CREATED, DELETING, UPDATING, or DEGRADED
   // any other status will result in a standard outlined box
   status?: 'RUNNING' | 'STARTING' | 'USED' | 'DEGRADED' | 'DELETING' | 'UPDATING' | 'CREATED' | string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  icon?: any;
+  icon?: IconDefinition | Component | string;
   size?: number;
 }
 let { status = 'UNKNOWN', icon, size = 20 }: Props = $props();
@@ -32,10 +34,10 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
     title={status}>
     {#if status === 'DELETING' || status === 'UPDATING'}
       <Spinner size="1.4em" />
-    {:else if typeof icon === 'string'}
-       <Icon icon={icon} />
     {:else}
-       <Icon icon={icon} size={size} />
+      {#if icon}
+        <Icon icon={icon} size={size} />
+      {/if}
     {/if}
   </div>
   {#if status === 'CREATED'}


### PR DESCRIPTION
### What does this PR do?
Updates icon type in UI lib with types that are supported by `Icon` component

### Screenshot / video of UI
Should be no visual change


### What issues does this PR fix or reference?
- [x] needs rebase after https://github.com/podman-desktop/podman-desktop/pull/15657

### How to test this PR?
Go through the app and try to see the icons if they works correctly

- [x] Tests are covering the bug fix or the new feature
