### PR TITLE
refactor: update containers routes to be nested

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -159,15 +159,18 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/" breadcrumb="Dashboard Page" navigationHint="root">
           <DashboardPage />
         </Route>
-        <Route path="/containers" breadcrumb="Containers" navigationHint="root">
-          <ContainerList searchTerm={meta.query.filter ?? ''} />
-        </Route>
-        <Route path="/containers/:id/*" let:meta firstmatch>
-          <Route path="/export" breadcrumb="Export Container">
-            <ContainerExport containerID={meta.params.id} />
+
+        <Route path="/containers/*" breadcrumb="Containers" navigationHint="root" firstmatch>
+          <Route path="/" breadcrumb="Containers" navigationHint="root">
+            <ContainerList searchTerm={meta.query.filter ?? ''} />
           </Route>
-          <Route breadcrumb="Container Details" navigationHint="details" path="/*">
-            <ContainerDetails containerID={meta.params.id} />
+          <Route path="/:id/*" let:meta firstmatch>
+            <Route path="/export" breadcrumb="Export Container">
+              <ContainerExport containerID={meta.params.id} />
+            </Route>
+            <Route breadcrumb="Container Details" navigationHint="details" path="/*">
+              <ContainerDetails containerID={meta.params.id} />
+            </Route>
           </Route>
         </Route>
 


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR groups related `containers/*` paths to be in the same root path in order to have correct hierarchy-based breadcrumbs rather than path-based.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/15612

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
