### PR TITLE
refactor(IconImage): migrated IconImage to svelte5

### DIFF
--- a/packages/renderer/src/lib/appearance/IconImage.svelte
+++ b/packages/renderer/src/lib/appearance/IconImage.svelte
@@ -1,23 +1,22 @@
 <script lang="ts">
+import type { Snippet } from 'svelte';
+
 import { AppearanceUtil } from './appearance-util';
 
-export let image: string | { light: string; dark: string } | undefined = undefined;
-export let alt: string | undefined = undefined;
-
-let imgSrc: string | undefined = undefined;
-
-$: getImgSrc(image);
-
-function getImgSrc(image: string | { light: string; dark: string } | undefined): void {
-  new AppearanceUtil()
-    .getImage(image)
-    .then(s => (imgSrc = s))
-    .catch((err: unknown) => console.error(`Error getting image ${image}`, err));
+interface Props {
+  image?: string | { light: string; dark: string };
+  alt?: string;
+  class?: string;
+  children?: Snippet;
 }
+
+let { image, alt, class: className = '', children }: Props = $props();
+
+let imgSrc: string | undefined = $derived(await new AppearanceUtil().getImage(image));
 </script>
 
 {#if imgSrc}
-  <img src={imgSrc} alt={alt} class={$$props.class} />
+  <img src={imgSrc} alt={alt} class={className} />
 {:else}
-  <slot />
+  {@render children?.()}
 {/if}

--- a/packages/renderer/src/lib/appearance/IconImage.svelte
+++ b/packages/renderer/src/lib/appearance/IconImage.svelte
@@ -12,7 +12,8 @@ interface Props {
 
 let { image, alt, class: className = '', children }: Props = $props();
 
-let imgSrc: string | undefined = $derived(await new AppearanceUtil().getImage(image));
+const appearanceUtil = new AppearanceUtil();
+let imgSrc: string | undefined = $derived(await appearanceUtil.getImage(image));
 </script>
 
 {#if imgSrc}

--- a/packages/renderer/src/lib/dashboard/ProviderCard.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderImages } from '@podman-desktop/api';
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { expect, test } from 'vitest';
 
@@ -50,9 +50,9 @@ test('Expect provider region', async () => {
     installationSupport: false,
     cleanupSupport: false,
   };
-  render(ProviderCard, { provider });
+  const { findByRole } = render(ProviderCard, { provider });
 
-  const region = screen.getByRole('region', { name: provider.name + ' Provider' });
+  const region = await findByRole('region', { name: provider.name + ' Provider' });
   expect(region).toBeInTheDocument();
 });
 
@@ -79,9 +79,9 @@ test('Expect provider name', async () => {
     installationSupport: false,
     cleanupSupport: false,
   };
-  render(ProviderCard, { provider });
+  const { findByLabelText } = render(ProviderCard, { provider });
 
-  const name = screen.getByLabelText('context-name');
+  const name = await findByLabelText('context-name');
   expect(name).toBeInTheDocument();
   expect(name.textContent).toContain(provider.name);
 });
@@ -110,12 +110,12 @@ test('Expect provider icon', async () => {
     cleanupSupport: false,
   };
 
-  render(ProviderCard, { provider });
+  const { findByRole } = render(ProviderCard, { provider });
 
   // allow IconImage to render
   await tick();
 
-  const logo = screen.getByRole('img');
+  const logo = await findByRole('img');
   expect(logo).toBeInTheDocument();
   expect(logo).toHaveAttribute('src', provider.images.icon);
 });
@@ -144,9 +144,9 @@ test('Expect no provider version', async () => {
     cleanupSupport: false,
     // no version
   };
-  render(ProviderCard, { provider });
+  const { queryByLabelText } = render(ProviderCard, { provider });
 
-  const version = screen.queryByLabelText('Provider Version');
+  const version = queryByLabelText('Provider Version');
   expect(version).not.toBeInTheDocument();
 });
 
