### PR TITLE
fix(renderer/extensions): display error when progress is 100 but error

### DIFF
--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -238,7 +238,7 @@ test('form should be in error even if log reached 100%', async () => {
   await userEvent.click(installButton);
 
   // Simulate 100% log
-  logCallback('Downloading sha256:random-sha256.tar - 100% - (55132/521578)');
+  logCallback('Downloading sha256:random-sha256.tar - 100% - (521578/521578)');
   const progressBar = getByRole('progressbar', { name: 'Installation progress' });
   await vi.waitFor(() => {
     expect(progressBar).toHaveStyle({ width: '100%' });

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -90,6 +90,8 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
     }
   }
 }
+
+const showForm = $derived(installInProgress || progressPercent !== 100 || !!inputfieldError);
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -102,7 +104,7 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
       <div>
         <label for="imageName" class="block pb-2 text-[var(--pd-modal-text)]">OCI Image:</label>
         <div class="min-h-14">
-          {#if installInProgress || progressPercent !== 100}
+          {#if showForm}
             <Input
               bind:value={imageName}
               name="imageName"
@@ -141,14 +143,13 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
       <Button
         type="link"
         on:click={closeCallback}>Cancel</Button>
-      {#if installInProgress || progressPercent !== 100}
+      {#if showForm}
         <Button
           icon={faCloudDownload}
           disabled={inputfieldError !== undefined}
           on:click={installExtension}
           inProgress={installInProgress}>Install</Button>
-      {/if}
-      {#if !installInProgress && progressPercent === 100}
+      {:else}
         <Button on:click={closeCallback}>Done</Button>
       {/if}
     


### PR DESCRIPTION
### What does this PR do?

While working on https://github.com/podman-desktop/podman-desktop/issues/15423, I noticed that the error in the manual extension installation form was not displayed if the percentage of download had reached 100% but the error happened after the download (in my case reading the downloaded files and seeing the extension package.json collides). This PR fixes this and introduces a derived value to know whether the form should be displayed.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for #15423

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

I added UT but it will be easier to test with the next PR that fixes the issue #15423

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
