### PR TITLE
chore(test): Fix k8s e2e tests for kind cluster deletion confirmation dialog

### DIFF
--- a/tests/playwright/src/model/pages/resource-details-page.ts
+++ b/tests/playwright/src/model/pages/resource-details-page.ts
@@ -18,8 +18,9 @@
 
 import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
-import type { ResourceElementActions } from '/@/model/core/operations';
+import { ResourceElementActions } from '/@/model/core/operations';
 import { DetailsPage } from '/@/model/pages/details-page';
+import { handleConfirmationDialog } from '/@/utility/operations';
 
 export class ResourceDetailsPage extends DetailsPage {
   readonly resourceStatus: Locator;
@@ -37,6 +38,11 @@ export class ResourceDetailsPage extends DetailsPage {
       });
       await playExpect(button).toBeEnabled({ timeout: timeout });
       await button.click();
+
+      // A confirmation dialog is displayed for deletion
+      if (operation === ResourceElementActions.Delete) {
+        await handleConfirmationDialog(this.page);
+      }
     });
   }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the Kubernetes e2e tests
 
### What issues does this PR fix 

after https://github.com/podman-desktop/podman-desktop/commit/bd7b9877fe8faf44f2496c361917476432b7fc9e was merged, the k8s e2e tests started failing because they did not handle the confirmation dialog shown when deleting a kind cluster from the details page.
 
### How to test this PR?

https://github.com/podman-desktop/podman-desktop/actions/runs/21589033041
