### PR TITLE
feat(podman): add support for TCP remote connections

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -62,7 +62,7 @@
         "podman.system.connections.remote": {
           "type": "boolean",
           "default": false,
-          "description": "Load remote system connections (ssh)"
+          "description": "Load remote system connections (ssh, tcp)"
         },
         "podman.machine.cpus": {
           "type": "number",

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
@@ -22,8 +22,8 @@ import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { PodmanRemoteConnections } from './podman-remote-connections';
-import type { PodmanRemoteDirectTunnel } from './podman-remote-direct-tunnel';
 import type { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
+import type { PodmanRemoteTcpTunnel } from './podman-remote-tcp-tunnel';
 
 vi.mock('node:fs');
 
@@ -46,8 +46,8 @@ class TestPodmanRemoteConnections extends PodmanRemoteConnections {
     return super.createSshTunnel(host, port, username, privateKey, remotePath, localPath);
   }
 
-  createDirectTunnel(host: string, port: number, localPath: string): PodmanRemoteDirectTunnel {
-    return super.createDirectTunnel(host, port, localPath);
+  createTcpTunnel(host: string, port: number, localPath: string): PodmanRemoteTcpTunnel {
+    return super.createTcpTunnel(host, port, localPath);
   }
 
   async refreshRemoteConnections(): Promise<void> {

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
@@ -22,6 +22,7 @@ import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { PodmanRemoteConnections } from './podman-remote-connections';
+import type { PodmanRemoteDirectTunnel } from './podman-remote-direct-tunnel';
 import type { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
 
 vi.mock('node:fs');
@@ -34,7 +35,7 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 class TestPodmanRemoteConnections extends PodmanRemoteConnections {
-  createTunnel(
+  createSshTunnel(
     host: string,
     port: number,
     username: string,
@@ -42,7 +43,11 @@ class TestPodmanRemoteConnections extends PodmanRemoteConnections {
     remotePath: string,
     localPath: string,
   ): PodmanRemoteSshTunnel {
-    return super.createTunnel(host, port, username, privateKey, remotePath, localPath);
+    return super.createSshTunnel(host, port, username, privateKey, remotePath, localPath);
+  }
+
+  createDirectTunnel(host: string, port: number, localPath: string): PodmanRemoteDirectTunnel {
+    return super.createDirectTunnel(host, port, localPath);
   }
 
   async refreshRemoteConnections(): Promise<void> {
@@ -56,8 +61,8 @@ test('should do nothing if the configuration is disabled', async () => {
   } as unknown as extensionApi.Configuration);
   const podmanRemoteConnections = new TestPodmanRemoteConnections(extensionContext, provider);
 
-  // spy createTunnel method
-  const spyCreateTunnel = vi.spyOn(podmanRemoteConnections, 'createTunnel');
+  // spy createSshTunnel method
+  const spyCreateSshTunnel = vi.spyOn(podmanRemoteConnections, 'createSshTunnel');
 
   // spy refreshRemoteConnections method
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
@@ -69,7 +74,7 @@ test('should do nothing if the configuration is disabled', async () => {
   await vi.waitFor(() => expect(extensionApi.configuration.getConfiguration).toHaveBeenCalled());
 
   // no connection should be created
-  expect(spyCreateTunnel).not.toHaveBeenCalled();
+  expect(spyCreateSshTunnel).not.toHaveBeenCalled();
   expect(spyRefreshRemoteConnections).not.toHaveBeenCalled();
 });
 
@@ -84,8 +89,8 @@ test('should check connections if configuration is enabled', async () => {
     stdout: JSON.stringify([]),
   } as unknown as extensionApi.RunResult);
 
-  // spy createTunnel method
-  const spyCreateTunnel = vi.spyOn(podmanRemoteConnections, 'createTunnel');
+  // spy createSshTunnel method
+  const spyCreateSshTunnel = vi.spyOn(podmanRemoteConnections, 'createSshTunnel');
 
   // spy refreshRemoteConnections method
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
@@ -97,7 +102,7 @@ test('should check connections if configuration is enabled', async () => {
   await vi.waitFor(() => expect(extensionApi.configuration.getConfiguration).toHaveBeenCalled());
 
   // no connection should be created
-  expect(spyCreateTunnel).not.toHaveBeenCalled();
+  expect(spyCreateSshTunnel).not.toHaveBeenCalled();
   expect(spyRefreshRemoteConnections).toHaveBeenCalled();
 });
 
@@ -132,8 +137,8 @@ test('should check connections if configuration is enabled and a system connecti
     ]),
   } as unknown as extensionApi.RunResult);
 
-  // spy createTunnel method
-  const spyCreateTunnel = vi.spyOn(podmanRemoteConnections, 'createTunnel');
+  // spy createSshTunnel method
+  const spyCreateSshTunnel = vi.spyOn(podmanRemoteConnections, 'createSshTunnel');
 
   // spy refreshRemoteConnections method
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
@@ -145,6 +150,43 @@ test('should check connections if configuration is enabled and a system connecti
   await vi.waitFor(() => expect(extensionApi.configuration.getConfiguration).toHaveBeenCalled());
 
   // no connection should be created
-  expect(spyCreateTunnel).not.toHaveBeenCalled();
+  expect(spyCreateSshTunnel).not.toHaveBeenCalled();
   expect(spyRefreshRemoteConnections).toHaveBeenCalled();
+});
+
+test('should create direct tunnel for tcp connections', async () => {
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: () => true,
+  } as unknown as extensionApi.Configuration);
+  const podmanRemoteConnections = new TestPodmanRemoteConnections(extensionContext, provider);
+
+  // mock exec method for listing podman system connections with a TCP connection
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    stdout: JSON.stringify([
+      {
+        IsMachine: false,
+        URI: 'tcp://192.168.1.100:2375',
+        Identity: '',
+        Name: 'TcpRemoteConnection',
+      },
+    ]),
+  } as unknown as extensionApi.RunResult);
+
+  // spy createSshTunnel method - should NOT be called for TCP connections
+  const spyCreateSshTunnel = vi.spyOn(podmanRemoteConnections, 'createSshTunnel');
+
+  // spy refreshRemoteConnections method
+  const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
+
+  // start
+  podmanRemoteConnections.start();
+
+  // wait for the getConfiguration being called
+  await vi.waitFor(() => expect(extensionApi.configuration.getConfiguration).toHaveBeenCalled());
+
+  // should call refreshRemoteConnections
+  expect(spyRefreshRemoteConnections).toHaveBeenCalled();
+
+  // SSH tunnel should not be called for TCP connections
+  expect(spyCreateSshTunnel).not.toHaveBeenCalled();
 });

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
@@ -31,7 +31,7 @@ interface ConnectionListFormatJson {
   Name: string;
   IsMachine?: boolean;
   URI: string;
-  Identity: string;
+  Identity?: string;
 }
 
 interface RemoteSystemConnection {

--- a/extensions/podman/packages/extension/src/remote/podman-remote-direct-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-direct-tunnel.ts
@@ -1,0 +1,146 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import * as net from 'node:net';
+
+import type { ProviderConnectionStatus } from '@podman-desktop/api';
+
+export class PodmanRemoteDirectTunnel {
+  // local server for listening on the local file socket
+  #server: net.Server | undefined;
+
+  #status: ProviderConnectionStatus = 'unknown';
+
+  #reconnect: boolean = false;
+
+  #reconnectTimeout: NodeJS.Timeout | undefined;
+
+  #resolveConnected: (value: boolean) => void = () => {};
+  #connected: Promise<boolean>;
+
+  #listening: boolean = false;
+
+  constructor(
+    private host: string,
+    private port: number,
+    private localPath: string,
+  ) {
+    this.#connected = new Promise<boolean>((resolve, _reject) => {
+      this.#resolveConnected = resolve;
+    });
+  }
+
+  dispose(): void {
+    this.disconnect();
+  }
+
+  status(): ProviderConnectionStatus {
+    return this.#status;
+  }
+
+  connect(): void {
+    this.#reconnect = true;
+    this.#listening = false;
+    this.#connected = new Promise<boolean>((resolve, _reject) => {
+      this.#resolveConnected = resolve;
+    });
+
+    // Create a local server to listen on the local file socket
+    this.#server = net.createServer(localSocket => {
+      // Create a connection to the remote socket via TCP
+      const remoteSocket = net.createConnection({ host: this.host, port: this.port });
+
+      remoteSocket.on('connect', () => {
+        // Forward data from local to remote
+        localSocket.on('data', data => {
+          remoteSocket.write(data);
+        });
+
+        // Forward data from remote to local
+        remoteSocket.on('data', (data: string | Uint8Array) => {
+          localSocket.write(data);
+        });
+      });
+
+      // Handle local socket close
+      localSocket.on('close', () => {
+        remoteSocket.end();
+      });
+
+      // Handle remote socket close
+      remoteSocket.on('close', () => {
+        localSocket.end();
+      });
+
+      // Handle local socket error
+      localSocket.on('error', err => {
+        console.error('Podman tcp tunnel local socket error', err);
+        remoteSocket.end();
+      });
+
+      // Handle remote socket error
+      remoteSocket.on('error', (err: unknown) => {
+        console.error(`Podman tcp tunnel remote socket error ${this.host}:${this.port}`, err);
+        localSocket.end();
+      });
+    });
+
+    // Listen on the local file socket
+    this.#server.listen(this.localPath, () => {
+      this.#listening = true;
+      this.#status = 'started';
+      this.#resolveConnected(true);
+    });
+
+    // Handle server error
+    this.#server.on('error', err => {
+      console.error('Server error:', err);
+      this.#status = 'unknown';
+      this.handleReconnect();
+    });
+
+    // when closed, reconnect
+    this.#server.on('close', () => {
+      this.#status = 'stopped';
+      this.handleReconnect();
+    });
+  }
+
+  handleReconnect(): void {
+    // need to reconnect if no timeout is set for now
+    if (this.#reconnect && !this.#reconnectTimeout) {
+      this.#reconnectTimeout = setTimeout(() => {
+        this.#reconnectTimeout = undefined;
+        this.connect();
+      }, 30000);
+    }
+  }
+
+  disconnect(): void {
+    // Set the reconnect flag to false to prevent reconnecting
+    this.#reconnect = false;
+    this.#server?.close();
+  }
+
+  isConnected(): Promise<boolean> {
+    return this.#connected;
+  }
+
+  protected isListening(): boolean {
+    return this.#listening;
+  }
+}

