### PR TITLE
chore(ui): show disabled Create new button with warning

### DIFF
--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
@@ -56,11 +56,19 @@ const buttonTitle = $derived(
         : undefined) ?? 'Create new',
 );
 
-const showCreateNewButton = $derived(
+const hasConnectionFactory = $derived(
   provider.containerProviderConnectionCreation ||
     provider.kubernetesProviderConnectionCreation ||
     provider.vmProviderConnectionCreation,
 );
+
+const hasWarnings = $derived(provider.warnings && provider.warnings.length > 0);
+
+const warningsTooltip = $derived(provider.warnings?.map(w => w.details ?? w.name).join('. ') ?? '');
+
+const showCreateNewButton = $derived(hasConnectionFactory || hasWarnings);
+
+const isCreateButtonDisabled = $derived(!hasConnectionFactory && hasWarnings);
 
 const showSetupButton = $derived(
   globalContext && (isOnboardingEnabled(provider, globalContext) || hasAnyConfiguration(provider)),
@@ -92,10 +100,11 @@ function handleSetup(): void {
   {:else}
     <div class="flex flex-row justify-around flex-wrap gap-2">
       {#if showCreateNewButton}
-        <Tooltip bottom tip="Create new {providerDisplayName}">
+        <Tooltip bottom tip={isCreateButtonDisabled ? warningsTooltip : `Create new ${providerDisplayName}`}>
           <Button
             aria-label="Create new {providerDisplayName}"
             inProgress={providerInstallationInProgress}
+            disabled={isCreateButtonDisabled}
             onclick={handleCreateNew}>
             {buttonTitle} ...
           </Button>


### PR DESCRIPTION
### What does this PR do?

The purpose of the following changes request is to display disabled `Create new ...` button in case if there is no `KubernetesProviderConnectionFactory` registered but provider has a warning messages. Warning messages are shown in the tooltip.

In case if there is no warning messages settled and there is no `KubernetesProviderConnectionFactory` in the provider, `Create new ...` will be hidden as it implemented by default.

The following changes request is decomposition of https://github.com/podman-desktop/podman-desktop/pull/14773

### Screenshot / video of UI

<img width="1379" height="965" src="https://github.com/user-attachments/assets/4c55498a-32cc-4a60-a097-99a86484b9cf" />
<img width="1379" height="965" src="https://github.com/user-attachments/assets/904dafad-74c7-42ef-b550-3019b9267ad8" />

### What issues does this PR fix or reference?

part of https://github.com/podman-desktop/podman-desktop/issues/14145

### How to test this PR?

- Navigate to Resources page in Settings section.
- Make sure that Podman is running.
- Hover the `Create new ...` (in Kind section) button and make sure that there is `Create new Kind cluster` text is displayed in the Tooltip.
- Shutdown Podman machine and wait until it will be fully stopped.
- Make sure, that `Create new ...` (in Kind section) marked as disabled.
- Hover on the following button and make sure that there is `Start your container provider (e.g. Podman) to create Kind clusters` text is displayed on macOS or Windows, or `Install and start a container engine (e.g. Podman) to create Kind clusters` text is displayed on Linux.

- [x] Tests are covering the bug fix or the new feature
