### PR TITLE
feat(authentication): implement extension allowance  and session access control

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -411,8 +411,8 @@ test('getSession returns undefined when extension access is explicitly denied', 
 
   expect(session).toBeDefined();
 
-  // Now deny access for ext2
-  authModule.updateAllowedExtension('company.auth-provider', session!.account.label, 'ext2', 'Extension 2', false);
+  // Now deny access for ext2 (using account.id for allowance key)
+  authModule.updateAllowedExtension('company.auth-provider', session!.account.id, 'ext2', 'Extension 2', false);
 
   // ext2 should not get the session
   const sessionForExt2 = await authModule.getSession(
@@ -439,8 +439,8 @@ test('getSession returns session when extension access is allowed', async () => 
 
   expect(session).toBeDefined();
 
-  // Allow access for ext2
-  authModule.updateAllowedExtension('company.auth-provider', session!.account.label, 'ext2', 'Extension 2', true);
+  // Allow access for ext2 (using account.id for allowance key)
+  authModule.updateAllowedExtension('company.auth-provider', session!.account.id, 'ext2', 'Extension 2', true);
 
   // ext2 should get the session
   const sessionForExt2 = await authModule.getSession(
@@ -496,8 +496,8 @@ test('getSession prompts for allowance when accessing session without prior deci
   expect(sessionForExt2).toBeDefined();
   expect(sessionForExt2?.id).toBe(session!.id);
 
-  // Allowance should be stored
-  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.label, 'ext2')).toBe(true);
+  // Allowance should be stored (keyed by account.id)
+  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.id, 'ext2')).toBe(true);
 });
 
 test('getSession denies access when user clicks Deny on allowance prompt but does not store denial', async () => {
@@ -532,8 +532,8 @@ test('getSession denies access when user clicks Deny on allowance prompt but doe
   // Session should not be returned
   expect(sessionForExt2).toBeUndefined();
 
-  // Denial should NOT be stored - allows prompting again next time
-  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.label, 'ext2')).toBeUndefined();
+  // Denial should NOT be stored - allows prompting again next time (keyed by account.id)
+  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.id, 'ext2')).toBeUndefined();
 });
 
 test('getSession auto-allows creating extension to reuse its own session in silent mode', async () => {
@@ -554,8 +554,8 @@ test('getSession auto-allows creating extension to reuse its own session in sile
 
   expect(session).toBeDefined();
 
-  // Creating extension should be auto-allowed
-  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.label, 'ext1')).toBe(true);
+  // Creating extension should be auto-allowed (keyed by account.id)
+  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.id, 'ext1')).toBe(true);
 
   // Reset mock to ensure no prompts happen
   vi.mocked(mb.showMessageBox).mockClear();

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -347,3 +347,227 @@ test('authentication shows confirmation request when signing out from a session'
     }),
   );
 });
