### PR TITLE
feat(split-button): add SplitButton component with unit tests

### DIFF
--- a/packages/ui/src/lib/button/SplitButton.spec.ts
+++ b/packages/ui/src/lib/button/SplitButton.spec.ts
@@ -1,0 +1,658 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { SplitButtonOption } from './SplitButton.svelte';
+import SplitButton from './SplitButton.svelte';
+
+const mockOptions: SplitButtonOption[] = [
+  { id: 'merge', label: 'Merge', description: 'Merge all commits' },
+  { id: 'squash', label: 'Squash and merge', description: 'Squash commits into one' },
+  { id: 'rebase', label: 'Rebase and merge', description: 'Rebase commits onto base' },
+];
+
+describe('SplitButton', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('renders with noSelectionLabel when no option is selected', () => {
+    render(SplitButton, { props: { options: mockOptions, noSelectionLabel: 'Select...' } });
+    expect(screen.getByText('Select...')).toBeInTheDocument();
+  });
+
+  test('renders with specified selected option', () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['squash'], noSelectionLabel: 'Select...' },
+    });
+    expect(screen.getByRole('button', { name: /squash and merge/i })).toBeInTheDocument();
+  });
+
+  test('opens dropdown when chevron button is clicked', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+    const dropdownButton = screen.getByLabelText('Select action');
+    await fireEvent.click(dropdownButton);
+
+    expect(screen.getByText('Squash and merge')).toBeInTheDocument();
+    expect(screen.getByText('Rebase and merge')).toBeInTheDocument();
+  });
+
+  test('shows option descriptions in dropdown', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+    const dropdownButton = screen.getByLabelText('Select action');
+    await fireEvent.click(dropdownButton);
+
+    expect(screen.getByText('Merge all commits')).toBeInTheDocument();
+    expect(screen.getByText('Squash commits into one')).toBeInTheDocument();
+  });
+
+  test('calls onAction with all selected options when main button is clicked', async () => {
+    const onAction = vi.fn();
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', onAction },
+    });
+
+    const mainButton = screen.getByText('Merge');
+    await fireEvent.click(mainButton);
+
+    expect(onAction).toHaveBeenCalledWith([mockOptions[0]]);
+  });
+
+  test('selects option without triggering action when dropdown item is clicked', async () => {
+    const onAction = vi.fn();
+    const onSelect = vi.fn();
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', onAction, onSelect },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    // Select squash option
+    await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+
+    // Action should NOT be called - only selection changes
+    expect(onAction).not.toHaveBeenCalled();
+    // But onSelect should be called with all selected options (squash replaces merge in single-select)
+    expect(onSelect).toHaveBeenCalledWith([mockOptions[1]]);
+  });
+
+  test('shows checkmark icon for selected option', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    // The first option (Merge) should have the checkmark
+    const mergeOption = screen.getByRole('option', { name: /^merge\s/i });
+    expect(mergeOption.querySelector('svg')).toBeInTheDocument();
+  });
+
+  test('triggers action with all selected options when main button is clicked after selection', async () => {
+    const onAction = vi.fn();
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', onAction },
+    });
+
+    // Open dropdown and select squash option
+    await fireEvent.click(screen.getByLabelText('Select action'));
+    await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+
+    // Now click main button
+    await fireEvent.click(screen.getByRole('button', { name: /squash and merge/i }));
+
+    expect(onAction).toHaveBeenCalledWith([mockOptions[1]]);
+  });
+
+  test('closes dropdown when option is selected', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // Select an option
+    await fireEvent.click(screen.getByRole('option', { name: /rebase and merge/i }));
+
+    // Dropdown should be closed
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('closes dropdown when Escape is pressed', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // Press Escape
+    await fireEvent.keyUp(window, { key: 'Escape' });
+
+    // Dropdown should be closed
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('closes dropdown when clicking outside', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    // Open dropdown
+    await fireEvent.click(screen.getByLabelText('Select action'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // Click outside
+    await fireEvent.click(document.body);
+
+    // Dropdown should be closed
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('disables button when disabled prop is true', () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', disabled: true },
+    });
+
+    expect(screen.getByText('Merge').closest('button')).toBeDisabled();
+    expect(screen.getByLabelText('Select action')).toBeDisabled();
+  });
+
+  test('does not open dropdown when disabled', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', disabled: true },
+    });
+
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('does not call onAction when disabled', async () => {
+    const onAction = vi.fn();
+    render(SplitButton, {
+      props: {
+        options: mockOptions,
+        selectedOptionIds: ['merge'],
+        noSelectionLabel: 'Select...',
+        disabled: true,
+        onAction,
+      },
+    });
+
+    await fireEvent.click(screen.getByText('Merge'));
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  test('shows spinner when inProgress', () => {
+    const { container } = render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', inProgress: true },
+    });
+
+    // Spinner component should be present (has role="status")
+    expect(container.querySelector('[role="status"]')).toBeInTheDocument();
+  });
+
+  test('disables buttons when inProgress', () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', inProgress: true },
+    });
+
+    expect(screen.getByText('Merge').closest('button')).toBeDisabled();
+    expect(screen.getByLabelText('Select action')).toBeDisabled();
+  });
+
+  test('applies secondary type styling', () => {
+    const { container } = render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', type: 'secondary' },
+    });
+
+    const mainButton = container.querySelector('button');
+    expect(mainButton?.className).toContain('border-[var(--pd-button-secondary)]');
+  });
+
+  test('applies danger type styling', () => {
+    const { container } = render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...', type: 'danger' },
+    });
+
+    const mainButton = container.querySelector('button');
+    expect(mainButton?.className).toContain('border-[var(--pd-button-danger-border)]');
+  });
+
+  test('renders with custom aria-label', () => {
+    render(SplitButton, {
+      props: {
+        options: mockOptions,
+        selectedOptionIds: ['merge'],
+        noSelectionLabel: 'Select...',
+        'aria-label': 'Merge options',
+      },
+    });
+
+    expect(screen.getByLabelText('Merge options')).toBeInTheDocument();
+  });
+
+  test('renders with title tooltip', () => {
+    render(SplitButton, {
+      props: {
+        options: mockOptions,
+        selectedOptionIds: ['merge'],
+        noSelectionLabel: 'Select...',
+        title: 'Choose merge strategy',
+      },
+    });
+
+    expect(screen.getByTitle('Choose merge strategy')).toBeInTheDocument();
+  });
+
+  test('sets aria-expanded correctly on dropdown toggle', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    const dropdownButton = screen.getByLabelText('Select action');
+
+    expect(dropdownButton).toHaveAttribute('aria-expanded', 'false');
+
+    await fireEvent.click(dropdownButton);
+
+    expect(dropdownButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('marks selected option with aria-selected', async () => {
+    render(SplitButton, {
+      props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select...' },
+    });
+
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    const mergeOption = screen.getByRole('option', { name: /^merge\s/i });
+    expect(mergeOption).toHaveAttribute('aria-selected', 'true');
+
+    const squashOption = screen.getByRole('option', { name: /squash and merge/i });
+    expect(squashOption).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('shows emptyLabel and disables button when options array is empty', () => {
+    render(SplitButton, { props: { options: [], noSelectionLabel: 'Select...', emptyLabel: 'No items available' } });
+
+    expect(screen.getByText('No items available')).toBeInTheDocument();
+    expect(screen.getByText('No items available').closest('button')).toBeDisabled();
+    expect(screen.getByLabelText('Select action')).toBeDisabled();
+  });
+
+  test('uses default emptyLabel when not provided', () => {
+    render(SplitButton, { props: { options: [], noSelectionLabel: 'Select...' } });
+
+    expect(screen.getByText('No options available')).toBeInTheDocument();
+  });
+
+  test('does not open dropdown when options are empty', async () => {
+    render(SplitButton, { props: { options: [], noSelectionLabel: 'Select...' } });
+
+    await fireEvent.click(screen.getByLabelText('Select action'));
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  describe('noActionLabel mode (all options disabled)', () => {
+    const allDisabledOptions: SplitButtonOption[] = [
+      { id: 'opt1', label: 'Option 1', disabled: true, description: 'Not available' },
+      { id: 'opt2', label: 'Option 2', disabled: true, description: 'Also not available' },
+    ];
+
+    test('shows noActionLabel when all options are disabled', () => {
+      render(SplitButton, {
+        props: { options: allDisabledOptions, noSelectionLabel: 'Select...', noActionLabel: 'Show options...' },
+      });
+
+      expect(screen.getByText('Show options...')).toBeInTheDocument();
+    });
+
+    test('uses default noActionLabel when not provided', () => {
+      render(SplitButton, { props: { options: allDisabledOptions, noSelectionLabel: 'Select...' } });
+
+      expect(screen.getByText('Show options...')).toBeInTheDocument();
+    });
+
+    test('main button is enabled in noAction mode', () => {
+      render(SplitButton, {
+        props: { options: allDisabledOptions, noSelectionLabel: 'Select...', noActionLabel: 'Show options...' },
+      });
+
+      const mainButton = screen.getByText('Show options...').closest('button');
+      expect(mainButton).toBeEnabled();
+    });
+
+    test('clicking main button opens dropdown instead of calling onAction', async () => {
+      const onAction = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: allDisabledOptions,
+          noSelectionLabel: 'Select...',
+          noActionLabel: 'Show options...',
+          onAction,
+        },
+      });
+
+      await fireEvent.click(screen.getByText('Show options...'));
+
+      // Should open dropdown
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      // Should NOT call onAction
+      expect(onAction).not.toHaveBeenCalled();
+    });
+
+    test('dropdown shows all disabled options with descriptions', async () => {
+      render(SplitButton, {
+        props: { options: allDisabledOptions, noSelectionLabel: 'Select...', noActionLabel: 'Show options...' },
+      });
+
+      await fireEvent.click(screen.getByText('Show options...'));
+
+      expect(screen.getByText('Option 1')).toBeInTheDocument();
+      expect(screen.getByText('Option 2')).toBeInTheDocument();
+      expect(screen.getByText('Not available')).toBeInTheDocument();
+      expect(screen.getByText('Also not available')).toBeInTheDocument();
+    });
+
+    test('disabled options cannot be selected', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: allDisabledOptions,
+          noSelectionLabel: 'Select...',
+          noActionLabel: 'Show options...',
+          onSelect,
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByText('Show options...'));
+
+      // Try to select a disabled option
+      await fireEvent.click(screen.getByRole('option', { name: /option 1/i }));
+
+      // onSelect should NOT be called
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    test('dropdown toggle (chevron) also works in noAction mode', async () => {
+      render(SplitButton, {
+        props: { options: allDisabledOptions, noSelectionLabel: 'Select...', noActionLabel: 'Show options...' },
+      });
+
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('noSelectionLabel mode (no option selected)', () => {
+    test('shows noSelectionLabel when no option is selected', () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...' },
+      });
+
+      expect(screen.getByText('Select an option...')).toBeInTheDocument();
+    });
+
+    test('main button is enabled in noSelection mode', () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...' },
+      });
+
+      const mainButton = screen.getByText('Select an option...').closest('button');
+      expect(mainButton).toBeEnabled();
+    });
+
+    test('clicking main button opens dropdown instead of calling onAction', async () => {
+      const onAction = vi.fn();
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...', onAction },
+      });
+
+      await fireEvent.click(screen.getByText('Select an option...'));
+
+      // Should open dropdown
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      // Should NOT call onAction
+      expect(onAction).not.toHaveBeenCalled();
+    });
+
+    test('dropdown shows all options when in noSelection mode', async () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...' },
+      });
+
+      await fireEvent.click(screen.getByText('Select an option...'));
+
+      expect(screen.getByText('Merge')).toBeInTheDocument();
+      expect(screen.getByText('Squash and merge')).toBeInTheDocument();
+      expect(screen.getByText('Rebase and merge')).toBeInTheDocument();
+    });
+
+    test('selecting an option calls onSelect and updates button label', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...', onSelect },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByText('Select an option...'));
+
+      // Select an option
+      await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+
+      // onSelect should be called with all selected options
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[1]]);
+    });
+
+    test('does not show noSelectionLabel when option is selected', () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Select an option...' },
+      });
+
+      expect(screen.queryByText('Select an option...')).not.toBeInTheDocument();
+      expect(screen.getByText('Merge')).toBeInTheDocument();
+    });
+
+    test('dropdown toggle (chevron) works in noSelection mode', async () => {
+      render(SplitButton, {
+        props: { options: mockOptions, selectedOptionIds: [], noSelectionLabel: 'Select an option...' },
+      });
+
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('multipleSelection mode', () => {
+    test('allows selecting multiple options', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+          onSelect,
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Select first option
+      await fireEvent.click(screen.getByRole('option', { name: /^merge\s/i }));
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[0]]);
+
+      // Select second option
+      await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[0], mockOptions[1]]);
+    });
+
+    test('dropdown stays open after selection in multipleSelection mode', async () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Select an option
+      await fireEvent.click(screen.getByRole('option', { name: /^merge\s/i }));
+
+      // Dropdown should still be open
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    test('shows checkmark for all selected options', async () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: ['merge', 'squash'],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Both selected options should have checkmarks
+      const mergeOption = screen.getByRole('option', { name: /^merge\s/i });
+      const squashOption = screen.getByRole('option', { name: /squash and merge/i });
+      const rebaseOption = screen.getByRole('option', { name: /rebase and merge/i });
+
+      expect(mergeOption.querySelector('svg')).toBeInTheDocument();
+      expect(squashOption.querySelector('svg')).toBeInTheDocument();
+      expect(rebaseOption.querySelector('svg')).not.toBeInTheDocument();
+    });
+
+    test('can deselect an option by clicking again', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: ['merge', 'squash'],
+          noSelectionLabel: 'Select options...',
+          onSelect,
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Deselect merge option
+      await fireEvent.click(screen.getByRole('option', { name: /^merge\s/i }));
+
+      // Should only have squash selected
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[1]]);
+    });
+
+    test('button appearance unchanged with 0 selections', () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Should show noSelectionLabel
+      expect(screen.getByText('Select options...')).toBeInTheDocument();
+    });
+
+    test('button appearance unchanged with 1 selection', () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: ['merge'],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Should show the selected option's label (first selected is used for display)
+      expect(screen.getByText('Merge')).toBeInTheDocument();
+    });
+
+    test('listbox has aria-multiselectable attribute in multipleSelection mode', async () => {
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      const listbox = screen.getByRole('listbox');
+      expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
+    });
+
+    test('calls onSelect with all selected options', async () => {
+      const onSelect = vi.fn();
+      render(SplitButton, {
+        props: {
+          options: mockOptions,
+          multipleSelection: true,
+          selectedOptionIds: [],
+          noSelectionLabel: 'Select options...',
+          onSelect,
+        },
+      });
+
+      // Open dropdown
+      await fireEvent.click(screen.getByLabelText('Select action'));
+
+      // Select an option
+      await fireEvent.click(screen.getByRole('option', { name: /squash and merge/i }));
+
+      // onSelect should be called with all selected options
+      expect(onSelect).toHaveBeenCalledWith([mockOptions[1]]);
+    });
+  });
+});

