### PR TITLE
chore: fix capitalization of Image to pull

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -126,7 +126,7 @@ describe('PullImage', () => {
     expect(button).toBeInTheDocument();
     expect(button).toBeDisabled();
 
-    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
     await userEvent.click(textbox);
     await userEvent.paste('some-valid-image');
 
@@ -157,10 +157,10 @@ describe('PullImage', () => {
     expect(errorMesssage).toHaveTextContent('Image does not exists');
   });
 
-  test('Expect that focus is in `Image to Pull` field after page is opened', async () => {
+  test('Expect that focus is in `Image to pull` field after page is opened', async () => {
     render(PullImage);
 
-    const pullImageInput = screen.getByRole('textbox', { name: 'Image to Pull' });
+    const pullImageInput = screen.getByRole('textbox', { name: 'Image to pull' });
     expect(pullImageInput.matches(':focus')).toBe(true);
   });
 
@@ -249,7 +249,7 @@ test('Expect if no docker.io shortname to use Podman FQN', async () => {
   vi.mocked(window.resolveShortnameImage).mockResolvedValue(['someregistry/test1']);
   render(PullImage);
 
-  const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+  const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
   await userEvent.click(textbox);
   await userEvent.paste('test1');
 
@@ -269,7 +269,7 @@ test('Expect if no docker.io shortname but checkbox not checked to use docker hu
   vi.mocked(window.resolveShortnameImage).mockResolvedValue(['someregistry/test1']);
   render(PullImage);
 
-  const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+  const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
   await userEvent.click(textbox);
   await userEvent.paste('test1');
 
@@ -287,7 +287,7 @@ test('Expect if docker.io shortname exists to not use Podman FQN', async () => {
   vi.mocked(window.resolveShortnameImage).mockResolvedValue(['someregistry/test1', 'docker.io/test1']);
   render(PullImage);
 
-  const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+  const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
   await userEvent.click(textbox);
   await userEvent.paste('test1');
 
@@ -305,7 +305,7 @@ test('Expect if docker.io shortname exists to not use Podman FQN', async () => {
 test('Expect not to check not shortname images', async () => {
   render(PullImage);
 
-  const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+  const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
   await userEvent.click(textbox);
   await userEvent.paste('test1/');
 
@@ -463,7 +463,7 @@ describe('container connections', () => {
     });
 
     // type into the textbox
-    const textbox = getByRole('textbox', { name: 'Image to Pull' });
+    const textbox = getByRole('textbox', { name: 'Image to pull' });
     await userEvent.click(textbox); // focus
     await userEvent.paste('test1'); // paste
 
@@ -527,7 +527,7 @@ describe('Preferred Registries', () => {
 
     render(PullImage);
 
-    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
     await userEvent.click(textbox);
     await userEvent.paste('ngin');
 
@@ -555,7 +555,7 @@ describe('Preferred Registries', () => {
 
     render(PullImage);
 
-    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
     await userEvent.click(textbox);
     await userEvent.paste('nginx');
 
@@ -574,7 +574,7 @@ describe('Preferred Registries', () => {
 
     render(PullImage);
 
-    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
     await userEvent.click(textbox);
     await userEvent.paste('nginx');
 
@@ -595,7 +595,7 @@ describe('Preferred Registries', () => {
 
     render(PullImage);
 
-    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
     await userEvent.click(textbox);
     await userEvent.paste('nginx');
 
@@ -619,7 +619,7 @@ describe('Preferred Registries', () => {
 
     render(PullImage);
 
-    const textbox = screen.getByRole('textbox', { name: 'Image to Pull' });
+    const textbox = screen.getByRole('textbox', { name: 'Image to pull' });
     await userEvent.click(textbox);
     await userEvent.paste('nginx');
 

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -361,7 +361,7 @@ async function searchFunction(value: string): Promise<void> {
       <div class="self-center text-[var(--pd-table-body-text)] pb-4">Specify preferred registries for pulling images in <Link on:click={gotoManageRegistries}>Settings &gt; Registries</Link>.</div>
 
       <label for="imageName" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-        >Image to Pull</label>
+        >Image to pull</label>
       <div class="flex flex-col">
         <Typeahead
           id="imageName"


### PR DESCRIPTION
chore: fix capitalization of Image to pull

### What does this PR do?

Very small nitpick.. we don't capitalize for labels and noticed this
small one.

Should be "Image to pull" vs "Image to Pull".

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="392" height="224" alt="Screenshot 2026-01-29 at 4 46 57 PM" src="https://github.com/user-attachments/assets/6b68f506-c870-425f-89bb-ea38242078a4" />



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

`pnpm watch`

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
