### PR TITLE
fix(main/extension-installer): check extension in image does not collide with installed one

### DIFF
--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -31,6 +31,7 @@ import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalo
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { ExtensionInfo } from '/@api/extension-info.js';
 
 import { ContributionManager } from '../contribution-manager.js';
 import { DockerDesktopContribution, DockerDesktopInstaller } from '../docker-extension/docker-desktop-installer.js';
@@ -187,8 +188,9 @@ export class ExtensionInstaller {
     const finalFolderPath = path.join(unpackedFolder, imageNameWithoutSpecialChars);
 
     // grab all extensions
+    let extensions: ExtensionInfo[] = [];
     if (isPDExtension) {
-      const extensions = await this.extensionLoader.listExtensions();
+      extensions = await this.extensionLoader.listExtensions();
 
       // check if the extension is already installed for that path
       const alreadyInstalledExtension = extensions.find(extension => extension.path === finalFolderPath);
@@ -229,6 +231,10 @@ export class ExtensionInstaller {
       }
       if (analyzedExtension?.error) {
         sendError('Could not load extension: ' + analyzedExtension?.error);
+        return;
+      }
+      if (extensions.find(extension => extension.id === analyzedExtension?.id)) {
+        sendError(`Extension ${analyzedExtension?.id} is already installed.`);
         return;
       }
       return analyzedExtension;


### PR DESCRIPTION
### What does this PR do?

This PR ensures the extension being installed does not collide with the installed one. This is possible now when installing a custom extension. The collision is checked in this PR on the extension publisher and name as suggested here https://github.com/podman-desktop/podman-desktop/issues/15423#issue-3748463848. In this case, the installation form now displays an error message (see video below).

Requires a rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/15739 is merged

### Screenshot / video of UI

https://github.com/user-attachments/assets/9c386f84-7a9b-4e8c-bed7-5a81dd36fd10


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15423

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- Install extension "Bootable Container extension" from the Catalog of Podman Desktop. Check the extension status is Active.
- Click "Install custom..." top-right button. Enter following URL: 
```
ghcr.io/podman-desktop/podman-desktop-extension-bootc:nightly
```
- Click the "Install" button and check that the error message appears (see video above for an example).

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
