### PR TITLE
refactor(semver): switches from compare-versions to semver

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -445,10 +445,10 @@
     "@podman-desktop/api": "workspace:*",
     "@podman-desktop/podman-extension-api": "workspace:*",
     "async-mutex": "^0.5.0",
-    "compare-versions": "^6.1.1",
     "inversify": "^7.11.0",
     "mustache": "^4.2.0",
     "ps-list": "^9.0.0",
+    "semver": "^7.7.3",
     "smol-toml": "1.6.0",
     "ssh2": "^1.17.0",
     "winreg": "^1.2.5"

--- a/extensions/podman/packages/extension/src/checks/macos-checks.ts
+++ b/extensions/podman/packages/extension/src/checks/macos-checks.ts
@@ -19,7 +19,7 @@
 import * as os from 'node:os';
 
 import * as extensionApi from '@podman-desktop/api';
-import { compare } from 'compare-versions';
+import { compare } from 'semver';
 
 import { BaseCheck } from './base-check';
 
@@ -61,7 +61,7 @@ export class MacVersionCheck extends BaseCheck {
 
   async execute(): Promise<extensionApi.CheckResult> {
     const darwinVersion = os.release();
-    if (compare(darwinVersion, MINIMUM_VERSION, '>=')) {
+    if (compare(darwinVersion, MINIMUM_VERSION) >= 0) {
       return this.createSuccessfulResult();
     }
     return this.createFailureResult({

--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-podman-version-check.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************/
 import type { CheckResult } from '@podman-desktop/api';
-import { compareVersions } from 'compare-versions';
 import { inject, injectable } from 'inversify';
+import { compare } from 'semver';
 
 import { BaseCheck } from '/@/checks/base-check';
 import { PodmanBinary } from '/@/utils/podman-binary';
@@ -47,6 +47,6 @@ export class HyperVPodmanVersionCheck extends BaseCheck {
   private async isPodmanVersionSupported(): Promise<boolean> {
     const binaryInfo = await this.podmanBinary.getBinaryInfo();
     if (!binaryInfo) return false;
-    return compareVersions(binaryInfo?.version, HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
+    return compare(binaryInfo?.version, HyperVPodmanVersionCheck.PODMAN_MINIMUM_VERSION_FOR_HYPERV) >= 0;
   }
 }

--- a/extensions/podman/packages/extension/src/checks/windows/wsl-version-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/wsl-version-check.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 import type extensionApi from '@podman-desktop/api';
-import { compare } from 'compare-versions';
 import { injectable } from 'inversify';
+import { coerce, compare } from 'semver';
 
 import { MemoizedBaseCheck } from '/@/checks/memoized-base-check';
 import { WslHelper } from '/@/helpers/wsl-helper';
@@ -34,7 +34,8 @@ export class WSLVersionCheck extends MemoizedBaseCheck {
       const wslHelper = new WslHelper();
       const wslVersionData = await wslHelper.getWSLVersionData();
       if (wslVersionData.wslVersion) {
-        if (compare(wslVersionData.wslVersion, this.minVersion, '>=')) {
+        const wslVersion = coerce(wslVersionData.wslVersion);
+        if (wslVersion && compare(wslVersion, this.minVersion) >= 0) {
           return this.createSuccessfulResult();
         } else {
           return this.createFailureResult({

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -26,7 +26,7 @@ import type { ContainerEngineInfo, RunError } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import type { PodmanExtensionApi, PodmanRunOptions } from '@podman-desktop/podman-extension-api';
 import { Mutex } from 'async-mutex';
-import { compareVersions } from 'compare-versions';
+import { compare } from 'semver';
 
 import {
   CLEANUP_REQUIRED_MACHINE_KEY,
@@ -1826,38 +1826,34 @@ const PODMAN_MINIMUM_VERSION_FOR_NOW_FLAG_INIT = '4.0.0';
 
 // Checks if start now flag at machine init is supported.
 export function isStartNowAtMachineInitSupported(podmanVersion: string): boolean {
-  return compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_NOW_FLAG_INIT) >= 0;
+  return compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_NOW_FLAG_INIT) >= 0;
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_ROOTFUL_MACHINE_INIT = '4.1.0';
 
 // Checks if rootful machine init is supported.
 export function isRootfulMachineInitSupported(podmanVersion: string): boolean {
-  return compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_ROOTFUL_MACHINE_INIT) >= 0;
+  return compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_ROOTFUL_MACHINE_INIT) >= 0;
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_PLAYBOOK_MACHINE_INIT = '5.4.0';
 
 // Checks if playbook option is supported.
 export function isPlaybookMachineInitSupported(podmanVersion: string): boolean {
-  return compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_PLAYBOOK_MACHINE_INIT) >= 0;
+  return compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_PLAYBOOK_MACHINE_INIT) >= 0;
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_NEW_SOCKET_LOCATION = '4.5.0';
 
 export function isPodmanSocketLocationMoved(podmanVersion: string): boolean {
-  return (
-    extensionApi.env.isLinux && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_NEW_SOCKET_LOCATION) >= 0
-  );
+  return extensionApi.env.isLinux && compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_NEW_SOCKET_LOCATION) >= 0;
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING = '4.6.0';
 
 // Checks if user mode networking is supported. Only Windows platform allows this parameter to be tuned
 export function isUserModeNetworkingSupported(podmanVersion: string): boolean {
-  return (
-    extensionApi.env.isWindows && compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING) >= 0
-  );
+  return extensionApi.env.isWindows && compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_USER_MODE_NETWORKING) >= 0;
 }
 
 const PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT = '5.2.0-rc1';
@@ -1867,7 +1863,7 @@ export function isLibkrunSupported(podmanVersion: string): boolean {
   return (
     extensionApi.env.isMac &&
     os.arch() === 'arm64' &&
-    compareVersions(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT) >= 0
+    compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_LIBKRUN_SUPPORT) >= 0
   );
 }
 
@@ -1877,7 +1873,7 @@ export function setWSLEnabled(enabled: boolean): void {
 }
 
 export function isPodman5OrLater(podmanVersion: string): boolean {
-  return compareVersions(podmanVersion, '5.0.0') >= 0;
+  return compare(podmanVersion, '5.0.0') >= 0;
 }
 
 export function sendTelemetryRecords(

--- a/extensions/podman/packages/extension/src/installer/base-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/base-installer.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { InstallCheck } from '@podman-desktop/api';
-import { compare } from 'compare-versions';
+import { compare } from 'semver';
 
 import { getBundledPodmanVersion } from '/@/utils/podman-bundled';
 
@@ -32,6 +32,6 @@ export abstract class BaseInstaller implements Installer {
   abstract getPreflightChecks(): InstallCheck[];
 
   requireUpdate(installedVersion: string): boolean {
-    return compare(installedVersion, getBundledPodmanVersion(), '<');
+    return compare(installedVersion, getBundledPodmanVersion()) < 0;
   }
 }

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -20,8 +20,8 @@ import { mkdir, readFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
-import { compare } from 'compare-versions';
 import { inject, injectable, optional } from 'inversify';
+import { compare } from 'semver';
 
 import { getDetectionChecks } from '/@/checks/detection-checks';
 import {
@@ -274,7 +274,7 @@ export class PodmanInstall {
       if (
         extensionApi.env.isWindows &&
         updateInfo.installedVersion === '5.3.1' &&
-        compare(updateInfo.bundledVersion, '5.4.0', '>=')
+        compare(updateInfo.bundledVersion, '5.4.0') >= 0
       ) {
         // The updating from 5.3.1 -> 5.4.X have failed on Windows
         const result = await extensionApi.window.showInformationMessage(

--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
     "adm-zip": "^0.5.16",
     "check-disk-space": "^3.4.0",
     "chokidar": "^3.6.0",
-    "compare-versions": "^6.1.1",
     "culori": "^4.0.2",
     "date.js": "^0.3.3",
     "dockerode": "^4.0.9",

--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -16,8 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { compareVersions } from 'compare-versions';
 import { inject, injectable } from 'inversify';
+import { compare } from 'semver';
 
 import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
@@ -153,7 +153,7 @@ export class ExtensionsUpdater {
         }
         // now, compare versions
         // if installed version is greater or equal to latest available version, skip
-        if (compareVersions(installedVersion, latestAvailableVersion.version) >= 0) {
+        if (compare(installedVersion, latestAvailableVersion.version) >= 0) {
           console.log(
             `Skipping update for extension ${installedExtension.id} because installed version ${installedVersion} is greater or equal to latest available version ${latestAvailableVersion.version}`,
           );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
-      compare-versions:
-        specifier: ^6.1.1
-        version: 6.1.1
       culori:
         specifier: ^4.0.2
         version: 4.0.2
@@ -116,7 +113,7 @@ importers:
         version: 1.9.1
       tar:
         specifier: ^7.5.3
-        version: 7.5.6
+        version: 7.5.4
       tar-fs:
         specifier: ^3.1.1
         version: 3.1.1
@@ -542,9 +539,6 @@ importers:
       async-mutex:
         specifier: ^0.5.0
         version: 0.5.0
-      compare-versions:
-        specifier: ^6.1.1
-        version: 6.1.1
       inversify:
         specifier: ^7.11.0
         version: 7.11.0(reflect-metadata@0.2.2)
@@ -554,6 +548,9 @@ importers:
       ps-list:
         specifier: ^9.0.0
         version: 9.0.0
+      semver:
+        specifier: ^7.7.3
+        version: 7.7.3
       smol-toml:
         specifier: 1.6.0
         version: 1.6.0
@@ -11027,9 +11024,10 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.6:
-    resolution: {integrity: sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==}
+  tar@7.5.4:
+    resolution: {integrity: sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -14323,7 +14321,7 @@ snapshots:
       nopt: 6.0.0
       proc-log: 2.0.1
       semver: 7.7.3
-      tar: 7.5.6
+      tar: 7.5.4
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -14362,7 +14360,7 @@ snapshots:
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
       semver: 7.7.3
-      tar: 7.5.6
+      tar: 7.5.4
       yargs: 17.7.2
     transitivePeerDependencies:
       - bluebird
@@ -14382,7 +14380,7 @@ snapshots:
       ora: 5.4.1
       read-binary-file-arch: 1.0.6
       semver: 7.7.3
-      tar: 7.5.6
+      tar: 7.5.4
       yargs: 17.7.2
     transitivePeerDependencies:
       - bluebird
@@ -17103,7 +17101,7 @@ snapshots:
       resedit: 1.7.2
       sanitize-filename: 1.6.3
       semver: 7.7.3
-      tar: 7.5.6
+      tar: 7.5.4
       temp-file: 3.4.0
     transitivePeerDependencies:
       - bluebird
@@ -17143,7 +17141,7 @@ snapshots:
       plist: 3.1.0
       resedit: 1.7.2
       semver: 7.7.3
-      tar: 7.5.6
+      tar: 7.5.4
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
     transitivePeerDependencies:
@@ -17648,7 +17646,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 9.0.1
-      tar: 7.5.6
+      tar: 7.5.4
       unique-filename: 2.0.1
     transitivePeerDependencies:
       - bluebird
@@ -22139,7 +22137,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.7.3
-      tar: 7.5.6
+      tar: 7.5.4
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -24419,7 +24417,7 @@ snapshots:
       fast-fifo: 1.3.2
       streamx: 2.22.0
 
-  tar@7.5.6:
+  tar@7.5.4:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0


### PR DESCRIPTION
### What does this PR do?
Replaces `compare-versions` with `semver`

### Screenshot / video of UI


### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/15651

### How to test this PR?
Pr checks

- [x] Tests are covering the bug fix or the new feature
