### PR TITLE
refactor(import): use alias to import from api package

### DIFF
--- a/packages/main/src/plugin/image-details-files.ts
+++ b/packages/main/src/plugin/image-details-files.ts
@@ -18,9 +18,8 @@
 
 import type { ImageFile, ImageFilesystemLayer } from '@podman-desktop/api';
 
+import { FilesystemTree } from '/@api/filesystem-tree.js';
 import type { ImageFilesystemLayerUI } from '/@api/image-filesystem-layers.js';
-
-import { FilesystemTree } from '../../../api/src/filesystem-tree.js';
 
 export function toImageFilesystemLayerUIs(layers: ImageFilesystemLayer[]): ImageFilesystemLayerUI[] {
   const result: ImageFilesystemLayerUI[] = [];

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -115,6 +115,7 @@ import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
 import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
 import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
 import type { ContainerCreateOptions as PodmanContainerCreateOptions, PlayKubeInfo } from '/@api/libpod/libpod.js';
+import type { ListOrganizerItem } from '/@api/list-organizer.js';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
 import type { Menu } from '/@api/menu.js';
 import type { NetworkInspectInfo } from '/@api/network-info.js';
@@ -141,7 +142,6 @@ import type { ViewInfoUI } from '/@api/view-info.js';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 import type { WebviewInfo } from '/@api/webview-info.js';
 
-import type { ListOrganizerItem } from '../../../api/src/list-organizer.js';
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import { TrayMenu } from '../tray-menu.js';
 import { createHash, isMac } from '../util.js';

--- a/packages/main/src/plugin/list-organizer.spec.ts
+++ b/packages/main/src/plugin/list-organizer.spec.ts
@@ -19,8 +19,8 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { IConfigurationRegistry } from '/@api/configuration/models.js';
+import type { ListOrganizerItem, SavedListOrganizerConfig } from '/@api/list-organizer.js';
 
-import type { ListOrganizerItem, SavedListOrganizerConfig } from '../../../api/src/list-organizer.js';
 import { ListOrganizerRegistry } from './list-organizer.js';
 
 let listOrganizerRegistry: ListOrganizerRegistry;

--- a/packages/main/src/plugin/list-organizer.ts
+++ b/packages/main/src/plugin/list-organizer.ts
@@ -20,8 +20,7 @@ import { inject, injectable } from 'inversify';
 
 import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import { IDisposable } from '/@api/disposable.js';
-
-import { type ListOrganizerItem, SavedListOrganizerConfig } from '../../../api/src/list-organizer.js';
+import type { ListOrganizerItem, SavedListOrganizerConfig } from '/@api/list-organizer.js';
 
 // Dynamic list organizer registry - populated by frontend components during initialization
 const REGISTERED_LISTS: Record<string, string[]> = {};

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -100,6 +100,7 @@ import type { KubernetesContextResources } from '/@api/kubernetes-resources';
 import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting';
 import type { Guide } from '/@api/learning-center/guide';
 import type { ContainerCreateOptions as PodmanContainerCreateOptions, PlayKubeInfo } from '/@api/libpod/libpod';
+import type { ListOrganizerItem } from '/@api/list-organizer';
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info';
 import type { Menu } from '/@api/menu.js';
 import { NavigationPage } from '/@api/navigation-page';
@@ -128,7 +129,6 @@ import type { ViewInfoUI } from '/@api/view-info';
 import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info';
 import type { WebviewInfo } from '/@api/webview-info';
 
-import type { ListOrganizerItem } from '../../api/src/list-organizer';
 import type { ContextInfo } from '../../main/src/plugin/api/context-info';
 
 export type DialogResultCallback = (openDialogReturnValue: Electron.OpenDialogReturnValue) => void;


### PR DESCRIPTION
### What does this PR do?
do not use relative import `../../api` when importing from api package
use alias

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
