### PR TITLE
[WIP] feat(podman-desktop-api): enhanced register method

### DIFF
--- a/packages/api/src/documentation-info.ts
+++ b/packages/api/src/documentation-info.ts
@@ -40,7 +40,16 @@ export type GoToInfo =
   | (ContainerInfo & { type: 'Container'; icon: GoToIcon })
   | (ImageInfo & { type: 'Image'; icon: GoToIcon })
   | (VolumeInfo & { type: 'Volume'; icon: GoToIcon })
-  | (NavigationInfo & { type: 'Navigation'; icon: GoToIcon });
+  | (NavigationInfo & { type: 'Navigation'; icon: GoToIcon })
+  // For commands that are registered as navigation routes (e.g. navigating to extensionresources)
+  | (NavigationCommandInfo & { type: 'NavigationCommand'; icon: GoToIcon });
+
+export interface NavigationCommandInfo {
+  name: string;
+  command: string;
+  id: string;
+  hidden?: boolean;
+}
 
 export interface NavigationInfo {
   name: string;

--- a/packages/api/src/navigation-route-info.ts
+++ b/packages/api/src/navigation-route-info.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Information about a registered navigation route
+ */
+export interface NavigationRouteInfo {
+  /**
+   * Unique identifier for the route
+   */
+  routeId: string;
+
+  /**
+   * The command that will be executed when navigating to this route
+   */
+  commandId: string;
+
+  /**
+   * Human-readable title for the route
+   */
+  title?: string;
+
+  /**
+   * Icon for the route
+   */
+  icon?: string | { light: string; dark: string };
+
+  /**
+   * Extension ID that registered this route
+   */
+  extensionId?: string;
+}

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5043,8 +5043,10 @@ declare module '@podman-desktop/api' {
      *   // todo: do something with the trackingId
      * });
      *
-     * // register the route
-     * navigation.register('download-page', 'redirect-download-command');
+     * // register the route with metadata
+     * navigation.register('download-page', 'redirect-download-command', {
+     *   title: 'Open Download Page'
+     * });
      *
      * // when needed call the navigate with the route id registered to
      * // trigger the command
