### PR TITLE
fix(DropdDownMenuItem): unified icon size

### DIFF
--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.spec.ts
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.spec.ts
@@ -63,27 +63,27 @@ test('Expect tooltip is used if not empty', async () => {
   expect(span).toBeInTheDocument();
 });
 
-test('Expect font awesome icon to have class h-4 w-4', async () => {
+test('Expect font awesome icon to have class w-4 text-md', async () => {
   render(DropDownMenuItem, {
     title: 'dummy-title',
     icon: faCircleUp,
   });
 
   const icon = screen.getByRole('img', { hidden: true });
-  expect(icon).toHaveClass('h-4 w-4 text-md');
+  expect(icon).toHaveClass('w-4 text-md');
 });
 
-test('Expect string icon to have class h-4 w-4', async () => {
+test('Expect string icon to have class w-4 text-md', async () => {
   render(DropDownMenuItem, {
     title: 'dummy-title',
     icon: 'fas fa-circle-up',
   });
 
   const icon = screen.getByRole('img', { hidden: true });
-  expect(icon).toHaveClass('h-4 w-4 text-md');
+  expect(icon).toHaveClass('w-4 text-md');
 });
 
-test('Expect component icon to have class h-4 w-4', async () => {
+test('Expect component icon to have class w-4 text-md', async () => {
   render(DropDownMenuItem, {
     title: 'dummy-title',
     icon: StarIcon,
@@ -92,5 +92,5 @@ test('Expect component icon to have class h-4 w-4', async () => {
   const img = screen.getByRole('img', { hidden: true });
   const imgComponent = img.firstChild;
   expect(imgComponent).toBeInTheDocument();
-  expect(imgComponent).toHaveClass('h-4 w-4 text-md');
+  expect(imgComponent).toHaveClass('w-4 text-md');
 });

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.spec.ts
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.spec.ts
@@ -22,6 +22,7 @@ import { faCircleUp } from '@fortawesome/free-solid-svg-icons';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
+import StarIcon from '../icons/StarIcon.svelte';
 import DropDownMenuItem from './DropDownMenuItem.svelte';
 
 test('Expect custom font icon on the contributed action', async () => {
@@ -60,4 +61,36 @@ test('Expect tooltip is used if not empty', async () => {
   // grab the svg element
   const span = screen.getByTitle('tooltip');
   expect(span).toBeInTheDocument();
+});
+
+test('Expect font awesome icon to have class h-4 w-4', async () => {
+  render(DropDownMenuItem, {
+    title: 'dummy-title',
+    icon: faCircleUp,
+  });
+
+  const icon = screen.getByRole('img', { hidden: true });
+  expect(icon).toHaveClass('h-4 w-4 text-md');
+});
+
+test('Expect string icon to have class h-4 w-4', async () => {
+  render(DropDownMenuItem, {
+    title: 'dummy-title',
+    icon: 'fas fa-circle-up',
+  });
+
+  const icon = screen.getByRole('img', { hidden: true });
+  expect(icon).toHaveClass('h-4 w-4 text-md');
+});
+
+test('Expect component icon to have class h-4 w-4', async () => {
+  render(DropDownMenuItem, {
+    title: 'dummy-title',
+    icon: StarIcon,
+  });
+
+  const img = screen.getByRole('img', { hidden: true });
+  const imgComponent = img.firstChild;
+  expect(imgComponent).toBeInTheDocument();
+  expect(imgComponent).toHaveClass('h-4 w-4 text-md');
 });

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
@@ -27,11 +27,7 @@ const disabledClasses = 'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--
       title={tooltip !== '' ? tooltip : title}
       class="group flex items-center no-underline whitespace-nowrap"
       tabindex="-1">
-      {#if typeof icon === 'string'}
-        <Icon icon={icon} />
-      {:else}
-        <Icon class="h-4 w-4 text-md" icon={icon}/>
-      {/if}
+      <Icon class="h-4 w-4 text-md" icon={icon} />
       {#if title}<span class="ml-2">{title}</span>{/if}
     </span>
   </div>

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
@@ -25,9 +25,9 @@ const disabledClasses = 'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--
   <div class={`p-2.5 ${enabled ? enabledClasses : disabledClasses}`} role="none" onclick={onClick}>
     <span
       title={tooltip !== '' ? tooltip : title}
-      class="group flex items-center no-underline whitespace-nowrap"
+      class="group flex items-center no-underline whitespace-nowrap h-4"
       tabindex="-1">
-      <Icon class="h-4 w-4 text-md" icon={icon} />
+      <Icon class="w-4 text-md" icon={icon} />
       {#if title}<span class="ml-2">{title}</span>{/if}
     </span>
   </div>


### PR DESCRIPTION
### What does this PR do?
Fixes size of icon when is the string icon is rendered

### Screenshot / video of UI

Previous: 

https://github.com/podman-desktop/podman-desktop/pull/15567#pullrequestreview-3655618747

After:


<img width="1051" height="700" alt="image" src="https://github.com/user-attachments/assets/de153cd2-4564-48f1-b96d-987bfd00c9eb" />



### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/15567

### How to test this PR?
Checkout to https://github.com/podman-desktop/podman-desktop/pull/15567 and go through ai lab, long click the back button, there should be the ai lab icon with right size

- [x] Tests are covering the bug fix or the new feature
