### PR TITLE
feat: add iconRight and iconRightAlign props to SettingsNavItem

### DIFF
--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
@@ -135,8 +135,8 @@ test('svg icon should be visible', () => {
   expect(svg).toBeInTheDocument();
 });
 
-describe('icon position', () => {
-  test('default icon position should be left', () => {
+describe('icon', () => {
+  test('icon should be displayed on the left', () => {
     const { getByRole } = render(SettingsNavItem, {
       title: 'DummyTitle',
       href: '/dummy/path',
@@ -147,17 +147,52 @@ describe('icon position', () => {
     expect(svg).toBeInTheDocument();
     expect(svg.parentElement).toHaveClass('flex-row');
   });
+});
 
-  test('icon position right should use reverse row', () => {
-    const { getByRole } = render(SettingsNavItem, {
+describe('iconRight', () => {
+  test('iconRight with align end should be at far right', () => {
+    const { getAllByRole } = render(SettingsNavItem, {
       title: 'DummyTitle',
       href: '/dummy/path',
       selected: false,
       icon: MyIcon,
-      iconPosition: 'right',
+      iconRight: MyIcon,
+      iconRightAlign: 'end',
     });
-    const svg = getByRole('img', { hidden: true });
-    expect(svg).toBeInTheDocument();
-    expect(svg.parentElement).toHaveClass('flex-row-reverse');
+    const svgs = getAllByRole('img', { hidden: true });
+    expect(svgs).toHaveLength(2);
+    // First icon (left) should be in the title span
+    expect(svgs[0].parentElement).toHaveClass('flex-row');
+    // Second icon (right) should be in the end container with px-2
+    expect(svgs[1].parentElement).toHaveClass('px-2');
+  });
+
+  test('iconRight with align inline should be next to title', () => {
+    const { getAllByRole } = render(SettingsNavItem, {
+      title: 'DummyTitle',
+      href: '/dummy/path',
+      selected: false,
+      icon: MyIcon,
+      iconRight: MyIcon,
+      iconRightAlign: 'inline',
+    });
+    const svgs = getAllByRole('img', { hidden: true });
+    expect(svgs).toHaveLength(2);
+    // Both icons should be in the same flex-row container
+    expect(svgs[0].parentElement).toHaveClass('flex-row');
+    expect(svgs[1].parentElement).toHaveClass('flex-row');
+  });
+
+  test('iconRight defaults to end alignment', () => {
+    const { getAllByRole } = render(SettingsNavItem, {
+      title: 'DummyTitle',
+      href: '/dummy/path',
+      selected: false,
+      iconRight: MyIcon,
+    });
+    const svgs = getAllByRole('img', { hidden: true });
+    expect(svgs).toHaveLength(1);
+    // Icon should be in the end container with px-2
+    expect(svgs[0].parentElement).toHaveClass('px-2');
   });
 });

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -12,7 +12,8 @@ interface Props {
   child?: boolean;
   selected?: boolean;
   icon?: IconDefinition | Component | string;
-  iconPosition?: 'left' | 'right';
+  iconRight?: IconDefinition | Component | string;
+  iconRightAlign?: 'inline' | 'end';
   onClick?: () => void;
 }
 
@@ -24,7 +25,8 @@ let {
   child = false,
   selected = false,
   icon = undefined,
-  iconPosition = 'left',
+  iconRight = undefined,
+  iconRightAlign = 'end',
   onClick = (): void => {},
 }: Props = $props();
 
@@ -51,22 +53,27 @@ function click(): void {
     class:hover:bg-[var(--pd-secondary-nav-text-hover-bg)]={!selected}
     class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]={!selected}>
     <span
-      class="group-hover:block flex gap-x-2 items-center"
-      class:flex-row={iconPosition === 'left'}
-      class:flex-row-reverse={iconPosition === 'right'}
+      class="group-hover:block flex flex-row gap-x-2 items-center"
       class:capitalize={!child}>
       {#if icon}
           <Icon icon={icon}/>
       {/if}
       <span>{title}</span>
+      {#if iconRight && iconRightAlign === 'inline'}
+        <Icon icon={iconRight}/>
+      {/if}
     </span>
     {#if section}
-      <div class="px-2 relative w-4 h-4 text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
+      <div class="px-2 flex items-center text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
         {#if expanded}
-          <Icon icon='fas fa-angle-down' class="text-md absolute left-0 top-0.5 transform origin-center transition-transform duration-200 -rotate-90" />
+          <Icon icon='fas fa-angle-down' class="text-md transform origin-center transition-transform duration-200 -rotate-90" />
         {:else}
-          <Icon icon='fas fa-angle-right' class="text-md absolute left-0 top-0.5 transform origin-center transition-transform duration-200 rotate-90" />
+          <Icon icon='fas fa-angle-right' class="text-md transform origin-center transition-transform duration-200 rotate-90" />
         {/if}
+      </div>
+    {:else if iconRight && iconRightAlign === 'end'}
+      <div class="px-2 flex items-center">
+        <Icon icon={iconRight}/>
       </div>
     {/if}
   </div>


### PR DESCRIPTION
### What does this PR do?
This PR adds the prop iconRight and iconRightAlign to the SettingsNavItem.svelte component. This allow to have icons in SettingsNavItems as needed for [#14163](https://github.com/podman-desktop/podman-desktop/issues/14163) design, left and right icons. Also the iconRightAlign prop can make the icon right to be "inline" or at the "end" of the container.
<img width="223" height="52" alt="Captura de pantalla 2026-01-12 a las 13 44 09" src="https://github.com/user-attachments/assets/729fb3c0-061d-497b-924f-8f890af49fea" />


### Screenshot / video of UI
Before:
<img width="181" height="71" alt="Captura de pantalla 2026-01-12 a las 13 46 12" src="https://github.com/user-attachments/assets/a646d3df-0a99-46ee-a2cc-cbfbb73ad7be" />
After:
<img width="186" height="86" alt="Captura de pantalla 2026-01-12 a las 13 45 43" src="https://github.com/user-attachments/assets/129168f8-7bbc-44ee-b4ee-af753b8e6747" />


### What issues does this PR fix or reference?
Part of #14163 

### How to test this PR?
Use the SettingsNavItem.svelte component with the iconRight and iconRightAlign props set. For example in PreferencesNavigation.svelte component, adds:

`<SettingsNavItem
      icon={KubernetesIcon}
      iconRight={KubernetesIcon}
      iconRightAlign="end"
      title="TestItem"
      href="/test/url"
      selected={meta.url === '/test/url'}
    />`

- [ ] Tests are covering the bug fix or the new feature
