### PR TITLE
feat(storybook): expand Tooltip stories with sizes and contexts

### DIFF
--- a/storybook/src/stories/Tooltip.stories.svelte
+++ b/storybook/src/stories/Tooltip.stories.svelte
@@ -1,18 +1,22 @@
 <script context="module" lang="ts">
 import { Tooltip } from '@podman-desktop/ui-svelte';
-import StarIcon from '@podman-desktop/ui-svelte/icons/StarIcon';
-import { type Args, defineMeta, type StoryContext } from '@storybook/addon-svelte-csf';
+import { defineMeta } from '@storybook/addon-svelte-csf';
 
 /**
  * These are the stories for the `Tooltip` component.
  * Allow to display a tooltip at a given position (top, bottom, etc.).
+ * Supports simple text tooltips and complex content using snippets.
  */
+// biome-ignore lint/correctness/noUnusedVariables: Story is used in markup
 const { Story } = defineMeta({
   component: Tooltip,
   render: template,
   title: 'Tooltip',
   tags: ['autodocs'],
   argTypes: {
+    kind: {
+      table: { disable: true },
+    },
     tip: {
       control: 'text',
       description: 'Text to show in the tooltip',
@@ -50,7 +54,6 @@ const { Story } = defineMeta({
     },
     bottomRight: {
       control: 'boolean',
-
       description: 'Flag the tooltip as being at the bottom right',
       defaultValue: false,
     },
@@ -61,75 +64,105 @@ const { Story } = defineMeta({
     },
   },
 });
+
+// biome-ignore lint/correctness/noUnusedVariables: used in markup
+const placementVariants = [
+  { name: 'Top', args: { tip: 'this is a custom top tooltip', top: true } },
+  { name: 'Top Left', args: { tip: 'this is a custom top left tooltip', topLeft: true } },
+  { name: 'Top Right', args: { tip: 'this is a custom top right tooltip', topRight: true } },
+  { name: 'Right', args: { tip: 'this is a custom right tooltip', right: true } },
+  { name: 'Bottom', args: { tip: 'this is a custom bottom tooltip', bottom: true } },
+  { name: 'Bottom Left', args: { tip: 'this is a custom bottom left tooltip', bottomLeft: true } },
+  { name: 'Bottom Right', args: { tip: 'this is a custom bottom right tooltip', bottomRight: true } },
+  { name: 'Left', args: { tip: 'this is a custom left tooltip', left: true } },
+];
+
+// biome-ignore lint/correctness/noUnusedVariables: used in markup
+const longText =
+  'This is a very long tooltip message that demonstrates how tooltips handle extended content. It can contain detailed information that users need to understand the context of the UI element.';
 </script>
 
-{#snippet template({ _children, ...args }: Args<typeof Story>, _context: StoryContext<typeof Story>)}
-  <div class="p-5 align-middle items-center flex flex-row">
-    Move mouse over the star icon to see the tooltip
-    <Tooltip {...args}>
-      <StarIcon />
-    </Tooltip>
-  </div>
+{#snippet template({ ...args })}
+  {#if args.kind === 'placements'}
+    <div class="bg-(--pd-content-card-bg) p-4">
+      <div class="flex flex-col gap-4 text-(--pd-content-text)">
+        <div class="text-sm font-semibold text-(--pd-content-text)">Placements</div>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {#each placementVariants as variant (variant.name)}
+            <div class="flex flex-col gap-2">
+              <div class="text-xs text-(--pd-content-text)">{variant.name}</div>
+              <Tooltip {...variant.args}>
+                <span
+                  class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-(--pd-tooltip-border) text-xs text-(--pd-tooltip-text)">
+                  i
+                </span>
+              </Tooltip>
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+  {:else if args.kind === 'long'}
+    <div class="bg-(--pd-content-card-bg) p-4">
+      <div class="flex flex-row items-center gap-2 text-(--pd-content-text)">
+        <span>Long text tooltip example</span>
+        <Tooltip top tip={longText}>
+          <span
+            class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-(--pd-tooltip-border) text-xs text-(--pd-tooltip-text)">
+            i
+          </span>
+        </Tooltip>
+      </div>
+    </div>
+  {:else if args.kind === 'snippet'}
+    <div class="bg-(--pd-content-card-bg) p-4">
+      <div class="flex flex-row items-center gap-2 text-(--pd-content-text)">
+        <span>Snippet tooltip content</span>
+        <Tooltip>
+          {#snippet tipSnippet()}
+            <div class="flex flex-col gap-1 max-w-64">
+              <div class="font-semibold">Custom snippet content</div>
+              <div class="text-xs">
+                Useful for richer tooltip layouts with multiple lines of information.
+              </div>
+            </div>
+          {/snippet}
+          <span
+            class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-(--pd-tooltip-border) text-xs text-(--pd-tooltip-text)">
+            i
+          </span>
+        </Tooltip>
+      </div>
+    </div>
+  {:else if args.kind === 'container'}
+    <div class="bg-(--pd-content-card-bg) p-4">
+      <div class="flex flex-row items-center gap-2 text-(--pd-content-text)">
+        <span>Container/class example</span>
+        <Tooltip tip="Top-right tooltip with container class applied" topRight containerClass="inline-flex" class="mb-[20px]">
+          <span
+            class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-(--pd-tooltip-border) text-xs text-(--pd-tooltip-text)">
+            i
+          </span>
+        </Tooltip>
+      </div>
+    </div>
+  {:else}
+    <div class="bg-(--pd-content-card-bg) p-4">
+      <div class="flex flex-row items-center gap-2 text-(--pd-content-text)">
+        <span>Move mouse over the icon to see the tooltip</span>
+        <Tooltip {...args}>
+          <span
+            class="inline-flex h-5 w-5 items-center justify-center rounded-full border border-(--pd-tooltip-border) text-xs text-(--pd-tooltip-text)">
+            i
+          </span>
+        </Tooltip>
+      </div>
+    </div>
+  {/if}
 {/snippet}
 
-<Story
-  name="Basic"
-  args={{
-    tip: 'this is a custom tooltip',
-  }} />
-
-<Story
-  name="Top"
-  args={{
-    tip: 'this is a custom top tooltip',
-    top: true,
-  }} />
-
-<Story
-  name="Top Left"
-  args={{
-    tip: 'this is a custom top left tooltip',
-    topLeft: true,
-  }} />
-
-<Story
-  name="Top Right"
-  args={{
-    tip: 'this is a custom top right tooltip',
-    topRight: true,
-  }} />
-
-<Story
-  name="Right"
-  args={{
-    tip: 'this is a custom right tooltip',
-    right: true,
-  }} />
-
-<Story
-  name="Bottom"
-  args={{
-    tip: 'this is a custom bottom tooltip',
-    bottom: true,
-  }} />
-
-<Story
-  name="Bottom Left"
-  args={{
-    tip: 'this is a custom bottom left tooltip',
-    bottomLeft: true,
-  }} />
-
-<Story
-  name="Bottom Right"
-  args={{
-    tip: 'this is a custom bottom right tooltip',
-    bottomRight: true,
-  }} />
-
-<Story
-  name="Left"
-  args={{
-    tip: 'this is a custom left tooltip',
-    left: true,
-  }} />
+<Story name="Basic" args={{ tip: 'this is a custom tooltip' }} />
+<Story name="Placements" args={{ kind: 'placements' }} />
+<Story name="Long Text" args={{ kind: 'long' }} />
+<Story name="Snippet Content" args={{ kind: 'snippet' }} />
+<Story name="Container/Class" args={{ kind: 'container' }} />


### PR DESCRIPTION
- Removed unused imports and simplified the story definitions.
- Added new story examples for different tooltip placements and long text handling.
- Enhanced documentation within the stories to clarify tooltip capabilities.

### What does this PR do?

### Screenshot / video of UI

<img width="2120" height="5093" alt="image" src="https://github.com/user-attachments/assets/2662b9f6-0b3f-4b5a-9d8a-dc28e72476ec" />

### What issues does this PR fix or reference?

Fixes #15782

### How to test this PR?

```bash
pnpm run storybook:dev
```

Navigate to `/?path=/docs/tooltip--docs`