### PR TITLE
fix(main/notification-registry): dispose the right notification

### DIFF
--- a/packages/main/src/plugin/tasks/notification-registry.ts
+++ b/packages/main/src/plugin/tasks/notification-registry.ts
@@ -76,7 +76,7 @@ export class NotificationRegistry {
     return Disposable.create(() => {
       notificationTask.dispose();
       electronNotification.dispose();
-      this.removeNotificationById(this.notificationId);
+      this.removeNotificationById(notification.id);
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

It fixes an issue where notifications are not removed correctly.
This PR ensures that when disposing a notification, it uses the right id. Before, It was using a class property that increments with each new notification.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15761

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?


Close Podman Desktop.
Remove podman + podman machines, and reset podman-desktop config to restart onboarding.

```bash
podman machine reset -f                        
sudo /opt/podman/bin/podman-mac-helper uninstall
sudo rm /etc/paths.d/podman-pkg     
sudo rm -rfv /opt/podman        
rm -rf ~/.local/share/containers/podman         
rm -rf ~/.local/share/containers/storage   
rm -rf ~/.local/share/containers/podman-desktop
```

Compile Podman Desktop

```bash
pnpm compile:current 
```

Launch from dist folder, do the onboarding for Podman : install Podman and create the Podman machine. Ensure that the notification on the dashboard is not present after onboarding (see issue for a screenshot of the notification).


<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
