### PR TITLE
feat: disable internal Kubernetes Dashboard when extension provides kube dashboard feature

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -554,11 +554,10 @@ export class PluginSystem {
     container.bind<FilesystemMonitoring>(FilesystemMonitoring).toSelf().inSingletonScope();
     container.bind<CustomPickRegistry>(CustomPickRegistry).toSelf().inSingletonScope();
     container.bind<OnboardingRegistry>(OnboardingRegistry).toSelf().inSingletonScope();
+    container.bind<FeatureRegistry>(FeatureRegistry).toSelf().inSingletonScope();
     container.bind<KubernetesClient>(KubernetesClient).toSelf().inSingletonScope();
     const kubernetesClient = container.get<KubernetesClient>(KubernetesClient);
     await kubernetesClient.init();
-
-    container.bind<FeatureRegistry>(FeatureRegistry).toSelf().inSingletonScope();
 
     container.bind<CloseBehavior>(CloseBehavior).toSelf().inSingletonScope();
     const closeBehaviorConfiguration = container.get<CloseBehavior>(CloseBehavior);

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -19,6 +19,7 @@
 import type { Cluster, Context, KubeConfig, User } from '@kubernetes/client-node';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import type { ConfigurationRegistry } from '../configuration-registry.js';
@@ -62,6 +63,7 @@ describe('context tests', () => {
   const experimentalConfigurationManager: ExperimentalConfigurationManager = {
     isExperimentalConfigurationEnabled: vi.fn(),
   } as unknown as ExperimentalConfigurationManager;
+  const featureRegistry: FeatureRegistry = {} as unknown as FeatureRegistry;
 
   function createClient(): TestKubernetesClient {
     const configurationRegistry: ConfigurationRegistry = {} as unknown as ConfigurationRegistry;
@@ -80,6 +82,7 @@ describe('context tests', () => {
       fileSystemMonitoring,
       telemetry,
       experimentalConfigurationManager,
+      featureRegistry,
     );
 
     client.setUsers(originalUsers);

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -47,6 +47,7 @@ import * as clientNode from '@kubernetes/client-node';
 import type { FileSystemWatcher } from '@podman-desktop/api';
 import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
+import type { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
@@ -85,7 +86,9 @@ const experimentalConfigurationManager: ExperimentalConfigurationManager = {
 } as unknown as ExperimentalConfigurationManager;
 const makeApiClientMock = vi.fn();
 const getContextObjectMock = vi.fn();
-
+const featureRegistry: FeatureRegistry = {
+  onFeaturesUpdated: vi.fn(),
+} as unknown as FeatureRegistry;
 const podAndDeploymentTestYAML = `apiVersion: v1
 kind: Pod
 metadata:
@@ -269,6 +272,7 @@ function createTestClient(namespace?: string): TestKubernetesClient {
     fileSystemMonitoring,
     telemetry,
     experimentalConfigurationManager,
+    featureRegistry,
   );
   if (namespace) {
     client.setInitialNamespace(namespace);
@@ -476,6 +480,7 @@ test('Check connection to Kubernetes cluster', async () => {
     fileSystemMonitoring,
     telemetry,
     experimentalConfigurationManager,
+    featureRegistry,
   );
   const result = await client.checkConnection();
   expect(result).toBeTruthy();
@@ -490,6 +495,7 @@ test('Check connection to Kubernetes cluster in error', async () => {
     fileSystemMonitoring,
     telemetry,
     experimentalConfigurationManager,
+    featureRegistry,
   );
   const result = await client.checkConnection();
   expect(result).toBeFalsy();
@@ -508,6 +514,7 @@ test('Check update with empty kubeconfig file', async () => {
     fileSystemMonitoring,
     telemetry,
     experimentalConfigurationManager,
+    featureRegistry,
   );
   await client.refresh();
   expect(consoleErrorSpy).toBeCalledWith(expect.stringContaining('is empty. Skipping'));

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -72,6 +72,7 @@ import type { WebSocket } from 'ws';
 import type { Tags } from 'yaml';
 import { parseAllDocuments } from 'yaml';
 
+import { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
@@ -190,7 +191,7 @@ export class KubernetesClient {
    */
   private apiResources = new Map<string, Array<V1APIResource>>();
 
-  private contextsState: ContextsManagerInterface;
+  private contextsState?: ContextsManagerInterface;
   private contextsStatesDispatcher: ContextsStatesDispatcher | undefined;
 
   private readonly _onDidUpdateKubeconfig = new Emitter<containerDesktopAPI.KubeconfigUpdateEvent>();
@@ -217,6 +218,8 @@ export class KubernetesClient {
     private readonly telemetry: Telemetry,
     @inject(ExperimentalConfigurationManager)
     private readonly experimentalConfigurationManager: ExperimentalConfigurationManager,
+    @inject(FeatureRegistry)
+    private readonly featureRegistry: FeatureRegistry,
   ) {
     this.kubeConfig = new KubeConfig();
     this.contextsState = new ContextsManager(this.apiSender);
@@ -284,6 +287,15 @@ export class KubernetesClient {
         }
         await this.setKubeconfig(Uri.file(val));
         this.setupWatcher(val);
+      }
+    });
+
+    this.featureRegistry.onFeaturesUpdated(async features => {
+      const kubeDashboardRegistered = features.includes('kubernetes-dashboard');
+      if (kubeDashboardRegistered) {
+        await this.KubernetesManagerStop();
+      } else {
+        await this.KubernetesManagerStart();
       }
     });
   }
@@ -615,7 +627,7 @@ export class KubernetesClient {
     this.apiSender.send('kubeconfig-update');
     const configCopy = new KubeConfig();
     configCopy.loadFromString(this.kubeConfig.exportConfig());
-    await this.contextsState.update(configCopy);
+    await this.contextsState?.update(configCopy);
   }
 
   newError(message: string, cause: Error): Error {
@@ -1125,7 +1137,7 @@ export class KubernetesClient {
       users: this.kubeConfig.users,
       currentContext: this.kubeConfig.currentContext,
     });
-    await this.contextsState.update(newConfig);
+    await this.contextsState?.update(newConfig);
     this.apiSender.send('kubernetes-context-update');
   }
 
@@ -1406,23 +1418,28 @@ export class KubernetesClient {
   }
 
   public getContextsGeneralState(): Map<string, ContextGeneralState> {
-    return this.contextsState.getContextsGeneralState();
+    return this.contextsState?.getContextsGeneralState() ?? new Map();
   }
 
   public getCurrentContextGeneralState(): ContextGeneralState {
-    return this.contextsState.getCurrentContextGeneralState();
+    return (
+      this.contextsState?.getCurrentContextGeneralState() ?? {
+        reachable: false,
+        resources: { pods: 0, deployments: 0 },
+      }
+    );
   }
 
   public registerGetCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
-    return this.contextsState.registerGetCurrentContextResources(resourceName);
+    return this.contextsState?.registerGetCurrentContextResources(resourceName) ?? [];
   }
 
   public unregisterGetCurrentContextResources(resourceName: ResourceName): KubernetesObject[] {
-    return this.contextsState.unregisterGetCurrentContextResources(resourceName);
+    return this.contextsState?.unregisterGetCurrentContextResources(resourceName) ?? [];
   }
 
   public dispose(): void {
-    this.contextsState.dispose();
+    this.contextsState?.dispose();
   }
 
   async execIntoContainer(
@@ -1780,7 +1797,7 @@ export class KubernetesClient {
    * @returns
    */
   public async refreshContextState(context: string): Promise<void> {
-    return this.contextsState.refreshContextState(context);
+    return this.contextsState?.refreshContextState(context);
   }
 
   protected ensurePortForwardService(): KubernetesPortForwardService {
@@ -1811,48 +1828,58 @@ export class KubernetesClient {
   }
 
   public getContextsHealths(): ContextHealth[] {
-    if (!this.contextsStatesDispatcher) {
-      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
-    }
-    return this.contextsStatesDispatcher?.getContextsHealths();
+    return this.contextsStatesDispatcher?.getContextsHealths() ?? [];
   }
 
   public getContextsPermissions(): ContextPermission[] {
-    if (!this.contextsStatesDispatcher) {
-      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
-    }
-    return this.contextsStatesDispatcher.getContextsPermissions();
+    return this.contextsStatesDispatcher?.getContextsPermissions() ?? [];
   }
 
   public getResourcesCount(): ResourceCount[] {
-    if (!this.contextsStatesDispatcher) {
-      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
-    }
-    return this.contextsStatesDispatcher.getResourcesCount();
+    return this.contextsStatesDispatcher?.getResourcesCount() ?? [];
   }
 
   public getActiveResourcesCount(): ResourceCount[] {
-    if (!this.contextsStatesDispatcher) {
-      throw new Error('contextsStatesDispatcher is undefined. This should not happen in Kubernetes experimental');
-    }
-    return this.contextsStatesDispatcher.getActiveResourcesCount();
+    return this.contextsStatesDispatcher?.getActiveResourcesCount() ?? [];
   }
 
   public getResources(contextNames: string[], resourceName: string): KubernetesContextResources[] {
-    if (!this.contextsStatesDispatcher) {
-      throw new Error(
-        `contextsStatesDispatcher is undefined when getting ${resourceName}. This should not happen in Kubernetes experimental`,
-      );
-    }
-    return this.contextsStatesDispatcher.getResources(contextNames, resourceName);
+    return this.contextsStatesDispatcher?.getResources(contextNames, resourceName) ?? [];
   }
 
   public getTroubleshootingInformation(): KubernetesTroubleshootingInformation {
-    if (!this.contextsStatesDispatcher) {
-      throw new Error(
-        `contextsStatesDispatcher is undefined when getting troubleshooting information. This should not happen in Kubernetes experimental`,
-      );
+    return (
+      this.contextsStatesDispatcher?.getTroubleshootingInformation() ?? {
+        healthCheckers: [],
+        permissionCheckers: [],
+        informers: [],
+      }
+    );
+  }
+
+  // This method is called when an extension providing the Kubernetes feature is enabled
+  protected async KubernetesManagerStop(): Promise<void> {
+    const emptyKubeConfig = new KubeConfig();
+    await this.contextsState?.update(emptyKubeConfig);
+    this.contextsState?.dispose();
+    this.contextsState = undefined;
+    this.contextsStatesDispatcher?.dispose();
+    this.contextsStatesDispatcher = undefined;
+  }
+
+  // This method is called when an extension providing Kubernetes feature is disabled
+  protected async KubernetesManagerStart(): Promise<void> {
+    const statesExperimental = this.experimentalConfigurationManager.isExperimentalConfigurationEnabled(
+      'kubernetes.statesExperimental',
+    );
+    if (statesExperimental) {
+      const manager = new ContextsManagerExperimental();
+      this.contextsState = manager;
+      this.contextsStatesDispatcher = new ContextsStatesDispatcher(manager, this.apiSender);
+      this.contextsStatesDispatcher.init();
+    } else {
+      this.contextsState = new ContextsManager(this.apiSender);
     }
-    return this.contextsStatesDispatcher.getTroubleshootingInformation();
+    await this.contextsState?.update(this.kubeConfig);
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -247,6 +247,12 @@ export class KubernetesClient {
           type: 'boolean',
           default: true,
         },
+        ['kubernetes.useInternalKubernetes']: {
+          description: 'Use internal Kubernetes',
+          hidden: true,
+          type: 'boolean',
+          default: true,
+        },
       },
     };
 
@@ -1865,6 +1871,7 @@ export class KubernetesClient {
     this.contextsState = undefined;
     this.contextsStatesDispatcher?.dispose();
     this.contextsStatesDispatcher = undefined;
+    await this.configurationRegistry.updateConfigurationValue('kubernetes.useInternalKubernetes', false);
   }
 
   // This method is called when an extension providing Kubernetes feature is disabled
@@ -1881,5 +1888,6 @@ export class KubernetesClient {
       this.contextsState = new ContextsManager(this.apiSender);
     }
     await this.contextsState?.update(this.kubeConfig);
+    await this.configurationRegistry.updateConfigurationValue('kubernetes.useInternalKubernetes', true);
   }
 }

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
@@ -33,6 +33,7 @@ import type { WebSocket } from 'isomorphic-ws';
 import { afterEach, beforeEach, describe, expect, type MockedFunction, test, vi } from 'vitest';
 
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+import type { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { KubernetesClient } from '/@/plugin/kubernetes/kubernetes-client.js';
 import {
@@ -53,6 +54,7 @@ const telemetry: Telemetry = {} as unknown as Telemetry;
 const experimentalConfigurationManager: ExperimentalConfigurationManager = {
   isExperimentalConfigurationEnabled: vi.fn(),
 } as unknown as ExperimentalConfigurationManager;
+const featureRegistry: FeatureRegistry = {} as unknown as FeatureRegistry;
 
 const mockCoreV1Api = {
   readNamespacedPod: vi.fn(),
@@ -176,6 +178,7 @@ describe('PortForwardConnectionService', () => {
         fileSystemMonitoring,
         telemetry,
         experimentalConfigurationManager,
+        featureRegistry,
       ),
     );
     global.fetch = vi.fn();
@@ -256,6 +259,7 @@ describe('PortForwardConnectionService', () => {
         fileSystemMonitoring,
         telemetry,
         experimentalConfigurationManager,
+        featureRegistry,
       ),
     );
 

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -97,9 +97,6 @@ test('Test rendering of the navigation bar with empty items', async (_arg: unkno
   expect(volumes).toBeInTheDocument();
   const settings = screen.getByRole('link', { name: 'Settings' });
   expect(settings).toBeInTheDocument();
-
-  const kubernetes = screen.queryByRole('link', { name: 'Kubernetes' });
-  expect(kubernetes).toBeInTheDocument();
 });
 
 test('Test contributions', () => {

--- a/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
@@ -46,7 +46,7 @@ test('check navigation registry items', async () => {
   await fetchNavigationRegistries();
   const registries = get(navigationRegistry);
   // expect 8 items in the registry
-  expect(registries.length).equal(8);
+  expect(registries.length).equal(7);
 });
 
 test('check update properties', async () => {

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -171,7 +171,7 @@ configurationProperties.subscribe(() => {
 
 function handleKubernetesGroup(): void {
   window
-    .getConfigurationValue<string[]>('kubernetes.useInternalKubernetes')
+    .getConfigurationValue<boolean>('kubernetes.useInternalKubernetes')
     ?.then(value => {
       if (value) {
         if (!values.find(item => item.name === 'Kubernetes')) {

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -68,9 +68,9 @@ const init = (): void => {
   values.push(createNavigationImageEntry());
   values.push(createNavigationVolumeEntry());
   values.push(createNavigationNetworkEntry());
-  values.push(createNavigationKubernetesGroup());
   values.push(createNavigationExtensionEntry());
   values.push(createNavigationExtensionGroup());
+  handleKubernetesGroup();
   hideItems().catch((err: unknown) => console.error('Error hiding navigation items', err));
 };
 
@@ -164,5 +164,26 @@ configurationProperties.subscribe(() => {
       })
       .then(() => hideItems())
       .catch((err: unknown) => console.error('Error getting configuration value navbar.disabledItems', err));
+
+    handleKubernetesGroup();
   }
 });
+
+function handleKubernetesGroup(): void {
+  window
+    .getConfigurationValue<string[]>('kubernetes.useInternalKubernetes')
+    ?.then(value => {
+      if (value) {
+        if (!values.find(item => item.name === 'Kubernetes')) {
+          const extensionsIndex = values.findIndex(item => item.name === 'Extensions');
+          if (extensionsIndex !== -1) {
+            values.splice(extensionsIndex, 0, createNavigationKubernetesGroup());
+          }
+        }
+      } else {
+        values = values.filter(item => item.name !== 'Kubernetes');
+      }
+    })
+    .then(() => hideItems())
+    .catch((err: unknown) => console.error('Error getting configuration value kubernetes.useInternalKubernetes', err));
+}


### PR DESCRIPTION
### What does this PR do?

- disable internal Kubernetes dashboard when an extension providing kubernetes-dashboard feature is enabled
- enable internal Kubernetes dashboard when an extension providing  kubernetes-dashboard feature is disabled
- With non-experimental internal kubernetes, the user needs to restart after disabling extension, for the internal dashboard to work correctly
- With experimental internal kubernetes, the dashboard works correctly as soon as the extension is disabled

Disabling the dashboard means:
- all the informers are stopped
- the Kubernetes icon in the left bar is hidden

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #15723 

### How to test this PR?

For testing, 2 extensions providing kubernetes-dashboard can be used:
- https://github.com/feloy/podman-desktop-dev-ext-features-kubernetes-dashboard (image at quay.io/phmartin/features-kube-dashboard:1)
- the kubernetes dashbord extension, modified to register kubernetes-dashboard feature, image at quay.io/phmartin/k8s-dashboard:contrib1

#### When internal experimental is enabled

1. have a Kubernetes cluster accessible in kubeconfig file
2. start Podman Desktop
3. check that Kubernetes dashboard is accessible (via Kubernetes icon on the left menu ) and that the cluster is accessible, and the monitoring is running(1)
4. install and enable an extension providing the kubernetes-dashboard feature (see above)
5. check that the icon on the left menu has disappeared
6. check that the monitoring has stopped(1)
7. disable the extension providing the kubernetes-dashboard feature
8. check that the Kubernetes icon is visible
9. check that the cluster is accessible, and the monitoring is running(1)


(1) you can check the informers in `(?) > Troubleshooting > Kubernetes`, or with the CLI `lsof -i | grep cluster-ip-or-name`. You should not have any informers connected when the monitoring is stopped (if you are using the `podman-desktop-dev-ext-features-kubernetes-dashboard` extension which does not start informers on its side), and you should have 12 when monitoring is running (more or less, depending on terminal connections, resources not permitted, etc). If you test with the real kubernetes dashboard extension, it should start informers on its side, but you should never have 24 informers started.

#### When internal experimental is disabled

Same steps, except that you need to completely stop and restart Podman Desktop after point 8, for the monitoring to restart correctly.

- [x] Tests are covering the bug fix or the new feature