--- a/extensions/podman/packages/extension/src/remote/podman-remote-tcp-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-tcp-tunnel.spec.ts
@@ -1,0 +1,220 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { rm } from 'node:fs/promises';
+import type { AddressInfo } from 'node:net';
+import { createConnection, createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { PodmanRemoteTcpTunnel } from './podman-remote-tcp-tunnel';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+class TestPodmanRemoteTcpTunnel extends PodmanRemoteTcpTunnel {
+  isListening(): boolean {
+    return super.isListening();
+  }
+}
+
+test('should have unknown status initially', () => {
+  const tunnel = new TestPodmanRemoteTcpTunnel('localhost', 12345, '/tmp/test.sock');
+  expect(tunnel.status()).toBe('unknown');
+});
+
+test('should be able to connect to a TCP server', async () => {
+  let tcpPort = 0;
+  let tcpServerConnected = false;
+
+  // create a TCP server to act as the remote
+  const tcpServer = createServer(_socket => {
+    tcpServerConnected = true;
+  }).listen(0, '127.0.0.1', () => {
+    const address: AddressInfo = tcpServer.address() as AddressInfo;
+    tcpPort = address?.port;
+  });
+
+  // wait for the server to be listening
+  await vi.waitFor(() => expect(tcpPort).toBeGreaterThan(0));
+
+  // create a socket path for the local tunnel endpoint
+  let socketOrNpipePath: string;
+  if (process.platform === 'win32') {
+    socketOrNpipePath = '\\\\.\\pipe\\test-tcp-tunnel';
+  } else {
+    socketOrNpipePath = join(tmpdir(), 'test-tcp-tunnel.sock');
+  }
+
+  // delete file if exists
+  await rm(socketOrNpipePath, { force: true });
+
+  const podmanRemoteTcpTunnel = new TestPodmanRemoteTcpTunnel('127.0.0.1', tcpPort, socketOrNpipePath);
+
+  podmanRemoteTcpTunnel.connect();
+
+  // wait for the tunnel to be connected and listening
+  await vi.waitFor(() => expect(podmanRemoteTcpTunnel.status()).toBe('started'));
+  await vi.waitFor(() => expect(podmanRemoteTcpTunnel.isListening()).toBeTruthy());
+
+  // verify that isConnected resolves to true
+  const isConnected = await podmanRemoteTcpTunnel.isConnected();
+  expect(isConnected).toBeTruthy();
+
+  let connectedToLocal = false;
+  // send a request to the tunnel using the socket path
+  const client = createConnection({ path: socketOrNpipePath }, () => {
+    connectedToLocal = true;
+  });
+
+  await vi.waitFor(() => expect(connectedToLocal).toBeTruthy());
+
+  // wait for the TCP server to receive the connection
+  await vi.waitFor(() => expect(tcpServerConnected).toBeTruthy());
+
+  client.end();
+  podmanRemoteTcpTunnel.disconnect();
+  tcpServer.close();
+});
+
+test('should handle unreachable remote server', async () => {
+  // create a socket path for the local tunnel endpoint
+  let socketOrNpipePath: string;
+  if (process.platform === 'win32') {
+    socketOrNpipePath = '\\\\.\\pipe\\test-tcp-tunnel-unreachable';
+  } else {
+    socketOrNpipePath = join(tmpdir(), 'test-tcp-tunnel-unreachable.sock');
+  }
+
+  // delete file if exists
+  await rm(socketOrNpipePath, { force: true });
+
+  // Try to connect to a port that doesn't exist
+  const podmanRemoteTcpTunnel = new TestPodmanRemoteTcpTunnel('127.0.0.1', 59999, socketOrNpipePath);
+
+  podmanRemoteTcpTunnel.connect();
+
+  // status should remain unknown since the remote is unreachable
+  await vi.waitFor(() => expect(podmanRemoteTcpTunnel.status()).toBe('unknown'), { timeout: 5000 });
+
+  // the tunnel should not be listening since connection failed
+  expect(podmanRemoteTcpTunnel.isListening()).toBeFalsy();
+
+  podmanRemoteTcpTunnel.disconnect();
+});
+
+test('should forward data between local and remote', async () => {
+  let tcpPort = 0;
+  const receivedData: string[] = [];
+
+  // create a TCP server that echoes data back
+  const tcpServer = createServer(socket => {
+    socket.on('data', data => {
+      receivedData.push(data.toString());
+      socket.write(`echo: ${data.toString()}`);
+    });
+  }).listen(0, '127.0.0.1', () => {
+    const address: AddressInfo = tcpServer.address() as AddressInfo;
+    tcpPort = address?.port;
+  });
+
+  // wait for the server to be listening
+  await vi.waitFor(() => expect(tcpPort).toBeGreaterThan(0));
+
+  // create a socket path for the local tunnel endpoint
+  let socketOrNpipePath: string;
+  if (process.platform === 'win32') {
+    socketOrNpipePath = '\\\\.\\pipe\\test-tcp-tunnel-data';
+  } else {
+    socketOrNpipePath = join(tmpdir(), 'test-tcp-tunnel-data.sock');
+  }
+
+  // delete file if exists
+  await rm(socketOrNpipePath, { force: true });
+
+  const podmanRemoteTcpTunnel = new TestPodmanRemoteTcpTunnel('127.0.0.1', tcpPort, socketOrNpipePath);
+
+  podmanRemoteTcpTunnel.connect();
+
+  // wait for the tunnel to be connected and listening
+  await vi.waitFor(() => expect(podmanRemoteTcpTunnel.status()).toBe('started'));
+  await vi.waitFor(() => expect(podmanRemoteTcpTunnel.isListening()).toBeTruthy());
+
+  const responseData: string[] = [];
+
+  // connect to the local socket and send data
+  const client = createConnection({ path: socketOrNpipePath }, () => {
+    client.write('hello');
+  });
+
+  client.on('data', data => {
+    responseData.push(data.toString());
+  });
+
+  // wait for the remote server to receive the data
+  await vi.waitFor(() => expect(receivedData).toContain('hello'));
+
+  // wait for the response to be received
+  await vi.waitFor(() => expect(responseData).toContain('echo: hello'));
+
+  client.end();
+  podmanRemoteTcpTunnel.disconnect();
+  tcpServer.close();
+});
+
+test('should disconnect properly', async () => {
+  let tcpPort = 0;
+
+  // create a TCP server
+  const tcpServer = createServer(_socket => {}).listen(0, '127.0.0.1', () => {
+    const address: AddressInfo = tcpServer.address() as AddressInfo;
+    tcpPort = address?.port;
+  });
+
+  // wait for the server to be listening
+  await vi.waitFor(() => expect(tcpPort).toBeGreaterThan(0));
+
+  // create a socket path for the local tunnel endpoint
+  let socketOrNpipePath: string;
+  if (process.platform === 'win32') {
+    socketOrNpipePath = '\\\\.\\pipe\\test-tcp-tunnel-disconnect';
+  } else {
+    socketOrNpipePath = join(tmpdir(), 'test-tcp-tunnel-disconnect.sock');
+  }
+
+  // delete file if exists
+  await rm(socketOrNpipePath, { force: true });
+
+  const podmanRemoteTcpTunnel = new TestPodmanRemoteTcpTunnel('127.0.0.1', tcpPort, socketOrNpipePath);
+
+  podmanRemoteTcpTunnel.connect();
+
+  // wait for the tunnel to be connected
+  await vi.waitFor(() => expect(podmanRemoteTcpTunnel.status()).toBe('started'));
+
+  // disconnect the tunnel
+  podmanRemoteTcpTunnel.disconnect();
+
+  // status should be stopped
+  await vi.waitFor(() => expect(podmanRemoteTcpTunnel.status()).toBe('stopped'));
+
+  tcpServer.close();
+});

--- a/extensions/podman/packages/extension/src/remote/podman-remote-tcp-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-tcp-tunnel.ts
@@ -105,7 +105,7 @@ export class PodmanRemoteTcpTunnel {
           localSocket.end();
           // Update status and trigger reconnect when remote becomes unreachable
           this.#status = 'unknown';
-          this.handleReconnect();
+          this.#server?.close();
         });
       });
 