@@ -174,9 +174,9 @@ test('Expect provider version', async () => {
     version: '1.2.3',
     cleanupSupport: false,
   };
-  render(ProviderCard, { provider });
+  const { findByLabelText } = render(ProviderCard, { provider });
 
-  const version = screen.getByLabelText('Provider Version');
+  const version = await findByLabelText('Provider Version');
   expect(version).toBeInTheDocument();
   expect(version.textContent).toBe('v' + provider.version);
 });
@@ -204,9 +204,9 @@ test('Expect provider state', async () => {
     installationSupport: false,
     cleanupSupport: false,
   };
-  render(ProviderCard, { provider });
+  const { findByLabelText } = render(ProviderCard, { provider });
 
-  const state = screen.getByLabelText('Actual State');
+  const state = await findByLabelText('Actual State');
   expect(state).toBeInTheDocument();
   expect(state.textContent).toContain('NOT-INSTALLED');
 });

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
@@ -35,9 +35,9 @@ beforeAll(() => {
 });
 
 test('Expect configured provider shows update button', async () => {
-  verifyStatus(ProviderConfigured, 'configured', false);
+  await verifyStatus(ProviderConfigured, 'configured', false);
 });
 
 test('Expect configured provider does not show update button if version same', async () => {
-  verifyStatus(ProviderConfigured, 'configured', true);
+  await verifyStatus(ProviderConfigured, 'configured', true);
 });

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
 
