### PR TITLE
feat: manual sync for certificates to multiple targets

### DIFF
--- a/extensions/podman/packages/extension/src/certificate-sync/podman-certificate-sync.spec.ts
+++ b/extensions/podman/packages/extension/src/certificate-sync/podman-certificate-sync.spec.ts
@@ -1,0 +1,553 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as crypto from 'node:crypto';
+
+import type { CancellationToken, Progress, RunResult } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+
+import type { MachineJSON, MachineJSONListOutput } from '../types';
+import * as util from '../utils/util';
+import { PodmanCertificateSync } from './podman-certificate-sync';
+
+vi.mock('@podman-desktop/api', async () => ({
+  ProgressLocation: {
+    TASK_WIDGET: 1,
+  },
+  window: {
+    withProgress: vi.fn(),
+  },
+  EventEmitter: class {
+    event = vi.fn();
+    fire = vi.fn();
+    dispose = vi.fn();
+  },
+}));
+
+vi.mock('../utils/util', () => ({
+  execPodman: vi.fn(),
+}));
+
+// Sample PEM certificate for testing
+const SAMPLE_CERT_1 = `-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJAKHBfpY1+EroMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl
+c3QxMB4XDTI0MDEwMTAwMDAwMFoXDTI1MDEwMTAwMDAwMFowETEPMA0GA1UEAwwG
+dGVzdDEwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAu5P4wfqJNaVg5Y5+EH0X3F4T
+-----END CERTIFICATE-----`;
+
+const SAMPLE_CERT_2 = `-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJAKHBfpY1+EroMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl
+c3QyMB4XDTI0MDEwMTAwMDAwMFoXDTI1MDEwMTAwMDAwMFowETEPMA0GA1UEAwwG
+dGVzdDIwXDANBgkqhkiG9w0BAQEFAANLADBIAkEAu5P4wfqJNaVg5Y5+EH0X3F4T
+-----END CERTIFICATE-----`;
+
+// Helper to get fingerprint like the class does
+function getFingerprint(pem: string): string {
+  const hash = crypto.createHash('sha256').update(pem).digest('hex');
+  return hash.substring(0, 16);
+}
+
+describe('PodmanCertificateSync', () => {
+  let certSync: PodmanCertificateSync;
+  let mockGetMachineList: Mock<() => Promise<MachineJSONListOutput>>;
+  let execPodmanMock: Mock;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockGetMachineList = vi.fn<() => Promise<MachineJSONListOutput>>();
+    certSync = new PodmanCertificateSync(mockGetMachineList);
+    execPodmanMock = vi.mocked(util.execPodman);
+  });
+
+  describe('getTargets', () => {
+    test('should return empty array when no machines exist', async () => {
+      mockGetMachineList.mockResolvedValue({ list: [], error: '' });
+
+      const targets = await certSync.getTargets();
+
+      expect(targets).toEqual([]);
+    });
+
+    test('should return only running VM-based machines', async () => {
+      const machines: MachineJSON[] = [
+        { Name: 'running-vm', Running: true, VMType: 'qemu' } as MachineJSON,
+        { Name: 'stopped-vm', Running: false, VMType: 'qemu' } as MachineJSON,
+        { Name: 'native-linux', Running: true, VMType: '' } as MachineJSON,
+      ];
+      mockGetMachineList.mockResolvedValue({ list: machines, error: '' });
+
+      const targets = await certSync.getTargets();
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0]).toEqual({ id: 'running-vm', name: 'running-vm' });
+    });
+
+    test('should return multiple running VM machines', async () => {
+      const machines: MachineJSON[] = [
+        { Name: 'machine1', Running: true, VMType: 'qemu' } as MachineJSON,
+        { Name: 'machine2', Running: true, VMType: 'libkrun' } as MachineJSON,
+      ];
+      mockGetMachineList.mockResolvedValue({ list: machines, error: '' });
+
+      const targets = await certSync.getTargets();
+
+      expect(targets).toHaveLength(2);
+      expect(targets.map(t => t.name)).toEqual(['machine1', 'machine2']);
+    });
+
+    test('should return empty array and log error when getMachineList fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockGetMachineList.mockRejectedValue(new Error('Connection failed'));
+
+      const targets = await certSync.getTargets();
+
+      expect(targets).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to get Podman machines for certificate sync:', expect.any(Error));
+    });
+
+    test('should log error when getMachineList returns error string', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockGetMachineList.mockResolvedValue({
+        list: [],
+        error: 'podman machine command failed',
+      });
+
+      const targets = await certSync.getTargets();
+
+      expect(targets).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error getting Podman machines for certificate sync: podman machine command failed',
+      );
+    });
+  });
+
+  describe('synchronize', () => {
+    test('should return early when no certificates provided', async () => {
+      await certSync.synchronize('test-machine', []);
+
+      expect(extensionApi.window.withProgress).not.toHaveBeenCalled();
+    });
+
+    test('should call withProgress with correct options including cancellable', async () => {
+      vi.mocked(extensionApi.window.withProgress).mockImplementation(async (_options, task) => {
+        const mockProgress: Progress<{ message?: string; increment?: number }> = {
+          report: vi.fn(),
+        };
+        const mockToken: CancellationToken = {
+          isCancellationRequested: false,
+          onCancellationRequested: vi.fn(),
+        };
+        await task(mockProgress, mockToken);
+      });
+
+      // Mock all the SSH commands
+      execPodmanMock.mockResolvedValue({ stdout: '', stderr: '', command: '' } as RunResult);
+
+      await certSync.synchronize('my-machine', [SAMPLE_CERT_1]);
+
+      expect(extensionApi.window.withProgress).toHaveBeenCalledWith(
+        {
+          location: extensionApi.ProgressLocation.TASK_WIDGET,
+          title: 'Synchronizing certificates to my-machine',
+          cancellable: true,
+        },
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('doSynchronize (via synchronize)', () => {
+    let mockProgress: Progress<{ message?: string; increment?: number }>;
+    let mockToken: CancellationToken;
+    let reportCalls: Array<{ message?: string; increment?: number }>;
+
+    beforeEach(() => {
+      reportCalls = [];
+      mockProgress = {
+        report: vi.fn().mockImplementation(data => reportCalls.push(data)),
+      };
+      mockToken = {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(),
+      };
+
+      vi.mocked(extensionApi.window.withProgress).mockImplementation(async (_options, task) => {
+        await task(mockProgress, mockToken);
+      });
+    });
+
+    test('should upload new certificates when VM has none', async () => {
+      // Mock: no existing certificates on VM
+      execPodmanMock.mockImplementation(async (args: string[]) => {
+        const command = args.join(' ');
+        if (command.includes('ls -1')) {
+          return { stdout: '', stderr: '', command: '' } as RunResult;
+        }
+        return { stdout: '', stderr: '', command: '' } as RunResult;
+      });
+
+      await certSync.synchronize('test-machine', [SAMPLE_CERT_1, SAMPLE_CERT_2]);
+
+      // Verify mkdir was called (with token for cancellation support)
+      expect(execPodmanMock).toHaveBeenCalledWith(
+        ['machine', 'ssh', 'test-machine', 'sudo mkdir -p /etc/pki/ca-trust/source/anchors'],
+        undefined,
+        expect.objectContaining({ token: expect.any(Object) }),
+      );
+
+      // Verify certificates were uploaded (base64 encoded)
+      const uploadCalls = execPodmanMock.mock.calls.filter(call =>
+        call[0].some((arg: string) => arg.includes('base64 -d')),
+      );
+      expect(uploadCalls).toHaveLength(2);
+
+      // Verify update-ca-trust was called
+      expect(execPodmanMock).toHaveBeenCalledWith(
+        ['machine', 'ssh', 'test-machine', 'sudo update-ca-trust'],
+        undefined,
+        expect.objectContaining({ token: expect.any(Object) }),
+      );
+
+      // Verify podman services were restarted
+      expect(execPodmanMock).toHaveBeenCalledWith(
+        ['machine', 'ssh', 'test-machine', 'sudo systemctl restart podman.socket podman.service'],
+        undefined,
+        expect.objectContaining({ token: expect.any(Object) }),
+      );
+    });
+
+    test('should skip existing certificates with matching fingerprint', async () => {
+      const fingerprint1 = getFingerprint(SAMPLE_CERT_1);
+
+      // Mock: VM already has cert 1
+      execPodmanMock.mockImplementation(async (args: string[]) => {
+        const command = args.join(' ');
+        if (command.includes('ls -1')) {
+          return {
+            stdout: `/etc/pki/ca-trust/source/anchors/podman-desktop-${fingerprint1}.crt\n`,
+            stderr: '',
+            command: '',
+          } as RunResult;
+        }
+        return { stdout: '', stderr: '', command: '' } as RunResult;
+      });
+
+      await certSync.synchronize('test-machine', [SAMPLE_CERT_1, SAMPLE_CERT_2]);
+
+      // Only cert 2 should be uploaded (cert 1 already exists)
+      const uploadCalls = execPodmanMock.mock.calls.filter(call =>
+        call[0].some((arg: string) => arg.includes('base64 -d')),
+      );
+      expect(uploadCalls).toHaveLength(1);
+    });
+
+    test('should delete stale certificates not on host', async () => {
+      const staleFingerprint = 'abcd1234abcd1234';
+
+      // Mock: VM has a certificate that's not on the host
+      execPodmanMock.mockImplementation(async (args: string[]) => {
+        const command = args.join(' ');
+        if (command.includes('ls -1')) {
+          return {
+            stdout: `/etc/pki/ca-trust/source/anchors/podman-desktop-${staleFingerprint}.crt\n`,
+            stderr: '',
+            command: '',
+          } as RunResult;
+        }
+        return { stdout: '', stderr: '', command: '' } as RunResult;
+      });
+
+      await certSync.synchronize('test-machine', [SAMPLE_CERT_1]);
+
+      // Verify stale certificate was deleted (with token for cancellation support)
+      expect(execPodmanMock).toHaveBeenCalledWith(
+        [
+          'machine',
+          'ssh',
+          'test-machine',
+          `sudo rm -f /etc/pki/ca-trust/source/anchors/podman-desktop-${staleFingerprint}.crt`,
+        ],
+        undefined,
+        expect.objectContaining({ token: expect.any(Object) }),
+      );
+    });
+
+    test('should report progress correctly', async () => {
+      execPodmanMock.mockResolvedValue({ stdout: '', stderr: '', command: '' } as RunResult);
+
+      await certSync.synchronize('test-machine', [SAMPLE_CERT_1]);
+
+      // Check progress reports
+      expect(reportCalls.some(r => r.increment === 5)).toBe(true); // mkdir
+      expect(reportCalls.some(r => r.increment === 10)).toBe(true); // check existing
+      expect(reportCalls.some(r => r.increment === 90)).toBe(true); // update-ca-trust
+      expect(reportCalls.some(r => r.increment === 95)).toBe(true); // restart services
+      expect(reportCalls.some(r => r.increment === 100)).toBe(true); // done
+      expect(reportCalls.some(r => r.increment === -1)).toBe(true); // cleanup
+    });
+
+    test('should fail sync when certificate upload fails', async () => {
+      let uploadCount = 0;
+
+      execPodmanMock.mockImplementation(async (args: string[]) => {
+        const command = args.join(' ');
+        if (command.includes('ls -1')) {
+          return { stdout: '', stderr: '', command: '' } as RunResult;
+        }
+        if (command.includes('base64 -d')) {
+          uploadCount++;
+          if (uploadCount === 1) {
+            throw new Error('SSH connection failed');
+          }
+        }
+        return { stdout: '', stderr: '', command: '' } as RunResult;
+      });
+
+      await expect(certSync.synchronize('test-machine', [SAMPLE_CERT_1, SAMPLE_CERT_2])).rejects.toThrow(
+        'SSH connection failed',
+      );
+
+      // Should have only attempted first upload before failing
+      expect(uploadCount).toBe(1);
+    });
+
+    test('should stop gracefully when cancellation is requested before starting', async () => {
+      // Set cancellation requested before starting
+      mockToken.isCancellationRequested = true;
+
+      execPodmanMock.mockResolvedValue({ stdout: '', stderr: '', command: '' } as RunResult);
+
+      // Should resolve without throwing - task manager will show cancelled status
+      await certSync.synchronize('test-machine', [SAMPLE_CERT_1]);
+
+      // No commands should have been executed
+      expect(execPodmanMock).not.toHaveBeenCalled();
+    });
+
+    test('should stop gracefully when cancellation is requested mid-process', async () => {
+      let commandCount = 0;
+
+      execPodmanMock.mockImplementation(async (args: string[]) => {
+        const command = args.join(' ');
+        commandCount++;
+
+        // Cancel after mkdir command
+        if (command.includes('mkdir')) {
+          mockToken.isCancellationRequested = true;
+        }
+
+        if (command.includes('ls -1')) {
+          return { stdout: '', stderr: '', command: '' } as RunResult;
+        }
+        return { stdout: '', stderr: '', command: '' } as RunResult;
+      });
+
+      // Should resolve without throwing - task manager will show cancelled status
+      await certSync.synchronize('test-machine', [SAMPLE_CERT_1]);
+
+      // Should have only executed mkdir (1 command), then stopped
+      expect(commandCount).toBe(1);
+    });
+
+    test('should stop gracefully during certificate upload loop when cancelled', async () => {
+      let uploadCount = 0;
+
+      execPodmanMock.mockImplementation(async (args: string[]) => {
+        const command = args.join(' ');
+
+        if (command.includes('ls -1')) {
+          return { stdout: '', stderr: '', command: '' } as RunResult;
+        }
+
+        if (command.includes('base64 -d')) {
+          uploadCount++;
+          // Cancel after first upload
+          if (uploadCount === 1) {
+            mockToken.isCancellationRequested = true;
+          }
+        }
+
+        return { stdout: '', stderr: '', command: '' } as RunResult;
+      });
+
+      // Should resolve without throwing - task manager will show cancelled status
+      await certSync.synchronize('test-machine', [SAMPLE_CERT_1, SAMPLE_CERT_2]);
+
+      // Should have only uploaded 1 certificate before cancellation was detected
+      expect(uploadCount).toBe(1);
+    });
+  });
+
+  describe('getCertificateFingerprint', () => {
+    test('should generate consistent fingerprints', async () => {
+      // Access the private method by casting
+      const certSyncAny = certSync as unknown as {
+        getCertificateFingerprint: (pem: string) => string;
+      };
+
+      const fp1 = certSyncAny.getCertificateFingerprint(SAMPLE_CERT_1);
+      const fp2 = certSyncAny.getCertificateFingerprint(SAMPLE_CERT_1);
+
+      expect(fp1).toBe(fp2);
+      expect(fp1).toHaveLength(16);
+      expect(fp1).toMatch(/^[a-f0-9]+$/);
+    });
+
+    test('should generate different fingerprints for different certs', async () => {
+      const certSyncAny = certSync as unknown as {
+        getCertificateFingerprint: (pem: string) => string;
+      };
+
+      const fp1 = certSyncAny.getCertificateFingerprint(SAMPLE_CERT_1);
+      const fp2 = certSyncAny.getCertificateFingerprint(SAMPLE_CERT_2);
+
+      expect(fp1).not.toBe(fp2);
+    });
+  });
+
+  describe('buildSyncSummary', () => {
+    test('should return "No changes" when nothing changed', () => {
+      const certSyncAny = certSync as unknown as {
+        buildSyncSummary: (deleted: number, added: number, unchanged: number) => string;
+      };
+
+      expect(certSyncAny.buildSyncSummary(0, 0, 0)).toBe('No changes');
+    });
+
+    test('should show added count', () => {
+      const certSyncAny = certSync as unknown as {
+        buildSyncSummary: (deleted: number, added: number, unchanged: number) => string;
+      };
+
+      expect(certSyncAny.buildSyncSummary(0, 3, 0)).toBe('Certificates: 3 added');
+    });
+
+    test('should show removed count', () => {
+      const certSyncAny = certSync as unknown as {
+        buildSyncSummary: (deleted: number, added: number, unchanged: number) => string;
+      };
+
+      expect(certSyncAny.buildSyncSummary(2, 0, 0)).toBe('Certificates: 2 removed');
+    });
+
+    test('should show unchanged count', () => {
+      const certSyncAny = certSync as unknown as {
+        buildSyncSummary: (deleted: number, added: number, unchanged: number) => string;
+      };
+
+      expect(certSyncAny.buildSyncSummary(0, 0, 5)).toBe('Certificates: 5 unchanged');
+    });
+
+    test('should show all counts when all present', () => {
+      const certSyncAny = certSync as unknown as {
+        buildSyncSummary: (deleted: number, added: number, unchanged: number) => string;
+      };
+
+      expect(certSyncAny.buildSyncSummary(1, 2, 3)).toBe('Certificates: 2 added, 1 removed, 3 unchanged');
+    });
+  });
+
+  describe('getRemoteCertificateFingerprints', () => {
+    test('should parse fingerprints from ls output', async () => {
+      execPodmanMock.mockResolvedValue({
+        stdout: `/etc/pki/ca-trust/source/anchors/podman-desktop-abc123def456.crt
+/etc/pki/ca-trust/source/anchors/podman-desktop-1234567890ab.crt
+`,
+        stderr: '',
+        command: '',
+      } as RunResult);
+
+      const certSyncAny = certSync as unknown as {
+        getRemoteCertificateFingerprints: (machineName: string, anchorsPath: string) => Promise<Set<string>>;
+      };
+
+      const fingerprints = await certSyncAny.getRemoteCertificateFingerprints(
+        'test-machine',
+        '/etc/pki/ca-trust/source/anchors',
+      );
+
+      expect(fingerprints.size).toBe(2);
+      expect(fingerprints.has('abc123def456')).toBe(true);
+      expect(fingerprints.has('1234567890ab')).toBe(true);
+    });
+
+    test('should return empty set when no certificates exist', async () => {
+      execPodmanMock.mockResolvedValue({
+        stdout: '',
+        stderr: '',
+        command: '',
+      } as RunResult);
+
+      const certSyncAny = certSync as unknown as {
+        getRemoteCertificateFingerprints: (machineName: string, anchorsPath: string) => Promise<Set<string>>;
+      };
+
+      const fingerprints = await certSyncAny.getRemoteCertificateFingerprints(
+        'test-machine',
+        '/etc/pki/ca-trust/source/anchors',
+      );
+
+      expect(fingerprints.size).toBe(0);
+    });
+
+    test('should return empty set and warn when ls fails', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      execPodmanMock.mockRejectedValue(new Error('SSH failed'));
+
+      const certSyncAny = certSync as unknown as {
+        getRemoteCertificateFingerprints: (machineName: string, anchorsPath: string) => Promise<Set<string>>;
+      };
+
+      const fingerprints = await certSyncAny.getRemoteCertificateFingerprints(
+        'test-machine',
+        '/etc/pki/ca-trust/source/anchors',
+      );
+
+      expect(fingerprints.size).toBe(0);
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to list existing certificates on VM:', expect.any(Error));
+    });
+  });
+
+  describe('notifyTargetsChanged', () => {
+    let mockFire: Mock;
+
+    beforeEach(() => {
+      vi.resetAllMocks();
+
+      // Create a shared mock for fire
+      mockFire = vi.fn();
+
+      // Mock EventEmitter to use our tracked fire function
+      // @ts-expect-error - mocking class
+      extensionApi.EventEmitter = class {
+        event = vi.fn();
+        fire = mockFire;
+        dispose = vi.fn();
+      };
+    });
+
+    test('should fire onDidChangeTargets when notifyTargetsChanged is called', () => {
+      const sync = new PodmanCertificateSync(vi.fn());
+
+      sync.notifyTargetsChanged();
+
+      expect(mockFire).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/extensions/podman/packages/extension/src/certificate-sync/podman-certificate-sync.ts
+++ b/extensions/podman/packages/extension/src/certificate-sync/podman-certificate-sync.ts
@@ -1,0 +1,377 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as crypto from 'node:crypto';
+
+import type {
+  CancellationToken,
+  CertificateSyncTarget,
+  CertificateSyncTargetProvider,
+  Event,
+  Progress,
+  RunError,
+} from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
+
+import type { MachineJSON, MachineJSONListOutput } from '../types';
+import { execPodman } from '../utils/util';
+
+/**
+ * Function type for getting the list of Podman machines.
+ */
+export type GetMachineListFn = () => Promise<MachineJSONListOutput>;
+
+/**
+ * Podman Certificate Sync Provider
+ *
+ * Provides certificate synchronization targets for Podman machines (local VMs on macOS/Windows).
+ * Uploads certificates to /etc/pki/ca-trust/source/anchors/ and updates the trust store.
+ */
+export class PodmanCertificateSync implements CertificateSyncTargetProvider {
+  private readonly _onDidChangeTargets = new extensionApi.EventEmitter<void>();
+  readonly onDidChangeTargets: Event<void> = this._onDidChangeTargets.event;
+
+  constructor(private readonly getMachineList: GetMachineListFn) {}
+
+  /**
+   * Notify that sync targets have changed (e.g., machine started/stopped).
+   * Called from startMachine/stopMachine handlers.
+   */
+  notifyTargetsChanged(): void {
+    this._onDidChangeTargets.fire();
+  }
+
+  /**
+   * Get available Podman machines that support certificate synchronization.
+   * Only returns running VM-based machines (macOS/Windows).
+   */
+  async getTargets(): Promise<CertificateSyncTarget[]> {
+    const targets: CertificateSyncTarget[] = [];
+
+    try {
+      const machineListOutput = await this.getMachineList();
+
+      // Log error if present (getMachineList can return error without throwing)
+      if (machineListOutput.error) {
+        console.error(`Error getting Podman machines for certificate sync: ${machineListOutput.error}`);
+      }
+
+      const machines = machineListOutput.list;
+
+      for (const machine of machines) {
+        // Only include running VM-based machines
+        if (this.supportsSynchronization(machine)) {
+          targets.push({
+            id: machine.Name,
+            name: machine.Name,
+          });
+        }
+      }
+    } catch (error) {
+      console.error('Failed to get Podman machines for certificate sync:', error);
+    }
+
+    return targets;
+  }
+
+  /**
+   * Check if a machine supports certificate synchronization.
+   * Must be running and VM-based (has VMType).
+   */
+  private supportsSynchronization(machine: MachineJSON): boolean {
+    // Must be running
+    if (!machine.Running) {
+      return false;
+    }
+
+    // Must have VMType (local VM on macOS/Windows)
+    // Native Linux Podman has no VMType and certificates are already available
+    return !!machine.VMType;
+  }
+
+  /**
+   * Synchronize certificates to a specific Podman machine target.
+   * Supports cancellation - user can cancel the operation via the task manager.
+   */
+  async synchronize(targetId: string, certificates: string[]): Promise<void> {
+    const machineName = targetId;
+    const totalCerts = certificates.length;
+
+    if (totalCerts === 0) {
+      return;
+    }
+
+    await extensionApi.window.withProgress(
+      {
+        location: extensionApi.ProgressLocation.TASK_WIDGET,
+        title: `Synchronizing certificates to ${machineName}`,
+        cancellable: true,
+      },
+      async (progress: Progress<{ message?: string; increment?: number }>, token: CancellationToken) => {
+        await this.doSynchronize(machineName, certificates, progress, token);
+      },
+    );
+  }
+
+  /**
+   * Perform the actual certificate synchronization with progress reporting.
+   * Uses a diff-based algorithm:
+   * 1. Get existing certificates on VM
+   * 2. Delete certificates that no longer exist on host
+   * 3. Upload only new certificates (skip existing ones with matching fingerprint)
+   *
+   * Supports cancellation - checks token before each major operation.
+   *
+   * Note: progress.report({ increment }) SETS the progress value, doesn't add to it.
+   */
+  private async doSynchronize(
+    machineName: string,
+    certificates: string[],
+    progress: Progress<{ message?: string; increment?: number }>,
+    token: CancellationToken,
+  ): Promise<void> {
+    const anchorsPath = '/etc/pki/ca-trust/source/anchors';
+
+    // Helper to check if cancelled - returns true if should stop
+    const isCancelled = (): boolean => token.isCancellationRequested;
+
+    try {
+      // Check for cancellation before starting
+      if (isCancelled()) return;
+
+      // Step 1: Ensure the anchors directory exists (0% -> 5%)
+      progress.report({ message: `Creating anchors directory on ${machineName}`, increment: 5 });
+      await this.runMachineCommand(machineName, `sudo mkdir -p ${anchorsPath}`, token);
+
+      if (isCancelled()) return;
+
+      // Step 2: Get existing certificate fingerprints from VM (5% -> 10%)
+      progress.report({ message: `Checking existing certificates on ${machineName}`, increment: 10 });
+      const remoteFingerprints = await this.getRemoteCertificateFingerprints(machineName, anchorsPath, token);
+
+      if (isCancelled()) return;
+
+      // Step 3: Build map of host certificates (fingerprint -> PEM)
+      const hostCertificates = new Map<string, string>();
+      for (const pem of certificates) {
+        if (!pem) continue;
+        const fingerprint = this.getCertificateFingerprint(pem);
+        hostCertificates.set(fingerprint, pem);
+      }
+      const hostFingerprints = new Set(hostCertificates.keys());
+
+      // Step 4: Calculate diff
+      // Stale: on remote but not on host (need to delete)
+      const staleFingerprints = [...remoteFingerprints].filter(fp => !hostFingerprints.has(fp));
+      // New: on host but not on remote (need to upload)
+      const newFingerprints = [...hostFingerprints].filter(fp => !remoteFingerprints.has(fp));
+      // Existing: on both (skip, already synced)
+      const existingCount = hostFingerprints.size - newFingerprints.length;
+
+      // Step 5: Delete stale certificates (10% -> 20%)
+      if (staleFingerprints.length > 0) {
+        if (isCancelled()) return;
+        progress.report({
+          message: `Removing ${staleFingerprints.length} obsolete certificate(s) from ${machineName}`,
+          increment: 15,
+        });
+        await this.deleteRemoteCertificates(machineName, anchorsPath, staleFingerprints, token);
+      }
+      progress.report({ increment: 20 });
+
+      // Step 6: Upload only new certificates (20% -> 85%)
+      const totalNew = newFingerprints.length;
+      if (totalNew > 0) {
+        for (let i = 0; i < newFingerprints.length; i++) {
+          // Check for cancellation before each certificate upload
+          if (isCancelled()) return;
+
+          const fingerprint = newFingerprints[i];
+          if (!fingerprint) continue;
+
+          const pem = hostCertificates.get(fingerprint);
+          if (!pem) continue;
+
+          const filename = `podman-desktop-${fingerprint}.crt`;
+          const remotePath = `${anchorsPath}/${filename}`;
+
+          // Update progress
+          const currentPercent = 20 + Math.floor(((i + 1) / totalNew) * 65);
+          progress.report({
+            message: `Uploading new certificates to ${machineName}`,
+            increment: currentPercent,
+          });
+
+          // Write certificate to VM using base64 encoding to handle special characters
+          const base64Cert = Buffer.from(pem).toString('base64');
+          await this.runMachineCommand(
+            machineName,
+            `echo '${base64Cert}' | base64 -d | sudo tee ${remotePath} > /dev/null`,
+            token,
+          );
+        }
+      } else {
+        progress.report({ increment: 85 });
+      }
+
+      if (isCancelled()) return;
+
+      // Step 7: Update the CA trust store (85% -> 92%)
+      progress.report({ message: `Updating CA trust store on ${machineName}`, increment: 90 });
+      await this.runMachineCommand(machineName, 'sudo update-ca-trust', token);
+
+      if (isCancelled()) return;
+
+      // Step 8: Restart podman services to pick up new certificates (92% -> 100%)
+      progress.report({ message: `Restarting Podman services on ${machineName}`, increment: 95 });
+      await this.runMachineCommand(machineName, 'sudo systemctl restart podman.socket podman.service', token);
+
+      if (isCancelled()) return;
+
+      // Final summary
+      const summary = this.buildSyncSummary(staleFingerprints.length, totalNew, existingCount);
+      progress.report({ message: `${summary} on ${machineName}`, increment: 100 });
+    } catch (error) {
+      // If cancelled, just return silently - task manager will show cancelled status
+      if (isCancelled() || (error as RunError)?.cancelled) {
+        return;
+      }
+      // Re-throw non-cancellation errors - these will show in UI
+      throw error;
+    } finally {
+      progress.report({ increment: -1 });
+    }
+  }
+
+  /**
+   * Build a human-readable summary of the sync operation.
+   */
+  private buildSyncSummary(deleted: number, added: number, unchanged: number): string {
+    const parts: string[] = [];
+    if (added > 0) parts.push(`${added} added`);
+    if (deleted > 0) parts.push(`${deleted} removed`);
+    if (unchanged > 0) parts.push(`${unchanged} unchanged`);
+
+    if (parts.length === 0) {
+      return 'No changes';
+    }
+    return `Certificates: ${parts.join(', ')}`;
+  }
+
+  /**
+   * Run a command on a Podman machine via SSH.
+   * If the command fails, execPodman will throw a RunError.
+   * Supports cancellation via token - will kill the SSH process if cancelled.
+   */
+  private async runMachineCommand(machineName: string, command: string, token?: CancellationToken): Promise<void> {
+    await execPodman(['machine', 'ssh', machineName, command], undefined, { token });
+  }
+
+  /**
+   * Run a command on a Podman machine via SSH and return the output.
+   * Supports cancellation via token - will kill the SSH process if cancelled.
+   */
+  private async runMachineCommandWithOutput(
+    machineName: string,
+    command: string,
+    token?: CancellationToken,
+  ): Promise<string> {
+    const result = await execPodman(['machine', 'ssh', machineName, command], undefined, { token });
+    return result.stdout;
+  }
+
+  /**
+   * Get the set of certificate fingerprints currently on the remote machine.
+   * Parses filenames like 'podman-desktop-abc123.crt' to extract fingerprints.
+   */
+  private async getRemoteCertificateFingerprints(
+    machineName: string,
+    anchorsPath: string,
+    token?: CancellationToken,
+  ): Promise<Set<string>> {
+    const fingerprints = new Set<string>();
+
+    try {
+      // List podman-desktop managed certificate files, suppress errors if none exist
+      const output = await this.runMachineCommandWithOutput(
+        machineName,
+        `ls -1 ${anchorsPath}/podman-desktop-*.crt 2>/dev/null || true`,
+        token,
+      );
+
+      // Parse output to extract fingerprints from filenames
+      const lines = output
+        .trim()
+        .split('\n')
+        .filter(line => line.length > 0);
+      const fingerprintRegex = /podman-desktop-([a-f0-9]+)\.crt$/;
+      for (const line of lines) {
+        // Extract fingerprint from filename: /path/podman-desktop-FINGERPRINT.crt
+        const match = fingerprintRegex.exec(line);
+        if (match?.[1]) {
+          fingerprints.add(match[1]);
+        }
+      }
+    } catch (error) {
+      // Silently ignore cancellation errors - caller checks isCancelled()
+      if (token?.isCancellationRequested || (error as RunError)?.cancelled) {
+        return fingerprints;
+      }
+      // If listing fails for other reasons, assume no existing certificates
+      console.warn('Failed to list existing certificates on VM:', error);
+    }
+
+    return fingerprints;
+  }
+
+  /**
+   * Delete certificates from the remote machine by their fingerprints.
+   */
+  private async deleteRemoteCertificates(
+    machineName: string,
+    anchorsPath: string,
+    fingerprints: string[],
+    token?: CancellationToken,
+  ): Promise<void> {
+    if (fingerprints.length === 0) {
+      return;
+    }
+
+    // Build list of files to delete
+    const filesToDelete = fingerprints.map(fp => `${anchorsPath}/podman-desktop-${fp}.crt`).join(' ');
+
+    try {
+      await this.runMachineCommand(machineName, `sudo rm -f ${filesToDelete}`, token);
+    } catch (error) {
+      // Silently ignore cancellation errors - caller checks isCancelled()
+      if (token?.isCancellationRequested || (error as RunError)?.cancelled) {
+        return;
+      }
+      console.error('Failed to delete stale certificates:', error);
+      // Continue even if deletion fails for other reasons
+    }
+  }
+
+  /**
+   * Generate a unique fingerprint for a certificate based on its SHA-256 hash.
+   */
+  private getCertificateFingerprint(pem: string): string {
+    const hash = crypto.createHash('sha256').update(pem).digest('hex');
+    return hash.substring(0, 16); // Use first 16 chars for reasonable uniqueness
+  }
+}

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -53,6 +53,7 @@ import type { InstalledPodman } from '/@/utils/podman-binary';
 import { PodmanBinary } from '/@/utils/podman-binary';
 
 import { CertificateDetectionService } from './certificate-detection/certificate-detection-service';
+import { PodmanCertificateSync } from './certificate-sync/podman-certificate-sync';
 import { getDetectionChecks } from './checks/detection-checks';
 import { MacKrunkitPodmanMachineCreationCheck, MacPodmanInstallCheck } from './checks/macos-checks';
 import { PodmanCleanupMacOS } from './cleanup/podman-cleanup-macos';
@@ -118,6 +119,9 @@ let podmanBinary: PodmanBinary;
 
 let certificateDetectionService: CertificateDetectionService | undefined;
 let certificateDetectionInterval: NodeJS.Timeout | undefined;
+
+// Certificate sync provider instance - used by startMachine/stopMachine to notify target changes
+let podmanCertificateSync: PodmanCertificateSync | undefined;
 
 const wslHelper = new WslHelper();
 const qemuHelper = new QemuHelper();
@@ -869,6 +873,8 @@ export async function startMachine(
       logger: new LoggerDelegator(context, logger),
     });
     provider.updateStatus('started');
+    // Notify certificate sync about machine status change
+    podmanCertificateSync?.notifyTargetsChanged();
   } catch (err) {
     telemetryRecords.error = err;
     if (skipHandleError) {
@@ -900,6 +906,8 @@ export async function stopMachine(
       logger: new LoggerDelegator(context, logger),
     });
     provider.updateStatus('stopped');
+    // Notify certificate sync about machine status change
+    podmanCertificateSync?.notifyTargetsChanged();
   } catch (err: unknown) {
     telemetryRecords.error = err;
     throw err;
@@ -1418,6 +1426,10 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   start(extensionContext, provider, podmanInstall, podmanConfiguration, version).catch((error: unknown) => {
     console.error('Error starting the Podman extension', error);
   });
+
+  // Register certificate sync target provider for Podman machines
+  podmanCertificateSync = new PodmanCertificateSync(getJSONMachineList);
+  extensionContext.subscriptions.push(extensionApi.certificates.registerSyncTargetProvider(podmanCertificateSync));
 
   return {
     exec,

--- a/packages/api/src/certificate-sync-target.ts
+++ b/packages/api/src/certificate-sync-target.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CertificateSyncTarget } from '@podman-desktop/api';
+
+/**
+ * Extended target with extension info for UI display.
+ * Returned by the registry (only includes trusted extensions).
+ */
+export interface CertificateSyncTargetInfo extends CertificateSyncTarget {
+  /** ID of the extension that registered the provider */
+  extensionId: string;
+  /** Display name of the extension */
+  extensionName: string;
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -19,6 +19,7 @@
 // Top-level API files
 export * from './async-disposable.js';
 export * from './certificate-info.js';
+export * from './certificate-sync-target.js';
 export * from './cli-tool-info.js';
 export * from './color-info.js';
 export * from './command-info.js';

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4370,6 +4370,124 @@ declare module '@podman-desktop/api' {
   }
 
   /**
+   * A target for certificate synchronization contributed by an extension.
+   */
+  export interface CertificateSyncTarget {
+    /**
+     * Unique identifier for the target within the extension.
+     */
+    id: string;
+
+    /**
+     * Display name for the target.
+     */
+    name: string;
+  }
+
+  /**
+   * Provider interface for extensions that contribute certificate sync targets.
+   */
+  export interface CertificateSyncTargetProvider {
+    /**
+     * Get all available sync targets from this provider.
+     * @returns A promise that resolves to an array of sync targets.
+     */
+    getTargets(): Promise<CertificateSyncTarget[]>;
+
+    /**
+     * Synchronize certificates to a specific target.
+     * @param targetId The ID of the target to synchronize to.
+     * @param certificates Array of PEM-encoded certificates to synchronize.
+     */
+    synchronize(targetId: string, certificates: string[]): Promise<void>;
+
+    /**
+     * Event fired when the available targets change.
+     * Extensions must fire this event when targets are added, removed, or modified.
+     * The registry determines the source extension automatically.
+     */
+    onDidChangeTargets: Event<void>;
+  }
+
+  /**
+   * Information about a certificate from the host system.
+   */
+  export interface CertificateInfo {
+    /**
+     * The certificate subject's common name (CN) with fallback to O or full DN.
+     */
+    subjectCommonName: string;
+
+    /**
+     * The full subject distinguished name (DN).
+     * Example: "CN=example.com, O=Example Inc, C=US"
+     */
+    subject: string;
+
+    /**
+     * The certificate issuer's common name (CN) with fallback to O or full DN.
+     */
+    issuerCommonName: string;
+
+    /**
+     * The full issuer distinguished name (DN).
+     * Example: "CN=DigiCert Global Root CA, O=DigiCert Inc, C=US"
+     */
+    issuer: string;
+
+    /**
+     * The certificate serial number in hexadecimal format.
+     */
+    serialNumber: string;
+
+    /**
+     * The date from which the certificate is valid (notBefore).
+     * ISO 8601 string format.
+     */
+    validFrom?: string;
+
+    /**
+     * The date until which the certificate is valid (notAfter).
+     * ISO 8601 string format.
+     */
+    validTo?: string;
+
+    /**
+     * Indicates whether this is a Certificate Authority (CA) certificate.
+     */
+    isCA: boolean;
+  }
+
+  /**
+   * Namespace for certificate management and synchronization.
+   */
+  export namespace certificates {
+    /**
+     * Register a certificate sync target provider.
+     *
+     * Extensions can use this to contribute sync targets (e.g., VMs, remote hosts)
+     * where host certificates can be synchronized.
+     *
+     * Each extension can register at most one provider. Attempting to register a
+     * second provider from the same extension will throw an error.
+     *
+     * Note: Only preinstalled extensions (bundled with Podman Desktop) can register
+     * sync targets. User-installed extensions will have their targets excluded from
+     * the UI entirely for security reasons.
+     *
+     * @param provider The certificate sync target provider.
+     * @returns A [disposable](#Disposable) that unregisters this provider when being disposed.
+     */
+    export function registerSyncTargetProvider(provider: CertificateSyncTargetProvider): Disposable;
+
+    /**
+     * An event that fires when a provider's available sync targets change.
+     * Extensions can listen to this event to refresh their UI when targets are added, removed, or modified.
+     */
+    export const onDidChangeTargets: Event<void>;
+  }
+
+  /**
    * Namespace for authentication.
    */
   export namespace authentication {

--- a/packages/main/src/plugin/certificate-sync-target-registry.spec.ts
+++ b/packages/main/src/plugin/certificate-sync-target-registry.spec.ts
@@ -1,0 +1,572 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CertificateSyncTarget, CertificateSyncTargetProvider, Disposable } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+
+import type { IPCHandle } from './api.js';
+import {
+  type CertificateSyncExtensionInfo,
+  CertificateSyncTargetRegistry,
+} from './certificate-sync-target-registry.js';
+import type { Certificates } from './certificates.js';
+
+// Mock provider factory
+function createMockProvider(targets: CertificateSyncTarget[] = []): CertificateSyncTargetProvider {
+  let listener: (() => void) | undefined;
+  return {
+    getTargets: vi.fn().mockResolvedValue(targets),
+    synchronize: vi.fn().mockResolvedValue(undefined),
+    onDidChangeTargets: vi.fn().mockImplementation((callback: () => void) => {
+      listener = callback;
+      return { dispose: vi.fn() } as Disposable;
+    }),
+    _fireChangeEvent: (): void => listener?.(),
+  } as CertificateSyncTargetProvider & { _fireChangeEvent: () => void };
+}
+
+// Mock certificates service
+function createMockCertificates(certs: string[] = []): Certificates {
+  return {
+    getAllCertificates: vi.fn().mockReturnValue(certs),
+  } as unknown as Certificates;
+}
+
+// Extension info factories
+function createTrustedExtension(id = 'trusted-ext', name = 'Trusted Extension'): CertificateSyncExtensionInfo {
+  return { id, name, removable: false };
+}
+
+function createUntrustedExtension(id = 'untrusted-ext', name = 'Untrusted Extension'): CertificateSyncExtensionInfo {
+  return { id, name, removable: true };
+}
+
+describe('CertificateSyncTargetRegistry', () => {
+  let registry: CertificateSyncTargetRegistry;
+  let mockCertificates: Certificates;
+  let mockIpcHandle: IPCHandle;
+  let mockApiSender: ApiSenderType;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCertificates = createMockCertificates(['cert1', 'cert2']);
+    mockIpcHandle = vi.fn();
+    mockApiSender = { send: vi.fn(), receive: vi.fn() } as unknown as ApiSenderType;
+    registry = new CertificateSyncTargetRegistry(mockCertificates, mockIpcHandle, mockApiSender);
+  });
+
+  describe('init', () => {
+    test('should register certificates:getSyncTargets IPC handle', () => {
+      registry.init();
+
+      expect(mockIpcHandle).toHaveBeenCalledWith('certificates:getSyncTargets', expect.any(Function));
+    });
+
+    test('should register certificates:synchronizeToTargets IPC handle', () => {
+      registry.init();
+
+      expect(mockIpcHandle).toHaveBeenCalledWith('certificates:synchronizeToTargets', expect.any(Function));
+    });
+
+    test('should notify renderer via apiSender when targets change', async () => {
+      registry.init();
+
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      registry.registerProvider(createTrustedExtension(), provider);
+
+      await vi.waitFor(() => {
+        expect(mockApiSender.send).toHaveBeenCalledWith('certificate-sync-targets-update');
+      });
+    });
+  });
+
+  describe('registerProvider', () => {
+    test('should register a provider successfully', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+
+      expect(disposable).toBeDefined();
+      expect(provider.getTargets).toHaveBeenCalled();
+    });
+
+    test('should throw error when same extension registers twice', () => {
+      const provider1 = createMockProvider();
+      const provider2 = createMockProvider();
+      const extensionInfo = createTrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider1);
+
+      expect(() => registry.registerProvider(extensionInfo, provider2)).toThrow(
+        `Extension 'trusted-ext' has already registered a certificate sync target provider`,
+      );
+    });
+
+    test('should allow different extensions to register', () => {
+      const provider1 = createMockProvider();
+      const provider2 = createMockProvider();
+      const ext1 = createTrustedExtension('ext1', 'Extension 1');
+      const ext2 = createTrustedExtension('ext2', 'Extension 2');
+
+      expect(() => {
+        registry.registerProvider(ext1, provider1);
+        registry.registerProvider(ext2, provider2);
+      }).not.toThrow();
+    });
+
+    test('should subscribe to provider onDidChangeTargets', () => {
+      const provider = createMockProvider();
+      const extensionInfo = createTrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider);
+
+      expect(provider.onDidChangeTargets).toHaveBeenCalled();
+    });
+
+    test('should fetch targets on registration', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(provider.getTargets).toHaveBeenCalled();
+      });
+    });
+
+    test('should fire onDidChangeTargets event after initial fetch', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+      const eventHandler = vi.fn();
+
+      registry.onDidChangeTargets(eventHandler);
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(eventHandler).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('trust model', () => {
+    test('should include targets from trusted extensions (removable === false)', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets).toHaveLength(1);
+        expect(targets[0]?.name).toBe('Target 1');
+      });
+    });
+
+    test('should exclude targets from untrusted extensions (removable === true)', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createUntrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(provider.getTargets).not.toHaveBeenCalled();
+      });
+
+      const targets = registry.getTargets();
+      expect(targets).toHaveLength(0);
+    });
+  });
+
+  describe('getTargets', () => {
+    test('should return empty array when no providers registered', () => {
+      const targets = registry.getTargets();
+      expect(targets).toEqual([]);
+    });
+
+    test('should return targets with composite ID as id', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('my-ext');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets).toHaveLength(1);
+        expect(targets[0]?.id).toBe('my-ext:target1');
+      });
+    });
+
+    test('should include extension info in targets', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext-id', 'Extension Name');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets[0]).toMatchObject({
+          extensionId: 'ext-id',
+          extensionName: 'Extension Name',
+        });
+      });
+    });
+
+    test('should aggregate targets from multiple extensions', async () => {
+      const provider1 = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const provider2 = createMockProvider([{ id: 'target2', name: 'Target 2' }]);
+      const ext1 = createTrustedExtension('ext1');
+      const ext2 = createTrustedExtension('ext2');
+
+      registry.registerProvider(ext1, provider1);
+      registry.registerProvider(ext2, provider2);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('synchronize', () => {
+    test('should synchronize to target successfully', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      await registry.synchronize('ext1:target1');
+
+      expect(provider.synchronize).toHaveBeenCalledWith('target1', ['cert1', 'cert2']);
+    });
+
+    test('should throw error for non-existent target', async () => {
+      await expect(registry.synchronize('non-existent')).rejects.toThrow(`Target 'non-existent' not found`);
+    });
+
+    test('should pass certificates from Certificates service', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      await registry.synchronize('ext1:target1');
+
+      expect(mockCertificates.getAllCertificates).toHaveBeenCalled();
+      expect(provider.synchronize).toHaveBeenCalledWith('target1', ['cert1', 'cert2']);
+    });
+
+    test('should use original targetId when calling provider', async () => {
+      const provider = createMockProvider([{ id: 'my-original-id', name: 'Target' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      await registry.synchronize('ext1:my-original-id');
+
+      expect(provider.synchronize).toHaveBeenCalledWith('my-original-id', expect.any(Array));
+    });
+  });
+
+  describe('synchronizeToTargets', () => {
+    test('should sync to multiple targets in parallel', async () => {
+      const provider = createMockProvider([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+      ]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(2);
+      });
+
+      const result = await registry.synchronizeToTargets(['ext1:target1', 'ext1:target2']);
+
+      expect(result.errors).toHaveLength(0);
+      expect(provider.synchronize).toHaveBeenCalledTimes(2);
+    });
+
+    test('should return empty errors array on success', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      const result = await registry.synchronizeToTargets(['ext1:target1']);
+
+      expect(result.errors).toEqual([]);
+    });
+
+    test('should collect errors from failed targets', async () => {
+      const provider = createMockProvider([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+      ]);
+      (provider.synchronize as Mock).mockImplementation((targetId: string) => {
+        if (targetId === 'target2') {
+          return Promise.reject(new Error('Sync failed'));
+        }
+        return Promise.resolve();
+      });
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(2);
+      });
+
+      const result = await registry.synchronizeToTargets(['ext1:target1', 'ext1:target2']);
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toEqual({
+        targetId: 'ext1:target2',
+        error: 'Sync failed',
+      });
+    });
+
+    test('should continue syncing other targets when one fails', async () => {
+      const provider = createMockProvider([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+        { id: 'target3', name: 'Target 3' },
+      ]);
+      (provider.synchronize as Mock).mockImplementation((targetId: string) => {
+        if (targetId === 'target2') {
+          return Promise.reject(new Error('Sync failed'));
+        }
+        return Promise.resolve();
+      });
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(3);
+      });
+
+      await registry.synchronizeToTargets(['ext1:target1', 'ext1:target2', 'ext1:target3']);
+
+      expect(provider.synchronize).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('dispose behavior', () => {
+    test('should remove provider on dispose', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      disposable.dispose();
+
+      const targets = registry.getTargets();
+      expect(targets).toHaveLength(0);
+    });
+
+    test('should clear cached targets on dispose', async () => {
+      const provider = createMockProvider([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+      ]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(2);
+      });
+
+      disposable.dispose();
+
+      expect(registry.getTargets()).toHaveLength(0);
+    });
+
+    test('should fire onDidChangeTargets on dispose', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+      const eventHandler = vi.fn();
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+      registry.onDidChangeTargets(eventHandler);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      eventHandler.mockClear();
+      disposable.dispose();
+
+      expect(eventHandler).toHaveBeenCalled();
+    });
+
+    test('should discard stale targets when disposed during in-flight getTargets', async () => {
+      let resolveGetTargets: (targets: CertificateSyncTarget[]) => void;
+      const provider: CertificateSyncTargetProvider & { _fireChangeEvent: () => void } = {
+        getTargets: vi.fn().mockReturnValue(
+          new Promise<CertificateSyncTarget[]>(resolve => {
+            resolveGetTargets = resolve;
+          }),
+        ),
+        synchronize: vi.fn(),
+        onDidChangeTargets: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+        _fireChangeEvent: vi.fn(),
+      };
+      const extensionInfo = createTrustedExtension('ext1');
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+
+      // Dispose while getTargets() is still pending
+      disposable.dispose();
+
+      // Now resolve the in-flight getTargets — results should be discarded
+      resolveGetTargets!([{ id: 'target1', name: 'Stale Target' }]);
+      await vi.waitFor(() => {
+        expect(provider.getTargets).toHaveBeenCalled();
+      });
+
+      expect(registry.getTargets()).toHaveLength(0);
+    });
+
+    test('should allow re-registration after dispose', () => {
+      const provider1 = createMockProvider();
+      const provider2 = createMockProvider();
+      const extensionInfo = createTrustedExtension();
+
+      const disposable = registry.registerProvider(extensionInfo, provider1);
+      disposable.dispose();
+
+      expect(() => registry.registerProvider(extensionInfo, provider2)).not.toThrow();
+    });
+
+    test('should unsubscribe from provider event on dispose', async () => {
+      const disposeEventSub = vi.fn();
+      const provider: CertificateSyncTargetProvider = {
+        getTargets: vi.fn().mockResolvedValue([]),
+        synchronize: vi.fn(),
+        onDidChangeTargets: vi.fn().mockReturnValue({ dispose: disposeEventSub }),
+      };
+      const extensionInfo = createTrustedExtension();
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+      disposable.dispose();
+
+      expect(disposeEventSub).toHaveBeenCalled();
+    });
+  });
+
+  describe('provider onDidChangeTargets refresh', () => {
+    test('should refresh targets when provider fires onDidChangeTargets', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]) as CertificateSyncTargetProvider & {
+        _fireChangeEvent: () => void;
+      };
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      // Update mock to return new targets
+      (provider.getTargets as Mock).mockResolvedValue([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+      ]);
+
+      // Fire the change event
+      provider._fireChangeEvent();
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    test('should handle provider.getTargets() error gracefully', async () => {
+      const provider = createMockProvider();
+      (provider.getTargets as Mock).mockRejectedValue(new Error('Failed to get targets'));
+      const extensionInfo = createTrustedExtension();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+
+      const targets = registry.getTargets();
+      expect(targets).toHaveLength(0);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('composite key handling', () => {
+    test('should build correct composite key format', async () => {
+      const provider = createMockProvider([{ id: 'my-target', name: 'Target' }]);
+      const extensionInfo = createTrustedExtension('my-extension');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets[0]?.id).toBe('my-extension:my-target');
+      });
+    });
+
+    test('should handle targets with colons in their IDs', async () => {
+      const provider = createMockProvider([{ id: 'target:with:colons', name: 'Target' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets[0]?.id).toBe('ext1:target:with:colons');
+      });
+
+      await registry.synchronize('ext1:target:with:colons');
+      expect(provider.synchronize).toHaveBeenCalledWith('target:with:colons', expect.any(Array));
+    });
+  });
+});

