### PR TITLE
chore(extension-api): enhance PodInspectInfo

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2760,6 +2760,22 @@ declare module '@podman-desktop/api' {
        */
       Networks?: Array<string>;
     };
+    /**
+     * CPUPeriod contains the CPU period of the pod
+     */
+    cpu_period?: number;
+    /**
+     * CPUQuota contains the CPU quota of the pod
+     */
+    cpu_quota?: number;
+    /**
+     * CPUSetCPUs contains linux specific CPU data for the pod
+     */
+    cpuset_cpus?: string;
+    /**
+     * Mounts contains volume related information for the pod
+     */
+    mounts?: Array<InspectMount>;
   }
 
   interface AuthConfig {
@@ -2958,6 +2974,15 @@ declare module '@podman-desktop/api' {
     Output: string;
   }
 
+  export interface InspectMount {
+    Name?: string;
+    Source: string;
+    Destination: string;
+    Mode: string;
+    RW: boolean;
+    Propagation: string;
+  }
+
   export interface ContainerInspectInfo {
     engineId: string;
     engineName: string;
@@ -3001,14 +3026,7 @@ declare module '@podman-desktop/api' {
         DeviceSize: string;
       };
     };
-    Mounts: Array<{
-      Name?: string;
-      Source: string;
-      Destination: string;
-      Mode: string;
-      RW: boolean;
-      Propagation: string;
-    }>;
+    Mounts: Array<InspectMount>;
     Config: {
       Hostname: string;
       Domainname: string;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2769,9 +2769,25 @@ declare module '@podman-desktop/api' {
      */
     cpu_quota?: number;
     /**
+     * CPUShares contains the cpu shares for the pod
+     */
+    cpu_shares?: number;
+    /**
      * CPUSetCPUs contains linux specific CPU data for the pod
      */
     cpuset_cpus?: string;
+    /**
+     * CPUSetMems contains linux specific CPU data for the pod
+     */
+    cpuset_mems?: string;
+    /**
+     * MemoryLimit contains the specified cgroup memory limit for the pod
+     */
+    memory_limit?: number;
+    /**
+     * MemorySwap contains the specified memory swap limit for the pod
+     */
+    memory_swap?: number;
     /**
      * Mounts contains volume related information for the pod
      */


### PR DESCRIPTION
### What does this PR do?

Adding missing properties `mounts`, `cpuset_cpus`, `cpu_quota` and `cpu_period` in `PodInspectInfo`.

Reference https://docs.podman.io/en/latest/_static/api.html?version=v4.1#tag/pods/operation/PodInspectLibpod

### What issues does this PR fix or reference?

Would be helpful for https://github.com/podman-desktop/extension-podman-quadlet/issues/1161

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Typecheck should be happy
