### PR TITLE
feat(product.json/release-notes): add overrides for product release notes

### DIFF
--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -39,6 +39,7 @@ import { Disposable } from '/@/plugin/types/disposable.js';
 import { isLinux, isWindows } from '/@/util.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type { ReleaseNotesInfo } from '/@api/release-notes-info.js';
+import product from '/@product.json' with { type: 'json' };
 
 import rootPackage from '../../../../package.json' with { type: 'json' };
 import { TaskManager } from './tasks/task-manager.js';
@@ -78,6 +79,11 @@ export class Updater {
   }
 
   public async openReleaseNotes(version: string): Promise<void> {
+    if (product.releaseNotes.url) {
+      shell.openExternal(product.releaseNotes.url).catch(console.error);
+      return;
+    }
+
     if (version === 'current') {
       version = app.getVersion();
     } else if (version === 'latest') {
@@ -99,6 +105,24 @@ export class Updater {
   }
 
   public async getReleaseNotes(): Promise<ReleaseNotesInfo> {
+    if (
+      product.releaseNotes.image &&
+      product.releaseNotes.summary &&
+      product.releaseNotes.title &&
+      product.releaseNotes.blog &&
+      product.releaseNotes.url
+    ) {
+      return {
+        releaseNotesAvailable: true,
+        notesURL: product.releaseNotes.url,
+        notes: {
+          image: product.releaseNotes.image,
+          blog: product.releaseNotes.blog,
+          title: product.releaseNotes.title,
+          summary: product.releaseNotes.summary,
+        },
+      };
+    }
     let version = app.getVersion();
     if (import.meta.env.DEV && version.endsWith('-next')) {
       // use the latest release version published on GitHub

--- a/product.json
+++ b/product.json
@@ -69,5 +69,12 @@
         "link": "https://www.linkedin.com/company/podman-desktop/"
       }
     ]
+  },
+  "releaseNotes": {
+    "url": "",
+    "blog": "",
+    "title": "",
+    "image": "",
+    "summary": ""
   }
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new field for release notes in the product.json file. It currently contains empty strings to allow downstream overrides (see comment https://github.com/podman-desktop/podman-desktop/issues/15275#issuecomment-3737445083 ). The structure of the field has been instructed by comment https://github.com/podman-desktop/podman-desktop/issues/15275#issuecomment-3718114906.

To review, you can hide the whitespace changes.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15275

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Check that the release notes banner is displayed correctly. You can force the display by setting:

```ts
  showBanner = true;
```

in packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte

Then try to make a custom release note banner by filling product.json fields:

```json
  "releaseNotes": {
    "url": "http://google.com",
    "blog": "blog",
    "title": "title",
    "image": "https://fastly.picsum.photos/id/569/200/200.jpg?hmac=rzX0dRJRyZs2NIa_h_87CJVeoetRLtTlweCZmYrYlCA",
    "summary": "- **Feature 1**: Allow feature 1 to work well.\n- **Feature 2**: Ensure feature 2 is working\n- **Feature 3**: Feature 3 is new, try it now"
  }
```
<img width="1138" height="1045" alt="Screenshot 2026-01-13 at 15 52 10" src="https://github.com/user-attachments/assets/733bad46-93e6-4846-bfc0-202bc6662d43" />

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
