### PR TITLE
refactor(learning-center-test): remove usage of ../main

### DIFF
--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -27,11 +27,10 @@ import LearningCenter from './LearningCenter.svelte';
 
 const guides: Guide[] = [
   {
-    id: 'podman-desktop-for-kubernetes',
-    url: 'https://developers.redhat.com/articles/2023/11/06/working-kubernetes-podman-desktop',
-    title: 'Working with Kubernetes',
-    description:
-      "Understand how Podman's design philosophy can handle pods just as it handles containers, in consistent way with Kubernetes architectures.",
+    id: 'podman-desktop-learning-center-example',
+    url: 'https://podman-desktop.io/learning-center/example',
+    title: 'My Title',
+    description: 'fake description',
     categories: ['Kubernetes'],
     icon: '',
   },

--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -21,8 +21,21 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
-import learningCenter from '../../../../main/src/plugin/learning-center/guides.json';
+import type { Guide } from '/@api/learning-center/guide';
+
 import LearningCenter from './LearningCenter.svelte';
+
+const guides: Guide[] = [
+  {
+    id: 'podman-desktop-for-kubernetes',
+    url: 'https://developers.redhat.com/articles/2023/11/06/working-kubernetes-podman-desktop',
+    title: 'Working with Kubernetes',
+    description:
+      "Understand how Podman's design philosophy can handle pods just as it handles containers, in consistent way with Kubernetes architectures.",
+    categories: ['Kubernetes'],
+    icon: '',
+  },
+];
 
 vi.mock('svelte/transition', () => ({
   slide: (): { delay: number; duration: number } => ({
@@ -36,7 +49,7 @@ vi.mock('svelte/transition', () => ({
 }));
 
 beforeEach(() => {
-  vi.mocked(window.listGuides).mockResolvedValue(learningCenter.guides);
+  vi.mocked(window.listGuides).mockResolvedValue(guides);
 });
 
 afterEach(() => {
@@ -47,7 +60,7 @@ test('LearningCenter component shows carousel with guides', async () => {
   render(LearningCenter);
 
   await vi.waitFor(() => {
-    const firstCard = screen.getByText(learningCenter.guides[0].title);
+    const firstCard = screen.getByText(guides[0].title);
     expect(firstCard).toBeVisible();
   });
 });
@@ -55,16 +68,16 @@ test('LearningCenter component shows carousel with guides', async () => {
 test('Clicking on LearningCenter title hides carousel with guides', async () => {
   render(LearningCenter);
   await vi.waitFor(() => {
-    const firstCard = screen.getByText(learningCenter.guides[0].title);
+    const firstCard = screen.getByText(guides[0].title);
     expect(firstCard).toBeVisible();
   });
 
   const button = screen.getByRole('button', { name: 'Learning Center' });
   expect(button).toBeInTheDocument();
-  expect(screen.queryByText(learningCenter.guides[0].title)).toBeInTheDocument();
+  expect(screen.queryByText(guides[0].title)).toBeInTheDocument();
   await fireEvent.click(button);
   await vi.waitFor(async () => {
-    expect(screen.queryByText(learningCenter.guides[0].title)).not.toBeInTheDocument();
+    expect(screen.queryByText(guides[0].title)).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
### What does this PR do?
avoid importing guides from `../../main` and defines its own mocked data in the test

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
