### PR TITLE
refactor(extension/podman): mv LinuxSocketCompatibility to dedicated file 

### DIFF
--- a/extensions/podman/packages/extension/src/compatibility-mode/compatibility-mode.spec.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/compatibility-mode.spec.ts
@@ -21,45 +21,11 @@ import { afterEach, expect, test, vi } from 'vitest';
 
 import { DarwinSocketCompatibility } from '/@/compatibility-mode/darwin-socket-compatibility';
 
-import { getSocketCompatibility, LinuxSocketCompatibility } from './compatibility-mode';
+import { getSocketCompatibility } from './compatibility-mode';
 
 afterEach(() => {
   vi.resetAllMocks();
   vi.restoreAllMocks();
-});
-
-// Linux tests
-test('linux: compatibility mode pass', async () => {
-  Object.defineProperty(process, 'platform', {
-    value: 'linux',
-  });
-  expect(() => getSocketCompatibility()).toBeTruthy();
-});
-
-// Fail when trying to use runSystemdCommand with a command that's not "enable" or "disable"
-test('linux: fail when trying to use runSystemdCommand with a command that is not "enable" or "disable"', async () => {
-  Object.defineProperty(process, 'platform', {
-    value: 'linux',
-  });
-
-  const socketCompatClass = new LinuxSocketCompatibility();
-  await expect(socketCompatClass.runSystemdCommand('start', 'enabled')).rejects.toThrowError(
-    'runSystemdCommand only accepts enable or disable as the command',
-  );
-});
-
-test('linux: pass enabling when systemctl command exists', async () => {
-  Object.defineProperty(process, 'platform', {
-    value: 'linux',
-  });
-
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
-
-  const socketCompatClass = new LinuxSocketCompatibility();
-
-  // Expect enable() to pass since systemctl command exists
-  await expect(socketCompatClass.enable()).resolves.toBeUndefined();
-  expect(extensionApi.window.showErrorMessage).not.toHaveBeenCalled();
 });
 
 // Windows tests

--- a/extensions/podman/packages/extension/src/compatibility-mode/linux-socket-compatibility.spec.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/linux-socket-compatibility.spec.ts
@@ -15,11 +15,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************/
+import { existsSync } from 'node:fs';
+
 import * as extensionApi from '@podman-desktop/api';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getSocketCompatibility } from '/@/compatibility-mode/compatibility-mode';
 import { LinuxSocketCompatibility } from '/@/compatibility-mode/linux-socket-compatibility';
+
+vi.mock(import('node:fs'));
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -34,12 +38,62 @@ test('linux: compatibility mode pass', async () => {
   expect(() => getSocketCompatibility()).toBeTruthy();
 });
 
