### PR TITLE
refactor(learning-center): remove useless definition of mocks

### DIFF
--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import learningCenter from '../../../../main/src/plugin/learning-center/guides.json';
 import LearningCenter from './LearningCenter.svelte';
@@ -35,31 +35,8 @@ vi.mock('svelte/transition', () => ({
   }),
 }));
 
-class ResizeObserver {
-  observe = vi.fn();
-  disconnect = vi.fn();
-  unobserve = vi.fn();
-}
-
-const updateConfigurationValueMock = vi.fn();
-const getConfigurationValueMock = vi.fn();
-const listGuidesMock = vi.fn().mockReturnValue(learningCenter.guides);
-
-beforeAll(() => {
-  Object.defineProperty(window, 'getConfigurationValue', {
-    value: getConfigurationValueMock,
-  });
-  Object.defineProperty(window, 'listGuides', {
-    value: listGuidesMock,
-  });
-  Object.defineProperty(window, 'updateConfigurationValue', {
-    value: updateConfigurationValueMock,
-  });
-  global.ResizeObserver = ResizeObserver;
-});
-
 beforeEach(() => {
-  listGuidesMock.mockReturnValue(learningCenter.guides);
+  vi.mocked(window.listGuides).mockResolvedValue(learningCenter.guides);
 });
 
 afterEach(() => {
@@ -94,22 +71,22 @@ test('Clicking on LearningCenter title hides carousel with guides', async () => 
 test('Toggling expansion sets configuration', async () => {
   render(LearningCenter);
 
-  expect(updateConfigurationValueMock).not.toHaveBeenCalled();
+  expect(window.updateConfigurationValue).not.toHaveBeenCalled();
 
   const button = screen.getByRole('button', { name: 'Learning Center' });
   expect(button).toBeInTheDocument();
   await waitFor(() => expect(button).toHaveAttribute('aria-expanded', 'true'));
 
   await fireEvent.click(button);
-  expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', false);
+  expect(window.updateConfigurationValue).toHaveBeenCalledWith('learningCenter.expanded', false);
   await waitFor(() => expect(button).toHaveAttribute('aria-expanded', 'false'));
 
   await fireEvent.click(button);
-  expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', true);
+  expect(window.updateConfigurationValue).toHaveBeenCalledWith('learningCenter.expanded', true);
   expect(button).toHaveAttribute('aria-expanded', 'true');
 
   await fireEvent.click(button);
-  expect(updateConfigurationValueMock).toHaveBeenCalledWith('learningCenter.expanded', false);
+  expect(window.updateConfigurationValue).toHaveBeenCalledWith('learningCenter.expanded', false);
   expect(button).toHaveAttribute('aria-expanded', 'false');
 });
 
@@ -121,20 +98,20 @@ test('Expanded when the config value not set', async () => {
 });
 
 test('Collapsed when the config value is set to not expanded', async () => {
-  getConfigurationValueMock.mockResolvedValue(false);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
   render(LearningCenter);
 
-  await waitFor(() => expect(getConfigurationValueMock).toBeCalled());
+  await waitFor(() => expect(window.getConfigurationValue).toBeCalled());
 
   const button = screen.getByRole('button', { name: 'Learning Center' });
   expect(button).toHaveAttribute('aria-expanded', 'false');
 });
 
 test('Expanded when the config value is set to expanded', async () => {
-  getConfigurationValueMock.mockResolvedValue(true);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
   render(LearningCenter);
 
-  await waitFor(() => expect(getConfigurationValueMock).toBeCalled());
+  await waitFor(() => expect(window.getConfigurationValue).toBeCalled());
 
   const button = screen.getByRole('button', { name: 'Learning Center' });
   expect(button).toHaveAttribute('aria-expanded', 'true');


### PR DESCRIPTION
### What does this PR do?
mocks are already done, no need to redefine them, so remove all the beforeAll block

prior to changes on removing the import of ../../../main

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
