### PR TITLE
refactor: migrated ConnectionStatus component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/ConnectionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionStatus.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-export let status: string;
+interface Props {
+  status: string;
+}
+
+let { status }: Props = $props();
 
 interface ConnectionStatusStyle {
   bgColor: string;
@@ -51,11 +55,13 @@ const statusesStyle = new Map<string, ConnectionStatusStyle>([
     },
   ],
 ]);
-$: statusStyle = statusesStyle.get(status) ?? {
-  bgColor: 'bg-[var(--pd-status-unknown)]',
-  txtColor: 'text-[var(--pd-status-unknown)]',
-  label: status.toUpperCase(),
-};
+let statusStyle = $derived(
+  statusesStyle.get(status) ?? {
+    bgColor: 'bg-[var(--pd-status-unknown)]',
+    txtColor: 'text-[var(--pd-status-unknown)]',
+    label: status.toUpperCase(),
+  },
+);
 </script>
 
 <div aria-label="Connection Status Icon" class="{roundIconStyle} {statusStyle.bgColor}"></div>


### PR DESCRIPTION
### What does this PR do?
Migrates ConnectionStatus to svelte5

### Screenshot / video of UI
Should be no change

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/15925

### How to test this PR?
Unit tests
- [x] Tests are covering the bug fix or the new feature
