### PR TITLE
fix(preferences): prevent loss of manual proxy settings on page navigation

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -25,6 +25,7 @@ import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import PreferencesProxiesRendering from '/@/lib/preferences/PreferencesProxiesRendering.svelte';
 import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
+import { manualProxySettings } from '/@/stores/manual-proxy-settings.svelte';
 
 // mock the ui library
 vi.mock(import('@podman-desktop/ui-svelte'), async importOriginal => {
@@ -494,6 +495,63 @@ describe('managed label', () => {
       expect(httpProxyInput).toBeDisabled();
       expect(httpsProxyInput).toBeDisabled();
       expect(noProxyInput).toBeDisabled();
+    });
+  });
+});
+
+describe('manual proxy settings persistence', () => {
+  test('should restore manual settings from store when in System mode', async () => {
+    manualProxySettings.settings = {
+      httpProxy: 'http://saved-proxy:8080',
+      httpsProxy: '',
+      noProxy: 'localhost',
+    };
+
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_SYSTEM);
+    vi.mocked(window.getProxySettings).mockResolvedValue({
+      httpProxy: undefined,
+      httpsProxy: undefined,
+      noProxy: 'local,169.254/16',
+    });
+
+    const { container } = render(PreferencesProxiesRendering);
+
+    await vi.waitFor(() => {
+      const httpInput = container.querySelector('input#httpProxy') as HTMLInputElement;
+      expect(httpInput.value).toBe('http://saved-proxy:8080');
+    });
+  });
+
+  test('should save settings to store when updating in Manual mode', async () => {
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_MANUAL);
+    vi.mocked(window.getProxySettings).mockResolvedValue({
+      httpProxy: '',
+      httpsProxy: '',
+      noProxy: '',
+    });
+    vi.mocked(window.setProxyState).mockResolvedValue(undefined);
+    vi.mocked(window.updateProxySettings).mockResolvedValue(undefined);
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+
+    manualProxySettings.settings = undefined;
+
+    const { container, getByRole } = render(PreferencesProxiesRendering);
+
+    await vi.waitFor(() => {
+      const httpInput = container.querySelector('input#httpProxy') as HTMLInputElement;
+      expect(httpInput).toBeInTheDocument();
+      expect(httpInput).not.toBeDisabled();
+    });
+
+    const httpInput = container.querySelector('input#httpProxy') as HTMLInputElement;
+    httpInput.value = 'http://new-proxy:8080';
+    await fireEvent.input(httpInput);
+
+    const updateBtn = getByRole('button', { name: 'Update' });
+    await fireEvent.click(updateBtn);
+
+    await vi.waitFor(() => {
+      expect(manualProxySettings.settings?.httpProxy).toBe('http://new-proxy:8080');
     });
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -2,9 +2,10 @@
 import { faPen } from '@fortawesome/free-solid-svg-icons';
 import { PROXY_CONFIG_KEYS, ProxyState } from '@podman-desktop/core-api';
 import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 
 import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
+import { manualProxySettings } from '/@/stores/manual-proxy-settings.svelte';
 
 import PreferencesManagedInput from './PreferencesManagedInput.svelte';
 import SettingsPage from './SettingsPage.svelte';
@@ -22,11 +23,25 @@ let noProxyLocked = false;
 let proxyEnabledLocked = false;
 
 onMount(async () => {
-  const proxySettings = await window.getProxySettings();
-  httpProxy = proxySettings?.httpProxy ?? '';
-  httpsProxy = proxySettings?.httpsProxy ?? '';
-  noProxy = proxySettings?.noProxy ?? '';
   proxyState = await window.getProxyState();
+
+  // Use saved manual settings only when not in manual mode (to preserve user input across page navigations)
+  const savedSettings = proxyState !== ProxyState.PROXY_MANUAL ? manualProxySettings.settings : undefined;
+
+  if (savedSettings) {
+    httpProxy = savedSettings.httpProxy;
+    httpsProxy = savedSettings.httpsProxy;
+    noProxy = savedSettings.noProxy;
+  } else {
+    const proxySettings = await window.getProxySettings();
+    httpProxy = proxySettings?.httpProxy ?? '';
+    httpsProxy = proxySettings?.httpsProxy ?? '';
+    noProxy = proxySettings?.noProxy ?? '';
+  }
+
+  if (proxyState === ProxyState.PROXY_MANUAL) {
+    manualProxySettings.settings = { httpProxy, httpsProxy, noProxy };
+  }
 
   // Check if proxy settings are locked by managed configuration
   const configProperties = await window.getConfigurationProperties();
@@ -49,6 +64,13 @@ onMount(async () => {
   }
 });
 
+onDestroy(() => {
+  // Store manual settings to avoid losing it when switching between pages
+  if (proxyState === ProxyState.PROXY_MANUAL) {
+    manualProxySettings.settings = { httpProxy, httpsProxy, noProxy };
+  }
+});
+
 function onProxyStateChange(key: string): void {
   for (const [state, label] of PROXY_LABELS) {
     if (label === key) {
@@ -62,6 +84,10 @@ async function updateProxySettings(): Promise<void> {
   await window.setProxyState(proxyState);
   if (proxyState !== ProxyState.PROXY_SYSTEM) {
     await window.updateProxySettings({ httpProxy, httpsProxy, noProxy });
+  }
+
+  if (proxyState === ProxyState.PROXY_MANUAL) {
+    manualProxySettings.settings = { httpProxy, httpsProxy, noProxy };
   }
 
   // loop over all providers and container connections to see if there are any running engines

--- a/packages/renderer/src/stores/manual-proxy-settings.spec.ts
+++ b/packages/renderer/src/stores/manual-proxy-settings.spec.ts
@@ -1,0 +1,50 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { manualProxySettings } from './manual-proxy-settings.svelte';
+
+describe('manualProxySettings', () => {
+  beforeEach(() => {
+    manualProxySettings.settings = undefined;
+  });
+
+  test('should be undefined initially', () => {
+    expect(manualProxySettings.settings).toBeUndefined();
+  });
+
+  test('should save manual proxy settings', () => {
+    const settings = {
+      httpProxy: 'http://proxy:8080',
+      httpsProxy: 'https://proxy:8443',
+      noProxy: 'localhost',
+    };
+
+    manualProxySettings.settings = settings;
+
+    expect(manualProxySettings.settings).toEqual(settings);
+  });
+
+  test('should clear settings', () => {
+    manualProxySettings.settings = { httpProxy: 'test', httpsProxy: '', noProxy: '' };
+    manualProxySettings.settings = undefined;
+
+    expect(manualProxySettings.settings).toBeUndefined();
+  });
+});

--- a/packages/renderer/src/stores/manual-proxy-settings.svelte.ts
+++ b/packages/renderer/src/stores/manual-proxy-settings.svelte.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface ManualProxySettings {
+  httpProxy: string;
+  httpsProxy: string;
+  noProxy: string;
+}
+
+export const manualProxySettings = $state<{ settings: ManualProxySettings | undefined }>({
+  settings: undefined,
+});

--- a/tests/playwright/src/specs/proxy-smoke.spec.ts
+++ b/tests/playwright/src/specs/proxy-smoke.spec.ts
@@ -124,19 +124,24 @@ test.describe
       await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
     });
 
-    test('System proxy resets the values', async ({ navigationBar }) => {
+    test('System proxy preserves manual values for re-use', async ({ navigationBar }) => {
       await proxyPage.selectProxy(ProxyTypes.System);
       await proxyPage.updateProxySettings();
       await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.System);
       await playExpect(proxyPage.httpProxy).not.toBeEnabled();
       await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
       await playExpect(proxyPage.noProxy).not.toBeEnabled();
+      // navigate away and back to verify persistence
       await navigationBar.openDashboard();
       const settingsBar = await navigationBar.openSettings();
       await settingsBar.proxyTab.click();
       await playExpect(proxyPage.heading).toBeVisible();
-      await playExpect(proxyPage.httpProxy).not.toHaveValue(httpProxyUrl);
-      await playExpect(proxyPage.httpsProxy).not.toHaveValue(httpsProxyUrl);
-      await playExpect(proxyPage.noProxy).not.toHaveValue(hostsDomains);
+      // manual proxy values are preserved in System mode for easy re-enablement
+      await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
+      await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
+      await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
+      await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+      await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+      await playExpect(proxyPage.noProxy).not.toBeEnabled();
     });
   });


### PR DESCRIPTION
### What does this PR do?

The following changes proposal fixes an issue where manual proxy settings were lost when switching to system mode and navigating away from the Proxy Settings page.

When user entered proxy values in manual mode, switched to system mode, and navigated to another page, the manual values were cleared because the component re-read settings from the backend (which now contained system proxy values).

Added a Svelte store (`manualProxySettings`) to preserve manual proxy values in UI memory. The store is updated on:                                                                                   
  - `onMount` - sync from backend when in Manual mode                                                                                                                                                                 
  - `onDestroy` - save current values as fallback                                                                                                                                                                     
  - `updateProxySettings` - save after user clicks Update   

### Screenshot / video of UI

With the proposed solution:

https://github.com/user-attachments/assets/7d22f171-0d64-4b29-b825-6e92e90784cf

Current behaviour:

https://github.com/user-attachments/assets/b3a30a63-d20b-4924-a2af-94aa9d005eef


### What issues does this PR fix or reference?

part of https://github.com/podman-desktop/podman-desktop/issues/9525

### How to test this PR?

- Open Podman Desktop
- Navigate to Settings page, then to Poxy page
- Select Manual mode, enter the proxy values
- Save preference by clicking Update button
- Switch to different page, e.g. Dashboard
- Go back to Proxy page, make sure, that manual preference is present
- Switch to System mode,
- Switch to different page, e.g. Dashboard
- Go back to Proxy page, make sure, that manual preference is present, but System mode is activated

- [x] Tests are covering the bug fix or the new feature
