### PR TITLE
fix(repository-info): move this util from api to website folder

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,9 +15,6 @@
     "test": "vitest run --coverage --passWithNoTests",
     "test:watch": "vitest watch --coverage --passWithNoTests"
   },
-  "dependencies": {
-    "hosted-git-info": "^9.0.2"
-  },
   "devDependencies": {
     "@types/hosted-git-info": "^3.0.5",
     "vite-plugin-dts": "^4.3.0",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -75,8 +75,6 @@ export * from './provider-info.js';
 export * from './proxy.js';
 export * from './pull-event.js';
 export * from './release-notes-info.js';
-export * from './repository-info-parser.js';
-export * from './repository-infos.js';
 export * from './status-bar.js';
 export * from './taskInfo.js';
 export * from './tasks-preferences.js';

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5141,27 +5141,4 @@ declare module '@podman-desktop/api' {
      */
     onDidChange: Event<SecretStorageChangeEvent>;
   }
-
-  /**
-   * Parses a repository URL to extract owner and repository information.
-   * It currently only supports GitHub repositories.
-   */
-  export class RepositoryInfoParser {
-    /**
-     * The owner of the GitHub repository (e.g., 'microsoft').
-     */
-    public readonly owner: string;
-    /**
-     * The name of the GitHub repository (e.g., 'vscode').
-     */
-    public readonly repository: string;
-
-    /**
-     * Creates an instance of RepositoryInfoParser.
-     * @param url The URL of the repository to parse.
-     * @throws {Error} If the URL cannot be parsed.
-     * @throws {Error} If the repository is not hosted on GitHub.
-     */
-    constructor(url: string);
-  }
 }

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -42,7 +42,6 @@ import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from '/@api/e
 import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
 import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
 import { PodInfo } from '/@api/pod-info.js';
-import { RepositoryInfoParser } from '/@api/repository-info-parser.js';
 import product from '/@product.json' with { type: 'json' };
 
 import { securityRestrictionCurrentHandler } from '../../security-restrictions-handler.js';
@@ -1666,7 +1665,6 @@ export class ExtensionLoader implements IAsyncDisposable {
       cli,
       imageChecker,
       navigation,
-      RepositoryInfoParser,
       net,
     };
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,10 +631,6 @@ importers:
         version: 4.0.18(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.2.3)(typescript@5.9.3))(terser@5.36.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/api:
-    dependencies:
-      hosted-git-info:
-        specifier: ^9.0.2
-        version: 9.0.2
     devDependencies:
       '@types/hosted-git-info':
         specifier: ^3.0.5
@@ -1252,6 +1248,9 @@ importers:
       docusaurus-plugin-typedoc:
         specifier: ^1.4.2
         version: 1.4.2(typedoc-plugin-markdown@4.10.0(typedoc@0.28.16(typescript@5.9.3)))
+      hosted-git-info:
+        specifier: ^9.0.2
+        version: 9.0.2
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@18.2.0)
@@ -8783,10 +8782,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.2.2:
-    resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.2.5:
     resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
@@ -20883,7 +20878,7 @@ snapshots:
 
   hosted-git-info@9.0.2:
     dependencies:
-      lru-cache: 11.2.2
+      lru-cache: 11.2.5
 
   hpack.js@2.1.6:
     dependencies:
@@ -21826,8 +21821,6 @@ snapshots:
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.2.2: {}
 
   lru-cache@11.2.5: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -35,6 +35,7 @@
     "clsx": "^2.1.1",
     "docusaurus-plugin-goatcounter": "^4.0.0",
     "docusaurus-plugin-typedoc": "^1.4.2",
+    "hosted-git-info": "^9.0.2",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/website/src/plugins/github-metadata-plugin.ts
+++ b/website/src/plugins/github-metadata-plugin.ts
@@ -18,9 +18,9 @@
 
 import type { Plugin } from '@docusaurus/types';
 
-import { GITHUB_OWNER, GITHUB_REPOSITORY } from '../../../packages/api/src/repository-infos';
 import type { GitHubMetadata } from './github-metadata';
 import { GitHubService } from './github-service';