@@ -90,15 +90,18 @@ test('Expect installed provider shows button', async () => {
   const initializationContext: InitializationContext = new InitializationContextImpl(
     InitializeAndStartMode,
   ) as unknown as InitializationContext;
-  render(ProviderInstalled, { provider: provider, initializationContext: initializationContext });
+  const { findByText, findByRole } = render(ProviderInstalled, {
+    provider: provider,
+    initializationContext: initializationContext,
+  });
 
-  const providerText = screen.getByText(content => content === 'MyProvider');
+  const providerText = await findByText(content => content === 'MyProvider');
   expect(providerText).toBeInTheDocument();
 
-  const installedText = screen.getByText(content => content.toLowerCase().includes('installed but not ready'));
+  const installedText = await findByText(content => content.toLowerCase().includes('installed but not ready'));
   expect(installedText).toBeInTheDocument();
 
-  const button = screen.getByRole('button', { name: 'Initialize and start' });
+  const button = await findByRole('button', { name: 'Initialize and start' });
   expect(button).toBeInTheDocument();
 
   await userEvent.click(button);
@@ -108,11 +111,11 @@ test('Expect installed provider shows button', async () => {
 });
 
 test('Expect installed provider shows update button', async () => {
-  verifyStatus(ProviderInstalled, 'installed', false);
+  await verifyStatus(ProviderInstalled, 'installed', false);
 });
 
 test('Expect installed provider does not show update button if version same', async () => {
-  verifyStatus(ProviderInstalled, 'installed', true);
+  await verifyStatus(ProviderInstalled, 'installed', true);
 });
 
 test('Expect to see the initialize context error if provider installation fails', async () => {
@@ -143,15 +146,18 @@ test('Expect to see the initialize context error if provider installation fails'
   const initializationContext: InitializationContext = new InitializationContextImpl(
     InitializeAndStartMode,
   ) as unknown as InitializationContext;
-  render(ProviderInstalled, { provider: provider, initializationContext: initializationContext });
+  const { findByText, findByRole } = render(ProviderInstalled, {
+    provider: provider,
+    initializationContext: initializationContext,
+  });
 
-  const providerText = screen.getByText(content => content === 'MyProvider');
+  const providerText = await findByText('MyProvider');
   expect(providerText).toBeInTheDocument();
 
-  const installedText = screen.getByText(content => content.toLowerCase().includes('installed but not ready'));
+  const installedText = await findByText('INSTALLED BUT NOT READY');
   expect(installedText).toBeInTheDocument();
 
-  const button = screen.getByRole('button', { name: 'Initialize and start' });
+  const button = await findByRole('button', { name: 'Initialize and start' });
   expect(button).toBeInTheDocument();
 
   await userEvent.click(button);

--- a/packages/renderer/src/lib/dashboard/ProviderReady.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderReady.spec.ts
@@ -34,9 +34,9 @@ beforeAll(() => {
 });
 
 test('Expect ready provider shows update button', async () => {
-  verifyStatus(ProviderReady, 'ready', false);
+  await verifyStatus(ProviderReady, 'ready', false);
 });
 
 test('Expect ready provider does not show update button if version same', async () => {
-  verifyStatus(ProviderReady, 'ready', true);
+  await verifyStatus(ProviderReady, 'ready', true);
 });

--- a/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
@@ -17,16 +17,16 @@
  ***********************************************************************/
 
 import type { ProviderStatus } from '@podman-desktop/api';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import { expect, test } from 'vitest';
 
 import { type InitializationContext, InitializeAndStartMode } from '/@/lib/dashboard/ProviderInitUtils';
 import type { ProviderInfo } from '/@api/provider-info';
 
-export function verifyStatus<
+export async function verifyStatus<
   C extends Component<{ provider: ProviderInfo; initializationContext: InitializationContext }>,
->(component: C, status: ProviderStatus, sameVersions: boolean): void {
+>(component: C, status: ProviderStatus, sameVersions: boolean): Promise<void> {
   const provider: ProviderInfo = {
     containerConnections: [],
     containerProviderConnectionCreation: false,
@@ -60,12 +60,14 @@ export function verifyStatus<
     initializationContext: initializationContext,
   });
 
-  const updateButton = screen.queryByRole('button', { name: 'Update to 1.0.1' });
-  if (sameVersions) {
-    expect(updateButton).not.toBeInTheDocument();
-  } else {
-    expect(updateButton).toBeInTheDocument();
-  }
+  await waitFor(() => {
+    const updateButton = screen.queryByRole('button', { name: 'Update to 1.0.1' });
+    if (sameVersions) {
+      expect(updateButton).not.toBeInTheDocument();
+    } else {
+      expect(updateButton).toBeInTheDocument();
+    }
+  });
 }
 
 test('vitest does not accept helper files without a test', () => {

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCard.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCard.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
@@ -46,10 +46,10 @@ test('Expect to see a div with extension id title', async () => {
     readme: '',
     icon: 'iconOfMyExtension.png',
   };
-  render(InstalledExtensionCard, { extension });
+  const { findByRole } = render(InstalledExtensionCard, { extension });
 
   // get role Extension Badge
-  const badge = screen.getByRole('region', { name: 'myExtensionId' });
+  const badge = await findByRole('region', { name: 'myExtensionId' });
   expect(badge).toBeInTheDocument();
   expect(badge).toHaveTextContent('built-in');
 });

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
@@ -47,30 +47,28 @@ test('Expect to see icon, link, badge and actions', async () => {
     readme: '',
     icon: 'iconOfMyExtension.png',
   };
-  render(InstalledExtensionCardLeft, { extension });
+  const { findByRole, findByLabelText } = render(InstalledExtensionCardLeft, { extension });
 
   // get actions be there
-  const actions = screen.getByRole('group', { name: 'Extension Actions' });
+  const actions = await findByRole('group', { name: 'Extension Actions' });
   expect(actions).toBeInTheDocument();
 
   // check status
-  const statusLabel = screen.getByLabelText('Extension Status Label');
+  const statusLabel = await findByLabelText('Extension Status Label');
   expect(statusLabel).toBeInTheDocument();
   expect(statusLabel).toHaveTextContent('ACTIVE');
 
   // get role Extension Badge
-  const badge = screen.getByRole('region', { name: 'Extension Badge' });
+  const badge = await findByRole('region', { name: 'Extension Badge' });
   expect(badge).toBeInTheDocument();
   expect(badge).toHaveTextContent('built-in');
 
   // check icon
-  // wait for image to be loaded
-  await new Promise(resolve => setTimeout(resolve, 200));
-  const icon = screen.getByRole('img');
+  const icon = await findByRole('img');
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('src', 'iconOfMyExtension.png');
 
   // and the link
-  const detailsButton = screen.getByRole('button', { name: 'foo extension details' });
+  const detailsButton = await findByRole('button', { name: 'foo extension details' });
   expect(detailsButton).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/InstalledExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionList.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
@@ -57,13 +57,13 @@ test('Expect to see each extension', async () => {
     readme: '',
     icon: 'iconOfMyExtension.png',
   };
-  render(InstalledExtensionList, { extensionInfos: [extension1, extension2] });
+  const { findByRole } = render(InstalledExtensionList, { extensionInfos: [extension1, extension2] });
 
   // get first extension
-  const myExtension1 = screen.getByRole('region', { name: 'myExtensionId1' });
+  const myExtension1 = await findByRole('region', { name: 'myExtensionId1' });
   expect(myExtension1).toBeInTheDocument();
 
   // get second extension
-  const myExtension2 = screen.getByRole('region', { name: 'myExtensionId2' });
+  const myExtension2 = await findByRole('region', { name: 'myExtensionId2' });
   expect(myExtension2).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
@@ -68,7 +68,7 @@ const closeCallback = vi.fn();
 const doCreateNew = vi.fn();
 
 test('Expect to call closeCallback if clicking on Close', async () => {
-  render(PreferencesProviderInstallationModal, {
+  const { findByRole } = render(PreferencesProviderInstallationModal, {
     providerToBeInstalled: {
       provider: providerInfo,
       displayName: 'provider',
@@ -78,7 +78,7 @@ test('Expect to call closeCallback if clicking on Close', async () => {
     preflightChecks: [],
   });
 
-  const button = screen.getByRole('button', { name: 'Close' });
+  const button = await findByRole('button', { name: 'Close' });
   expect(button).toBeInTheDocument();
 
   await userEvent.click(button);
@@ -86,7 +86,7 @@ test('Expect to call closeCallback if clicking on Close', async () => {
 });
 
 test('Expect to call closeCallback if clicking on Cancel', async () => {
-  render(PreferencesProviderInstallationModal, {
+  const { findByRole } = render(PreferencesProviderInstallationModal, {
     providerToBeInstalled: {
       provider: providerInfo,
       displayName: 'provider',
@@ -96,7 +96,7 @@ test('Expect to call closeCallback if clicking on Cancel', async () => {
     preflightChecks: [],
   });
 
-  const button = screen.getByRole('button', { name: 'Cancel' });
+  const button = await findByRole('button', { name: 'Cancel' });
   expect(button).toBeInTheDocument();
 
   await userEvent.click(button);
@@ -104,7 +104,7 @@ test('Expect to call closeCallback if clicking on Cancel', async () => {
 });
 
 test('Expect to call doCreateNew if clicking on Next', async () => {
-  render(PreferencesProviderInstallationModal, {
+  const { findByRole } = render(PreferencesProviderInstallationModal, {
     providerToBeInstalled: {
       provider: providerInfo,
       displayName: 'provider',
@@ -114,7 +114,7 @@ test('Expect to call doCreateNew if clicking on Next', async () => {
     preflightChecks: [],
   });
 
-  const button = screen.getByRole('button', { name: 'Next' });
+  const button = await findByRole('button', { name: 'Next' });
   expect(button).toBeInTheDocument();
 
   await userEvent.click(button);
@@ -122,7 +122,7 @@ test('Expect to call doCreateNew if clicking on Next', async () => {
 });
 
 test('Expect preflight check entry if preflights checks has some value', async () => {
-  render(PreferencesProviderInstallationModal, {
+  const { findByLabelText } = render(PreferencesProviderInstallationModal, {
     providerToBeInstalled: {
       provider: providerInfo,
       displayName: 'provider',
@@ -137,6 +137,6 @@ test('Expect preflight check entry if preflights checks has some value', async (
     ],
   });
 
-  const span = screen.getByLabelText('description');
+  const span = await findByLabelText('description');
   expect(span).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -34,7 +34,7 @@ async function openLink(e: MouseEvent, url: string): Promise<void> {
         <div class="flex flex-col rounded-lg">
           <div class="mx-auto max-w-[250px] mb-5">
             <IconImage
-              logo={providerToBeInstalled.provider.images.logo}
+              image={providerToBeInstalled.provider.images.logo}
               alt={providerToBeInstalled.provider.name}
               class="mx-auto max-h-12" />
           </div>

--- a/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
@@ -43,18 +43,18 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('class props should be propagated to button', () => {
-  const { getByRole } = render(ProviderButton, {
+test('class props should be propagated to button', async () => {
+  const { findByRole } = render(ProviderButton, {
     provider: PROVIDER_MOCK,
     onclick: vi.fn(),
     class: 'potatoes',
   });
 
-  const widget = getByRole('button', { name: 'provider1' });
+  const widget = await findByRole('button', { name: 'provider1' });
   expect(widget).toHaveClass('potatoes');
 });
 
-test('provider with an imageClass should render it', () => {
+test('provider with an imageClass should render it', async () => {
   const provider = {
     ...PROVIDER_MOCK,
     images: {
@@ -66,13 +66,13 @@ test('provider with an imageClass should render it', () => {
     },
   };
 
-  render(ProviderButton, {
+  const { findByRole } = render(ProviderButton, {
     provider,
     onclick: vi.fn(),
     class: 'potatoes',
   });
 
-  const icon = screen.getByRole('img');
+  const icon = await findByRole('img');
   expect(icon.className).contains('podman-desktop-icon-provider-monochrome-icon');
 });
 

--- a/packages/renderer/src/lib/statusbar/ProviderButtonStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButtonStatus.svelte
@@ -19,5 +19,5 @@ let { status, class: className = '' }: Props = $props();
 {:else if status === 'error'}
   <div aria-label="Connection Status Icon" class="h-[7px] w-[7px] absolute top-[0px] right-[-2px] rounded-full bg-[var(--pd-state-error)] border-1 border-[var(--pd-statusbar-bg)] {className}"></div>
 {:else if status === 'Update available'}
-  <IconImage image={arrowUp} aria-label="Connection Status Icon" class="h-[12px] w-auto absolute top-0 right-[-30%] {className}" />
+  <IconImage image={arrowUp} alt="Connection Status Icon" class="h-[12px] w-auto absolute top-0 right-[-30%] {className}" />
 {/if}

--- a/packages/renderer/src/lib/webview/Webviews.spec.ts
+++ b/packages/renderer/src/lib/webview/Webviews.spec.ts
@@ -60,9 +60,9 @@ test('check we have list of webviews in navigation bar', async () => {
 
   webviews.set(webviewTestList);
   const fakeMeta = { url: '/webviews' } as unknown as TinroRouteMeta;
-  render(Webviews, { meta: fakeMeta, iconWithTitle: false });
+  const { findAllByRole } = render(Webviews, { meta: fakeMeta, iconWithTitle: false });
 
-  const links = screen.getAllByRole('link');
+  const links = await findAllByRole('link');
 
   // check we have 2 links
   expect(links).toHaveLength(2);
@@ -107,9 +107,9 @@ test('check that title shows up if iconWithTitle is true', async () => {
 
   webviews.set(webviewTestList);
   const fakeMeta = { url: '/webviews' } as unknown as TinroRouteMeta;
-  render(Webviews, { meta: fakeMeta, iconWithTitle: true });
+  const { findAllByRole } = render(Webviews, { meta: fakeMeta, iconWithTitle: true });
 
-  const links = screen.getAllByRole('link');
+  const links = await findAllByRole('link');
 
   // check we have 2 links
   expect(links).toHaveLength(2);


### PR DESCRIPTION
### What does this PR do?
Migrates IconImage to svelte5 + fixing dependencies 

### Screenshot / video of UI


### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/15923
Related to https://github.com/podman-desktop/podman-desktop/issues/15914
### How to test this PR?
Unit tests

- [x] Tests are covering the bug fix or the new feature
