### PR TITLE
fix(ui/spinner): hide decorative SVG from screen readers

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
@@ -134,7 +134,7 @@ describe('test ProviderResultPage', async () => {
       expect(providerEntry).toBeInTheDocument();
       const cb = within(providerEntry).queryByRole('checkbox');
       expect(cb).not.toBeInTheDocument();
-      const spinner = within(providerEntry).queryByRole('img');
+      const spinner = within(providerEntry).queryByRole('status', { name: 'Loading' });
       expect(spinner).toBeInTheDocument();
     };
 

--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -182,16 +182,16 @@ test('Button inProgress must have a spinner', async () => {
   // render the component
   render(Button, { inProgress: true });
 
-  const svg = screen.getByRole('img');
-  expect(svg).toBeDefined();
+  const spinner = screen.getByRole('status', { name: 'Loading' });
+  expect(spinner).toBeDefined();
 });
 
 test('Button no progress no icon do not have spinner', async () => {
   // render the component
   render(Button, { inProgress: false });
 
-  const svg = screen.queryByRole('img');
-  expect(svg).toBeNull();
+  const spinner = screen.queryByRole('status', { name: 'Loading' });
+  expect(spinner).toBeNull();
 });
 
 test('Button hidden should be hidden', async () => {

--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -13,7 +13,7 @@ let { size = '2em', class: className, style }: Props = $props();
   aria-live="polite"
   class="flex justify-center items-center {className}"
   style={style}>
-  <svg width={size} height={size} viewBox="0 0 100 100" role="img">
+  <svg width={size} height={size} viewBox="0 0 100 100" aria-hidden="true">
     <defs>
       <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
         <stop offset="0%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>

--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -64,7 +64,7 @@ test('Expect deleting styling', async () => {
   expect(icon).toHaveAttribute('title', status);
   expect(icon).not.toHaveAttribute('border');
 
-  const spinner = screen.getByRole('img');
+  const spinner = screen.getByRole('status', { name: 'Loading' }).firstChild;
   expect(spinner).toBeInTheDocument();
   expect(spinner).toHaveAttribute('width', '1.4em');
 });
@@ -77,7 +77,7 @@ test('Expect updating styling', async () => {
   expect(icon).toHaveAttribute('title', status);
   expect(icon).not.toHaveAttribute('border');
 
-  const spinner = screen.getByRole('img');
+  const spinner = screen.getByRole('status', { name: 'Loading' }).firstChild;
   expect(spinner).toBeInTheDocument();
   expect(spinner).toHaveAttribute('width', '1.4em');
 });


### PR DESCRIPTION
### What does this PR do?

This PR hides the decorative SVG from screen readers for the Spinner UI component.

### Screenshot / video of UI

There should be no visible change.

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15805

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
