### PR TITLE
fix(ui/spinner): fix incorrect ARIA and role

### DIFF
--- a/packages/renderer/src/lib/image/PushImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushImageModal.spec.ts
@@ -137,7 +137,7 @@ describe('Expect Push Image dialog', () => {
   let callback: CallbackType | undefined;
   const closeCallback = vi.fn();
   function button(name: 'Cancel' | 'Push image' | 'Done'): HTMLElement | null {
-    return screen.queryByRole('button', { name });
+    return screen.queryByRole('button', { name }) ?? screen.queryByRole('button', { name: `Loading ${name}` });
   }
 
   function terminal(): HTMLElement | null {

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -37,7 +37,7 @@ test('Expect button html when passing a button tag in markdown', async () => {
     item: textComponent,
     inProgressCommandExecution: vi.fn(),
   });
-  const button = screen.getByRole('button', { name: 'label' });
+  const button = screen.getByRole('button', { name: 'Loading label' });
   expect(button).toBeInTheDocument();
   expect(button.dataset.command).toBe('command');
 });

--- a/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
@@ -88,8 +88,8 @@ test('Check with in-progress', async () => {
   // expect the in-progress is used
   const status = screen.getByRole('status', { name: 'in-progress' });
   expect(status).toBeInTheDocument();
-  const progressbar = screen.getByRole('progressbar');
-  expect(progressbar).toBeInTheDocument();
+  const spinner = screen.getByRole('status', { name: 'Loading' });
+  expect(spinner).toBeInTheDocument();
 
   // expect name is there
   const name = screen.getByText(IN_PROGRESS_TASK.name);

--- a/packages/ui/src/lib/progress/Spinner.spec.ts
+++ b/packages/ui/src/lib/progress/Spinner.spec.ts
@@ -29,8 +29,9 @@ describe('parent attributes should be propagate', () => {
       style: 'color: green;',
     });
 
-    const spinner = screen.getByRole('progressbar', { name: 'Loading', busy: true });
+    const spinner = screen.getByRole('status', { name: 'Loading' });
     expect(spinner).toBeDefined();
+    expect(spinner).toHaveAttribute('aria-live', 'polite');
 
     expect(spinner.getAttribute('style')).toBe('color: green;');
   });
@@ -40,8 +41,9 @@ describe('parent attributes should be propagate', () => {
       class: 'dummy-class',
     });
 
-    const spinner = screen.getByRole('progressbar', { name: 'Loading', busy: true });
+    const spinner = screen.getByRole('status', { name: 'Loading' });
     expect(spinner).toBeDefined();
+    expect(spinner).toHaveAttribute('aria-live', 'polite');
 
     expect(spinner.classList).toContain('dummy-class');
   });

--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -8,9 +8,9 @@ let { size = '2em', class: className, style }: Props = $props();
 </script>
 
 <i
-  role="progressbar"
+  role="status"
   aria-label="Loading"
-  aria-busy="true"
+  aria-live="polite"
   class="flex justify-center items-center {className}"
   style={style}>
   <svg width={size} height={size} viewBox="0 0 100 100" role="img">

--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -59,7 +59,7 @@ test('Expect degraded styling', async () => {
 test('Expect deleting styling', async () => {
   const status = 'DELETING';
   render(StatusIcon, { status });
-  const icon = screen.getByRole('status');
+  const icon = screen.getByRole('status', { name: status });
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
   expect(icon).not.toHaveAttribute('border');
@@ -72,7 +72,7 @@ test('Expect deleting styling', async () => {
 test('Expect updating styling', async () => {
   const status = 'UPDATING';
   render(StatusIcon, { status });
-  const icon = screen.getByRole('status');
+  const icon = screen.getByRole('status', { name: status });
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
   expect(icon).not.toHaveAttribute('border');


### PR DESCRIPTION
### What does this PR do?

This PR fixes the UI Spinner component ARIA and role.
NB: Because the role becomes "status", when used inside a button, the accessible name of button is now prefixed with "Loading", hence the test updates.

### Screenshot / video of UI

There should be no change.

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15804

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
