### PR TITLE
refactor: update networks routes to be nested

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -227,28 +227,6 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
             engineId={decodeURI(meta.params.engineId)}
             base64RepoTag={meta.params.base64RepoTag} />
         </Route>
-        <Route
-          path="/images/:id/:engineId/:base64RepoTag/*"
-          breadcrumb="Image Details"
-          let:meta
-          navigationHint="details">
-          <ImageDetails
-            imageID={meta.params.id}
-            engineId={decodeURI(meta.params.engineId)}
-            base64RepoTag={meta.params.base64RepoTag} />
-        </Route>
-        <Route path="/images/pull" breadcrumb="Pull an Image">
-          <PullImage />
-        </Route>
-        <Route path="/images/import" breadcrumb="Import Containers">
-          <ImportContainersImages />
-        </Route>
-        <Route path="/images/save" breadcrumb="Save Images">
-          <SaveImages />
-        </Route>
-        <Route path="/images/load" breadcrumb="Load Images">
-          <LoadImages />
-        </Route>
 
         <Route path="/networks/*" breadcrumb="Networks" navigationHint="root" firstmatch>
           <Route path="/" breadcrumb="Networks" navigationHint="root">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -217,10 +217,6 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
               base64RepoTag={meta.params.base64RepoTag} />
           </Route>
         </Route>
-
-        <Route path="/networks/create/*" breadcrumb="Create Network">
-          <CreateNetwork />
-        </Route>
         <Route
           path="/manifests/:id/:engineId/:base64RepoTag/*"
           breadcrumb="Manifest Details"
@@ -231,6 +227,41 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
             engineId={decodeURI(meta.params.engineId)}
             base64RepoTag={meta.params.base64RepoTag} />
         </Route>
+        <Route
+          path="/images/:id/:engineId/:base64RepoTag/*"
+          breadcrumb="Image Details"
+          let:meta
+          navigationHint="details">
+          <ImageDetails
+            imageID={meta.params.id}
+            engineId={decodeURI(meta.params.engineId)}
+            base64RepoTag={meta.params.base64RepoTag} />
+        </Route>
+        <Route path="/images/pull" breadcrumb="Pull an Image">
+          <PullImage />
+        </Route>
+        <Route path="/images/import" breadcrumb="Import Containers">
+          <ImportContainersImages />
+        </Route>
+        <Route path="/images/save" breadcrumb="Save Images">
+          <SaveImages />
+        </Route>
+        <Route path="/images/load" breadcrumb="Load Images">
+          <LoadImages />
+        </Route>
+
+        <Route path="/networks/*" breadcrumb="Networks" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Networks" navigationHint="root">
+            <NetworksList />
+          </Route>
+          <Route path="/create/*" breadcrumb="Create Network">
+            <CreateNetwork />
+          </Route>
+          <Route path="/:name/:engineId/*" breadcrumb="Network Details" let:meta navigationHint="details">
+            <NetworkDetails networkName={decodeURIComponent(meta.params.name)} engineId={decodeURIComponent(meta.params.engineId)} />
+          </Route>
+        </Route>
+
         <Route path="/pods" breadcrumb="Pods" navigationHint="root">
           <PodsList />
         </Route>
@@ -269,13 +300,6 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
           <Route path="/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
             <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
           </Route>
-        </Route>
-
-        <Route path="/networks" breadcrumb="Networks" navigationHint="root">
-          <NetworksList />
-        </Route>
-        <Route path="/networks/:name/:engineId/*" breadcrumb="Network Details" let:meta navigationHint="details">
-          <NetworkDetails networkName={decodeURIComponent(meta.params.name)} engineId={decodeURIComponent(meta.params.engineId)} />
         </Route>
         {#if $kubernetesNoCurrentContext}
           <Route path="/kubernetes/*" breadcrumb="Kubernetes" navigationHint="root">


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR groups related  `/networks/*` paths to be in the same root path in order to have correct hierarchy-based breadcrumbs rather than path-based.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/15612

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
- [ ] Tests are covering the bug fix or the new feature
