### PR TITLE
fix: fixed wrong alignment with left icons in setting menu

### DIFF
--- a/packages/renderer/src/lib/images/ExperimentalIcon.svelte
+++ b/packages/renderer/src/lib/images/ExperimentalIcon.svelte
@@ -13,7 +13,7 @@ let { size = '14', class: className = '', style: styleName = '' }: Props = $prop
   height={size}
   class={className}
   style={styleName}
-  viewBox="0 0 12.7279 12.7279"
+  viewBox="0 0 10 12.7279"
   version="1.1"
   aria-label="Experimental"
   xml:space="preserve"

--- a/packages/renderer/src/lib/images/PreferencesIcon.svelte
+++ b/packages/renderer/src/lib/images/PreferencesIcon.svelte
@@ -13,7 +13,7 @@ let { size = '14', class: className = '', style: styleName = '' }: Props = $prop
   height={size}
   class={className}
   style={styleName}
-  viewBox="0 0 12.7279 12.7279"
+  viewBox="0 0 10 12.7279"
   version="1.1"
   aria-label="Preferences"
   xml:space="preserve"

--- a/packages/renderer/src/lib/images/RegistriesIcon.svelte
+++ b/packages/renderer/src/lib/images/RegistriesIcon.svelte
@@ -13,7 +13,7 @@ let { size = '14', class: className = '', style: styleName = '' }: Props = $prop
   height={size}
   class={className}
   style={styleName}
-  viewBox="0 0 12.7279 12.7279"
+  viewBox="0 0 10 12.7279"
   version="1.1"
   aria-label="Registries"
   xml:space="preserve"


### PR DESCRIPTION
### What does this PR do?

Fixes a wrong alignment of left side icons in the settings menu, making some of them not being centered. 

### Screenshot / video of UI
Before:
<img width="1272" height="2226" alt="wrong-alignment" src="https://github.com/user-attachments/assets/08c9ba04-a0bd-43d6-a3fc-897b6e2b1ee7" />
After:
<img width="455" height="566" alt="Captura de pantalla 2026-02-04 a las 13 03 03" src="https://github.com/user-attachments/assets/b076a4f1-c8cd-4caa-bb2c-7b6ba20c4796" />

### What issues does this PR fix or reference?

Closes #15937 

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
