### PR TITLE
chore: include author to fix publisher's name on Windows binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "podman-desktop",
+  "author": "Podman Desktop",
   "productName": "Podman Desktop",
   "repository": "https://github.com/podman-desktop/podman-desktop",
   "homepage": "https://www.podman-desktop.io",


### PR DESCRIPTION
### What does this PR do?

when then there is no author in package.json, it results in having the Windows binary saying the publisher is `GitHub inc`
Sets it to`Podman Desktop` so it's more accurate

### Screenshot / video of UI

<img width="489" height="438" alt="image" src="https://github.com/user-attachments/assets/d274d5bf-ca31-436c-ad0c-ae6ab159ddaf" />


### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/15890

### How to test this PR?

build the Windows binary and check it using the https://github.com/podman-desktop/podman-desktop/issues/15890 steps

- [ ] Tests are covering the bug fix or the new feature
