### PR TITLE
fix(DockerCompat): fixed visibility when not defined

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -28,10 +28,10 @@ function updateDockerCompatibility(): void {
     .getConfigurationValue<boolean>(`${DockerCompatibilitySettings.SectionName}.${DockerCompatibilitySettings.Enabled}`)
     .then(result => {
       if (result !== undefined) {
-        settingsNavigationItems = settingsNavigationEntries.map(entry => ({
-          ...entry,
-          visible: entry.title === 'Docker Compatibility' ? result : true,
-        }));
+        const index = settingsNavigationEntries.findIndex(entry => entry.title === 'Docker Compatibility');
+        if (index !== -1) {
+          settingsNavigationItems[index].visible = result;
+        }
       }
     })
     .catch((err: unknown) =>
@@ -54,10 +54,10 @@ onMount(() => {
     // check for experimental configuration
     experimentalSection = value.some(configuration => !!configuration.experimental);
 
-    settingsNavigationItems = settingsNavigationEntries.map(entry => ({
-      ...entry,
-      visible: entry.title === 'Experimental' ? experimentalSection : true,
-    }));
+    const experimentalIndex = settingsNavigationEntries.findIndex(entry => entry.title === 'Experimental');
+    if (experimentalIndex !== -1) {
+      settingsNavigationItems[experimentalIndex].visible = experimentalSection;
+    }
 
     // update config properties
     configProperties = value.reduce((map, current) => {

--- a/packages/renderer/src/PreferencesNavigation.ts
+++ b/packages/renderer/src/PreferencesNavigation.ts
@@ -46,12 +46,12 @@ export const settingsNavigationEntries: SettingsNavItemConfig[] = [
   {
     title: 'Docker Compatibility',
     href: '/preferences/docker-compatibility',
-    visible: true,
+    visible: false,
     icon: DockerCompatibilityIcon,
   },
   { title: 'Registries', href: '/preferences/registries', visible: true, icon: RegistriesIcon },
   { title: 'Authentication', href: '/preferences/authentication-providers', visible: true, icon: AuthenticationIcon },
   { title: 'CLI Tools', href: '/preferences/cli-tools', visible: true, icon: CLIToolsIcon },
   { title: 'Kubernetes', href: '/preferences/kubernetes-contexts', visible: true, icon: KubernetesIcon },
-  { title: 'Experimental', href: '/preferences/experimental', visible: true, icon: ExperimentalIcon },
+  { title: 'Experimental', href: '/preferences/experimental', visible: false, icon: ExperimentalIcon },
 ];


### PR DESCRIPTION
### What does this PR do?
Fixes visibility of docker compact when not defined

### Screenshot / video of UI


### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/pull/15674

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
