### PR TITLE
refactor(Tooltip): use absolute px values and update Story

### DIFF
--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -63,7 +63,7 @@ let isPositioned = $state(false);
 let cleanupAutoUpdate: (() => void) | undefined;
 
 const tooltipInnerClasses =
-  'pt-[4px] pb-[5px] px-2 rounded-lg bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-inner-border)] backdrop-blur-sm';
+  'pt-[4px] pb-[5px] px-[8px] rounded-[9px] bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-inner-border)] backdrop-blur-sm';
 
 function getPreferredPlacement(): Placement {
   if (top) return 'top';
@@ -160,7 +160,7 @@ $effect((): (() => void) => {
   {#if isVisible && !$tooltipHidden && (tip ?? tipSnippet)}
     <div
       bind:this={tooltipElement}
-      class="fixed tooltip-content pointer-events-none text-base/4 z-[9999] rounded-[9px] border-[1px] border-[var(--pd-tooltip-outer-border)] shadow-[0_4px_12px_rgba(0,0,0,0.1)]"
+      class="fixed tooltip-content pointer-events-none text-[12px] leading-[16px] z-[9999] rounded-[9px] border-[1px] border-[var(--pd-tooltip-outer-border)] shadow-[0_4px_12px_rgba(0,0,0,0.1)]"
       class:opacity-0={!isPositioned}
       style="left: 0; top: 0;">
       {#if tip}

--- a/storybook/src/stories/Tooltip.stories.svelte
+++ b/storybook/src/stories/Tooltip.stories.svelte
@@ -84,10 +84,10 @@ const longText =
 
 {#snippet template({ ...args })}
   {#if args.kind === 'placements'}
-    <div class="bg-(--pd-content-card-bg) p-4">
+    <div class="bg-(--pd-content-card-bg) p-8">
       <div class="flex flex-col gap-4 text-(--pd-content-text)">
         <div class="text-sm font-semibold text-(--pd-content-text)">Placements</div>
-        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
           {#each placementVariants as variant (variant.name)}
             <div class="flex flex-col gap-2">
               <div class="text-xs text-(--pd-content-text)">{variant.name}</div>
@@ -103,7 +103,7 @@ const longText =
       </div>
     </div>
   {:else if args.kind === 'long'}
-    <div class="bg-(--pd-content-card-bg) p-4">
+    <div class="bg-(--pd-content-card-bg) p-8">
       <div class="flex flex-row items-center gap-2 text-(--pd-content-text)">
         <span>Long text tooltip example</span>
         <Tooltip top tip={longText}>
@@ -115,7 +115,7 @@ const longText =
       </div>
     </div>
   {:else if args.kind === 'snippet'}
-    <div class="bg-(--pd-content-card-bg) p-4">
+    <div class="bg-(--pd-content-card-bg) p-8">
       <div class="flex flex-row items-center gap-2 text-(--pd-content-text)">
         <span>Snippet tooltip content</span>
         <Tooltip>
@@ -135,7 +135,7 @@ const longText =
       </div>
     </div>
   {:else if args.kind === 'container'}
-    <div class="bg-(--pd-content-card-bg) p-4">
+    <div class="bg-(--pd-content-card-bg) p-8">
       <div class="flex flex-row items-center gap-2 text-(--pd-content-text)">
         <span>Container/class example</span>
         <Tooltip tip="Top-right tooltip with container class applied" topRight containerClass="inline-flex" class="mb-[20px]">
@@ -147,7 +147,7 @@ const longText =
       </div>
     </div>
   {:else}
-    <div class="bg-(--pd-content-card-bg) p-4">
+    <div class="bg-(--pd-content-card-bg) p-8">
       <div class="flex flex-row items-center gap-2 text-(--pd-content-text)">
         <span>Move mouse over the icon to see the tooltip</span>
         <Tooltip {...args}>


### PR DESCRIPTION
### What does this PR do?

- Fixes the appearance of the `Tooltip` component in Storybook (and only Storybook, no changes in Podman Desktop).
- Previously, we used `rem` values for padding and rounded-corner metrics, but due to slightly different relative base in our Storybook setup, this was broken (wrong distances from the label, clipped rounded corners). Now we're using `px` values and all is sunshine and cupcakes.
- Also updates tooltip story, so there's more space around and hence the tooltip is not clipped by the story bounding box.

### Screenshot / video of UI

Before:

- Top: Podman Desktop (correct)
- Bottom: Storybook story (incorrect)

<img width="1416" height="856" alt="image" src="https://github.com/user-attachments/assets/649e2110-dcb3-412c-8e6c-2e6bbbe26dbd" />

Now:

No change in Podman Desktop:

<img width="614" height="418" alt="CleanShot 2026-02-04 at 10 22 16@2x" src="https://github.com/user-attachments/assets/7311667d-ecd1-4858-bc11-8de395618d42" />

Correct appearance in Storybook:

<img width="2112" height="728" alt="CleanShot 2026-02-04 at 10 21 23@2x" src="https://github.com/user-attachments/assets/792848b1-ae47-4727-94e6-bc242f90960c" />

### What issues does this PR fix or reference?

Fixes: #16043

### How to test this PR?

1. Use Storybook
2. Navigate to the Tooltip story
3. Rollover over any (i) button
4. Observe no clipping happens and everything is alright.

- [ ] Tests are covering the bug fix or the new feature

No tests changed.