### PR TITLE
chore(argos): remove mermaid diagram from screenshots

### DIFF
--- a/website-argos/screenshot.css
+++ b/website-argos/screenshot.css
@@ -14,7 +14,9 @@ iframe,
 /* Different docs last-update dates can alter layout */
 .theme-last-updated,
 /* Mermaid diagrams are rendered client-side and produce layout shifts */
-  .docusaurus-mermaid-container {
+  .docusaurus-mermaid-container,
+/* Mermaid.ink external images can change between renders */
+  img[src*='mermaid.ink'] {
   display: none;
 }
 


### PR DESCRIPTION
### What does this PR do?
on PR check, argos ci is failing almost all the time it's about the mermaid diagram that has different rendering

the diagram was already excluded in the css but it looks like that it was not excluded in fact, adding new entry in the css


### Screenshot / video of UI

<img width="1418" height="664" alt="image" src="https://github.com/user-attachments/assets/60cfb042-4f9c-49da-a9c9-b9234c450baf" />

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/15875


### How to test this PR?

check argos-CI, should have the image being removed with this PR 🤞 

- [x] Tests are covering the bug fix or the new feature
