### PR TITLE
refactor(main/telemetry): merge event types in one object

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -219,7 +219,7 @@ import { StatusbarProvidersInit } from './statusbar/statusbar-providers-init.js'
 import { StatusBarRegistry } from './statusbar/statusbar-registry.js';
 import { NotificationRegistry } from './tasks/notification-registry.js';
 import { ProgressImpl } from './tasks/progress-impl.js';
-import { PAGE_EVENT_TYPE, Telemetry } from './telemetry/telemetry.js';
+import { EventType, Telemetry } from './telemetry/telemetry.js';
 import { TempFileService } from './temp-file-service.js';
 import { TerminalInit } from './terminal-init.js';
 import { TrayIconColor } from './tray-icon-color.js';
@@ -3059,7 +3059,7 @@ export class PluginSystem {
     );
 
     this.ipcHandle('telemetry:page', async (_listener, name: string): Promise<void> => {
-      return telemetry.track(PAGE_EVENT_TYPE, { name: name });
+      return telemetry.track(EventType.PAGE, { name: name });
     });
 
     this.ipcHandle('telemetry:configure', async (): Promise<void> => {

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -49,19 +49,15 @@ import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/tel
 import { Identity } from './identity.js';
 import type { TelemetryRule } from './telemetry-api.js';
 
-export const TRACK_EVENT_TYPE = 'track';
-export const PAGE_EVENT_TYPE = 'page';
-export const STARTUP_EVENT_TYPE = 'startup';
-export const SHUTDOWN_EVENT_TYPE = 'shutdown';
-export const FEEDBACK_EVENT_TYPE = 'feedback';
+export const EventType = {
+  TRACK: 'track',
+  PAGE: 'page',
+  STARTUP: 'startup',
+  SHUTDOWN: 'shutdown',
+  FEEDBACK: 'feedback',
+} as const;
 
-export type EventType =
-  | typeof TRACK_EVENT_TYPE
-  | typeof PAGE_EVENT_TYPE
-  | typeof STARTUP_EVENT_TYPE
-  | typeof SHUTDOWN_EVENT_TYPE
-  | typeof FEEDBACK_EVENT_TYPE
-  | string;
+export type EventType = (typeof EventType)[keyof typeof EventType] | string;
 
 /**
  * Handle the telemetry reporting.
@@ -267,7 +263,7 @@ export class Telemetry {
 
     await this.initTelemetry();
 
-    this.internalTrack(STARTUP_EVENT_TYPE).catch((err: unknown) => {
+    this.internalTrack(EventType.STARTUP).catch((err: unknown) => {
       console.log(`Error sending startup event: ${err}`);
     });
     let sendShutdownAnalytics = false;
@@ -276,7 +272,7 @@ export class Telemetry {
       if (!sendShutdownAnalytics && stoppedExtensions.val) {
         e.preventDefault();
         try {
-          this.internalTrack(SHUTDOWN_EVENT_TYPE).catch((err: unknown) => {
+          this.internalTrack(EventType.SHUTDOWN).catch((err: unknown) => {
             console.log(`Error sending shutdown event: ${err}`);
           });
           this.analytics?.closeAndFlush().catch((err: unknown) => {
@@ -317,7 +313,7 @@ export class Telemetry {
       All: true,
     };
 
-    if (event === PAGE_EVENT_TYPE) {
+    if (event === EventType.PAGE) {
       const name: string | undefined = typeof properties['name'] === 'string' ? properties['name'] : undefined;
 
       this.analytics?.page({ anonymousId, name, context, integrations });


### PR DESCRIPTION
### What does this PR do?

In the context of removing unused exports for issue https://github.com/podman-desktop/podman-desktop/issues/16053, the event types for Telemetry in the main package would become a bit inconsistent (see comment https://github.com/podman-desktop/podman-desktop/pull/16084#discussion_r2773155077).

This refactoring PR introduces a single object for event types so that it can be exported as a whole, and avoid unused exports of each type, or inconsistencies.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

See comment https://github.com/podman-desktop/podman-desktop/pull/16084#discussion_r2773155077

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
