### PR TITLE
fix: add primary types to buttons

### DIFF
--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -145,6 +145,7 @@ const showForm = $derived(installInProgress || progressPercent !== 100 || !!inpu
         on:click={closeCallback}>Cancel</Button>
       {#if showForm}
         <Button
+          type="primary"
           icon={faCloudDownload}
           disabled={inputfieldError !== undefined}
           on:click={installExtension}

--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -133,6 +133,7 @@ $effect(() => {
       {/if}
       {#if !pushFinished}
         <Button
+          type="primary"
           class="w-auto"
           icon={faCircleArrowUp}
           disabled={!isAuthenticatedForThisImage}

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -78,6 +78,7 @@ async function pushManifestFinished(): Promise<void> {
       {/if}
       {#if !pushFinished}
         <Button
+          type="primary"
           class="w-auto"
           icon={faCircleArrowUp}
           on:click={pushManifest}

--- a/packages/renderer/src/lib/image/RenameImageModal.svelte
+++ b/packages/renderer/src/lib/image/RenameImageModal.svelte
@@ -103,6 +103,7 @@ async function renameImage(imageName: string, imageTag: string): Promise<void> {
         on:click={closeCallback}>Cancel</Button>
       <Button
         class="col-start-4"
+        type="primary"
         disabled={disableSave(imageName, imageTag)}
         on:click={async (): Promise<void> => {
           await renameImage(imageName, imageTag);

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
@@ -166,6 +166,7 @@ function onUserStateChange(key: unknown): void {
           on:click={closeCallback}>Cancel</Button>
       <Button
           class="col-start-4"
+          type="primary"
           disabled={disableSave(contextName, contextNamespace)}
           on:click={async (): Promise<void> => {
           await editContext(contextName, contextNamespace, contextUser, contextCluster);

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -101,7 +101,7 @@ async function fetch(): Promise<void> {
   {#snippet buttons()}
   
       <Button aria-label="Cancel" class="mr-3" type="link" on:click={closeCallback}>Cancel</Button>
-      <Button aria-label="OK" on:click={closeCallback}>OK</Button>
+      <Button type="primary" aria-label="OK" on:click={closeCallback}>OK</Button>
     
   {/snippet}
 </Dialog>


### PR DESCRIPTION
### What does this PR do?

This PR adds explicit primary type in button components

### Screenshot / video of UI

Should be no visual changes

### What issues does this PR fix or reference?

Closes #15953 

### How to test this PR?


1. Open each dialog and verify the primary button appears as a filled purple button:
        - Troubleshooting Store Details → OK button
        - Edit Kubernetes Context → Save button
        - Rename Image → Rename Image button
        - Push Manifest → Push manifest button
        - Push Image → Push image button
        - Install Extension → Install button
2. Verify buttons work correctly
3. Test in both light and dark themes


- [x] Tests are covering the bug fix or the new feature
