### PR TITLE
refactor(compose): fix the original intent of describe methods

### DIFF
--- a/extensions/compose/src/handler.spec.ts
+++ b/extensions/compose/src/handler.spec.ts
@@ -49,33 +49,33 @@ test('updateConfigAndContextComposeBinary: make sure configuration gets updated 
   await handler.updateConfigAndContextComposeBinary(extensionContextMock);
 
   expect(configUpdateSpy).toHaveBeenCalledWith('binary.installComposeSystemWide', true);
-
-  describe('podman-compose', async () => {
-    test('updateConfigAndContextComposeBinary: should set isPodmanComposeInstalledSystemWide context to true when podman-compose is installed', async () => {
-      vi.mocked(detect.Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
-      vi.mocked(detect.Detect.prototype.checkSystemWidePodmanCompose).mockResolvedValue(true);
-
-      // Run updateConfigAndContextComposeBinary
-      await handler.updateConfigAndContextComposeBinary(extensionContextMock);
-
-      expect(vi.mocked(extensionApi.context.setValue)).toHaveBeenCalledWith(
-        'compose.isPodmanComposeInstalledSystemWide',
-        true,
-      );
-    });
-
-    test('updateConfigAndContextComposeBinary: should set isPodmanComposeInstalledSystemWide context to false when podman-compose is not installed', async () => {
-      vi.mocked(detect.Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
-      vi.mocked(detect.Detect.prototype.checkSystemWidePodmanCompose).mockResolvedValue(false);
-
-      // Run updateConfigAndContextComposeBinary
-      await handler.updateConfigAndContextComposeBinary(extensionContextMock);
-
-      expect(vi.mocked(extensionApi.context.setValue)).toHaveBeenCalledWith(
-        'compose.isPodmanComposeInstalledSystemWide',
-        false,
-      );
-    });
-  });
   expect(contextUpdateSpy).toHaveBeenCalledWith('compose.isComposeInstalledSystemWide', true);
+});
+
+describe('podman-compose', async () => {
+  test('updateConfigAndContextComposeBinary: should set isPodmanComposeInstalledSystemWide context to true when podman-compose is installed', async () => {
+    vi.mocked(detect.Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(detect.Detect.prototype.checkSystemWidePodmanCompose).mockResolvedValue(true);
+
+    // Run updateConfigAndContextComposeBinary
+    await handler.updateConfigAndContextComposeBinary(extensionContextMock);
+
+    expect(vi.mocked(extensionApi.context.setValue)).toHaveBeenCalledWith(
+      'compose.isPodmanComposeInstalledSystemWide',
+      true,
+    );
+  });
+
+  test('updateConfigAndContextComposeBinary: should set isPodmanComposeInstalledSystemWide context to false when podman-compose is not installed', async () => {
+    vi.mocked(detect.Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
+    vi.mocked(detect.Detect.prototype.checkSystemWidePodmanCompose).mockResolvedValue(false);
+
+    // Run updateConfigAndContextComposeBinary
+    await handler.updateConfigAndContextComposeBinary(extensionContextMock);
+
+    expect(vi.mocked(extensionApi.context.setValue)).toHaveBeenCalledWith(
+      'compose.isPodmanComposeInstalledSystemWide',
+      false,
+    );
+  });
 });


### PR DESCRIPTION

### What does this PR do?
there is a describe method in the middle of tests. It's probably related to an issue of a rebase.

Just move the inner describe method to the root level (it looks like a lot of changes but it's just moving the describe method below)

newer vitest versions failed to run these tests

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?


related to https://github.com/podman-desktop/podman-desktop/pull/16182


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
