### PR TITLE
refactor(CopyToClipboard): migrate to Svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/CopyToClipboard.svelte
+++ b/packages/renderer/src/lib/ui/CopyToClipboard.svelte
@@ -3,8 +3,13 @@ import { faPaste } from '@fortawesome/free-solid-svg-icons';
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
-export let clipboardData: string;
-export let title: string;
+interface Props {
+  clipboardData: string;
+  title: string;
+  class?: string;
+}
+
+let { clipboardData, title, class: className = '' }: Props = $props();
 
 async function copyTextToClipboard(): Promise<void> {
   await window.clipboardWriteText(clipboardData);
@@ -15,13 +20,13 @@ async function copyTextToClipboard(): Promise<void> {
   <Tooltip bottom tip="Copy to Clipboard">
     <button
       title="Copy To Clipboard"
-      class="ml-5 {$$props.class ?? ''}"
+      class="ml-5 {className}"
       aria-label="Copy To Clipboard"
-      on:click={copyTextToClipboard}>
+      onclick={copyTextToClipboard}>
       <Icon icon={faPaste} />
     </button>
   </Tooltip>
 </div>
-<div class="mt-1 my-auto text-xs truncate {$$props.class ?? ''}" aria-label="{title} copy to clipboard" title={title}>
+<div class="mt-1 my-auto text-xs truncate {className}" aria-label="{title} copy to clipboard" title={title}>
   {title}
 </div>


### PR DESCRIPTION
### What does this PR do?

Migrate the `packages/renderer/src/lib/ui/CopyToClipboard.svelte` component to Svelte5.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests in [packages/renderer/src/lib/ui/CopyToClipboard.spec.ts](https://github.com/podman-desktop/podman-desktop/blob/eaa421aff79ec65f5e739287b6f1179e158d05f6/packages/renderer/src/lib/ui/CopyToClipboard.spec.ts) ensure no regression
