### PR TITLE
refactor: update extensions routes to be nested

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -391,15 +391,18 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/troubleshooting/*" breadcrumb="Troubleshooting">
           <TroubleshootingPage />
         </Route>
-        <Route path="/extensions" breadcrumb="Extensions" navigationHint="root" let:meta>
-          {@const request = parseExtensionListRequest(meta)}
-          <ExtensionList
-            searchTerm={request.searchTerm}
-            screen={request.screen}
-          />
-        </Route>
-        <Route path="/extensions/details/:id/*" breadcrumb="Extension Details" let:meta navigationHint="details">
-          <ExtensionDetails extensionId={meta.params.id} />
+
+        <Route path="/extensions/*" breadcrumb="Extensions" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Extensions" navigationHint="root" let:meta>
+            {@const request = parseExtensionListRequest(meta)}
+            <ExtensionList
+              searchTerm={request.searchTerm}
+              screen={request.screen}
+            />
+          </Route>
+          <Route path="/details/:id/*" breadcrumb="Extension Details" let:meta navigationHint="details">
+            <ExtensionDetails extensionId={meta.params.id} />
+          </Route>
         </Route>
       </div>
     </div>

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -55,7 +55,7 @@ onMount(async () => {
   <Route path="/default/:key/*" breadcrumb="Preferences" let:meta>
     <PreferencesRendering key={meta.params.key} properties={properties} />
   </Route>
-  <Route path="/provider/:providerInternalId/*" breadcrumb="Resources" let:meta navigationHint="details">
+  <Route path="/provider/:providerInternalId/*" breadcrumb="Resources" let:meta navigationHint="root">
     <PreferencesProviderRendering providerInternalId={meta.params.providerInternalId} properties={properties} />
   </Route>
   <Route path="/provider-task/:providerInternalId/:taskId/*" breadcrumb="Resources" let:meta>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR groups related `extensions/*` paths to be in the same root path in order to have correct hierarchy-based breadcrumbs rather than path-based.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/15612
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
- Going to create Kubernetes resource such as Kind or Minikube from the empty Kubernetes page should show `Resources -> <resource-name>`
- Going to one of the suggested extensions in the empty Kubernetes page should show `Extension -> Extension details` instead of `Kubernetes -> Extension details`

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
