### PR TITLE
feat(Button): update component to use new color system with accessibility improvements

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -90,6 +90,10 @@ class TestColorRegistry extends ColorRegistry {
   override initCommon(): void {
     super.initCommon();
   }
+
+  override initDefaults(): void {
+    super.initDefaults();
+  }
 }
 
 const _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
@@ -790,7 +794,7 @@ describe('initTooltip', () => {
   });
 });
 
-describe('initCommon', () => {
+describe('initDefaults', () => {
   let spyOnRegisterColorDefinition: MockInstance<(definition: ColorDefinitionWithId) => void>;
 
   beforeEach(() => {
@@ -798,7 +802,7 @@ describe('initCommon', () => {
     spyOnRegisterColorDefinition = vi.spyOn(colorRegistry, 'registerColorDefinition');
     spyOnRegisterColorDefinition.mockReturnValue(undefined);
 
-    colorRegistry.initCommon();
+    colorRegistry.initDefaults();
   });
 
   afterEach(() => {
@@ -806,13 +810,17 @@ describe('initCommon', () => {
   });
 
   test('registers item-disabled color using registerColorDefinition', () => {
-    expect(spyOnRegisterColorDefinition).toHaveBeenCalledTimes(1);
+    // initDefaults registers 2 colors using registerColorDefinition: item-disabled and item-hover
+    expect(spyOnRegisterColorDefinition).toHaveBeenCalledTimes(2);
 
-    // check the call
-    const call = spyOnRegisterColorDefinition.mock.calls[0];
-    const definition = call?.[0];
+    // check the item-disabled call
+    const itemDisabledCall = spyOnRegisterColorDefinition.mock.calls.find(
+      call => call?.[0]?.id === 'default-item-disabled',
+    );
+    expect(itemDisabledCall).toBeDefined();
 
-    expect(definition?.id).toBe('item-disabled');
+    const definition = itemDisabledCall?.[0];
+    expect(definition?.id).toBe('default-item-disabled');
     expect(definition?.dark).toBeDefined();
     expect(definition?.light).toBeDefined();
 

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -347,6 +347,25 @@ export class ColorRegistry {
       dark: white,
       light: charcoal[900],
     });
+
+    this.registerColor(`${def}text-link`, {
+      dark: violet[400],
+      light: violet[700],
+    });
+
+    this.registerColorDefinition(
+      this.color(`${def}item-disabled`)
+        .withLight(colorPaletteHelper(stone[600]).withAlpha(0.4))
+        .withDark(colorPaletteHelper(stone[300]).withAlpha(0.4))
+        .build(),
+    );
+
+    this.registerColorDefinition(
+      this.color(`${def}item-hover`)
+        .withLight(colorPaletteHelper(violet[600]).withAlpha(0.1))
+        .withDark(colorPaletteHelper(violet[400]).withAlpha(0.1))
+        .build(),
+    );
   }
 
   protected initNotificationDot(): void {
@@ -1004,6 +1023,16 @@ export class ColorRegistry {
 
   // button
   protected initButton(): void {
+    const itemDisabled = this.#definitions.get('default-item-disabled');
+    const textLink = this.#definitions.get('default-text-link');
+    const hoverItem = this.#definitions.get('default-item-hover');
+
+    if (!itemDisabled || !textLink || !hoverItem) {
+      throw new Error(
+        'default-item-disabled, default-text-link and default-item-hover colors must be defined before button colors',
+      );
+    }
+
     const button = 'button-';
 
     this.registerColor(`${button}primary-bg`, {
@@ -1016,29 +1045,69 @@ export class ColorRegistry {
       light: violet[600],
     });
 
+    this.registerColorDefinition(
+      this.color(`${button}primary-border`)
+        .withLight(colorPaletteHelper(transparent))
+        .withDark(colorPaletteHelper(violet[300]).withAlpha(0.4))
+        .build(),
+    );
+
+    // @deprecated since 2026-02-06. See https://github.com/podman-desktop/podman-desktop/pull/14876
+    // Use `button-secondary-bg` instead
     this.registerColor(`${button}secondary`, {
       dark: transparent,
       light: violet[200],
     });
 
+    this.registerColor(`${button}secondary-bg`, {
+      dark: transparent,
+      light: violet[200],
+    });
+
+    // @deprecated since 2026-02-06. See https://github.com/podman-desktop/podman-desktop/pull/14876
+    // Use `button-secondary-hover-bg` instead
     this.registerColor(`${button}secondary-hover`, {
       dark: slate[700],
       light: violet[100],
     });
+
+    this.registerColor(`${button}secondary-hover-bg`, {
+      dark: slate[700],
+      light: violet[100],
+    });
+
+    this.registerColorDefinition(
+      this.color(`${button}secondary-border`)
+        .withLight(colorPaletteHelper(violet[700]))
+        .withDark(colorPaletteHelper(stone[300]).withAlpha(0.4))
+        .build(),
+    );
 
     this.registerColor(`${button}text`, {
       dark: white,
       light: white,
     });
 
+    this.registerColor(`${button}primary-text`, {
+      dark: white,
+      light: white,
+    });
+
+    this.registerColor(`${button}secondary-text`, {
+      dark: stone[100],
+      light: violet[700],
+    });
+
+    // deprecated since 2026-02-06. See https://github.com/podman-desktop/podman-desktop/pull/14876
+    // Use `button-disabled-bg` instead
     this.registerColor(`${button}disabled`, {
       dark: stone[700],
       light: stone[300],
     });
 
     this.registerColor(`${button}disabled-text`, {
-      dark: charcoal[50],
-      light: gray[900],
+      dark: itemDisabled.dark,
+      light: itemDisabled.light,
     });
 
     this.registerColorDefinition(
@@ -1070,6 +1139,8 @@ export class ColorRegistry {
       light: red[100],
     });
 
+    // deprecated since 2026-02-06. See https://github.com/podman-desktop/podman-desktop/pull/14876
+    // Use `button-disabled-bg` instead
     this.registerColor(`${button}danger-disabled-border`, {
       dark: red[600],
       light: red[200],
@@ -1082,9 +1153,16 @@ export class ColorRegistry {
       light: red[700],
     });
 
+    // deprecated since 2026-02-06. See https://github.com/podman-desktop/podman-desktop/pull/14876
+    // Unused color (disabled buttons always use `button-disabled-bg`)
     this.registerColor(`${button}danger-disabled-bg`, {
       dark: transparent,
       light: transparent,
+    });
+
+    this.registerColor(`${button}disabled-bg`, {
+      dark: stone[700],
+      light: stone[300],
     });
 
     this.registerColor(`${button}tab-border`, {
@@ -1093,8 +1171,8 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${button}tab-border-selected`, {
-      dark: purple[500],
-      light: purple[600],
+      dark: textLink.dark,
+      light: textLink.light,
     });
 
     this.registerColor(`${button}tab-hover-border`, {
@@ -1103,13 +1181,13 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${button}tab-text`, {
-      dark: gray[400],
-      light: charcoal[200],
+      dark: textLink.dark,
+      light: textLink.light,
     });
 
     this.registerColor(`${button}tab-text-selected`, {
-      dark: white,
-      light: black,
+      dark: textLink.dark,
+      light: textLink.light,
     });
 
     this.registerColorDefinition(
@@ -1119,17 +1197,30 @@ export class ColorRegistry {
         .build(),
     );
 
-    this.registerColor(`${button}link-text`, {
-      dark: purple[400],
-      light: purple[700],
+    this.registerColor(`${button}link-bg`, {
+      dark: transparent,
+      light: transparent,
     });
 
-    this.registerColorDefinition(
-      this.color(`${button}link-hover-bg`)
-        .withLight(colorPaletteHelper(black).withAlpha(0.13))
-        .withDark(colorPaletteHelper(white).withAlpha(0.13))
-        .build(),
-    );
+    this.registerColor(`${button}link-text`, {
+      dark: textLink.dark,
+      light: textLink.light,
+    });
+
+    this.registerColor(`${button}link-hover-bg`, {
+      dark: hoverItem.dark,
+      light: hoverItem.light,
+    });
+
+    this.registerColor(`${button}focus-ring`, {
+      dark: textLink.dark,
+      light: textLink.light,
+    });
+
+    this.registerColor(`${button}focus-ring-danger`, {
+      dark: red[500],
+      light: red[700],
+    });
 
     // deprecated since 2026-02-06. See https://github.com/podman-desktop/podman-desktop/pull/14876
     // Unused color
@@ -1689,12 +1780,5 @@ export class ColorRegistry {
     });
   }
 
-  protected initCommon(): void {
-    this.registerColorDefinition(
-      this.color('item-disabled')
-        .withLight(colorPaletteHelper(stone[600]).withAlpha(0.4))
-        .withDark(colorPaletteHelper(stone[300]).withAlpha(0.4))
-        .build(),
-    );
-  }
+  protected initCommon(): void {}
 }

--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -35,11 +35,14 @@ test('Check primary button styling', async () => {
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('bg-[var(--pd-button-primary-bg)]');
   expect(button).toHaveClass('hover:bg-[var(--pd-button-primary-hover-bg)]');
-  expect(button).toHaveClass('border-none');
+  expect(button).toHaveClass('border');
+  expect(button).toHaveClass('border-[var(--pd-button-primary-border)]');
+  expect(button).toHaveClass('shadow-[0px_1px_4px_0px_rgba(0,0,0,0.1)]');
+  expect(button).toHaveClass('px-[16px]');
   expect(button).toHaveClass('py-[5px]');
-  expect(button).toHaveClass('text-[var(--pd-button-text)]');
-  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
-  expect(button).toHaveClass('outline-transparent');
+  expect(button).toHaveClass('rounded-[6px]');
+  expect(button).toHaveClass('min-h-[28px]');
+  expect(button).toHaveClass('text-[var(--pd-button-primary-text)]');
 });
 
 test('Check disabled/in-progress primary button styling', async () => {
@@ -48,7 +51,8 @@ test('Check disabled/in-progress primary button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('bg-[var(--pd-button-disabled)]');
+  expect(button).toHaveClass('bg-[var(--pd-button-disabled-bg)]');
+  expect(button).toHaveClass('px-[16px]');
   expect(button).toHaveClass('py-[5px]');
   expect(button).toHaveClass('text-[var(--pd-button-disabled-text)]');
 });
@@ -60,7 +64,7 @@ test('Check primary button is the default', async () => {
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
   expect(button).toHaveClass('bg-[var(--pd-button-primary-bg)]');
-  expect(button).toHaveClass('text-[var(--pd-button-text)]');
+  expect(button).toHaveClass('text-[var(--pd-button-primary-text)]');
 });
 
 test('Check secondary button styling', async () => {
@@ -69,15 +73,15 @@ test('Check secondary button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('border-[var(--pd-button-secondary)]');
-  expect(button).toHaveClass('border-[1px]');
-  expect(button).toHaveClass('py-[4px]');
-  expect(button).toHaveClass('text-[var(--pd-button-secondary)]');
-  expect(button).toHaveClass('hover:bg-[var(--pd-button-secondary-hover)]');
-  expect(button).toHaveClass('hover:border-[var(--pd-button-secondary-hover)]');
-  expect(button).toHaveClass('hover:text-[var(--pd-button-text)]');
-  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
-  expect(button).toHaveClass('outline-transparent');
+  expect(button).toHaveClass('bg-[var(--pd-button-secondary-bg)]');
+  expect(button).toHaveClass('border');
+  expect(button).toHaveClass('border-[var(--pd-button-secondary-border)]');
+  expect(button).toHaveClass('shadow-[0px_1px_4px_0px_rgba(0,0,0,0.1)]');
+  expect(button).toHaveClass('px-[16px]');
+  expect(button).toHaveClass('py-[5px]');
+  expect(button).toHaveClass('rounded-[6px]');
+  expect(button).toHaveClass('text-[var(--pd-button-secondary-text)]');
+  expect(button).toHaveClass('hover:bg-[var(--pd-button-secondary-hover-bg)]');
 });
 
 test('Check danger button styling', async () => {
@@ -86,16 +90,15 @@ test('Check danger button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('border-[var(--pd-button-danger-border)]');
-  expect(button).toHaveClass('border-2');
-  expect(button).toHaveClass('px-4');
-  expect(button).toHaveClass('py-[3px]');
   expect(button).toHaveClass('bg-[var(--pd-button-danger-bg)]');
+  expect(button).toHaveClass('border');
+  expect(button).toHaveClass('border-[var(--pd-button-danger-border)]');
+  expect(button).toHaveClass('shadow-[0px_1px_4px_0px_rgba(0,0,0,0.1)]');
+  expect(button).toHaveClass('px-[16px]');
+  expect(button).toHaveClass('py-[5px]');
+  expect(button).toHaveClass('rounded-[6px]');
   expect(button).toHaveClass('text-[var(--pd-button-danger-text)]');
   expect(button).toHaveClass('hover:bg-[var(--pd-button-danger-hover-bg)]');
-  expect(button).toHaveClass('hover:text-[var(--pd-button-danger-hover-text)]');
-  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
-  expect(button).toHaveClass('outline-transparent');
 });
 
 test('Check disabled/in-progress secondary button styling', async () => {
@@ -104,11 +107,9 @@ test('Check disabled/in-progress secondary button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('border-[var(--pd-button-disabled)]');
-  expect(button).toHaveClass('border-[1px]');
-  expect(button).toHaveClass('px-4');
-  expect(button).toHaveClass('py-[4px]');
-  expect(button).toHaveClass('bg-[var(--pd-button-disabled)]');
+  expect(button).toHaveClass('bg-[var(--pd-button-disabled-bg)]');
+  expect(button).toHaveClass('px-[16px]');
+  expect(button).toHaveClass('py-[5px]');
   expect(button).toHaveClass('text-[var(--pd-button-disabled-text)]');
 });
 
@@ -118,13 +119,13 @@ test('Check link button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('border-none');
-  expect(button).toHaveClass('px-4');
+  expect(button).toHaveClass('border');
+  expect(button).toHaveClass('border-transparent');
+  expect(button).toHaveClass('px-[16px]');
   expect(button).toHaveClass('py-[5px]');
+  expect(button).toHaveClass('rounded-[6px]');
   expect(button).toHaveClass('hover:bg-[var(--pd-button-link-hover-bg)]');
   expect(button).toHaveClass('text-[var(--pd-button-link-text)]');
-  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
-  expect(button).toHaveClass('outline-transparent');
 });
 
 test('Check disabled/in-progress link button styling', async () => {
@@ -133,7 +134,7 @@ test('Check disabled/in-progress link button styling', async () => {
   // check for a few elements of the styling
   const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
-  expect(button).toHaveClass('px-4');
+  expect(button).toHaveClass('px-[16px]');
   expect(button).toHaveClass('py-[5px]');
   expect(button).toHaveClass('text-[var(--pd-button-disabled-text)]');
 });
@@ -148,8 +149,6 @@ test('Check tab button styling', async () => {
   expect(button).toHaveClass('border-[var(--pd-button-tab-border)]');
   expect(button).toHaveClass('pb-1');
   expect(button).toHaveClass('text-[var(--pd-button-tab-text)]');
-  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
-  expect(button).toHaveClass('outline-transparent');
 });
 
 test('Check selected tab button styling', async () => {


### PR DESCRIPTION
Update the Button component to consume the new color token system established in previous PRs, with visual modernization and accessibility improvements.

- Standardize padding (`px-[16px] py-[5px]`), border radius (6px), and box shadows
- Migrate to new color tokens (`primary-text`, `secondary-bg`, `disabled-bg`, `focus-ring`, etc.)
- Add `aria-disabled`, `aria-busy`, `focus-visible:`, `motion-reduce:transition-none`, minimum target sizes
- Add cursor states and console warning for icon-only buttons missing `aria-label`
- Update all test assertions to match new styling

## Context

This is **PR 3 of 3** splitting the work from #14876 (Button modernization):
1. #16186 — Update existing color registry values → new Tailwind palette
2. #16188 — Add new color definitions (new tokens, cross-references)
3. **This PR**: Button component implementation (styling, accessibility)

## Test plan

- [x] All 15 Button tests pass
- [x] Icon-only buttons correctly emit `aria-label` console warning
- [x] No new lint errors introduced
- [x] All button types render correctly (primary, secondary, danger, link, tab)
- [x] Disabled and loading states work properly
- [x] Keyboard navigation shows focus indicators (`focus-visible`)
- [x] Reduced motion preference is respected

Depends on #16188
Fixes #16189

---

## Screenshots

<img width="1524" height="905" alt="image" src="https://github.com/user-attachments/assets/dab96084-0522-4a6e-ad70-4cb3f458dbc0" />

<img width="1524" height="906" alt="image" src="https://github.com/user-attachments/assets/0901706a-719c-4e2c-b524-6f6496a30676" />

For more examples and testing, please run Storybook.

---

<img width="1876" height="447" alt="image" src="https://github.com/user-attachments/assets/0fff1b4a-226c-4dc8-8628-4afcdadc0b91" />

<img width="1876" height="447" alt="image" src="https://github.com/user-attachments/assets/39ffe14d-23c4-4dc0-b266-71a3ccc8762d" />

<img width="1876" height="447" alt="image" src="https://github.com/user-attachments/assets/de8794b8-7782-447c-bb50-bc88f0b082eb" />

<img width="1876" height="447" alt="image" src="https://github.com/user-attachments/assets/f27750ee-960d-406e-85ae-f1932f3d8778" />

<img width="1876" height="813" alt="image" src="https://github.com/user-attachments/assets/f03aea65-ffed-457c-9d67-c8566864a1cf" />

<img width="1876" height="813" alt="image" src="https://github.com/user-attachments/assets/f7bf04f5-df28-4e79-8baa-b6c42be598ab" />

<img width="1876" height="583" alt="image" src="https://github.com/user-attachments/assets/2d0bddee-fea8-4c4a-86e7-7500e22a973b" />

<img width="1876" height="583" alt="image" src="https://github.com/user-attachments/assets/44401179-c6e2-4baf-bd46-e65813bfc405" />

---

<img width="2956" height="2914" alt="CleanShot 2026-02-10 at 15 43 12@2x" src="https://github.com/user-attachments/assets/e355f551-790f-4ed9-8cc2-1b9d71f4f1df" />

<img width="2956" height="2914" alt="CleanShot 2026-02-10 at 15 43 17@2x" src="https://github.com/user-attachments/assets/e04dc4c6-c286-40c2-a51e-2dea00b8f226" />