--- a/packages/ui/src/lib/button/SplitButton.svelte
+++ b/packages/ui/src/lib/button/SplitButton.svelte
@@ -1,0 +1,392 @@
+<script lang="ts">
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { type Component, type Snippet, tick } from 'svelte';
+
+import Icon from '../icons/Icon.svelte';
+import Spinner from '../progress/Spinner.svelte';
+import type { ButtonType } from './Button';
+
+export interface SplitButtonOption {
+  id: string;
+  label: string;
+  icon?: IconDefinition | Component | string;
+  description?: string;
+  disabled?: boolean;
+}
+
+interface Props {
+  title?: string;
+  inProgress?: boolean;
+  disabled?: boolean;
+  type?: Exclude<ButtonType, 'link' | 'tab'>;
+  icon?: IconDefinition | Component | string;
+  options: SplitButtonOption[];
+  /** Selected option ID(s) - works for both single and multi-select modes */
+  selectedOptionIds?: string[];
+  /** Enable multiple selection mode */
+  multipleSelection?: boolean;
+  emptyLabel?: string;
+  /** Label shown when options exist but none are actionable (all disabled) */
+  noActionLabel?: string;
+  /** Label shown when options exist but none is selected (clicking opens dropdown) */
+  noSelectionLabel: string;
+  class?: string;
+  'aria-label'?: string;
+  /** Called when main button is clicked with all selected options */
+  onAction?: (options: SplitButtonOption[]) => void;
+  /** Called when selection changes with all selected options */
+  onSelect?: (options: SplitButtonOption[]) => void;
+  children?: Snippet;
+}
+
+let {
+  title,
+  inProgress = false,
+  disabled = false,
+  type = 'primary',
+  icon,
+  options,
+  selectedOptionIds = $bindable([]),
+  multipleSelection = false,
+  emptyLabel = 'No options available',
+  noActionLabel = 'Show options...',
+  noSelectionLabel,
+  class: classNames = '',
+  'aria-label': ariaLabel,
+  onAction,
+  onSelect,
+  children,
+}: Props = $props();
+
+let showDropdown = $state(false);
+let buttonRef = $state<HTMLDivElement>();
+let dropdownToggleRef = $state<HTMLButtonElement>();
+let optionRefs: HTMLElement[] = $state([]);
+let highlightIndex = $state(-1);
+
+const pageStep = 10;
+
+const isEmpty = $derived(options.length === 0);
+// First selected option (used for button display)
+const selectedOption = $derived(options.find(o => selectedOptionIds.includes(o.id)));
+// All selected options
+const selectedOptions = $derived(options.filter(o => selectedOptionIds.includes(o.id)));
+// Check if an option is selected
+const isOptionSelected = (optionId: string): boolean => selectedOptionIds.includes(optionId);
+// Check if any option is actionable (not disabled)
+const hasActionableOption = $derived(options.some(o => !o.disabled));
+// Check if no option is selected (for button display purposes)
+const hasNoSelection = $derived(!isEmpty && hasActionableOption && selectedOptionIds.length === 0);
+// Main action is disabled when explicitly disabled or no options exist
+const isMainDisabled = $derived(disabled || isEmpty);
+// Dropdown can be opened even if selected option is disabled (to see/change options)
+const isDropdownDisabled = $derived(disabled || isEmpty);
+// Show "no action" mode when options exist but none are actionable
+const isNoActionMode = $derived(!isEmpty && !hasActionableOption);
+
+function handleEscape({ key }: KeyboardEvent): void {
+  if (key === 'Escape' && showDropdown) {
+    closeDropdown();
+  }
+}
+
+function onWindowClick(e: MouseEvent): void {
+  if (!buttonRef?.contains(e.target as Node)) {
+    showDropdown = false;
+  }
+}
+
+function handleMainClick(): void {
+  if (inProgress) return;
+
+  // In "no action" or "no selection" mode, clicking main button opens dropdown
+  if (isNoActionMode || hasNoSelection) {
+    showDropdown = !showDropdown;
+    return;
+  }
+
+  if (!isMainDisabled && selectedOptions.length > 0) {
+    // Close dropdown before executing action
+    showDropdown = false;
+    onAction?.(selectedOptions);
+  }
+}
+
+async function handleDropdownClick(e: MouseEvent): Promise<void> {
+  e.stopPropagation();
+  if (!isDropdownDisabled && !inProgress) {
+    if (!showDropdown) {
+      await openDropdown();
+    } else {
+      showDropdown = false;
+    }
+  }
+}
+
+async function openDropdown(): Promise<void> {
+  showDropdown = true;
+  highlightIndex = options.findIndex(o => !o.disabled);
+  await tick();
+  optionRefs[highlightIndex]?.focus();
+}
+
+function closeDropdown(): void {
+  showDropdown = false;
+  dropdownToggleRef?.focus();
+}
+
+function findNextIndex(from: number, direction: 1 | -1): number {
+  let i = from + direction;
+  while (i >= 0 && i < options.length) {
+    if (!options[i].disabled) return i;
+    i += direction;
+  }
+  return from;
+}
+
+async function handleDropdownKeyDown(e: KeyboardEvent): Promise<void> {
+  if (!showDropdown) {
+    if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+      await openDropdown();
+      e.preventDefault();
+    }
+    return;
+  }
+  switch (e.key) {
+    case 'ArrowDown':
+      highlightIndex = findNextIndex(highlightIndex, 1);
+      optionRefs[highlightIndex]?.focus();
+      e.preventDefault();
+      break;
+    case 'ArrowUp':
+      if (highlightIndex <= 0) {
+        closeDropdown();
+      } else {
+        highlightIndex = findNextIndex(highlightIndex, -1);
+        optionRefs[highlightIndex]?.focus();
+      }
+      e.preventDefault();
+      break;
+    case 'PageDown':
+      highlightIndex = Math.min(options.length - 1, highlightIndex + pageStep);
+      optionRefs[highlightIndex]?.focus();
+      e.preventDefault();
+      break;
+    case 'PageUp':
+      highlightIndex = Math.max(0, highlightIndex - pageStep);
+      optionRefs[highlightIndex]?.focus();
+      e.preventDefault();
+      break;
+    case 'Home':
+      highlightIndex = options.findIndex(o => !o.disabled);
+      optionRefs[highlightIndex]?.focus();
+      e.preventDefault();
+      break;
+    case 'End':
+      highlightIndex = options.findLastIndex(o => !o.disabled);
+      optionRefs[highlightIndex]?.focus();
+      e.preventDefault();
+      break;
+    case 'Enter':
+    case ' ':
+      if (highlightIndex >= 0) {
+        selectOption(options[highlightIndex]);
+        e.stopPropagation();
+      }
+      e.preventDefault();
+      break;
+    case 'Escape':
+      closeDropdown();
+      e.stopPropagation();
+      break;
+  }
+}
+
+function selectOption(option: SplitButtonOption): void {
+  if (option.disabled) return;
+
+  if (multipleSelection) {
+    // Toggle selection in multi-select mode
+    if (selectedOptionIds.includes(option.id)) {
+      selectedOptionIds = selectedOptionIds.filter(id => id !== option.id);
+    } else {
+      selectedOptionIds = [...selectedOptionIds, option.id];
+    }
+    // Keep dropdown open in multi-select mode
+  } else {
+    // Single-select mode: replace with single item
+    selectedOptionIds = [option.id];
+    closeDropdown();
+  }
+
+  // Notify parent with all selected options
+  const allSelected = options.filter(o => selectedOptionIds.includes(o.id));
+  onSelect?.(allSelected);
+}
+
+const styles = {
+  primary: {
+    button: {
+      enabled:
+        'bg-[var(--pd-button-primary-bg)] text-[var(--pd-button-text)] hover:bg-[var(--pd-button-primary-hover-bg)]',
+      disabled: 'bg-[var(--pd-button-disabled)] text-[var(--pd-button-disabled-text)]',
+    },
+    divider: 'bg-[var(--pd-button-text)]',
+    border: 'border-[var(--pd-button-primary-bg)]',
+    containerBg: 'bg-[var(--pd-button-primary-bg)]',
+    focusOutline: 'focus-visible:outline-[var(--pd-button-primary-hover-bg)]',
+  },
+  secondary: {
+    button: {
+      enabled:
+        'border-[1px] border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] hover:text-[var(--pd-button-text)]',
+      disabled:
+        'border-[1px] border-[var(--pd-button-disabled)] bg-[var(--pd-button-disabled)] text-[var(--pd-button-disabled-text)]',
+    },
+    divider: 'bg-[var(--pd-button-secondary)]',
+    border: 'border-[var(--pd-button-secondary)]',
+    containerBg: 'bg-[var(--pd-button-secondary)]',
+    focusOutline: 'focus-visible:outline-[var(--pd-button-secondary)]',
+  },
+  danger: {
+    button: {
+      enabled:
+        'border-2 border-[var(--pd-button-danger-border)] bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] hover:bg-[var(--pd-button-danger-hover-bg)] hover:text-[var(--pd-button-danger-hover-text)]',
+      disabled:
+        'border-2 border-[var(--pd-button-danger-disabled-border)] text-[var(--pd-button-danger-disabled-text)] bg-[var(--pd-button-danger-disabled-bg)]',
+    },
+    divider: 'bg-[var(--pd-button-danger-text)]',
+    border: 'border-[var(--pd-button-danger-border)]',
+    containerBg: 'bg-[var(--pd-button-danger-bg)]',
+    focusOutline: 'focus-visible:outline-[var(--pd-button-danger-hover-bg)]',
+  },
+};
+
+const currentStyle = $derived(styles[type]);
+
+// Main button styling (enabled in "no action" or "no selection" mode to allow opening dropdown)
+const mainClasses = $derived(
+  (isMainDisabled && !isNoActionMode && !hasNoSelection) || inProgress
+    ? currentStyle.button.disabled
+    : currentStyle.button.enabled,
+);
+
+// Dropdown toggle styling (disabled only when empty or explicitly disabled)
+const dropdownClasses = $derived(
+  isDropdownDisabled || inProgress ? currentStyle.button.disabled : currentStyle.button.enabled,
+);
+
+const dividerClasses = $derived(
+  isDropdownDisabled || inProgress ? 'bg-[var(--pd-button-disabled-text)]' : currentStyle.divider,
+);
+
+const borderClasses = $derived(
+  isDropdownDisabled || inProgress ? 'border-[var(--pd-button-disabled)]' : currentStyle.border,
+);
+
+const containerBgClasses = $derived(
+  isDropdownDisabled || inProgress ? 'bg-[var(--pd-button-disabled)]' : currentStyle.containerBg,
+);
+
+// Determine the label to display on the button
+const buttonLabel = $derived.by(() => {
+  if (isEmpty) return emptyLabel;
+  if (isNoActionMode) return noActionLabel;
+  if (hasNoSelection) return noSelectionLabel;
+  if (!children && selectedOption) return selectedOption.label;
+  return undefined;
+});
+</script>
+
+<svelte:window onkeyup={handleEscape} onclick={onWindowClick} />
+
+<div class="relative inline-block" bind:this={buttonRef}>
+  <!-- Split button container -->
+  <div class="flex flex-row items-center rounded-[4px] overflow-hidden border {borderClasses} {containerBgClasses} {classNames}">
+    <!-- Main action button -->
+    <button
+      type="button"
+      class="relative px-4 py-[5px] whitespace-nowrap select-none transition-all motion-reduce:transition-none outline-transparent {currentStyle.focusOutline} rounded-l-[4px] {mainClasses}"
+      title={title}
+      aria-label={ariaLabel}
+      onclick={handleMainClick}
+      disabled={(isMainDisabled && !isNoActionMode && !hasNoSelection) || inProgress}>
+      <div class="flex flex-row items-center gap-2">
+        {#if inProgress}
+          <Spinner size="1em" />
+        {:else if icon}
+          <Icon {icon} />
+        {/if}
+
+        {#if buttonLabel !== undefined}
+          <span>{buttonLabel}</span>
+        {:else if children}
+          <span>{@render children()}</span>
+        {/if}
+      </div>
+    </button>
+
+    <!-- Divider -->
+    <div class="w-[1px] h-4 {dividerClasses} shrink-0"></div>
+
+    <!-- Dropdown toggle button -->
+    <button
+      type="button"
+      class="px-2 py-[5px] self-stretch flex items-center transition-all outline-transparent {currentStyle.focusOutline} rounded-r-[4px] {dropdownClasses}"
+      aria-label="Select action"
+      aria-haspopup="listbox"
+      aria-expanded={showDropdown}
+      bind:this={dropdownToggleRef}
+      onclick={handleDropdownClick}
+      onkeydown={handleDropdownKeyDown}
+      disabled={isDropdownDisabled || inProgress}>
+      <Icon icon={faChevronDown} class="w-3 text-current" />
+    </button>
+  </div>
+
+  <!-- Dropdown menu -->
+  {#if showDropdown}
+    <div
+      class="absolute right-0 mt-1 min-w-full w-max bg-[var(--pd-dropdown-bg)] border border-[var(--pd-dropdown-border)] rounded-md shadow-lg z-50"
+      role="listbox"
+      aria-label="Select action"
+      aria-multiselectable={multipleSelection}>
+      {#each options as option, i (option.id)}
+        {@const selected = isOptionSelected(option.id)}
+        <div
+          class="w-full text-left px-4 py-2 first:rounded-t-md last:rounded-b-md flex items-center gap-2 hover:bg-[var(--pd-dropdown-item-hover-bg)] hover:text-[var(--pd-dropdown-item-hover-text)] text-[var(--pd-dropdown-item-text)] cursor-pointer"
+          class:bg-[var(--pd-dropdown-item-hover-bg)]={highlightIndex === i}
+          class:text-[var(--pd-dropdown-item-hover-text)]={highlightIndex === i}
+          class:bg-[var(--pd-dropdown-item-selected-bg)]={selected && highlightIndex !== i}
+          class:opacity-60={option.disabled}
+          class:cursor-not-allowed={option.disabled}
+          role="option"
+          tabindex="-1"
+          aria-selected={selected}
+          aria-disabled={option.disabled}
+          bind:this={optionRefs[i]}
+          onmouseenter={(): void => { highlightIndex = i; }}
+          onmouseleave={(): void => { if (highlightIndex === i) highlightIndex = -1; }}
+          onclick={(): void => { if (!option.disabled) selectOption(option); }}
+          onkeydown={handleDropdownKeyDown}>
+          <span class="w-4 flex-shrink-0">
+            {#if selected && !option.disabled}
+              <Icon icon={faCheck} class="w-4 text-current"/>
+            {/if}
+          </span>
+          {#if option.icon}
+            <Icon icon={option.icon} class="w-4" />
+          {/if}
+          <div class="flex flex-col">
+            <span class="font-medium">{option.label}</span>
+            {#if option.description}
+              <span class="text-xs text-[var(--pd-dropdown-item-description-text)] opacity-70"
+                >{option.description}</span>
+            {/if}
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -20,6 +20,8 @@ import type { ButtonType } from './button/Button';
 import Button from './button/Button.svelte';
 import CloseButton from './button/CloseButton.svelte';
 import Expandable from './button/Expandable.svelte';
+import type { SplitButtonOption } from './button/SplitButton.svelte';
+import SplitButton from './button/SplitButton.svelte';
 import Carousel from './carousel/Carousel.svelte';
 import Checkbox from './checkbox/Checkbox.svelte';
 import Dropdown from './dropdown/Dropdown.svelte';
@@ -52,7 +54,7 @@ import { tablePersistence } from './table/table-persistence-store.svelte';
 import Tooltip from './tooltip/Tooltip.svelte';
 import { isFontAwesomeIcon } from './utils/icon-utils';
 
-export type { ButtonType, ListOrganizerItem, TablePersistence };
+export type { ButtonType, ListOrganizerItem, SplitButtonOption, TablePersistence };
 export {
   Button,
   Carousel,
@@ -79,6 +81,7 @@ export {
   SearchInput,
   SettingsNavItem,
   Spinner,
+  SplitButton,
   StatusIcon,
   Tab,
   Table,

--- a/storybook/src/stories/button/SplitButton.stories.svelte
+++ b/storybook/src/stories/button/SplitButton.stories.svelte
@@ -1,0 +1,531 @@
+<!--
+  Copyright (C) 2026 Red Hat, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script context="module" lang="ts">
+import {
+  faCube,
+  faFlask,
+  faGlobe,
+  faPlay,
+  faRocket,
+  faServer,
+  faTerminal,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons';
+import { SplitButton } from '@podman-desktop/ui-svelte';
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import { fn } from 'storybook/test';
+import type { ComponentProps } from 'svelte';
+
+// #region Mock data
+
+/**
+ * Git merge strategy options — the canonical example from PR #16033.
+ * Matches exactly what dgolovin's video demonstrates.
+ */
+const mergeOptions = [
+  { id: 'merge', label: 'Merge', description: 'Merge all commits into the base branch' },
+  { id: 'squash', label: 'Squash and merge', description: 'Combine all commits into one before merging' },
+  { id: 'rebase', label: 'Rebase and merge', description: 'Rebase commits onto the base branch' },
+];
+
+/** Deploy target options — production is disabled (requires approval). */
+const deployOptions = [
+  { id: 'dev', label: 'Deploy to dev', description: 'Development environment', icon: faFlask },
+  { id: 'staging', label: 'Deploy to staging', description: 'Staging environment', icon: faServer },
+  {
+    id: 'prod',
+    label: 'Deploy to production',
+    description: 'Requires approval from the ops team',
+    icon: faGlobe,
+    disabled: true,
+  },
+];
+
+/** Container start modes — each with a distinct icon. */
+const containerStartOptions = [
+  { id: 'start', label: 'Start', description: 'Start container in the background', icon: faPlay },
+  { id: 'interactive', label: 'Start interactive', description: 'Start with an attached terminal', icon: faTerminal },
+  { id: 'fresh', label: 'Start fresh', description: 'Remove existing container and recreate it', icon: faCube },
+];
+
+/** Danger-type options for destructive image operations. */
+const deleteOptions = [
+  { id: 'delete', label: 'Delete image', description: 'Remove this image from local storage', icon: faTrash },
+  {
+    id: 'delete-containers',
+    label: 'Delete image and containers',
+    description: 'Remove image and all containers that use it',
+    icon: faTrash,
+  },
+  {
+    id: 'force',
+    label: 'Force delete',
+    description: 'Force removal even if used by running containers',
+    icon: faRocket,
+  },
+];
+
+/** All options disabled — exercises the noActionLabel mode. */
+const allDisabledOptions = [
+  { id: 'opt1', label: 'Option 1', description: 'Requires a running Podman machine', disabled: true },
+  { id: 'opt2', label: 'Option 2', description: 'Not available in this context', disabled: true },
+  { id: 'opt3', label: 'Option 3', description: 'Needs elevated permissions', disabled: true },
+];
+
+/** Only one option available. */
+const singleOption = [
+  { id: 'only', label: 'Only option', description: 'This is the only available action in the current state' },
+];
+
+/** Long option labels to test overflow and layout. */
+const longLabelOptions = [
+  {
+    id: 'a',
+    label: 'Run automated integration tests against staging environment',
+    description: 'Takes approximately 15-20 minutes to complete',
+  },
+  {
+    id: 'b',
+    label: 'Deploy with zero-downtime rolling update strategy',
+    description: 'Updates pods one by one without service interruption',
+  },
+  {
+    id: 'c',
+    label: 'Rollback to previous stable release',
+    description: 'Restores the last known-good deployment configuration',
+  },
+];
+
+// #endregion
+
+// #region Scenario groups
+
+// Scenario props always carry the two required SplitButton props; everything
+// else is optional. Deriving from ComponentProps avoids duplicating the types.
+type ScenarioProps = Pick<ComponentProps<typeof SplitButton>, 'options' | 'noSelectionLabel'> &
+  Partial<
+    Omit<ComponentProps<typeof SplitButton>, 'options' | 'noSelectionLabel' | 'onAction' | 'onSelect' | 'children'>
+  >;
+
+type Scenario = {
+  name: string;
+  props: ScenarioProps;
+};
+
+const typesScenarios: Scenario[] = [
+  {
+    name: 'Primary (default)',
+    props: { options: mergeOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Choose strategy...' },
+  },
+  {
+    name: 'Secondary',
+    props: {
+      type: 'secondary',
+      options: mergeOptions,
+      selectedOptionIds: ['squash'],
+      noSelectionLabel: 'Choose strategy...',
+    },
+  },
+  {
+    name: 'Danger',
+    props: {
+      type: 'danger',
+      options: deleteOptions,
+      selectedOptionIds: ['delete'],
+      noSelectionLabel: 'Choose action...',
+    },
+  },
+];
+
+const stateScenarios: Scenario[] = [
+  {
+    name: 'Ready (option selected)',
+    props: { options: mergeOptions, selectedOptionIds: ['merge'], noSelectionLabel: 'Choose strategy...' },
+  },
+  {
+    name: 'No selection (main button opens dropdown)',
+    props: { options: mergeOptions, selectedOptionIds: [], noSelectionLabel: 'Choose strategy...' },
+  },
+  {
+    name: 'In progress (spinner, both buttons disabled)',
+    props: {
+      options: mergeOptions,
+      selectedOptionIds: ['merge'],
+      noSelectionLabel: 'Choose strategy...',
+      inProgress: true,
+    },
+  },
+  {
+    name: 'Disabled',
+    props: {
+      options: mergeOptions,
+      selectedOptionIds: ['merge'],
+      noSelectionLabel: 'Choose strategy...',
+      disabled: true,
+    },
+  },
+  {
+    name: 'All options disabled (noActionLabel)',
+    props: {
+      options: allDisabledOptions,
+      selectedOptionIds: [],
+      noSelectionLabel: 'Choose...',
+      noActionLabel: 'Show options...',
+    },
+  },
+  {
+    name: 'Empty options list (emptyLabel)',
+    props: {
+      options: [],
+      selectedOptionIds: [],
+      noSelectionLabel: 'Choose...',
+      emptyLabel: 'No options available',
+    },
+  },
+];
+
+const iconScenarios: Scenario[] = [
+  {
+    name: 'Icons on options only',
+    props: { options: deployOptions, selectedOptionIds: ['dev'], noSelectionLabel: 'Choose target...' },
+  },
+  {
+    name: 'Icon on button + options',
+    props: {
+      options: containerStartOptions,
+      selectedOptionIds: ['start'],
+      noSelectionLabel: 'Choose start mode...',
+      icon: faPlay,
+    },
+  },
+  {
+    name: 'Icon on button only (no option icons)',
+    props: {
+      options: mergeOptions,
+      selectedOptionIds: ['merge'],
+      noSelectionLabel: 'Choose strategy...',
+      icon: faRocket,
+    },
+  },
+];
+
+const multiselectScenarios: Scenario[] = [
+  {
+    name: 'No selection',
+    props: {
+      options: mergeOptions,
+      multipleSelection: true,
+      selectedOptionIds: [],
+      noSelectionLabel: 'Choose strategies...',
+    },
+  },
+  {
+    name: 'One selected',
+    props: {
+      options: mergeOptions,
+      multipleSelection: true,
+      selectedOptionIds: ['merge'],
+      noSelectionLabel: 'Choose strategies...',
+    },
+  },
+  {
+    name: 'Two selected (checkmarks on both)',
+    props: {
+      options: mergeOptions,
+      multipleSelection: true,
+      selectedOptionIds: ['merge', 'squash'],
+      noSelectionLabel: 'Choose strategies...',
+    },
+  },
+  {
+    name: 'Secondary, two selected',
+    props: {
+      type: 'secondary',
+      options: mergeOptions,
+      multipleSelection: true,
+      selectedOptionIds: ['squash', 'rebase'],
+      noSelectionLabel: 'Choose strategies...',
+    },
+  },
+  {
+    name: 'Danger, one selected',
+    props: {
+      type: 'danger',
+      options: deleteOptions,
+      multipleSelection: true,
+      selectedOptionIds: ['delete'],
+      noSelectionLabel: 'Choose actions...',
+    },
+  },
+];
+
+const edgeScenarios: Scenario[] = [
+  {
+    name: 'Single option',
+    props: { options: singleOption, selectedOptionIds: ['only'], noSelectionLabel: 'Choose...' },
+  },
+  {
+    name: 'Long option labels',
+    props: { options: longLabelOptions, selectedOptionIds: [], noSelectionLabel: 'Choose an action...' },
+  },
+  {
+    name: 'Custom emptyLabel',
+    props: { options: [], noSelectionLabel: 'Choose...', emptyLabel: 'No Podman machine running' },
+  },
+  {
+    name: 'Custom noActionLabel',
+    props: {
+      options: allDisabledOptions,
+      selectedOptionIds: [],
+      noSelectionLabel: 'Choose...',
+      noActionLabel: 'Podman machine required',
+    },
+  },
+  {
+    name: 'With title tooltip',
+    props: {
+      options: mergeOptions,
+      selectedOptionIds: ['merge'],
+      noSelectionLabel: 'Choose strategy...',
+      title: 'Select a merge strategy then click to apply',
+    },
+  },
+  {
+    name: 'Danger + in progress',
+    props: {
+      type: 'danger',
+      options: deleteOptions,
+      selectedOptionIds: ['delete'],
+      noSelectionLabel: 'Choose action...',
+      inProgress: true,
+    },
+  },
+];
+
+// #endregion
+
+const groupKinds: Record<string, { label: string; description: string; scenarios: Scenario[] }> = {
+  types: {
+    label: 'Button Types',
+    description: 'Primary, secondary, and danger visual styles',
+    scenarios: typesScenarios,
+  },
+  states: {
+    label: 'States',
+    description: 'All button states: selected, no selection, in progress, disabled, all disabled, empty',
+    scenarios: stateScenarios,
+  },
+  icons: {
+    label: 'With Icons',
+    description: 'FontAwesome icons on the main button and/or individual dropdown options',
+    scenarios: iconScenarios,
+  },
+  multiselect: {
+    label: 'Multi-select Mode',
+    description: 'Multiple options can be selected simultaneously; dropdown stays open between selections',
+    scenarios: multiselectScenarios,
+  },
+  edges: {
+    label: 'Edge Cases',
+    description: 'Boundary conditions, custom labels, and layout stress tests',
+    scenarios: edgeScenarios,
+  },
+};
+
+const onActionFn = fn().mockName('onAction');
+const onSelectFn = fn().mockName('onSelect');
+
+/**
+ * `SplitButton` combines a main action button with a dropdown option selector.
+ *
+ * The user first picks an option from the dropdown, then executes it via the main
+ * button. This avoids an always-visible list while still exposing the full set of
+ * actions on demand.
+ *
+ * **Modes:**
+ * - **Single-select** (default) — one option is active at a time; selecting a new one replaces the previous.
+ * - **Multi-select** (`multipleSelection`) — the dropdown stays open; any number of options can be toggled.
+ *
+ * **Special states:**
+ * - No selection — main button shows `noSelectionLabel`; clicking it opens the dropdown.
+ * - All options disabled — main button shows `noActionLabel`; clicking still opens the dropdown so users can
+ *   see why each option is unavailable.
+ * - Empty options — both buttons are disabled and show `emptyLabel`.
+ * - In progress — spinner replaces the icon; both buttons are disabled.
+ *
+ * Introduced in [PR #16033](https://github.com/podman-desktop/podman-desktop/pull/16033).
+ */
+// biome-ignore lint/correctness/noUnusedVariables: used in markup
+const { Story } = defineMeta({
+  component: SplitButton,
+  render: template,
+  title: 'Button/SplitButton',
+  tags: ['autodocs'],
+  argTypes: {
+    kind: { table: { disable: true } },
+    type: {
+      control: 'select',
+      options: ['primary', 'secondary', 'danger'],
+      description: 'Visual style of the button',
+    },
+    multipleSelection: {
+      control: 'boolean',
+      description: 'Allow selecting multiple options simultaneously; dropdown stays open between selections',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disable all interaction on both the main button and the dropdown toggle',
+    },
+    inProgress: {
+      control: 'boolean',
+      description: 'Show a spinner and disable interaction while an async action is running',
+    },
+    noSelectionLabel: {
+      control: 'text',
+      description: 'Label on the main button when no option is selected; clicking opens the dropdown',
+    },
+    noActionLabel: {
+      control: 'text',
+      description: 'Label when all options are disabled; clicking still opens the dropdown',
+    },
+    emptyLabel: {
+      control: 'text',
+      description: 'Label when the options array is empty; both buttons are disabled',
+    },
+  },
+  args: {
+    onAction: onActionFn,
+    onSelect: onSelectFn,
+    options: mergeOptions,
+    noSelectionLabel: 'Choose strategy...',
+    selectedOptionIds: ['merge'],
+  },
+});
+</script>
+
+{#snippet template({ ...args })}
+  {#if args.kind && groupKinds[args.kind as string]}
+    {@const group = groupKinds[args.kind as string]}
+    <div class="bg-(--pd-content-card-bg) p-6">
+      <div class="flex flex-col gap-4">
+        <div>
+          <div class="text-sm font-semibold text-(--pd-content-header)">{group.label}</div>
+          <div class="mt-1 text-xs text-(--pd-content-text)">{group.description}</div>
+        </div>
+        <!-- pb-48 reserves space so open dropdowns are not clipped -->
+        <div class="grid grid-cols-1 gap-x-6 gap-y-10 pb-48 sm:grid-cols-2 lg:grid-cols-3">
+          {#each group.scenarios as scenario (scenario.name)}
+            <div class="flex flex-col gap-2">
+              <div class="text-xs text-(--pd-content-text)">{scenario.name}</div>
+              <SplitButton {...scenario.props} onAction={onActionFn} onSelect={onSelectFn} />
+            </div>
+          {/each}
+        </div>
+      </div>
+    </div>
+  {:else}
+    <!-- Default rendering used by autodocs and the controls panel -->
+    <div class="bg-(--pd-content-card-bg) p-6 pb-48">
+      <SplitButton
+        options={mergeOptions}
+        noSelectionLabel="Choose strategy..."
+        selectedOptionIds={['merge']}
+        onAction={onActionFn}
+        onSelect={onSelectFn} />
+    </div>
+  {/if}
+{/snippet}
+
+<!-- Grouped display stories -->
+<Story name="Button Types" args={{ kind: 'types' }} />
+<Story name="States" args={{ kind: 'states' }} />
+<Story name="With Icons" args={{ kind: 'icons' }} />
+<Story name="Multi-select" args={{ kind: 'multiselect' }} />
+<Story name="Edge Cases" args={{ kind: 'edges' }} />
+
+<!--
+  Interactive real-world examples.
+  The SplitButton manages its own internal selection state via $bindable.
+  onAction and onSelect callbacks appear in the Storybook Actions panel.
+-->
+
+<Story name="Merge Strategy">
+  <!--
+    The canonical example from PR #16033.
+    Select a strategy in the dropdown, then click the main button to execute.
+    Starts with "Merge" pre-selected to match dgolovin's demo video.
+  -->
+  <div class="bg-(--pd-content-card-bg) flex flex-col gap-3 p-6 pb-48">
+    <div class="text-sm font-semibold text-(--pd-content-header)">Merge Strategy</div>
+    <div class="text-xs text-(--pd-content-text)">
+      Select a strategy in the dropdown, then click the main button to execute. Check the Actions panel below
+      to see onAction and onSelect calls.
+    </div>
+    <SplitButton
+      options={mergeOptions}
+      selectedOptionIds={['merge']}
+      noSelectionLabel="Choose strategy..."
+      title="Select a merge strategy"
+      onAction={onActionFn}
+      onSelect={onSelectFn} />
+  </div>
+</Story>
+
+<Story name="Deploy Target">
+  <!--
+    Production is disabled (requires approval).
+    Starts with no selection — clicking the main button opens the dropdown
+    rather than triggering an action, illustrating the noSelection mode.
+  -->
+  <div class="bg-(--pd-content-card-bg) flex flex-col gap-3 p-6 pb-48">
+    <div class="text-sm font-semibold text-(--pd-content-header)">Deploy Target</div>
+    <div class="text-xs text-(--pd-content-text)">
+      Production is disabled (requires approval). No initial selection — the main button opens the dropdown
+      instead of executing an action until a target is chosen.
+    </div>
+    <SplitButton
+      options={deployOptions}
+      selectedOptionIds={[]}
+      noSelectionLabel="Choose deploy target..."
+      icon={faRocket}
+      onAction={onActionFn}
+      onSelect={onSelectFn} />
+  </div>
+</Story>
+
+<Story name="Container Start Mode">
+  <!--
+    All options have icons; the main button also carries the faPlay icon.
+    Starts with "Start" pre-selected as the sensible default.
+  -->
+  <div class="bg-(--pd-content-card-bg) flex flex-col gap-3 p-6 pb-48">
+    <div class="text-sm font-semibold text-(--pd-content-header)">Container Start Mode</div>
+    <div class="text-xs text-(--pd-content-text)">
+      Pick a start mode from the dropdown, then click the main button to launch. Each option carries an icon
+      and description.
+    </div>
+    <SplitButton
+      options={containerStartOptions}
+      selectedOptionIds={['start']}
+      noSelectionLabel="Choose start mode..."
+      icon={faPlay}
+      onAction={onActionFn}
+      onSelect={onSelectFn} />
+  </div>
+</Story>


### PR DESCRIPTION
### What does this PR do?

- Introduces a new SplitButton component in Svelte, allowing for single and multi-selection options.
- Implemets various features including dropdown functionality, option selection, and action handling.
- Provides fine tuning for corner cases: button name when no option provided, button name when nothing selected from options selected 
- Component unit tests

### Screenshot / video of UI


https://github.com/user-attachments/assets/b39097f2-ca49-4edc-a6f8-e4906cc3c7ed


### What issues does this PR fix or reference?

Related to #14729.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the new UI control functionality
