### PR TITLE
feat(HelpMenu): adding LinkedIn item

### DIFF
--- a/product.json
+++ b/product.json
@@ -61,6 +61,12 @@
         "tooltip": "Join Slack #podman-desktop channel",
         "icon": "fab fa-slack",
         "link": "https://slack.k8s.io"
+      },
+      {
+        "title": "@podman-desktop",
+        "tooltip": "Follow Podman Desktop LinkedIn account",
+        "icon": "fab fa-linkedin",
+        "link": "https://www.linkedin.com/company/podman-desktop/"
       }
     ]
   }


### PR DESCRIPTION
### What does this PR do?

Adding the LinkedIn item in the HelpMenu to increase the visibility of the account

### Screenshot / video of UI

<img width="289" height="374" alt="image" src="https://github.com/user-attachments/assets/b78f705a-faec-42b0-a5fb-b32c098d802c" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15381

### How to test this PR?

You can checkout the branch and open the `(?)` menu, click on the new added `LinkedIn` item and assert it open the LinkedIn page of Podman Desktop
