### PR TITLE
feat(main): add Zod schema and parse extensions manifest

### DIFF
--- a/packages/main/src/plugin/extension/extension-analyzer.spec.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.spec.ts
@@ -25,6 +25,7 @@ import * as path from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ExtensionAnalyzer } from './extension-analyzer.js';
+import type { ExtensionManifest } from './extension-manifest-schema.js';
 
 let extensionAnalyzer: ExtensionAnalyzer;
 
@@ -52,7 +53,7 @@ describe('analyze extension and main', () => {
       publisher: 'fooPublisher',
       name: 'fooName',
       main: 'main-entry.js',
-    };
+    } as unknown as ExtensionManifest;
 
     // mock loadManifest
     const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
@@ -88,7 +89,7 @@ describe('analyze extension and main', () => {
       publisher: 'fooPublisher',
       name: 'fooName',
       main: 'main-entry.js',
-    };
+    } as unknown as ExtensionManifest;
 
     // mock loadManifest
     const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
@@ -120,7 +121,7 @@ describe('analyze extension and main', () => {
       publisher: 'fooPublisher',
       name: 'fooName',
       // no main entry
-    };
+    } as unknown as ExtensionManifest;
 
     // mock loadManifest
     const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');
@@ -152,7 +153,7 @@ describe('analyze extension and main', () => {
       publisher: 'fooPublisher',
       name: 'fooName',
       // no main entry
-    };
+    } as unknown as ExtensionManifest;
 
     // mock loadManifest
     const loadManifestMock = vi.spyOn(extensionAnalyzer, 'loadManifest');

