### PR TITLE
fix(Experimental features): disabled feature value udpate

### DIFF
--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -100,7 +100,7 @@ export class ConfigurationImpl implements containerDesktopAPI.Configuration {
 
     // remove the value if undefined
     if (value === undefined) {
-      if (localView[localKey]) {
+      if (localView[localKey] !== undefined) {
         delete localView[localKey];
         delete this[localKey];
         this.apiSender.send('configuration-changed', configurationChangedEvent);

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -221,7 +221,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
         const configurationValue = this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE);
         if (configurationValue !== undefined) {
           if (
-            configProperty.default &&
+            configProperty.default !== undefined &&
             this.isDefaultScope(configProperty.scope) &&
             configurationValue[key] === undefined
           ) {

--- a/packages/main/src/plugin/experimental-configuration-manager.spec.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.spec.ts
@@ -167,7 +167,7 @@ describe('ExperimentalConfigurationManager', () => {
 
       await experimentalConfigurationManager.disableExperimentalConfiguration(key, scope);
 
-      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, undefined, scope);
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, false, scope);
     });
 
     test('should disable configuration with array of scopes', async () => {
@@ -177,18 +177,8 @@ describe('ExperimentalConfigurationManager', () => {
       await experimentalConfigurationManager.disableExperimentalConfiguration(key, scopes);
 
       expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledTimes(2);
-      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenNthCalledWith(
-        1,
-        key,
-        undefined,
-        scopes[0],
-      );
-      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenNthCalledWith(
-        2,
-        key,
-        undefined,
-        scopes[1],
-      );
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenNthCalledWith(1, key, false, scopes[0]);
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenNthCalledWith(2, key, false, scopes[1]);
     });
 
     test('should disable configuration without scope', async () => {
@@ -196,7 +186,7 @@ describe('ExperimentalConfigurationManager', () => {
 
       await experimentalConfigurationManager.disableExperimentalConfiguration(key);
 
-      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, undefined, undefined);
+      expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, false, undefined);
     });
   });
 

--- a/packages/main/src/plugin/experimental-configuration-manager.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.ts
@@ -90,10 +90,10 @@ export class ExperimentalConfigurationManager {
   ): Promise<void> {
     if (Array.isArray(scope)) {
       for (const scopeItem of scope) {
-        await this.configurationRegistry.updateConfigurationValue(key, undefined, scopeItem);
+        await this.configurationRegistry.updateConfigurationValue(key, false, scopeItem);
       }
     } else {
-      await this.configurationRegistry.updateConfigurationValue(key, undefined, scope);
+      await this.configurationRegistry.updateConfigurationValue(key, false, scope);
     }
   }
 

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
@@ -180,7 +180,7 @@ describe('init', () => {
     expect(showFeedbackDialogSpy).toBeCalled();
   });
 
-  test(`should remove old configs with 'false' value`, async () => {
+  test(`should skip disabled features with 'false' value`, async () => {
     const conf = false;
     configurationGetMock.mockReturnValue(conf);
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
@@ -193,7 +193,7 @@ describe('init', () => {
 
     expect(setReminderSpy).not.toHaveBeenCalled();
     expect(setSpy).not.toHaveBeenCalled();
-    expect(saveSpy).toHaveBeenCalledWith('feat.feature1');
+    expect(saveSpy).not.toHaveBeenCalled();
     expect(feedbackForm.experimentalFeatures.get('feat.feature1')).toBe(undefined);
   });
 });
@@ -214,14 +214,13 @@ describe('save', () => {
     expect(updateMock).toHaveBeenCalledWith('feature1', conf);
   });
 
-  test('should call update with empty object and then undefined for missing experimental config', async () => {
+  test('should call update with undefined for missing experimental config', async () => {
     vi.spyOn(feedbackForm.experimentalFeatures, 'get').mockReturnValue(undefined);
 
     await feedbackForm.save('feat.feature1');
 
-    expect(updateMock).toHaveBeenCalledTimes(2);
-    expect(updateMock).toHaveBeenNthCalledWith(1, 'feature1', {});
-    expect(updateMock).toHaveBeenNthCalledWith(2, 'feature1', undefined);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith('feature1', undefined);
   });
 });
 

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -61,11 +61,6 @@ export class ExperimentalFeatureFeedbackHandler {
     const secondPart = parts[1];
     const configuration = this.#configurationRegistry.getConfiguration(firstPart);
     if (secondPart) {
-      // HACK for features that are set as disabled with false (old config)
-      // temporarily enable them and immediately disable, to remove them
-      if (conf === undefined) {
-        await configuration?.update(secondPart, {});
-      }
       await configuration?.update(secondPart, conf);
     }
   }
@@ -106,10 +101,6 @@ export class ExperimentalFeatureFeedbackHandler {
       const conf = this.#configurationRegistry.getConfiguration(firstPart).get(secondPart);
       // Configuration does not exist (feature is not enabled), or is set to false
       if (!conf) {
-        if (typeof conf === 'boolean') {
-          // Remove the feature if has value false using logic in save
-          await this.save(configurationKey);
-        }
         continue;
       }
 

--- a/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
@@ -53,7 +53,7 @@ async function onCheckedAll(event: { detail: boolean }): Promise<void> {
         continue;
       }
 
-      const settings = event.detail ? {} : undefined;
+      const settings = event.detail ? {} : false;
       await window.updateExperimentalConfigurationValue(property.id, settings, property.scope);
     }
   } finally {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -159,13 +159,13 @@ async function onChange(recordId: string, value: boolean | string | number): Pro
   clearTimeout(recordUpdateTimeout);
 
   // HACK: when updating experimental features (representated in settings.json by object)
-  // disabling this feature will set undefined as a value
+  // disabling this feature will set false as a value
   // enabling will set empty object
   if (record.type === 'object' && typeof value === 'boolean') {
     if (value) {
       recordValue = {};
     } else {
-      recordValue = undefined;
+      recordValue = false;
     }
   } else {
     // update the value


### PR DESCRIPTION
### What does this PR do?

This PR changes disabled value for experimental features enabled by default from undefined to false

### Screenshot / video of UI


### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/15760

### How to test this PR?
Try to disable/ enable exp feature that is enabled (statusbarProviders) disabled (experimental dashboard) by default
Try to restart between every switch to see if the changes are persistent.

The issue was having the statusbar enabled by default (on main e.g. ) and trying to switch it off (on main it would disapear from config), after the restart it would be enabled aggain.
Now when you disable the statusbarProviders there should be a "false" value and it should NOT enable after the restart




Tests should also cover legacy support
- [x] Tests are covering the bug fix or the new feature
