### PR TITLE
refactor(main/list-organizer): replace method only used in test by getter

### DIFF
--- a/packages/main/src/plugin/list-organizer.spec.ts
+++ b/packages/main/src/plugin/list-organizer.spec.ts
@@ -65,8 +65,14 @@ describe('ListOrganizerRegistry', () => {
     ]);
   });
 
+  // Get default configuration for a list kind
+  function getDefaultListConfig(listKind: string): SavedListOrganizerConfig[] {
+    const defaults = listOrganizerRegistry.getRegisteredLists[listKind] ?? [];
+    return defaults.map(name => ({ id: name, enabled: true }));
+  }
+
   test('should return empty defaults for unknown table types', () => {
-    const defaultConfig = listOrganizerRegistry.getDefaultListConfig('unknown');
+    const defaultConfig = getDefaultListConfig('unknown');
     expect(defaultConfig).toEqual([]);
   });
 
@@ -75,7 +81,7 @@ describe('ListOrganizerRegistry', () => {
     mockConfiguration.get.mockReturnValue([]);
     await listOrganizerRegistry.loadListConfig('container', ['Status', 'Name', 'Actions']);
 
-    const containerConfig = listOrganizerRegistry.getDefaultListConfig('container');
+    const containerConfig = getDefaultListConfig('container');
     expect(containerConfig).toEqual([
       { id: 'Status', enabled: true },
       { id: 'Name', enabled: true },
@@ -85,7 +91,7 @@ describe('ListOrganizerRegistry', () => {
     // Auto-register image layout by calling load
     await listOrganizerRegistry.loadListConfig('image', ['Status', 'Name', 'Actions']);
 
-    const imageConfig = listOrganizerRegistry.getDefaultListConfig('image');
+    const imageConfig = getDefaultListConfig('image');
     expect(imageConfig).toEqual([
       { id: 'Status', enabled: true },
       { id: 'Name', enabled: true },
@@ -205,7 +211,7 @@ describe('ListOrganizerRegistry', () => {
   });
 
   test('should handle unknown table types', () => {
-    const config = listOrganizerRegistry.getDefaultListConfig('unknown');
+    const config = getDefaultListConfig('unknown');
     expect(config).toEqual([]);
   });
 

--- a/packages/main/src/plugin/list-organizer.ts
+++ b/packages/main/src/plugin/list-organizer.ts
@@ -36,10 +36,8 @@ export class ListOrganizerRegistry implements IDisposable {
     this.#disposables = [];
   }
 
-  // Get default configuration for a list kind
-  getDefaultListConfig(listKind: string): SavedListOrganizerConfig[] {
-    const defaults = this.registeredLists[listKind] ?? [];
-    return defaults.map(name => ({ id: name, enabled: true }));
+  public get getRegisteredLists(): Record<string, string[]> {
+    return this.registeredLists;
   }
 
   // Load list configuration (with fallback to defaults)


### PR DESCRIPTION
### What does this PR do?

This PR refactors the ListOrganizerRegistry to replace a method only used in tests by a getter and moves the logic to a test file function.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15051

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