+
+test('readAllowedExtensions returns empty array when no allowances exist', () => {
+  expect(authModule.readAllowedExtensions('provider1', 'account1')).toEqual([]);
+});
+
+test('updateAllowedExtension adds new extension allowance', () => {
+  authModule.updateAllowedExtension('provider1', 'account1', 'ext1', 'Extension 1', true);
+
+  const allowances = authModule.readAllowedExtensions('provider1', 'account1');
+  expect(allowances).toHaveLength(1);
+  expect(allowances[0]).toEqual({ id: 'ext1', name: 'Extension 1', allowed: true });
+});
+
+test('updateAllowedExtension updates existing extension allowance', () => {
+  authModule.updateAllowedExtension('provider1', 'account1', 'ext1', 'Extension 1', true);
+  authModule.updateAllowedExtension('provider1', 'account1', 'ext1', 'Extension 1', false);
+
+  const allowances = authModule.readAllowedExtensions('provider1', 'account1');
+  expect(allowances).toHaveLength(1);
+  expect(allowances[0]).toEqual({ id: 'ext1', name: 'Extension 1', allowed: false });
+});
+
+test('updateAllowedExtension sends authentication-provider-update event', () => {
+  authModule.updateAllowedExtension('provider1', 'account1', 'ext1', 'Extension 1', true);
+
+  expect(apiSender.send).toHaveBeenCalledWith('authentication-provider-update', { id: 'provider1' });
+});
+
+test('isAccessAllowed returns undefined when no allowances exist', () => {
+  expect(authModule.isAccessAllowed('provider1', 'account1', 'ext1')).toBeUndefined();
+});
+
+test('isAccessAllowed returns true when extension is allowed', () => {
+  authModule.updateAllowedExtension('provider1', 'account1', 'ext1', 'Extension 1', true);
+
+  expect(authModule.isAccessAllowed('provider1', 'account1', 'ext1')).toBe(true);
+});
+
+test('isAccessAllowed returns false when extension is denied', () => {
+  authModule.updateAllowedExtension('provider1', 'account1', 'ext1', 'Extension 1', false);
+
+  expect(authModule.isAccessAllowed('provider1', 'account1', 'ext1')).toBe(false);
+});
+
+test('isAccessAllowed returns undefined for unknown extension when other extensions exist', () => {
+  authModule.updateAllowedExtension('provider1', 'account1', 'ext1', 'Extension 1', true);
+
+  expect(authModule.isAccessAllowed('provider1', 'account1', 'ext2')).toBeUndefined();
+});
+
+test('getSession returns undefined when extension access is explicitly denied', async () => {
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authModule.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  // First create a session
+  const session = await authModule.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  // Now deny access for ext2
+  authModule.updateAllowedExtension('company.auth-provider', session!.account.label, 'ext2', 'Extension 2', false);
+
+  // ext2 should not get the session
+  const sessionForExt2 = await authModule.getSession(
+    { id: 'ext2', label: 'Extension 2' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { silent: true },
+  );
+
+  expect(sessionForExt2).toBeUndefined();
+});
+
+test('getSession returns session when extension access is allowed', async () => {
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authModule.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  // First create a session
+  const session = await authModule.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  // Allow access for ext2
+  authModule.updateAllowedExtension('company.auth-provider', session!.account.label, 'ext2', 'Extension 2', true);
+
+  // ext2 should get the session
+  const sessionForExt2 = await authModule.getSession(
+    { id: 'ext2', label: 'Extension 2' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { silent: true },
+  );
+
+  expect(sessionForExt2).toBeDefined();
+  expect(sessionForExt2?.id).toBe(session!.id);
+});
+
+test('getSession prompts for allowance when accessing session without prior decision', async () => {
+  const mb = {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }), // User clicks "Allow"
+  } as unknown as MessageBox;
+  const authentication = new AuthenticationImpl(apiSender, mb);
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authentication.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  // First create a session with ext1
+  const session = await authentication.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  // Reset mock to track only the next call
+  vi.mocked(mb.showMessageBox).mockClear();
+  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 1 }); // User clicks "Allow"
+
+  // ext2 tries to access the session - should prompt for allowance
+  const sessionForExt2 = await authentication.getSession(
+    { id: 'ext2', label: 'Extension 2' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+  );
+
+  // Should have prompted the user
+  expect(mb.showMessageBox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      title: 'Allow Access',
+      message: expect.stringContaining('Extension 2'),
+      buttons: ['Deny', 'Allow'],
+    }),
+  );
+
+  // Session should be returned after user allowed
+  expect(sessionForExt2).toBeDefined();
+  expect(sessionForExt2?.id).toBe(session!.id);
+
+  // Allowance should be stored
+  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.label, 'ext2')).toBe(true);
+});
+
+test('getSession denies access when user clicks Deny on allowance prompt but does not store denial', async () => {
+  const mb = {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }), // First call: Allow (for createIfNone)
+  } as unknown as MessageBox;
+  const authentication = new AuthenticationImpl(apiSender, mb);
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authentication.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  // First create a session with ext1
+  const session = await authentication.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  // Reset mock - user will click "Deny" this time
+  vi.mocked(mb.showMessageBox).mockClear();
+  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 0 }); // User clicks "Deny"
+
+  // ext2 tries to access the session - user denies
+  const sessionForExt2 = await authentication.getSession(
+    { id: 'ext2', label: 'Extension 2' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+  );
+
+  // Session should not be returned
+  expect(sessionForExt2).toBeUndefined();
+
+  // Denial should NOT be stored - allows prompting again next time
+  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.label, 'ext2')).toBeUndefined();
+});
+
+test('getSession returns undefined in silent mode when no allowance decision exists', async () => {
+  const mb = {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }),
+  } as unknown as MessageBox;
+  const authentication = new AuthenticationImpl(apiSender, mb);
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authentication.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  // First create a session with ext1
+  const session = await authentication.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  // Reset mock
+  vi.mocked(mb.showMessageBox).mockClear();
+
+  // ext2 tries to access the session in silent mode
+  const sessionForExt2 = await authentication.getSession(
+    { id: 'ext2', label: 'Extension 2' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { silent: true },
+  );
+
+  // Should NOT have prompted (silent mode)
+  expect(mb.showMessageBox).not.toHaveBeenCalled();
+
+  // Session should not be returned in silent mode without prior allowance
+  expect(sessionForExt2).toBeUndefined();
+});

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -378,6 +378,14 @@ export class AuthenticationImpl {
           this._signInRequestsData.delete(request.id);
           this._signInRequests.delete(providerId);
         }
+        // Auto-allow the creating extension to access its own session
+        this.updateAllowedExtension(
+          providerId,
+          newSession.account.label,
+          requestingExtension.id,
+          requestingExtension.label,
+          true,
+        );
         this.addAccountUsage(providerId, newSession.id, requestingExtension.id, requestingExtension.label);
         return newSession;
       } else {


### PR DESCRIPTION
### What does this PR do?

The simple change to return `true` from `isAccessAllowed` does not work because of error in condition used. It just starts triggering authentication workflow in external browser for every authentication request regardless of the existing sessions.

Another problem is that serialized authentication session from previous podman desktop session does not store extension id. It is similar to vscode implementation. So there is no way to verify what extension created restored session and after restart when any extension will try to reuse restored session user should confirm it.

This fix implements in memory storage for that matter.  

- Added methods to read/update allowed extensions for authentication providers
- Implemented a check for access permissions for extensions
- Updated tests to cover new functionality

### Screenshot / video of UI

Depending on having stored session in secure SSO Extension storage you should see the requests shown below.

1. If you have no authentication sessions  saved in secure storage and start podman desktop with Red Hat SSO and Sandbox extension when you try to create Sandbox connection you should see following behavior:
* Request to allow Sandbox to sign in using Red Hat SSO on first attempt to create Sandbox connection
* No request for following connection, because previously created session is used

https://github.com/user-attachments/assets/d788569d-c35f-4e16-8708-d34a407b48bb

2. If you have authentication sessions from previous podman desktop session after restart sandbox will try to get new session and authentication module ask user to confirm if existing session can be used by Sandbox extension:

https://github.com/user-attachments/assets/be2f3f05-2af8-4ce7-9b50-b039e8eac61c

### What issues does this PR fix or reference?

Fix #15699.

### How to test this PR?

See videos attached above.

- [x] Tests are covering the bug fix or the new feature
