### PR TITLE
chore: update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ mailing list, or chat. Instead, you have two options:
 - Open a private GitHub Security Vulnerability Advisory
   ([GitHub documentation](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/report-a-vulnerability/privately-reporting-a-security-vulnerability)).
 - Send an email with as many details as possible to
-  [cncf-podman-desktop-security@lists.cncf.io](mailto:cncf-podman-desktop-security@lists.cncf.io?subject=Security%20Vunerablity%20Report).
+  [cncf-podman-desktop-security@lists.cncf.io](mailto:cncf-podman-desktop-security@lists.cncf.io?subject=Security%20Vulnerablity%20Report).
   This is a private mailing list for the core maintainers.
 
 ## Security Announcements

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,37 @@
-## Security and Disclosure Information Policy for the Podman Desktop Project
+# Security and Disclosure Information Policy for the Podman Desktop Project
 
-The Podman Desktop Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.
+This is the security policy for the Podman Desktop project. It applies to all repositories
+in the [Podman Desktop GitHub organization](https://github.com/podman-desktop).
+
+- [Reporting a Vulnerability](#Reporting-a-Vulnerability)
+- [Security Announcements](#Security-Announcements)
+- [Security Vulnerability Response](#Security-Vulnerability-Response)
+
+## Reporting a Vulnerability
+
+If you think you've identified a security issue in a Podman Desktop project,
+please **DO NOT** report the issue publicly via the GitHub issue tracker,
+mailing list, or chat. Instead, you have two options:
+
+- Open a private GitHub Security Vulnerability Advisory
+  ([GitHub documentation](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/report-a-vulnerability/privately-reporting-a-security-vulnerability)).
+- Send an email with as many details as possible to
+  [cncf-podman-desktop-security@lists.cncf.io](mailto:cncf-podman-desktop-security@lists.cncf.io?subject=Security%20Vunerablity%20Report).
+  This is a private mailing list for the core maintainers.
+
+## Security Announcements
+
+The [cncf-podman-desktop-maintainers@lists.cncf.io](mailto:cncf-podman-desktop-maintainers@lists.cncf.io) email
+list is used for messages about Podman Desktop security announcements as well as general announcements and discussions.
+You can join the list [here](https://lists.cncf.io/g/cncf-podman-desktop-maintainers/join)
+or by sending an email to [cncf-podman-desktop-maintainers+subscribe@lists.cncf.io](mailto:cncf-podman-desktop-maintainers+subscribe@lists.cncf.io?subject=subscribe).
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the core maintainers within 3 working days.
+
+Any vulnerability information shared with core maintainers stays within a Podman Desktop project
+and will not be disseminated to other projects unless it is necessary to get the issue fixed.
+
+As the security issue moves from triage, to an identified fix, to release planning, the core
+maintainers will keep the reporter updated.


### PR DESCRIPTION
### What does this PR do?

Our security policy was still pointing to the policy in the containers org and needs to be updated. (e.g. disclosure should not be via the Podman security list)

We have one public mailing list today that anyone can join, cncf-podman-desktop-maintainers@lists.cncf.io. We've created a second, private list for security issues: cncf-podman-desktop-security@lists.cncf.io.

This PR keeps the same policy/process as the containers org, except:
- asks for disclosure via our own -security list
- adds GitHub security reporting as another option
- announcements are done via our own -maintainers. (announcements could go elsewhere later, but it doesn't seem worth creating another list at this point)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #15762.

### How to test this PR?

Read the text, compare to other CNCF security policies, and see if there's anything we should change.