### PR TITLE
fix(storybook): enable HMR for UI components and color theme changes

### DIFF
--- a/storybook/vite.config.js
+++ b/storybook/vite.config.js
@@ -78,8 +78,8 @@ function colorRegistryWatcher() {
             await execAsync('pnpm run storybook:css', { cwd: ROOT_DIR });
             console.log('[color-registry-watcher] themes.css regenerated successfully\n');
 
-            // Trigger full reload using Vite Environment API
-            this.environment.hot.send({
+            // Trigger full reload
+            server.ws.send({
               type: 'full-reload',
               path: '*',
             });

--- a/storybook/vite.config.js
+++ b/storybook/vite.config.js
@@ -78,8 +78,8 @@ function colorRegistryWatcher() {
             await execAsync('pnpm run storybook:css', { cwd: ROOT_DIR });
             console.log('[color-registry-watcher] themes.css regenerated successfully\n');
 
-            // Trigger full reload
-            server.ws.send({
+            // Trigger full reload using Vite Environment API
+            this.environment.hot.send({
               type: 'full-reload',
               path: '*',
             });

--- a/storybook/vite.config.js
+++ b/storybook/vite.config.js
@@ -114,7 +114,7 @@ export default defineConfig({
   },
   plugins: [
     tailwindcss(),
-    svelte({ configFile: '../svelte.config.js', hot: true }),
+    svelte({ configFile: '../svelte.config.js', compilerOptions: { hmr: true } }),
     svelteTesting(),
     colorRegistryWatcher(),
   ],


### PR DESCRIPTION
### What does this PR do?

This PR improves the Storybook development experience by enabling proper Hot Module Replacement for both UI components and color theme changes.

**1. Enhanced Svelte Plugin Configuration**
- Point to shared `svelte.config.js` to eliminate warnings
- Explicitly enable HMR with `hot: true`

**2. Added UI Package Watch Support**
- Configure Vite to watch `@podman-desktop/ui-svelte` in node_modules
- Allows HMR to pick up changes when UI package is rebuilt

**3. Added Color Registry Watcher Plugin**
- Custom Vite plugin using `chokidar` to watch:
  - `packages/main/src/plugin/color-registry.ts`
  - `tailwind-color-palette.json`
- Automatically regenerates `themes.css` when these files change
- Triggers full page reload to apply new colors

### Developer Workflow

For **UI component development**, run two commands in parallel:

**Terminal 1 - UI Package Watch Mode:**
```bash
cd packages/ui && pnpm run watch
```

**Terminal 2 - Storybook:**
```bash
pnpm storybook:dev
```

The UI watch mode automatically rebuilds components when source files change, and Storybook's HMR picks up the dist folder changes.

For **color theme development**, just run Storybook as normal - the new plugin automatically handles theme regeneration.


### What issues does this PR fix or reference?

Fixes #16108

### How to test this PR?

1. Start Storybook: `pnpm storybook:dev`
2. **Test color changes**: Edit `color-registry.ts` or `tailwind-color-palette.json`, save, and verify colors update without restart
3. Start UI watch: `cd packages/ui && pnpm run watch` (in a separate terminal)
4. **Test component changes**: Edit `packages/ui/src/lib/button/Button.svelte`, save, and verify changes appear without restart

### Technical Details

- Uses `chokidar` for reliable file watching (already available as a transitive dependency)
- Debouncing prevents multiple concurrent regenerations
- Proper cleanup when dev server closes
- Clear console logging for developer feedback

Co-Authored-By: Claude <noreply@anthropic.com>