+import { GITHUB_OWNER, GITHUB_REPOSITORY } from './repository-info/repository-infos';
 
 export default async function githubMetadataPlugin(): Promise<Plugin<GitHubMetadata>> {
   const githubService = new GitHubService(GITHUB_OWNER, GITHUB_REPOSITORY);

--- a/website/src/plugins/github-service.spec.ts
+++ b/website/src/plugins/github-service.spec.ts
@@ -20,10 +20,9 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
-import { GITHUB_OWNER, GITHUB_REPOSITORY } from '/@api/repository-infos';
-
 import type { GitHubMetadata } from './github-metadata';
 import { GitHubService } from './github-service';
+import { GITHUB_OWNER, GITHUB_REPOSITORY } from './repository-info/repository-infos';
 import { mockReleaseData } from './test/resources/mock-release-data';
 import { mockRepositoryData } from './test/resources/mock-repository-data';
 

--- a/website/src/plugins/repository-info/repository-info-parser.spec.ts
+++ b/website/src/plugins/repository-info/repository-info-parser.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/website/src/plugins/repository-info/repository-info-parser.ts
+++ b/website/src/plugins/repository-info/repository-info-parser.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/website/src/plugins/repository-info/repository-infos.spec.ts
+++ b/website/src/plugins/repository-info/repository-infos.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import rootPackage from '../../../package.json' with { type: 'json' };
-import { RepositoryInfoParser } from './repository-info-parser.js';
+import { expect, test } from 'vitest';
 
-export const REPOSITORY_URL = rootPackage.repository;
-export const REPOSITORY_HOMEPAGE = rootPackage.homepage;
+import { GITHUB_OWNER, GITHUB_REPOSITORY, REPOSITORY_HOMEPAGE, REPOSITORY_URL } from './repository-infos.js';
 
-const parser = new RepositoryInfoParser(REPOSITORY_URL);
-
-export const GITHUB_OWNER = parser.owner;
-export const GITHUB_REPOSITORY = parser.repository;
+test('check constants correctly extracted from package.json', async () => {
+  expect(REPOSITORY_URL).toBe('https://github.com/podman-desktop/podman-desktop');
+  expect(REPOSITORY_HOMEPAGE).toBe('https://www.podman-desktop.io');
+  expect(GITHUB_OWNER).toBe('podman-desktop');
+  expect(GITHUB_REPOSITORY).toBe('podman-desktop');
+});

--- a/website/src/plugins/repository-info/repository-infos.ts
+++ b/website/src/plugins/repository-info/repository-infos.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test } from 'vitest';
+import rootPackage from '../../../../package.json' with { type: 'json' };
+import { RepositoryInfoParser } from './repository-info-parser.js';
 
-import { GITHUB_OWNER, GITHUB_REPOSITORY, REPOSITORY_HOMEPAGE, REPOSITORY_URL } from './repository-infos.js';
+export const REPOSITORY_URL = rootPackage.repository;
+export const REPOSITORY_HOMEPAGE = rootPackage.homepage;
 
-test('check constants correctly extracted from package.json', async () => {
-  expect(REPOSITORY_URL).toBe('https://github.com/podman-desktop/podman-desktop');
-  expect(REPOSITORY_HOMEPAGE).toBe('https://www.podman-desktop.io');
-  expect(GITHUB_OWNER).toBe('podman-desktop');
-  expect(GITHUB_REPOSITORY).toBe('podman-desktop');
-});
+const parser = new RepositoryInfoParser(REPOSITORY_URL);
+
+export const GITHUB_OWNER = parser.owner;
+export const GITHUB_REPOSITORY = parser.repository;


### PR DESCRIPTION
### What does this PR do?
it's preventing to import things in packages/renderer side 

breaking changes: remove it from extension api
added by https://github.com/podman-desktop/podman-desktop/pull/13363 (but no related issue)
I don't see usage at https://github.com/search?q=RepositoryInfoParser+language%3ATypeScript&type=code&l=TypeScript&p=1


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/16194

related to https://github.com/podman-desktop/podman-desktop/issues/15496
### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
