### PR TITLE
feat: add update image ui

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -46,6 +46,7 @@ import LoadImages from './lib/image/LoadImages.svelte';
 import PullImage from './lib/image/PullImage.svelte';
 import RunImage from './lib/image/RunImage.svelte';
 import SaveImages from './lib/image/SaveImages.svelte';
+import UpdateImages from './lib/image/UpdateImages.svelte';
 import IngressDetails from './lib/ingresses-routes/IngressDetails.svelte';
 import IngressesRoutesList from './lib/ingresses-routes/IngressesRoutesList.svelte';
 import RouteDetails from './lib/ingresses-routes/RouteDetails.svelte';
@@ -220,6 +221,9 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         </Route>
         <Route path="/images/save" breadcrumb="Save Images">
           <SaveImages />
+        </Route>
+        <Route path="/images/update" breadcrumb="Update Images">
+          <UpdateImages />
         </Route>
         <Route path="/images/load" breadcrumb="Load Images">
           <LoadImages />

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-import { faArrowUp, faDownload, faEdit, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowUp,
+  faDownload,
+  faEdit,
+  faLayerGroup,
+  faPlay,
+  faSync,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons';
 import { createEventDispatcher, onMount } from 'svelte';
 import { router } from 'tinro';
 
@@ -10,6 +18,7 @@ import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { context } from '/@/stores/context';
 import { runImageInfo } from '/@/stores/run-image-store';
 import { saveImagesInfo } from '/@/stores/save-images-store';
+import { updateImagesInfo } from '/@/stores/update-images-store';
 import type { Menu } from '/@api/menu.js';
 import { MenuContext } from '/@api/menu-context.js';
 
@@ -98,6 +107,11 @@ function saveImage(): void {
   saveImagesInfo.set([image]);
   router.goto('/images/save');
 }
+
+function updateImage(): void {
+  updateImagesInfo.set([image]);
+  router.goto('/images/update');
+}
 </script>
 
 <ListItemButtonIcon title="Run Image" onClick={(): Promise<void> => runImage(image)} detailed={detailed} icon={faPlay} />
@@ -144,6 +158,14 @@ function saveImage(): void {
     menu={dropdownMenu}
     detailed={detailed}
     icon={faDownload} />
+
+  <ListItemButtonIcon
+    title="Check for Update"
+    tooltip="Check if a newer version of this image is available"
+    onClick={updateImage}
+    menu={dropdownMenu}
+    detailed={detailed}
+    icon={faSync} />
 
   <ActionsWrapper dropdownMenu={groupingContributions} dropdownMenuAsMenuActionItem={groupingContributions}>
     <ContributionActions

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowCircleDown, faCube, faDownload, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleDown, faCube, faDownload, faSync, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
 import {
   Button,
   FilteredEmptyScreen,
@@ -27,6 +27,7 @@ import { context } from '/@/stores/context';
 import { filtered, imagesInfos, searchPattern } from '/@/stores/images';
 import { providerInfos } from '/@/stores/providers';
 import { saveImagesInfo } from '/@/stores/save-images-store';
+import { updateImagesInfo } from '/@/stores/update-images-store';
 import { viewsContributions } from '/@/stores/views';
 import type { ContainerInfo } from '/@api/container-info';
 import type { ImageInfo } from '/@api/image-info';
@@ -220,6 +221,17 @@ async function saveSelectedImages(): Promise<void> {
   router.goto('/images/save');
 }
 
+// update the items selected in the list
+async function updateSelectedImages(): Promise<void> {
+  const selectedImages = images.filter(image => image.selected);
+  if (selectedImages.length === 0) {
+    return;
+  }
+
+  updateImagesInfo.set(selectedImages);
+  router.goto('/images/update');
+}
+
 let selectedItemsNumber: number | undefined = $state();
 
 let statusColumn = new TableColumn<ImageInfoUI>('Status', {
@@ -337,6 +349,11 @@ function label(item: ImageInfoUI): string {
         title="Save {selectedItemsNumber} selected items"
         aria-label="Save images"
         icon={faDownload} />
+      <Button
+        on:click={updateSelectedImages}
+        title="Update {selectedItemsNumber} selected items"
+        aria-label="Update images"
+        icon={faSync} />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
   {/snippet}

--- a/packages/renderer/src/lib/image/UpdateImageColumnEnvironment.svelte
+++ b/packages/renderer/src/lib/image/UpdateImageColumnEnvironment.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import Label from '/@/lib/ui/Label.svelte';
+import ProviderInfoCircle from '/@/lib/ui/ProviderInfoCircle.svelte';
+import { containerConnectionCount, providerInfos } from '/@/stores/providers';
+
+import type { UpdateImageInfoUI } from './UpdateImages.svelte';
+
+interface Props {
+  object: UpdateImageInfoUI;
+}
+
+let { object }: Props = $props();
+
+const [providerId, connectionName] = $derived(object.image.engineId.split('.'));
+
+const connection = $derived(
+  $providerInfos
+    .find(provider => provider.id === providerId)
+    ?.containerConnections?.find(({ name }) => name === connectionName),
+);
+
+const displayName = $derived.by(() => {
+  if (!connection) return object.image.engineId;
+
+  if ($containerConnectionCount[connection.type] > 1) return connection.displayName;
+
+  return connection.type;
+});
+</script>
+
+<Label tip={connection?.endpoint?.socketPath} name={displayName}>
+  <ProviderInfoCircle type={connection?.type} />
+</Label>

--- a/packages/renderer/src/lib/image/UpdateImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/UpdateImageColumnName.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import { formatImageDisplayName, getFullImageRef } from './update-image-util';
+import type { UpdateImageInfoUI } from './UpdateImages.svelte';
+
+interface Props {
+  object: UpdateImageInfoUI;
+}
+
+let { object }: Props = $props();
+
+let displayName = $derived(formatImageDisplayName(object.image.name, object.image.tag));
+let fullRef = $derived(getFullImageRef(object.image.name, object.image.tag));
+</script>
+
+<div class="flex flex-col max-w-full">
+  <div class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis whitespace-nowrap" title={fullRef}>
+    {displayName}
+  </div>
+  <div class="flex flex-row text-sm gap-1 w-full">
+    <div class="text-[var(--pd-table-body-text-sub-secondary)]">{object.image.shortId}</div>
+    <div class="font-extra-light text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">{object.image.tag}</div>
+  </div>
+</div>

--- a/packages/renderer/src/lib/image/UpdateImageColumnResult.svelte
+++ b/packages/renderer/src/lib/image/UpdateImageColumnResult.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+import { Spinner } from '@podman-desktop/ui-svelte';
+
+import Label from '/@/lib/ui/Label.svelte';
+
+import { getResultStyle } from './update-image-util';
+import type { UpdateImageInfoUI } from './UpdateImages.svelte';
+
+interface Props {
+  object: UpdateImageInfoUI;
+}
+
+let { object }: Props = $props();
+
+let resultStyle = $derived(getResultStyle(object.updating, object.updated, object.error));
+</script>
+
+<div class="flex flex-col gap-1">
+  {#if object.updating}
+    <Label role="status" name="Updating">
+      <Spinner size="12" />
+    </Label>
+  {:else if resultStyle}
+    <Label role="status" name={resultStyle.label}>
+      <div class="w-2 h-2 shrink-0 {resultStyle.dotColor} rounded-full"></div>
+    </Label>
+    {#if object.error}
+      <div 
+        class="text-xs text-[var(--pd-status-terminated)] truncate max-w-[200px]" 
+        title={object.error}>
+        {object.error}
+      </div>
+    {/if}
+  {:else}
+    <span class="text-[var(--pd-table-body-text-secondary)]">-</span>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/image/UpdateImageColumnSize.svelte
+++ b/packages/renderer/src/lib/image/UpdateImageColumnSize.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+import type { UpdateImageInfoUI } from './UpdateImages.svelte';
+
+interface Props {
+  object: UpdateImageInfoUI;
+}
+
+let { object }: Props = $props();
+</script>
+
+<div class="mx-1 text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis whitespace-nowrap">
+  <span title={object.image.humanSize}>{object.image.humanSize}</span>
+</div>

--- a/packages/renderer/src/lib/image/UpdateImageColumnStatus.svelte
+++ b/packages/renderer/src/lib/image/UpdateImageColumnStatus.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import Label from '/@/lib/ui/Label.svelte';
+
+import { getUpdateAvailableStyle } from './update-image-util';
+import type { UpdateImageInfoUI } from './UpdateImages.svelte';
+
+interface Props {
+  object: UpdateImageInfoUI;
+}
+
+let { object }: Props = $props();
+
+let statusStyle = $derived(getUpdateAvailableStyle(object.status));
+</script>
+
+<div class="flex flex-col gap-1 items-start text-left">
+  <div class="flex items-start">
+    <Label role="status" name={statusStyle.label}>
+      <div class="w-2 h-2 shrink-0 {statusStyle.dotColor} rounded-full"></div>
+    </Label>
+  </div>
+  {#if !object.status?.updateAvailable && object.status?.message}
+    <div 
+      class="text-xs text-[var(--pd-table-body-text-secondary)] truncate" 
+      title={object.status.message}>
+      {object.status.message}
+    </div>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/image/UpdateImages.spec.ts
+++ b/packages/renderer/src/lib/image/UpdateImages.spec.ts
@@ -1,0 +1,219 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { tick } from 'svelte';
+import { router } from 'tinro';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+
+import { imagesInfos } from '/@/stores/images';
+import { providerInfos } from '/@/stores/providers';
+import { updateImagesInfo } from '/@/stores/update-images-store';
+import type { ImageInfo } from '/@api/image-info';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
+
+import type { ImageInfoUI } from './ImageInfoUI';
+import UpdateImages from './UpdateImages.svelte';
+
+const imageInfo: ImageInfoUI = {
+  id: 'sha256:abc123',
+  shortId: 'abc123',
+  name: 'nginx',
+  tag: 'latest',
+  engineId: 'podman.podman-machine-default',
+  engineName: 'Podman Machine',
+  status: 'UNUSED',
+} as ImageInfoUI;
+
+const imageInfo2: ImageInfoUI = {
+  id: 'sha256:def456',
+  shortId: 'def456',
+  name: 'redis',
+  tag: '7',
+  engineId: 'podman.podman-machine-default',
+  engineName: 'Podman Machine',
+  status: 'UNUSED',
+} as ImageInfoUI;
+
+const providerConnection: ProviderContainerConnectionInfo = {
+  name: 'podman-machine-default',
+  status: 'started',
+  type: 'podman',
+} as ProviderContainerConnectionInfo;
+
+const provider: ProviderInfo = {
+  id: 'podman',
+  containerConnections: [providerConnection],
+} as ProviderInfo;
+
+const imageInfoFromStore: ImageInfo = {
+  Id: 'sha256:abc123',
+  RepoDigests: ['nginx@sha256:olddigest'],
+} as ImageInfo;
+
+beforeAll(() => {
+  (window as unknown as Record<string, unknown>).checkImageUpdateStatus = vi.fn();
+  (window as unknown as Record<string, unknown>).pullImage = vi.fn();
+  (window as unknown as Record<string, unknown>).deleteImage = vi.fn();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(window.checkImageUpdateStatus).mockResolvedValue({
+    status: 'normal',
+    updateAvailable: false,
+    message: 'Image is already the latest version',
+  });
+  vi.mocked(window.pullImage).mockResolvedValue();
+  vi.mocked(window.deleteImage).mockResolvedValue();
+  providerInfos.set([provider]);
+  imagesInfos.set([imageInfoFromStore]);
+});
+
+async function waitRender(): Promise<void> {
+  render(UpdateImages);
+  // Wait for the component to mount and auto-check to complete
+  await tick();
+  await tick();
+  await tick();
+}
+
+test('Expect redirect to /images/ if no images selected', async () => {
+  const goToMock = vi.spyOn(router, 'goto');
+  updateImagesInfo.set([]);
+  await waitRender();
+
+  expect(goToMock).toHaveBeenCalledWith('/images/');
+});
+
+test('Expect Update button is disabled when no updates available', async () => {
+  // Default mock returns updateAvailable: false
+  updateImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  const updateButton = screen.getByRole('button', { name: 'Update images' });
+  expect(updateButton).toBeInTheDocument();
+  expect(updateButton).toBeDisabled();
+});
+
+test('Expect Done button is present and enabled', async () => {
+  updateImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  const doneButton = screen.getByRole('button', { name: 'Done' });
+  expect(doneButton).toBeInTheDocument();
+  expect(doneButton).toBeEnabled();
+});
+
+test('Expect Done button navigates to /images/', async () => {
+  const goToMock = vi.spyOn(router, 'goto');
+  updateImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  const doneButton = screen.getByRole('button', { name: 'Done' });
+  await userEvent.click(doneButton);
+
+  expect(goToMock).toHaveBeenCalledWith('/images/');
+});
+
+test('Expect images displayed in table', async () => {
+  updateImagesInfo.set([imageInfo, imageInfo2]);
+  await waitRender();
+
+  expect(screen.getByText('nginx:latest')).toBeInTheDocument();
+  expect(screen.getByText('redis:7')).toBeInTheDocument();
+});
+
+test('Expect checkImageUpdateStatus called automatically on mount', async () => {
+  updateImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  expect(vi.mocked(window.checkImageUpdateStatus)).toHaveBeenCalledWith('nginx:latest', 'latest', [
+    'nginx@sha256:olddigest',
+  ]);
+});
+
+test('Expect Update button enabled when updates are available', async () => {
+  vi.mocked(window.checkImageUpdateStatus).mockResolvedValue({
+    status: 'normal',
+    updateAvailable: true,
+    remoteDigest: 'sha256:newdigest',
+    message: 'A new version is available',
+  });
+
+  updateImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  const updateButton = screen.getByRole('button', { name: 'Update images' });
+  expect(updateButton).toBeEnabled();
+});
+
+test('Expect pullImage called when updating (no delete needed)', async () => {
+  vi.mocked(window.checkImageUpdateStatus).mockResolvedValue({
+    status: 'normal',
+    updateAvailable: true,
+    remoteDigest: 'sha256:newdigest',
+    message: 'A new version is available',
+  });
+
+  updateImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  // Update button should be enabled after auto-check
+  const updateButton = screen.getByRole('button', { name: 'Update images' });
+  await userEvent.click(updateButton);
+  await tick();
+  await tick();
+
+  // Only pull is called - the pull automatically re-tags to the new image
+  expect(vi.mocked(window.pullImage)).toHaveBeenCalledWith(providerConnection, 'nginx:latest', expect.any(Function));
+  // deleteImage should NOT be called - pulling automatically handles the tag
+  expect(vi.mocked(window.deleteImage)).not.toHaveBeenCalled();
+});
+
+test('Expect status columns show correct values after auto-check', async () => {
+  vi.mocked(window.checkImageUpdateStatus).mockResolvedValue({
+    status: 'normal',
+    updateAvailable: true,
+    remoteDigest: 'sha256:newdigest',
+    message: 'A new version is available',
+  });
+
+  updateImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  expect(screen.getByText('Available')).toBeInTheDocument();
+  expect(screen.getByText('A new version is available')).toBeInTheDocument();
+});
+
+test('Expect error status displayed correctly', async () => {
+  vi.mocked(window.checkImageUpdateStatus).mockResolvedValue({
+    status: 'error',
+    updateAvailable: false,
+    message: 'Authentication failed',
+  });
+
+  updateImagesInfo.set([imageInfo]);
+  await waitRender();
+
+  expect(screen.getByText('Error')).toBeInTheDocument();
+  expect(screen.getByText('Authentication failed')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/image/UpdateImages.svelte
+++ b/packages/renderer/src/lib/image/UpdateImages.svelte
@@ -1,0 +1,332 @@
+<script lang="ts">
+import { faSync } from '@fortawesome/free-solid-svg-icons';
+import { Button, ErrorMessage, Spinner } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+import { router } from 'tinro';
+
+import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
+import Label from '/@/lib/ui/Label.svelte';
+import { imagesInfos } from '/@/stores/images';
+import { providerInfos } from '/@/stores/providers';
+import { updateImagesInfo } from '/@/stores/update-images-store';
+import type { ImageInfo } from '/@api/image-info';
+import type { ImageUpdateStatus } from '/@api/image-registry';
+import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
+
+import type { ImageInfoUI } from './ImageInfoUI';
+
+interface ImageUpdateInfo {
+  image: ImageInfoUI;
+  status?: ImageUpdateStatus;
+  updating: boolean;
+  updated: boolean;
+  error?: string;
+}
+
+let imagesToUpdate: ImageUpdateInfo[] = $state([]);
+let checkError = $state('');
+let updateError = $state('');
+
+let updateInProgress = $state(false);
+let hasChecked = $state(false);
+
+// Get all started provider connections
+let providerConnections = $derived(
+  $providerInfos
+    .map(provider => provider.containerConnections)
+    .flat()
+    .filter(connection => connection.status === 'started'),
+);
+
+// Get all images from the store to lookup RepoDigests
+let allImages = $derived($imagesInfos);
+
+// Count of images that can be updated
+let updatableCount = $derived(imagesToUpdate.filter(info => info.status?.updateAvailable && !info.updated).length);
+
+onMount(() => {
+  const selectedImages = $updateImagesInfo;
+  if (selectedImages.length === 0) {
+    router.goto('/images/');
+    return;
+  }
+  imagesToUpdate = selectedImages.map(image => ({
+    image,
+    updating: false,
+    updated: false,
+  }));
+
+  // Clear the store to avoid stale data on subsequent navigations
+  updateImagesInfo.set([]);
+
+  // Automatically check for updates on page load
+  checkForUpdates().catch((err: unknown) => {
+    checkError = err instanceof Error ? err.message : String(err);
+  });
+});
+
+function goBack(): void {
+  router.goto('/images/');
+}
+
+// Find the ImageInfo from store to get RepoDigests
+function getImageInfo(imageUI: ImageInfoUI): ImageInfo | undefined {
+  return allImages.find(img => img.Id === imageUI.id);
+}
+
+// Find the provider connection for an image using engineId
+// engineId format is "${providerId}.${connectionName}" (e.g., "podman.podman-machine-default")
+function getProviderConnection(engineId: string): ProviderContainerConnectionInfo | undefined {
+  // Split engineId to get provider id and connection name
+  const dotIndex = engineId.indexOf('.');
+  if (dotIndex === -1) {
+    // Fallback: try to match by name directly
+    return providerConnections.find(conn => conn.name === engineId);
+  }
+
+  const providerId = engineId.substring(0, dotIndex);
+  const connectionName = engineId.substring(dotIndex + 1);
+
+  // Find the provider by id and then the connection by name
+  const provider = $providerInfos.find(p => p.id === providerId);
+  if (provider) {
+    return provider.containerConnections.find(conn => conn.name === connectionName && conn.status === 'started');
+  }
+
+  return undefined;
+}
+
+async function checkForUpdates(): Promise<void> {
+  checkError = '';
+
+  try {
+    for (const info of imagesToUpdate) {
+      const imageRef = `${info.image.name}:${info.image.tag}`;
+      const imageInfo = getImageInfo(info.image);
+      const localDigests = imageInfo?.RepoDigests ?? [];
+
+      try {
+        const status = await window.checkImageUpdateStatus(imageRef, info.image.tag, localDigests);
+        info.status = status;
+      } catch (err: unknown) {
+        info.status = {
+          status: 'error',
+          updateAvailable: false,
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }
+    hasChecked = true;
+  } catch (err: unknown) {
+    checkError = err instanceof Error ? err.message : String(err);
+  }
+}
+
+async function updateImages(): Promise<void> {
+  updateError = '';
+  updateInProgress = true;
+
+  try {
+    for (const info of imagesToUpdate) {
+      // Skip if not updatable or already updated
+      if (!info.status?.updateAvailable || info.updated) {
+        continue;
+      }
+
+      const providerConnection = getProviderConnection(info.image.engineId);
+      if (!providerConnection) {
+        const availableConnections = providerConnections.map(c => c.name).join(', ');
+        console.error(
+          `No provider connection found for engineId "${info.image.engineId}". Available: ${availableConnections}`,
+        );
+        info.error = `No provider connection found for engineId "${info.image.engineId}". Available connections: ${availableConnections}`;
+        continue;
+      }
+
+      info.updating = true;
+      info.error = undefined;
+
+      try {
+        const imageRef = `${info.image.name}:${info.image.tag}`;
+        console.log(`Updating image ${imageRef} from engine ${info.image.engineId}`);
+
+        // Pull the new image - this automatically re-tags to the new image
+        // The old image will become dangling if this was its only tag,
+        // or keep its other tags if it had multiple (e.g., alpine:2.6)
+        console.log(`Pulling image ${imageRef}...`);
+        await window.pullImage(providerConnection, imageRef, () => {});
+        console.log(`Pull complete for ${imageRef}`);
+
+        info.updated = true;
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        console.error(`Failed to update image ${info.image.name}:${info.image.tag}:`, err);
+        info.error = errorMessage;
+      } finally {
+        info.updating = false;
+      }
+    }
+  } catch (err: unknown) {
+    updateError = err instanceof Error ? err.message : String(err);
+  } finally {
+    updateInProgress = false;
+  }
+}
+
+interface LabelStatusStyle {
+  dotColor: string;
+  label: string;
+}
+
+function getUpdateAvailableStyle(imgstatus?: ImageUpdateStatus): LabelStatusStyle {
+  if (!imgstatus) {
+    return {
+      dotColor: 'bg-[var(--pd-status-paused)]',
+      label: 'Checking',
+    };
+  }
+  if (imgstatus.status === 'error') {
+    return {
+      dotColor: 'bg-[var(--pd-status-terminated)]',
+      label: 'Error',
+    };
+  }
+  if (imgstatus.updateAvailable) {
+    return {
+      dotColor: 'bg-[var(--pd-status-connected)]',
+      label: 'Available',
+    };
+  }
+  // Check if the image cannot be checked (local, dangling, or immutable)
+  if (imgstatus.status === 'skipped') {
+    return {
+      dotColor: 'bg-[var(--pd-status-stopped)]',
+      label: 'N/A',
+    };
+  }
+  return {
+    dotColor: 'bg-[var(--pd-status-stopped)]',
+    label: 'Up to date',
+  };
+}
+
+function getResultStyle(info: ImageUpdateInfo): LabelStatusStyle | undefined {
+  if (info.updating) {
+    return {
+      dotColor: 'bg-[var(--pd-status-starting)]',
+      label: 'Updating',
+    };
+  }
+  if (info.updated) {
+    return {
+      dotColor: 'bg-[var(--pd-status-connected)]',
+      label: 'Updated',
+    };
+  }
+  if (info.error) {
+    return {
+      dotColor: 'bg-[var(--pd-status-terminated)]',
+      label: 'Failed',
+    };
+  }
+  return undefined;
+}
+</script>
+
+<EngineFormPage title="Update Images">
+  {#snippet icon()}
+    <i class="fas fa-sync fa-2x" aria-hidden="true"></i>
+  {/snippet}
+  {#snippet content()}
+    <div class="flex flex-col gap-4">
+      <!-- Images Table -->
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm text-left text-[var(--pd-table-body-text)]" aria-label="images to update">
+          <thead class="text-xs uppercase bg-[var(--pd-table-header-bg)] text-[var(--pd-table-header-text)]">
+            <tr>
+              <th class="px-4 py-3">Image</th>
+              <th class="px-4 py-3">Update Available</th>
+              <th class="px-4 py-3">Message</th>
+              <th class="px-4 py-3">Result</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each imagesToUpdate as info (info.image.id + info.image.engineId + info.image.tag)}
+              {@const isDigest = info.image.tag.startsWith('sha256:') || info.image.tag.startsWith('sha384:') || info.image.tag.startsWith('sha512:')}
+              {@const displayTag = isDigest ? '' : `:${info.image.tag}`}
+              {@const imageDisplay = `${info.image.name}${displayTag}`}
+              {@const fullImageRef = `${info.image.name}:${info.image.tag}`}
+              {@const updateStyle = getUpdateAvailableStyle(info.status)}
+              {@const resultStyle = getResultStyle(info)}
+              <tr class="border-b border-[var(--pd-table-body-text-secondary)] bg-[var(--pd-content-bg)]" aria-label="image {fullImageRef}">
+                <td class="px-4 py-3 font-medium whitespace-nowrap" title={fullImageRef}>
+                  {imageDisplay.length > 50 ? imageDisplay.slice(0, 47) + '...' : imageDisplay}
+                </td>
+                <td class="px-4 py-3" aria-label="update status {updateStyle.label}">
+                  <Label role="status" name={updateStyle.label}>
+                    <div class="w-2 h-2 shrink-0 {updateStyle.dotColor} rounded-full"></div>
+                  </Label>
+                </td>
+                <td class="px-4 py-3 max-w-xs truncate text-[var(--pd-table-body-text-secondary)]" aria-label="message" title={info.status?.message ?? ''}>
+                  {info.status?.message ?? '-'}
+                </td>
+                <td class="px-4 py-3 max-w-xs" aria-label="result {resultStyle?.label ?? 'pending'}">
+                  {#if info.updating}
+                    <Label role="status" name="Updating">
+                      <Spinner size="12" />
+                    </Label>
+                  {:else if resultStyle}
+                    <Label role="status" name={resultStyle.label}>
+                      <div class="w-2 h-2 shrink-0 {resultStyle.dotColor} rounded-full"></div>
+                    </Label>
+                    {#if info.error}
+                      <div class="text-xs text-[var(--pd-status-terminated)] truncate mt-1" aria-label="error" title={info.error}>
+                        {info.error}
+                      </div>
+                    {/if}
+                  {:else}
+                    <span class="text-[var(--pd-table-body-text-secondary)]">-</span>
+                  {/if}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Action Buttons -->
+      <div class="w-full flex flex-row space-x-4 pt-4">
+        <Button
+          type="secondary"
+          class="w-full"
+          on:click={goBack}
+          aria-label="Done"
+          disabled={updateInProgress}>
+          Done
+        </Button>
+        <Button
+          class="w-full"
+          on:click={updateImages}
+          inProgress={updateInProgress}
+          icon={faSync}
+          aria-label="Update images"
+          disabled={!hasChecked || updatableCount === 0 || updateInProgress}>
+          Update {updatableCount} Image{updatableCount !== 1 ? 's' : ''}
+        </Button>
+      </div>
+
+      <!-- Error Messages -->
+      <div aria-label="checkError">
+        {#if checkError}
+          <ErrorMessage error={checkError} />
+        {/if}
+      </div>
+      <div aria-label="updateError">
+        {#if updateError}
+          <ErrorMessage error={updateError} />
+        {/if}
+      </div>
+    </div>
+  {/snippet}
+</EngineFormPage>
+

--- a/packages/renderer/src/lib/image/update-image-util.ts
+++ b/packages/renderer/src/lib/image/update-image-util.ts
@@ -1,0 +1,106 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ImageUpdateStatus } from '/@api/image-registry';
+
+export interface UpdateStatusStyle {
+  dotColor: string;
+  label: string;
+}
+
+/**
+ * Get display style for update availability status
+ */
+export function getUpdateAvailableStyle(status?: ImageUpdateStatus): UpdateStatusStyle {
+  if (!status) {
+    return {
+      dotColor: 'bg-[var(--pd-status-paused)]',
+      label: 'Checking',
+    };
+  }
+  if (status.status === 'error') {
+    return {
+      dotColor: 'bg-[var(--pd-status-terminated)]',
+      label: 'Error',
+    };
+  }
+  if (status.updateAvailable) {
+    return {
+      dotColor: 'bg-[var(--pd-status-connected)]',
+      label: 'Available',
+    };
+  }
+  // Check if the image cannot be checked (local, dangling, or immutable)
+  if (status.status === 'skipped') {
+    return {
+      dotColor: 'bg-[var(--pd-status-stopped)]',
+      label: 'N/A',
+    };
+  }
+  return {
+    dotColor: 'bg-[var(--pd-status-stopped)]',
+    label: 'Up to date',
+  };
+}
+
+export interface ResultStatusStyle {
+  dotColor: string;
+  label: string;
+}
+
+/**
+ * Get display style for update result
+ */
+export function getResultStyle(updating: boolean, updated: boolean, error?: string): ResultStatusStyle | undefined {
+  if (updating) {
+    return {
+      dotColor: 'bg-[var(--pd-status-starting)]',
+      label: 'Updating',
+    };
+  }
+  if (updated) {
+    return {
+      dotColor: 'bg-[var(--pd-status-connected)]',
+      label: 'Updated',
+    };
+  }
+  if (error) {
+    return {
+      dotColor: 'bg-[var(--pd-status-terminated)]',
+      label: 'Failed',
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Format image display name, truncating if needed
+ */
+export function formatImageDisplayName(name: string, tag: string, maxLength = 50): string {
+  const isDigest = tag.startsWith('sha256:') || tag.startsWith('sha384:') || tag.startsWith('sha512:');
+  const displayTag = isDigest ? '' : `:${tag}`;
+  const fullDisplay = `${name}${displayTag}`;
+  return fullDisplay.length > maxLength ? fullDisplay.slice(0, maxLength - 3) + '...' : fullDisplay;
+}
+
+/**
+ * Get full image reference
+ */
+export function getFullImageRef(name: string, tag: string): string {
+  return `${name}:${tag}`;
+}

--- a/packages/renderer/src/stores/update-images-store.spec.ts
+++ b/packages/renderer/src/stores/update-images-store.spec.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { get } from 'svelte/store';
+import { afterEach, expect, test } from 'vitest';
+
+import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
+
+import { updateImagesInfo } from './update-images-store';
+
+const imageInfo: ImageInfoUI = {
+  id: 'id',
+} as ImageInfoUI;
+
+afterEach(() => {
+  // Reset store to avoid state leakage between tests
+  updateImagesInfo.set([]);
+});
+
+test('check that update image store is filled', async () => {
+  // initial images
+  updateImagesInfo.set([imageInfo]);
+  const imageInfoInStore = get(updateImagesInfo);
+  expect(imageInfoInStore.length).equal(1);
+  expect(imageInfoInStore[0]).equal(imageInfo);
+});

--- a/packages/renderer/src/stores/update-images-store.ts
+++ b/packages/renderer/src/stores/update-images-store.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
+
+import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
+
+/**
+ * Defines the store used to define the images to update.
+ */
+export const updateImagesInfo: Writable<ImageInfoUI[]> = writable([]);


### PR DESCRIPTION
### What does this PR do?

the ui is a table that shows the image information
that related to retrieval of the update. allows users
to visual see what images can and cant be updated and why

### Screenshot / video of UI

https://github.com/user-attachments/assets/04aae497-3f98-49eb-b6ef-d7f21bb0f20e

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Depends on: https://github.com/podman-desktop/podman-desktop/pull/15363

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

rebase ontop of https://github.com/podman-desktop/podman-desktop/pull/15363 
Try updating an image

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
