### PR TITLE
fix: catalog shouldn't expose incompatible extensions

### DIFF
--- a/packages/main/src/plugin/extension/catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extension/catalog/extensions-catalog.spec.ts
@@ -286,7 +286,7 @@ test('should get all extensions', async () => {
 });
 
 test('should filter incompatible extension versions', async () => {
-  // mock current version being 2.0.0
+  // mock current version as 1.5.0
   vi.mocked(extensionApiVersion.getApiVersion).mockReturnValue('1.5.0');
 
   server = setupServer(

--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -18,10 +18,8 @@
 
 import { compareVersions } from 'compare-versions';
 import { inject, injectable } from 'inversify';
-import { coerce, satisfies } from 'semver';
 
 import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
-import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionsUpdaterSettings } from '/@/plugin/extension/updater/extensions-updater-settings.js';
 import { ExtensionInstaller } from '/@/plugin/install/extension-installer.js';
@@ -47,8 +45,6 @@ export class ExtensionsUpdater {
     private extensionInstaller: ExtensionInstaller,
     @inject(Telemetry)
     private telemetry: Telemetry,
-    @inject(ExtensionApiVersion)
-    private extensionApiVersion: ExtensionApiVersion,
   ) {}
 
   async init(): Promise<void> {
@@ -126,7 +122,7 @@ export class ExtensionsUpdater {
 
   // check if some extensions can be updated or not
   async doCheckForUpdates(): Promise<void> {
-    // grab list of extensions
+    // grab list of compatible extensions
     const availableExtensions = await this.extensionCatalog.getExtensions();
 
     // now, grab list of installed extensions
@@ -148,24 +144,8 @@ export class ExtensionsUpdater {
 
         // if found compare versions
         const installedVersion = installedExtension.version;
-        const appVersion = this.extensionApiVersion.getApiVersion();
 
-        // coerce the podman desktop Version
-        const currentPodmanDesktopVersion = coerce(appVersion);
-
-        // filter out versions non-compliant with this version of Podman Desktop
-        const availableVersions = availableExtension.versions.filter(version => {
-          const extensionRequirePodmanDesktopVersion = version.podmanDesktopVersion;
-          if (extensionRequirePodmanDesktopVersion && currentPodmanDesktopVersion) {
-            //  keep the versions that are compatible with this version of Podman Desktop
-            return satisfies(currentPodmanDesktopVersion, extensionRequirePodmanDesktopVersion);
-          } else {
-            // if no version is specified, keep the version
-            return true;
-          }
-        });
-
-        const filteredPreviewVersions = availableVersions.filter(version => version.preview === false);
+        const filteredPreviewVersions = availableExtension.versions.filter(version => version.preview === false);
         // take latest version
         const latestAvailableVersion = filteredPreviewVersions?.[0];
         if (!latestAvailableVersion) {


### PR DESCRIPTION
### What does this PR do?

The extension catalog currently exposes all extensions from getExtensions(). The only users of this are the extension updater (which filters out incompatible extensions) and the renderer extension catalog (which currently didn't, and allows you to install them).

This moves the filtering of incompatible extensions from the updater directly into the catalog getExtensions(). This simplifies the updater and fixes the issue in the renderer.

Tests updated. It felt odd to remove the test from the updater at first, but this case can never happen and the same test is now directly in the catalog.

(replaces draft PR attempt #15769 that filtered in the renderer)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #15767.

### How to test this PR?

To test manually:

- Clone the catalog and edit to include a new extension version with an incompatible version like `"podmanDesktopVersion": "^1.28.0"`.
- Serve the catalog (or just the static/api folder).
- Edit product.json to point the catalog.default to the new catalog url.
- Confirm that the extension version above is shown in Extensions > Catalog before this change but not after.

- [x] Tests are covering the bug fix or the new feature