### PR TITLE
fix: catalog shouldn't list incompatible extensions

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -56,6 +56,7 @@
     "@zerodevx/svelte-toast": "^0.9.6",
     "electron-context-menu": "4.1.1",
     "js-yaml": "^4.1.1",
+    "semver": "^7.7.3",
     "tinro": "^0.6.12",
     "validator": "^13.15.26"
   }

--- a/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtensionList.svelte
@@ -26,7 +26,7 @@ async function fetchCatalog(): Promise<void> {
 </script>
 
 <div class="flex flex-col grow px-5 py-3">
-  {#if catalogExtensions.length > 0}
+  {#if catalogExtensions?.length > 0}
     <div class="mb-4 flex flex-row">
       <div class="flex items-center text-[var(--pd-content-header)]">{title}</div>
       <div class="flex-1 text-right">

--- a/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.svelte
@@ -24,7 +24,7 @@ const extensionsUtils = new ExtensionsUtils();
 
 const catalogExtensions: Readable<CatalogExtensionInfoUI[]> = derived(
   [catalogExtensionInfos, featuredExtensionInfos, combinedInstalledExtensions],
-  ([$catalogExtensionInfos, $featuredExtensionInfos, $combinedInstalledExtensions]) => {
+  ([$catalogExtensionInfos, $featuredExtensionInfos, $combinedInstalledExtensions], set) => {
     if (category) {
       const filteredCategory = category;
       $catalogExtensionInfos = $catalogExtensionInfos.filter(catalogExtension =>
@@ -44,11 +44,15 @@ const catalogExtensions: Readable<CatalogExtensionInfoUI[]> = derived(
       );
     }
 
-    return extensionsUtils.extractCatalogExtensions(
-      $catalogExtensionInfos,
-      $featuredExtensionInfos,
-      $combinedInstalledExtensions,
-    );
+    Promise.resolve(
+      extensionsUtils.extractCatalogExtensions(
+        $catalogExtensionInfos,
+        $featuredExtensionInfos,
+        $combinedInstalledExtensions,
+      ),
+    )
+      .then(v => set(v))
+      .catch((err: unknown) => console.error('Error updating catalog', err));
   },
 );
 </script>

--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { type CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
@@ -94,11 +94,18 @@ const combined: CombinedExtensionInfoUI[] = [
   },
 ] as unknown[] as CombinedExtensionInfoUI[];
 
+async function renderIt(searchTerm?: string): Promise<void> {
+  render(ExtensionList, { searchTerm: searchTerm });
+
+  // wait for page to be rendered
+  await waitFor(() => expect(screen.queryByText('extensions')).toBeInTheDocument());
+}
+
 test('Expect to see extensions', async () => {
   catalogExtensionInfos.set([aFakeExtension, bFakeExtension]);
   extensionInfos.set(combined);
 
-  render(ExtensionList);
+  await renderIt();
 
   const headingExtensions = screen.getByRole('heading', { name: 'extensions' });
   expect(headingExtensions).toBeInTheDocument();
@@ -124,7 +131,7 @@ test('Expect to see empty screen on extension page only', async () => {
   catalogExtensionInfos.set([aFakeExtension]);
   extensionInfos.set([]);
 
-  render(ExtensionList, { searchTerm: 'A' });
+  await renderIt('A');
 
   let title = screen.queryByText(`No extensions matching 'A' found`);
   expect(title).toBeInTheDocument();
@@ -141,7 +148,7 @@ test('Expect to see empty screen on catalog page only', async () => {
   catalogExtensionInfos.set([]);
   extensionInfos.set(combined);
 
-  render(ExtensionList, { searchTerm: 'A' });
+  await renderIt('A');
 
   let title = screen.queryByText(`No extensions matching 'A' found`);
   expect(title).not.toBeInTheDocument();
@@ -158,7 +165,7 @@ test('Expect to see empty screens on both pages', async () => {
   catalogExtensionInfos.set([]);
   extensionInfos.set([]);
 
-  render(ExtensionList, { searchTerm: 'foo' });
+  await renderIt('foo');
 
   let title = screen.getByText(`No extensions matching 'foo' found`);
   expect(title).toBeInTheDocument();
@@ -175,7 +182,7 @@ test('Search extension page searches also description', async () => {
   catalogExtensionInfos.set([aFakeExtension]);
   extensionInfos.set(combined);
 
-  render(ExtensionList, { searchTerm: 'bar' });
+  await renderIt('bar');
 
   const myExtension1 = screen.getByRole('region', { name: 'idAInstalled' });
   expect(myExtension1).toBeInTheDocument();
@@ -187,7 +194,7 @@ test('Search extension page searches also description', async () => {
   cleanup();
 
   // Change the search
-  render(ExtensionList, { searchTerm: 'foo' });
+  await renderIt('foo');
 
   // The extension should not be there as it doesn't have "foo" in the description
   const myExtension2 = screen.queryByRole('region', { name: 'idAInstalled' });
@@ -198,7 +205,7 @@ test('Search catalog page searches also description', async () => {
   catalogExtensionInfos.set([aFakeExtension, bFakeExtension]);
   extensionInfos.set([]);
 
-  render(ExtensionList, { searchTerm: 'bar' });
+  await renderIt('bar');
 
   // Click on the catalog
   const catalogTab = screen.getByRole('button', { name: 'Catalog' });
@@ -217,7 +224,7 @@ test('Expect to see local extensions tab content', async () => {
   catalogExtensionInfos.set([]);
   extensionInfos.set([]);
 
-  render(ExtensionList);
+  await renderIt();
 
   // select the local extensions tab
   const localModeTab = screen.getByRole('button', { name: 'Local Extensions' });
@@ -232,7 +239,7 @@ test('Switching tabs keeps only terms in search term', async () => {
   catalogExtensionInfos.set([aFakeExtension, bFakeExtension]);
   extensionInfos.set([]);
 
-  render(ExtensionList, { searchTerm: 'bar category:bar not:installed' });
+  await renderIt('bar category:bar not:installed');
 
   // Click on the catalog
   const catalogTab = screen.getByRole('button', { name: 'Catalog' });

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -33,7 +33,7 @@ let filteredInstalledItems: number = $derived($combinedInstalledExtensions.lengt
 // need to add in the catalog extension a flag to know if extension is featured or not
 // and featured extensions need to be displayed first
 const enhancedCatalogExtensions: CatalogExtensionInfoUI[] = $derived(
-  extensionsUtils.extractCatalogExtensions(
+  await extensionsUtils.extractCatalogExtensions(
     $catalogExtensionInfos,
     $featuredExtensionInfos,
     $combinedInstalledExtensions,

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -200,10 +200,10 @@ beforeEach(() => {
   extensionsUtils = new ExtensionsUtils();
 });
 
-describe('extractCatalogExtensions', () => {
+describe('extractCatalogExtensions', async () => {
   test('Expect first one should be featured even having a name starting with Y letter then Z extension, then A extension and then B extension', async () => {
     // get UI objects
-    const catalogExtensionsUI = extensionsUtils.extractCatalogExtensions(
+    const catalogExtensionsUI = await extensionsUtils.extractCatalogExtensions(
       catalogExtensions,
       featuredExtensions,
       installedExtensions,
@@ -379,9 +379,9 @@ describe('filters', () => {
     },
   ] as unknown[] as CombinedExtensionInfoUI[];
 
-  test('filterCatalogExtensions with single word', () => {
+  test('filterCatalogExtensions with single word', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -392,9 +392,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with single word and installed', () => {
+  test('filterCatalogExtensions with single word and installed', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -405,9 +405,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with single word and not installed', () => {
+  test('filterCatalogExtensions with single word and not installed', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -417,9 +417,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions.length).toBe(0);
   });
 
-  test('filterCatalogExtensions with single word and installed and not installed, only first boolean is used', () => {
+  test('filterCatalogExtensions with single word and installed and not installed, only first boolean is used', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -430,9 +430,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with multiple words found', () => {
+  test('filterCatalogExtensions with multiple words found', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -443,9 +443,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with multiple words and one is not found', () => {
+  test('filterCatalogExtensions with multiple words and one is not found', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -455,9 +455,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions.length).toBe(0);
   });
 
-  test('filterCatalogExtensions with multiple words found and one category', () => {
+  test('filterCatalogExtensions with multiple words found and one category', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -468,9 +468,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with multiple words found and multiple categories found', () => {
+  test('filterCatalogExtensions with multiple words found and multiple categories found', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -481,9 +481,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with multiple words found and multiple categories with one not found ', () => {
+  test('filterCatalogExtensions with multiple words found and multiple categories with one not found ', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -493,9 +493,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions.length).toBe(0);
   });
 
-  test('filterCatalogExtensions with multiple words found and one keyword', () => {
+  test('filterCatalogExtensions with multiple words found and one keyword', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -506,9 +506,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with multiple words found and multiple keywords found', () => {
+  test('filterCatalogExtensions with multiple words found and multiple keywords found', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
@@ -519,9 +519,9 @@ describe('filters', () => {
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with multiple words found and multiple keywords with one not found ', () => {
+  test('filterCatalogExtensions with multiple words found and multiple keywords with one not found ', async () => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
+      await extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,


### PR DESCRIPTION
### What does this PR do?

The extension catalog currently filters out unlisted and preview extensions, but it doesn't filter out extensions that are incompatible with the current Podman Desktop version. As a result, you can install extensions that require (e.g.) 1.25.0 on any version, where they will likely fail.

The fix applies the same code as the extension updater https://github.com/podman-desktop/podman-desktop/blob/main/packages/main/src/plugin/extension/updater/extensions-updater.ts#L161 to filtering the catalog in extensions-utils.ts. Since we need the current version the function needs to be async now.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #15767.

### How to test this PR?

Test not added yet.

- [x] Tests are covering the bug fix or the new feature