### PR TITLE
refactor(main/list-organizer): scope record const to class

### DIFF
--- a/packages/main/src/plugin/list-organizer.ts
+++ b/packages/main/src/plugin/list-organizer.ts
@@ -22,12 +22,12 @@ import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configura
 import { IDisposable } from '/@api/disposable.js';
 import type { ListOrganizerItem, SavedListOrganizerConfig } from '/@api/list-organizer.js';
 
-// Dynamic list organizer registry - populated by frontend components during initialization
-const REGISTERED_LISTS: Record<string, string[]> = {};
-
 @injectable()
 export class ListOrganizerRegistry implements IDisposable {
   #disposables: IDisposable[] = [];
+
+  // Dynamic list organizer registry - populated by frontend components during initialization
+  private registeredLists: Record<string, string[]> = {};
 
   constructor(@inject(IConfigurationRegistry) private configurationRegistry: IConfigurationRegistry) {}
 
@@ -38,7 +38,7 @@ export class ListOrganizerRegistry implements IDisposable {
 
   // Get default configuration for a list kind
   getDefaultListConfig(listKind: string): SavedListOrganizerConfig[] {
-    const defaults = REGISTERED_LISTS[listKind] ?? [];
+    const defaults = this.registeredLists[listKind] ?? [];
     return defaults.map(name => ({ id: name, enabled: true }));
   }
 
@@ -46,8 +46,8 @@ export class ListOrganizerRegistry implements IDisposable {
   async loadListConfig(listKind: string, availableColumns: string[]): Promise<ListOrganizerItem[]> {
     try {
       // Auto-register the list if not already registered
-      if (!REGISTERED_LISTS[listKind]) {
-        REGISTERED_LISTS[listKind] = availableColumns;
+      if (!this.registeredLists[listKind]) {
+        this.registeredLists[listKind] = availableColumns;
 
         // Register the configuration with the configuration registry
         const listConfiguration: IConfigurationNode = {
@@ -94,7 +94,7 @@ export class ListOrganizerRegistry implements IDisposable {
 
   // Helper: Create default list items
   private createDefaultListItems(listKind: string, availableColumns: string[]): ListOrganizerItem[] {
-    const defaults = REGISTERED_LISTS[listKind] ?? availableColumns;
+    const defaults = this.registeredLists[listKind] ?? availableColumns;
     return defaults.map((colName, index) => ({
       id: colName,
       label: this.getColumnLabel(colName),
@@ -122,7 +122,7 @@ export class ListOrganizerRegistry implements IDisposable {
     const mergedItems: ListOrganizerItem[] = [];
 
     // Get default order to determine originalOrder for each column
-    const defaults = REGISTERED_LISTS[listKind] ?? availableColumns;
+    const defaults = this.registeredLists[listKind] ?? availableColumns;
     const getOriginalOrder = (id: string): number => {
       const index = defaults.indexOf(id);
       return index >= 0 ? index : defaults.length; // Put unknown items at the end


### PR DESCRIPTION
### What does this PR do?

This PR is a refactor of the list-organizer (main package). It ensure the record const is scoped to the class and not publicly exposed.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix of https://github.com/podman-desktop/podman-desktop/issues/15051

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

There should be no change.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
