### PR TITLE
feat(container-env-filter): filter pods and container by environment

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -22,6 +22,7 @@ import NoContainerEngineEmptyScreen from '/@/lib/image/NoContainerEngineEmptyScr
 import SolidPodIcon from '/@/lib/images/SolidPodIcon.svelte';
 import { PodUtils } from '/@/lib/pod/pod-utils';
 import ContainerEngineEnvironmentColumn from '/@/lib/table/columns/ContainerEngineEnvironmentColumn.svelte';
+import EnvironmentDropdown from '/@/lib/ui/EnvironmentDropdown.svelte';
 import { CONTAINER_LIST_VIEW } from '/@/lib/view/views';
 import { handleNavigation } from '/@/navigation';
 import { containersInfos } from '/@/stores/containers';
@@ -48,6 +49,8 @@ interface Props {
 }
 
 let { searchTerm = '' }: Props = $props();
+
+let selectedEnvironment = $state('');
 
 function fromExistingImage(): void {
   openChoiceModal = false;
@@ -250,6 +253,10 @@ let containerGroups = $derived.by(() => {
           return containerInfo.state !== 'RUNNING';
         }
         return true;
+      })
+      .filter(containerInfo => {
+        if (!selectedEnvironment) return true;
+        return containerInfo.engineId === selectedEnvironment;
       });
   });
   // Remove groups with all containers filtered
