### PR TITLE
fix(renderer): add id plus tag identifer for save images

### DIFF
--- a/packages/renderer/src/lib/image/SaveImages.spec.ts
+++ b/packages/renderer/src/lib/image/SaveImages.spec.ts
@@ -259,3 +259,59 @@ test('Expect display correctly images to save', async () => {
   const inputHttpdWithDefaultTag = screen.getByRole('textbox', { name: 'image httpd:latest' });
   expect(inputHttpdWithDefaultTag).toBeInTheDocument();
 });
+
+test('Expect images with same ID but different tags to render without duplicate key error', async () => {
+  // This tests the scenario where the same image has multiple tags (e.g., alpine:latest and alpine:2.6)
+  // Both share the same image ID but have different tags
+  const sharedImageId = 'sha256:e738dfbe7a10356ea998e8acc7493c0bfae5ed919ad7eb99550ab60d7f47e214';
+  saveImagesInfo.set([
+    {
+      id: sharedImageId,
+      shortId: 'e738dfbe7a10',
+      name: 'docker.io/library/alpine',
+      tag: 'latest',
+      engineId: 'podman.podman-machine-default',
+    },
+    {
+      id: sharedImageId,
+      shortId: 'e738dfbe7a10',
+      name: 'docker.io/library/alpine',
+      tag: '2.6',
+      engineId: 'podman.podman-machine-default',
+    },
+  ] as ImageInfoUI[]);
+  await waitRender();
+
+  // Both images should be displayed without errors
+  const alpineLatest = screen.getByRole('textbox', { name: 'image docker.io/library/alpine:latest' });
+  expect(alpineLatest).toBeInTheDocument();
+  const alpine26 = screen.getByRole('textbox', { name: 'image docker.io/library/alpine:2.6' });
+  expect(alpine26).toBeInTheDocument();
+});
+
+test('Expect images with same ID and tag but different engines to render without duplicate key error', async () => {
+  // This tests the scenario where two different engines have the same image (same id+tag)
+  // The composite key must include engineId to guarantee uniqueness
+  const sharedImageId = 'sha256:e738dfbe7a10356ea998e8acc7493c0bfae5ed919ad7eb99550ab60d7f47e214';
+  saveImagesInfo.set([
+    {
+      id: sharedImageId,
+      shortId: 'e738dfbe7a10',
+      name: 'docker.io/library/alpine',
+      tag: 'latest',
+      engineId: 'podman.podman-machine-default',
+    },
+    {
+      id: sharedImageId,
+      shortId: 'e738dfbe7a10',
+      name: 'docker.io/library/alpine',
+      tag: 'latest',
+      engineId: 'docker.docker-desktop',
+    },
+  ] as ImageInfoUI[]);
+  await waitRender();
+
+  // Both images should be displayed without errors - query all with same name since they have identical display names
+  const alpineImages = screen.getAllByRole('textbox', { name: 'image docker.io/library/alpine:latest' });
+  expect(alpineImages).toHaveLength(2);
+});

--- a/packages/renderer/src/lib/image/SaveImages.svelte
+++ b/packages/renderer/src/lib/image/SaveImages.svelte
@@ -148,7 +148,7 @@ async function saveImages(): Promise<void> {
           class="flex flex-row justify-center w-full pt-5 text-sm font-medium text-[var(--pd-content-card-header-text)]">
           <div class="flex flex-col grow">Images to save</div>
         </div>
-        {#each imagesToSave as imageToSave, index (imageToSave.id)}
+        {#each imagesToSave as imageToSave, index (`${imageToSave.id}:${imageToSave.tag}:${imageToSave.engineId}`)}
           {@const imageAndTag = `${imageToSave.name}:${imageToSave.tag}`}
           {@const imageDisplayName = `${imageToSave.name === '<none>' ? imageToSave.shortId : imageAndTag}`}
           <div class="flex flex-row justify-center w-full py-1">


### PR DESCRIPTION
now images with the same id but different tag can also be saved

Assisted-by: Cursor

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes: https://github.com/podman-desktop/podman-desktop/issues/15748

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
