### PR TITLE
refactor(charCode): remove const keyword on the export

### DIFF
--- a/packages/api/src/context/charCode.ts
+++ b/packages/api/src/context/charCode.ts
@@ -24,10 +24,9 @@
 // Names from https://blog.codinghorror.com/ascii-pronunciation-rules-for-programmers/
 
 /**
- * An inlined enum containing useful character codes (to be used with String.charCodeAt).
- * Please leave the const keyword such that it gets inlined when compiled to JavaScript!
+ * An enum containing useful character codes (to be used with String.charCodeAt).
  */
-export const enum CharCode {
+export enum CharCode {
   Null = 0,
   /**
    * The `\b` character.


### PR DESCRIPTION
### What does this PR do?
it does not work with verbatimModuleSyntax option of typescript on the import side with 'const'

https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15496

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
