### PR TITLE
chore: update app routes to be nested based on root path

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -97,11 +97,11 @@ beforeEach(() => {
   vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
 });
 
-test('test /image/run/* route', async () => {
+test('test /images/run/* route', async () => {
   render(App);
   expect(mocks.RunImage).not.toHaveBeenCalled();
   expect(mocks.DashboardPage).toHaveBeenCalled();
-  router.goto('/image/run/basic');
+  router.goto('/images/run/basic');
   await tick();
   expect(mocks.RunImage).toHaveBeenCalled();
 });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -156,42 +156,106 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <SendFeedback />
         <ToastHandler />
         <ToastTaskNotifications />
+
         <Route path="/" breadcrumb="Dashboard Page" navigationHint="root">
           <DashboardPage />
         </Route>
-        <Route path="/containers" breadcrumb="Containers" navigationHint="root">
-          <ContainerList searchTerm={meta.query.filter ?? ''} />
-        </Route>
-        <Route path="/containers/:id/*" let:meta firstmatch>
-          <Route path="/export" breadcrumb="Export Container">
-            <ContainerExport containerID={meta.params.id} />
+
+        <Route path="/containers/*" breadcrumb="Containers" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Containers" navigationHint="root">
+            <ContainerList searchTerm={meta.query.filter ?? ''} />
           </Route>
-          <Route breadcrumb="Container Details" navigationHint="details" path="/*">
-            <ContainerDetails containerID={meta.params.id} />
+          <Route path="/:id/*" let:meta firstmatch>
+            <Route path="/export" breadcrumb="Export Container">
+              <ContainerExport containerID={meta.params.id} />
+            </Route>
+            <Route breadcrumb="Container Details" navigationHint="details" path="/*">
+              <ContainerDetails containerID={meta.params.id} />
+            </Route>
           </Route>
         </Route>
 
         <Route path="/kube/play" breadcrumb="Podman Kube Play">
           <KubePlayYAML />
         </Route>
-        <Route path="/image/run/*" breadcrumb="Run Image">
-          <RunImage />
+
+        <Route path="/images/*" breadcrumb="Images" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Images" navigationHint="root">
+            <ImagesList />
+          </Route>
+          <Route path="/existing-image-create-container" breadcrumb="Select image" >
+            <CreateContainerFromExistingImage />
+          </Route>
+          <Route path="/run/*" breadcrumb="Run Image">
+            <RunImage />
+          </Route>
+          <Route path="/build" breadcrumb="Build an Image" let:meta>
+            <BuildImageFromContainerfile taskId={+meta.query.taskId}/>
+          </Route>
+          <Route path="/pull" breadcrumb="Pull an Image">
+            <PullImage />
+          </Route>
+          <Route path="/import" breadcrumb="Import Containers">
+            <ImportContainersImages />
+          </Route>
+          <Route path="/save" breadcrumb="Save Images">
+            <SaveImages />
+          </Route>
+          <Route path="/load" breadcrumb="Load Images">
+            <LoadImages />
+          </Route>
+          <Route path="/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
+            <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
+          </Route>
+          <Route
+            path="/:id/:engineId/:base64RepoTag/*"
+            breadcrumb="Image Details"
+            let:meta
+            navigationHint="details">
+            <ImageDetails
+              imageID={meta.params.id}
+              engineId={decodeURI(meta.params.engineId)}
+              base64RepoTag={meta.params.base64RepoTag} />
+          </Route>
         </Route>
-        <Route path="/images" breadcrumb="Images" navigationHint="root">
-          <ImagesList />
+
+        <Route path="/networks/*" breadcrumb="Networks" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Networks" navigationHint="root">
+            <NetworksList />
+          </Route>
+          <Route path="/create/*" breadcrumb="Create Network">
+            <CreateNetwork />
+          </Route>
+          <Route path="/:name/:engineId/*" breadcrumb="Network Details" let:meta navigationHint="details">
+            <NetworkDetails networkName={decodeURIComponent(meta.params.name)} engineId={decodeURIComponent(meta.params.engineId)} />
+          </Route>
         </Route>
-        <Route path="/images/existing-image-create-container" breadcrumb="Select image" >
-          <CreateContainerFromExistingImage />
+
+        <Route path="/volumes/*" breadcrumb="Volumes" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Volumes" navigationHint="root">
+            <VolumesList />
+          </Route>
+          <Route path="/create" breadcrumb="Create a Volume">
+            <CreateVolume />
+          </Route>
+          <Route path="/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
+            <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
+          </Route>
         </Route>
-        <Route path="/images/build" breadcrumb="Build an Image" let:meta>
-          <BuildImageFromContainerfile taskId={+meta.query.taskId}/>
+
+        <Route path="/extensions/*" breadcrumb="Extensions" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Extensions" navigationHint="root" let:meta>
+            {@const request = parseExtensionListRequest(meta)}
+            <ExtensionList
+              searchTerm={request.searchTerm}
+              screen={request.screen}
+            />
+          </Route>
+          <Route path="/details/:id/*" breadcrumb="Extension Details" let:meta navigationHint="details">
+            <ExtensionDetails extensionId={meta.params.id} />
+          </Route>
         </Route>
-        <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
-          <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
-        </Route>
-        <Route path="/networks/create/*" breadcrumb="Create Network">
-          <CreateNetwork />
-        </Route>
+
         <Route
           path="/manifests/:id/:engineId/:base64RepoTag/*"
           breadcrumb="Manifest Details"
@@ -201,28 +265,6 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
             imageID={meta.params.id}
             engineId={decodeURI(meta.params.engineId)}
             base64RepoTag={meta.params.base64RepoTag} />
-        </Route>
-        <Route
-          path="/images/:id/:engineId/:base64RepoTag/*"
-          breadcrumb="Image Details"
-          let:meta
-          navigationHint="details">
-          <ImageDetails
-            imageID={meta.params.id}
-            engineId={decodeURI(meta.params.engineId)}
-            base64RepoTag={meta.params.base64RepoTag} />
-        </Route>
-        <Route path="/images/pull" breadcrumb="Pull an Image">
-          <PullImage />
-        </Route>
-        <Route path="/images/import" breadcrumb="Import Containers">
-          <ImportContainersImages />
-        </Route>
-        <Route path="/images/save" breadcrumb="Save Images">
-          <SaveImages />
-        </Route>
-        <Route path="/images/load" breadcrumb="Load Images">
-          <LoadImages />
         </Route>
         <Route path="/pods" breadcrumb="Pods" navigationHint="root">
           <PodsList />
@@ -251,21 +293,7 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/pod-create-from-containers" breadcrumb="Create Pod">
           <PodCreateFromContainers />
         </Route>
-        <Route path="/volumes" breadcrumb="Volumes" navigationHint="root">
-          <VolumesList />
-        </Route>
-        <Route path="/volumes/create" breadcrumb="Create a Volume">
-          <CreateVolume />
-        </Route>
-        <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
-          <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
-        </Route>
-        <Route path="/networks" breadcrumb="Networks" navigationHint="root">
-          <NetworksList />
-        </Route>
-        <Route path="/networks/:name/:engineId/*" breadcrumb="Network Details" let:meta navigationHint="details">
-          <NetworkDetails networkName={decodeURIComponent(meta.params.name)} engineId={decodeURIComponent(meta.params.engineId)} />
-        </Route>
+        
         {#if $kubernetesNoCurrentContext}
           <Route path="/kubernetes/*" breadcrumb="Kubernetes" navigationHint="root">
             <KubernetesDashboard />
@@ -390,16 +418,6 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         </Route>
         <Route path="/troubleshooting/*" breadcrumb="Troubleshooting">
           <TroubleshootingPage />
-        </Route>
-        <Route path="/extensions" breadcrumb="Extensions" navigationHint="root" let:meta>
-          {@const request = parseExtensionListRequest(meta)}
-          <ExtensionList
-            searchTerm={request.searchTerm}
-            screen={request.screen}
-          />
-        </Route>
-        <Route path="/extensions/details/:id/*" breadcrumb="Extension Details" let:meta navigationHint="details">
-          <ExtensionDetails extensionId={meta.params.id} />
         </Route>
       </div>
     </div>

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -229,7 +229,7 @@ test('Expect a local image to have an active run image button', async () => {
   expect(selectImagebutton).not.toBeDisabled();
 
   await user.click(selectImagebutton);
-  expect(router.goto).toHaveBeenCalledWith('/image/run/basic');
+  expect(router.goto).toHaveBeenCalledWith('/images/run/basic');
 });
 
 test('Expect no user input to show only local images', async () => {

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -297,7 +297,7 @@ async function buildContainerFromImage(): Promise<void> {
     const chosenImage = imageUtils.getImagesInfoUI(localImages[0], []);
     if (chosenImage.length > 0) {
       runImageInfo.set(chosenImage[0]);
-      router.goto('/image/run/basic');
+      router.goto('/images/run/basic');
     }
   }
 }

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -60,7 +60,7 @@ onMount(async () => {
 
 async function runImage(imageInfo: ImageInfoUI): Promise<void> {
   runImageInfo.set(imageInfo);
-  router.goto('/image/run/basic');
+  router.goto('/images/run/basic');
 }
 
 async function deleteImage(): Promise<void> {

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -55,7 +55,7 @@ onMount(async () => {
   <Route path="/default/:key/*" breadcrumb="Preferences" let:meta>
     <PreferencesRendering key={meta.params.key} properties={properties} />
   </Route>
-  <Route path="/provider/:providerInternalId/*" breadcrumb="Resources" let:meta navigationHint="details">
+  <Route path="/provider/:providerInternalId/*" breadcrumb="Resources" let:meta navigationHint="root">
     <PreferencesProviderRendering providerInternalId={meta.params.providerInternalId} properties={properties} />
   </Route>
   <Route path="/provider-task/:providerInternalId/:taskId/*" breadcrumb="Resources" let:meta>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR groups related paths to be in the same root path in order to have correct hierarchy-based breadcrumbs rather than path-based.
**No changes have been made to Kubernetes routes**

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/15612

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
Check that the updated routes work correctly and that hierarchy-based breadcrumbs show up
Some of the cases that should be fixed now:
- Going to image from container details page should show `Images -> Image details` instead of `Containers -> image details`
- Creating image from the container list page using `Existing image` should show `Images -> Select image` instead of `Containers -> Select image`, same thing for the `Run image` page after selecting an image
- Going to create Kubernetes resource such as Kind or Minikube from the empty Kubernetes page should show `Resources -> <resource-name>`
- Going to one of the suggested extensions in the empty Kubernetes page should show `Extension -> Extension details` instead of `Kubernetes -> Extension details`

- [ ] Tests are covering the bug fix or the new feature
