### PR TITLE
chore(test): toggle rootless and rootful mode changes e2e test

### DIFF
--- a/tests/playwright/src/model/core/operations.ts
+++ b/tests/playwright/src/model/core/operations.ts
@@ -21,4 +21,5 @@ export enum ResourceElementActions {
   Restart = 'Restart',
   Stop = 'Stop',
   Delete = 'Delete',
+  Edit = 'Edit',
 }


### PR DESCRIPTION
### What does this PR do?
Creates e2e test case that switches from rootful to rootless and back modes.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/14870