### PR TITLE
chore(test): ensure registry cleanup on test failure

### DIFF
--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -30,6 +30,7 @@ import { SettingsBar } from '/@/model/pages/settings-bar';
 import { NavigationBar } from '/@/model/workbench/navigation';
 import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
 import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteRegistry } from '/@/utility/operations';
 import { isWindows } from '/@/utility/platform';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
@@ -75,8 +76,14 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   imagesPage = await navigationBar.openImages();
 });
 
-test.afterAll(async ({ runner }) => {
-  await runner.close();
+test.afterAll(async ({ runner, page }) => {
+  try {
+    await deleteRegistry(page, 'GitHub').catch((error: unknown) => {
+      console.log('Failed to delete registry:', error);
+    });
+  } finally {
+    await runner.close();
+  }
 });
 
 test.describe.serial('Image Manifest E2E Validation', { tag: '@smoke' }, () => {

--- a/tests/playwright/src/specs/registry-image.spec.ts
+++ b/tests/playwright/src/specs/registry-image.spec.ts
@@ -45,7 +45,9 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
 test.afterAll(async ({ runner, page }) => {
   try {
     await deleteImage(page, imageUrl);
-    await deleteRegistry(page, 'GitHub');
+    await deleteRegistry(page, 'GitHub').catch((error: unknown) => {
+      console.log('Failed to delete registry:', error);
+    });
   } finally {
     await runner.close();
   }

--- a/tests/playwright/src/specs/registry.spec.ts
+++ b/tests/playwright/src/specs/registry.spec.ts
@@ -19,6 +19,7 @@
 import { RegistriesPage } from '/@/model/pages/registries-page';
 import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
 import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteRegistry } from '/@/utility/operations';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 let registryUrl: string;
@@ -36,8 +37,14 @@ test.beforeAll(async ({ runner, welcomePage, page }) => {
   await waitForPodmanMachineStartup(page);
 });
 
-test.afterAll(async ({ runner }) => {
-  await runner.close();
+test.afterAll(async ({ runner, page }) => {
+  try {
+    await deleteRegistry(page, 'GitHub').catch((error: unknown) => {
+      console.log('Failed to delete registry:', error);
+    });
+  } finally {
+    await runner.close();
+  }
 });
 
 test.describe.serial('Registries handling verification', { tag: '@smoke' }, () => {


### PR DESCRIPTION
### What does this PR do?
Ensure that registry tests cleanup the registry even when a test fails.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/e2e/issues/553
