### PR TITLE
chore(website): added links to the icons under adopters section

### DIFF
--- a/website/src/components/AdoptersCard.tsx
+++ b/website/src/components/AdoptersCard.tsx
@@ -5,21 +5,30 @@ interface AdoptersCardProps {
   readonly logo: string;
   readonly logoDark?: string; // Optional dark mode logo
   readonly alt: string;
+  readonly url: string;
   readonly width: string;
   readonly height: string;
 }
 
-function AdoptersCard({ logo, logoDark, alt, width, height }: AdoptersCardProps): JSX.Element {
+function AdoptersCard({ logo, logoDark, alt, url, width, height }: AdoptersCardProps): JSX.Element {
   return (
     <div className="flex items-center">
-      <ThemedImage
-        alt={alt}
-        sources={{
-          light: logo,
-          dark: logoDark ?? logo,
-        }}
-        style={{ width, height, opacity: 1 }}
-      />
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block cursor-pointer"
+        style={{ width, height }}>
+        <ThemedImage
+          alt={alt}
+          sources={{
+            light: logo,
+            dark: logoDark ?? logo,
+          }}
+          style={{ width: '100%', height: '100%', opacity: 1 }}
+          className="object-contain"
+        />
+      </a>
     </div>
   );
 }

--- a/website/src/pages/community/index.tsx
+++ b/website/src/pages/community/index.tsx
@@ -52,6 +52,7 @@ export default function Home(): JSX.Element {
       logo: '/img/adopters/amadeus_logo_light.svg',
       logoDark: '/img/adopters/amadeus_logo_dark.svg',
       alt: 'amadeus',
+      url: 'https://amadeus.com/',
       width: '167px',
       height: '68px',
     },
@@ -60,6 +61,7 @@ export default function Home(): JSX.Element {
       id: 'eost-logo',
       logo: '/img/adopters/eost.png',
       alt: 'eost',
+      url: 'https://eost.unistra.fr/',
       width: '83px',
       height: '83px',
     },
@@ -275,6 +277,7 @@ export default function Home(): JSX.Element {
                 logo={logo.logo}
                 logoDark={logo.logoDark}
                 alt={logo.alt}
+                url={logo.url}
                 width={logo.width}
                 height={logo.height}
               />


### PR DESCRIPTION
### What does this PR do?
adds clickable links to the icons under the adopters section
### Screenshot / video of UI

https://github.com/user-attachments/assets/e4b772a8-7911-4b07-8c8a-da76537ac5ae


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
