### PR TITLE
fix(windows uninstall): use dynamic product name for Windows registry cleanup

### DIFF
--- a/buildResources/installer.nsh
+++ b/buildResources/installer.nsh
@@ -1,6 +1,6 @@
 !macro customUnInit
   ; Remove startup registry entry
-  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "Podman Desktop"
-  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" "Podman Desktop"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCT_NAME}"
+  DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" "${PRODUCT_NAME}"
 
 !macroend


### PR DESCRIPTION
### What does this PR do?

Replaces hardcoded "Podman Desktop" string with `${PRODUCT_NAME}` variable
in the NSIS uninstaller script for registry key deletion.

The auto-start registry entry is created by Electron using the `setLoginItemSettings` function:

```ts
app.setLoginItemSettings({
  openAtLogin: true,
  path: `"${this.podmanDesktopBinaryPath}"`,
  args,
});
```

Which by default will use the `productName` in the electron builder..

```js
productName: product.name,
```

Which comes from product.json:

```json
"name": "Podman Desktop",
```

The uninstaller must then use the samename to properly clean up:

```sh
DeleteRegValue HKCU "...\Run" "${PRODUCT_NAME}"
DeleteRegValue HKCU "...\StartupApproved\Run" "${PRODUCT_NAME}"
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/15843

### How to test this PR?

1. Build and install Podman Desktop on Windows 10/11
2. Enable "Start on login" in preferences after installing
3. Uninstall the application
4. Verify registry keys are removed from:
   - `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`
   - `HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
