### PR TITLE
fix(color-registry): restore contrast for text colors in dark theme

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -286,7 +286,7 @@ test('initContent', async () => {
   // check the first call
   expect(spyOnRegisterColor.mock.calls[0]?.[0]).toStrictEqual('content-breadcrumb');
   expect(spyOnRegisterColor.mock.calls[0]?.[1].light).toBe(tailwindColorPalette.purple[900]);
-  expect(spyOnRegisterColor.mock.calls[0]?.[1].dark).toBe(tailwindColorPalette.gray[600]);
+  expect(spyOnRegisterColor.mock.calls[0]?.[1].dark).toBe(tailwindColorPalette.gray[400]);
 });
 
 describe('registerColor', () => {

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -367,7 +367,7 @@ export class ColorRegistry {
       light: gray[300],
     });
     this.registerColor(`${glNav}icon`, {
-      dark: gray[600],
+      dark: gray[400],
       light: charcoal[200],
     });
     this.registerColor(`${glNav}icon-hover`, {
@@ -545,7 +545,7 @@ export class ColorRegistry {
   protected initContent(): void {
     const ct = 'content-';
     this.registerColor(`${ct}breadcrumb`, {
-      dark: gray[600],
+      dark: gray[400],
       light: purple[900],
     });
 
@@ -560,17 +560,17 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${ct}text`, {
-      dark: gray[700],
+      dark: gray[400],
       light: gray[900],
     });
 
     this.registerColor(`${ct}sub-header`, {
-      dark: gray[900],
+      dark: gray[400],
       light: purple[900],
     });
 
     this.registerColor(`${ct}header-icon`, {
-      dark: gray[600],
+      dark: gray[400],
       light: purple[700],
     });
 
@@ -605,7 +605,7 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${ct}card-light-title`, {
-      dark: gray[800],
+      dark: gray[500],
       light: purple[900],
     });
 
@@ -655,12 +655,12 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${ct}card-carousel-nav`, {
-      dark: gray[800],
+      dark: gray[500],
       light: gray[300],
     });
 
     this.registerColor(`${ct}card-carousel-hover-nav`, {
-      dark: gray[600],
+      dark: gray[400],
       light: gray[500],
     });
 
@@ -718,11 +718,11 @@ export class ColorRegistry {
       light: gray[700],
     });
     this.registerColor(`${sNav}hover-text`, {
-      dark: gray[700],
+      dark: gray[400],
       light: charcoal[200],
     });
     this.registerColor(`${sNav}placeholder-text`, {
-      dark: gray[700],
+      dark: gray[500],
       light: charcoal[200],
     });
     this.registerColor(`${sNav}stroke`, {
@@ -742,7 +742,7 @@ export class ColorRegistry {
       light: charcoal[100],
     });
     this.registerColor(`${sNav}icon`, {
-      dark: gray[700],
+      dark: gray[400],
       light: charcoal[200],
     });
     this.registerColor(`${sNav}focused-icon`, {
@@ -754,7 +754,7 @@ export class ColorRegistry {
       light: gray[700],
     });
     this.registerColor(`${sNav}hover-icon`, {
-      dark: gray[700],
+      dark: gray[400],
       light: purple[600],
     });
   }
@@ -851,7 +851,7 @@ export class ColorRegistry {
     const tab = 'table-';
     // color of columns names
     this.registerColor(`${tab}header-text`, {
-      dark: gray[600],
+      dark: gray[400],
       light: charcoal[200],
     });
     // color of up/down arrows when column is not the ordered one
@@ -862,7 +862,7 @@ export class ColorRegistry {
 
     // color for most text in tables
     this.registerColor(`${tab}body-text`, {
-      dark: gray[700],
+      dark: gray[400],
       light: charcoal[100],
     });
     // color for the text in the main column of the table (generally Name)
@@ -889,7 +889,7 @@ export class ColorRegistry {
       light: charcoal[500],
     });
     this.registerColor(`${details}empty-icon`, {
-      dark: gray[600],
+      dark: gray[400],
       light: charcoal[200],
     });
     this.registerColor(`${details}empty-header`, {
@@ -897,7 +897,7 @@ export class ColorRegistry {
       light: charcoal[500],
     });
     this.registerColor(`${details}empty-sub-header`, {
-      dark: gray[600],
+      dark: gray[400],
       light: charcoal[500],
     });
     this.registerColor(`${details}empty-cmdline-bg`, {
@@ -917,7 +917,7 @@ export class ColorRegistry {
       light: gray[300],
     });
     this.registerColor(`${details}card-header`, {
-      dark: gray[700],
+      dark: gray[400],
       light: charcoal[300],
     });
     this.registerColor(`${details}card-text`, {
@@ -929,7 +929,7 @@ export class ColorRegistry {
   protected initTab(): void {
     const tab = 'tab-';
     this.registerColor(`${tab}text`, {
-      dark: gray[600],
+      dark: gray[400],
       light: charcoal[200],
     });
     this.registerColor(`${tab}text-highlight`, {
@@ -1077,7 +1077,7 @@ export class ColorRegistry {
       light: gray[600],
     });
     this.registerColor(`${button}tab-text`, {
-      dark: gray[600],
+      dark: gray[400],
       light: charcoal[200],
     });
     this.registerColor(`${button}tab-text-selected`, {
@@ -1277,7 +1277,7 @@ export class ColorRegistry {
       light: purple[200],
     });
     this.registerColor(`${label}text`, {
-      dark: gray[500],
+      dark: gray[400],
       light: charcoal[300],
     });
 
@@ -1350,7 +1350,7 @@ export class ColorRegistry {
       light: charcoal[200],
     });
     this.registerColor(`${status}not-running`, {
-      dark: gray[700],
+      dark: gray[500],
       light: gray[900],
     });
     // "Warning"
@@ -1440,7 +1440,7 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${onboarding}inactive-dot-border`, {
-      dark: gray[700],
+      dark: gray[500],
       light: gray[700],
     });
   }

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -764,7 +764,7 @@ export class ColorRegistry {
     const sNav = 'input-checkbox-';
 
     this.registerColor(`${sNav}disabled`, {
-      dark: gray[700],
+      dark: gray[600],
       light: charcoal[200],
     });
     this.registerColor(`${sNav}indeterminate`, {
@@ -1136,7 +1136,7 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${ab}disabled-text`, {
-      dark: gray[900],
+      dark: gray[700],
       light: gray[900],
     });
 
@@ -1154,7 +1154,7 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${ab}details-disabled-text`, {
-      dark: gray[900],
+      dark: gray[700],
       light: gray[900],
     });
     this.registerColor(`${ab}details-disabled-bg`, {
@@ -1246,7 +1246,7 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${dropdown}disabled-item-text`, {
-      dark: gray[900],
+      dark: gray[700],
       light: charcoal[100],
     });
     this.registerColor(`${dropdown}disabled-item-bg`, {
@@ -1263,7 +1263,7 @@ export class ColorRegistry {
       light: charcoal[900],
     });
     this.registerColor(`${input}${select}hover-text`, {
-      dark: gray[900],
+      dark: gray[400],
       light: charcoal[200],
     });
   }


### PR DESCRIPTION
### What does this PR do?

This PR fixes contrast issues in dark theme that were introduced during the Tailwind 4 color migration (#16104). The new Tailwind 4 gray scale has inverted lightness values compared to the old palette - the old `gray[600]` was ~71% lightness (light gray), but the new `gray[600]` is only 44.6% lightness (dark gray).

This caused 27 color tokens using `gray[600-900]` to become nearly invisible on dark backgrounds. The PR updates these tokens to use lighter gray values (`gray[400-700]`) to restore proper contrast.

**Fixed color tokens:**

- **Navigation**: `global-nav-icon` (sidebar labels)
- **Content area**: breadcrumbs, text, sub-headers, icons, carousel navigation
- **Tables**: header and body text
- **Input fields**: placeholders, icons, hover states, select hover text
- **Details pages**: empty state icons and text
- **Tabs**: inactive tab text
- **Labels**: label badge text
- **Status indicators**: "not running" status
- **Onboarding**: inactive dot borders
- **Checkboxes**: disabled state
- **Action buttons**: disabled states (regular and details variants)
- **Dropdowns**: disabled item text

### Screenshot / video of UI

- Left: old (broken)
- Right: fixed (this PR)

<img width="4474" height="2078" alt="image" src="https://github.com/user-attachments/assets/c9f7ca3e-49c4-4072-95ec-6358393012d5" />

<img width="4474" height="2078" alt="image" src="https://github.com/user-attachments/assets/e54d2ceb-99f2-48b2-a855-05dd011ac910" />

### What issues does this PR fix or reference?

Closes #16160

### How to test this PR?

1. **Visual inspection in dark theme** - Check the following UI elements for proper text/icon visibility:
   - Sidebar navigation labels (Dashboard, Containers, Pods, etc.)
   - Content area breadcrumbs and headers
   - Table headers and body text
   - Input field placeholders and icons
   - Tab labels (inactive state)
   - Empty state messages
   - Label badges
   - Status indicators
   - Disabled checkboxes
   - Disabled action buttons (icon buttons)
   - Dropdown menu items and section headers (e.g., "Community" in footer menu)

2. **Run tests**:

```bash
pnpm vitest run packages/main/src/plugin/color-registry.spec.ts
```

All 50 tests should pass, including the updated test for `content-breadcrumb`.

3. **Compare with light theme** - Verify that light theme remains unaffected (no changes were made to light theme colors).

- [x] Tests are covering the bug fix or the new feature
