### PR TITLE
fix(renderer): open SearchBar on F1 key only

### DIFF
--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -400,40 +400,39 @@ describe('Command Palette', () => {
       description: 'Ctrl+Shift+P',
       shortcut: '{Control>}{Shift>}p{/Shift}{/Control}',
       expectedTabText: 'Ctrl+Shift+P All',
+      shouldOpen: false,
     },
     {
       description: 'F1 key',
       shortcut: '{F1}',
       expectedTabText: 'F1 > Commands',
+      shouldOpen: true,
     },
     {
       description: '> key',
       shortcut: '>',
       expectedTabText: 'F1 > Commands',
+      shouldOpen: false,
     },
     {
       description: 'Ctrl+K',
       shortcut: '{Control>}k{/Control}',
       expectedTabText: 'Ctrl+K Documentation',
+      shouldOpen: false,
     },
     {
       description: 'Ctrl+F',
       shortcut: '{Control>}f{/Control}',
       expectedTabText: 'Ctrl+F Go to',
+      shouldOpen: false,
     },
   ];
 
-  test.each(
-    shortcutTabTestCases,
-  )('Expect that $description opens command palette with $expectedTabText tab selected', async ({
+  test.each(shortcutTabTestCases)('Expect that $description selects $expectedTabText tab', async ({
     shortcut,
     expectedTabText,
   }) => {
-    render(CommandPalette);
-
-    // check command palette is not displayed initially
-    const inputBefore = screen.queryByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
-    expect(inputBefore).not.toBeInTheDocument();
+    render(CommandPalette, { display: true });
 
     // press the shortcut
     await userEvent.keyboard(shortcut);
@@ -457,6 +456,23 @@ describe('Command Palette', () => {
         expect(button).not.toHaveClass('border-[var(--pd-button-tab-border-selected)]');
       }
     });
+  });
+
+  test.each(shortcutTabTestCases)('Check that $description key can open the command palette: $shouldOpen', async ({
+    shortcut,
+    shouldOpen,
+  }) => {
+    render(CommandPalette);
+    // check command palette is not displayed initially
+    const inputBefore = screen.queryByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    expect(inputBefore).not.toBeInTheDocument();
+
+    await userEvent.keyboard(shortcut);
+    if (shouldOpen) {
+      expect(screen.queryByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL })).toBeInTheDocument();
+    } else {
+      expect(screen.queryByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL })).not.toBeInTheDocument();
+    }
   });
 
   test('Expect that clicking tabs switches between them correctly', async () => {

--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -168,6 +168,11 @@ function displaySearchBar(): void {
 }
 
 async function handleKeydown(e: KeyboardEvent): Promise<void> {
+  // open palette only if F1 key is pressed when palette is not already visible
+  if (!display && e.key !== `${F1}`) {
+    return;
+  }
+
   // toggle display using F1 or ESC keys
   if (e.key === `${F1}` || e.key === '>') {
     selectedFilteredIndex = 0;
@@ -194,11 +199,6 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
       displaySearchBar();
       e.preventDefault();
     }
-  }
-
-  // for other keys, only check if it's being displayed
-  if (!display) {
-    return;
   }
 
   // no items, abort


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

This PR edits the behavior of Search Bar to open only if F1 key pressed

### Screenshot / video of UI

### What issues does this PR fix or reference?

Closes #15219

### How to test this PR?

1. Press any Search Bar shortcut key other than F1 – the Search Bar should not open.
2. Press F1 – the Search Bar should open.

- [x] Tests are covering the bug fix or the new feature