@@ -392,6 +399,7 @@ function label(item: ContainerGroupInfoUI | ContainerInfoUI): string {
     <Button on:click={toggleCreateContainer} icon={faPlusCircle} title="Create a container">Create</Button>
   {/snippet}
   {#snippet bottomAdditionalActions()}
+    <EnvironmentDropdown bind:selectedEnvironment={selectedEnvironment} />
     {#if selectedItemsNumber && selectedItemsNumber > 0}
       <div class="inline-flex space-x-2">
         <Button
@@ -451,6 +459,8 @@ function label(item: ContainerGroupInfoUI | ContainerInfoUI): string {
               e.preventDefault();
             }}
             searchTerm={containerUtils.filterSearchTerm(searchTerm)} />
+        {:else if selectedEnvironment && currentContainers.length > 0}
+          <FilteredEmptyScreen icon={ContainerIcon} kind="containers" searchTerm="selected environment" onResetFilter={(): void => { selectedEnvironment = ''; }} />
         {:else}
           <ContainerEmptyScreen
             runningOnly={containerUtils.filterIsRunning(searchTerm)}

--- a/packages/renderer/src/lib/network/NetworksList.spec.ts
+++ b/packages/renderer/src/lib/network/NetworksList.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { NetworkInspectInfo, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import type { NetworkContainer } from 'dockerode';
 import { tick } from 'svelte';
 import { get } from 'svelte/store';
@@ -248,4 +248,153 @@ test('Expect environment column sorted by engineId', async () => {
   const cells = screen.getAllByRole('cell', { name: /Network/ });
   expect(cells[0]).toHaveTextContent('Network 2');
   expect(cells[1]).toHaveTextContent('Network 1');
+});
+
+test('Expect environment dropdown to appear with multiple running connections', async () => {
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
+    {
+      id: 'podman',
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          displayName: 'Podman Machine',
+          status: 'started',
+          type: 'podman',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+    {
+      id: 'docker',
+      name: 'docker',
+      status: 'started',
+      internalId: 'docker-internal-id',
+      containerConnections: [
+        {
+          name: 'docker-context',
+          displayName: 'Docker Desktop',
+          status: 'started',
+          type: 'docker',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  const podmanNetwork: NetworkInspectInfo = {
+    ...network1,
+    Name: 'podman-network',
+    engineId: 'podman.podman-machine-default',
+    engineName: 'Podman Machine',
+  };
+  const dockerNetwork: NetworkInspectInfo = {
+    ...network2,
+    Name: 'docker-network',
+    engineId: 'docker.docker-context',
+    engineName: 'Docker Desktop',
+  };
+
+  vi.mocked(window.listNetworks).mockResolvedValue([podmanNetwork, dockerNetwork]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+
+  await waitFor(
+    () => {
+      expect(get(providerInfos)).toHaveLength(2);
+      expect(get(networksListInfo)).not.toHaveLength(0);
+    },
+    { timeout: 2000 },
+  );
+
+  render(NetworksList);
+  await tick();
+
+  // Environment dropdown should be visible
+  const environmentDropdown = screen.getByLabelText('Environment');
+  expect(environmentDropdown).toBeInTheDocument();
+});
+
+test('Expect environment dropdown to filter networks by selected environment', async () => {
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
+    {
+      id: 'podman',
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          displayName: 'Podman Machine',
+          status: 'started',
+          type: 'podman',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+    {
+      id: 'docker',
+      name: 'docker',
+      status: 'started',
+      internalId: 'docker-internal-id',
+      containerConnections: [
+        {
+          name: 'docker-context',
+          displayName: 'Docker Desktop',
+          status: 'started',
+          type: 'docker',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  const podmanNetwork: NetworkInspectInfo = {
+    ...network1,
+    Name: 'podman-network',
+    engineId: 'podman.podman-machine-default',
+    engineName: 'Podman Machine',
+  };
+  const dockerNetwork: NetworkInspectInfo = {
+    ...network2,
+    Name: 'docker-network',
+    engineId: 'docker.docker-context',
+    engineName: 'Docker Desktop',
+  };
+
+  vi.mocked(window.listNetworks).mockResolvedValue([podmanNetwork, dockerNetwork]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+
+  await waitFor(
+    () => {
+      expect(get(providerInfos)).toHaveLength(2);
+      expect(get(networksListInfo)).not.toHaveLength(0);
+    },
+    { timeout: 2000 },
+  );
+
+  render(NetworksList);
+  await tick();
+
+  // Both networks should be visible initially
+  expect(screen.getByText('podman-network')).toBeInTheDocument();
+  expect(screen.getByText('docker-network')).toBeInTheDocument();
+
+  // Select Podman environment from dropdown
+  const dropdownContainer = screen.getByLabelText('Environment');
+  const dropdownButton = within(dropdownContainer).getByRole('button');
+  await fireEvent.click(dropdownButton);
+
+  const podmanOption = await waitFor(async () => {
+    await tick();
+    return screen.getByRole('button', { name: 'Podman' });
+  });
+  await fireEvent.click(podmanOption);
+
+  // Only podman network should be visible
+  await waitFor(() => {
+    expect(screen.getByText('podman-network')).toBeInTheDocument();
+    expect(screen.queryByText('docker-network')).not.toBeInTheDocument();
+  });
 });

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -19,6 +19,7 @@ import NoContainerEngineEmptyScreen from '/@/lib/image/NoContainerEngineEmptyScr
 import PodIcon from '/@/lib/images/PodIcon.svelte';
 import PodmanKubePlay from '/@/lib/kube/PodmanKubePlay.svelte';
 import ContainerEngineEnvironmentColumn from '/@/lib/table/columns/ContainerEngineEnvironmentColumn.svelte';
+import EnvironmentDropdown from '/@/lib/ui/EnvironmentDropdown.svelte';
 import { filtered, podsInfos, searchPattern } from '/@/stores/pods';
 import { providerInfos } from '/@/stores/providers';
 
@@ -36,12 +37,20 @@ interface Props {
 
 let { searchTerm = $bindable('') }: Props = $props();
 
+let selectedEnvironment = $state('');
+
 $effect(() => {
   searchPattern.set(searchTerm);
 });
 
 let pods: PodInfoUI[] = $state([]);
 let enginesList: EngineInfoUI[] = $state([]);
+
+// Filter pods by selected environment
+const filteredPods = $derived.by(() => {
+  if (!selectedEnvironment) return pods;
+  return pods.filter(pod => pod.engineId === selectedEnvironment);
+});
 
 const providerConnections = $derived(
   $providerInfos
@@ -182,6 +191,7 @@ function label(pod: PodInfoUI): string {
   {/snippet}
 
   {#snippet bottomAdditionalActions()}
+    <EnvironmentDropdown bind:selectedEnvironment={selectedEnvironment} />
     {#if selectedItemsNumber > 0}
       <Button
         on:click={(): void =>
@@ -237,7 +247,7 @@ function label(pod: PodInfoUI): string {
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />
-    {:else if $filtered.length === 0}
+    {:else if filteredPods.length === 0}
       {#if searchTerm}
         <FilteredEmptyScreen
           icon={PodIcon}
@@ -247,6 +257,8 @@ function label(pod: PodInfoUI): string {
             searchTerm = podUtils.filterResetSearchTerm(searchTerm);
             e.preventDefault();
           }} />
+      {:else if selectedEnvironment && pods.length > 0}
+        <FilteredEmptyScreen icon={PodIcon} kind="pods" searchTerm="selected environment" onResetFilter={(): void => { selectedEnvironment = ''; }} />
       {:else}
         <PodEmptyScreen />
       {/if}
@@ -254,7 +266,7 @@ function label(pod: PodInfoUI): string {
       <Table
         kind="pod"
         bind:selectedItemsNumber={selectedItemsNumber}
-        data={pods}
+        data={filteredPods}
         columns={columns}
         row={row}
         defaultSortColumn="Name"

--- a/packages/renderer/src/lib/ui/EnvironmentDropdown.spec.ts
+++ b/packages/renderer/src/lib/ui/EnvironmentDropdown.spec.ts
@@ -1,0 +1,621 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as providers from '/@/stores/providers';
+
+import EnvironmentDropdown from './EnvironmentDropdown.svelte';
+
+vi.mock(import('/@/stores/providers'));
+
+const PODMAN_PROVIDER: ProviderInfo = {
+  id: 'podman',
+  name: 'Podman',
+  kubernetesConnections: [],
+  vmConnections: [],
+  containerConnections: [
+    {
+      name: 'podman-machine-default',
+      displayName: 'Podman Machine',
+      status: 'started',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/var/run/podman.sock',
+      },
+    },
+  ],
+} as unknown as ProviderInfo;
+
+const PODMAN_PROVIDER_WITH_MULTIPLE_CONNECTIONS: ProviderInfo = {
+  id: 'podman',
+  name: 'Podman',
+  kubernetesConnections: [],
+  vmConnections: [],
+  containerConnections: [
+    {
+      name: 'podman-machine-default',
+      displayName: 'Podman Machine Default',
+      status: 'started',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/var/run/podman.sock',
+      },
+    },
+    {
+      name: 'podman-machine-remote',
+      displayName: 'Podman Remote',
+      status: 'started',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/var/run/podman-remote.sock',
+      },
+    },
+  ],
+} as unknown as ProviderInfo;
+
+const DOCKER_PROVIDER: ProviderInfo = {
+  id: 'docker',
+  name: 'Docker',
+  kubernetesConnections: [],
+  vmConnections: [],
+  containerConnections: [
+    {
+      name: 'docker-context',
+      displayName: 'Docker Desktop',
+      status: 'started',
+      type: 'docker',
+      endpoint: {
+        socketPath: '/var/run/docker.sock',
+      },
+    },
+  ],
+} as unknown as ProviderInfo;
+
+const STOPPED_PROVIDER: ProviderInfo = {
+  id: 'stopped-podman',
+  name: 'Stopped Podman',
+  kubernetesConnections: [],
+  vmConnections: [],
+  containerConnections: [
+    {
+      name: 'stopped-machine',
+      displayName: 'Stopped Machine',
+      status: 'stopped',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/var/run/stopped.sock',
+      },
+    },
+  ],
+} as unknown as ProviderInfo;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect dropdown to be hidden with zero running environments', async () => {
+  vi.mocked(providers).providerInfos = writable([]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.queryByLabelText('Environment');
+  expect(dropdown).not.toBeInTheDocument();
+});
+
+test('Expect dropdown to be hidden with only one running environment', async () => {
+  vi.mocked(providers).providerInfos = writable([PODMAN_PROVIDER]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.queryByLabelText('Environment');
+  expect(dropdown).not.toBeInTheDocument();
+});
+
+test('Expect dropdown to be hidden with only stopped connections', async () => {
+  vi.mocked(providers).providerInfos = writable([STOPPED_PROVIDER]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.queryByLabelText('Environment');
+  expect(dropdown).not.toBeInTheDocument();
+});
+
+test('Expect dropdown to show with multiple running environments', async () => {
+  vi.mocked(providers).providerInfos = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.getByLabelText('Environment');
+  expect(dropdown).toBeInTheDocument();
+  // Multiple "Environment:" texts exist (in sizer and in dropdown)
+  expect(screen.getAllByText('Environment:').length).toBeGreaterThanOrEqual(1);
+});
+
+test('Expect "All" to be the default option', async () => {
+  vi.mocked(providers).providerInfos = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.getByRole('button');
+  expect(dropdown.textContent).toContain('All');
+});
+
+test('Expect running environments to appear in dropdown options', async () => {
+  vi.mocked(providers).providerInfos = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+
+  // "All" option should be present (there are 2 - one in trigger, one in dropdown)
+  const allButtons = screen.getAllByRole('button', { name: /All$/ });
+  expect(allButtons.length).toBeGreaterThanOrEqual(2);
+
+  // Single connection types should show capitalized type name
+  expect(screen.getByRole('button', { name: 'Podman' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Docker' })).toBeInTheDocument();
+});
+
+test('Expect stopped environments to be filtered out', async () => {
+  vi.mocked(providers).providerInfos = writable([PODMAN_PROVIDER, DOCKER_PROVIDER, STOPPED_PROVIDER]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+
+  // Running environments should be present
+  expect(screen.getByRole('button', { name: 'Podman' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Docker' })).toBeInTheDocument();
+
+  // Stopped environment should NOT be present
+  expect(screen.queryByRole('button', { name: 'Stopped Machine' })).not.toBeInTheDocument();
+});
+
+test('Expect multiple connections of same type to show displayName', async () => {
+  vi.mocked(providers).providerInfos = writable([PODMAN_PROVIDER_WITH_MULTIPLE_CONNECTIONS]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+
+  // Should show displayName when there are multiple connections of same type
+  expect(screen.getByRole('button', { name: 'Podman Machine Default' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Podman Remote' })).toBeInTheDocument();
+});
+
+test('Expect selecting an environment to update the value', async () => {
+  vi.mocked(providers).providerInfos = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.getByRole('button');
+  expect(dropdown.textContent).toContain('All');
+
+  await fireEvent.click(dropdown);
+
+  const dockerOption = screen.getByRole('button', { name: 'Docker' });
+  await fireEvent.click(dockerOption);
+
+  // After selection, the dropdown should show "Docker"
+  expect(dropdown.textContent).toContain('Docker');
+});
+
+test('Expect selecting an environment to update the dropdown display', async () => {
+  vi.mocked(providers).providerInfos = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+
+  const podmanOption = screen.getByRole('button', { name: 'Podman' });
+  await fireEvent.click(podmanOption);
+
+  // Dropdown should now display "Podman"
+  expect(dropdown.textContent).toContain('Podman');
+});
+
+test('Expect mixed running and stopped connections to only show running ones when multiple running', async () => {
+  const mixedProvider: ProviderInfo = {
+    id: 'mixed',
+    name: 'Mixed',
+    kubernetesConnections: [],
+    vmConnections: [],
+    containerConnections: [
+      {
+        name: 'running-connection-1',
+        displayName: 'Running Connection 1',
+        status: 'started',
+        type: 'podman',
+        endpoint: {
+          socketPath: '/var/run/running1.sock',
+        },
+      },
+      {
+        name: 'running-connection-2',
+        displayName: 'Running Connection 2',
+        status: 'started',
+        type: 'podman',
+        endpoint: {
+          socketPath: '/var/run/running2.sock',
+        },
+      },
+      {
+        name: 'stopped-connection',
+        displayName: 'Stopped Connection',
+        status: 'stopped',
+        type: 'podman',
+        endpoint: {
+          socketPath: '/var/run/stopped.sock',
+        },
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  vi.mocked(providers).providerInfos = writable([mixedProvider]);
+
+  render(EnvironmentDropdown);
+
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+
+  // Running connections should be present (multiple of same type shows displayName)
+  expect(screen.getByRole('button', { name: 'Running Connection 1' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Running Connection 2' })).toBeInTheDocument();
+
+  // Should not show stopped connection
+  expect(screen.queryByRole('button', { name: 'Stopped Connection' })).not.toBeInTheDocument();
+});
+
+test('Expect dropdown to be hidden when only one running connection among mixed', async () => {
+  const mixedProvider: ProviderInfo = {
+    id: 'mixed',
+    name: 'Mixed',
+    kubernetesConnections: [],
+    vmConnections: [],
+    containerConnections: [
+      {
+        name: 'running-connection',
+        displayName: 'Running Connection',
+        status: 'started',
+        type: 'podman',
+        endpoint: {
+          socketPath: '/var/run/running.sock',
+        },
+      },
+      {
+        name: 'stopped-connection',
+        displayName: 'Stopped Connection',
+        status: 'stopped',
+        type: 'podman',
+        endpoint: {
+          socketPath: '/var/run/stopped.sock',
+        },
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  vi.mocked(providers).providerInfos = writable([mixedProvider]);
+
+  render(EnvironmentDropdown);
+
+  // Dropdown should be hidden since only 1 running connection
+  const dropdown = screen.queryByLabelText('Environment');
+  expect(dropdown).not.toBeInTheDocument();
+});
+
+test('Expect selectedEnvironment to reset when selected connection stops (dropdown hides)', async () => {
+  const providerStore = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+  vi.mocked(providers).providerInfos = providerStore;
+
+  render(EnvironmentDropdown);
+
+  // Select Docker environment
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+  const dockerOption = screen.getByRole('button', { name: 'Docker' });
+  await fireEvent.click(dockerOption);
+
+  expect(dropdown.textContent).toContain('Docker');
+
+  // Docker connection stops
+  const stoppedDockerProvider: ProviderInfo = {
+    ...DOCKER_PROVIDER,
+    containerConnections: [
+      {
+        ...DOCKER_PROVIDER.containerConnections[0],
+        status: 'stopped',
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  providerStore.set([PODMAN_PROVIDER, stoppedDockerProvider]);
+
+  // Wait for effect to run - dropdown should disappear (only 1 connection left)
+  await vi.waitFor(() => {
+    expect(screen.queryByLabelText('Environment')).not.toBeInTheDocument();
+  });
+});
+
+test('Expect selectedEnvironment to reset when selected connection stops (dropdown remains visible)', async () => {
+  // Create a third provider so dropdown stays visible after one stops
+  const LIMA_PROVIDER: ProviderInfo = {
+    id: 'lima',
+    name: 'Lima',
+    kubernetesConnections: [],
+    vmConnections: [],
+    containerConnections: [
+      {
+        name: 'lima-default',
+        displayName: 'Lima Default',
+        status: 'started',
+        type: 'docker',
+        endpoint: {
+          socketPath: '/var/run/lima.sock',
+        },
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  const providerStore = writable([PODMAN_PROVIDER, DOCKER_PROVIDER, LIMA_PROVIDER]);
+  vi.mocked(providers).providerInfos = providerStore;
+
+  render(EnvironmentDropdown);
+
+  // Select Docker environment
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+  const dockerOption = screen.getByRole('button', { name: 'Docker Desktop' });
+  await fireEvent.click(dockerOption);
+
+  expect(dropdown.textContent).toContain('Docker Desktop');
+
+  // Docker connection stops - but Podman + Lima still running (2 connections)
+  const stoppedDockerProvider: ProviderInfo = {
+    ...DOCKER_PROVIDER,
+    containerConnections: [
+      {
+        ...DOCKER_PROVIDER.containerConnections[0],
+        status: 'stopped',
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  providerStore.set([PODMAN_PROVIDER, stoppedDockerProvider, LIMA_PROVIDER]);
+
+  // Dropdown should still be visible (2 running connections)
+  // But should show "All" because Docker (selected) is no longer available
+  await vi.waitFor(() => {
+    expect(screen.getByLabelText('Environment')).toBeInTheDocument();
+    expect(screen.getByRole('button').textContent).toContain('All');
+  });
+});
+
+test('Expect selectedEnvironment to reset when selected connection is removed', async () => {
+  const providerStore = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+  vi.mocked(providers).providerInfos = providerStore;
+
+  render(EnvironmentDropdown);
+
+  // Select Docker environment
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+  const dockerOption = screen.getByRole('button', { name: 'Docker' });
+  await fireEvent.click(dockerOption);
+
+  expect(dropdown.textContent).toContain('Docker');
+
+  // Docker provider is removed entirely
+  providerStore.set([PODMAN_PROVIDER]);
+
+  // Wait for effect to run - dropdown should disappear (only 1 connection left)
+  await vi.waitFor(() => {
+    expect(screen.queryByLabelText('Environment')).not.toBeInTheDocument();
+  });
+});
+
+test('Expect selectedEnvironment to NOT reset when a different connection stops', async () => {
+  const providerStore = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+  vi.mocked(providers).providerInfos = providerStore;
+
+  render(EnvironmentDropdown);
+
+  // Select Podman environment
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+  const podmanOption = screen.getByRole('button', { name: 'Podman' });
+  await fireEvent.click(podmanOption);
+
+  expect(dropdown.textContent).toContain('Podman');
+
+  // Docker connection stops (but Podman is still selected)
+  const stoppedDockerProvider: ProviderInfo = {
+    ...DOCKER_PROVIDER,
+    containerConnections: [
+      {
+        ...DOCKER_PROVIDER.containerConnections[0],
+        status: 'stopped',
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  providerStore.set([PODMAN_PROVIDER, stoppedDockerProvider]);
+
+  // Give time for any effects to run
+  await new Promise(resolve => setTimeout(resolve, 50));
+
+  // Dropdown disappears (only 1 running connection) but selection was valid before
+  // The key point: selectedEnvironment still held "Podman" which was valid
+  expect(screen.queryByLabelText('Environment')).not.toBeInTheDocument();
+});
+
+test('Expect selectedEnvironment to reset when all connections stop except one', async () => {
+  const providerStore = writable([PODMAN_PROVIDER_WITH_MULTIPLE_CONNECTIONS]);
+  vi.mocked(providers).providerInfos = providerStore;
+
+  render(EnvironmentDropdown);
+
+  // Select the remote podman machine
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+  const remoteOption = screen.getByRole('button', { name: 'Podman Remote' });
+  await fireEvent.click(remoteOption);
+
+  expect(dropdown.textContent).toContain('Podman Remote');
+
+  // Remote connection stops - only one running connection remains
+  const partiallyStoppedProvider: ProviderInfo = {
+    ...PODMAN_PROVIDER_WITH_MULTIPLE_CONNECTIONS,
+    containerConnections: [
+      PODMAN_PROVIDER_WITH_MULTIPLE_CONNECTIONS.containerConnections[0],
+      {
+        ...PODMAN_PROVIDER_WITH_MULTIPLE_CONNECTIONS.containerConnections[1],
+        status: 'stopped',
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  providerStore.set([partiallyStoppedProvider]);
+
+  // Wait for effect to run - dropdown should disappear (only 1 connection left)
+  await vi.waitFor(() => {
+    expect(screen.queryByLabelText('Environment')).not.toBeInTheDocument();
+  });
+});
+
+test('Expect dropdown to disappear when connections reduce from multiple to one', async () => {
+  const providerStore = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+  vi.mocked(providers).providerInfos = providerStore;
+
+  render(EnvironmentDropdown);
+
+  // Initially dropdown should be visible
+  const dropdown = screen.getByLabelText('Environment');
+  expect(dropdown).toBeInTheDocument();
+
+  // Docker connection stops - only Podman remains
+  const stoppedDockerProvider: ProviderInfo = {
+    ...DOCKER_PROVIDER,
+    containerConnections: [
+      {
+        ...DOCKER_PROVIDER.containerConnections[0],
+        status: 'stopped',
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  providerStore.set([PODMAN_PROVIDER, stoppedDockerProvider]);
+
+  // Wait for re-render - dropdown should disappear
+  await vi.waitFor(() => {
+    expect(screen.queryByLabelText('Environment')).not.toBeInTheDocument();
+  });
+});
+
+test('Expect dropdown to disappear when all connections stop', async () => {
+  const providerStore = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+  vi.mocked(providers).providerInfos = providerStore;
+
+  render(EnvironmentDropdown);
+
+  // Initially dropdown should be visible
+  expect(screen.getByLabelText('Environment')).toBeInTheDocument();
+
+  // All connections stop
+  const stoppedPodmanProvider: ProviderInfo = {
+    ...PODMAN_PROVIDER,
+    containerConnections: [
+      {
+        ...PODMAN_PROVIDER.containerConnections[0],
+        status: 'stopped',
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  const stoppedDockerProvider: ProviderInfo = {
+    ...DOCKER_PROVIDER,
+    containerConnections: [
+      {
+        ...DOCKER_PROVIDER.containerConnections[0],
+        status: 'stopped',
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  providerStore.set([stoppedPodmanProvider, stoppedDockerProvider]);
+
+  // Wait for re-render - dropdown should disappear
+  await vi.waitFor(() => {
+    expect(screen.queryByLabelText('Environment')).not.toBeInTheDocument();
+  });
+});
+
+test('Expect selectedEnvironment to reset when dropdown hides even if selected value still exists', async () => {
+  const providerStore = writable([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+  vi.mocked(providers).providerInfos = providerStore;
+
+  render(EnvironmentDropdown);
+
+  // Select Podman environment
+  const dropdown = screen.getByRole('button');
+  await fireEvent.click(dropdown);
+  const podmanOption = screen.getByRole('button', { name: 'Podman' });
+  await fireEvent.click(podmanOption);
+
+  // Verify Podman is selected
+  expect(dropdown.textContent).toContain('Podman');
+
+  // Docker stops - only Podman remains, dropdown should hide
+  // But Podman (the selected value) is still running!
+  const stoppedDockerProvider: ProviderInfo = {
+    ...DOCKER_PROVIDER,
+    containerConnections: [
+      {
+        ...DOCKER_PROVIDER.containerConnections[0],
+        status: 'stopped',
+      },
+    ],
+  } as unknown as ProviderInfo;
+
+  providerStore.set([PODMAN_PROVIDER, stoppedDockerProvider]);
+
+  // Dropdown should disappear because only 1 connection remains
+  await vi.waitFor(() => {
+    expect(screen.queryByLabelText('Environment')).not.toBeInTheDocument();
+  });
+
+  // Now bring Docker back - dropdown should reappear with "All" selected (reset)
+  providerStore.set([PODMAN_PROVIDER, DOCKER_PROVIDER]);
+
+  await vi.waitFor(() => {
+    expect(screen.queryByLabelText('Environment')).toBeInTheDocument();
+  });
+
+  // The dropdown should show "All" (not "Podman") because selectedEnvironment was reset
+  const newDropdown = screen.getByRole('button');
+  expect(newDropdown.textContent).toContain('All');
+});

--- a/packages/renderer/src/lib/ui/EnvironmentDropdown.svelte
+++ b/packages/renderer/src/lib/ui/EnvironmentDropdown.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+import { Dropdown } from '@podman-desktop/ui-svelte';
+
+import { providerInfos } from '/@/stores/providers';
+
+import { capitalize } from './Util';
+
+interface Props {
+  selectedEnvironment?: string;
+}
+
+let { selectedEnvironment = $bindable('') }: Props = $props();
+
+// Get all running container connections
+const runningConnections = $derived(
+  $providerInfos.flatMap(provider =>
+    provider.containerConnections
+      .filter(connection => connection.status === 'started')
+      .map(connection => ({
+        ...connection,
+        engineId: `${provider.id}.${connection.name}`,
+      })),
+  ),
+);
+
+// Count running connections per type for labeling
+const runningConnectionCount = $derived(
+  runningConnections.reduce(
+    (acc, connection) => {
+      acc[connection.type] = (acc[connection.type] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>,
+  ),
+);
+
+// Get all running container connections as environment options
+const environmentOptions = $derived.by(() => {
+  const options: { label: string; value: string }[] = [{ label: 'All', value: '' }];
+
+  runningConnections.forEach(connection => {
+    // Show connection type if there's only one of that type, otherwise show displayName
+    const label = runningConnectionCount[connection.type] > 1 ? connection.displayName : capitalize(connection.type);
+
+    options.push({
+      label,
+      value: connection.engineId,
+    });
+  });
+
+  return options;
+});
+
+// Only show dropdown when there are multiple environments to choose from
+const showDropdown = $derived(runningConnections.length > 1);
+
+// Reset selectedEnvironment if:
+// 1. The currently selected value no longer exists in options, OR
+// 2. The dropdown is hidden (only one or no environments remain)
+$effect(() => {
+  if (selectedEnvironment && (!showDropdown || !environmentOptions.some(opt => opt.value === selectedEnvironment))) {
+    selectedEnvironment = '';
+  }
+});
+
+// Find the longest option label to set consistent width
+const longestLabel = $derived(
+  environmentOptions.reduce((longest, option) => (option.label.length > longest.length ? option.label : longest), ''),
+);
+
+function handleChange(value: string): void {
+  selectedEnvironment = value;
+}
+</script>
+
+{#if showDropdown}
+  <div class="inline-grid max-w-64">
+    <!-- Sizer: renders longest option to establish grid cell width -->
+    <div class="invisible col-start-1 row-start-1 flex items-center px-1 py-1 whitespace-nowrap" aria-hidden="true">
+      <span class="mr-1">Environment:</span>
+      <span class="truncate">{longestLabel}</span>
+      <span class="w-4 shrink-0"></span>
+    </div>
+    <!-- Actual dropdown in same grid cell -->
+    <Dropdown
+      ariaLabel="Environment"
+      name="environment"
+      class="col-start-1 row-start-1 whitespace-nowrap !grow-0"
+      value={selectedEnvironment}
+      onChange={handleChange}
+      options={environmentOptions}>
+      {#snippet left()}
+        <div class="mr-1 text-[var(--pd-input-field-placeholder-text)]">Environment:</div>
+      {/snippet}
+    </Dropdown>
+  </div>
+{/if}

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -20,8 +20,8 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { type ProviderInfo } from '@podman-desktop/core-api';
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { type ProviderContainerConnectionInfo, type ProviderInfo } from '@podman-desktop/core-api';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 /* eslint-disable import/no-duplicates */
 import { tick } from 'svelte';
@@ -512,4 +512,205 @@ test('Expect environment column sorted by engineId', async () => {
   const cells = screen.getAllByRole('cell', { name: /volume-/ });
   expect(cells[0]).toHaveTextContent('volume-bbb');
   expect(cells[1]).toHaveTextContent('volume-aaa');
+});
+
+test('Expect environment dropdown to appear with multiple running connections', async () => {
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
+    {
+      id: 'podman',
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          displayName: 'Podman Machine',
+          status: 'started',
+          type: 'podman',
+        },
+      ],
+    } as ProviderInfo,
+    {
+      id: 'docker',
+      name: 'docker',
+      status: 'started',
+      internalId: 'docker-internal-id',
+      containerConnections: [
+        {
+          name: 'docker-context',
+          displayName: 'Docker Desktop',
+          status: 'started',
+          type: 'docker',
+        },
+      ],
+    } as ProviderInfo,
+  ]);
+
+  vi.mocked(window.listVolumes).mockResolvedValue([
+    {
+      Volumes: [
+        {
+          Driver: 'local',
+          Labels: {},
+          Mountpoint: '/var/lib/volumes/podman-volume',
+          Name: 'podman-volume',
+          Options: {},
+          Scope: 'local',
+          engineName: 'Podman Machine',
+          engineId: 'podman.podman-machine-default',
+          UsageData: { RefCount: 0, Size: -1 },
+          containersUsage: [],
+          CreatedAt: '',
+        },
+      ],
+      Warnings: [],
+      engineId: 'podman.podman-machine-default',
+      engineName: 'Podman Machine',
+    },
+    {
+      Volumes: [
+        {
+          Driver: 'local',
+          Labels: {},
+          Mountpoint: '/var/lib/volumes/docker-volume',
+          Name: 'docker-volume',
+          Options: {},
+          Scope: 'local',
+          engineName: 'Docker Desktop',
+          engineId: 'docker.docker-context',
+          UsageData: { RefCount: 0, Size: -1 },
+          containersUsage: [],
+          CreatedAt: '',
+        },
+      ],
+      Warnings: [],
+      engineId: 'docker.docker-context',
+      engineName: 'Docker Desktop',
+    },
+  ]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+
+  const volumesEventStoreInfo = volumesEventStore.setup();
+  await volumesEventStoreInfo.fetch();
+
+  await waitFor(() => {
+    expect(get(volumeListInfos)).not.toHaveLength(0);
+    expect(get(providerInfos)).toHaveLength(2);
+  });
+
+  await waitRender({});
+
+  // Environment dropdown should be visible
+  const environmentDropdown = screen.getByLabelText('Environment');
+  expect(environmentDropdown).toBeInTheDocument();
+});
+
+test('Expect environment dropdown to filter volumes by selected environment', async () => {
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
+    {
+      id: 'podman',
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          displayName: 'Podman Machine',
+          status: 'started',
+          type: 'podman',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+    {
+      id: 'docker',
+      name: 'docker',
+      status: 'started',
+      internalId: 'docker-internal-id',
+      containerConnections: [
+        {
+          name: 'docker-context',
+          displayName: 'Docker Desktop',
+          status: 'started',
+          type: 'docker',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  vi.mocked(window.listVolumes).mockResolvedValue([
+    {
+      Volumes: [
+        {
+          Driver: 'local',
+          Labels: {},
+          Mountpoint: '/var/lib/containers/storage/volumes/podman/_data',
+          Name: 'podman-volume',
+          Options: {},
+          Scope: 'local',
+          engineId: 'podman.podman-machine-default',
+          engineName: 'Podman Machine',
+          UsageData: { RefCount: 1, Size: -1 },
+          containersUsage: [],
+          CreatedAt: '',
+        },
+      ],
+      Warnings: [],
+      engineId: 'podman.podman-machine-default',
+      engineName: 'Podman Machine',
+    },
+    {
+      Volumes: [
+        {
+          Driver: 'local',
+          Labels: {},
+          Mountpoint: '/var/lib/docker/volumes/docker/_data',
+          Name: 'docker-volume',
+          Options: {},
+          Scope: 'local',
+          engineId: 'docker.docker-context',
+          engineName: 'Docker Desktop',
+          UsageData: { RefCount: 1, Size: -1 },
+          containersUsage: [],
+          CreatedAt: '',
+        },
+      ],
+      Warnings: [],
+      engineId: 'docker.docker-context',
+      engineName: 'Docker Desktop',
+    },
+  ]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+
+  await waitFor(() => {
+    expect(get(providerInfos)).toHaveLength(2);
+    expect(get(volumeListInfos)).not.toHaveLength(0);
+  });
+
+  render(VolumesList);
+  await tick();
+
+  // Both volumes should be visible initially
+  expect(screen.getByText('podman-volume')).toBeInTheDocument();
+  expect(screen.getByText('docker-volume')).toBeInTheDocument();
+
+  // Select Podman environment from dropdown
+  const dropdownContainer = screen.getByLabelText('Environment');
+  const dropdownButton = within(dropdownContainer).getByRole('button');
+  await fireEvent.click(dropdownButton);
+
+  const podmanOption = await waitFor(async () => {
+    await tick();
+    return screen.getByRole('button', { name: 'Podman' });
+  });
+  await fireEvent.click(podmanOption);
+
+  // Only podman volume should be visible
+  await waitFor(() => {
+    expect(screen.getByText('podman-volume')).toBeInTheDocument();
+    expect(screen.queryByText('docker-volume')).not.toBeInTheDocument();
+  });
 });

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -21,6 +21,7 @@ import Prune from '/@/lib/engine/Prune.svelte';
 import NoContainerEngineEmptyScreen from '/@/lib/image/NoContainerEngineEmptyScreen.svelte';
 import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
 import ContainerEngineEnvironmentColumn from '/@/lib/table/columns/ContainerEngineEnvironmentColumn.svelte';
+import EnvironmentDropdown from '/@/lib/ui/EnvironmentDropdown.svelte';
 import { providerInfos } from '/@/stores/providers';
 import { fetchVolumesWithData, filtered, searchPattern, volumeListInfos } from '/@/stores/volumes';
 
@@ -34,8 +35,12 @@ import type { VolumeInfoUI } from './VolumeInfoUI';
 export let searchTerm = '';
 $: searchPattern.set(searchTerm);
 
+let selectedEnvironment = '';
 let volumes: VolumeInfoUI[] = [];
 let enginesList: EngineInfoUI[];
+
+// Filter volumes by selected environment
+$: filteredVolumes = selectedEnvironment ? volumes.filter(v => v.engineId === selectedEnvironment) : volumes;
 
 $: providerConnections = $providerInfos
   .map(provider => provider.containerConnections)
@@ -208,6 +213,7 @@ function label(obj: VolumeInfoUI): string {
   {/snippet}
 
   {#snippet bottomAdditionalActions()}
+    <EnvironmentDropdown bind:selectedEnvironment={selectedEnvironment} />
     {#if selectedItemsNumber > 0}
       <Button
         on:click={(): void =>
@@ -233,11 +239,13 @@ function label(obj: VolumeInfoUI): string {
       {:else}
         <VolumeEmptyScreen />
       {/if}
+    {:else if filteredVolumes.length === 0 && selectedEnvironment}
+      <FilteredEmptyScreen icon={VolumeIcon} kind="volumes" searchTerm="selected environment" onResetFilter={(): void => { selectedEnvironment = ''; }} />
     {:else}
       <Table
         kind="volume"
         bind:selectedItemsNumber={selectedItemsNumber}
-        data={volumes}
+        data={filteredVolumes}
         columns={columns}
         row={row}
         defaultSortColumn="Name"


### PR DESCRIPTION
### What does this PR do?

PR adds `Environment` combo box to Containers, Pods, Images, Volumes and Network pages to filter table using selected environment.

### Screenshot / video of UI

https://github.com/user-attachments/assets/8f7974d9-fb73-4e2a-85a5-943100bfffbb


### What issues does this PR fix or reference?

Fix #14106.


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
