### PR TITLE
feat: register features declared by extensions

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2025 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { Certificates } from '/@/plugin/certificates.js';
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
 import type { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
+import type { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import type { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
@@ -155,6 +156,10 @@ const configurationRegistry: ConfigurationRegistry = {
 const imageRegistry: ImageRegistry = {
   registerRegistry: vi.fn(),
 } as unknown as ImageRegistry;
+
+const featureRegistry: FeatureRegistry = {
+  registerFeatures: vi.fn(),
+} as unknown as FeatureRegistry;
 
 const apiSender: ApiSenderType = { send: vi.fn() } as unknown as ApiSenderType;
 
@@ -382,6 +387,7 @@ beforeEach(() => {
     extensionDevelopmentFolder,
     extensionAnalyzer,
     extensionApiVersion,
+    featureRegistry,
   );
 });
 
@@ -773,6 +779,40 @@ test('Verify extension do not add configuration to subscriptions', async () => {
 
   await extensionLoader.deactivateExtension(id);
   expect(disposable.dispose).not.toHaveBeenCalled();
+});
+
+test('Verify extension activate registers extension features and the disposable is added to subscriptions', async () => {
+  const id = 'extension.foo';
+  const subscriptions: Disposable[] = [];
+  const disposable = {
+    dispose: vi.fn(),
+  } as unknown as Disposable;
+  vi.mocked(featureRegistry.registerFeatures).mockReturnValue(disposable);
+  const analyzedExtension: AnalyzedExtension = {
+    id: id,
+    name: 'id',
+    path: 'dummy',
+    api: {} as typeof containerDesktopAPI,
+    mainPath: '',
+    removable: false,
+    devMode: false,
+    manifest: {
+      contributes: {
+        features: ['feature1', 'feature2'],
+      },
+    },
+    subscriptions,
+    readme: '',
+    dispose: vi.fn(),
+  };
+
+  expect(featureRegistry.registerFeatures).not.toHaveBeenCalled();
+  expect(subscriptions.length).toBe(0);
+  await extensionLoader.activateExtension(analyzedExtension, {});
+
+  expect(featureRegistry.registerFeatures).toHaveBeenCalledWith(id, ['feature1', 'feature2']);
+  expect(subscriptions.length).greaterThanOrEqual(1);
+  expect(subscriptions[0]).toBe(disposable);
 });
 
 test('Verify disable extension updates configuration', async () => {

--- a/packages/main/src/plugin/feature-registry.spec.ts
+++ b/packages/main/src/plugin/feature-registry.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { FeatureRegistry } from '/@/plugin/feature-registry.js';
+
+class TestFeatureRegistry extends FeatureRegistry {
+  public override listFeatures(): string[] {
+    return super.listFeatures();
+  }
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('FeatureRegistry', () => {
+  let featureRegistry: TestFeatureRegistry;
+
+  beforeEach(() => {
+    featureRegistry = new TestFeatureRegistry();
+  });
+
+  test('should list registered features', () => {
+    expect(featureRegistry.listFeatures()).toEqual([]);
+    const dispose1 = featureRegistry.registerFeatures('extensionId1', ['feature1', 'feature2']);
+    const dispose2 = featureRegistry.registerFeatures('extensionId2', ['feature3', 'feature4']);
+    expect(featureRegistry.listFeatures()).toEqual(['feature1', 'feature2', 'feature3', 'feature4']);
+    dispose1.dispose();
+    expect(featureRegistry.listFeatures()).toEqual(['feature3', 'feature4']);
+    dispose2.dispose();
+    expect(featureRegistry.listFeatures()).toEqual([]);
+  });
+
+  test('handler passed to onFeaturesUpdatedis called when features are registered and unregistered', () => {
+    const listener: (features: string[]) => void = vi.fn();
+    featureRegistry.onFeaturesUpdated(listener);
+    expect(listener).not.toHaveBeenCalled();
+
+    const dispose1 = featureRegistry.registerFeatures('extensionId1', ['feature1', 'feature2']);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(['feature1', 'feature2']);
+
+    vi.mocked(listener).mockClear();
+    const dispose2 = featureRegistry.registerFeatures('extensionId2', ['feature3', 'feature4']);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(['feature1', 'feature2', 'feature3', 'feature4']);
+
+    vi.mocked(listener).mockClear();
+    dispose1.dispose();
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(['feature3', 'feature4']);
+
+    vi.mocked(listener).mockClear();
+    dispose2.dispose();
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith([]);
+  });
+});

--- a/packages/main/src/plugin/feature-registry.spec.ts
+++ b/packages/main/src/plugin/feature-registry.spec.ts
@@ -48,7 +48,7 @@ describe('FeatureRegistry', () => {
     expect(featureRegistry.listFeatures()).toEqual([]);
   });
 
-  test('handler passed to onFeaturesUpdatedis called when features are registered and unregistered', () => {
+  test('handler passed to onFeaturesUpdated is called when features are registered and unregistered', () => {
     const listener: (features: string[]) => void = vi.fn();
     featureRegistry.onFeaturesUpdated(listener);
     expect(listener).not.toHaveBeenCalled();

--- a/packages/main/src/plugin/feature-registry.ts
+++ b/packages/main/src/plugin/feature-registry.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { injectable } from 'inversify';
+
+import { Emitter } from '/@/plugin/events/emitter.js';
+import { Event } from '/@api/event.js';
+
+import { Disposable } from './types/disposable.js';
+
+@injectable()
+export class FeatureRegistry {
+  private extFeaturesContribution: Map<string, string[]>;
+
+  private readonly _onFeaturesUpdated = new Emitter<string[]>();
+  readonly onFeaturesUpdated: Event<string[]> = this._onFeaturesUpdated.event;
+
+  constructor() {
+    this.extFeaturesContribution = new Map();
+  }
+
+  registerFeatures(extensionId: string, features: string[]): Disposable {
+    this.extFeaturesContribution.set(extensionId, features);
+    this._onFeaturesUpdated.fire(this.listFeatures());
+
+    return Disposable.create(() => {
+      this.unregisterFeatures(extensionId);
+    });
+  }
+
+  unregisterFeatures(extensionId: string): void {
+    this.extFeaturesContribution.delete(extensionId);
+    this._onFeaturesUpdated.fire(this.listFeatures());
+  }
+
+  protected listFeatures(): string[] {
+    return Array.from(this.extFeaturesContribution.values()).flat();
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -54,6 +54,7 @@ import { ContainerfileParser } from '/@/plugin/containerfile-parser.js';
 import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionWatcher } from '/@/plugin/extension/extension-watcher.js';
+import { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { LockedConfiguration } from '/@/plugin/locked-configuration.js';
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
@@ -556,6 +557,8 @@ export class PluginSystem {
     container.bind<KubernetesClient>(KubernetesClient).toSelf().inSingletonScope();
     const kubernetesClient = container.get<KubernetesClient>(KubernetesClient);
     await kubernetesClient.init();
+
+    container.bind<FeatureRegistry>(FeatureRegistry).toSelf().inSingletonScope();
 
     container.bind<CloseBehavior>(CloseBehavior).toSelf().inSingletonScope();
     const closeBehaviorConfiguration = container.get<CloseBehavior>(CloseBehavior);


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

An extension can now contribute "Features".

When an extension is activated, the features contributed by the extensions are registered, so the core can use the `onFeaturesUpdated` event handler to activate or deactivate the internal implementation of the feature. 


This is necessary for #15723, following the proposal described in https://github.com/podman-desktop/podman-desktop/issues/15723#issuecomment-3755287817

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of #15723

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
