### PR TITLE
chore(test): ensure confirmation dialog is handled by using string comparison for enums

### DIFF
--- a/tests/playwright/src/model/pages/resource-connection-card-page.ts
+++ b/tests/playwright/src/model/pages/resource-connection-card-page.ts
@@ -63,7 +63,7 @@ export class ResourceConnectionCardPage extends ResourceCardPage {
       await button.click();
 
       // A confirmation dialog is displayed for deletion
-      if (operation === ResourceElementActions.Delete) {
+      if (String(operation) === ResourceElementActions.Delete) {
         await handleConfirmationDialog(this.page);
       }
     });

--- a/tests/playwright/src/model/pages/resource-details-page.ts
+++ b/tests/playwright/src/model/pages/resource-details-page.ts
@@ -40,7 +40,7 @@ export class ResourceDetailsPage extends DetailsPage {
       await button.click();
 
       // A confirmation dialog is displayed for deletion
-      if (operation === ResourceElementActions.Delete) {
+      if (String(operation) === ResourceElementActions.Delete) {
         await handleConfirmationDialog(this.page);
       }
     });


### PR DESCRIPTION
### What does this PR do?

This PR updates the POM pages to correctly handle delete confirmation dialogs when they are triggered by external repositories, such as the Minikube extension.
It changes the operation check to use a string comparison instead of an enum type

### What issues does this PR fix or reference?
https://github.com/podman-desktop/extension-minikube/issues/876

### How to test this PR?

- cd ~/podman-desktop/tests/playwright
- pnpm build
- Create the tarball: npm pack
- cd ~/extension-minikube
- pnpm install /path/to/podman-desktop-tests-playwright-1.9.0-next.tgz