### PR TITLE
chore: add the option to adjust the icon button size

### DIFF
--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -20,7 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { beforeAll, describe, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import Markdown from './Markdown.svelte';
 
@@ -31,6 +31,10 @@ async function waitRender(customProperties: object): Promise<void> {
 
 beforeAll(() => {
   Object.defineProperty(window, 'executeCommand', { value: vi.fn() });
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
 });
 
 test('Expect to have bold', async () => {

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -77,7 +77,7 @@ describe('Custom button', () => {
     expect(markdownContent).toContainHTML('Name of the button</button>');
   });
 
-  test('Expect button to be rendered as a icon with args', async () => {
+  test('Expect button to be rendered as a icon with args with default size ', async () => {
     vi.mocked(window.executeCommand).mockResolvedValue({});
 
     const icon = 'faIconIcon';
@@ -86,6 +86,26 @@ describe('Custom button', () => {
     expect(markdownContent).toBeInTheDocument();
     expect(markdownContent).toContainHTML(
       `<button class="fa-solid ${icon} before:px-1 fa-3x hover:text-[var(--pd-action-button-primary-hover-text)]"`,
+    );
+    expect(markdownContent).toContainHTML('data-command="command"');
+    expect(markdownContent).toContainHTML(`data-args="arg1"`);
+    expect(markdownContent).toContainHTML('</button>');
+
+    const iconButton = screen.getByRole('button', { name: icon });
+    expect(iconButton).toBeDefined();
+    await fireEvent.click(iconButton);
+    expect(window.executeCommand).toBeCalledWith('command', 'arg1');
+  });
+
+  test('Expect button to be rendered as a icon with args with custom size ', async () => {
+    vi.mocked(window.executeCommand).mockResolvedValue({});
+
+    const icon = 'faIconIcon';
+    await waitRender({ markdown: `:button[${icon}]{command=command args='["arg1"]' size='fa-xs'}` });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent).toContainHTML(
+      `<button class="fa-solid ${icon} before:px-1 fa-xs hover:text-[var(--pd-action-button-primary-hover-text)]"`,
     );
     expect(markdownContent).toContainHTML('data-command="command"');
     expect(markdownContent).toContainHTML(`data-args="arg1"`);

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -45,7 +45,7 @@ export function button(d: Directive): void {
   if (d.attributes && 'command' in d.attributes && 'args' in d.attributes) {
     this.tag(`
       <button 
-        class="fa-solid ${this.encode(d.label)} before:px-1 ${this.encode(d.attributes.size ?? '') ?? 'fa-3x'} hover:text-[var(--pd-action-button-primary-hover-text)]" 
+        class="fa-solid ${this.encode(d.label)} before:px-1 ${this.encode(d.attributes.size ?? 'fa-3x')} hover:text-[var(--pd-action-button-primary-hover-text)]" 
         aria-label="${this.encode(d.label)}"
         data-command="${this.encode(d.attributes.command)}" 
         data-args="${JSON.parse(d.attributes.args)}">

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -45,7 +45,7 @@ export function button(d: Directive): void {
   if (d.attributes && 'command' in d.attributes && 'args' in d.attributes) {
     this.tag(`
       <button 
-        class="fa-solid ${this.encode(d.label)} before:px-1 fa-3x hover:text-[var(--pd-action-button-primary-hover-text)]" 
+        class="fa-solid ${this.encode(d.label)} before:px-1 ${this.encode(d.attributes.size) ?? 'fa-3x'} hover:text-[var(--pd-action-button-primary-hover-text)]" 
         aria-label="${this.encode(d.label)}"
         data-command="${this.encode(d.attributes.command)}" 
         data-args="${JSON.parse(d.attributes.args)}">

--- a/packages/renderer/src/lib/markdown/micromark-button-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-button-directive.ts
@@ -45,7 +45,7 @@ export function button(d: Directive): void {
   if (d.attributes && 'command' in d.attributes && 'args' in d.attributes) {
     this.tag(`
       <button 
-        class="fa-solid ${this.encode(d.label)} before:px-1 ${this.encode(d.attributes.size) ?? 'fa-3x'} hover:text-[var(--pd-action-button-primary-hover-text)]" 
+        class="fa-solid ${this.encode(d.label)} before:px-1 ${this.encode(d.attributes.size ?? '') ?? 'fa-3x'} hover:text-[var(--pd-action-button-primary-hover-text)]" 
         aria-label="${this.encode(d.label)}"
         data-command="${this.encode(d.attributes.command)}" 
         data-args="${JSON.parse(d.attributes.args)}">


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds size attribute to markdown buttons with icons

### Screenshot / video of UI
Before:
<img width="1156" height="835" alt="Screenshot 2026-01-27 at 10 07 33 AM" src="https://github.com/user-attachments/assets/9df3da29-3b92-4a7a-bfdd-c0971e1dd905" />

After:
<img width="1156" height="835" alt="Screenshot 2026-01-27 at 9 59 28 AM" src="https://github.com/user-attachments/assets/1791c5a0-4933-4133-978b-6000fb2ba808" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Needed for https://github.com/podman-desktop/extension-github/pull/107

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
