### PR TITLE
fix(renderer/HelpActionsItems): clean up event listener

### DIFF
--- a/packages/renderer/src/lib/help/HelpActionsItems.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActionsItems.spec.ts
@@ -111,4 +111,21 @@ describe('HelpActionsItems component', () => {
       expect(item).toBeVisible();
     });
   });
+
+  test('should dispose of the listener when the component is unmounted', () => {
+    const disposeMock = vi.fn();
+    vi.mocked(window.events.receive).mockReturnValue({
+      dispose: disposeMock,
+    });
+
+    const { unmount } = render(HelpActionsItems, { items: Items });
+
+    expect(window.events.receive).toHaveBeenCalledWith('toggle-help-menu', expect.any(Function));
+
+    expect(disposeMock).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(disposeMock).toHaveBeenCalled();
+  });
 });

--- a/packages/renderer/src/lib/help/HelpActionsItems.svelte
+++ b/packages/renderer/src/lib/help/HelpActionsItems.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
 
 import { ActionKind, type ItemAction, type ItemInfo } from '/@api/help-menu';
 
@@ -13,7 +14,13 @@ const { items }: Props = $props();
 
 let showMenu = $state(false);
 let outsideWindow = $state<HTMLDivElement | undefined>();
-window.events?.receive('toggle-help-menu', toggleMenu);
+
+onMount(() => {
+  const disposable = window.events?.receive('toggle-help-menu', toggleMenu);
+  return (): void => {
+    disposable?.dispose();
+  };
+});
 
 function toggleMenu(): void {
   showMenu = !showMenu;


### PR DESCRIPTION
### What does this PR do?

This PR cleans up the event listener when unmounting the HelpActionsItems items. This is done by keeping a reference to the created event, and disposing it.

### Screenshot / video of UI

No change

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15493

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Verify that the help menu still opens correctly.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
