### PR TITLE
feat: add pagination to Table component

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -467,7 +467,8 @@ function label(item: ContainerGroupInfoUI | ContainerInfoUI): string {
           key={key}
           label={label}
           enableLayoutConfiguration={true}
-          on:update={(): ContainerGroupInfoUI[] => (containerGroups = [...containerGroups])}>
+          on:update={(): ContainerGroupInfoUI[] => (containerGroups = [...containerGroups])}
+        pageSize={5}>
         </Table>
       {/if}
     </div>

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -650,3 +650,112 @@ describe('Table#collapsed', () => {
     expect(layoutButton).not.toBeInTheDocument();
   });
 });
+
+describe('pagination', () => {
+  interface Item {
+    id: string;
+    name?: string;
+  }
+
+  const ROW = new Row<Item>({
+    selectable: (): boolean => true,
+  });
+
+  const SIMPLE_COLUMN = new Column<Item, string>('Name', {
+    width: '3fr',
+    renderMapping: (obj): string => obj.name ?? 'unknown',
+    renderer: SimpleColumn,
+  });
+
+  test('check whole data is displayed if size is lower than page size', async () => {
+    render(Table<Item>, {
+      kind: 'demo',
+      data: [
+        {
+          id: 'foo',
+          name: 'foo',
+        },
+        {
+          id: 'bar',
+          name: 'bar',
+        },
+      ],
+      columns: [SIMPLE_COLUMN],
+      row: ROW,
+      pageSize: 5,
+    });
+
+    // 2 people = header + 2 rows
+    const rows = await screen.findAllByRole('row');
+    expect(rows).toBeDefined();
+    expect(rows.length).toBe(3);
+
+    // first data row should contain John and his age
+    expect(rows[1].textContent).toContain('foo');
+
+    // second data row should contain Henry and his age
+    expect(rows[2].textContent).toContain('bar');
+  });
+
+  test('check first page is displayed if size is greater than page size', async () => {
+    render(Table<Item>, {
+      kind: 'demo',
+      data: [
+        {
+          id: 'id-1',
+          name: 'name-1',
+        },
+        {
+          id: 'id-2',
+          name: 'name-2',
+        },
+        {
+          id: 'id-3',
+          name: 'name-3',
+        },
+        {
+          id: 'id-4',
+          name: 'name-4',
+        },
+        {
+          id: 'id-5',
+          name: 'name-5',
+        },
+        {
+          id: 'id-6',
+          name: 'name-6',
+        },
+        {
+          id: 'id-7',
+          name: 'name-7',
+        },
+        {
+          id: 'id-8',
+          name: 'name-8',
+        },
+        {
+          id: 'id-9',
+          name: 'name-9',
+        },
+        {
+          id: 'id-10',
+          name: 'name-10',
+        },
+      ],
+      columns: [SIMPLE_COLUMN],
+      row: ROW,
+      pageSize: 5,
+    });
+
+    // 5 people = header + 5 rows
+    const rows = await screen.findAllByRole('row');
+    expect(rows).toBeDefined();
+    expect(rows.length).toBe(6);
+
+    // first data row should contain John and his age
+    expect(rows[1].textContent).toContain('name-1');
+
+    // second data row should contain Henry and his age
+    expect(rows[5].textContent).toContain('name-5');
+  });
+});


### PR DESCRIPTION
### What does this PR do?

As we are experimenting performance issues on Kortex due to table displaying of lots of elements, I thought I might me worth experimenting adding pagination to the Table component

Please note that this implementation does not guaranty that there will be pageSize rows in the table as child elements are also included.

Asking for feedback on the design and inner knowledge as an existing test is failing

This PR contains also a modification of the containers table so that you can easily test. Just make sure you have more than 5 containers

### Screenshot / video of UI

![page-table](https://github.com/user-attachments/assets/54f6cebf-9b01-4ac7-ab39-ac6cfca8c0fc)

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Check the containers table

- [x] Tests are covering the bug fix or the new feature
