### PR TITLE
fix(plugin): address admzip filename issue on macos

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -425,8 +425,9 @@ export class ExtensionLoader implements IAsyncDisposable {
     if (fs.existsSync(this.pluginsScanDirectory)) {
       // add watcher
       fs.watch(this.pluginsScanDirectory, (_, filename) => {
-        // need to load the file
-        if (filename) {
+        // Only process .cdix extension files
+        // Note: macOS fs.watch can emit an unintended error when watching a newly created directory
+        if (filename?.endsWith('.cdix')) {
           const packagedFile = path.resolve(this.pluginsScanDirectory, filename);
           setTimeout(() => {
             this.loadPackagedFile(packagedFile).catch((error: unknown) => {


### PR DESCRIPTION
when a new directory is created fs.watcher emits an unintended error. We should filter only by .cdix extension files to avoid this

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/15286

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
 on macos 
 remove the config files
 ```rm -rf ~/.local/share/containers/podman-desktop```
 run with pnpm watch and look for the logs discussed in the issue
 i noticed it was flaky so try a couple of times

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

Looking for feedback for creating a test. So far I think this is mac specific 
