### PR TITLE
fix(navigation): skipped adding index.html route to navigation history

### DIFF
--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -64,6 +64,20 @@ export function goForward(): void {
   }
 }
 
+// In production we are going from 'index.html' to the Dashboard page during startup, so we need to skip this route
+function isValidRoute(url: string): boolean {
+  // Must start with '/' for relative routes
+  if (!url.startsWith('/')) {
+    return false;
+  }
+
+  if (url.includes('.html')) {
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Check if a URL is a submenu base route that immediately redirects.
  * Submenu routes (like /kubernetes) redirect to their first item (like /kubernetes/dashboard)
@@ -85,6 +99,10 @@ router.subscribe(navigation => {
     // Skip submenu base routes - they immediately redirect to a sub-page
     // and shouldn't be in the history stack
     if (isSubmenuBaseRoute(navigation.url)) {
+      return;
+    }
+
+    if (!isValidRoute(navigation.url)) {
       return;
     }
 


### PR DESCRIPTION
### What does this PR do?
In the production we are going from `../index.html` to `/`
This PR adds a check that we are skipping the *.html page 

### Screenshot / video of UI

### What issues does this PR fix or reference?
Closes #15979 

### How to test this PR?
Run PD In production the back button should be disabled by default (after moving around the app it should enable)

- [x] Tests are covering the bug fix or the new feature
