### PR TITLE
chore(renderer/extensions): remove product name and rename pre-installed extension

### DIFF
--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.spec.ts
@@ -55,7 +55,7 @@ test('Expect to have description and version', async () => {
   expect(version).toHaveTextContent('v1.2.3');
 
   // not removable
-  expect(region).not.toHaveTextContent('Podman Desktop built-in extension');
+  expect(region).not.toHaveTextContent('Pre-installed');
 });
 
 test('Expect to have podman desktop extension info (removable = false)', async () => {
@@ -80,5 +80,5 @@ test('Expect to have podman desktop extension info (removable = false)', async (
   expect(region).toBeInTheDocument();
 
   // region contains the details
-  expect(region).toHaveTextContent('Podman Desktop built-in extension');
+  expect(region).toHaveTextContent('Pre-installed');
 });

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardRight.svelte
@@ -20,7 +20,7 @@ let { extension }: Props = $props();
   </div>
   <div class="absolute bottom-0 flex flex-col text-[var(--pd-content-text)] text-sm">
     <div>
-      {extension.removable ? '' : 'Podman Desktop built-in extension'}
+      {extension.removable ? '' : 'Pre-installed'}
     </div>
     <div aria-label="Version">
       {#if extension.version}


### PR DESCRIPTION
### What does this PR do?

This PR removes the product name and rename the built-in extension to pre-installed in the Extension list.

Question: should we also rename other occurences of "built-in extension" to "pre-installed"?

### Screenshot / video of UI
<img width="1138" height="1045" alt="Screenshot 2026-01-13 at 09 32 10" src="https://github.com/user-attachments/assets/cc54cad7-6598-43e2-ac33-81d299b896fb" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix of https://github.com/podman-desktop/podman-desktop/issues/15407

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
