### PR TITLE
fix(StatusIcon): fixed icon size in StatusIcon component

### DIFF
--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -27,12 +27,12 @@ const IconComponent = icon;
     <!-- fas fa- and far fa- and fab fa- for Font awesome icons -->
     <!-- -icon for extension icons e.g. 'kind-icon' -->
     {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.startsWith('fab fa-') || icon.endsWith('-icon')}
-        <span class={`${icon} ${size} ${className}`} {role} {title}></span>
+        <span class={`${icon} ${size} ${className} flex flex-row`} {role} {title}></span>
     {:else if icon.startsWith('data:image/')}
-        <img src={icon} alt={title ?? ''} {title} {role} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
+        <img src={icon} alt={title ?? ''} {title} {role} class={`${className} flex flex-row`} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
     {/if}
 {:else}
     {#if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
-        <span {role} {title}><IconComponent class={className} {size}/></span>
+        <span {role} {title}><IconComponent class={`${className} flex flex-row`} {size}/></span>
     {/if}
 {/if}

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -27,12 +27,12 @@ const IconComponent = icon;
     <!-- fas fa- and far fa- and fab fa- for Font awesome icons -->
     <!-- -icon for extension icons e.g. 'kind-icon' -->
     {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.startsWith('fab fa-') || icon.endsWith('-icon')}
-        <span class={`${icon} ${size} ${className} flex flex-row`} {role} {title}></span>
+        <span class={`${icon} ${size} ${className}`} {role} {title}></span>
     {:else if icon.startsWith('data:image/')}
-        <img src={icon} alt={title ?? ''} {title} {role} class={`${className} flex flex-row`} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
+        <img src={icon} alt={title ?? ''} {title} {role} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
     {/if}
 {:else}
     {#if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
-        <span {role} {title}><IconComponent class={`${className} flex flex-row`} {size}/></span>
+        <span {role} {title}><IconComponent class={className} {size}/></span>
     {/if}
 {/if}

--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -81,3 +81,12 @@ test('Expect updating styling', async () => {
   expect(spinner).toBeInTheDocument();
   expect(spinner).toHaveAttribute('width', '1.4em');
 });
+
+test('Expect icon to not have text-xs class', async () => {
+  const status = 'RUNNING';
+  render(StatusIcon, { status });
+  const icon = screen.getByRole('status');
+  expect(icon).toBeInTheDocument();
+
+  expect(icon).not.toHaveClass('text-xs');
+});

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -20,7 +20,7 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
 
 <div class="grid place-content-center" style="position:relative">
   <div
-    class="grid place-content-center rounded-sm aspect-square text-xs"
+    class="grid place-content-center rounded-sm aspect-square"
     class:bg-[var(--pd-status-running)]={status === 'RUNNING' || status === 'USED'}
     class:bg-[var(--pd-status-starting)]={status === 'STARTING'}
     class:bg-[var(--pd-status-degraded)]={status === 'DEGRADED'}


### PR DESCRIPTION
### What does this PR do?
Fixes StatusIcon size and centering

### Screenshot / video of UI
Prev:
<img width="445" height="392" alt="Image" src="https://github.com/user-attachments/assets/839943fa-32f0-450e-8123-1240dbeba3c2" />

Now: 
<img width="1148" height="770" alt="image" src="https://github.com/user-attachments/assets/1069d2e2-8026-42c9-8a30-2a8203e1db19" />


### What issues does this PR fix or reference?
Closes: #15682 

### How to test this PR?
Open Container table and see the status icons
Check other places in UI if there is nothing broken 

- [ ] Tests are covering the bug fix or the new feature
