### PR TITLE
feat: added troubleshooting section in settings menu

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -4,6 +4,7 @@ import { onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 
 import PreferencesIcon from '/@/lib/images/PreferencesIcon.svelte';
+import ShortcutArrowIcon from '/@/lib/images/ShortcutArrowIcon.svelte';
 import { type NavItem, settingsNavigationEntries, type SettingsNavItemConfig } from '/@/PreferencesNavigation';
 import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants';
 import { DockerCompatibilitySettings } from '/@api/docker-compatibility-info';
@@ -123,5 +124,14 @@ onMount(() => {
       {/if}
     {/each}
     <!-- Default configuration properties end -->
+    <div class="mx-3 my-2 border-t border-(--pd-global-nav-bg-border)"></div>
+    <SettingsNavItem
+      icon='fas fa-crosshairs'
+      iconRight={ShortcutArrowIcon}
+      iconRightAlign="end"
+      title="Troubleshooting"
+      href="/troubleshooting/repair-connections"
+      selected={meta.url === '/troubleshooting/repair-connections'}
+    />
   </div>
 </nav>


### PR DESCRIPTION
### What does this PR do?

This PR adds the troubleshooting item to the settings menu.

### Screenshot / video of UI

<img width="357" height="296" alt="Captura de pantalla 2026-02-03 a las 17 10 10" src="https://github.com/user-attachments/assets/2ef66484-bc13-4155-9db7-98c1450caf59" />

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/14163

### How to test this PR?

Check the settings menu to see the new item.

- [ ] Tests are covering the bug fix or the new feature
