### PR TITLE
fix: add bottom spacing to resources page

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -435,7 +435,7 @@ $effect(() => {
         class="text-[var(--pd-content-text)] underline underline-offset-2">Extensions</a>
     </span>
   {/snippet}
-  <div class="pb-0.5" role="region" aria-label="Featured Provider Resources">
+  <div role="region" aria-label="Featured Provider Resources">
     <EmptyScreen
       aria-label="no-resource-panel"
       icon={EngineIcon}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -435,7 +435,7 @@ $effect(() => {
         class="text-[var(--pd-content-text)] underline underline-offset-2">Extensions</a>
     </span>
   {/snippet}
-  <div class="h-full" role="region" aria-label="Featured Provider Resources">
+  <div class="pb-0.5" role="region" aria-label="Featured Provider Resources">
     <EmptyScreen
       aria-label="no-resource-panel"
       icon={EngineIcon}


### PR DESCRIPTION
### What does this PR do?
Fixes the spacing issue on the Resources page, allowing the content to size naturally and preventing the bottom content from being cut off.

### Screenshot / video of UI

<img width="1384" height="869" alt="Screenshot of UI with space" src="https://github.com/user-attachments/assets/b0d2bef9-505b-414e-8514-6f42c23d9de0" />

### What issues does this PR fix or reference?

This helps to fix #15466 

### How to test this PR?

1. Go to Settings > Resources.
2. Scroll down to the bottom of the page .
3. Verify that the Resources provider content at the bottom has proper spacing and is not squished against the edge.

- [x] Tests are covering the bug fix or the new feature