@@ -5053,8 +5055,9 @@ declare module '@podman-desktop/api' {
      *
      * @param routeId a unique string value that could be used in {@link navigation.navigate}
      * @param commandId the command that will be executed on navigate
+     * @param options optional metadata for the route (title, icon)
      */
-    export function register(routeId: string, commandId: string): Disposable;
+    export function register(routeId: string, commandId: string, options?: NavigationRouteOptions): Disposable;
 
     /**
      * Allow extension to navigate to a custom route.
@@ -5064,6 +5067,21 @@ declare module '@podman-desktop/api' {
      * @param args the arguments to provide to the command linked to the routeId
      */
     export function navigate(routeId: string, ...args: unknown[]): Promise<void>;
+  }
+
+  /**
+   * Options for registering a navigation route with metadata.
+   */
+  export interface NavigationRouteOptions {
+    /**
+     * A human-readable title for this route that will appear in the command palette
+     */
+    title: string;
+
+    /**
+     * Optional base64 PNG image (for transparency / non vector icons)
+     */
+    icon?: string | { light: string; dark: string };
   }
 
   /**

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1614,10 +1614,27 @@ export class ExtensionLoader implements IAsyncDisposable {
       navigate: async (routeId: string, ...args: unknown[]): Promise<void> => {
         return this.navigationManager.navigateToRoute(`${extensionInfo.id}.${routeId}`, args);
       },
-      register: (routeId: string, commandId: string): Disposable => {
+      register: (
+        routeId: string,
+        commandId: string,
+        options?: containerDesktopAPI.NavigationRouteOptions,
+      ): Disposable => {
+        // Try to find webview for this extension to get its display name
+        // Same logic as in navigation-registry-extension.svelte.ts
+        const webviews = webviewRegistry.listWebviews();
+        const extensionWebview = webviews.find(w => w.sourcePath === extensionInfo.extensionPath);
+
+        let displayName: string = extensionInfo.label;
+        if (extensionWebview) {
+          displayName = extensionWebview.name;
+        }
+
         const disposable = this.navigationManager.registerRoute({
-          routeId: `${extensionInfo.id}.${routeId}`,
+          routeId: routeId,
           commandId: commandId,
+          extensionId: displayName,
+          title: options?.title,
+          icon: options?.icon,
         });
 
         disposables.push(disposable);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3147,6 +3147,10 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('navigation:getRoutes', async () => {
+      return navigationManager.getNavigationRoutes();
+    });
+
     this.ipcHandle('onboardingRegistry:listOnboarding', async (): Promise<OnboardingInfo[]> => {
       return onboardingRegistry.listOnboarding();
     });

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -307,6 +307,63 @@ test('check navigateToExtensionsCatalog', async () => {
   });
 });
 
+describe('getNavigationRoutes', () => {
+  test('should return empty array when no routes are registered', () => {
+    const routes = navigationManager.getNavigationRoutes();
+    expect(routes).toEqual([]);
+  });
+
+  test('should return all registered routes with metadata', () => {
+    // Register multiple routes with different metadata
+    navigationManager.registerRoute({
+      routeId: 'route1',
+      commandId: 'command1',
+      title: 'Route One',
+      icon: 'icon1',
+      extensionId: 'Extension 1',
+    });
+
+    navigationManager.registerRoute({
+      routeId: 'route2',
+      commandId: 'command2',
+      title: 'Route Two',
+      icon: { light: 'light-icon', dark: 'dark-icon' },
+      extensionId: 'Extension 2',
+    });
+
+    navigationManager.registerRoute({
+      routeId: 'route3',
+      commandId: 'command3',
+      // No title, icon, or extensionId
+    });
+
+    const routes = navigationManager.getNavigationRoutes();
+
+    expect(routes).toHaveLength(3);
+    expect(routes[0]).toEqual({
+      routeId: 'route1',
+      commandId: 'command1',
+      title: 'Route One',
+      icon: 'icon1',
+      extensionId: 'Extension 1',
+    });
+    expect(routes[1]).toEqual({
+      routeId: 'route2',
+      commandId: 'command2',
+      title: 'Route Two',
+      icon: { light: 'light-icon', dark: 'dark-icon' },
+      extensionId: 'Extension 2',
+    });
+    expect(routes[2]).toEqual({
+      routeId: 'route3',
+      commandId: 'command3',
+      title: undefined,
+      icon: undefined,
+      extensionId: undefined,
+    });
+  });
+});
+
 describe('register navigation commands', () => {
   beforeEach(() => {
     navigationManager.init();

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -16,7 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { NavigateToExtensionsCatalogOptions, ProviderContainerConnection } from '@podman-desktop/api';
+import type {
+  NavigateToExtensionsCatalogOptions,
+  NavigationRouteOptions,
+  ProviderContainerConnection,
+} from '@podman-desktop/api';
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 
 import { CommandRegistry } from '/@/plugin/command-registry.js';
@@ -27,14 +31,17 @@ import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import { IDisposable } from '/@api/disposable.js';
 import { NavigationPage } from '/@api/navigation-page.js';
 import type { NavigationRequest } from '/@api/navigation-request.js';
+import { NavigationRouteInfo } from '/@api/navigation-route-info.js';
 
 import { ProviderRegistry } from '../provider-registry.js';
 import { Disposable } from '../types/disposable.js';
 import { WebviewRegistry } from '../webview/webview-registry.js';
 
-export interface NavigationRoute {
+export interface NavigationRoute extends Omit<NavigationRouteOptions, 'title'> {
   routeId: string;
   commandId: string;
+  title?: string;
+  extensionId?: string;
 }
 
 @injectable()
@@ -113,6 +120,21 @@ export class NavigationManager {
 
   hasRoute(routeId: string): boolean {
     return this.#registry.has(routeId);
+  }
+
+  getNavigationRoutes(): NavigationRouteInfo[] {
+    const routes: NavigationRouteInfo[] = [];
+    this.#registry.forEach((route, routeId) => {
+      routes.push({
+        routeId,
+        commandId: route.commandId,
+        title: route.title,
+        icon: route.icon,
+        extensionId: route.extensionId,
+      });
+    });
+
+    return routes;
   }
 
   async navigateToRoute(routeId: string, ...args: unknown[]): Promise<void> {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -106,6 +106,7 @@ import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } 
 import type { Menu } from '/@api/menu.js';
 import { NavigationPage } from '/@api/navigation-page';
 import type { NavigationRequest } from '/@api/navigation-request';
+import type { NavigationRouteInfo } from '/@api/navigation-route-info';
 import type { NetworkInspectInfo } from '/@api/network-info';
 import type { NotificationCard, NotificationCardOptions } from '/@api/notification';
 import type { OnboardingInfo, OnboardingStatus } from '/@api/onboarding';
@@ -1679,6 +1680,10 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld('getCommandPaletteCommands', async (): Promise<CommandInfo[]> => {
     return ipcInvoke('commands:getCommandPaletteCommands');
+  });
+
+  contextBridge.exposeInMainWorld('getNavigationRoutes', async (): Promise<NavigationRouteInfo[]> => {
+    return ipcInvoke('navigation:getRoutes');
   });
 
   contextBridge.exposeInMainWorld('listExtensions', async (): Promise<ExtensionInfo[]> => {


### PR DESCRIPTION
### What does this PR do?
Enhances register methpd exported by podman desktop API 

+ changes to command pallete/ related parts of code to show the routes to extension that registers the route (another PR)

We can also just add some flag that would add the route to command pallete 
- will split this into smaller PRs, so far this is just a POC 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/15650

### How to test this PR?
Clone https://github.com/containers/podman-desktop-extension-ai-lab/pull/4094 
in there link the podman-desktop-api with this one using `pnpm link`

See that there are registered routes for AI lab and the navigation works though command palette

- [x] Tests are covering the bug fix or the new feature