-// Fail when trying to use runSystemdCommand with a command that's not "enable" or "disable"
-test('linux: fail when trying to use runSystemdCommand with a command that is not "enable" or "disable"', async () => {
-  const socketCompatClass = new LinuxSocketCompatibility();
-  await expect(socketCompatClass.runSystemdCommand('start', 'enabled')).rejects.toThrowError(
-    'runSystemdCommand only accepts enable or disable as the command',
-  );
+describe('runSystemdCommand', () => {
+  // Fail when trying to use runSystemdCommand with a command that's not "enable" or "disable"
+  test('linux: fail when trying to use runSystemdCommand with a command that is not "enable" or "disable"', async () => {
+    const socketCompatClass = new LinuxSocketCompatibility();
+    await expect(socketCompatClass.runSystemdCommand('start', 'enabled')).rejects.toThrowError(
+      'runSystemdCommand only accepts enable or disable as the command',
+    );
+  });
+
+  test('systemctl error should show user error message', async () => {
+    vi.mocked(extensionApi.process.exec).mockRejectedValue('dummy');
+
+    const socketCompatClass = new LinuxSocketCompatibility();
+    await socketCompatClass.runSystemdCommand('enable', 'enable');
+
+    expect(extensionApi.window.showErrorMessage).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching('Error running systemctl command: dummy'),
+      'OK',
+    );
+  });
+
+  test('enable command should ask user to create symlink', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Yes');
+
+    const socketCompatClass = new LinuxSocketCompatibility();
+    await socketCompatClass.runSystemdCommand('enable', 'enable');
+
+    expect(extensionApi.process.exec).toHaveBeenLastCalledWith('pkexec', [
+      'ln',
+      '-s',
+      '/run/podman/podman.sock',
+      '/var/run/docker.sock',
+    ]);
+  });
+
+  test('error in symlink creation should show user error message', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Yes');
+    vi.mocked(extensionApi.process.exec).mockImplementation(async (command): Promise<extensionApi.RunResult> => {
+      switch (command) {
+        case 'systemctl':
+          return { command, stdout: '', stderr: '' };
+        case 'pkexec':
+          throw new Error('dummy pkexec error');
+        default:
+          throw new Error(`unknown command ${command}`);
+      }
+    });
+
+    const socketCompatClass = new LinuxSocketCompatibility();
+    await socketCompatClass.runSystemdCommand('enable', 'enable');
+
+    expect(extensionApi.window.showErrorMessage).toHaveBeenCalledExactlyOnceWith(
+      'Error creating symlink: Error: dummy pkexec error',
+      'OK',
+    );
+  });
 });
 
 test('linux: pass enabling when systemctl command exists', async () => {
@@ -50,4 +104,54 @@ test('linux: pass enabling when systemctl command exists', async () => {
   // Expect enable() to pass since systemctl command exists
   await expect(socketCompatClass.enable()).resolves.toBeUndefined();
   expect(extensionApi.window.showErrorMessage).not.toHaveBeenCalled();
+});
+
+describe('tooltip', () => {
+  test.each<{
+    enabled: boolean;
+    text: string;
+  }>([
+    {
+      enabled: true,
+      text: 'Disable Linux Docker socket compatibility for Podman.',
+    },
+    {
+      enabled: false,
+      text: 'Enable Linux Docker socket compatibility for Podman.',
+    },
+  ])('text should be $text when isEnabled is $enabled', ({ enabled, text }) => {
+    // Mock that the binary is found
+    const socketCompatClass = new LinuxSocketCompatibility();
+
+    vi.spyOn(socketCompatClass, 'isEnabled').mockReturnValue(enabled);
+
+    expect(socketCompatClass.tooltipText()).toEqual(text);
+  });
+});
+
+describe('isEnabled', () => {
+  test('should return true if corresponding file exists', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    const socketCompatClass = new LinuxSocketCompatibility();
+
+    expect(socketCompatClass.isEnabled()).toBeTruthy();
+    expect(existsSync).toHaveBeenCalledExactlyOnceWith(`/etc/systemd/system/socket.target.wants/podman.socket`);
+  });
+
+  test('should return false if corresponding file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const socketCompatClass = new LinuxSocketCompatibility();
+
+    expect(socketCompatClass.isEnabled()).toBeFalsy();
+    expect(existsSync).toHaveBeenCalledExactlyOnceWith(`/etc/systemd/system/socket.target.wants/podman.socket`);
+  });
+});
+
+test('disable exec systemctl disable', async () => {
+  const socketCompatClass = new LinuxSocketCompatibility();
+
+  await socketCompatClass.disable();
+  expect(extensionApi.process.exec).toHaveBeenCalledExactlyOnceWith('systemctl', ['disable', '--now', 'podman.socket']);
 });

