### PR TITLE
fix(ui): capitalize Password in registry settings

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -78,7 +78,7 @@ describe('PreferencesRegistriesEditing', () => {
     const addRegistryBtn = screen.getByRole('button', { name: 'Add registry' });
     await userEvent.click(addRegistryBtn);
     let button = screen.getByRole('button', { name: 'Add' });
-    const password = screen.getByPlaceholderText('password');
+    const password = screen.getByPlaceholderText('Password');
     const username = screen.getByPlaceholderText('username');
     const url = screen.getByPlaceholderText('https://registry.io');
     expect(button).toBeVisible();

--- a/packages/renderer/src/lib/ui/PasswordInput.spec.ts
+++ b/packages/renderer/src/lib/ui/PasswordInput.spec.ts
@@ -63,7 +63,7 @@ test('expect default input#type to be password', async () => {
   const name = 'my-special-password';
   const { getByLabelText } = render(PasswordInput, { id: 'foo', name: name });
 
-  const input = getByLabelText('password foo');
+  const input = getByLabelText('Password foo');
   assert(input instanceof HTMLInputElement);
   expect(input).toHaveAttribute('type', 'password');
 });
@@ -75,7 +75,7 @@ test('expect hide button to set input#type to text', async () => {
   const btn = getByRole('button', { name: 'show/hide' });
   await fireEvent.click(btn);
 
-  const input = getByLabelText('password foo');
+  const input = getByLabelText('Password foo');
   await vi.waitFor(() => {
     expect(input).toHaveAttribute('type', 'text');
   });
@@ -85,7 +85,7 @@ test('typing should callback oninput listener', async () => {
   const oninput = vi.fn();
   const { getByLabelText } = render(PasswordInput, { id: 'foo', oninput: oninput });
 
-  const input = getByLabelText('password foo');
+  const input = getByLabelText('Password foo');
   assert(input instanceof HTMLInputElement);
   await fireEvent.input(input, { target: { value: 'potato' } });
 
@@ -103,7 +103,7 @@ test('check specific name is applied', async () => {
   const name = 'my-special-password';
   render(PasswordInput, { id: 'foo', name: name });
 
-  const input = screen.getByLabelText('password foo') as HTMLInputElement;
+  const input = screen.getByLabelText('Password foo') as HTMLInputElement;
   expect(input).toBeInTheDocument();
   expect(input.name).toBe(name);
 });
@@ -111,7 +111,7 @@ test('check specific name is applied', async () => {
 test('check default name is set if not specified', async () => {
   render(PasswordInput, { id: 'foo' });
 
-  const input = screen.getByLabelText('password foo') as HTMLInputElement;
+  const input = screen.getByLabelText('Password foo') as HTMLInputElement;
   expect(input).toBeInTheDocument();
   expect(input.name).toBe('password-foo');
 });

--- a/packages/renderer/src/lib/ui/PasswordInput.svelte
+++ b/packages/renderer/src/lib/ui/PasswordInput.svelte
@@ -35,9 +35,9 @@ async function onShowHide(event: MouseEvent): Promise<void> {
 <Input
   id="password-{id}"
   name={name ?? `password-${id}`}
-  placeholder="password"
+  placeholder="Password"
   bind:value={password}
-  aria-label="password {id}"
+  aria-label="Password {id}"
   bind:readonly={readonly}
   type={type}
   {...restProps}


### PR DESCRIPTION
## Summary
- capitalize the password field label text from password to Password in PasswordInput
- update renderer tests that assert this placeholder and label text
- keep behavior unchanged (text casing only)

Closes #14747

## Testing
- pnpm run build:preload:types
- pnpm run build:ui
- pnpm vitest --run --project=renderer packages/renderer/src/lib/ui/PasswordInput.spec.ts packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts