### PR TITLE
chore: patch dmg builder to have the background image working

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,9 @@
       "electron-builder-notarize>js-yaml": "^3.14.2",
       "@kubernetes/client-node>js-yaml": "^4.1.1",
       "tmp-promise>tmp": "^0.2.5"
+    },
+    "patchedDependencies": {
+      "dmg-builder": "patches/dmg-builder.patch"
     }
   },
   "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"

--- a/patches/dmg-builder.patch
+++ b/patches/dmg-builder.patch
@@ -1,0 +1,13 @@
+diff --git a/vendor/dmgbuild/core.py b/vendor/dmgbuild/core.py
+index 1adc35289fc604f3dd5545d3d86fbacb6baeaf69..473e70a3a7a4e9285517634a0749d9da82211699 100644
+--- a/vendor/dmgbuild/core.py
++++ b/vendor/dmgbuild/core.py
+@@ -255,7 +255,7 @@ def build_dmg():
+       icvp['backgroundColorBlue'] = float(c.b)
+     elif background_file:
+       alias = Alias.for_file(background_file)
+-      background_bmk = Bookmark.for_file(background_file)
++      # background_bmk = Bookmark.for_file(background_file)
+ 
+       icvp['backgroundType'] = 2
+       icvp['backgroundImageAlias'] = biplist.Data(alias.to_bytes())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,11 @@ overrides:
   '@kubernetes/client-node>js-yaml': ^4.1.1
   tmp-promise>tmp: ^0.2.5
 
+patchedDependencies:
+  dmg-builder:
+    hash: b1937a6dd1c958dfabaa5fd32cb2ede7972c4d6143ccb1e7fe5963e19e34cc3d
+    path: patches/dmg-builder.patch
+
 importers:
 
   .:
@@ -17114,7 +17119,7 @@ snapshots:
       chromium-pickle-js: 0.2.0
       config-file-ts: 0.2.8-rc1
       debug: 4.4.3
-      dmg-builder: 26.0.12(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12))
+      dmg-builder: 26.0.12(patch_hash=b1937a6dd1c958dfabaa5fd32cb2ede7972c4d6143ccb1e7fe5963e19e34cc3d)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12))
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
@@ -17155,7 +17160,7 @@ snapshots:
       chromium-pickle-js: 0.2.0
       config-file-ts: 0.2.8-rc1
       debug: 4.4.3
-      dmg-builder: 26.0.12(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12))
+      dmg-builder: 26.0.12(patch_hash=b1937a6dd1c958dfabaa5fd32cb2ede7972c4d6143ccb1e7fe5963e19e34cc3d)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12))
       dotenv: 16.6.1
       dotenv-expand: 11.0.7
       ejs: 3.1.10
@@ -18740,7 +18745,7 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dmg-builder@26.0.12(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12)):
+  dmg-builder@26.0.12(patch_hash=b1937a6dd1c958dfabaa5fd32cb2ede7972c4d6143ccb1e7fe5963e19e34cc3d)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12)):
     dependencies:
       app-builder-lib: 26.0.12(dmg-builder@26.0.12)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12))
       builder-util: 26.0.11
@@ -18929,7 +18934,7 @@ snapshots:
       builder-util: 26.0.11
       builder-util-runtime: 9.3.1
       chalk: 4.1.2
-      dmg-builder: 26.0.12(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12))
+      dmg-builder: 26.0.12(patch_hash=b1937a6dd1c958dfabaa5fd32cb2ede7972c4d6143ccb1e7fe5963e19e34cc3d)(electron-builder-squirrel-windows@25.1.8(dmg-builder@26.0.12))
       fs-extra: 10.1.0
       is-ci: 3.0.1
       lazy-val: 1.0.5


### PR DESCRIPTION
### What does this PR do?
fix dmg background display on macOS 26.2

### Screenshot / video of UI

<img width="652" height="492" alt="image" src="https://github.com/user-attachments/assets/7c27d2c7-0909-4bb6-9834-c15a2374560b" />


### What issues does this PR fix or reference?

related to
https://github.com/electron-userland/electron-builder/issues/9072

fixes https://github.com/podman-desktop/podman-desktop/issues/15695

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