@@ -123,7 +123,10 @@ export class PodmanRemoteTcpTunnel {
 
       // when closed, reconnect
       this.#server.on('close', () => {
-        this.#status = 'stopped';
+        if (this.#status !== 'unknown') {
+          this.#status = 'stopped';
+        }
+        this.#listening = false;
         this.handleReconnect();
       });
 

--- a/extensions/podman/packages/extension/src/remote/podman-remote-tcp-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-tcp-tunnel.ts
@@ -103,6 +103,9 @@ export class PodmanRemoteTcpTunnel {
         remoteSocket.on('error', (err: unknown) => {
           console.error(`Podman tcp tunnel remote socket error ${this.host}:${this.port}`, err);
           localSocket.end();
+          // Update status and trigger reconnect when remote becomes unreachable
+          this.#status = 'unknown';
+          this.handleReconnect();
         });
       });
 


### PR DESCRIPTION
### What does this PR do?

This PR adds support for TCP remote connections (tcp://) in Podman Desktop, enabling users to connect to remote Podman instances that expose their API over TCP.

Changes include:
- New `PodmanRemoteDirectTunnel` class to handle direct TCP connections which mirrors ssh connection functionality
- Updated `PodmanRemoteConnections` to detect and process tcp:// URIs alongside ssh://
- Updated configuration description to mention TCP support
- Added unit tests for TCP connection handling

Use cases:

- Connecting to Podman instances with `tcp://0.0.0.0:2375`
- LAN-based container management without SSH overhead
- CI/CD environments where SSH keys are impractical
- Docker-compatible API endpoints exposed over TCP

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

<img width="1067" height="120" alt="image" src="https://github.com/user-attachments/assets/e860f0df-4d2a-4925-a31b-d8da958a4a50" />

<img width="2248" height="1678" alt="image" src="https://github.com/user-attachments/assets/274e175e-7344-4951-863d-43d84dacdf55" />

<img width="2248" height="1683" alt="image" src="https://github.com/user-attachments/assets/d0316cd9-1315-43ca-a11c-aa4908708d4b" />


### What issues does this PR fix or reference?

It fixes solutions proposed in comments of https://github.com/containers/podman/issues/24144 and also helps in cases like #14869 where ssh passphrase is present


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->
1. Build and run Podman Desktop
2. Enable remote connections in Settings: Podman > Load remote system connections (ssh, tcp)
3. On a remote machine, expose Podman over TCP:
    ```bash
     podman system service --time=0 tcp:0.0.0.0:3307
    ```
4. Add a TCP connection:
    ```bash
     podman system connection add test-tcp tcp://<remote-ip>:3307
    ```
5. Verify the connection appears in the Resources panel
6. Test container operations through the TCP connection

Unit tests:
```bash
pnpm test:extensions:podman
```
    
All 494 tests pass, including the new TCP connection test.

- [x] Tests are covering the bug fix or the new feature
