### PR TITLE
chore(color-registry): move initCommon() code to initDefaults()

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -87,8 +87,8 @@ class TestColorRegistry extends ColorRegistry {
     super.initLabel();
   }
 
-  override initCommon(): void {
-    super.initCommon();
+  override initDefaults(): void {
+    super.initDefaults();
   }
 }
 
@@ -790,28 +790,47 @@ describe('initTooltip', () => {
   });
 });
 
-describe('initCommon', () => {
+describe('initDefaults', () => {
+  let spyOnRegisterColor: MockInstance<(colorId: string, definition: ColorDefinition) => void>;
   let spyOnRegisterColorDefinition: MockInstance<(definition: ColorDefinitionWithId) => void>;
 
   beforeEach(() => {
-    // mock the registerColorDefinition
+    // mock both methods since initDefaults uses both
+    spyOnRegisterColor = vi.spyOn(colorRegistry, 'registerColor');
+    spyOnRegisterColor.mockReturnValue(undefined);
+
     spyOnRegisterColorDefinition = vi.spyOn(colorRegistry, 'registerColorDefinition');
     spyOnRegisterColorDefinition.mockReturnValue(undefined);
 
-    colorRegistry.initCommon();
+    colorRegistry.initDefaults();
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
+  test('registers default-text color using registerColor', () => {
+    // Should call registerColor at least once for default-text
+    expect(spyOnRegisterColor).toHaveBeenCalled();
+
+    // Find the default-text color registration
+    const defaultTextCall = spyOnRegisterColor.mock.calls.find(call => call?.[0] === 'default-text');
+    expect(defaultTextCall).toBeDefined();
+
+    const definition = defaultTextCall?.[1];
+    expect(definition?.light).toBe(tailwindColorPalette.charcoal[900]);
+    expect(definition?.dark).toBe(tailwindColorPalette.white);
+  });
+
   test('registers item-disabled color using registerColorDefinition', () => {
-    expect(spyOnRegisterColorDefinition).toHaveBeenCalledTimes(1);
+    // Should call registerColorDefinition at least once
+    expect(spyOnRegisterColorDefinition).toHaveBeenCalled();
 
-    // check the call
-    const call = spyOnRegisterColorDefinition.mock.calls[0];
-    const definition = call?.[0];
+    // Find the item-disabled color registration
+    const itemDisabledCall = spyOnRegisterColorDefinition.mock.calls.find(call => call?.[0]?.id === 'item-disabled');
+    expect(itemDisabledCall).toBeDefined();
 
+    const definition = itemDisabledCall?.[0];
     expect(definition?.id).toBe('item-disabled');
     expect(definition?.dark).toBeDefined();
     expect(definition?.light).toBeDefined();

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -334,7 +334,6 @@ export class ColorRegistry {
     this.initTerminal();
     this.initProgressBar();
     this.initBadge();
-    this.initCommon();
   }
 
   protected initDefaults(): void {
@@ -345,6 +344,13 @@ export class ColorRegistry {
       dark: white,
       light: charcoal[900],
     });
+
+    this.registerColorDefinition(
+      this.color('item-disabled')
+        .withLight(colorPaletteHelper(stone[600]).withAlpha(0.4))
+        .withDark(colorPaletteHelper(stone[300]).withAlpha(0.4))
+        .build(),
+    );
   }
 
   protected initNotificationDot(): void {
@@ -1654,14 +1660,5 @@ export class ColorRegistry {
       dark: gray[600],
       light: gray[600],
     });
-  }
-
-  protected initCommon(): void {
-    this.registerColorDefinition(
-      this.color('item-disabled')
-        .withLight(colorPaletteHelper(stone[600]).withAlpha(0.4))
-        .withDark(colorPaletteHelper(stone[300]).withAlpha(0.4))
-        .build(),
-    );
   }
 }


### PR DESCRIPTION
### What does this PR do?

Refactors the `ColorRegistry` initialization by consolidating the `item-disabled` color registration into the `initDefaults()` method and removing the redundant `initCommon()` method.

**Changes:**
- Removed `initCommon()` method and its call from `initColors()`
- Moved `item-disabled` color registration directly into `initDefaults()`
- Updated test suite to replace `initCommon` tests with comprehensive `initDefaults` tests

This simplifies the initialization structure without any functional changes.

### What issues does this PR fix or reference?

Fixes #16110

### How to test this PR?

1. Run the color registry unit tests:
   pnpm test color-registry.spec.ts

Co-Authored-By: Claude <noreply@anthropic.com>