### PR TITLE
refactor(extension/podman): make darwin-socket-compatibility.ts use execPodman

### DIFF
--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.spec.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.spec.ts
@@ -26,11 +26,17 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { DarwinSocketCompatibility } from '/@/compatibility-mode/darwin-socket-compatibility';
 import * as extension from '/@/extension';
 import { findRunningMachine } from '/@/extension';
-import { getPodmanCli } from '/@/utils/podman-cli';
+import * as util from '/@/utils/util';
 
 vi.mock(import('/@/extension'));
 vi.mock(import('node:fs'));
-vi.mock(import('/@/utils/podman-cli'));
+vi.mock(
+  import('/@/utils/util'),
+  (): Partial<typeof util> => ({
+    appHomeDir: () => 'appHomeDir',
+    execPodman: vi.fn(),
+  }),
+);
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -50,8 +56,6 @@ beforeEach(() => {
   Object.defineProperty(process, 'platform', {
     value: 'darwin',
   });
-
-  vi.mocked(getPodmanCli).mockReturnValue('podman');
 });
 
 test('darwin: compatibility mode binary not found failure', async () => {
@@ -214,8 +218,8 @@ describe('promptRestart', () => {
 
     await socketCompatClass.promptRestart(PODMAN_MACHINE_MOCK);
 
-    expect(extensionApi.process.exec).toHaveBeenCalledWith('podman', ['machine', 'stop', PODMAN_MACHINE_MOCK]);
-    expect(extensionApi.process.exec).toHaveBeenCalledWith('podman', ['machine', 'start', PODMAN_MACHINE_MOCK]);
+    expect(util.execPodman).toHaveBeenCalledWith(['machine', 'stop', PODMAN_MACHINE_MOCK]);
+    expect(util.execPodman).toHaveBeenCalledWith(['machine', 'start', PODMAN_MACHINE_MOCK]);
   });
 });
 

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
@@ -22,7 +22,7 @@ import extensionApi from '@podman-desktop/api';
 
 import { SocketCompatibility } from '/@/compatibility-mode/socket-compatibility';
 import { findRunningMachine } from '/@/extension';
-import { getPodmanCli } from '/@/utils/podman-cli';
+import { execPodman } from '/@/utils/util';
 
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.
@@ -104,8 +104,8 @@ export class DarwinSocketCompatibility extends SocketCompatibility {
       );
       if (result === 'Yes') {
         // Await since we must wait for the machine to stop before starting it again
-        await extensionApi.process.exec(getPodmanCli(), ['machine', 'stop', machine]);
-        await extensionApi.process.exec(getPodmanCli(), ['machine', 'start', machine]);
+        await execPodman(['machine', 'stop', machine]);
+        await execPodman(['machine', 'start', machine]);
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?

Replace the `process.exec` by execPodman in the `darwin-socket-compatibility.ts` file. More details in https://github.com/podman-desktop/podman-desktop/issues/15539.

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/15539

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