--- a/packages/main/src/plugin/certificate-sync-target-registry.ts
+++ b/packages/main/src/plugin/certificate-sync-target-registry.ts
@@ -1,0 +1,279 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type * as containerDesktopAPI from '@podman-desktop/api';
+import type { CertificateSyncTargetInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { inject, injectable } from 'inversify';
+
+import { IPCHandle } from './api.js';
+import { Certificates } from './certificates.js';
+import { Emitter } from './events/emitter.js';
+import { Disposable } from './types/disposable.js';
+
+/**
+ * Minimal extension info needed for the certificate sync registry.
+ */
+export interface CertificateSyncExtensionInfo {
+  id: string;
+  name: string;
+  removable: boolean;
+}
+
+/**
+ * Internal representation of a registered provider with extension metadata.
+ */
+interface RegisteredProvider {
+  extensionInfo: CertificateSyncExtensionInfo;
+  provider: containerDesktopAPI.CertificateSyncTargetProvider;
+}
+
+/**
+ * Internal target info with composite ID for unique lookup.
+ * The `id` field keeps the original target ID from the provider.
+ * The `compositeId` is used as the map key and returned to UI for unique identification.
+ */
+interface InternalCertificateSyncTargetInfo extends CertificateSyncTargetInfo {
+  /** Composite key: extensionId:targetId */
+  compositeId: string;
+}
+
+/**
+ * Registry for certificate sync target providers.
+ *
+ * Implements a trust model where only preinstalled extensions (bundled with
+ * Podman Desktop) can register synchronization targets. User-installed
+ * extensions will have their targets not shown in the UI for security reasons.
+ */
+@injectable()
+export class CertificateSyncTargetRegistry {
+  private providers: Map<string, RegisteredProvider> = new Map();
+  // Flat map with composite keys: extensionId:targetId -> target
+  private targetsCache: Map<string, InternalCertificateSyncTargetInfo> = new Map();
+
+  private readonly _onDidChangeTargets = new Emitter<void>();
+  readonly onDidChangeTargets: containerDesktopAPI.Event<void> = this._onDidChangeTargets.event;
+
+  constructor(
+    @inject(Certificates)
+    private certificates: Certificates,
+    @inject(IPCHandle)
+    private readonly ipcHandle: IPCHandle,
+    @inject(ApiSenderType)
+    private readonly apiSender: ApiSenderType,
+  ) {}
+
+  init(): void {
+    this.ipcHandle('certificates:getSyncTargets', async (): Promise<CertificateSyncTargetInfo[]> => {
+      return this.getTargets();
+    });
+
+    this.ipcHandle(
+      'certificates:synchronizeToTargets',
+      async (_listener, targetIds: string[]): Promise<{ errors: { targetId: string; error: string }[] }> => {
+        return this.synchronizeToTargets(targetIds);
+      },
+    );
+
+    this.onDidChangeTargets(() => {
+      this.apiSender.send('certificate-sync-targets-update');
+    });
+  }
+
+  /**
+   * Build a composite key for a target.
+   */
+  private buildTargetKey(extensionId: string, targetId: string): string {
+    return `${extensionId}:${targetId}`;
+  }
+
+  /**
+   * Clear all cached targets for a specific extension.
+   */
+  private clearProviderTargets(extensionId: string): void {
+    for (const [key, target] of this.targetsCache) {
+      if (target.extensionId === extensionId) {
+        this.targetsCache.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Update the cached targets for the provider registered by the given extension.
+   * Only caches targets from trusted (preinstalled) extensions.
+   */
+  private async updateProviderTargets(extensionId: string, registered: RegisteredProvider): Promise<void> {
+    const { extensionInfo } = registered;
+
+    // Clear existing targets for this extension
+    this.clearProviderTargets(extensionId);
+
+    // Skip untrusted (user-installed) extensions
+    if (extensionInfo.removable) {
+      return;
+    }
+
+    try {
+      const targets = await registered.provider.getTargets();
+
+      // Guard: if disposed during the await, the provider map entry will be
+      // gone or replaced by a new instance — discard the stale results.
+      if (this.providers.get(extensionId) !== registered) {
+        return;
+      }
+
+      for (const target of targets) {
+        const compositeId = this.buildTargetKey(extensionId, target.id);
+        this.targetsCache.set(compositeId, {
+          ...target,
+          compositeId,
+          extensionId,
+          extensionName: extensionInfo.name,
+        });
+      }
+    } catch (error) {
+      console.error(`Error getting targets from provider (${extensionId}):`, error);
+    }
+  }
+
+  /**
+   * Register a certificate sync target provider.
+   *
+   * Each extension can register at most one provider. Attempting to register a
+   * second provider from the same extension will throw an error.
+   *
+   * @param extensionInfo Information about the extension registering the provider.
+   * @param provider The provider implementation.
+   * @returns A disposable that unregisters the provider when disposed.
+   */
+  registerProvider(
+    extensionInfo: CertificateSyncExtensionInfo,
+    provider: containerDesktopAPI.CertificateSyncTargetProvider,
+  ): Disposable {
+    const extensionId = extensionInfo.id;
+
+    if (this.providers.has(extensionId)) {
+      throw new Error(`Extension '${extensionId}' has already registered a certificate sync target provider`);
+    }
+
+    const registered: RegisteredProvider = {
+      extensionInfo,
+      provider,
+    };
+
+    this.providers.set(extensionId, registered);
+
+    // Fetch targets and notify listeners
+    const refreshTargets = (): void => {
+      this.updateProviderTargets(extensionId, registered)
+        .catch((err: unknown) => {
+          console.error(`Error updating targets for provider (${extensionId}):`, err);
+        })
+        .finally(() => {
+          this._onDidChangeTargets.fire();
+        });
+    };
+
+    // Subscribe to provider's onDidChangeTargets event
+    const providerEventSubscription = provider.onDidChangeTargets(refreshTargets);
+
+    // Initial fetch of targets
+    refreshTargets();
+
+    return Disposable.create((): void => {
+      // Unsubscribe from provider event
+      providerEventSubscription.dispose();
+      this.providers.delete(extensionId);
+      // Clear cached targets for this extension
+      this.clearProviderTargets(extensionId);
+      // Notify listeners that targets have changed
+      this._onDidChangeTargets.fire();
+    });
+  }
+
+  /**
+   * Get all sync targets from trusted (preinstalled) providers only.
+   *
+   * Returns cached targets that are updated when providers fire onDidChangeTargets.
+   * Target IDs returned to UI are composite keys (extensionId:targetId) to ensure uniqueness.
+   *
+   * Applies the trust model:
+   * - Preinstalled extensions (removable === false): targets are included
+   * - User-installed extensions (removable === true): targets are excluded
+   *
+   * @returns An array of sync targets with extension info, using compositeId as id.
+   */
+  getTargets(): CertificateSyncTargetInfo[] {
+    // Return targets with compositeId as the id for UI usage
+    return Array.from(this.targetsCache.values()).map(target => ({
+      ...target,
+      id: target.compositeId,
+    }));
+  }
+
+  /**
+   * Synchronize certificates to a specific target.
+   * O(1) lookup using the composite target ID.
+   *
+   * @param compositeId The composite target ID (extensionId:originalTargetId).
+   * @throws Error if the target is not found.
+   */
+  async synchronize(compositeId: string): Promise<void> {
+    const target = this.targetsCache.get(compositeId);
+    if (!target) {
+      throw new Error(`Target '${compositeId}' not found`);
+    }
+
+    const registered = this.providers.get(target.extensionId);
+    if (!registered) {
+      throw new Error(`Provider for target '${compositeId}' not found`);
+    }
+
+    const certificatePems = this.certificates.getAllCertificates();
+    await registered.provider.synchronize(target.id, certificatePems);
+  }
+
+  /**
+   * Synchronize certificates to multiple targets in parallel.
+   *
+   * Each target runs independently - errors in one target don't affect others.
+   *
+   * @param targetIds Array of composite target IDs to synchronize to.
+   * @returns Object containing an array of errors for failed targets.
+   */
+  async synchronizeToTargets(targetIds: string[]): Promise<{ errors: { targetId: string; error: string }[] }> {
+    // Run all targets in parallel - each target has its own cancellation handling
+    const results = await Promise.allSettled(targetIds.map(id => this.synchronize(id)));
+
+    // Collect errors from failed targets
+    const errors: { targetId: string; error: string }[] = [];
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        const targetId = targetIds[index];
+        if (targetId) {
+          errors.push({
+            targetId,
+            error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+          });
+        }
+      }
+    });
+
+    return { errors };
+  }
+}

--- a/packages/main/src/plugin/certificate.spec.ts
+++ b/packages/main/src/plugin/certificate.spec.ts
@@ -569,8 +569,8 @@ describe('parseCertificate with valid certificates', () => {
     // Should have valid dates as ISO 8601 strings
     expect(typeof result.validFrom).toBe('string');
     expect(typeof result.validTo).toBe('string');
-    expect(result.validFrom).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-    expect(result.validTo).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(result.validFrom).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+    expect(result.validTo).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
 
     // Should have serial number as hex
     expect(result.serialNumber).toMatch(/^[0-9A-F]+$/);

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -268,7 +268,8 @@ export class Certificates {
       }
 
       // Convert serial number to hex string
-      const serialNumber = Array.from(cert.serialNumber.valueBlock.valueHexView)
+      const hexView = cert.serialNumber.valueBlock.valueHexView;
+      const serialNumber = Array.from(new Uint8Array(hexView))
         .map(b => b.toString(16).padStart(2, '0').toUpperCase())
         .join('');
 

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -21,6 +21,7 @@ import * as https from 'node:https';
 import * as path from 'node:path';
 import * as tls from 'node:tls';
 
+import type { Event } from '@podman-desktop/api';
 import type { CertificateInfo } from '@podman-desktop/core-api';
 import * as asn1js from 'asn1js';
 import { injectable } from 'inversify';
@@ -29,6 +30,7 @@ import wincaAPI from 'win-ca/api';
 
 import { isLinux, isMac, isWindows } from '/@/util.js';
 
+import { Emitter } from './events/emitter.js';
 import { spawnWithPromise } from './util/spawn-promise.js';
 
 /**
@@ -64,6 +66,9 @@ const OID_NAME_MAP: Record<string, string> = {
 @injectable()
 export class Certificates {
   private allCertificates: string[] = [];
+
+  private readonly _onDidChangeCertificates = new Emitter<void>();
+  readonly onDidChangeCertificates: Event<void> = this._onDidChangeCertificates.event;
 
   /**
    * Setup all certificates globally depending on the platform.

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -36,6 +36,7 @@ import { app } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { AuthenticationImpl } from '/@/plugin/authentication.js';
+import type { CertificateSyncTargetRegistry } from '/@/plugin/certificate-sync-target-registry.js';
 import type { Certificates } from '/@/plugin/certificates.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { ColorRegistry } from '/@/plugin/color-registry.js';
@@ -282,6 +283,7 @@ const dialogRegistry: DialogRegistry = {
 } as unknown as DialogRegistry;
 
 const certificates: Certificates = {} as unknown as Certificates;
+const certificateSyncTargetRegistry: CertificateSyncTargetRegistry = {} as unknown as CertificateSyncTargetRegistry;
 
 const extensionApiVersion: ExtensionApiVersion = {
   getApiVersion: vi.fn(),
@@ -380,6 +382,7 @@ beforeEach(() => {
     dialogRegistry,
     safeStorageRegistry,
     certificates,
+    certificateSyncTargetRegistry,
     extensionWatcher,
     extensionDevelopmentFolder,
     extensionAnalyzer,

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -36,6 +36,7 @@ import { inject, injectable, preDestroy } from 'inversify';
 
 import { AuthenticationImpl } from '/@/plugin/authentication.js';
 import { CancellationTokenSource } from '/@/plugin/cancellation-token.js';
+import { CertificateSyncTargetRegistry } from '/@/plugin/certificate-sync-target-registry.js';
 import { Certificates } from '/@/plugin/certificates.js';
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import { ColorRegistry } from '/@/plugin/color-registry.js';
@@ -214,6 +215,8 @@ export class ExtensionLoader implements IAsyncDisposable {
     private safeStorageRegistry: SafeStorageRegistry,
     @inject(Certificates)
     private certificates: Certificates,
+    @inject(CertificateSyncTargetRegistry)
+    private certificateSyncTargetRegistry: CertificateSyncTargetRegistry,
     @inject(ExtensionWatcher)
     private extensionWatcher: ExtensionWatcher,
     @inject(ExtensionDevelopmentFolders)
@@ -1405,6 +1408,23 @@ export class ExtensionLoader implements IAsyncDisposable {
       },
     };
 
+    // Certificate sync target registry with extension info for trust model
+    const certificateSyncTargetRegistry = this.certificateSyncTargetRegistry;
+    const certificateSyncExtensionInfo = {
+      id: extensionInfo.id,
+      name: extensionInfo.name,
+      removable: analyzedExtension.removable,
+    };
+
+    const certificates: typeof containerDesktopAPI.certificates = {
+      registerSyncTargetProvider: provider => {
+        const registration = certificateSyncTargetRegistry.registerProvider(certificateSyncExtensionInfo, provider);
+        disposables.push(registration);
+        return registration;
+      },
+      onDidChangeTargets: certificateSyncTargetRegistry.onDidChangeTargets,
+    };
+
     const authenticationProviderRegistry = this.authenticationProviderRegistry;
 
     const authentication: typeof containerDesktopAPI.authentication = {
@@ -1678,6 +1698,7 @@ export class ExtensionLoader implements IAsyncDisposable {
       InputBoxValidationSeverity,
       QuickPickItemKind,
       authentication,
+      certificates,
       context: contextAPI,
       cli,
       imageChecker,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -44,7 +44,6 @@ import type {
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import type {
   CertificateInfo,
-  CertificateSyncTargetInfo,
   CliToolInfo,
   ColorInfo,
   CommandInfo,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -44,6 +44,7 @@ import type {
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import type {
   CertificateInfo,
+  CertificateSyncTargetInfo,
   CliToolInfo,
   ColorInfo,
   CommandInfo,
@@ -174,6 +175,7 @@ import { AppearanceInit } from './appearance-init.js';
 import { AuthenticationImpl } from './authentication.js';
 import { AutostartEngine } from './autostart-engine.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
+import { CertificateSyncTargetRegistry } from './certificate-sync-target-registry.js';
 import { Certificates } from './certificates.js';
 import { CliToolRegistry } from './cli-tool-registry.js';
 import { CloseBehavior } from './close-behavior.js';
@@ -546,17 +548,6 @@ export class PluginSystem {
     const colorRegistry = container.get<ColorRegistry>(ColorRegistry);
     colorRegistry.init();
 
-    container.bind<Certificates>(Certificates).toSelf().inSingletonScope();
-    const certificates = container.get<Certificates>(Certificates);
-    await certificates.init();
-
-    container.bind<Proxy>(Proxy).toSelf().inSingletonScope();
-    const proxy = container.get<Proxy>(Proxy);
-    await proxy.init();
-
-    const exec = new Exec(proxy);
-    container.bind<Exec>(Exec).toConstantValue(exec);
-
     container.bind<Telemetry>(Telemetry).toSelf().inSingletonScope();
     const telemetry = container.get<Telemetry>(Telemetry);
     await telemetry.init();
@@ -567,6 +558,20 @@ export class PluginSystem {
     container.bind<TaskManager>(TaskManager).toSelf().inSingletonScope();
     const taskManager = container.get<TaskManager>(TaskManager);
     taskManager.init();
+
+    // Certificates must be bound after TaskManager (dependency) and before Proxy (dependent)
+    container.bind<Certificates>(Certificates).toSelf().inSingletonScope();
+    const certificates = container.get<Certificates>(Certificates);
+    await certificates.init();
+
+    container.bind<CertificateSyncTargetRegistry>(CertificateSyncTargetRegistry).toSelf().inSingletonScope();
+
+    container.bind<Proxy>(Proxy).toSelf().inSingletonScope();
+    const proxy = container.get<Proxy>(Proxy);
+    await proxy.init();
+
+    const exec = new Exec(proxy);
+    container.bind<Exec>(Exec).toConstantValue(exec);
 
     container.bind<NotificationRegistry>(NotificationRegistry).toSelf().inSingletonScope();
     container.bind<MenuRegistry>(MenuRegistry).toSelf().inSingletonScope();
@@ -2449,6 +2454,9 @@ export class PluginSystem {
     this.ipcHandle('certificates:listCertificates', async (): Promise<CertificateInfo[]> => {
       return certificates.getAllCertificateInfos();
     });
+
+    const certificateSyncTargetRegistry = container.get<CertificateSyncTargetRegistry>(CertificateSyncTargetRegistry);
+    certificateSyncTargetRegistry.init();
 
     this.ipcHandle(
       'provider-registry:startProviderConnectionLifecycle',

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -43,6 +43,7 @@ import type {
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import type {
   CertificateInfo,
+  CertificateSyncTargetInfo,
   CliToolInfo,
   ColorInfo,
   CommandInfo,
@@ -2715,6 +2716,17 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('listCertificates', async (): Promise<CertificateInfo[]> => {
     return ipcInvoke('certificates:listCertificates');
   });
+
+  contextBridge.exposeInMainWorld('getCertificateSyncTargets', async (): Promise<CertificateSyncTargetInfo[]> => {
+    return ipcInvoke('certificates:getSyncTargets');
+  });
+
+  contextBridge.exposeInMainWorld(
+    'synchronizeCertificatesToTargets',
+    async (targetIds: string[]): Promise<{ errors: { targetId: string; error: string }[] }> => {
+      return ipcInvoke('certificates:synchronizeToTargets', targetIds);
+    },
+  );
 }
 
 // expose methods

--- a/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
+import { faArrowsRotate, faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
 import type { CertificateInfo } from '@podman-desktop/core-api';
-import { FilteredEmptyScreen, SearchInput, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
+import type { SplitButtonOption } from '@podman-desktop/ui-svelte';
+import {
+  Button,
+  FilteredEmptyScreen,
+  SearchInput,
+  SplitButton,
+  Table,
+  TableColumn,
+  TableRow,
+} from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy } from 'svelte';
 
 import SettingsPage from '/@/lib/preferences/SettingsPage.svelte';
-import { certificatesInfos, filtered, searchPattern } from '/@/stores/certificates';
+import { certificatesInfos, certificateSyncTargets, filtered, searchPattern } from '/@/stores/certificates';
 
 import { getIssuerDisplayNameWithSelfSigned, getSubjectDisplayName } from './certificate-util';
 import CertificateColumnExpires from './CertificateColumnExpires.svelte';
@@ -28,6 +39,67 @@ let { searchTerm = $bindable('') }: Props = $props();
 $effect(() => {
   searchPattern.set(searchTerm);
 });
+
+// Create options for the SplitButton from sync targets (only trusted extensions are included)
+let options: SplitButtonOption[] = $derived(
+  $certificateSyncTargets.map(target => ({
+    id: target.id,
+    label: target.name,
+  })),
+);
+
+// Show simple button when there's exactly one target
+let showSimpleButton = $derived(options.length === 1);
+
+// Enable multiple selection when there are multiple targets
+let useMultipleSelection = $derived(options.length > 1);
+
+// Track selected option IDs (empty array = no selection)
+let selectedOptionIds = $state<string[]>([]);
+
+// Clear selection if current selection is no longer valid
+$effect(() => {
+  const validIds = selectedOptionIds.filter(id => options.some(o => o.id === id));
+  if (validIds.length !== selectedOptionIds.length) {
+    selectedOptionIds = validIds;
+  }
+});
+
+// Sync progress state
+let syncInProgress = $state(false);
+// Error state - true if sync failed
+let syncError = $state(false);
+
+// Clear errors when starting a new sync
+function clearErrors(): void {
+  syncError = false;
+}
+
+// Unified sync function for both single and multiple targets
+async function synchronizeToTargets(selectedOptions: SplitButtonOption[]): Promise<void> {
+  if (selectedOptions.length === 0) return;
+
+  clearErrors();
+  syncInProgress = true;
+  try {
+    const targetIds = selectedOptions.map(option => option.id);
+    const result = await window.synchronizeCertificatesToTargets(targetIds);
+    if (result.errors.length > 0) {
+      syncError = true;
+    }
+  } catch (err: unknown) {
+    syncError = true;
+  } finally {
+    syncInProgress = false;
+  }
+}
+
+// Open task manager to show error details
+function openTaskManager(): void {
+  window
+    .executeCommand('show-task-manager')
+    .catch((err: unknown) => console.error('Failed to open task manager:', err));
+}
 
 let certificates: CertificateInfoUI[] = $derived(
   $filtered.map((cert, index) => ({
@@ -115,9 +187,42 @@ onDestroy(() => {
   {/snippet}
   {#snippet header()}
   <div class="flex flex-col w-full">  
-    <div class="flex w-full max-w-[905px] mt-4 pl-7">
+    <div class="flex w-full max-w-[905px] justify-between items-center mt-4 pl-7 pr-10 self-center">
       <SearchInput title="certificates" searchTerm={searchTerm} oninput={updateSearchValue} class="w-[200px]"/>
+      {#if showSimpleButton}
+        <Button
+          icon={faArrowsRotate}
+          onclick={(): void => { synchronizeToTargets([options[0]]).catch((err: unknown) => console.error('Failed to synchronize certificates:', err)); }}
+          inProgress={syncInProgress}>
+          Synchronize to {options[0].label}
+        </Button>
+      {:else}
+        <SplitButton
+          options={options}
+          selectedOptionIds={selectedOptionIds}
+          multipleSelection={useMultipleSelection}
+          emptyLabel="No synchronization targets available"
+          noSelectionLabel="Synchronize to ..."
+          icon={faArrowsRotate}
+          onAction={synchronizeToTargets}
+          onSelect={(selected): void => { selectedOptionIds = selected.map(o => o.id); }}
+          inProgress={syncInProgress}>
+            Synchronize to ({selectedOptionIds.length})
+        </SplitButton>
+      {/if}
     </div>
+    {#if syncError}
+      <div class="flex w-full max-w-[905px] mt-2 pl-7 pr-10 self-center justify-end" role="alert">
+        <button
+          class="flex items-center text-[var(--pd-state-error)] text-sm hover:underline cursor-pointer"
+          aria-label="Open task manager to see error details"
+          title="Open task manager to see error details"
+          onclick={openTaskManager}>
+          <Icon size="1.1x" class="mr-2 text-[var(--pd-state-error)]" icon={faCircleExclamation} />
+          <span>Error: certificates couldn't be synced</span>
+        </button>
+      </div>
+    {/if}
   </div>
   {/snippet}
     <div class="flex flex-col -mx-5 py-2 w-full">

--- a/packages/renderer/src/stores/certificates.ts
+++ b/packages/renderer/src/stores/certificates.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { CertificateInfo } from '@podman-desktop/core-api';
+import type { CertificateInfo, CertificateSyncTargetInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { derived, writable } from 'svelte/store';
 
@@ -52,3 +52,24 @@ export const searchPattern = writable('');
 export const filtered = derived([searchPattern, certificatesInfos], ([$searchPattern, $certificatesInfos]) =>
   $certificatesInfos.filter(certificateInfo => findMatchInLeaves(certificateInfo, $searchPattern.toLowerCase())),
 );
+
+// Certificate sync targets store
+export const certificateSyncTargets: Writable<CertificateSyncTargetInfo[]> = writable([]);
+
+// use helper here as window methods are initialized after the store in tests
+const getCertificateSyncTargets = (): Promise<CertificateSyncTargetInfo[]> => {
+  return window.getCertificateSyncTargets();
+};
+
+// Sync targets need to update when extensions start/stop, targets change, or machine state changes
+const syncTargetsWindowEvents = ['extensions-started', 'certificate-sync-targets-update'];
+
+export const certificateSyncTargetsEventStore = new EventStore<CertificateSyncTargetInfo[]>(
+  'certificate-sync-targets',
+  certificateSyncTargets,
+  checkForUpdate,
+  syncTargetsWindowEvents,
+  windowListeners,
+  getCertificateSyncTargets,
+);
+certificateSyncTargetsEventStore.setupWithDebounce();

--- a/packages/ui/src/lib/button/SplitButton.spec.ts
+++ b/packages/ui/src/lib/button/SplitButton.spec.ts
@@ -1,0 +1,658 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SplitButtonOption } from './SplitButton.svelte';
+import SplitButton from './SplitButton.svelte';
+
+const mockOptions: SplitButtonOption[] = [
+  { id: 'merge', label: 'Merge', description: 'Merge all commits' },
+  { id: 'squash', label: 'Squash and merge', description: 'Squash commits into one' },
+  { id: 'rebase', label: 'Rebase and merge', description: 'Rebase commits onto base' },
+];
+
+describe('SplitButton', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('renders with noSelectionLabel when no option is selected', () => {
+    render(SplitButton, { props: { options: mockOptions, noSelectionLabel: 'Select...' } });
+    expect(screen.getByText('Select...')).toBeInTheDocument();
+  });
+
+  test('renders with specified selected option', () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['squash'], noSelectionLabel: 'Select...' },
+    });
+    expect(screen.getByRole('button', { name: /squash and merge/i })).toBeInTheDocument();
+  });
+
+  test('opens dropdown when chevron button is clicked', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+    const dropdownButton = screen.getByLabelText('Select action');
+    await fireEvent.click(dropdownButton);
+
+    expect(screen.getByText('Squash and merge')).toBeInTheDocument();
+    expect(screen.getByText('Rebase and merge')).toBeInTheDocument();
+  });
+
+  test('shows option descriptions in dropdown', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+    const dropdownButton = screen.getByLabelText('Select action');
+    await fireEvent.click(dropdownButton);
+
+    expect(screen.getByText('Merge all commits')).toBeInTheDocument();
+    expect(screen.getByText('Squash commits into one')).toBeInTheDocument();
+  });
+
+  test('calls onAction with all selected options when main button is clicked', async () => {
+    const onAction = vi.fn();
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', onAction },
+    });
+
+    const mainButton = screen.getByText('Merge');
+    await fireEvent.click(mainButton);
+
+    expect(onAction).toHaveBeenCalledWith([mockOptions[0]]);
+  });
+
+  test('selects option without triggering action when dropdown item is clicked', async () => {
+    const onAction = vi.fn();
+    const onSelect = vi.fn();
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', onAction, onSelect },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    // Select squash option
+    await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+
+    // Action should NOT be called - only selection changes
+    expect(onAction).not.toHaveBeenCalled();
+    // But onSelect should be called with all selected options (squash replaces merge in single-select)
+    expect(onSelect).toHaveBeenCalledWith([mockOptions[1]]);
+  });
+
+  test('shows checkmark icon for selected option', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    // The first option (Merge) should have the checkmark
+    const mergeOption = screen.getByRole('option', { name: /^merge\s/i });
+    expect(mergeOption.querySelector('svg')).toBeInTheDocument();
+  });
+
+  test('triggers action with all selected options when main button is clicked after selection', async () => {
+    const onAction = vi.fn();
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', onAction },
+    });
+
+    // Open dropdown and select squash option
+    await fireEvent.click(screen.getByLabelText('Select action'));
+    await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+
+    // Now click main button
+    await fireEvent.click(screen.getByRole('button', { name: /squash and merge/i }));
+
+    expect(onAction).toHaveBeenCalledWith([mockOptions[1]]);
+  });
+
+  test('closes dropdown when option is selected', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // Select an option
+    await fireEvent.click(screen.getByRole('option', { name: /rebase and merge/i }));
+
+    // Dropdown should be closed
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('closes dropdown when Escape is pressed', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // Press Escape
+    await fireEvent.keyUp(window, { key: 'Escape' });
+
+    // Dropdown should be closed
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('closes dropdown when clicking outside', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // Click outside
+    await fireEvent.click(document.body);
+
+    // Dropdown should be closed
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('disables button when disabled prop is true', () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', disabled: true },
+    });
+
+    expect(screen.getByText('Merge').closest('button')).toBeDisabled();
+    expect(screen.getByLabelText('Select action')).toBeDisabled();
+  });
+
+  test('does not open dropdown when disabled', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', disabled: true },
+    });
+
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('does not call onAction when disabled', async () => {
+    const onAction = vi.fn();
+    render(SplitButton, {
+      props: {
+        options: mockOptions,
+        selectedOptionIds: ['merge'],
+        noSelectionLabel: 'Select...',
+        disabled: true,
+        onAction,
+      },
+    });
+
+    await fireEvent.click(screen.getByText('Merge'));
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  test('shows spinner when inProgress', () => {
+    const { container } = render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', inProgress: true },
+    });
+
+    // Spinner component should be present
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  test('disables buttons when inProgress', () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', inProgress: true },
+    });
+
+    expect(screen.getByText('Merge').closest('button')).toBeDisabled();
+    expect(screen.getByLabelText('Select action')).toBeDisabled();
+  });
+
+  test('applies secondary type styling', () => {
+    const { container } = render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', type: 'secondary' },
+    });
+
+    const mainButton = container.querySelector('button');
+    expect(mainButton?.className).toContain('border-[var(--pd-button-secondary)]');
+  });
+
+  test('applies danger type styling', () => {
+    const { container } = render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', type: 'danger' },
+    });
+
+    const mainButton = container.querySelector('button');
+    expect(mainButton?.className).toContain('border-[var(--pd-button-danger-border)]');
+  });
+
+  test('renders with custom aria-label', () => {
+    render(SplitButton, {
+      props: {
+        options: mockOptions,
+        selectedOptionIds: ['merge'],
+        noSelectionLabel: 'Select...',
+        'aria-label': 'Merge options',
+      },
+    });
+
+    expect(screen.getByLabelText('Merge options')).toBeInTheDocument();
+  });
+
+  test('renders with title tooltip', () => {
+    render(SplitButton, {
+      props: {
+        options: mockOptions,
+        selectedOptionIds: ['merge'],
+        noSelectionLabel: 'Select...',
+        title: 'Choose merge strategy',
+      },
+    });
+
+    expect(screen.getByTitle('Choose merge strategy')).toBeInTheDocument();
+  });
+
+  test('sets aria-expanded correctly on dropdown toggle', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    const dropdownButton = screen.getByLabelText('Select action');
+
+    expect(dropdownButton).toHaveAttribute('aria-expanded', 'false');
+
+    await fireEvent.click(dropdownButton);
+
+    expect(dropdownButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('marks selected option with aria-selected', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    const mergeOption = screen.getByRole('option', { name: /^merge\s/i });
+    expect(mergeOption).toHaveAttribute('aria-selected', 'true');
+
+    const squashOption = screen.getByRole('option', { name: /squash and merge/i });
+    expect(squashOption).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('shows emptyLabel and disables button when options array is empty', () => {
+    render(SplitButton, { props: { options: [], noSelectionLabel: 'Select...', emptyLabel: 'No items available' } });
+
+    expect(screen.getByText('No items available')).toBeInTheDocument();
+    expect(screen.getByText('No items available').closest('button')).toBeDisabled();
+    expect(screen.getByLabelText('Select action')).toBeDisabled();
+  });
+
+  test('uses default emptyLabel when not provided', () => {
+    render(SplitButton, { props: { options: [], noSelectionLabel: 'Select...' } });
+
+    expect(screen.getByText('No options available')).toBeInTheDocument();
+  });
+
+  test('does not open dropdown when options are empty', async () => {
+    render(SplitButton, { props: { options: [], noSelectionLabel: 'Select...' } });
+
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  describe('noActionLabel mode (all options disabled)', () => {
+    const allDisabledOptions: SplitButtonOption[] = [
+      { id: 'opt1', label: 'Option 1', disabled: true, description: 'Not available' },
+      { id: 'opt2', label: 'Option 2', disabled: true, description: 'Also not available' },
+    ];
+
+    test('shows noActionLabel when all options are disabled', () => {
+      render(SplitButton, {
+        props: { options: allDisabledOptions, noSelectionLabel: 'Select...', noActionLabel: 'Show options...' },
+      });
+
+      expect(screen.getByText('Show options...')).toBeInTheDocument();
+    });
+
+    test('uses default noActionLabel when not provided', () => {
+      render(SplitButton, { props: { options: allDisabledOptions, noSelectionLabel: 'Select...' } });
+
+      expect(screen.getByText('Show options...')).toBeInTheDocument();
+    });
+
+    test('main button is enabled in noAction mode', () => {
+      render(SplitButton, {
+        props: { options: allDisabledOptions, noSelectionLabel: 'Select...', noActionLabel: 'Show options...' },
+      });
+
+      const mainButton = screen.getByText('Show options...').closest('button');
+      expect(mainButton).toBeEnabled();
+    });
+
+    test('clicking main button opens dropdown instead of calling onAction', async () => {
+      const onAction = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: allDisabledOptions,
+          noSelectionLabel: 'Select...',
+          noActionLabel: 'Show options...',
+          onAction,
+        },
+      });
+
+      await fireEvent.click(screen.getByText('Show options...'));
+
+      // Should open dropdown
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      // Should NOT call onAction
+      expect(onAction).not.toHaveBeenCalled();
+    });
+
+    test('dropdown shows all disabled options with descriptions', async () => {
+      render(SplitButton, {
+        props: { options: allDisabledOptions, noSelectionLabel: 'Select...', noActionLabel: 'Show options...' },
+      });
+
+      await fireEvent.click(screen.getByText('Show options...'));
+
+      expect(screen.getByText('Option 1')).toBeInTheDocument();
+      expect(screen.getByText('Option 2')).toBeInTheDocument();
+      expect(screen.getByText('Not available')).toBeInTheDocument();
+      expect(screen.getByText('Also not available')).toBeInTheDocument();
+    });
+
+    test('disabled options cannot be selected', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: allDisabledOptions,
+          noSelectionLabel: 'Select...',
+          noActionLabel: 'Show options...',
+          onSelect,
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByText('Show options...'));
+
+      // Try to select a disabled option
+      await fireEvent.click(screen.getByRole('option', { name: /option 1/i }));
+
+      // onSelect should NOT be called
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    test('dropdown toggle (chevron) also works in noAction mode', async () => {
+      render(SplitButton, {
+        props: { options: allDisabledOptions, noSelectionLabel: 'Select...', noActionLabel: 'Show options...' },
+      });
+
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('noSelectionLabel mode (no option selected)', () => {
+    test('shows noSelectionLabel when no option is selected', () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...' },
+      });
+
+      expect(screen.getByText('Select an option...')).toBeInTheDocument();
+    });
+
+    test('main button is enabled in noSelection mode', () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...' },
+      });
+
+      const mainButton = screen.getByText('Select an option...').closest('button');
+      expect(mainButton).toBeEnabled();
+    });
+
+    test('clicking main button opens dropdown instead of calling onAction', async () => {
+      const onAction = vi.fn();
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...', onAction },
+      });
+
+      await fireEvent.click(screen.getByText('Select an option...'));
+
+      // Should open dropdown
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      // Should NOT call onAction
+      expect(onAction).not.toHaveBeenCalled();
+    });
+
+    test('dropdown shows all options when in noSelection mode', async () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...' },
+      });
+
+      await fireEvent.click(screen.getByText('Select an option...'));
+
+      expect(screen.getByText('Merge')).toBeInTheDocument();
+      expect(screen.getByText('Squash and merge')).toBeInTheDocument();
+      expect(screen.getByText('Rebase and merge')).toBeInTheDocument();
+    });
+
+    test('selecting an option calls onSelect and updates button label', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...', onSelect },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByText('Select an option...'));
+
+      // Select an option
+      await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+
+      // onSelect should be called with all selected options
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[1]]);
+    });
+
+    test('does not show noSelectionLabel when option is selected', () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select an option...' },
+      });
+
+      expect(screen.queryByText('Select an option...')).not.toBeInTheDocument();
+      expect(screen.getByText('Merge')).toBeInTheDocument();
+    });
+
+    test('dropdown toggle (chevron) works in noSelection mode', async () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...' },
+      });
+
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('multipleSelection mode', () => {
+    test('allows selecting multiple options', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+          onSelect,
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Select first option
+      await fireEvent.click(screen.getByRole('option', { name: /^merge\s/i }));
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[0]]);
+
+      // Select second option
+      await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[0], mockOptions[1]]);
+    });
+
+    test('dropdown stays open after selection in multipleSelection mode', async () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Select an option
+      await fireEvent.click(screen.getByRole('option', { name: /^merge\s/i }));
+
+      // Dropdown should still be open
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    test('shows checkmark for all selected options', async () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: ['merge', 'squash'],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Both selected options should have checkmarks
+      const mergeOption = screen.getByRole('option', { name: /^merge\s/i });
+      const squashOption = screen.getByRole('option', { name: /squash and merge/i });
+      const rebaseOption = screen.getByRole('option', { name: /rebase and merge/i });
+
+      expect(mergeOption.querySelector('svg')).toBeInTheDocument();
+      expect(squashOption.querySelector('svg')).toBeInTheDocument();
+      expect(rebaseOption.querySelector('svg')).not.toBeInTheDocument();
+    });
+
+    test('can deselect an option by clicking again', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: ['merge', 'squash'],
+          noSelectionLabel: 'Select options...',
+          onSelect,
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Deselect merge option
+      await fireEvent.click(screen.getByRole('option', { name: /^merge\s/i }));
+
+      // Should only have squash selected
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[1]]);
+    });
+
+    test('button appearance unchanged with 0 selections', () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Should show noSelectionLabel
+      expect(screen.getByText('Select options...')).toBeInTheDocument();
+    });
+
+    test('button appearance unchanged with 1 selection', () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: ['merge'],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Should show the selected option's label (first selected is used for display)
+      expect(screen.getByText('Merge')).toBeInTheDocument();
+    });
+
+    test('listbox has aria-multiselectable attribute in multipleSelection mode', async () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      const listbox = screen.getByRole('listbox');
+      expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    test('calls onSelect with all selected options', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+          onSelect,
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Select an option
+      await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+
+      // onSelect should be called with all selected options
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[1]]);
+    });
+  });
+});

--- a/packages/ui/src/lib/button/SplitButton.svelte
+++ b/packages/ui/src/lib/button/SplitButton.svelte
@@ -1,0 +1,298 @@
+<script lang="ts">
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import type { Component, Snippet } from 'svelte';
+
+import Icon from '../icons/Icon.svelte';
+import Spinner from '../progress/Spinner.svelte';
+import type { ButtonType } from './Button';
+
+export interface SplitButtonOption {
+  id: string;
+  label: string;
+  icon?: IconDefinition | Component | string;
+  description?: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  title?: string;
+  inProgress?: boolean;
+  disabled?: boolean;
+  type?: Exclude<ButtonType, 'link' | 'tab'>;
+  icon?: IconDefinition | Component | string;
+  options: SplitButtonOption[];
+  /** Selected option ID(s) - works for both single and multi-select modes */
+  selectedOptionIds?: string[];
+  /** Enable multiple selection mode */
+  multipleSelection?: boolean;
+  emptyLabel?: string;
+  /** Label shown when options exist but none are actionable (all disabled) */
+  noActionLabel?: string;
+  /** Label shown when options exist but none is selected (clicking opens dropdown) */
+  noSelectionLabel: string;
+  class?: string;
+  'aria-label'?: string;
+  /** Called when main button is clicked with all selected options */
+  onAction?: (options: SplitButtonOption[]) => void;
+  /** Called when selection changes with all selected options */
+  onSelect?: (options: SplitButtonOption[]) => void;
+  children?: Snippet;
+}
+
+let {
+  title,
+  inProgress = false,
+  disabled = false,
+  type = 'primary',
+  icon,
+  options,
+  selectedOptionIds = $bindable([]),
+  multipleSelection = false,
+  emptyLabel = 'No options available',
+  noActionLabel = 'Show options...',
+  noSelectionLabel,
+  class: classNames = '',
+  'aria-label': ariaLabel,
+  onAction,
+  onSelect,
+  children,
+}: Props = $props();
+
+let showDropdown = $state(false);
+let buttonRef = $state<HTMLDivElement>();
+
+const isEmpty = $derived(options.length === 0);
+// First selected option (used for button display)
+const selectedOption = $derived(options.find(o => selectedOptionIds.includes(o.id)));
+// All selected options
+const selectedOptions = $derived(options.filter(o => selectedOptionIds.includes(o.id)));
+// Check if an option is selected
+const isOptionSelected = (optionId: string): boolean => selectedOptionIds.includes(optionId);
+// Check if any option is actionable (not disabled)
+const hasActionableOption = $derived(options.some(o => !o.disabled));
+// Check if no option is selected (for button display purposes)
+const hasNoSelection = $derived(!isEmpty && hasActionableOption && selectedOptionIds.length === 0);
+// Main action is disabled when explicitly disabled or no options exist
+const isMainDisabled = $derived(disabled || isEmpty);
+// Dropdown can be opened even if selected option is disabled (to see/change options)
+const isDropdownDisabled = $derived(disabled || isEmpty);
+// Show "no action" mode when options exist but none are actionable
+const isNoActionMode = $derived(!isEmpty && !hasActionableOption);
+
+function handleEscape({ key }: KeyboardEvent): void {
+  if (key === 'Escape') {
+    showDropdown = false;
+  }
+}
+
+function onWindowClick(e: MouseEvent): void {
+  if (!buttonRef?.contains(e.target as Node)) {
+    showDropdown = false;
+  }
+}
+
+function handleMainClick(): void {
+  if (inProgress) return;
+
+  // In "no action" or "no selection" mode, clicking main button opens dropdown
+  if (isNoActionMode || hasNoSelection) {
+    showDropdown = !showDropdown;
+    return;
+  }
+
+  if (!isMainDisabled && selectedOptions.length > 0) {
+    // Close dropdown before executing action
+    showDropdown = false;
+    onAction?.(selectedOptions);
+  }
+}
+
+function handleDropdownClick(e: MouseEvent): void {
+  e.stopPropagation();
+  if (!isDropdownDisabled && !inProgress) {
+    showDropdown = !showDropdown;
+  }
+}
+
+function selectOption(option: SplitButtonOption): void {
+  if (option.disabled) return;
+
+  if (multipleSelection) {
+    // Toggle selection in multi-select mode
+    if (selectedOptionIds.includes(option.id)) {
+      selectedOptionIds = selectedOptionIds.filter(id => id !== option.id);
+    } else {
+      selectedOptionIds = [...selectedOptionIds, option.id];
+    }
+    // Keep dropdown open in multi-select mode
+  } else {
+    // Single-select mode: replace with single item
+    selectedOptionIds = [option.id];
+    showDropdown = false;
+  }
+
+  // Notify parent with all selected options
+  const allSelected = options.filter(o => selectedOptionIds.includes(o.id));
+  onSelect?.(allSelected);
+}
+
+const styles = {
+  primary: {
+    button: {
+      enabled:
+        'bg-[var(--pd-button-primary-bg)] text-[var(--pd-button-text)] hover:bg-[var(--pd-button-primary-hover-bg)]',
+      disabled: 'bg-[var(--pd-button-disabled)] text-[var(--pd-button-disabled-text)]',
+    },
+    divider: 'bg-[var(--pd-button-text)]',
+    border: 'border-[var(--pd-button-primary-bg)]',
+    containerBg: 'bg-[var(--pd-button-primary-bg)]',
+    focusOutline: 'focus:outline-[var(--pd-button-primary-hover-bg)]',
+  },
+  secondary: {
+    button: {
+      enabled:
+        'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-text)]',
+      disabled:
+        'border-[1px] border-[var(--pd-button-disabled)] bg-[var(--pd-button-disabled)] text-[var(--pd-button-disabled-text)]',
+    },
+    divider: 'bg-[var(--pd-button-secondary)]',
+    border: 'border-[var(--pd-button-secondary)]',
+    containerBg: 'bg-[var(--pd-button-disabled)]',
+    focusOutline: 'focus:outline-[var(--pd-button-secondary)]',
+  },
+  danger: {
+    button: {
+      enabled:
+        'border-2 border-[var(--pd-button-danger-border)] bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] hover:bg-[var(--pd-button-danger-hover-bg)] hover:text-[var(--pd-button-danger-hover-text)]',
+      disabled:
+        'border-2 border-[var(--pd-button-danger-disabled-border)] text-[var(--pd-button-danger-disabled-text)] bg-[var(--pd-button-danger-disabled-bg)]',
+    },
+    divider: 'bg-[var(--pd-button-danger-text)]',
+    border: 'border-[var(--pd-button-danger-border)]',
+    containerBg: 'bg-[var(--pd-button-danger-bg)]',
+    focusOutline: 'focus:outline-[var(--pd-button-danger-hover-bg)]',
+  },
+};
+
+const currentStyle = $derived(styles[type]);
+
+// Main button styling (enabled in "no action" or "no selection" mode to allow opening dropdown)
+const mainClasses = $derived(
+  (isMainDisabled && !isNoActionMode && !hasNoSelection) || inProgress
+    ? currentStyle.button.disabled
+    : currentStyle.button.enabled,
+);
+
+// Dropdown toggle styling (disabled only when empty or explicitly disabled)
+const dropdownClasses = $derived(
+  isDropdownDisabled || inProgress ? currentStyle.button.disabled : currentStyle.button.enabled,
+);
+
+const dividerClasses = $derived(
+  isDropdownDisabled || inProgress ? 'bg-[var(--pd-button-disabled-text)]' : currentStyle.divider,
+);
+
+const borderClasses = $derived(
+  isDropdownDisabled || inProgress ? 'border-[var(--pd-button-disabled)]' : currentStyle.border,
+);
+
+const containerBgClasses = $derived(
+  isDropdownDisabled || inProgress ? 'bg-[var(--pd-button-disabled)]' : currentStyle.containerBg,
+);
+
+// Determine the label to display on the button
+const buttonLabel = $derived.by(() => {
+  if (isEmpty) return emptyLabel;
+  if (isNoActionMode) return noActionLabel;
+  if (hasNoSelection) return noSelectionLabel;
+  if (!children && selectedOption) return selectedOption.label;
+  return undefined;
+});
+</script>
+
+<svelte:window onkeyup={handleEscape} onclick={onWindowClick} />
+
+<div class="relative inline-block" bind:this={buttonRef}>
+  <!-- Split button container -->
+  <div class="flex flex-row items-center rounded-[4px] overflow-hidden border {borderClasses} {containerBgClasses} {classNames}">
+    <!-- Main action button -->
+    <button
+      type="button"
+      class="relative px-4 py-[5px] whitespace-nowrap select-none transition-all outline-transparent {currentStyle.focusOutline} rounded-l-[4px] {mainClasses}"
+      title={title}
+      aria-label={ariaLabel}
+      onclick={handleMainClick}
+      disabled={(isMainDisabled && !isNoActionMode && !hasNoSelection) || inProgress}>
+      <div class="flex flex-row items-center gap-2">
+        {#if inProgress}
+          <Spinner size="1em" />
+        {:else if icon}
+          <Icon {icon} />
+        {/if}
+
+        {#if buttonLabel !== undefined}
+          <span>{buttonLabel}</span>
+        {:else if children}
+          <span>{@render children()}</span>
+        {/if}
+      </div>
+    </button>
+
+    <!-- Divider -->
+    <div class="w-[1px] h-4 {dividerClasses} shrink-0"></div>
+
+    <!-- Dropdown toggle button -->
+    <button
+      type="button"
+      class="px-2 py-[5px] self-stretch flex items-center transition-all outline-transparent {currentStyle.focusOutline} rounded-r-[4px] {dropdownClasses}"
+      aria-label="Select action"
+      aria-haspopup="listbox"
+      aria-expanded={showDropdown}
+      onclick={handleDropdownClick}
+      disabled={isDropdownDisabled || inProgress}>
+      <Icon icon={faChevronDown} class="w-3 text-current" />
+    </button>
+  </div>
+
+  <!-- Dropdown menu -->
+  {#if showDropdown}
+    <div
+      class="absolute right-0 mt-1 min-w-full w-max bg-[var(--pd-dropdown-bg)] border border-[var(--pd-dropdown-border)] rounded-md shadow-lg z-50"
+      role="listbox"
+      aria-multiselectable={multipleSelection}>
+      {#each options as option (option.id)}
+        {@const selected = isOptionSelected(option.id)}
+        <button
+          type="button"
+          class="w-full text-left px-4 py-2 first:rounded-t-md last:rounded-b-md flex items-center gap-2
+            {option.disabled
+              ? 'text-[var(--pd-dropdown-item-disabled-text)] cursor-not-allowed opacity-60'
+              : 'hover:bg-[var(--pd-dropdown-item-hover-bg)] hover:text-[var(--pd-dropdown-item-hover-text)] text-[var(--pd-dropdown-item-text)]'}"
+          class:bg-[var(--pd-dropdown-item-selected-bg)]={selected && !option.disabled}
+          role="option"
+          aria-selected={selected}
+          aria-disabled={option.disabled}
+          disabled={option.disabled}
+          onclick={(): void => selectOption(option)}>
+          <!-- Checkmark for selected option(s) -->
+          <span class="w-4 flex-shrink-0">
+            {#if selected && !option.disabled}
+              <Icon icon={faCheck} class="w-4 text-current" />
+            {/if}
+          </span>
+          {#if option.icon}
+            <Icon icon={option.icon} class="w-4" />
+          {/if}
+          <div class="flex flex-col">
+            <span class="font-medium">{option.label}</span>
+            {#if option.description}
+              <span class="text-xs text-[var(--pd-dropdown-item-description-text)] opacity-70"
+                >{option.description}</span>
+            {/if}
+          </div>
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -20,6 +20,8 @@ import type { ButtonType } from './button/Button';
 import Button from './button/Button.svelte';
 import CloseButton from './button/CloseButton.svelte';
 import Expandable from './button/Expandable.svelte';
+import type { SplitButtonOption } from './button/SplitButton.svelte';
+import SplitButton from './button/SplitButton.svelte';
 import Carousel from './carousel/Carousel.svelte';
 import Checkbox from './checkbox/Checkbox.svelte';
 import Dropdown from './dropdown/Dropdown.svelte';
@@ -51,7 +53,7 @@ import { tablePersistence } from './table/table-persistence-store.svelte';
 import Tooltip from './tooltip/Tooltip.svelte';
 import { isFontAwesomeIcon } from './utils/icon-utils';
 
-export type { ButtonType, ListOrganizerItem, TablePersistence };
+export type { ButtonType, ListOrganizerItem, SplitButtonOption, TablePersistence };
 export {
   Button,
   Carousel,
@@ -77,6 +79,7 @@ export {
   SearchInput,
   SettingsNavItem,
   Spinner,
+  SplitButton,
   StatusIcon,
   Tab,
   Table,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -8,7 +8,8 @@
     "preserveValueImports": false,
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"]
+      "/@/*": ["./src/*"],
+      "/@svelte-ui/*": ["./src/lib/*"]
     },
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@svelte-ui/': join(PACKAGE_ROOT, 'src/lib') + '/',
     },
   },
   plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js', hot: !process.env.VITEST }), svelteTesting()],


### PR DESCRIPTION
### What does this PR do?

This PR based on PRs below and should be merged after them:
* https://github.com/podman-desktop/podman-desktop/pull/15669
* https://github.com/podman-desktop/podman-desktop/pull/15671
* https://github.com/podman-desktop/podman-desktop/pull/16033
* https://github.com/podman-desktop/podman-desktop/pull/16279

### Screenshot / video of UI

It adds 'Synchronize' button to Certificates preference page to manually upload local CA certificates to multiple targets (VMs). For now they are uploaded to VMs  `/etc/pki/ca-trust/source/anchors` folder.

To test Certificates with multiple synchronization targets use extensions that contributes two fake targets:

* `git clone https://github.com/dgolovin/certificate-sync-provider-test-ext repository`
* `pnpm install`
* `pnpm build`

Then run podman desktop on this branch

* pnpm install
* pnpm watch --extension-folder=../certificate-sync-provider-test-ext repository
* There should be two additional targets

<img width="386" height="280" alt="image" src="https://github.com/user-attachments/assets/8e815a69-cae2-4ac9-86c1-1d571567723e" />

because it in this use case it is treated as pre-installed and trusted to access your local certificates.

If you install it as external extension form `ghcr.io/dgolovin/certificate-sync-provider-test-ext:latest` there would not be any additional sync targets, because external extensions are not trusted.

`Synchronize to` button looks different for states described below:

1. No Sync Targets state when not cert synchronization targets contributed:


<img width="444" height="280" alt="image" src="https://github.com/user-attachments/assets/58bdb132-ebbb-498e-abd4-85091741f5bd" />

2. Only one synchronization target is available:


<img width="444" height="280" alt="image" src="https://github.com/user-attachments/assets/4f62211d-a557-48cc-bf99-d0610b001fdd" />


3. When multiple synchronization targets are available, but nothing selected yet


https://github.com/user-attachments/assets/4a2b84f6-6b3b-4de4-aa10-3d712747b456


4. When multiple synchronization targets are available, but one selected


https://github.com/user-attachments/assets/16d5037b-d8d9-4d75-9412-fc3cad8de921


5. When multiple synchronization targets are available and multiple selected


https://github.com/user-attachments/assets/45c9d61c-2809-4e1a-9a8f-c8abf1550f7b


6. When multiple synchronization targets are available and nothing selected when you click button it shows selection list

Current implementation does not save selection between PD sessions


Synchronization progress is reported in Task Manager one task per each target


https://github.com/user-attachments/assets/d8d3a62d-f2ff-4e3b-9a87-4ac0ec47657d



### What issues does this PR fix or reference?

Related to #14729.

### How to test this PR?

# Testing Certificate Synchronization

This guide describes how to test the certificate synchronization feature in Podman Desktop using a local TLS registry.

## Prerequisites

- Podman Desktop installed and running
- Podman machine running (macOS/Windows) or native Podman (Linux)
- OpenSSL installed
- Administrative/sudo privileges

## Steps

### 1. Create a temporary directory for certificates

```bash
export CERT_DIR=$(mktemp -d)
```

### 2. Generate a self-signed certificate with SANs

```bash
openssl req -newkey rsa:2048 -nodes -sha256 \
  -keyout "$CERT_DIR/registry.key" -x509 -days 1 \
  -out "$CERT_DIR/registry.crt" \
  -subj "/CN=localhost" \
  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
```

### 3. Start a TLS-enabled container registry

```bash
podman rm -f test-registry 2>/dev/null || true
podman run -d --rm --name test-registry \
  -p 5443:5000 \
  -v "$CERT_DIR:/certs:Z" \
  -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/registry.crt \
  -e REGISTRY_HTTP_TLS_KEY=/certs/registry.key \
  docker.io/library/registry:2
```

Wait a few seconds for the registry to start.

### 4. Verify the certificate is NOT trusted (should fail)

```bash
podman pull localhost:5443/test:latest
```

This should fail with a certificate error, confirming the certificate is not yet trusted.

### 5. Add certificate to local trust store

#### macOS

```bash
sudo security add-trusted-cert -d -r trustRoot \
  -k /Library/Keychains/System.keychain "$CERT_DIR/registry.crt"
```

#### Linux (RHEL/Fedora/CentOS)

```bash
sudo cp "$CERT_DIR/registry.crt" /etc/pki/ca-trust/source/anchors/test-registry.crt
sudo update-ca-trust
```

#### Linux (Debian/Ubuntu)

```bash
sudo cp "$CERT_DIR/registry.crt" /usr/local/share/ca-certificates/test-registry.crt
sudo update-ca-certificates
```

#### Windows (PowerShell as Administrator)

```powershell
Import-Certificate -FilePath "C:\path\to\registry.crt" -CertStoreLocation Cert:\LocalMachine\Root
```

Or using certutil (Command Prompt as Administrator):

```cmd
certutil -addstore -f "ROOT" "C:\path\to\registry.crt"
```

### 6. Synchronize certificates to Podman VM

1. Open **Podman Desktop**
8. Navigate to **Settings → Certificates**
9. The newly added certificate should appear in the list
10. Click **"Synchronize to \<machine-name\>"** button to sync certificates to the VM

> **Note:** On Linux without a Podman VM (native Podman), certificates are already available system-wide. No synchronization is needed.

### 7. Verify the certificate IS trusted by pushing a test image

```bash
podman pull docker.io/library/alpine:latest
podman tag alpine:latest localhost:5443/test:latest
podman push localhost:5443/test:latest
```

A successful push confirms the certificate is now trusted after synchronization.

### 8. (Optional) Verify pull also works

```bash
podman rmi localhost:5443/test:latest
podman pull localhost:5443/test:latest
```

This should also succeed, further confirming the certificate synchronization worked.

## Cleanup

Stop and remove the test registry:

```bash
podman rm -f test-registry
```

Remove the certificate from the trust store:

#### macOS

```bash
sudo security delete-certificate -c "localhost" /Library/Keychains/System.keychain
```

#### Linux (RHEL/Fedora/CentOS)

```bash
sudo rm /etc/pki/ca-trust/source/anchors/test-registry.crt
sudo update-ca-trust
```

#### Linux (Debian/Ubuntu)

```bash
sudo rm /usr/local/share/ca-certificates/test-registry.crt
sudo update-ca-certificates
```

#### Windows (PowerShell as Administrator)

```powershell
Get-ChildItem Cert:\LocalMachine\Root | Where-Object { $_.Subject -eq "CN=localhost" } | Remove-Item
```

Remove the temporary directory:

```bash
rm -rf "$CERT_DIR"
```

- [ ] Tests are covering the bug fix or the new feature
