### PR TITLE
chore(renderer/ProviderResultPage): explicit spinner size in px + self-closing tag

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderResultPage.svelte
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.svelte
@@ -154,7 +154,7 @@ function onSeverityClicked(severity: 'critical' | 'high' | 'medium' | 'low' | 's
           <div class="flex flex-row items-center">
             <span class="grow">{provider.info.label}</span>
             {#if provider.state === 'running'}
-              <Spinner size="12"></Spinner>
+              <Spinner size="12px"/>
             {/if}
             {#if provider.state === 'failed'}
               <span class="text-[var(--pd-state-error)] mt-1">


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/15816#pullrequestreview-3683303671, this PR explicitly sets the width of the spinner in pixels (`px`). This should do no change at all. It also self closes the tag.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
