### PR TITLE
feat(renderer): adding confirmation dialog when deleting connection

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -4,6 +4,7 @@ import { Buffer } from 'buffer';
 import type { Snippet } from 'svelte';
 import { router } from 'tinro';
 
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import LoadingIconButton from '/@/lib/ui/LoadingIconButton.svelte';
 import type { ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
@@ -190,7 +191,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
         {/if}
         {#if connection.lifecycleMethods.includes('delete')}
           <LoadingIconButton
-            clickAction={(): Promise<void> => deleteConnectionProvider(provider, connection)}
+            clickAction={withConfirmation.bind(undefined, deleteConnectionProvider.bind(undefined, provider, connection), `delete ${connection.name}`)}
             action="delete"
             icon={faTrash}
             state={connectionStatus}

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -25,7 +25,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import { providerInfos } from '/@/stores/providers';
@@ -58,6 +58,14 @@ const EMPTY_PROVIDER_MOCK: ProviderInfo = {
   extensionId: '',
   cleanupSupport: false,
 };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(window.showMessageBox).mockResolvedValue({
+    response: 0,
+  });
+});
 
 test('Expect that the right machine is displayed', async () => {
   const socketPath = '/my/common-socket-path';

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
@@ -25,12 +25,20 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 import type { ProviderInfo } from '/@api/provider-info';
 
 import PreferencesKubernetesConnectionRendering from './PreferencesKubernetesConnectionRendering.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(window.showMessageBox).mockResolvedValue({
+    response: 0,
+  });
+});
 
 test('Expect that removing the connection is going back to the previous page', async () => {
   const kindCluster1 = 'kind cluster 1';

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
@@ -21,7 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
-import { assert, expect, test, vi } from 'vitest';
+import { assert, beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 import type { ProviderInfo } from '/@api/provider-info';
@@ -29,6 +29,14 @@ import type { ProviderInfo } from '/@api/provider-info';
 import * as preferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesVmConnectionRendering from './PreferencesVmConnectionRendering.svelte';
 import type { IConnectionRestart } from './Util';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(window.showMessageBox).mockResolvedValue({
+    response: 0,
+  });
+});
 
 test('Expect that removing the connection is going back to the previous page', async () => {
   const vm1 = 'vm 1';

--- a/tests/playwright/src/model/pages/resource-connection-card-page.ts
+++ b/tests/playwright/src/model/pages/resource-connection-card-page.ts
@@ -18,8 +18,9 @@
 
 import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
-import type { ResourceElementActions } from '/@/model/core/operations';
+import { ResourceElementActions } from '/@/model/core/operations';
 import { PodmanMachinePrivileges } from '/@/model/core/types';
+import { handleConfirmationDialog } from '/@/utility/operations';
 
 import { ResourceCardPage } from './resource-card-page';
 
@@ -60,6 +61,11 @@ export class ResourceConnectionCardPage extends ResourceCardPage {
       });
       await playExpect(button).toBeEnabled({ timeout: timeout });
       await button.click();
+
+      // A confirmation dialog is displayed for deletion
+      if (operation === ResourceElementActions.Delete) {
+        await handleConfirmationDialog(this.page);
+      }
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

Adding a confirmation dialog for the `delete` action in the `PreferencesConnectionActions.svelte`

### Screenshot / video of UI

<img width="1052" height="703" alt="image" src="https://github.com/user-attachments/assets/51a68432-0f3e-430c-8647-a7dfe0fa4637" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15590

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
