### PR TITLE
refactor: update volumes routes to be nested

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -251,15 +251,19 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/pod-create-from-containers" breadcrumb="Create Pod">
           <PodCreateFromContainers />
         </Route>
-        <Route path="/volumes" breadcrumb="Volumes" navigationHint="root">
-          <VolumesList />
+        
+        <Route path="/volumes/*" breadcrumb="Volumes" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Volumes" navigationHint="root">
+            <VolumesList />
+          </Route>
+          <Route path="/create" breadcrumb="Create a Volume">
+            <CreateVolume />
+          </Route>
+          <Route path="/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
+            <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
+          </Route>
         </Route>
-        <Route path="/volumes/create" breadcrumb="Create a Volume">
-          <CreateVolume />
-        </Route>
-        <Route path="/volumes/:name/:engineId/*" breadcrumb="Volume Details" let:meta navigationHint="details">
-          <VolumeDetails volumeName={decodeURI(meta.params.name)} engineId={decodeURI(meta.params.engineId)} />
-        </Route>
+
         <Route path="/networks" breadcrumb="Networks" navigationHint="root">
           <NetworksList />
         </Route>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR groups related `volumes/*` paths to be in the same root path in order to have correct hierarchy-based breadcrumbs rather than path-based.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/15612

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
