### PR TITLE
refactor: update images routes to be nested

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -97,11 +97,11 @@ beforeEach(() => {
   vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
 });
 
-test('test /image/run/* route', async () => {
+test('test /images/run/* route', async () => {
   render(App);
   expect(mocks.RunImage).not.toHaveBeenCalled();
   expect(mocks.DashboardPage).toHaveBeenCalled();
-  router.goto('/image/run/basic');
+  router.goto('/images/run/basic');
   await tick();
   expect(mocks.RunImage).toHaveBeenCalled();
 });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -174,21 +174,47 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/kube/play" breadcrumb="Podman Kube Play">
           <KubePlayYAML />
         </Route>
-        <Route path="/image/run/*" breadcrumb="Run Image">
-          <RunImage />
+
+        <Route path="/images/*" breadcrumb="Images" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Images" navigationHint="root">
+            <ImagesList />
+          </Route>
+          <Route path="/existing-image-create-container" breadcrumb="Select image" >
+            <CreateContainerFromExistingImage />
+          </Route>
+          <Route path="/run/*" breadcrumb="Run Image">
+            <RunImage />
+          </Route>
+          <Route path="/build" breadcrumb="Build an Image" let:meta>
+            <BuildImageFromContainerfile taskId={+meta.query.taskId}/>
+          </Route>
+          <Route path="/pull" breadcrumb="Pull an Image">
+            <PullImage />
+          </Route>
+          <Route path="/import" breadcrumb="Import Containers">
+            <ImportContainersImages />
+          </Route>
+          <Route path="/save" breadcrumb="Save Images">
+            <SaveImages />
+          </Route>
+          <Route path="/load" breadcrumb="Load Images">
+            <LoadImages />
+          </Route>
+          <Route path="/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
+            <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
+          </Route>
+          <Route
+            path="/:id/:engineId/:base64RepoTag/*"
+            breadcrumb="Image Details"
+            let:meta
+            navigationHint="details">
+            <ImageDetails
+              imageID={meta.params.id}
+              engineId={decodeURI(meta.params.engineId)}
+              base64RepoTag={meta.params.base64RepoTag} />
+          </Route>
         </Route>
-        <Route path="/images" breadcrumb="Images" navigationHint="root">
-          <ImagesList />
-        </Route>
-        <Route path="/images/existing-image-create-container" breadcrumb="Select image" >
-          <CreateContainerFromExistingImage />
-        </Route>
-        <Route path="/images/build" breadcrumb="Build an Image" let:meta>
-          <BuildImageFromContainerfile taskId={+meta.query.taskId}/>
-        </Route>
-        <Route path="/images/:id/:engineId" breadcrumb="Images" let:meta navigationHint="root">
-          <ImagesList searchTerm={meta.params.id} imageEngineId={meta.params.engineId} />
-        </Route>
+
         <Route path="/networks/create/*" breadcrumb="Create Network">
           <CreateNetwork />
         </Route>
@@ -201,28 +227,6 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
             imageID={meta.params.id}
             engineId={decodeURI(meta.params.engineId)}
             base64RepoTag={meta.params.base64RepoTag} />
-        </Route>
-        <Route
-          path="/images/:id/:engineId/:base64RepoTag/*"
-          breadcrumb="Image Details"
-          let:meta
-          navigationHint="details">
-          <ImageDetails
-            imageID={meta.params.id}
-            engineId={decodeURI(meta.params.engineId)}
-            base64RepoTag={meta.params.base64RepoTag} />
-        </Route>
-        <Route path="/images/pull" breadcrumb="Pull an Image">
-          <PullImage />
-        </Route>
-        <Route path="/images/import" breadcrumb="Import Containers">
-          <ImportContainersImages />
-        </Route>
-        <Route path="/images/save" breadcrumb="Save Images">
-          <SaveImages />
-        </Route>
-        <Route path="/images/load" breadcrumb="Load Images">
-          <LoadImages />
         </Route>
         <Route path="/pods" breadcrumb="Pods" navigationHint="root">
           <PodsList />

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -229,7 +229,7 @@ test('Expect a local image to have an active run image button', async () => {
   expect(selectImagebutton).not.toBeDisabled();
 
   await user.click(selectImagebutton);
-  expect(router.goto).toHaveBeenCalledWith('/image/run/basic');
+  expect(router.goto).toHaveBeenCalledWith('/images/run/basic');
 });
 
 test('Expect no user input to show only local images', async () => {

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -297,7 +297,7 @@ async function buildContainerFromImage(): Promise<void> {
     const chosenImage = imageUtils.getImagesInfoUI(localImages[0], []);
     if (chosenImage.length > 0) {
       runImageInfo.set(chosenImage[0]);
-      router.goto('/image/run/basic');
+      router.goto('/images/run/basic');
     }
   }
 }

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -60,7 +60,7 @@ onMount(async () => {
 
 async function runImage(imageInfo: ImageInfoUI): Promise<void> {
   runImageInfo.set(imageInfo);
-  router.goto('/image/run/basic');
+  router.goto('/images/run/basic');
 }
 
 async function deleteImage(): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR groups related `images/*` paths to be in the same root path in order to have correct hierarchy-based breadcrumbs rather than path-based.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/15612

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
- Going to image from container details page should show `Images -> Image details` instead of `Containers -> image details`
- Creating image from the container list page using `Existing image` should show `Images -> Select image` instead of `Containers -> Select image`, same thing for the `Run image` page after selecting an image

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
