### PR TITLE
refactor(chevronExpander): introduce expandable chevron icon

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { Link } from '@podman-desktop/ui-svelte';
-import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { ChevronExpander, Link } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import DetailsCell from '/@/lib/details/DetailsCell.svelte';
@@ -75,7 +73,7 @@ if (container.groupInfo.created) {
     <tr>
       <DetailsCell style="cursor-pointer flex items-center" onClick={(): boolean => (labelsDropdownOpen = !labelsDropdownOpen)}>
         Labels
-        <Icon class="ml-1" size="0.9x" icon={labelsDropdownOpen ? faChevronDown : faChevronRight} />
+        <ChevronExpander expanded={labelsDropdownOpen} size="0.9x" class="ml-1" />
       </DetailsCell>
       <DetailsCell>
         {#if labelsDropdownOpen}

--- a/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import type { V1ObjectMeta } from '@kubernetes/client-node';
-import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { ChevronExpander } from '@podman-desktop/ui-svelte';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
@@ -80,7 +79,7 @@ if (artifact?.annotations) {
         style="cursor-pointer flex items-center"
         onClick={(): boolean => (internalLabelsDropdownOpen = !internalLabelsDropdownOpen)}>
         Internal Labels
-        <Icon class="ml-1" size="0.9x" icon={internalLabelsDropdownOpen ? faChevronDown : faChevronRight} />
+        <ChevronExpander expanded={internalLabelsDropdownOpen} size="0.9x" class="ml-1" />
       </Cell>
       <Cell>
         {#if internalLabelsDropdownOpen}
@@ -112,7 +111,7 @@ if (artifact?.annotations) {
         style="cursor-pointer flex items-center"
         onClick={(): boolean => (internalAnnotationsDropdownOpen = !internalAnnotationsDropdownOpen)}>
         Internal Annotations
-        <Icon class="ml-1" size="0.9x" icon={internalAnnotationsDropdownOpen ? faChevronDown : faChevronRight} />
+        <ChevronExpander expanded={internalAnnotationsDropdownOpen} size="0.9x" class="ml-1" />
       </Cell>
       <Cell>
         {#if internalAnnotationsDropdownOpen}

--- a/packages/ui/src/lib/button/Expandable.spec.ts
+++ b/packages/ui/src/lib/button/Expandable.spec.ts
@@ -120,3 +120,11 @@ test('Check clicking fires an event', async () => {
   expect(clickMock).toHaveBeenCalledTimes(2);
   expect(clickMock).toHaveBeenCalledWith(true);
 });
+
+test('Check chevron is present', async () => {
+  renderIt(false);
+
+  const title = screen.getByText('Title');
+  const chevronIcon = title.parentElement?.querySelector('svg');
+  expect(chevronIcon).toBeInTheDocument();
+});

--- a/packages/ui/src/lib/button/Expandable.svelte
+++ b/packages/ui/src/lib/button/Expandable.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import type { Snippet } from 'svelte';
 import { fade, slide } from 'svelte/transition';
 
-import Icon from '../icons/Icon.svelte';
+import ChevronExpander from '../icons/ChevronExpander.svelte';
 
 interface Props {
   expanded?: boolean;
@@ -29,11 +28,7 @@ function toggle(): void {
 <div class="flex flex-col w-full gap-2">
   <button onclick={(): void => toggle()} aria-expanded="{expanded}">
     <div class="flex flex-row space-x-1 items-center">
-      {#if expanded}
-        <Icon icon={faChevronDown} class='w-4'/>
-      {:else}
-        <Icon icon={faChevronRight} class='w-4'/>
-      {/if}
+      <ChevronExpander expanded={expanded} class="w-4" />
       {@render title?.()}
     </div>
   </button>

--- a/packages/ui/src/lib/icons/ChevronExpander.spec.ts
+++ b/packages/ui/src/lib/icons/ChevronExpander.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+
+import ChevronExpander from './ChevronExpander.svelte';
+
+describe('ChevronExpander', () => {
+  test('should render collapsed state by default', () => {
+    render(ChevronExpander, {});
+
+    const icon = screen.getByRole('img', { hidden: true });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('rotate-0');
+    expect(icon).not.toHaveClass('rotate-90');
+  });
+
+  test('should render expanded state when expanded=true', () => {
+    render(ChevronExpander, { expanded: true });
+
+    const icon = screen.getByRole('img', { hidden: true });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('rotate-90');
+    expect(icon).not.toHaveClass('rotate-0');
+  });
+
+  test('should have transition classes', () => {
+    render(ChevronExpander, {});
+
+    const icon = screen.getByRole('img', { hidden: true });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('transition-transform');
+    expect(icon).toHaveClass('duration-200');
+  });
+
+  test('should have motion-reduce class for accessibility', () => {
+    render(ChevronExpander, {});
+
+    const icon = screen.getByRole('img', { hidden: true });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('motion-reduce:transition-none');
+  });
+
+  test('should apply custom class', () => {
+    render(ChevronExpander, { class: 'custom-class ml-2' });
+
+    const icon = screen.getByRole('img', { hidden: true });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('custom-class');
+    expect(icon).toHaveClass('ml-2');
+  });
+
+  test('should apply size prop', () => {
+    render(ChevronExpander, { size: '2x' });
+
+    const icon = screen.getByRole('img', { hidden: true });
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('style', expect.stringContaining('font-size: 2em;'));
+  });
+});

--- a/packages/ui/src/lib/icons/ChevronExpander.svelte
+++ b/packages/ui/src/lib/icons/ChevronExpander.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+
+import Icon from './Icon.svelte';
+
+interface Props {
+  expanded?: boolean;
+  size?: string;
+  class?: string;
+}
+
+let { expanded = false, size = undefined, class: className = '' }: Props = $props();
+</script>
+
+<Icon
+  icon={faChevronRight}
+  {size}
+  class="transition-transform duration-200 motion-reduce:transition-none {expanded ? 'rotate-90' : 'rotate-0'} {className}" />

--- a/packages/ui/src/lib/icons/index.ts
+++ b/packages/ui/src/lib/icons/index.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import ChevronExpander from './ChevronExpander.svelte';
 import ContainerIcon from './ContainerIcon.svelte';
 import Icon from './Icon.svelte';
 import StarIcon from './StarIcon.svelte';
 
-export { ContainerIcon, Icon, StarIcon };
+export { ChevronExpander, ContainerIcon, Icon, StarIcon };

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -24,6 +24,7 @@ import Carousel from './carousel/Carousel.svelte';
 import Checkbox from './checkbox/Checkbox.svelte';
 import Dropdown from './dropdown/Dropdown.svelte';
 import DropdownMenu from './dropdownMenu';
+import ChevronExpander from './icons/ChevronExpander.svelte';
 import Input from './inputs/Input.svelte';
 import NumberInput from './inputs/NumberInput.svelte';
 import SearchInput from './inputs/SearchInput.svelte';
@@ -55,6 +56,7 @@ export {
   Button,
   Carousel,
   Checkbox,
+  ChevronExpander,
   CloseButton,
   DetailsPage,
   Dropdown,

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
@@ -90,8 +90,9 @@ test('Expect section styling', async () => {
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
   expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild?.childNodes[2]).toBeInTheDocument();
-  expect(element.firstChild?.childNodes[2]).toContainHTML('fas');
+  const chevronContainer = element.firstChild?.childNodes[2] as HTMLElement;
+  expect(chevronContainer).toBeInTheDocument();
+  expect(chevronContainer.querySelector('svg')).toBeInTheDocument();
 });
 
 test('Expect sections expand', async () => {
@@ -101,16 +102,17 @@ test('Expect sections expand', async () => {
 
   const element = screen.getByLabelText(title);
   expect(element).toBeInTheDocument();
-  expect(element.firstChild).toBeInTheDocument();
-  expect(element.firstChild?.childNodes[2]).toBeInTheDocument();
-  expect(element.firstChild?.childNodes[2]).toContainHTML('fa-angle-right');
-  expect(element.firstChild?.childNodes[2]).not.toContainHTML('fa-angle-down');
 
+  const chevronContainer = element.firstChild?.childNodes[2] as HTMLElement;
+  expect(chevronContainer).toBeInTheDocument();
+
+  const chevronIcon = chevronContainer.querySelector('svg') as SVGElement;
+  expect(chevronIcon).toBeInTheDocument();
+  expect(chevronIcon).toHaveClass('rotate-0');
+
+  // expand section
   await fireEvent.click(element);
-
-  // since it is animated, we'll test that the down angle has appeared (and
-  // not wait for right angle to disappear)
-  expect(element.firstChild?.childNodes[2]).toContainHTML('fa-angle-down');
+  expect(chevronIcon).toHaveClass('rotate-90');
 });
 
 test('fa icon should be visible', () => {

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -2,6 +2,7 @@
 import type { IconDefinition } from '@fortawesome/free-regular-svg-icons';
 import type { Component } from 'svelte';
 
+import ChevronExpander from '../icons/ChevronExpander.svelte';
 import Icon from '../icons/Icon.svelte';
 
 interface Props {
@@ -64,12 +65,8 @@ function click(): void {
       {/if}
     </span>
     {#if section}
-      <div class="px-2 flex items-center text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
-        {#if expanded}
-          <Icon icon='fas fa-angle-down' class="text-md transform origin-center transition-transform duration-200 -rotate-90" />
-        {:else}
-          <Icon icon='fas fa-angle-right' class="text-md transform origin-center transition-transform duration-200 rotate-90" />
-        {/if}
+      <div class="px-2 text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
+        <ChevronExpander expanded={expanded} />
       </div>
     {:else if iconRight && iconRightAlign === 'end'}
       <div class="px-2 flex items-center">

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -18,13 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { Table, TableColumn, tablePersistence } from '/@/lib';
-import { Icon } from '/@/lib/icons';
 import SimpleColumn from '/@/lib/table/SimpleColumn.svelte';
 import { Column, Row } from '/@/lib/table/table';
 
@@ -472,23 +470,6 @@ describe('Table#collapsed', () => {
   });
 
   describe('collapse icons', () => {
-    let chevronDown: HTMLImageElement;
-    let chevronRight: HTMLImageElement;
-
-    beforeEach(() => {
-      const { container: chevronDownContainer } = render(Icon, {
-        icon: faChevronDown,
-        size: '0.8x',
-        class: 'text-[var(--pd-table-body-text)] cursor-pointer',
-      });
-      chevronDown = within(chevronDownContainer).getByRole('img', { hidden: true });
-
-      const { container: chevronRightContainer } = render(Icon, {
-        icon: faChevronRight,
-      });
-      chevronRight = within(chevronRightContainer).getByRole('img', { hidden: true });
-    });
-
     test('item without name should have correct icon when expanded', async () => {
       const { getByRole } = render(Table<Item>, {
         kind: 'demo',
@@ -505,7 +486,9 @@ describe('Table#collapsed', () => {
       });
 
       const button = getByRole('button', { name: 'Collapse Row' });
-      expect(button).toContainHTML(chevronDown.innerHTML);
+      const chevronIcon = button.querySelector('svg') as SVGElement;
+      expect(chevronIcon).toBeInTheDocument();
+      expect(chevronIcon).toHaveClass('rotate-90');
     });
 
     test('item without name should have correct icon when collapsed', async () => {
@@ -524,7 +507,9 @@ describe('Table#collapsed', () => {
       });
 
       const button = getByRole('button', { name: 'Expand Row' });
-      expect(button).toContainHTML(chevronRight.innerHTML);
+      const chevronIcon = button.querySelector('svg') as SVGElement;
+      expect(chevronIcon).toBeInTheDocument();
+      expect(chevronIcon).toHaveClass('rotate-0');
     });
   });
 

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -8,12 +8,11 @@
 <script lang="ts" generics="T extends { selected?: boolean; name?: string }">
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
-import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { onMount, tick } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
 import Checkbox from '../checkbox/Checkbox.svelte';
-import Icon from '../icons/Icon.svelte';
+import ChevronExpander from '../icons/ChevronExpander.svelte';
 import type { ListOrganizerItem } from '../layouts/ListOrganizer';
 import ListOrganizer from '../layouts/ListOrganizer.svelte';
 /* eslint-enable import/no-duplicates */
@@ -461,9 +460,10 @@ async function resetColumns(): Promise<void> {
                 aria-expanded={!collapsed.includes(itemKey)}
                 on:click={toggleChildren.bind(undefined, itemKey)}
               >
-                <Icon size="0.8x"
-                  class="text-[var(--pd-table-body-text)] cursor-pointer"
-                  icon={!collapsed.includes(itemKey) ? faChevronDown : faChevronRight}/>
+                <ChevronExpander
+                  expanded={!collapsed.includes(itemKey)}
+                  size="0.8x"
+                  class="text-[var(--pd-table-body-text)] cursor-pointer" />
               </button>
             {/if}
           </div>


### PR DESCRIPTION
### What does this PR do?
This PR adds a new component ChevronExpander, that matches the design expectations mentioned in https://github.com/podman-desktop/podman-desktop/issues/14165, adds animation and reduce-motion. It also updates all occurrences of the own implementations of expandable chevron with this new component.

Closed https://github.com/podman-desktop/podman-desktop/issues/14165
- [x] Tests are covering the bug fix or the new feature
