### PR TITLE
chore(fix): adding missing permissions compared to flathub repo

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -206,7 +206,11 @@ const config = {
       '--device=dri',
       // Read/write home directory access
       '--filesystem=home',
-      // Read-only access to the host OS filesystem required for managed-configuration
+      // Read-only access to /usr and /etc for managed-configuration support.
+      // Flatpak sandboxes these directories, so we can't use --filesystem=/usr/share/podman-desktop:ro directly.
+      // host-os:ro only exposes /usr and parts of /etc (not the full filesystem).
+      // See: https://github.com/flatpak/flatpak/issues/5575
+      // See: https://man7.org/linux/man-pages/man5/flatpak-metadata.5.html (host-os section)
       '--filesystem=host-os:ro',
       // Read podman socket
       '--filesystem=xdg-run/podman:create',

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -206,6 +206,8 @@ const config = {
       '--device=dri',
       // Read/write home directory access
       '--filesystem=home',
+      // Read-only access to the host OS filesystem required for managed-configuration
+      '--filesystem=host-os:ro',
       // Read podman socket
       '--filesystem=xdg-run/podman:create',
       // Read/write containers directory access (ability to save the application preferences)
@@ -226,6 +228,8 @@ const config = {
       '--talk-name=org.kde.StatusNotifierWatcher',
       // Allow to interact with Flatpak system to execute commands outside the application's sandbox
       '--talk-name=org.freedesktop.Flatpak',
+      // required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810 when the user uses --socket=wayland in their flatpak run
+      '--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons',
       '--env=XDG_SESSION_TYPE=x11',
     ],
     useWaylandFlags: 'false',


### PR DESCRIPTION
### What does this PR do?
* Adds missing permissions and configurations compared to flathub repo https://github.com/flathub/io.podman_desktop.PodmanDesktop
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #15831
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
* Checkout branch
* `pnpm install`
* `pnpm compile:current --linux flatpak`
* `flatpak install <path_to_built_file>`

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
