### PR TITLE
refactor(extension/podman): extract DarwinSocketCompatibility to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/compatibility-mode/compatibility-mode.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/compatibility-mode.ts
@@ -17,130 +17,13 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 
 import * as extensionApi from '@podman-desktop/api';
 
+import { DarwinSocketCompatibility } from '/@/compatibility-mode/darwin-socket-compatibility';
 import { SocketCompatibility } from '/@/compatibility-mode/socket-compatibility';
-import { findRunningMachine } from '/@/extension';
-import { getPodmanCli } from '/@/utils/podman-cli';
 
 const podmanSystemdSocket = 'podman.socket';
-
-export class DarwinSocketCompatibility extends SocketCompatibility {
-  // Shows the details of the compatibility mode on what we do.
-  details =
-    'The podman-mac-helper binary will be run, linking the Docker socket to Podman. This requires administrative privileges.';
-
-  // This will show the "opposite" of what the current state is
-  // "Enable" if it's currently disabled, "Disable" if it's currently enabled
-  // for tooltip text
-  tooltipText(): string {
-    const text = 'macOS Docker socket compatibility for Podman.';
-    return this.isEnabled() ? `Disable ${text}` : `Enable ${text}`;
-  }
-
-  // Find the podman-mac-helper binary which should only be located in either
-  // brew or podman's install location
-  findPodmanHelper(): string {
-    const podmanPath = '/opt/podman/bin/podman-mac-helper';
-    const homebrewPath = '/opt/homebrew/bin/podman-mac-helper';
-    const userBinaryPath = '/usr/local/bin/podman-mac-helper';
-
-    if (fs.existsSync(podmanPath)) {
-      return podmanPath;
-    } else if (fs.existsSync(homebrewPath)) {
-      return homebrewPath;
-    } else if (fs.existsSync(userBinaryPath)) {
-      return userBinaryPath;
-    } else {
-      return '';
-    }
-  }
-
-  // Check to see if com.github.containers.podman.helper-<username>.plist exists
-  isEnabled(): boolean {
-    const username = os.userInfo().username;
-    const filename = `/Library/LaunchDaemons/com.github.containers.podman.helper-${username}.plist`;
-    return fs.existsSync(filename);
-  }
-
-  // Run command for podman mac helper in admin mode
-  async runMacHelperCommandWithAdminPriv(command: string, args: string[]): Promise<void> {
-    try {
-      // Have to run with admin mode
-      const result = await extensionApi.process.exec(command, args, { isAdmin: true });
-      if (result.stderr?.includes('Error:')) {
-        throw new Error(result.stderr);
-      }
-    } catch (error) {
-      throw new Error(`Unable to run command: ${String(error)}`);
-    }
-  }
-
-  async runCommand(command: string, description: string): Promise<void> {
-    // Find the podman-mac-helper binary
-    const podmanHelperBinary = this.findPodmanHelper();
-    if (podmanHelperBinary === '') {
-      await extensionApi.window.showErrorMessage('podman-mac-helper binary not found.', 'OK');
-      return;
-    }
-
-    try {
-      await this.runMacHelperCommandWithAdminPriv(podmanHelperBinary, [command]);
-      await extensionApi.window.showInformationMessage(
-        `Docker socket compatibility mode for Podman has been ${description}.`,
-      );
-    } catch (error) {
-      console.error(`Error running podman-mac-helper: ${error}`);
-      await extensionApi.window.showErrorMessage(`Error running podman-mac-helper: ${error}`, 'OK');
-    }
-  }
-
-  // Prompt the user that you need to restart the current podman machine for the changes to take effect
-  async promptRestart(machine: string): Promise<void> {
-    if (machine) {
-      const result = await extensionApi.window.showInformationMessage(
-        `Restarting your Podman machine is required to apply the changes. Would you like to restart the Podman machine '${machine}' now?`,
-        'Yes',
-        'Cancel',
-      );
-      if (result === 'Yes') {
-        // Await since we must wait for the machine to stop before starting it again
-        await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machine]);
-        await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machine]);
-      }
-    }
-  }
-
-  // Enable the compatibility mode by running podman-mac-helper install
-  // Run the command with admin privileges and output the result to the user
-  async enable(): Promise<void> {
-    await this.runCommand('install', 'enabled');
-
-    // Prompt the user to restart the podman machine if it's running
-    return findRunningMachine().then(isRunning => {
-      if (isRunning) {
-        this.promptRestart(isRunning).catch((e: unknown) =>
-          console.error(`Failed at restarting podman machine ${isRunning}. Error: ${String(e)}`),
-        );
-      }
-    });
-  }
-
-  async disable(): Promise<void> {
-    await this.runCommand('uninstall', 'disabled');
-
-    // Prompt the user to restart the podman machine if it's running
-    return findRunningMachine().then(isRunning => {
-      if (isRunning) {
-        this.promptRestart(isRunning).catch((e: unknown) =>
-          console.error(`Failed at restarting podman machine ${isRunning}. Error: ${String(e)}`),
-        );
-      }
-    });
-  }
-}
 
 export class LinuxSocketCompatibility extends SocketCompatibility {
   details =

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.spec.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.spec.ts
@@ -1,0 +1,131 @@
+/**********************************************************************
+ * Copyright (C) 2023-2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync, type PathLike } from 'node:fs';
+
+import * as extensionApi from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { DarwinSocketCompatibility } from '/@/compatibility-mode/darwin-socket-compatibility';
+import * as extension from '/@/extension';
+import { findRunningMachine } from '/@/extension';
+
+vi.mock(import('/@/extension'));
+vi.mock(import('node:fs'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+
+  // Mock that findRunningMachine returns undefined
+  vi.mocked(findRunningMachine).mockResolvedValue(undefined);
+
+  // mock existsSync to return true only if '/usr/local/bin/podman-mac-helper' is passed in,
+  // forcing it to return false for all other paths.
+  // this imitates that the binary is found in /usr/local/bin and not other folders
+  vi.mocked(existsSync).mockImplementation((path: PathLike): boolean => {
+    return path === '/usr/local/bin/podman-mac-helper';
+  });
+});
+
+test('darwin: compatibility mode binary not found failure', async () => {
+  // Mock platform to be darwin
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+  });
+
+  // Mock that the binary is not found
+  const socketCompatClass = new DarwinSocketCompatibility();
+  const spyFindPodmanHelper = vi.spyOn(socketCompatClass, 'findPodmanHelper');
+  spyFindPodmanHelper.mockReturnValue('');
+
+  // Expect the error to show when it's not found / enable isn't ran.
+  await socketCompatClass.enable();
+  expect(extensionApi.window.showErrorMessage).toHaveBeenCalledWith('podman-mac-helper binary not found.', 'OK');
+});
+
+test('darwin: DarwinSocketCompatibility class, test runMacHelperCommandWithAdminPriv ran within runCommand', async () => {
+  // Mock platform to be darwin
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+  });
+
+  const socketCompatClass = new DarwinSocketCompatibility();
+
+  // Mock that the binary is found
+  const spyFindPodmanHelper = vi.spyOn(socketCompatClass, 'findPodmanHelper');
+  spyFindPodmanHelper.mockReturnValue('/opt/podman/bin/podman-mac-helper');
+
+  // Mock that admin command ran successfully (since we cannot test interactive mode priv in vitest / has to be integration tests)
+  const spyMacHelperCommand = vi.spyOn(socketCompatClass, 'runMacHelperCommandWithAdminPriv');
+  spyMacHelperCommand.mockImplementation(() => {
+    return Promise.resolve();
+  });
+
+  // Run the command
+  await socketCompatClass.runCommand('enable', 'enabled');
+
+  // Expect that mac helper command was ran
+  expect(spyMacHelperCommand).toHaveBeenCalled();
+});
+
+test('darwin: DarwinSocketCompatibility class, test promptRestart ran within runCommand', async () => {
+  // Mock platform to be darwin
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+  });
+
+  const socketCompatClass = new DarwinSocketCompatibility();
+
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+
+  const spyFindRunningMachine = vi.spyOn(extension, 'findRunningMachine');
+  spyFindRunningMachine.mockImplementation(() => {
+    return Promise.resolve('default');
+  });
+
+  // Mock that enable ran successfully
+  const spyEnable = vi.spyOn(socketCompatClass, 'runCommand');
+  spyEnable.mockImplementation(() => {
+    return Promise.resolve();
+  });
+
+  const spyPromptRestart = vi.spyOn(socketCompatClass, 'promptRestart');
+
+  // Run the command
+  await socketCompatClass.enable();
+
+  // Expect that promptRestart was ran
+  expect(spyPromptRestart).toHaveBeenCalled();
+});
+
+test('darwin: mock fs.existsSync returns /usr/local/bin/podman-mac-helper', async () => {
+  // Mock platform to be darwin
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+  });
+
+  // Mock that the binary is found
+  const socketCompatClass = new DarwinSocketCompatibility();
+
+  // Run findPodmanHelper
+  const binaryPath = socketCompatClass.findPodmanHelper();
+
+  // Expect binaryPath to be /usr/local/bin/podman-mac-helper
+  expect(binaryPath).toBe('/usr/local/bin/podman-mac-helper');
+});

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
@@ -1,0 +1,140 @@
+/**********************************************************************
+ * Copyright (C) 2023-2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import fs from 'node:fs';
+import os from 'node:os';
+
+import extensionApi from '@podman-desktop/api';
+
+import { SocketCompatibility } from '/@/compatibility-mode/socket-compatibility';
+import { findRunningMachine } from '/@/extension';
+import { getPodmanCli } from '/@/utils/podman-cli';
+
+export class DarwinSocketCompatibility extends SocketCompatibility {
+  // Shows the details of the compatibility mode on what we do.
+  details =
+    'The podman-mac-helper binary will be run, linking the Docker socket to Podman. This requires administrative privileges.';
+
+  // This will show the "opposite" of what the current state is
+  // "Enable" if it's currently disabled, "Disable" if it's currently enabled
+  // for tooltip text
+  tooltipText(): string {
+    const text = 'macOS Docker socket compatibility for Podman.';
+    return this.isEnabled() ? `Disable ${text}` : `Enable ${text}`;
+  }
+
+  // Find the podman-mac-helper binary which should only be located in either
+  // brew or podman's install location
+  findPodmanHelper(): string {
+    const podmanPath = '/opt/podman/bin/podman-mac-helper';
+    const homebrewPath = '/opt/homebrew/bin/podman-mac-helper';
+    const userBinaryPath = '/usr/local/bin/podman-mac-helper';
+
+    if (fs.existsSync(podmanPath)) {
+      return podmanPath;
+    } else if (fs.existsSync(homebrewPath)) {
+      return homebrewPath;
+    } else if (fs.existsSync(userBinaryPath)) {
+      return userBinaryPath;
+    } else {
+      return '';
+    }
+  }
+
+  // Check to see if com.github.containers.podman.helper-<username>.plist exists
+  isEnabled(): boolean {
+    const username = os.userInfo().username;
+    const filename = `/Library/LaunchDaemons/com.github.containers.podman.helper-${username}.plist`;
+    return fs.existsSync(filename);
+  }
+
+  // Run command for podman mac helper in admin mode
+  async runMacHelperCommandWithAdminPriv(command: string, args: string[]): Promise<void> {
+    try {
+      // Have to run with admin mode
+      const result = await extensionApi.process.exec(command, args, { isAdmin: true });
+      if (result.stderr?.includes('Error:')) {
+        throw new Error(result.stderr);
+      }
+    } catch (error) {
+      throw new Error(`Unable to run command: ${String(error)}`);
+    }
+  }
+
+  async runCommand(command: string, description: string): Promise<void> {
+    // Find the podman-mac-helper binary
+    const podmanHelperBinary = this.findPodmanHelper();
+    if (podmanHelperBinary === '') {
+      await extensionApi.window.showErrorMessage('podman-mac-helper binary not found.', 'OK');
+      return;
+    }
+
+    try {
+      await this.runMacHelperCommandWithAdminPriv(podmanHelperBinary, [command]);
+      await extensionApi.window.showInformationMessage(
+        `Docker socket compatibility mode for Podman has been ${description}.`,
+      );
+    } catch (error) {
+      console.error(`Error running podman-mac-helper: ${error}`);
+      await extensionApi.window.showErrorMessage(`Error running podman-mac-helper: ${error}`, 'OK');
+    }
+  }
+
+  // Prompt the user that you need to restart the current podman machine for the changes to take effect
+  async promptRestart(machine: string): Promise<void> {
+    if (machine) {
+      const result = await extensionApi.window.showInformationMessage(
+        `Restarting your Podman machine is required to apply the changes. Would you like to restart the Podman machine '${machine}' now?`,
+        'Yes',
+        'Cancel',
+      );
+      if (result === 'Yes') {
+        // Await since we must wait for the machine to stop before starting it again
+        await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machine]);
+        await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machine]);
+      }
+    }
+  }
+
+  // Enable the compatibility mode by running podman-mac-helper install
+  // Run the command with admin privileges and output the result to the user
+  async enable(): Promise<void> {
+    await this.runCommand('install', 'enabled');
+
+    // Prompt the user to restart the podman machine if it's running
+    return findRunningMachine().then(isRunning => {
+      if (isRunning) {
+        this.promptRestart(isRunning).catch((e: unknown) =>
+          console.error(`Failed at restarting podman machine ${isRunning}. Error: ${String(e)}`),
+        );
+      }
+    });
+  }
+
+  async disable(): Promise<void> {
+    await this.runCommand('uninstall', 'disabled');
+
+    // Prompt the user to restart the podman machine if it's running
+    return findRunningMachine().then(isRunning => {
+      if (isRunning) {
+        this.promptRestart(isRunning).catch((e: unknown) =>
+          console.error(`Failed at restarting podman machine ${isRunning}. Error: ${String(e)}`),
+        );
+      }
+    });
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Extract the `DarwinSocketCompatibility` and corresponding tests to dedicate files.

> :notebook: sidenote, I had to update slightly the tests I moved because they were doing vi.mock inside the tests, and this has magically not working after the move, so probably some kind of side effect between the one for linux and darwin.

:bulb: bonus, I added https://github.com/podman-desktop/podman-desktop/pull/15951/commits/c59408c2961a89881affb1af5e7186d985419ea1 which increase the coverage of the `DarwinSocketCompatibility` class.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Following
- https://github.com/podman-desktop/podman-desktop/pull/15941
- https://github.com/podman-desktop/podman-desktop/pull/15942

Required for https://github.com/podman-desktop/podman-desktop/issues/15543

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
