### PR TITLE
refactor(extension/podman): mv darwin test to dedicated file

### DIFF
--- a/extensions/podman/packages/extension/src/compatibility-mode/compatibility-mode.spec.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/compatibility-mode.spec.ts
@@ -16,10 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as extensionApi from '@podman-desktop/api';
 import { afterEach, expect, test, vi } from 'vitest';
-
-import { DarwinSocketCompatibility } from '/@/compatibility-mode/darwin-socket-compatibility';
 
 import { getSocketCompatibility } from './compatibility-mode';
 
@@ -37,49 +34,4 @@ test('windows: compatibility mode fail', async () => {
 
   // Expect getSocketCompatibility to return error since Linux is not supported yet
   expect(() => getSocketCompatibility()).toThrowError();
-});
-
-test('darwin: test promptRestart IS NOT ran when findRunningMachine returns undefined for enable AND disable', async () => {
-  // Mock platform to be darwin
-  Object.defineProperty(process, 'platform', {
-    value: 'darwin',
-  });
-
-  const socketCompatClass = new DarwinSocketCompatibility();
-
-  // Mock execPromise was ran successfully
-  vi.mock('execPromise', () => {
-    return Promise.resolve();
-  });
-
-  // Mock that enable ran successfully
-  const spyEnable = vi.spyOn(socketCompatClass, 'runCommand');
-  spyEnable.mockImplementation(() => {
-    return Promise.resolve();
-  });
-
-  // Mock that disable ran successfully
-  const spyDisable = vi.spyOn(socketCompatClass, 'runCommand');
-  spyDisable.mockImplementation(() => {
-    return Promise.resolve();
-  });
-
-  // Mock that findRunningMachine returns undefined
-  vi.mock('./../extension', () => {
-    return {
-      findRunningMachine: (): Promise<void> => {
-        return Promise.resolve();
-      },
-    };
-  });
-
-  const spyPromptRestart = vi.spyOn(extensionApi.window, 'showInformationMessage');
-
-  // Enable shouldn't call promptRestart
-  await socketCompatClass.enable();
-  expect(spyPromptRestart).not.toHaveBeenCalled();
-
-  // Disable shouldn't call promptRestart
-  await socketCompatClass.disable();
-  expect(spyPromptRestart).not.toHaveBeenCalled();
 });

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.spec.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.spec.ts
@@ -218,3 +218,23 @@ describe('promptRestart', () => {
     expect(extensionApi.process.exec).toHaveBeenCalledWith('podman', ['machine', 'start', PODMAN_MACHINE_MOCK]);
   });
 });
+
+test('darwin: test promptRestart IS NOT ran when findRunningMachine returns undefined for enable AND disable', async () => {
+  const socketCompatClass = new DarwinSocketCompatibility();
+
+  // Mock that enable ran successfully
+  vi.spyOn(socketCompatClass, 'runCommand').mockResolvedValue(undefined);
+
+  // Mock that disable ran successfully
+  vi.spyOn(socketCompatClass, 'runCommand').mockResolvedValue(undefined);
+
+  const spyPromptRestart = vi.spyOn(extensionApi.window, 'showInformationMessage');
+
+  // Enable shouldn't call promptRestart
+  await socketCompatClass.enable();
+  expect(spyPromptRestart).not.toHaveBeenCalled();
+
+  // Disable shouldn't call promptRestart
+  await socketCompatClass.disable();
+  expect(spyPromptRestart).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
### What does this PR do?

When working on https://github.com/podman-desktop/podman-desktop/issues/15543 I forgot to move one test about the `DarwinSocketCompatibility`.

> ⚠️ I simplified the test content because it was using unnecessary complex syntax  (probably required in older version of vitest)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/15543

### How to test this PR?

N/A
