### PR TITLE
chore(api): add index files when we have multiple files in folder

### DIFF
--- a/packages/api/src/configuration/index.ts
+++ b/packages/api/src/configuration/index.ts
@@ -1,0 +1,20 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export * from './constants.js';
+export * from './models.js';

--- a/packages/api/src/context/index.ts
+++ b/packages/api/src/context/index.ts
@@ -1,0 +1,20 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export * from './charCode.js';
+export * from './context.js';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// Top-level API files
+export * from './async-disposable.js';
+export * from './cli-tool-info.js';
+export * from './color-info.js';
+export * from './command-info.js';
+export * from './container-info.js';
+export * from './container-inspect-info.js';
+export * from './container-stats-info.js';
+export * from './containerfile-info.js';
+export * from './contribution-info.js';
+export * from './dialog.js';
+export * from './disposable.js';
+export * from './disposable-group.js';
+export * from './docker-compatibility-info.js';
+export * from './documentation-info.js';
+export * from './event.js';
+export * from './explore-feature.js';
+export * from './extension-development-folders-info.js';
+export * from './extension-info.js';
+export * from './extension-loader-settings.js';
+export * from './feedback.js';
+export * from './filesystem-tree.js';
+export * from './font-info.js';
+export * from './help-menu.js';
+export * from './history-info.js';
+export * from './icon-info.js';
+export * from './image-checker-info.js';
+export * from './image-files-info.js';
+export * from './image-filesystem-layers.js';
+export * from './image-info.js';
+export * from './image-inspect-info.js';
+export * from './image-registry.js';
+export * from './kubernetes-context.js';
+export * from './kubernetes-contexts-healths.js';
+export * from './kubernetes-contexts-permissions.js';
+export * from './kubernetes-contexts-states.js';
+export * from './kubernetes-informer-info.js';
+export * from './kubernetes-navigation.js';
+export * from './kubernetes-port-forward-model.js';
+export * from './kubernetes-resource-count.js';
+export * from './kubernetes-resources.js';
+export * from './kubernetes-troubleshooting.js';
+export * from './list-organizer.js';
+export * from './manifest-info.js';
+export * from './menu.js';
+export * from './menu-context.js';
+export * from './navigation-page.js';
+export * from './navigation-request.js';
+export * from './network-info.js';
+export * from './notification.js';
+export * from './onboarding.js';
+export * from './openshift-types.js';
+export * from './pod-info.js';
+export * from './prefered-registries-info.js';
+export * from './provider-info.js';
+export * from './proxy.js';
+export * from './pull-event.js';
+export * from './release-notes-info.js';
+export * from './repository-info-parser.js';
+export * from './repository-infos.js';
+export * from './status-bar.js';
+export * from './taskInfo.js';
+export * from './tasks-preferences.js';
+export * from './telemetry.js';
+export * from './theme-info.js';
+export * from './tray-menu-info.js';
+export * from './view-info.js';
+export * from './volume-info.js';
+export * from './webview-info.js';

--- a/packages/api/src/recommendations/index.ts
+++ b/packages/api/src/recommendations/index.ts
@@ -1,0 +1,20 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export * from './recommendations.js';
+export * from './recommendations-settings.js';

--- a/packages/api/src/status-bar/index.ts
+++ b/packages/api/src/status-bar/index.ts
@@ -1,0 +1,20 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export * from './pin-constants.js';
+export * from './pin-option.js';


### PR DESCRIPTION
### What does this PR do?
add exports from index files (when there is at least more than one file in the folder)

will ease the export of the files contained in the api package

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15496

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
