### PR TITLE
chore: fixed navigating over kubernetes submenu

### DIFF
--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -19,6 +19,7 @@
 import { get } from 'svelte/store';
 import { router } from 'tinro';
 
+import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import { navigationRegistry } from '/@/stores/navigation/navigation-registry';
 
 /**
@@ -99,7 +100,16 @@ router.subscribe(navigation => {
     // Skip submenu base routes - they immediately redirect to a sub-page
     // and shouldn't be in the history stack
     if (isSubmenuBaseRoute(navigation.url)) {
-      return;
+      // When going to Kubernetes page (submenu) - `/kubernetes` and you:
+      // 1. DONT have created cluster yet, you will be redirected to the Empty page - `/kubernetes`
+      // 2. HAVE created cluster, you are imidiatly redirected to the Dashboard page - `/kubernetes/dashboard`
+      // When going back in case:
+      // 1. We want to go to `/kubernetes` page where should be the Empty Kubernetes page
+      // 2. We want to skip the `kubernetes` submenu base route - `/kubernetes` since we have not actually navigated to it
+      // (we have been imidiatly redirected to the Kubernetes Dashboard page)
+      if (!get(kubernetesNoCurrentContext)) {
+        return;
+      }
     }
 
     if (!isValidRoute(navigation.url)) {


### PR DESCRIPTION
### What does this PR do?
Improves navigation when going over kubernetes submenu

### Screenshot / video of UI
Prev:

https://github.com/user-attachments/assets/8261cc5f-03ed-4746-8ff1-9c72bb89d2a4

Now:

[Screencast_20260203_135023.webm](https://github.com/user-attachments/assets/7107f25c-94d1-48f5-bdd3-c4d6ff355a27)


### What issues does this PR fix or reference?
Problem mentioned by @MarsKubeX  in 
https://github.com/podman-desktop/podman-desktop/pull/15927#pullrequestreview-3739016993

### How to test this PR?
You can follow the video 

Or go back from kubernetes while having the context created and not having context created 

- [x] Tests are covering the bug fix or the new feature
