### PR TITLE
chore(renderer/extensions): update typo in test

### DIFF
--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -119,7 +119,7 @@ test('install button should always be disable when extensionInstallFromImage is 
 
   await userEvent.click(installButton);
 
-  logCallback('Downloading sha256:random-sha256.tar - 100% - (55132/521578)');
+  logCallback('Downloading sha256:random-sha256.tar - 100% - (521578/521578)');
 
   const progressBar = screen.getByRole('progressbar', { name: 'Installation progress' });
   await vi.waitFor(() => {


### PR DESCRIPTION
### What does this PR do?

Following comment https://github.com/podman-desktop/podman-desktop/pull/15739#discussion_r2703659962, this PR updates a typo in a renderer test: the 100% value has a wrong ratio value.

### Screenshot / video of UI

No change.

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
