### PR TITLE
feat(extension-api): expose navigateToImageBuild

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4973,6 +4973,8 @@ declare module '@podman-desktop/api' {
 
     // Navigate to the Images page
     export function navigateToImages(): Promise<void>;
+    // Navigate to the Images Build page
+    export function navigateToImageBuild(): Promise<void>;
     // Navigate to a specific image referenced by id, engineId and tag
     export function navigateToImage(id: string, engineId: string, tag: string): Promise<void>;
 

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -1391,6 +1391,19 @@ describe('Navigation', async () => {
     expect(sendMock).toBeCalledWith('navigate', { page: NavigationPage.CONTAINERS });
   });
 
+  test('navigateToImageBuild', async () => {
+    const api = createApi();
+
+    // Spy send method
+    const sendMock = vi.spyOn(apiSender, 'send');
+
+    await api.navigation.navigateToImageBuild();
+    expect(sendMock).toBeCalledWith('navigate', {
+      page: NavigationPage.IMAGE_BUILD,
+      parameters: { taskId: undefined },
+    });
+  });
+
   test.each([
     {
       name: 'navigateToContainer valid',

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1533,6 +1533,9 @@ export class ExtensionLoader implements IAsyncDisposable {
     };
 
     const navigation: typeof containerDesktopAPI.navigation = {
+      navigateToImageBuild: async (): Promise<void> => {
+        await this.navigationManager.navigateToImageBuild();
+      },
       navigateToDashboard: async (): Promise<void> => {
         await this.navigationManager.navigateToDashboard();
       },


### PR DESCRIPTION
### What does this PR do?

The `navigateToImageBuild` already exists in the core, let's expose it to the extensions.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15692

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