--- a/extensions/podman/packages/extension/src/compatibility-mode/linux-socket-compatibility.spec.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/linux-socket-compatibility.spec.ts
@@ -1,0 +1,53 @@
+/*********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+import * as extensionApi from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { getSocketCompatibility } from '/@/compatibility-mode/compatibility-mode';
+import { LinuxSocketCompatibility } from '/@/compatibility-mode/linux-socket-compatibility';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  Object.defineProperty(process, 'platform', {
+    value: 'linux',
+  });
+});
+
+// Linux tests
+test('linux: compatibility mode pass', async () => {
+  expect(() => getSocketCompatibility()).toBeTruthy();
+});
+
+// Fail when trying to use runSystemdCommand with a command that's not "enable" or "disable"
+test('linux: fail when trying to use runSystemdCommand with a command that is not "enable" or "disable"', async () => {
+  const socketCompatClass = new LinuxSocketCompatibility();
+  await expect(socketCompatClass.runSystemdCommand('start', 'enabled')).rejects.toThrowError(
+    'runSystemdCommand only accepts enable or disable as the command',
+  );
+});
+
+test('linux: pass enabling when systemctl command exists', async () => {
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
+
+  const socketCompatClass = new LinuxSocketCompatibility();
+
+  // Expect enable() to pass since systemctl command exists
+  await expect(socketCompatClass.enable()).resolves.toBeUndefined();
+  expect(extensionApi.window.showErrorMessage).not.toHaveBeenCalled();
+});

--- a/extensions/podman/packages/extension/src/compatibility-mode/linux-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/linux-socket-compatibility.ts
@@ -1,0 +1,99 @@
+/*********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import fs from 'node:fs';
+
+import extensionApi from '@podman-desktop/api';
+
+import { SocketCompatibility } from '/@/compatibility-mode/socket-compatibility';
+
+const podmanSystemdSocket = 'podman.socket';
+
+export class LinuxSocketCompatibility extends SocketCompatibility {
+  details =
+    'Administrative privileges are required to enable or disable the systemd Podman socket for Docker compatibility.';
+
+  // This will show the "opposite" of what the current state is
+  // "Enable" if it's currently disabled, "Disable" if it's currently enabled
+  // for tooltip text
+  tooltipText(): string {
+    const text = 'Linux Docker socket compatibility for Podman.';
+    return this.isEnabled() ? `Disable ${text}` : `Enable ${text}`;
+  }
+
+  // isEnabled() checks to see if /etc/systemd/system/socket.target.wants/podman.socket exists
+  isEnabled(): boolean {
+    const filename = '/etc/systemd/system/socket.target.wants/podman.socket';
+    return fs.existsSync(filename);
+  }
+
+  // Runs the systemd command either 'enable' or 'disable'
+  async runSystemdCommand(command: string, description: string): Promise<void> {
+    // Only allow enable or disable, throw error if anything else is inputted
+    if (command !== 'enable' && command !== 'disable') {
+      throw new Error('runSystemdCommand only accepts enable or disable as the command');
+    }
+
+    // Create the full command to run with --now as well as the podman socket name
+    const fullCommand = [command, '--now', podmanSystemdSocket];
+
+    try {
+      // Have to run via sudo
+      await extensionApi.process.exec('systemctl', fullCommand);
+    } catch (error) {
+      console.error(`Error running systemctl command: ${error}`);
+      await extensionApi.window.showErrorMessage(`Error running systemctl command: ${error}`, 'OK');
+      return;
+    }
+
+    // Show information message to the user that they may need to run
+    // ln -s /run/podman/podman.sock /var/run/docker.sock to enable Docker compatibility
+    if (command === 'enable') {
+      // Show information and give the user an option of Yes or Cancel
+      const result = await extensionApi.window.showInformationMessage(
+        'Do you want to create a symlink from /run/podman/podman.sock to /var/run/docker.sock to enable Docker compatibility without having to set the DOCKER_HOST environment variable?',
+        'Yes',
+        'Cancel',
+      );
+      // If the user clicked Yes, run the ln command
+      if (result === 'Yes') {
+        try {
+          await extensionApi.process.exec('pkexec', ['ln', '-s', '/run/podman/podman.sock', '/var/run/docker.sock']);
+          await extensionApi.window.showInformationMessage(
+            'Symlink created successfully. The Podman socket is now available at /var/run/docker.sock.',
+          );
+        } catch (error) {
+          console.error(`Error creating symlink: ${error}`);
+          await extensionApi.window.showErrorMessage(`Error creating symlink: ${error}`, 'OK');
+          return;
+        }
+      }
+    }
+    await extensionApi.window.showInformationMessage(
+      `Podman systemd socket has been ${description} for Docker compatibility.`,
+    );
+  }
+
+  async enable(): Promise<void> {
+    return this.runSystemdCommand('enable', 'enabled');
+  }
+
+  async disable(): Promise<void> {
+    return this.runSystemdCommand('disable', 'disabled');
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Extracting the LinuxSocketCompatibility class to a dedicated class with its corresponding tests

💡 bonus commit https://github.com/podman-desktop/podman-desktop/pull/15981/commits/ff0c5a54d746b49bc25e8f947affaa65fbb27024 to increase coverage of the LinuxSocketCompatibility 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes  https://github.com/podman-desktop/podman-desktop/issues/15543

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
