### PR TITLE
chore(kind): configure provider warnings based on the dependent container connections

### DIFF
--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -140,11 +140,20 @@ function updateKubernetesFactoryRegistration(
 
   if (runningConnections.length > 0) {
     kubernetesFactoryDisposable ??= registerKubernetesFactory(provider, telemetryLogger);
+    provider.updateWarnings([]);
   } else {
     if (kubernetesFactoryDisposable) {
       kubernetesFactoryDisposable.dispose();
       kubernetesFactoryDisposable = undefined;
     }
+    provider.updateWarnings([
+      {
+        name: 'Container Engine Required',
+        details: extensionApi.env.isLinux
+          ? 'Install and start a container engine (e.g. Podman) to create Kind clusters'
+          : 'Start your container provider (e.g. Podman) to create Kind clusters',
+      },
+    ]);
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

The following changes request configures the provider warnings based on the dependent running connections. If the creation factory is disabled (unregistered), then provider configures with the warning message indicating that dependent container provider should be running at the moment.

The following changes request is decomposition of https://github.com/podman-desktop/podman-desktop/pull/14773

### Screenshot / video of UI

No changes on the UI. Internal changes only.

### What issues does this PR fix or reference?

part of https://github.com/podman-desktop/podman-desktop/issues/14145

### How to test this PR?

No steps provided to check the following changes.

- [x] Tests are covering the bug fix or the new feature
