### PR TITLE
chore: ensure two-way value binding for enum items

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -22,9 +22,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, type RenderResult, screen } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { type Component, type ComponentProps, tick } from 'svelte';
+import { tick } from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { getInitialValue } from '/@/lib/preferences/Util';
@@ -37,17 +37,13 @@ beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
 });
 
-async function awaitRender(
-  record: IConfigurationPropertyRecordedSchema,
-  customProperties: any,
-): Promise<RenderResult<Component<ComponentProps<typeof PreferencesRenderingItemFormat>>>> {
-  const RenderResult = render(PreferencesRenderingItemFormat, {
+async function awaitRender(record: IConfigurationPropertyRecordedSchema, customProperties: any): Promise<void> {
+  render(PreferencesRenderingItemFormat, {
     record,
     initialValue: getInitialValue(record),
     ...customProperties,
   });
   await tick();
-  return RenderResult;
 }
 
 test('Expect to see checkbox enabled', async () => {
@@ -306,34 +302,6 @@ test('Expect enum to have the givenValue selected', async () => {
   expect(input).toBeInTheDocument();
   expect(input.children[0]).toHaveAttribute('name', 'record');
   expect(input).toHaveTextContent('second');
-});
-
-test('Expect reset enum value to update dropdown value', async () => {
-  const record: IConfigurationPropertyRecordedSchema = {
-    id: 'record',
-    title: 'record',
-    parentId: 'parent.record',
-    description: 'record-description',
-    type: 'string',
-    enum: ['first', 'second'],
-    default: 'first',
-  };
-  const { rerender } = await awaitRender(record, { givenValue: 'first' });
-  const dropdown = screen.getByRole('button', { name: 'first' });
-  expect(dropdown).toBeInTheDocument();
-  await userEvent.click(dropdown);
-
-  const nonDefaultValue = screen.getByRole('button', { name: 'second' });
-  expect(nonDefaultValue).toBeInTheDocument();
-  await userEvent.click(nonDefaultValue);
-
-  let dropdownValue = screen.getByLabelText('hidden input');
-  expect(dropdownValue).toHaveValue('second');
-
-  await rerender({ ...record, resetToDefault: true });
-
-  dropdownValue = screen.getByLabelText('hidden input');
-  expect(dropdownValue).toHaveValue('first');
 });
 
 test('Expect a text input when record is type string', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -22,9 +22,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render, type RenderResult, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { tick } from 'svelte';
+import { type Component, type ComponentProps, tick } from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { getInitialValue } from '/@/lib/preferences/Util';
@@ -37,13 +37,17 @@ beforeAll(() => {
   (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
 });
 
-async function awaitRender(record: IConfigurationPropertyRecordedSchema, customProperties: any): Promise<void> {
-  render(PreferencesRenderingItemFormat, {
+async function awaitRender(
+  record: IConfigurationPropertyRecordedSchema,
+  customProperties: any,
+): Promise<RenderResult<Component<ComponentProps<typeof PreferencesRenderingItemFormat>>>> {
+  const RenderResult = render(PreferencesRenderingItemFormat, {
     record,
     initialValue: getInitialValue(record),
     ...customProperties,
   });
   await tick();
+  return RenderResult;
 }
 
 test('Expect to see checkbox enabled', async () => {
@@ -302,6 +306,34 @@ test('Expect enum to have the givenValue selected', async () => {
   expect(input).toBeInTheDocument();
   expect(input.children[0]).toHaveAttribute('name', 'record');
   expect(input).toHaveTextContent('second');
+});
+
+test('Expect reset enum value to update dropdown value', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'string',
+    enum: ['first', 'second'],
+    default: 'first',
+  };
+  const { rerender } = await awaitRender(record, { givenValue: 'first' });
+  const dropdown = screen.getByRole('button', { name: 'first' });
+  expect(dropdown).toBeInTheDocument();
+  await userEvent.click(dropdown);
+
+  const nonDefaultValue = screen.getByRole('button', { name: 'second' });
+  expect(nonDefaultValue).toBeInTheDocument();
+  await userEvent.click(nonDefaultValue);
+
+  let dropdownValue = screen.getByLabelText('hidden input');
+  expect(dropdownValue).toHaveValue('second');
+
+  await rerender({ ...record, resetToDefault: true });
+
+  dropdownValue = screen.getByLabelText('hidden input');
+  expect(dropdownValue).toHaveValue('first');
 });
 
 test('Expect a text input when record is type string', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -124,9 +124,9 @@ function isEqual(first: IConfigurationPropertyRecordedSchema, second: IConfigura
 
 function autoSave(): Promise<void> {
   if (enableAutoSave) {
-    return new Promise((_, reject) => {
+    return new Promise((resolve, reject) => {
       recordUpdateTimeout = setTimeout(() => {
-        update(record).catch((err: unknown) => reject(err));
+        update(record).then(resolve, (err: unknown) => reject(err));
       }, 1000);
     });
   }
@@ -227,7 +227,11 @@ function numberItemValue(): number {
         value={typeof givenValue === 'string' ? givenValue : (recordValue ?? '')}
         onChange={onChange} />
     {:else if record.enum && record.enum.length > 0}
-      <EnumItem record={record} value={typeof givenValue === 'string' ? givenValue : recordValue} onChange={onChange} />
+      {#if typeof givenValue === 'string'}
+        <EnumItem record={record} bind:value={givenValue} onChange={onChange} />
+      {:else}
+        <EnumItem record={record} bind:value={recordValue} onChange={onChange} />
+      {/if}
     {:else if record.format === 'password'}
       <PasswordStringItem
         record={record}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -124,9 +124,9 @@ function isEqual(first: IConfigurationPropertyRecordedSchema, second: IConfigura
 
 function autoSave(): Promise<void> {
   if (enableAutoSave) {
-    return new Promise((resolve, reject) => {
+    return new Promise((_, reject) => {
       recordUpdateTimeout = setTimeout(() => {
-        update(record).then(resolve, (err: unknown) => reject(err));
+        update(record).catch((err: unknown) => reject(err));
       }, 1000);
     });
   }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
This PR adds `bind:` for the value of enum items rendered in `PreferencesRenderingItemFormat`.
The problem was that `PreferencesRenderingItemFormat` passed the prop value to `EnumItem` and that prop was bound to `Dropdown` in `EnumItem`:
`PreferencesRenderingItemFormat` -> `EnumItem` <-> `Dropdown`.
However, once value was changed by `Dropdown`, `EnumItem` stopped responding to value changes coming from `PreferencesRenderingItemFormat`, so the new value following a reset in `PreferencesRenderingItemFormat` wasn't changed in `EnumItem` and `Dropdown`.
Adding a two-way binding in `PreferencesRenderingItemFormat` so that:
`PreferencesRenderingItemFormat` <-> `EnumItem` <-> `Dropdown`
fixed this problem

### Screenshot / video of UI

https://github.com/user-attachments/assets/995bc042-f315-408f-8f65-5ba9c4b2845f



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/15242

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
