### PR TITLE
refactor(renderer): optimize onProxyStateChange iteration and type safety

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -132,6 +132,108 @@ describe('dropdown', () => {
       expect(window.setProxyState).toHaveBeenCalledWith(ProxyState.PROXY_MANUAL);
     });
   });
+
+  test('dropdown#onChange should update value to Disabled', async () => {
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_MANUAL);
+
+    render(PreferencesProxiesRendering);
+
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalled();
+    });
+
+    const [, { onChange }] = vi.mocked(Dropdown).mock.calls[0];
+    const disabledLabel = PROXY_LABELS.get(ProxyState.PROXY_DISABLED);
+
+    onChange?.(disabledLabel as unknown as string);
+
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          value: disabledLabel,
+        }),
+      );
+    });
+  });
+
+  test('dropdown#onChange should update value to System', async () => {
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_MANUAL);
+
+    render(PreferencesProxiesRendering);
+
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalled();
+    });
+
+    const [, { onChange }] = vi.mocked(Dropdown).mock.calls[0];
+    const systemLabel = PROXY_LABELS.get(ProxyState.PROXY_SYSTEM);
+
+    onChange?.(systemLabel as unknown as string);
+
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          value: systemLabel,
+        }),
+      );
+    });
+  });
+
+  test('dropdown#onChange should handle invalid label gracefully', async () => {
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_DISABLED);
+
+    render(PreferencesProxiesRendering);
+
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalled();
+    });
+
+    const [, { onChange }] = vi.mocked(Dropdown).mock.calls[0];
+
+    // call with invalid label
+    expect(() => onChange?.('InvalidLabel')).not.toThrow();
+    expect(() => onChange?.(undefined as unknown as string)).not.toThrow();
+    expect(() => onChange?.(null as unknown as string)).not.toThrow();
+    expect(() => onChange?.('')).not.toThrow();
+
+    // state should remain unchanged (PROXY_DISABLED)
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          value: PROXY_LABELS.get(ProxyState.PROXY_DISABLED),
+        }),
+      );
+    });
+  });
+
+  test('dropdown#onChange should ignore case-mismatched labels', async () => {
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_DISABLED);
+
+    render(PreferencesProxiesRendering);
+
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalled();
+    });
+
+    const [, { onChange }] = vi.mocked(Dropdown).mock.calls[0];
+
+    // call with a wrong case (labels are 'Manual', not 'manual' or 'MANUAL')
+    onChange?.('manual'); // lowercase
+    onChange?.('MANUAL'); // uppercase
+
+    // state should remain unchanged because labels don't match
+    await vi.waitFor(() => {
+      expect(Dropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          value: PROXY_LABELS.get(ProxyState.PROXY_DISABLED),
+        }),
+      );
+    });
+  });
 });
 
 describe('managed label', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -49,10 +49,12 @@ onMount(async () => {
   }
 });
 
-function onProxyStateChange(key: unknown): void {
-  const entry = PROXY_LABELS.entries().find(([_, label]) => label === key);
-  if (entry) {
-    proxyState = entry[0];
+function onProxyStateChange(key: string): void {
+  for (const [state, label] of PROXY_LABELS) {
+    if (label === key) {
+      proxyState = state;
+      return;
+    }
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

The following changes request replaces using `PROXY_LABELS.entries().find(...)` with simple map iteration to avoid recreating a new array each call. Also, `.find()` method is a method of an Array object, not the Iterator. `Map.prototype.entries()` returns the `MapIterator` and method was added in ES2024. Chromium 122+ and Electron 29+ is supporting this method, but this could be a problem, when Podman Desktop will be built using custom electron. In this case Podman Desktop will throw an exception `❌ ERROR: PROXY_LABELS.entries(...).find is not a function`.

### Screenshot / video of UI

No updates on the UI side.

### What issues does this PR fix or reference?

part of https://github.com/podman-desktop/podman-desktop/issues/9525

### How to test this PR?

- Open Podman Desktop
- Navigate to Settings page -> Proxy page
- Make sure that switching between different type of proxy (System, Manual, Disabled) works the same as before this refactor

- [x] Tests are covering the bug fix or the new feature
