### PR TITLE
fix: do not consider proxy as enabled if only noProxy is defined

### DIFF
--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -196,3 +196,25 @@ describe.each([
     expect(ensureURL(original)).toBe(converted);
   });
 });
+
+test('check isEnabled returns false when proxy is system but noProxy is not empty', async () => {
+  vi.mocked(getProxySettingsFromSystem).mockResolvedValue({
+    httpProxy: undefined,
+    httpsProxy: undefined,
+    noProxy: 'localhost,127.0.0.1',
+  });
+  await proxy?.setState(ProxyState.PROXY_SYSTEM);
+  await proxy?.setProxy(undefined);
+  expect(proxy?.isEnabled()).toBe(false);
+});
+
+test('check isEnabled returns true when proxy is system and some proxy is enabled', async () => {
+  vi.mocked(getProxySettingsFromSystem).mockResolvedValue({
+    httpProxy: 'http://127.0.0.1:8080',
+    httpsProxy: undefined,
+    noProxy: 'localhost,127.0.0.1',
+  });
+  await proxy?.setState(ProxyState.PROXY_SYSTEM);
+  await proxy?.setProxy(undefined);
+  expect(proxy?.isEnabled()).toBe(true);
+});

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -179,7 +179,11 @@ export class Proxy {
   }
 
   isEnabled(): boolean {
-    return this.proxyState !== ProxyState.PROXY_DISABLED && this.proxySettings !== undefined;
+    return (
+      this.proxyState !== ProxyState.PROXY_DISABLED &&
+      this.proxySettings !== undefined &&
+      (this.proxySettings.httpProxy !== undefined || this.proxySettings.httpsProxy !== undefined)
+    );
   }
 
   async setState(state: ProxyState): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Philippe Martin <phmartin@redhat.com>

### What does this PR do?

Do not consider proxy as enabled if only noProxy is defined

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #15826 
Fixes #15817 

### How to test this PR?

See #15817  steps to reproduce

- [x] Tests are covering the bug fix or the new feature
