### PR TITLE
chore(test): skip test when usermode networking is enabled

### DIFF
--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -207,6 +207,8 @@ for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of mac
     });
 
     test('Restart the machine', async ({ page }) => {
+      test.skip(userNet, 'Restarting podman machine is flaky in cicd pipeline with usermode networking');
+
       const machineCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, PODMAN_MACHINE_NAME);
       await machineCard.performConnectionAction(ResourceElementActions.Restart);
 

--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -207,7 +207,10 @@ for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of mac
     });
 
     test('Restart the machine', async ({ page }) => {
-      test.skip(isCI && userNet, 'Restarting podman machine is flaky in cicd pipeline with usermode networking');
+      test.skip(
+        isCI && userNet,
+        'Restarting podman machine is flaky in cicd pipeline with usermode networking. This issue is tracked in https://github.com/podman-desktop/podman-desktop/issues/15889',
+      );
 
       const machineCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, PODMAN_MACHINE_NAME);
       await machineCard.performConnectionAction(ResourceElementActions.Restart);

--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -33,7 +33,7 @@ import {
   verifyMachinePrivileges,
   verifyVirtualizationProvider,
 } from '/@/utility/operations';
-import { isLinux, isWindows } from '/@/utility/platform';
+import { isCI, isLinux, isWindows } from '/@/utility/platform';
 import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '/@/utility/provider';
 import { waitForPodmanMachineStartup, waitUntil } from '/@/utility/wait';
 
@@ -207,7 +207,7 @@ for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of mac
     });
 
     test('Restart the machine', async ({ page }) => {
-      test.skip(userNet, 'Restarting podman machine is flaky in cicd pipeline with usermode networking');
+      test.skip(isCI && userNet, 'Restarting podman machine is flaky in cicd pipeline with usermode networking');
 
       const machineCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, PODMAN_MACHINE_NAME);
       await machineCard.performConnectionAction(ResourceElementActions.Restart);


### PR DESCRIPTION
### What does this PR do?
Skips podman machine restart e2e test when user mode networking in cicd pipeline due to flaky behavior in azure vms.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/15889
