### PR TITLE
refactor(context-info): use interface rather than implementation

### DIFF
--- a/packages/main/src/plugin/api/context-info.ts
+++ b/packages/main/src/plugin/api/context-info.ts
@@ -15,10 +15,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { Context } from '../context/context.js';
+import type { IContext } from '/@api/context/context.js';
 
 export interface ContextInfo {
   readonly id: number;
-  readonly parent?: Context;
+  readonly parent?: IContext;
   readonly extension?: string;
 }


### PR DESCRIPTION
### What does this PR do?
use IContext which is the interface rather than Context which is the implementation class

it'll help to move context-info to the api package if only interface is used


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
