### PR TITLE
refactor(extension/podman): extract  abstract SocketCompatibility to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/compatibility-mode/compatibility-mode.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/compatibility-mode.ts
@@ -21,20 +21,11 @@ import * as os from 'node:os';
 
 import * as extensionApi from '@podman-desktop/api';
 
+import { SocketCompatibility } from '/@/compatibility-mode/socket-compatibility';
 import { findRunningMachine } from '/@/extension';
 import { getPodmanCli } from '/@/utils/podman-cli';
 
 const podmanSystemdSocket = 'podman.socket';
-
-// Create an abstract class for compatibility mode (macOS only)
-// TODO: Windows, Linux
-abstract class SocketCompatibility {
-  abstract isEnabled(): boolean;
-  abstract enable(): Promise<void>;
-  abstract disable(): Promise<void>;
-  abstract details: string;
-  abstract tooltipText(): string;
-}
 
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.

--- a/extensions/podman/packages/extension/src/compatibility-mode/socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/socket-compatibility.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2023-2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+// Create an abstract class for compatibility mode
+// TODO: Windows
+export abstract class SocketCompatibility {
+  abstract isEnabled(): boolean;
+  abstract enable(): Promise<void>;
+  abstract disable(): Promise<void>;
+  abstract details: string;
+  abstract tooltipText(): string;
+}


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/15941, extracting the abstract class `SocketCompatibility` to a dedicated file. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/15543

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