--- a/packages/main/src/plugin/extension/extension-analyzer.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,14 +22,16 @@ import path from 'node:path';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { injectable } from 'inversify';
+import { z } from 'zod';
+
+import { ExtensionManifest, ExtensionManifestSchema } from './extension-manifest-schema.js';
 
 export interface AnalyzedExtension {
   id: string;
   name: string;
   // root folder (where is package.json)
   path: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  manifest: any;
+  manifest: ExtensionManifest;
   // main entry
   mainPath?: string;
   api?: typeof containerDesktopAPI;
@@ -75,7 +77,7 @@ export class ExtensionAnalyzer {
         id: '<unknown>',
         name: '<unknown>',
         path: resolvedExtensionPath,
-        manifest: undefined,
+        manifest: {} as unknown as ExtensionManifest,
         readme: '',
         api: <typeof containerDesktopAPI>{},
         removable: removable,
@@ -124,9 +126,18 @@ export class ExtensionAnalyzer {
     return analyzedExtension;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async loadManifest(extensionPath: string): Promise<any> {
+  async loadManifest(extensionPath: string): Promise<ExtensionManifest> {
     const manifestPath = path.join(extensionPath, 'package.json');
-    return JSON.parse(await readFile(manifestPath, 'utf8'));
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+
+    // try to parse using zod
+    const result = ExtensionManifestSchema.safeParse(manifest);
+    if (result.success) {
+      return result.data;
+    } else {
+      console.error(`Error while parsing manifest for extension ${extensionPath}. ${z.prettifyError(result.error)}`);
+      // return the manifest as it is, even if it is not valid
+      return manifest as ExtensionManifest;
+    }
   }
 }

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -81,6 +81,7 @@ import type { AnalyzedExtension, ExtensionAnalyzer } from './extension-analyzer.
 import type { ExtensionDevelopmentFolders } from './extension-development-folders.js';
 import type { ActivatedExtension, AnalyzedExtensionWithApi, RequireCacheDict } from './extension-loader.js';
 import { ExtensionLoader } from './extension-loader.js';
+import type { ExtensionManifest } from './extension-manifest-schema.js';
 import type { ExtensionWatcher } from './extension-watcher.js';
 
 class TestExtensionLoader extends ExtensionLoader {
@@ -601,7 +602,7 @@ test('Verify extension error leads to failed state', async () => {
       mainPath: '',
       removable: false,
       devMode: false,
-      manifest: {},
+      manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
       dispose: vi.fn(),
@@ -632,7 +633,7 @@ test('Verify extension subscriptions are disposed when failed state reached', as
       mainPath: '',
       removable: false,
       devMode: false,
-      manifest: {},
+      manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
       dispose: vi.fn(),
@@ -667,7 +668,7 @@ test('Verify extension activate with a long timeout is flagged as error', async 
       mainPath: '',
       removable: false,
       devMode: false,
-      manifest: {},
+      manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
       dispose: vi.fn(),
@@ -699,7 +700,7 @@ test('Verify extension load triggers an onDidChange event', async () => {
     mainPath: '',
     removable: false,
     devMode: false,
-    manifest: {},
+    manifest: {} as unknown as ExtensionManifest,
     subscriptions: [],
     readme: '',
     dispose: vi.fn(),
@@ -722,7 +723,7 @@ test('Verify extension load', async () => {
     devMode: false,
     manifest: {
       version: '1.1',
-    },
+    } as unknown as ExtensionManifest,
     subscriptions: [],
     readme: '',
     dispose: vi.fn(),
@@ -765,7 +766,7 @@ test('Verify extension do not add configuration to subscriptions', async () => {
           title: 'dummy-configuration-title',
         },
       },
-    },
+    } as unknown as ExtensionManifest,
     subscriptions: subscriptions,
     readme: '',
     dispose: vi.fn(),
@@ -797,7 +798,7 @@ test('Verify extension activate registers extension features and the disposable 
       contributes: {
         features: ['feature1', 'feature2'],
       },
-    },
+    } as unknown as ExtensionManifest,
     subscriptions,
     readme: '',
     dispose: vi.fn(),
@@ -1349,7 +1350,7 @@ test('Verify extension uri', async () => {
       mainPath: '',
       removable: false,
       devMode: false,
-      manifest: {},
+      manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
       dispose: vi.fn(),
@@ -1385,7 +1386,7 @@ test('Verify exports and packageJSON', async () => {
       devMode: false,
       manifest: {
         foo: 'bar',
-      },
+      } as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
       dispose: vi.fn(),
@@ -2885,7 +2886,7 @@ test('ExtensionLoader async dispose should stop all extensions', async () => {
       mainPath: '',
       removable: false,
       devMode: false,
-      manifest: {},
+      manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
       dispose: vi.fn(),

--- a/packages/main/src/plugin/extension/extension-manifest-schema.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-schema.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2022-2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import {
+  IconsContributionSchema,
+  MenuSchema,
+  OnboardingSchema,
+  RawThemeContributionSchema,
+  ViewContributionSchema,
+} from '@podman-desktop/core-api';
+import { IConfigurationNodeSchema } from '@podman-desktop/core-api/configuration';
+import { z } from 'zod';
+
+import { RawCommandSchema } from '/@/plugin/command-registry.js';
+
+export const ExtensionManifestSchema = z
+  .object({
+    name: z.string(),
+    displayName: z.string(),
+    version: z.string(),
+    publisher: z.string(),
+    description: z.string(),
+    main: z.string().optional(),
+    icon: z.union([z.string(), z.object({ light: z.string(), dark: z.string() })]).optional(),
+    extensionDependencies: z.array(z.string()).optional(),
+    extensionPack: z.array(z.string()).optional(),
+    engines: z
+      .object({
+        'podman-desktop': z.string().optional(),
+      })
+      .optional(),
+    contributes: z
+      .object({
+        configuration: IConfigurationNodeSchema.omit({ id: true }).optional(),
+        commands: z.array(RawCommandSchema).optional(),
+        menus: z.record(z.string(), z.array(MenuSchema)).optional(),
+        icons: IconsContributionSchema.optional(),
+        themes: z.array(RawThemeContributionSchema).optional(),
+        views: z.record(z.string(), z.array(ViewContributionSchema)).optional(),
+        onboarding: OnboardingSchema.optional(),
+        features: z.array(z.string()).optional(),
+      })
+      .optional(),
+  })
+  .loose();
+
+export type ExtensionManifest = z.infer<typeof ExtensionManifestSchema>;


### PR DESCRIPTION
### What does this PR do?

This PR parses extensions manifest with a Zod schema but for now it will only display an error if the schema is invalid while still loading the extension.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16050

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Check that extensions are still loading.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
