### PR TITLE
chore(renderer): import api using package rather than alias

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -2,6 +2,7 @@
 import './app.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
+import type { KubernetesNavigationRequest, NavigationRequest } from '@podman-desktop/core-api';
 import { tablePersistence } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
@@ -10,8 +11,6 @@ import KubernetesRoot from '/@/lib/kube/KubernetesRoot.svelte';
 import PinActions from '/@/lib/statusbar/PinActions.svelte';
 import { handleNavigation } from '/@/navigation';
 import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
-import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation';
-import type { NavigationRequest } from '/@api/navigation-request';
 
 import AppNavigation from './AppNavigation.svelte';
 import { navigateTo } from './kubernetesNavigation';

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { ContextGeneralState, ContributionInfo, ForwardConfig } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { readable } from 'svelte/store';
@@ -26,9 +27,6 @@ import type { TinroRouteMeta } from 'tinro';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
-import type { ContributionInfo } from '/@api/contribution-info';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import { AppearanceSettings } from '../../main/src/plugin/appearance-settings';
 import AppNavigation from './AppNavigation.svelte';

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -1,11 +1,10 @@
 <svelte:options runes={true} />
 
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
-
-import { NavigationPage } from '/@api/navigation-page';
 
 import { AppearanceSettings } from '../../main/src/plugin/appearance-settings';
 import AuthActions from './lib/authentication/AuthActions.svelte';

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -18,12 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import { configurationProperties } from './stores/configurationProperties';

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { DockerCompatibilitySettings } from '@podman-desktop/core-api';
+import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
@@ -6,8 +8,6 @@ import type { TinroRouteMeta } from 'tinro';
 import PreferencesIcon from '/@/lib/images/PreferencesIcon.svelte';
 import ShortcutArrowIcon from '/@/lib/images/ShortcutArrowIcon.svelte';
 import { type NavItem, settingsNavigationEntries, type SettingsNavItemConfig } from '/@/PreferencesNavigation';
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants';
-import { DockerCompatibilitySettings } from '/@api/docker-compatibility-info';
 
 import { configurationProperties } from './stores/configurationProperties';
 

--- a/packages/renderer/src/kubernetesNavigation.ts
+++ b/packages/renderer/src/kubernetesNavigation.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { KubernetesNavigationRequest } from '@podman-desktop/core-api';
 import { router } from 'tinro';
-
-import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation';
 
 export function navigateTo(nav: KubernetesNavigationRequest): void {
   if (!nav.name) {

--- a/packages/renderer/src/lib/actions/ContributionActions.svelte
+++ b/packages/renderer/src/lib/actions/ContributionActions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
 import { faPlug } from '@fortawesome/free-solid-svg-icons';
+import type { Menu } from '@podman-desktop/core-api';
 import { onDestroy } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
@@ -10,7 +11,6 @@ import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import { transformObjectToContext } from '/@/lib/context/ContextUtils';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { context as storeContext } from '/@/stores/context';
-import type { Menu } from '/@api/menu.js';
 
 interface Props {
   args: unknown[];

--- a/packages/renderer/src/lib/authentication/AuthActions.svelte
+++ b/packages/renderer/src/lib/authentication/AuthActions.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import { faKey, faSignIn, faSignOut } from '@fortawesome/free-solid-svg-icons';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
 
 import { handleNavigation } from '/@/navigation';
 import { authenticationProviders } from '/@/stores/authenticationProviders';
-import { NavigationPage } from '/@api/navigation-page';
 
 export let onBeforeToggle = (): void => {};
 let showMenu = false;

--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { faArrowsRotate, faFileCode, faPlay, faRocket, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { Menu } from '@podman-desktop/core-api';
+import { MenuContext } from '@podman-desktop/core-api';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
 import { createEventDispatcher, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -8,8 +10,6 @@ import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import FlatMenu from '/@/lib/ui/FlatMenu.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
-import type { Menu } from '/@api/menu.js';
-import { MenuContext } from '/@api/menu-context.js';
 
 import type { ComposeInfoUI } from './ComposeInfoUI';
 

--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContainerInfo, ContainerInspectInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 /* eslint-disable import/no-duplicates */
 import { tick } from 'svelte';
@@ -28,9 +29,6 @@ import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import { mockBreadcrumb } from '/@/stores/breadcrumb.spec';
 import { containersInfos } from '/@/stores/containers';
 import { providerInfos } from '/@/stores/providers';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ContainerInspectInfo } from '/@api/container-inspect-info';
-import { type ProviderInfo } from '/@api/provider-info';
 
 import ComposeDetails from './ComposeDetails.svelte';
 

--- a/packages/renderer/src/lib/compose/ComposeDetailsInspect.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsInspect.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { ContainerInspectInfo } from '@podman-desktop/core-api';
 import { onMount } from 'svelte';
 
 import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
-import type { ContainerInspectInfo } from '/@api/container-inspect-info';
 
 import type { ComposeInfoUI } from './ComposeInfoUI';
 

--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Link } from '@podman-desktop/ui-svelte';
 
 import DetailsCell from '/@/lib/details/DetailsCell.svelte';
 import DetailsTable from '/@/lib/details/DetailsTable.svelte';
 import DetailsTitle from '/@/lib/details/DetailsTitle.svelte';
 import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
 
 import type { ComposeInfoUI } from './ComposeInfoUI';
 

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject, V1ConfigMap } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -14,7 +15,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextConfigMaps } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable';
 
 import { ConfigMapSecretUtils } from './configmap-secret-utils';
 import ConfigMapDetailsSummary from './ConfigMapDetailsSummary.svelte';

--- a/packages/renderer/src/lib/configmaps-secrets/SecretDetails.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/SecretDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject, V1Secret } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -14,7 +15,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextSecrets } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable';
 
 import { ConfigMapSecretUtils } from './configmap-secret-utils';
 import ConfigMapSecretActions from './ConfigMapSecretActions.svelte';

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -11,6 +11,8 @@ import {
   faTerminal,
   faTrash,
 } from '@fortawesome/free-solid-svg-icons';
+import type { Menu } from '@podman-desktop/core-api';
+import { MenuContext, NavigationPage } from '@podman-desktop/core-api';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
 import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -22,9 +24,6 @@ import FlatMenu from '/@/lib/ui/FlatMenu.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { handleNavigation } from '/@/navigation';
 import { context } from '/@/stores/context';
-import type { Menu } from '/@api/menu.js';
-import { MenuContext } from '/@api/menu-context.js';
-import { NavigationPage } from '/@api/navigation-page';
 
 import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './ContainerInfoUI';
 

--- a/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
+
 import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
 
 import type { ContainerInfoUI } from './ContainerInfoUI';
 

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContainerInfo, ContainerInspectInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
@@ -25,8 +26,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import { containersInfos } from '/@/stores/containers';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ContainerInspectInfo } from '/@api/container-inspect-info';
 
 import ContainerDetails from './ContainerDetails.svelte';
 

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
 
+import type { ContainerInfo } from '@podman-desktop/core-api';
 import { ErrorMessage, Link, StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
@@ -10,7 +11,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { containersInfos } from '/@/stores/containers';
-import type { ContainerInfo } from '/@api/container-info';
 
 import { ContainerUtils } from './container-utils';
 import ContainerActions from './ContainerActions.svelte';

--- a/packages/renderer/src/lib/container/ContainerDetailsInspect.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsInspect.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { ContainerInspectInfo } from '@podman-desktop/core-api';
 import { onMount } from 'svelte';
 
 import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
-import type { ContainerInspectInfo } from '/@api/container-inspect-info';
 
 import type { ContainerInfoUI } from './ContainerInfoUI';
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
 
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { SerializeAddon } from '@xterm/addon-serialize';
@@ -10,7 +11,6 @@ import { router } from 'tinro';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import { getExistingTerminal, registerTerminal } from '/@/stores/container-terminal-store';
-import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';

--- a/packages/renderer/src/lib/container/ContainerExport.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerExport.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { Uri } from '@podman-desktop/api';
+import type { ContainerInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -26,7 +27,6 @@ import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { containersInfos } from '/@/stores/containers';
-import type { ContainerInfo } from '/@api/container-info';
 
 import ContainerExport from './ContainerExport.svelte';
 

--- a/packages/renderer/src/lib/container/ContainerExport.svelte
+++ b/packages/renderer/src/lib/container/ContainerExport.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
@@ -8,7 +9,6 @@ import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import { Uri } from '/@/lib/uri/Uri';
 import { handleNavigation } from '/@/navigation';
 import { containersInfos } from '/@/stores/containers';
-import { NavigationPage } from '/@api/navigation-page';
 
 import type { ContainerInfoUI } from './ContainerInfoUI';
 

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContainerInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, type RenderResult, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 /* eslint-disable import/no-duplicates */
@@ -28,8 +29,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { containersInfos } from '/@/stores/containers';
 import { providerInfos } from '/@/stores/providers';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import ContainerList from './ContainerList.svelte';
 

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { faPlay, faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { ContainerInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import {
   Button,
   FilteredEmptyScreen,
@@ -29,8 +31,6 @@ import { podsInfos } from '/@/stores/pods';
 import { providerInfos } from '/@/stores/providers';
 import { findMatchInLeaves } from '/@/stores/search-util';
 import { viewsContributions } from '/@/stores/views';
-import type { ContainerInfo } from '/@api/container-info';
-import { NavigationPage } from '/@api/navigation-page';
 
 import { ContainerUtils } from './container-utils';
 import ContainerColumnActions from './ContainerColumnActions.svelte';

--- a/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContainerInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 /* eslint-disable import/no-duplicates */
 import { tick } from 'svelte';
@@ -27,8 +28,6 @@ import { beforeAll, expect, test, vi } from 'vitest';
 
 import { containersInfos } from '/@/stores/containers';
 import { providerInfos } from '/@/stores/providers';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import ContainerList from './ContainerList.svelte';
 

--- a/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContainerStatsInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ContainerStatsInfo } from '/@api/container-stats-info';
 
 import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './ContainerInfoUI';
 import ContainerStatistics from './ContainerStatistics.svelte';

--- a/packages/renderer/src/lib/container/ContainerStatistics.svelte
+++ b/packages/renderer/src/lib/container/ContainerStatistics.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { ContainerStatsInfo } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 
 import Donut from '/@/lib/donut/Donut.svelte';
-import type { ContainerStatsInfo } from '/@api/container-stats-info';
 
 import { ContainerUtils } from './container-utils';
 import type { ContainerInfoUI } from './ContainerInfoUI';

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ImageInfo, ProviderStatus } from '@podman-desktop/api';
+import type { ImageSearchResult, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -27,8 +28,6 @@ import { router } from 'tinro';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ImageSearchResult } from '/@api/image-registry';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import CreateContainerFromExistingImage from './CreateContainerFromExistingImage.svelte';
 

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
 import { faArrowCircleDown, faCircleCheck, faCog, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import type {
+  ImageInfo,
+  ImageSearchOptions,
+  ProviderContainerConnectionInfo,
+  PullEvent,
+} from '@podman-desktop/core-api';
 import { Button, Checkbox, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import type { Terminal } from '@xterm/xterm';
@@ -19,10 +25,6 @@ import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { lastPage } from '/@/stores/breadcrumb';
 import { providerInfos } from '/@/stores/providers';
 import { runImageInfo } from '/@/stores/run-image-store';
-import type { ImageInfo } from '/@api/image-info';
-import type { ImageSearchOptions } from '/@api/image-registry';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
-import type { PullEvent } from '/@api/pull-event';
 
 const DOCKER_PREFIX = 'docker.io';
 const DOCKER_PREFIX_WITH_SLASH = DOCKER_PREFIX + '/';

--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContainerInfo, ViewInfoUI } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ViewInfoUI } from '/@api/view-info';
 
 import { ContainerUtils } from './container-utils';
 import { ContainerGroupInfoTypeUI, type ContainerGroupInfoUI, type ContainerInfoUI } from './ContainerInfoUI';

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { Port } from '@podman-desktop/api';
+import { type ContainerInfo, isViewContributionIcon, type ViewInfoUI } from '@podman-desktop/core-api';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import { Buffer } from 'buffer';
@@ -26,8 +27,6 @@ import moment from 'moment';
 
 import type { ContextUI } from '/@/lib/context/context';
 import { ContextKeyExpr } from '/@/lib/context/contextKey';
-import type { ContainerInfo } from '/@api/container-info';
-import { isViewContributionIcon, type ViewInfoUI } from '/@api/view-info';
 
 import type { ContainerGroupInfoUI, ContainerGroupPartInfoUI, ContainerInfoUI } from './ContainerInfoUI';
 import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';

--- a/packages/renderer/src/lib/context/context.ts
+++ b/packages/renderer/src/lib/context/context.ts
@@ -21,7 +21,7 @@
  *--------------------------------------------------------------------------------------------*/
 // based on https://github.com/microsoft/vscode/blob/3eed9319874b7ca037128962593b6a8630869253/src/vs/platform/contextkey/browser/contextKeyService.ts
 
-import type { IContext } from '/@api/context/context';
+import type { IContext } from '@podman-desktop/core-api/context';
 
 export class ContextUI implements IContext {
   private _value: Record<string, unknown>;

--- a/packages/renderer/src/lib/context/contextKey.ts
+++ b/packages/renderer/src/lib/context/contextKey.ts
@@ -29,10 +29,9 @@
 /* eslint-disable sonarjs/updated-loop-counter */
 /* eslint-disable sonarjs/function-return-type */
 import type { Event } from '@podman-desktop/api';
-
-import { CharCode } from '/@api/context/charCode.js';
-import type { ContextKeyValue, IContext } from '/@api/context/context.js';
-import type { IDisposable } from '/@api/disposable.js';
+import type { IDisposable } from '@podman-desktop/core-api';
+import type { ContextKeyValue, IContext } from '@podman-desktop/core-api/context';
+import { CharCode } from '@podman-desktop/core-api/context';
 
 import type { LexingError, Token } from './scanner.js';
 import { Scanner, TokenType } from './scanner.js';

--- a/packages/renderer/src/lib/context/scanner.ts
+++ b/packages/renderer/src/lib/context/scanner.ts
@@ -21,7 +21,7 @@
  *--------------------------------------------------------------------------------------------*/
 // based on https://github.com/microsoft/vscode/blob/3eed9319874b7ca037128962593b6a8630869253/src/vs/platform/contextkey/common/scanner.ts
 
-import { CharCode } from '/@api/context/charCode';
+import { CharCode } from '@podman-desktop/core-api/context';
 
 export const enum TokenType {
   LParen,

--- a/packages/renderer/src/lib/cronjob/CronJobDetails.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject, V1CronJob } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -14,7 +15,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextCronJobs } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable';
 
 import { CronJobUtils } from './cronjob-utils';
 import CronJobActions from './CronJobActions.svelte';

--- a/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
@@ -19,13 +19,13 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1CronJob } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as resourcesListen from '/@/lib/kube/resources-listen';
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
 import CronJobList from './CronJobList.svelte';
 

--- a/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
@@ -18,6 +18,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { NotificationCard, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { router } from 'tinro';
@@ -25,8 +26,6 @@ import { expect, test } from 'vitest';
 
 import { notificationQueue } from '/@/stores/notifications';
 import { providerInfos } from '/@/stores/providers';
-import type { NotificationCard } from '/@api/notification';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import NewContentOnDashboardBadge from './NewContentOnDashboardBadge.svelte';
 

--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.spec.ts
@@ -17,10 +17,9 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
+import type { NotificationCard } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { NotificationCard } from '/@api/notification';
 
 import NotificationCardItem from './NotificationCardItem.svelte';
 

--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import type { NotificationCard } from '@podman-desktop/core-api';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import Markdown from '/@/lib/markdown/Markdown.svelte';
-import type { NotificationCard } from '/@api/notification';
 
 export let notification: NotificationCard;
 

--- a/packages/renderer/src/lib/dashboard/NotificationsBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NotificationsBox.spec.ts
@@ -17,11 +17,11 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
+import type { NotificationCard } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
 import { notificationQueue } from '/@/stores/notifications';
-import type { NotificationCard } from '/@api/notification';
 
 import NotificationsBox from './NotificationsBox.svelte';
 

--- a/packages/renderer/src/lib/dashboard/NotificationsBox.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationsBox.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { NotificationCard } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
 import { notificationQueue } from '/@/stores/notifications';
-import type { NotificationCard } from '/@api/notification';
 
 import NotificationCardItem from './NotificationCardItem.svelte';
 

--- a/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { CheckStatus } from '@podman-desktop/core-api';
 import { Link, Spinner } from '@podman-desktop/ui-svelte';
-
-import type { CheckStatus } from '/@api/provider-info';
 
 export let preflightChecks: CheckStatus[] = [];
 

--- a/packages/renderer/src/lib/dashboard/ProviderCard.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.spec.ts
@@ -19,11 +19,10 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderImages } from '@podman-desktop/api';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { expect, test } from 'vitest';
-
-import type { ProviderInfo } from '/@api/provider-info';
 
 import ProviderCard from './ProviderCard.svelte';
 

--- a/packages/renderer/src/lib/dashboard/ProviderCard.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderCard.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+import type { ProviderInfo } from '@podman-desktop/core-api';
+
 import IconImage from '/@/lib/appearance/IconImage.svelte';
 import ProviderStatus from '/@/lib/ui/ProviderStatus.svelte';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import ProviderLinks from './ProviderLinks.svelte';
 

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Spinner } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import Steps from '/@/lib/ui/Steps.svelte';
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderCard from './ProviderCard.svelte';

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
 
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { Spinner } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
-import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';

--- a/packages/renderer/src/lib/dashboard/ProviderDetectionChecksButton.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderDetectionChecksButton.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 import { faList } from '@fortawesome/free-solid-svg-icons';
 import type { ProviderDetectionCheck } from '@podman-desktop/api';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
-
-import type { ProviderInfo } from '/@api/provider-info';
 
 export let provider: ProviderInfo;
 export let onDetectionChecks = (_detectionChecks: ProviderDetectionCheck[]): void => {};

--- a/packages/renderer/src/lib/dashboard/ProviderInstallationButton.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstallationButton.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import { faRocket } from '@fortawesome/free-solid-svg-icons';
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
-
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 export let provider: ProviderInfo;
 

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -18,13 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { type InitializationContext, InitializeAndStartMode } from '/@/lib/dashboard/ProviderInitUtils';
 import ProviderInstalled from '/@/lib/dashboard/ProviderInstalled.svelte';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
 
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { Spinner } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
@@ -8,8 +10,6 @@ import { onDestroy, onMount } from 'svelte';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import Steps from '/@/lib/ui/Steps.svelte';
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
-import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderCard from './ProviderCard.svelte';

--- a/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderLinks.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { Link } from '@podman-desktop/ui-svelte';
-
-import type { ProviderInfo } from '/@api/provider-info';
 
 export let provider: ProviderInfo;
 </script>

--- a/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderNotInstalled.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import type { ProviderDetectionCheck } from '@podman-desktop/api';
-
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderCard from './ProviderCard.svelte';

--- a/packages/renderer/src/lib/dashboard/ProviderReady.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderReady.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderCard from './ProviderCard.svelte';

--- a/packages/renderer/src/lib/dashboard/ProviderStarting.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderStarting.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ProviderInfo } from '/@api/provider-info';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 
 import ProviderCard from './ProviderCard.svelte';
 

--- a/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
@@ -17,12 +17,12 @@
  ***********************************************************************/
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import { expect, test } from 'vitest';
 
 import { type InitializationContext, InitializeAndStartMode } from '/@/lib/dashboard/ProviderInitUtils';
-import type { ProviderInfo } from '/@api/provider-info';
 
 export async function verifyStatus<
   C extends Component<{ provider: ProviderInfo; initializationContext: InitializationContext }>,

--- a/packages/renderer/src/lib/dashboard/ProviderStopped.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderStopped.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ProviderInfo } from '/@api/provider-info';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 
 import ProviderCard from './ProviderCard.svelte';
 

--- a/packages/renderer/src/lib/dashboard/ProviderUpdateButton.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderUpdateButton.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import { faBoxOpen } from '@fortawesome/free-solid-svg-icons';
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
-
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 export let provider: ProviderInfo;
 let updateInProgress = false;

--- a/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 export let provider: ProviderInfo;
 

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import { faCircleArrowUp } from '@fortawesome/free-solid-svg-icons';
+import type { ReleaseNotes } from '@podman-desktop/core-api';
 import { Button, CloseButton, Link } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import { updateAvailable } from '/@/stores/update-store';
-import type { ReleaseNotes } from '/@api/release-notes-info';
 
 let showBanner = $state(false);
 let notesAvailable = $state(false);

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { CoreV1Event, KubernetesObject, V1Deployment } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -17,7 +18,6 @@ import {
   kubernetesCurrentContextDeployments,
   kubernetesCurrentContextEvents,
 } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
 import { DeploymentUtils } from './deployment-utils';
 import DeploymentActions from './DeploymentActions.svelte';

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1Deployment } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -26,7 +27,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { listenResourcePermitted } from '/@/lib/kube/resource-permission';
 import * as resourcesListen from '/@/lib/kube/resources-listen';
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
 import DeploymentsList from './DeploymentsList.svelte';
 

--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContainerInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -26,7 +27,6 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { commandsInfos } from '/@/stores/commands';
 import { containersInfos } from '/@/stores/containers';
 import { context } from '/@/stores/context';
-import type { ContainerInfo } from '/@api/container-info';
 
 import CommandPalette from './CommandPalette.svelte';
 

--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -8,6 +8,16 @@ import {
   faMagnifyingGlass,
   faTerminal,
 } from '@fortawesome/free-solid-svg-icons';
+import type {
+  CommandInfo,
+  ContainerInfo,
+  DocumentationInfo,
+  GoToInfo,
+  ImageInfo,
+  PodInfo,
+  VolumeInfo,
+} from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { type Component, onMount, tick } from 'svelte';
@@ -26,13 +36,6 @@ import { imagesInfos } from '/@/stores/images';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
 import { podsInfos } from '/@/stores/pods';
 import { volumeListInfos } from '/@/stores/volumes';
-import type { CommandInfo } from '/@api/command-info';
-import type { ContainerInfo } from '/@api/container-info';
-import type { DocumentationInfo, GoToInfo } from '/@api/documentation-info';
-import type { ImageInfo } from '/@api/image-info';
-import { NavigationPage } from '/@api/navigation-page';
-import type { PodInfo } from '/@api/pod-info';
-import type { VolumeInfo } from '/@api/volume-info';
 
 import { createGoToItems, getGoToDisplayText } from './CommandPaletteUtils';
 import TextHighLight from './TextHighLight.svelte';

--- a/packages/renderer/src/lib/dialogs/CommandPaletteUtils.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPaletteUtils.spec.ts
@@ -19,15 +19,11 @@
 import '@testing-library/jest-dom/vitest';
 
 import { faCube, faImage } from '@fortawesome/free-solid-svg-icons';
+import type { ContainerInfo, GoToInfo, ImageInfo, PodInfo, VolumeInfo } from '@podman-desktop/core-api';
 import type { Component } from 'svelte';
 import { describe, expect, test } from 'vitest';
 
 import type { NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
-import type { ContainerInfo } from '/@api/container-info';
-import type { GoToInfo } from '/@api/documentation-info';
-import type { ImageInfo } from '/@api/image-info';
-import type { PodInfo } from '/@api/pod-info';
-import type { VolumeInfo } from '/@api/volume-info';
 
 import { createGoToItems, getGoToDisplayText } from './CommandPaletteUtils';
 

--- a/packages/renderer/src/lib/dialogs/CommandPaletteUtils.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPaletteUtils.ts
@@ -16,6 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type {
+  ContainerInfo,
+  GoToIcon,
+  GoToInfo,
+  ImageInfo,
+  NavigationInfo,
+  PodInfo,
+  VolumeInfo,
+} from '@podman-desktop/core-api';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { get } from 'svelte/store';
 
@@ -24,11 +33,6 @@ import PodIcon from '/@/lib/images/PodIcon.svelte';
 import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
 import { isDark } from '/@/stores/appearance';
 import type { NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
-import type { ContainerInfo } from '/@api/container-info';
-import type { GoToIcon, GoToInfo, NavigationInfo } from '/@api/documentation-info';
-import type { ImageInfo } from '/@api/image-info';
-import type { PodInfo } from '/@api/pod-info';
-import type { VolumeInfo } from '/@api/volume-info';
 
 // Helper function to get short ID (first 12 characters)
 function getShortId(id: string): string {

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import { faCircle, faCircleQuestion } from '@fortawesome/free-regular-svg-icons';
 import { faCircleExclamation, faInfo, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { type ButtonsType, type DropdownType, type IconButtonType } from '@podman-desktop/core-api';
 import { Button, type ButtonType, Dropdown } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy, onMount } from 'svelte';
 
 import Markdown from '/@/lib/markdown/Markdown.svelte';
-import { type ButtonsType, type DropdownType, type IconButtonType } from '/@api/dialog';
 
 import Dialog from './Dialog.svelte';
 import type { MessageBoxOptions } from './messagebox-input';

--- a/packages/renderer/src/lib/dialogs/messagebox-input.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-input.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ButtonsType } from '/@api/dialog';
+import type { ButtonsType } from '@podman-desktop/core-api';
 
 export interface MessageBoxOptions {
   id: number;

--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { EditorSettings } from '@podman-desktop/core-api/editor';
 import type monaco from 'monaco-editor';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
@@ -7,7 +8,6 @@ import type { Unsubscriber } from 'svelte/store';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 import { isDark } from '/@/stores/appearance';
-import { EditorSettings } from '/@api/editor/editor-settings';
 
 let divEl: HTMLDivElement;
 let editor: monaco.editor.IStandaloneCodeEditor;

--- a/packages/renderer/src/lib/explore-features/ExploreFeatureCard.spec.ts
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatureCard.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ExploreFeature } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { ExploreFeature } from '/@api/explore-feature';
 
 import ExploreFeatureCard from './ExploreFeatureCard.svelte';
 

--- a/packages/renderer/src/lib/explore-features/ExploreFeatureCard.svelte
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatureCard.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 import { faCirclePlay, faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+import type { ExploreFeature } from '@podman-desktop/core-api';
 import { Button, CloseButton, Link } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
-
-import type { ExploreFeature } from '/@api/explore-feature';
 
 interface Props {
   feature: ExploreFeature;

--- a/packages/renderer/src/lib/explore-features/ExploreFeatures.spec.ts
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatures.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ExploreFeature } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { exploreFeaturesInfo } from '/@/stores/explore-features';
-import type { ExploreFeature } from '/@api/explore-feature';
 
 import ExploreFeatures from './ExploreFeatures.svelte';
 

--- a/packages/renderer/src/lib/explore-features/ExploreFeatures.svelte
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatures.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { ExploreFeature } from '@podman-desktop/core-api';
 import { Carousel, Expandable } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
@@ -6,7 +7,6 @@ import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import { context } from '/@/stores/context';
 import { exploreFeaturesInfo } from '/@/stores/explore-features';
-import type { ExploreFeature } from '/@api/explore-feature';
 
 import ExploreFeatureCard from './ExploreFeatureCard.svelte';
 

--- a/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.spec.ts
@@ -18,13 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
 import { extensionInfos } from '/@/stores/extensions';
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api';
 
 import EmbeddableCatalogExtensionList from './EmbeddableCatalogExtensionList.svelte';
 

--- a/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -25,7 +26,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { type CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
 import { extensionInfos } from '/@/stores/extensions';
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api';
 
 import ExtensionDetails from './ExtensionDetails.svelte';
 

--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -18,13 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
 import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { type CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 import { catalogExtensionInfos } from '/@/stores/catalog-extensions';
 import { extensionInfos } from '/@/stores/extensions';
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api';
 
 import ExtensionList from './ExtensionList.svelte';
 

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
@@ -18,6 +18,8 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { OnboardingInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -25,8 +27,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { onboardingList } from '/@/stores/onboarding';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
-import type { OnboardingInfo } from '/@api/onboarding';
 
 import InstalledExtensionCardLeftOnboardingAndProperties from './InstalledExtensionCardLeftOnboardingAndProperties.svelte';
 

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.spec.ts
@@ -18,13 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ExtensionInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { extensionDevelopmentFolders } from '/@/stores/extensionDevelopmentFolders';
 import { extensionInfos } from '/@/stores/extensions';
-import type { ExtensionInfo } from '/@api/extension-info';
 
 import DevelopmentExtensionList from './DevelopmentExtensionList.svelte';
 

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionList.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { ExtensionDevelopmentFolderInfo, ExtensionInfo } from '@podman-desktop/core-api';
+import { ExtensionLoaderSettings } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -6,9 +8,6 @@ import type { Unsubscriber } from 'svelte/store';
 import DevelopmentExtensionListTable from '/@/lib/extensions/dev-mode/table/ListTable.svelte';
 import { extensionDevelopmentFolders } from '/@/stores/extensionDevelopmentFolders';
 import { extensionInfos } from '/@/stores/extensions';
-import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info';
-import type { ExtensionInfo } from '/@api/extension-info';
-import { ExtensionLoaderSettings } from '/@api/extension-loader-settings';
 
 import type { SelectableExtensionDevelopmentFolderInfoUI } from './development-folder-info-ui';
 import DevelopmentExtensionEmptyScreen from './DevelopmentExtensionEmptyScreen.svelte';

--- a/packages/renderer/src/lib/extensions/dev-mode/development-folder-info-ui.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/development-folder-info-ui.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info';
+import type { ExtensionDevelopmentFolderInfo } from '@podman-desktop/core-api';
 
 export interface SelectableExtensionDevelopmentFolderInfoUI extends ExtensionDevelopmentFolderInfo {
   selected: boolean;

--- a/packages/renderer/src/lib/extensions/extension-details-ui.ts
+++ b/packages/renderer/src/lib/extensions/extension-details-ui.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ExtensionError } from '@podman-desktop/core-api';
+
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
-import type { ExtensionError } from '/@api/extension-info';
 
 export interface ExtensionDetailsUI {
   displayName: string;

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api';
-import type { FeaturedExtension } from '/@api/featured/featured-api';
 
 import { ExtensionsUtils } from './extensions-utils';
 

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
+
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api';
-import type { FeaturedExtension } from '/@api/featured/featured-api';
 
 import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 import type { ExtensionDetailsUI } from './extension-details-ui';

--- a/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
@@ -18,11 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { FeaturedExtension as IFeaturedExtension } from '@podman-desktop/core-api/featured';
 import { render, screen } from '@testing-library/svelte';
 import { describe, expect, test } from 'vitest';
 
 import FeaturedExtension from '/@/lib/featured/FeaturedExtension.svelte';
-import type { FeaturedExtension as IFeaturedExtension } from '/@api/featured/featured-api';
 
 const fetchableFeaturedExtension: IFeaturedExtension = {
   builtin: true,

--- a/packages/renderer/src/lib/featured/FeaturedExtension.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import { faCheckCircle, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
-
-import type { FeaturedExtension } from '/@api/featured/featured-api';
 
 import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
 

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { FeaturedExtension } from '/@api/featured/featured-api';
 
 import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
 

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 import { render, screen } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { featuredExtensionInfos } from '/@/stores/featuredExtensions';
-import type { FeaturedExtension } from '/@api/featured/featured-api';
 
 import FeaturedExtensions from './FeaturedExtensions.svelte';
 

--- a/packages/renderer/src/lib/feedback/FeedbackForm.spec.ts
+++ b/packages/renderer/src/lib/feedback/FeedbackForm.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { TelemetryMessages } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { expect, test, vi } from 'vitest';
-
-import type { TelemetryMessages } from '/@api/telemetry';
 
 import FeedbackForm from './FeedbackForm.svelte';
 

--- a/packages/renderer/src/lib/feedback/FeedbackForm.svelte
+++ b/packages/renderer/src/lib/feedback/FeedbackForm.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
+import type { TelemetryMessages } from '@podman-desktop/core-api';
 import { Link } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-
-import type { TelemetryMessages } from '/@api/telemetry';
 
 let telemetryMessages: TelemetryMessages;
 

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { FeedbackCategory } from '@podman-desktop/core-api';
 import { CloseButton, Dropdown, Modal } from '@podman-desktop/ui-svelte';
-
-import type { FeedbackCategory } from '/@api/feedback';
 
 import DirectFeedback from './feedbackForms/DirectFeedback.svelte';
 import GitHubIssueFeedback from './feedbackForms/GitHubIssueFeedback.svelte';

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -8,12 +8,12 @@ import {
   faSmile,
   faStar,
 } from '@fortawesome/free-solid-svg-icons';
+import type { DirectFeedbackCategory, FeedbackProperties } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
-import type { DirectFeedbackCategory, FeedbackProperties } from '/@api/feedback';
 
 interface Props {
   onCloseForm: (confirmation: boolean) => void;

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -18,12 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { FeedbackCategory } from '@podman-desktop/core-api';
 import { render, type RenderResult } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { type Component, type ComponentProps } from 'svelte';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { FeedbackCategory } from '/@api/feedback';
 
 import GitHubIssueFeedback from './GitHubIssueFeedback.svelte';
 

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { FeedbackCategory, GitHubIssue } from '@podman-desktop/core-api';
 import { Button, Checkbox, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
-import type { FeedbackCategory, GitHubIssue } from '/@api/feedback';
 
 interface Props {
   onCloseForm: (confirm: boolean) => void;

--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { Dropdown } from '@podman-desktop/ui-svelte';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
@@ -25,7 +26,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
 import ContainerConnectionDropdownTest from '/@/lib/forms/ContainerConnectionDropdownTest.svelte';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 vi.mock('@podman-desktop/ui-svelte');
 

--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdown.svelte
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdown.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { Dropdown } from '@podman-desktop/ui-svelte';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 interface Props {
   connections: ProviderContainerConnectionInfo[];

--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdownTest.spec.ts
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdownTest.spec.ts
@@ -18,11 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { fireEvent, render } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import ContainerConnectionDropdownTest from '/@/lib/forms/ContainerConnectionDropdownTest.svelte';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 const MULTI_CONNECTIONS: ProviderContainerConnectionInfo[] = Array.from({ length: 5 }).map((_, index) => ({
   connectionType: 'container',

--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdownTest.svelte
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdownTest.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
+
 import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 interface Props {
   connections: ProviderContainerConnectionInfo[];

--- a/packages/renderer/src/lib/help/HelpActionsItems.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActionsItems.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { ActionKind, type ItemInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import { ActionKind, type ItemInfo } from '/@api/help-menu';
 
 import HelpActionsItems from './HelpActionsItems.svelte';
 

--- a/packages/renderer/src/lib/help/HelpActionsItems.svelte
+++ b/packages/renderer/src/lib/help/HelpActionsItems.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
+import { ActionKind, type ItemAction, type ItemInfo } from '@podman-desktop/core-api';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
-
-import { ActionKind, type ItemAction, type ItemInfo } from '/@api/help-menu';
 
 import HelpMenu from './HelpMenu.svelte';
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { render, type RenderResult, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { type Component, tick } from 'svelte';
@@ -29,7 +30,6 @@ import BuildImageFromContainerfile from '/@/lib/image/BuildImageFromContainerfil
 import { buildImagesInfo, getNextTaskId } from '/@/stores/build-images';
 import { providerInfos } from '/@/stores/providers';
 import { recommendedRegistries } from '/@/stores/recommendedRegistries';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 // xterm is used in the UI, but not tested, added in order to avoid the multiple warnings being shown during the test.
 vi.mock(import('@xterm/xterm'));

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -3,6 +3,8 @@
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faCube, faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import { type OpenDialogOptions } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
 import { onDestroy } from 'svelte';
 import { get, type Unsubscriber } from 'svelte/store';
@@ -21,8 +23,6 @@ import {
   lastUpdatedTaskId,
 } from '/@/stores/build-images';
 import { providerInfos } from '/@/stores/providers';
-import { NavigationPage } from '/@api/navigation-page';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 import { type BuildImageCallback, disconnectUI, eventCollect, reconnectUI, startBuild } from './build-image-task';
 import BuildImageFromContainerfileCards from './BuildImageFromContainerfileCards.svelte';

--- a/packages/renderer/src/lib/image/FilesystemLayerView.spec.ts
+++ b/packages/renderer/src/lib/image/FilesystemLayerView.spec.ts
@@ -18,10 +18,9 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ImageFile } from '@podman-desktop/api';
+import { FilesystemNode } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
-
-import { FilesystemNode } from '/@api/filesystem-tree';
 
 import FilesystemLayerView from './FilesystemLayerView.svelte';
 

--- a/packages/renderer/src/lib/image/FilesystemLayerView.svelte
+++ b/packages/renderer/src/lib/image/FilesystemLayerView.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import type { ImageFile, ImageFileSymlink } from '@podman-desktop/api';
+import type { FilesystemNode } from '@podman-desktop/core-api';
 import { SvelteMap } from 'svelte/reactivity';
-
-import type { FilesystemNode } from '/@api/filesystem-tree';
 
 import FilesystemLayerView from './FilesystemLayerView.svelte';
 import { ImageUtils } from './image-utils';

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { faArrowUp, faDownload, faEdit, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { Menu } from '@podman-desktop/core-api';
+import { MenuContext } from '@podman-desktop/core-api';
 import { createEventDispatcher, onMount } from 'svelte';
 import { router } from 'tinro';
 
@@ -10,8 +12,6 @@ import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { context } from '/@/stores/context';
 import { runImageInfo } from '/@/stores/run-image-store';
 import { saveImagesInfo } from '/@/stores/save-images-store';
-import type { Menu } from '/@api/menu.js';
-import { MenuContext } from '/@api/menu-context.js';
 
 import ActionsWrapper from './ActionsMenu.svelte';
 import { ImageUtils } from './image-utils';

--- a/packages/renderer/src/lib/image/ImageColumnName.svelte
+++ b/packages/renderer/src/lib/image/ImageColumnName.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
+
 import Badge from '/@/lib/ui/Badge.svelte';
 import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
 
 import type { ImageInfoUI } from './ImageInfoUI';
 

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContainerInfo, ImageInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
@@ -36,8 +37,6 @@ import { containersInfos } from '/@/stores/containers';
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
 import { imagesInfos } from '/@/stores/images';
 import { viewsContributions } from '/@/stores/views';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ImageInfo } from '/@api/image-info';
 
 import ImageDetails from './ImageDetails.svelte';
 

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ImageInfo } from '@podman-desktop/api';
+import type { ViewInfoUI } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
@@ -19,7 +20,6 @@ import { imageCheckerProviders } from '/@/stores/image-checker-providers';
 import { imageFilesProviders } from '/@/stores/image-files-providers';
 import { imagesInfos } from '/@/stores/images';
 import { viewsContributions } from '/@/stores/views';
-import type { ViewInfoUI } from '/@api/view-info';
 
 import { ImageUtils } from './image-utils';
 import ImageActions from './ImageActions.svelte';

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faStethoscope } from '@fortawesome/free-solid-svg-icons';
 import type { ImageInfo } from '@podman-desktop/api';
+import type { ImageCheckerInfo } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy, onMount } from 'svelte';
@@ -9,7 +10,6 @@ import type { Unsubscriber } from 'svelte/store';
 import type { CheckUI, ProviderUI } from '/@/lib/ui/ProviderResultPage';
 import ProviderResultPage from '/@/lib/ui/ProviderResultPage.svelte';
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
-import type { ImageCheckerInfo } from '/@api/image-checker-info';
 
 const orderStatus = ['failed', 'success'];
 const orderSeverity = ['critical', 'high', 'medium', 'low', undefined];

--- a/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFiles.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 import type { ImageInfo } from '@podman-desktop/api';
+import type { ImageFilesInfo, ImageFilesystemLayersUI, ImageFilesystemLayerUI } from '@podman-desktop/core-api';
 import { Button, Checkbox } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
 import { imageFilesProviders } from '/@/stores/image-files-providers';
-import type { ImageFilesInfo } from '/@api/image-files-info';
-import type { ImageFilesystemLayersUI, ImageFilesystemLayerUI } from '/@api/image-filesystem-layers';
 
 import FilesystemLayerView from './FilesystemLayerView.svelte';
 import ImageDetailsFilesLayers from './ImageDetailsFilesLayers.svelte';

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ImageFilesystemLayerUI } from '@podman-desktop/core-api';
 import { render, screen, within } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
-
-import type { ImageFilesystemLayerUI } from '/@api/image-filesystem-layers';
 
 import { signedHumanSize } from './ImageDetailsFilesLayers';
 import ImageDetailsFilesLayers from './ImageDetailsFilesLayers.svelte';

--- a/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsFilesLayers.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { ImageFilesystemLayerUI } from '@podman-desktop/core-api';
 import { createEventDispatcher } from 'svelte';
-
-import type { ImageFilesystemLayerUI } from '/@api/image-filesystem-layers';
 
 import { ImageUtils } from './image-utils';
 import ImageDetailsFilesExpandableCommand from './ImageDetailsFilesExpandableCommand.svelte';

--- a/packages/renderer/src/lib/image/ImageDetailsInspect.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsInspect.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { ImageInspectInfo } from '@podman-desktop/core-api';
 import { onMount } from 'svelte';
 
 import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
-import type { ImageInspectInfo } from '/@api/image-inspect-info';
 
 import type { ImageInfoUI } from './ImageInfoUI';
 

--- a/packages/renderer/src/lib/image/ImageEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/image/ImageEmptyScreen.spec.ts
@@ -19,12 +19,12 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import ImageEmptyScreen from './ImageEmptyScreen.svelte';
 

--- a/packages/renderer/src/lib/image/ImageInfoUI.ts
+++ b/packages/renderer/src/lib/image/ImageInfoUI.ts
@@ -17,9 +17,8 @@
  ***********************************************************************/
 
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import type { ViewContributionBadgeValue } from '@podman-desktop/core-api';
 import type { Component } from 'svelte';
-
-import type { ViewContributionBadgeValue } from '/@api/view-info';
 
 export interface ImageInfoUI {
   id: string;

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ImageInfo } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 /* eslint-disable import/no-duplicates */
@@ -32,7 +33,6 @@ import { IMAGE_LIST_VIEW_BADGES, IMAGE_LIST_VIEW_ICONS, IMAGE_VIEW_BADGES, IMAGE
 import { imagesInfos } from '/@/stores/images';
 import { providerInfos } from '/@/stores/providers';
 import { viewsContributions } from '/@/stores/views';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import ImagesList from './ImagesList.svelte';
 

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faArrowCircleDown, faCube, faDownload, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
+import type { ContainerInfo, ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
 import {
   Button,
   FilteredEmptyScreen,
@@ -28,9 +29,6 @@ import { filtered, imagesInfos, searchPattern } from '/@/stores/images';
 import { providerInfos } from '/@/stores/providers';
 import { saveImagesInfo } from '/@/stores/save-images-store';
 import { viewsContributions } from '/@/stores/views';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ImageInfo } from '/@api/image-info';
-import type { ViewInfoUI } from '/@api/view-info';
 
 import { ImageUtils } from './image-utils';
 import ImageColumnActions from './ImageColumnActions.svelte';

--- a/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
+++ b/packages/renderer/src/lib/image/ImportContainersImages.spec.ts
@@ -19,13 +19,13 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import ImportContainersImages from './ImportContainersImages.svelte';
 

--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -2,6 +2,7 @@
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { get } from 'svelte/store';
@@ -10,7 +11,6 @@ import { router } from 'tinro';
 import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 let containersToImport: { imagePath: string; nameWhenImporting: string }[] = $state([]);
 let importError: string = $state('');

--- a/packages/renderer/src/lib/image/LoadImages.spec.ts
+++ b/packages/renderer/src/lib/image/LoadImages.spec.ts
@@ -19,13 +19,13 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import LoadImages from './LoadImages.svelte';
 

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -2,6 +2,7 @@
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { get } from 'svelte/store';
@@ -10,7 +11,6 @@ import { router } from 'tinro';
 import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 let archivesToLoad = $state<string[]>([]);
 let loadError = $state<string>('');

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -18,6 +18,8 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import { PreferredRegistriesSettings } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -26,8 +28,6 @@ import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vi
 
 import { providerInfos } from '/@/stores/providers';
 import { recommendedRegistries } from '/@/stores/recommendedRegistries';
-import { PreferredRegistriesSettings } from '/@api/prefered-registries-info';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import PullImage from './PullImage.svelte';
 

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { faArrowCircleDown, faCog, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import type { ImageSearchOptions, ProviderContainerConnectionInfo, PullEvent } from '@podman-desktop/core-api';
+import { PreferredRegistriesSettings } from '@podman-desktop/core-api';
 import { Button, Checkbox, ErrorMessage, Link, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import type { Terminal } from '@xterm/xterm';
@@ -14,10 +16,6 @@ import type { TypeaheadItem } from '/@/lib/ui/Typeahead';
 import Typeahead from '/@/lib/ui/Typeahead.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { providerInfos } from '/@/stores/providers';
-import type { ImageSearchOptions } from '/@api/image-registry';
-import { PreferredRegistriesSettings } from '/@api/prefered-registries-info';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
-import type { PullEvent } from '/@api/pull-event';
 
 import RecommendedRegistry from './RecommendedRegistry.svelte';
 

--- a/packages/renderer/src/lib/image/PushImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushImageModal.spec.ts
@@ -18,12 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ImageInspectInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { Terminal } from '@xterm/xterm';
 import { tick } from 'svelte';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ImageInspectInfo } from '/@api/image-inspect-info';
 
 import type { ImageInfoUI } from './ImageInfoUI';
 import PushImageModal from './PushImageModal.svelte';

--- a/packages/renderer/src/lib/image/RecommendedRegistry.svelte
+++ b/packages/renderer/src/lib/image/RecommendedRegistry.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 
 import FeaturedExtensionDownload from '/@/lib/featured/FeaturedExtensionDownload.svelte';
 import { handleNavigation } from '/@/navigation';
 import { recommendedRegistries } from '/@/stores/recommendedRegistries';
-import { NavigationPage } from '/@api/navigation-page';
 
 interface Props {
   imageError?: string;

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ImageInspectInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -28,7 +29,6 @@ import RunImage from '/@/lib/image/RunImage.svelte';
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
 import { mockBreadcrumb } from '/@/stores/breadcrumb.spec';
 import { runImageInfo } from '/@/stores/run-image-store';
-import type { ImageInspectInfo } from '/@api/image-inspect-info';
 
 const originalConsoleDebug = console.debug;
 

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
 import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import type { OpenDialogOptions } from '@podman-desktop/api';
+import type {
+  ContainerCreateOptions,
+  DeviceMapping,
+  HostConfig,
+  HostConfigPortBinding,
+  ImageInspectInfo,
+  NetworkInspectInfo,
+} from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, Checkbox, Dropdown, ErrorMessage, Input, NumberInput, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
@@ -16,10 +25,6 @@ import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { containersInfos } from '/@/stores/containers';
 import { runImageInfo } from '/@/stores/run-image-store';
-import type { ContainerCreateOptions, DeviceMapping, HostConfig, HostConfigPortBinding } from '/@api/container-info';
-import type { ImageInspectInfo } from '/@api/image-inspect-info';
-import { NavigationPage } from '/@api/navigation-page';
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 interface PortInfo {
   port: string;

--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -16,12 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContainerInfo, ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ImageInfo } from '/@api/image-info';
-import type { ViewInfoUI } from '/@api/view-info';
 
 import { ImageUtils } from './image-utils';
 

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -16,6 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import {
+  type ContainerInfo,
+  type ImageInfo,
+  isViewContributionBadge,
+  isViewContributionIcon,
+  type ViewContributionBadgeValue,
+  type ViewInfoUI,
+} from '@podman-desktop/core-api';
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import { Buffer } from 'buffer';
 import { filesize } from 'filesize';
@@ -26,14 +34,6 @@ import type { ContextUI } from '/@/lib/context/context';
 import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
 import ManifestIcon from '/@/lib/images/ManifestIcon.svelte';
-import type { ContainerInfo } from '/@api/container-info';
-import type { ImageInfo } from '/@api/image-info';
-import {
-  isViewContributionBadge,
-  isViewContributionIcon,
-  type ViewContributionBadgeValue,
-  type ViewInfoUI,
-} from '/@api/view-info';
 
 import type { ImageInfoUI } from './ImageInfoUI';
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject, V1Ingress } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -14,7 +15,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextIngresses } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable';
 
 import { IngressRouteUtils } from './ingress-route-utils';
 import IngressRouteActions from './IngressRouteActions.svelte';

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.spec.ts
@@ -19,10 +19,9 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { V1Ingress } from '@kubernetes/client-node';
+import type { V1Route } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { V1Route } from '/@api/openshift-types';
 
 import IngressRouteDetailsSummary from './IngressRouteDetailsSummary.svelte';
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { V1Ingress } from '@kubernetes/client-node';
+import type { V1Route } from '@podman-desktop/core-api';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 
 import Table from '/@/lib/details/DetailsTable.svelte';
@@ -7,7 +8,6 @@ import KubeIngressArtifact from '/@/lib/kube/details/KubeIngressArtifact.svelte'
 import KubeIngressStatusArtifact from '/@/lib/kube/details/KubeIngressStatusArtifact.svelte';
 import KubeObjectMetaArtifact from '/@/lib/kube/details/KubeObjectMetaArtifact.svelte';
 import OpenshiftRouteArtifact from '/@/lib/kube/details/OpenshiftRouteArtifact.svelte';
-import type { V1Route } from '/@api/openshift-types';
 
 export let ingressRoute: V1Ingress | V1Route | undefined;
 export let kubeError: string | undefined = undefined;

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -19,12 +19,12 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1Ingress } from '@kubernetes/client-node';
+import type { V1Route } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { readable, writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { V1Route } from '/@api/openshift-types';
 
 import IngressesRoutesList from './IngressesRoutesList.svelte';
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { type KubernetesObject } from '@kubernetes/client-node';
+import type { V1Route } from '@podman-desktop/core-api';
 import { TableColumn, TableDurationColumn, TableRow } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
 
@@ -13,7 +14,6 @@ import {
   kubernetesCurrentContextRoutesFiltered,
   routeSearchPattern,
 } from '/@/stores/kubernetes-contexts-state';
-import type { V1Route } from '/@api/openshift-types';
 
 import ActionsColumn from './columns/Actions.svelte';
 import BackendColumn from './columns/Backend.svelte';

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { V1Route } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -31,7 +32,6 @@ import {
 } from '/@/lib/kube/tests-helpers/init-lists';
 import { lastPage } from '/@/stores/breadcrumb';
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { V1Route } from '/@api/openshift-types';
 
 import RouteDetails from './RouteDetails.svelte';
 

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { IDisposable, V1Route } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -14,8 +15,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextRoutes } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable';
-import type { V1Route } from '/@api/openshift-types';
 
 import { IngressRouteUtils } from './ingress-route-utils';
 import IngressRouteActions from './IngressRouteActions.svelte';

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.spec.ts
@@ -17,9 +17,8 @@
  ***********************************************************************/
 
 import type { V1Ingress } from '@kubernetes/client-node';
+import type { V1Route } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { V1Route } from '/@api/openshift-types';
 
 import { IngressRouteUtils } from './ingress-route-utils';
 import type { IngressUI } from './IngressUI';

--- a/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
+++ b/packages/renderer/src/lib/ingresses-routes/ingress-route-utils.ts
@@ -17,8 +17,7 @@
  ***********************************************************************/
 
 import type { V1Ingress } from '@kubernetes/client-node';
-
-import type { V1Route } from '/@api/openshift-types';
+import type { V1Route } from '@podman-desktop/core-api';
 
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';

--- a/packages/renderer/src/lib/job/JobDetails.svelte
+++ b/packages/renderer/src/lib/job/JobDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject, V1Job } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -14,7 +15,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextJobs } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable';
 
 import { JobUtils } from './job-utils';
 import JobActions from './JobActions.svelte';

--- a/packages/renderer/src/lib/job/JobList.spec.ts
+++ b/packages/renderer/src/lib/job/JobList.spec.ts
@@ -19,13 +19,13 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1Job } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as resourcesListen from '/@/lib/kube/resources-listen';
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
 import JobList from './JobList.svelte';
 

--- a/packages/renderer/src/lib/kube/KubeContextUI.ts
+++ b/packages/renderer/src/lib/kube/KubeContextUI.ts
@@ -17,8 +17,7 @@
  ***********************************************************************/
 
 import type { Context } from '@kubernetes/client-node';
-
-import type { KubeContext } from '/@api/kubernetes-context';
+import type { KubeContext } from '@podman-desktop/core-api';
 
 import { kubernetesIconBase64 } from './KubeIcon';
 

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -19,14 +19,14 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import type { PlayKubeInfo } from '@podman-desktop/core-api/libpod';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { PlayKubeInfo } from '/@api/libpod/libpod';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import KubePlayYAML from './KubePlayYAML.svelte';
 

--- a/packages/renderer/src/lib/kube/KubePlayYAML.svelte
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import type { OpenDialogOptions } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, Checkbox, ErrorMessage } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
@@ -13,8 +15,6 @@ import FileInput from '/@/lib/ui/FileInput.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { handleNavigation } from '/@/navigation';
 import { providerInfos } from '/@/stores/providers';
-import { NavigationPage } from '/@api/navigation-page';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 let runStarted = $state(false);
 let runFinished = $state(false);

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1Deployment } from '@kubernetes/client-node';
+import type { ContextGeneralState, ContextPermission, KubeContext, ResourceCount } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { readable, writable } from 'svelte/store';
@@ -31,10 +32,6 @@ import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import * as kubernetesExperimental from '/@/stores/kubernetes-experimental';
 import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
 import * as kubernetesReourcesCount from '/@/stores/kubernetes-resources-count';
-import type { KubeContext } from '/@api/kubernetes-context';
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
-import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
 import KubernetesDashboard from './KubernetesDashboard.svelte';
 import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { IDisposable, ResourceCount } from '@podman-desktop/core-api';
 import { Expandable, Link } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
@@ -24,8 +25,6 @@ import {
 import { isKubernetesExperimentalModeStore } from '/@/stores/kubernetes-experimental';
 import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
-import type { IDisposable } from '/@api/disposable';
-import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
 import deployAndTestKubernetesImage from './DeployAndTestKubernetes.png';
 import KubernetesDashboardGuideCard from './KubernetesDashboardGuideCard.svelte';

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { router } from 'tinro';
 import { expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import KubernetesEmptyPage from './KubernetesEmptyPage.svelte';
 

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { Button, Link } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
@@ -9,7 +10,6 @@ import EmbeddableCatalogExtensionList from '/@/lib/extensions/EmbeddableCatalogE
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 const kubernetesExternalDocs = 'https://podman-desktop.io/docs/kubernetes';
 

--- a/packages/renderer/src/lib/kube/KubernetesEmptyScreen.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyScreen.svelte
@@ -1,4 +1,5 @@
 <script lang='ts'>
+import type { IDisposable } from '@podman-desktop/core-api';
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import type { ComponentProps } from 'svelte';
 import { onDestroy, onMount } from 'svelte';
@@ -6,7 +7,6 @@ import { SvelteMap } from 'svelte/reactivity';
 
 import { listenResourcePermitted } from '/@/lib/kube/resource-permission';
 import KubernetesCheckConnection from '/@/lib/ui/KubernetesCheckConnection.svelte';
-import type { IDisposable } from '/@api/disposable';
 
 interface Props extends ComponentProps<EmptyScreen> {
   resources: string[];

--- a/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
@@ -19,12 +19,12 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { V1NamespaceList } from '@kubernetes/client-node';
+import type { ContextGeneralState } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import * as kubernetesContextsStateStore from '/@/stores/kubernetes-contexts-state';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import NamespaceDropdown from './NamespaceDropdown.svelte';
 

--- a/packages/renderer/src/lib/kube/active-resources-count-listen.ts
+++ b/packages/renderer/src/lib/kube/active-resources-count-listen.ts
@@ -16,8 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IDisposable } from '/@api/disposable.js';
-import type { ResourceCount } from '/@api/kubernetes-resource-count';
+import type { IDisposable, ResourceCount } from '@podman-desktop/core-api';
 
 // listenActiveResourcesCount listens the count of active resources
 export async function listenActiveResourcesCount(

--- a/packages/renderer/src/lib/kube/details/KubeContainerArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeContainerArtifact.spec.ts
@@ -19,12 +19,12 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { V1Container } from '@kubernetes/client-node';
+import { WorkloadKind } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state'; // Adjust the import path as necessary
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import KubeContainerArtifact from './KubeContainerArtifact.svelte';
 

--- a/packages/renderer/src/lib/kube/details/KubeContainerArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeContainerArtifact.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { V1Container } from '@kubernetes/client-node';
+import type { WorkloadKind } from '@podman-desktop/core-api';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
-import type { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import KubePortsList from './KubePortsList.svelte';
 

--- a/packages/renderer/src/lib/kube/details/KubeDeploymentArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeDeploymentArtifact.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import type { V1DeploymentSpec } from '@kubernetes/client-node';
+import { WorkloadKind } from '@podman-desktop/core-api';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import Container from './KubeContainerArtifact.svelte';
 

--- a/packages/renderer/src/lib/kube/details/KubePodSpecArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePodSpecArtifact.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import type { V1PodSpec } from '@kubernetes/client-node';
+import { WorkloadKind } from '@podman-desktop/core-api';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import Subtitle from '/@/lib/details/DetailsSubtitle.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import Container from './KubeContainerArtifact.svelte';
 import Volume from './KubeVolumeArtifact.svelte';

--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { type ForwardConfig, WorkloadKind } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import KubePort from './KubePort.svelte';
 

--- a/packages/renderer/src/lib/kube/details/KubePort.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePort.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import { faQuestionCircle, faSquareUpRight, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { ForwardConfig, PortMapping, WorkloadKind } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import CopyToClipboard from '/@/lib/ui/CopyToClipboard.svelte';
-import type { ForwardConfig, PortMapping, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import type { KubePortInfo } from './kube-port';
 

--- a/packages/renderer/src/lib/kube/details/KubePortsList.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePortsList.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { WorkloadKind } from '@podman-desktop/core-api';
 import { render, within } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import KubePortsList from './KubePortsList.svelte';
 

--- a/packages/renderer/src/lib/kube/details/KubePortsList.svelte
+++ b/packages/renderer/src/lib/kube/details/KubePortsList.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+import type { ForwardConfig, WorkloadKind } from '@podman-desktop/core-api';
+
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import { kubernetesCurrentContextPortForwards } from '/@/stores/kubernetes-contexts-state';
-import type { ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import type { KubePortInfo } from './kube-port';
 import KubePort from './KubePort.svelte';

--- a/packages/renderer/src/lib/kube/details/KubeServiceArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeServiceArtifact.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import type { V1ServiceSpec } from '@kubernetes/client-node';
+import { WorkloadKind } from '@podman-desktop/core-api';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
 import KubePorts from '/@/lib/kube/details/KubePortsList.svelte';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 interface Props {
   artifact?: V1ServiceSpec;

--- a/packages/renderer/src/lib/kube/details/OpenshiftRouteArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/OpenshiftRouteArtifact.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { V1Route } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
-
-import type { V1Route } from '/@api/openshift-types';
 
 import OpenshiftRouteArtifact from './OpenshiftRouteArtifact.svelte';
 

--- a/packages/renderer/src/lib/kube/details/OpenshiftRouteArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/OpenshiftRouteArtifact.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { V1Route } from '@podman-desktop/core-api';
 import { Link } from '@podman-desktop/ui-svelte';
 
 import Cell from '/@/lib/details/DetailsCell.svelte';
 import Title from '/@/lib/details/DetailsTitle.svelte';
-import type { V1Route } from '/@api/openshift-types';
 
 // Assuming V1Route type is imported or defined elsewhere
 export let artifact: V1Route | undefined;

--- a/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
@@ -18,11 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { V1Route } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import type { PodInfoContainerUI } from '/@/lib/pod/PodInfoUI';
-import type { V1Route } from '/@api/openshift-types';
 
 import PodActions from './PodActions.svelte';
 import type { PodUI } from './PodUI';

--- a/packages/renderer/src/lib/kube/pods/PodDetails.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { CoreV1Event, KubernetesObject, V1Pod } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -15,7 +16,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextEvents, kubernetesCurrentContextPods } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable';
 
 import KubernetesTerminalBrowser from './KubernetesTerminalBrowser.svelte';
 import { PodUtils } from './pod-utils';

--- a/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
@@ -19,13 +19,13 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject, V1Pod } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as resourcesListen from '/@/lib/kube/resources-listen';
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
 import PodsList from './PodsList.svelte';
 

--- a/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { FitAddon } from '@xterm/addon-fit';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { type IDisposable, Terminal } from '@xterm/xterm';
@@ -7,7 +8,6 @@ import { router } from 'tinro';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
-import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 export let podName: string;
 export let containerName: string;

--- a/packages/renderer/src/lib/kube/resource-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/resource-listen.spec.ts
@@ -17,10 +17,9 @@
  ***********************************************************************/
 
 import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { IDisposable } from '/@api/disposable.js';
 
 import { listenResource } from './resource-listen';
 import * as resourcesListen from './resources-listen';

--- a/packages/renderer/src/lib/kube/resource-listen.ts
+++ b/packages/renderer/src/lib/kube/resource-listen.ts
@@ -17,9 +17,8 @@
  ***********************************************************************/
 
 import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import type { Readable, Unsubscriber } from 'svelte/store';
-
-import type { IDisposable } from '/@api/disposable.js';
 
 import { isKubernetesExperimentalMode, listenResources } from './resources-listen';
 

--- a/packages/renderer/src/lib/kube/resource-permission.spec.ts
+++ b/packages/renderer/src/lib/kube/resource-permission.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { KubeContext } from '@podman-desktop/core-api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { kubernetesContextsPermissions } from '/@/stores/kubernetes-context-permission';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
-import type { KubeContext } from '/@api/kubernetes-context';
 
 import { listenResourcePermitted } from './resource-permission';
 

--- a/packages/renderer/src/lib/kube/resource-permission.ts
+++ b/packages/renderer/src/lib/kube/resource-permission.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContextPermission, IDisposable } from '@podman-desktop/core-api';
+
 import { kubernetesContextsPermissions } from '/@/stores/kubernetes-context-permission';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
-import type { IDisposable } from '/@api/disposable';
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
 
 export async function listenResourcePermitted(
   resourceName: string,

--- a/packages/renderer/src/lib/kube/resources-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.spec.ts
@@ -17,11 +17,11 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { KubernetesContextResources } from '@podman-desktop/core-api';
 import { writable } from 'svelte/store';
 import { beforeAll, expect, type Mock, test, vi } from 'vitest';
 
 import * as contexts from '/@/stores/kubernetes-contexts';
-import type { KubernetesContextResources } from '/@api/kubernetes-resources';
 
 import { listenResources } from './resources-listen';
 

--- a/packages/renderer/src/lib/kube/resources-listen.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.ts
@@ -17,11 +17,11 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import type { Unsubscriber, Writable } from 'svelte/store';
 
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import { findMatchInLeaves } from '/@/stores/search-util';
-import type { IDisposable } from '/@api/disposable.js';
 
 export interface ListenResourcesOptions {
   searchTermStore?: Writable<string>;

--- a/packages/renderer/src/lib/kube/tests-helpers/init-lists.ts
+++ b/packages/renderer/src/lib/kube/tests-helpers/init-lists.ts
@@ -17,11 +17,11 @@
  ***********************************************************************/
 
 import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
 import { vi } from 'vitest';
 
 import { listenResources } from '/@/lib/kube/resources-listen';
-import type { IDisposable } from '/@api/disposable';
 
 export type initListsReturnType = {
   updateResources: (objects: KubernetesObject[]) => void;

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -18,13 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { type ForwardConfig, WorkloadKind } from '@podman-desktop/core-api';
 import { fireEvent, render } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import PortForwardActions from '/@/lib/kubernetes-port-forward/PortForwardActions.svelte';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
-import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
 

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import { faSquareUpRight, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { type ForwardConfig } from '@podman-desktop/core-api';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 import { kubernetesCurrentContextPortForwards } from '/@/stores/kubernetes-contexts-state';
-import { type ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 interface Props {
   object: ForwardConfig;

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardIcon.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardIcon.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { ForwardConfig } from '@podman-desktop/core-api';
 import { StatusIcon } from '@podman-desktop/ui-svelte';
-
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import EthernetIcon from './EthernetIcon.svelte';
 

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
@@ -19,12 +19,12 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { KubernetesObject } from '@kubernetes/client-node';
+import { type PortMapping, WorkloadKind } from '@podman-desktop/core-api';
 import { fireEvent, render } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as store from '/@/stores/kubernetes-contexts-state'; // Adjust the import path as necessary
-import { type PortMapping, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import PodNameColumn from './PortForwardNameColumn.svelte';
 

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 import type { KubernetesObject } from '@kubernetes/client-node';
+import { type ForwardConfig, WorkloadKind } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 
 import { kubernetesCurrentContextPods } from '/@/stores/kubernetes-contexts-state';
-import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 interface Props {
   object: ForwardConfig;

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { type ForwardConfig, WorkloadKind } from '@podman-desktop/core-api';
 import { fireEvent, render, within } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
-import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import PortForwardList from './PortForwardingList.svelte';
 

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { faEthernet } from '@fortawesome/free-solid-svg-icons';
+import type { ForwardConfig, WorkloadKind } from '@podman-desktop/core-api';
 import { EmptyScreen, NavPage, Table, TableColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
 
 import PortForwardActions from '/@/lib/kubernetes-port-forward/PortForwardActions.svelte';
 import PortForwardIcon from '/@/lib/kubernetes-port-forward/PortForwardIcon.svelte';
 import { kubernetesCurrentContextPortForwards } from '/@/stores/kubernetes-contexts-state';
-import type { ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model';
 
 import PodNameColumn from './PortForwardNameColumn.svelte';
 

--- a/packages/renderer/src/lib/learning-center/GuideCard.svelte
+++ b/packages/renderer/src/lib/learning-center/GuideCard.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { Guide } from '@podman-desktop/core-api/learning-center';
 import { Button } from '@podman-desktop/ui-svelte';
-
-import type { Guide } from '/@api/learning-center/guide';
 
 interface Props {
   guide: Guide;

--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { Guide } from '@podman-desktop/core-api/learning-center';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-
-import type { Guide } from '/@api/learning-center/guide';
 
 import LearningCenter from './LearningCenter.svelte';
 

--- a/packages/renderer/src/lib/learning-center/LearningCenter.svelte
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { Guide } from '@podman-desktop/core-api/learning-center';
 import { Carousel, Expandable } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
-import type { Guide } from '/@api/learning-center/guide';
 
 import GuideCard from './GuideCard.svelte';
 

--- a/packages/renderer/src/lib/manifest/ManifestDetails.spec.ts
+++ b/packages/renderer/src/lib/manifest/ManifestDetails.spec.ts
@@ -18,11 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ImageInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { imagesInfos } from '/@/stores/images';
-import type { ImageInfo } from '/@api/image-info';
 
 import ManifestDetails from './ManifestDetails.svelte';
 

--- a/packages/renderer/src/lib/manifest/ManifestDetails.svelte
+++ b/packages/renderer/src/lib/manifest/ManifestDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ImageInfo } from '@podman-desktop/api';
+import type { ViewInfoUI } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
@@ -15,7 +16,6 @@ import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { containersInfos } from '/@/stores/containers';
 import { imagesInfos } from '/@/stores/images';
-import type { ViewInfoUI } from '/@api/view-info';
 
 interface Props {
   imageID: string;

--- a/packages/renderer/src/lib/network/CreateNetwork.spec.ts
+++ b/packages/renderer/src/lib/network/CreateNetwork.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { NetworkInspectInfo, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
@@ -28,8 +29,6 @@ import CreateNetwork from '/@/lib/network/CreateNetwork.svelte';
 import { mockBreadcrumb } from '/@/stores/breadcrumb.spec';
 import { networksListInfo } from '/@/stores/networks';
 import { providerInfos } from '/@/stores/providers';
-import type { NetworkInspectInfo } from '/@api/network-info';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/network/CreateNetwork.svelte
+++ b/packages/renderer/src/lib/network/CreateNetwork.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
 import { faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import type {
+  NetworkCreateFormInfo,
+  NetworkCreateOptions,
+  ProviderContainerConnectionInfo,
+} from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, Checkbox, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
@@ -13,9 +19,6 @@ import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { networksListInfo } from '/@/stores/networks';
 import { providerInfos } from '/@/stores/providers';
-import type { NetworkCreateFormInfo, NetworkCreateOptions } from '/@api/container-info';
-import { NavigationPage } from '/@api/navigation-page';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 let networkInfo: NetworkCreateFormInfo = $state({
   networkName: '',

--- a/packages/renderer/src/lib/network/NetworkDetails.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkDetails.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { NetworkInspectInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
@@ -25,7 +26,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import { networksListInfo } from '/@/stores/networks';
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 import NetworkDetails from './NetworkDetails.svelte';
 

--- a/packages/renderer/src/lib/network/NetworkDetailsInspect.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkDetailsInspect.spec.ts
@@ -18,11 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { NetworkInspectInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 import NetworkDetailsInspect from './NetworkDetailsInspect.svelte';
 import type { NetworkInfoUI } from './NetworkInfoUI';

--- a/packages/renderer/src/lib/network/NetworkDetailsInspect.svelte
+++ b/packages/renderer/src/lib/network/NetworkDetailsInspect.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { NetworkInspectInfo } from '@podman-desktop/core-api';
 import { onMount } from 'svelte';
 
 import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 import type { NetworkInfoUI } from './NetworkInfoUI';
 

--- a/packages/renderer/src/lib/network/NetworkDetailsSummary.svelte
+++ b/packages/renderer/src/lib/network/NetworkDetailsSummary.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Link } from '@podman-desktop/ui-svelte';
 
 import DetailsCell from '/@/lib/details/DetailsCell.svelte';
 import DetailsTable from '/@/lib/details/DetailsTable.svelte';
 import DetailsTitle from '/@/lib/details/DetailsTitle.svelte';
 import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
 
 import type { NetworkInfoUI } from './NetworkInfoUI';
 

--- a/packages/renderer/src/lib/network/NetworksList.spec.ts
+++ b/packages/renderer/src/lib/network/NetworksList.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { NetworkInspectInfo, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import type { NetworkContainer } from 'dockerode';
 import { tick } from 'svelte';
@@ -26,8 +27,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { networksListInfo, searchPattern } from '/@/stores/networks';
 import { providerInfos } from '/@/stores/providers';
-import type { NetworkInspectInfo } from '/@api/network-info';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import NetworksList from './NetworksList.svelte';
 

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, FilteredEmptyScreen, NavPage, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 
@@ -9,7 +10,6 @@ import ContainerEngineEnvironmentColumn from '/@/lib/table/columns/ContainerEngi
 import { handleNavigation } from '/@/navigation';
 import { filtered, searchPattern } from '/@/stores/networks';
 import { providerInfos } from '/@/stores/providers';
-import { NavigationPage } from '/@api/navigation-page';
 
 import NetworkColumnDriver from './columns/NetworkColumnDriver.svelte';
 import NetworkColumnId from './columns/NetworkColumnId.svelte';

--- a/packages/renderer/src/lib/network/network-utils.spec.ts
+++ b/packages/renderer/src/lib/network/network-utils.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NetworkInspectInfo } from '@podman-desktop/core-api';
 import type { NetworkContainer } from 'dockerode';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 import { NetworkUtils } from './network-utils';
 

--- a/packages/renderer/src/lib/network/network-utils.ts
+++ b/packages/renderer/src/lib/network/network-utils.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NetworkInspectInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
+
 import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 import type { NetworkContainer, NetworkInfoUI } from './NetworkInfoUI';
 

--- a/packages/renderer/src/lib/node/NodeDetails.svelte
+++ b/packages/renderer/src/lib/node/NodeDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { CoreV1Event, KubernetesObject, V1Node } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -14,7 +15,6 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextEvents, kubernetesCurrentContextNodes } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
 import { NodeUtils } from './node-utils';
 import NodeDetailsSummary from './NodeDetailsSummary.svelte';

--- a/packages/renderer/src/lib/node/NodeEmptyScreen.svelte
+++ b/packages/renderer/src/lib/node/NodeEmptyScreen.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+import type { ContextGeneralState } from '@podman-desktop/core-api';
+
 import NodeIcon from '/@/lib/images/NodeIcon.svelte';
 import KubernetesEmptyScreen from '/@/lib/kube/KubernetesEmptyScreen.svelte';
 import { kubernetesCurrentContextState } from '/@/stores/kubernetes-contexts-state';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 // If the current context is CONNECTED and we are on this empty screen
 // say that you may not have permission to view the nodes on your cluster.

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import type { TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 import { Button, FilteredEmptyScreen, NavPage, Table } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount, type Snippet } from 'svelte';
@@ -11,7 +12,6 @@ import KubeActions from '/@/lib/kube/KubeActions.svelte';
 import NamespaceDropdown from '/@/lib/kube/NamespaceDropdown.svelte';
 import { listenResources } from '/@/lib/kube/resources-listen';
 import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte';
-import type { IDisposable } from '/@api/disposable.js';
 
 import type { KubernetesObjectUI } from './KubernetesObjectUI';
 

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -28,6 +28,7 @@
 <script lang="ts">
 import { faCircleQuestion } from '@fortawesome/free-regular-svg-icons';
 import { faForward } from '@fortawesome/free-solid-svg-icons';
+import type { OnboardingInfo, OnboardingStepItem } from '@podman-desktop/core-api';
 import { Button, Link, Spinner } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy, onMount } from 'svelte';
@@ -39,7 +40,6 @@ import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import { lastPage } from '/@/stores/breadcrumb';
 import { context } from '/@/stores/context';
 import { onboardingList } from '/@/stores/onboarding';
-import type { OnboardingInfo, OnboardingStepItem } from '/@api/onboarding';
 
 import {
   type ActiveOnboardingStep,

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.spec.ts
@@ -17,13 +17,13 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import OnboardingComponent from './OnboardingComponent.svelte';
 

--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
 import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import type { OnboardingEmbeddedComponentType, ProviderInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
 
 import PreferencesConnectionCreationOrEditRendering from '/@/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { providerInfos } from '/@/stores/providers';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
-import type { OnboardingEmbeddedComponentType } from '/@api/onboarding';
-import type { ProviderInfo } from '/@api/provider-info';
 
 export let component: OnboardingEmbeddedComponentType;
 export let extensionId: string;

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.spec.ts
@@ -17,14 +17,14 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
+import type { OnboardingStepItem } from '@podman-desktop/core-api';
+import { CONFIGURATION_ONBOARDING_SCOPE } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { context } from '/@/stores/context';
-import { CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
-import type { OnboardingStepItem } from '/@api/onboarding';
 
 import OnboardingItem from './OnboardingItem.svelte';
 

--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import type { OnboardingStepItem } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import { CONFIGURATION_ONBOARDING_SCOPE } from '@podman-desktop/core-api/configuration';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
@@ -8,9 +11,6 @@ import PreferencesRenderingItem from '/@/lib/preferences/PreferencesRenderingIte
 import { isTargetScope } from '/@/lib/preferences/Util';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { context } from '/@/stores/context';
-import { CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import type { OnboardingStepItem } from '/@api/onboarding';
 
 import { replaceContextKeyPlaceholders, replaceContextKeyPlaceHoldersByRegex } from './onboarding-utils';
 

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.spec.ts
@@ -17,11 +17,11 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
+import type { OnboardingInfo, OnboardingStep } from '@podman-desktop/core-api';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
 import { ContextKeyExpr, type ContextKeyExpression } from '/@/lib/context/contextKey';
-import type { OnboardingInfo, OnboardingStep } from '/@api/onboarding';
 
 import {
   type ActiveOnboardingStep,

--- a/packages/renderer/src/lib/onboarding/onboarding-utils.ts
+++ b/packages/renderer/src/lib/onboarding/onboarding-utils.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { OnboardingInfo, OnboardingStatus, OnboardingStep } from '@podman-desktop/core-api';
+
 import type { ContextUI } from '/@/lib/context/context';
 import { ContextKeyExpr } from '/@/lib/context/contextKey';
-import type { OnboardingInfo, OnboardingStatus, OnboardingStep } from '/@api/onboarding';
 
 const SCOPE_ONBOARDING = 'onboarding';
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { V1Pod } from '@kubernetes/client-node';
+import type { SimpleContainerInfo, V1Route } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import * as jsYaml from 'js-yaml';
@@ -27,8 +28,6 @@ import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
-import type { SimpleContainerInfo } from '/@api/container-info';
-import type { V1Route } from '/@api/openshift-types';
 
 import DeployPodToKube from './DeployPodToKube.svelte';
 

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faExternalLink, faRocket } from '@fortawesome/free-solid-svg-icons';
 import type { V1NamespaceList, V1Pod } from '@kubernetes/client-node/dist/api';
+import type { V1Route } from '@podman-desktop/core-api';
 import { Button, Checkbox, ErrorMessage, Input, Link } from '@podman-desktop/ui-svelte';
 import * as jsYaml from 'js-yaml';
 import { onDestroy, onMount } from 'svelte';
@@ -11,7 +12,6 @@ import { ensureRestrictedSecurityContext } from '/@/lib/pod/pod-utils';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { lastPage } from '/@/stores/breadcrumb';
-import type { V1Route } from '/@api/openshift-types';
 
 export let resourceId: string;
 export let engineId: string;

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -8,6 +8,8 @@ import {
   faStop,
   faTrash,
 } from '@fortawesome/free-solid-svg-icons';
+import type { Menu } from '@podman-desktop/core-api';
+import { MenuContext } from '@podman-desktop/core-api';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
 import { createEventDispatcher, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -17,8 +19,6 @@ import { ContainerUtils } from '/@/lib/container/container-utils';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import FlatMenu from '/@/lib/ui/FlatMenu.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
-import type { Menu } from '/@api/menu.js';
-import { MenuContext } from '/@api/menu-context.js';
 
 import type { PodInfoUI } from './PodInfoUI';
 

--- a/packages/renderer/src/lib/pod/PodColumnName.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnName.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
+
 import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
 
 import type { PodInfoUI } from './PodInfoUI';
 

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -19,12 +19,12 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ContainerInspectInfo } from '@podman-desktop/api';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { expect, test, vi } from 'vitest';
 
 import { type PodCreation, podCreationHolder } from '/@/stores/creation-from-containers-store';
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import PodCreateFromContainers from './PodCreateFromContainers.svelte';
 

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
+import type { PodCreatePortOptions } from '@podman-desktop/core-api/libpod';
 import { Button, Checkbox, ErrorMessage, Input, StatusIcon } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy, onMount } from 'svelte';
@@ -12,9 +15,6 @@ import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { handleNavigation } from '/@/navigation';
 import { providerInfos } from '/@/stores/providers';
-import type { PodCreatePortOptions } from '/@api/libpod/libpod';
-import { NavigationPage } from '/@api/navigation-page';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import { type PodCreation, podCreationHolder } from '../../stores/creation-from-containers-store';
 

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { PodInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { router, type TinroRoute } from 'tinro';
@@ -25,7 +26,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import { podsInfos } from '/@/stores/pods';
-import type { PodInfo } from '/@api/pod-info';
 
 import PodDetails from './PodDetails.svelte';
 

--- a/packages/renderer/src/lib/pod/PodDetailsInspect.svelte
+++ b/packages/renderer/src/lib/pod/PodDetailsInspect.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { PodInspectInfo } from '@podman-desktop/core-api';
 import { onMount } from 'svelte';
 
 import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
-import type { PodInspectInfo } from '/@api/pod-info';
 
 import type { PodInfoUI } from './PodInfoUI';
 

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
@@ -18,12 +18,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ImageInfo, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ImageInfo } from '/@api/image-info';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import PodEmptyScreen from './PodEmptyScreen.svelte';
 

--- a/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
+++ b/packages/renderer/src/lib/pod/PodmanPodDetailsSummary.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Link } from '@podman-desktop/ui-svelte';
 
 import DetailsCell from '/@/lib/details/DetailsCell.svelte';
@@ -6,7 +7,6 @@ import DetailsSubtitle from '/@/lib/details/DetailsSubtitle.svelte';
 import DetailsTable from '/@/lib/details/DetailsTable.svelte';
 import DetailsTitle from '/@/lib/details/DetailsTitle.svelte';
 import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
 
 import type { PodInfoContainerUI, PodInfoUI } from './PodInfoUI';
 

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -20,6 +20,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type {
+  ContextGeneralState,
+  PodInfo,
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+} from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 /* eslint-disable import/no-duplicates */
@@ -32,9 +38,6 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import PodsList from '/@/lib/pod/PodsList.svelte';
 import { filtered, podsInfos } from '/@/stores/pods';
 import { providerInfos } from '/@/stores/providers';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
-import type { PodInfo } from '/@api/pod-info';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 const getProvidersInfoMock = vi.fn();
 const listPodsMock = vi.fn();

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { PodInfo } from '@podman-desktop/core-api';
 import {
   Button,
   FilteredEmptyScreen,
@@ -20,7 +21,6 @@ import PodmanKubePlay from '/@/lib/kube/PodmanKubePlay.svelte';
 import ContainerEngineEnvironmentColumn from '/@/lib/table/columns/ContainerEngineEnvironmentColumn.svelte';
 import { filtered, podsInfos, searchPattern } from '/@/stores/pods';
 import { providerInfos } from '/@/stores/providers';
-import type { PodInfo } from '/@api/pod-info';
 
 import { PodUtils } from './pod-utils';
 import PodColumnActions from './PodColumnActions.svelte';

--- a/packages/renderer/src/lib/pod/pod-utils.spec.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.spec.ts
@@ -18,10 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { PodInfo } from '@podman-desktop/core-api';
 import { expect, test } from 'vitest';
 
 import { ensureRestrictedSecurityContext, PodUtils } from '/@/lib/pod/pod-utils';
-import type { PodInfo } from '/@api/pod-info';
 
 function verifyPodSecurityContext(containers: any[], type = 'RuntimeDefault'): void {
   containers.forEach(container => {

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { PodInfo } from '@podman-desktop/core-api';
 import humanizeDuration from 'humanize-duration';
 import moment from 'moment';
-
-import type { PodInfo } from '/@api/pod-info';
 
 import type { PodInfoUI } from './PodInfoUI';
 

--- a/packages/renderer/src/lib/preferences/ExperimentalPage.spec.ts
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import { fireEvent, render } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import ExperimentalPage from '/@/lib/preferences/ExperimentalPage.svelte';
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import PreferencesRenderingItem from '/@/lib/preferences/PreferencesRenderingItem.svelte';
 import SettingsPage from '/@/lib/preferences/SettingsPage.svelte';
 import { getInitialValue } from '/@/lib/preferences/Util';
 import SlideToggle from '/@/lib/ui/SlideToggle.svelte';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 interface Props {
   properties: IConfigurationPropertyRecordedSchema[];

--- a/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
+++ b/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ExtensionInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ExtensionInfo } from '/@api/extension-info';
 
 import ExtensionIcon from './ExtensionIcon.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -20,11 +20,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { CliToolInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { CliToolInfo } from '/@api/cli-tool-info';
 
 import PreferencesCliTool from './PreferencesCliTool.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { faCircleArrowDown, faCircleArrowUp, faCircleXmark, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { CliToolInfo } from '@podman-desktop/core-api';
 import { Button, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import LoadingIconButton from '/@/lib/ui/LoadingIconButton.svelte';
-import type { CliToolInfo } from '/@api/cli-tool-info';
 
 import {
   type ConnectionCallback,

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -20,12 +20,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { CliToolInfo } from '@podman-desktop/core-api';
 import { within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/svelte';
 import { afterEach, beforeAll, expect, suite, test, vi } from 'vitest';
 
 import { cliToolInfos } from '/@/stores/cli-tools';
-import type { CliToolInfo } from '/@api/cli-tool-info';
 
 import PreferencesCliToolsRendering from './PreferencesCliToolsRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -18,14 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
-
 import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+} from '@podman-desktop/core-api';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import type { IConnectionStatus } from './Util';

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import { faEdit, faPlay, faRotateRight, faStop, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { Buffer } from 'buffer';
 import type { Snippet } from 'svelte';
 import { router } from 'tinro';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import LoadingIconButton from '/@/lib/ui/LoadingIconButton.svelte';
-import type { ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import {
   type ConnectionCallback,

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -22,6 +22,8 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { get } from 'svelte/store';
@@ -30,8 +32,6 @@ import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vi
 
 import { eventCollect, reconnectUI } from '/@/lib/preferences/preferences-connection-rendering-task';
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import PreferencesConnectionCreationOrEditRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
 import { faCubes } from '@fortawesome/free-solid-svg-icons';
 import type { AuditRequestItems, AuditResult, ConfigurationScope } from '@podman-desktop/api';
+import type {
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+} from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Button, EmptyScreen, ErrorMessage, Spinner } from '@podman-desktop/ui-svelte';
 import type { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
@@ -16,12 +22,6 @@ import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
 import { context } from '/@/stores/context';
 /* eslint-enable import/no-duplicates */
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import type {
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
 
 import EditableConnectionResourceItem from './item-formats/EditableConnectionResourceItem.svelte';
 import {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.spec.ts
@@ -22,12 +22,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { Terminal } from '@xterm/xterm';
 import type { Mock } from 'vitest';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 import PreferencesConnectionDetailsLogs from './PreferencesConnectionDetailsLogs.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
 
+import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from '@podman-desktop/core-api';
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
@@ -8,8 +10,6 @@ import { onDestroy, onMount } from 'svelte';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
-import type { ProviderContainerConnectionInfo, ProviderKubernetesConnectionInfo } from '/@api/provider-info';
-import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 import { writeToTerminal } from './Util';
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts
@@ -18,16 +18,16 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type {
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+} from '@podman-desktop/core-api';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { providerTerminals } from '/@/stores/provider-terminal-store';
-import type {
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
 
 import PreferencesConnectionDetailsTerminal from './PreferencesConnectionDetailsTerminal.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
@@ -2,6 +2,8 @@
 import '@xterm/xterm/css/xterm.css';
 
 import type { ProviderConnectionShellDimensions, ProviderConnectionStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo, ProviderInfo, ProviderVmConnectionInfo } from '@podman-desktop/core-api';
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { SerializeAddon } from '@xterm/addon-serialize';
@@ -12,8 +14,6 @@ import { onDestroy, onMount } from 'svelte';
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 import { getExistingTerminal, registerTerminal } from '/@/stores/provider-terminal-store';
-import type { ProviderContainerConnectionInfo, ProviderInfo, ProviderVmConnectionInfo } from '/@api/provider-info';
-import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 interface ProviderDetailsTerminalProps {
   provider: ProviderInfo;

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.spec.ts
@@ -22,10 +22,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 import PreferencesContainerConnectionDetailsSummary from './PreferencesContainerConnectionDetailsSummary.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import type { ContainerProviderConnection } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { filesize } from 'filesize';
 
 import Donut from '/@/lib/donut/Donut.svelte';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 import { PeerProperties } from './PeerProperties';
 import type { IProviderConnectionConfigurationPropertyRecorded } from './Util';

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
@@ -1,4 +1,10 @@
 <script lang="ts">
+import type {
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+} from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Buffer } from 'buffer';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -8,12 +14,6 @@ import PreferencesConnectionCreationRendering from '/@/lib/preferences/Preferenc
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { providerInfos } from '/@/stores/providers';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import type {
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
 
 import { isContainerConnection } from './Util';
 

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -22,6 +22,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
@@ -29,7 +30,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import PreferencesContainerConnectionRendering from './PreferencesContainerConnectionRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import type { ProviderConnectionInfo, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Tab } from '@podman-desktop/ui-svelte';
 import { Buffer } from 'buffer';
 import { onDestroy, onMount } from 'svelte';
@@ -13,9 +16,6 @@ import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { providerInfos } from '/@/stores/providers';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import { NavigationPage } from '/@api/navigation-page';
-import type { ProviderConnectionInfo, ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import { eventCollect } from './preferences-connection-rendering-task';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.spec.ts
@@ -22,10 +22,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderKubernetesConnectionInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
-
-import type { ProviderKubernetesConnectionInfo } from '/@api/provider-info';
 
 import PreferencesKubernetesConnectionDetailsSummary from './PreferencesKubernetesConnectionDetailsSummary.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import type { KubernetesProviderConnection } from '@podman-desktop/api';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import type { ProviderKubernetesConnectionInfo } from '/@api/provider-info';
+import type { ProviderKubernetesConnectionInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 
 import type { IProviderConnectionConfigurationPropertyRecorded } from './Util';
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
@@ -22,13 +22,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import PreferencesKubernetesConnectionRendering from './PreferencesKubernetesConnectionRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+import type { ProviderConnectionInfo, ProviderInfo, ProviderKubernetesConnectionInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Tab } from '@podman-desktop/ui-svelte';
 import { Buffer } from 'buffer';
 import { onDestroy, onMount } from 'svelte';
@@ -13,9 +16,6 @@ import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { providerInfos } from '/@/stores/providers';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import { NavigationPage } from '/@api/navigation-page';
-import type { ProviderConnectionInfo, ProviderInfo, ProviderKubernetesConnectionInfo } from '/@api/provider-info';
 
 import { eventCollect } from './preferences-connection-rendering-task';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContextGeneralState, KubeContext } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -27,8 +28,6 @@ import { kubernetesContextsPermissions } from '/@/stores/kubernetes-context-perm
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubernetesContextsState from '/@/stores/kubernetes-contexts-state';
 import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
-import type { KubeContext } from '/@api/kubernetes-context';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faQuestionCircle } from '@fortawesome/free-regular-svg-icons';
 import { faCopy, faPenToSquare, faRightToBracket, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { KubeContext, SelectedResourceName } from '@podman-desktop/core-api';
 import { Button, EmptyScreen, ErrorMessage, Spinner, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
@@ -14,8 +15,6 @@ import { kubernetesContextsPermissions } from '/@/stores/kubernetes-context-perm
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import { kubernetesContextsCheckingStateDelayed, kubernetesContextsState } from '/@/stores/kubernetes-contexts-state';
 import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
-import type { KubeContext } from '/@api/kubernetes-context';
-import type { SelectedResourceName } from '/@api/kubernetes-contexts-states';
 
 import PreferencesKubernetesContextsRenderingEditModal from './PreferencesKubernetesContextsRenderingEditModal.svelte';
 import SettingsPage from './SettingsPage.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.spec.ts
@@ -19,12 +19,11 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { Cluster, User } from '@kubernetes/client-node';
+import type { KubeContext } from '@podman-desktop/core-api';
 import { Dropdown } from '@podman-desktop/ui-svelte';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { KubeContext } from '/@api/kubernetes-context';
 
 import PreferencesKubernetesContextsRenderingEditModal from './PreferencesKubernetesContextsRenderingEditModal.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRenderingEditModal.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import type { Cluster, User } from '@kubernetes/client-node';
+import type { KubeContext } from '@podman-desktop/core-api';
 import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import Dialog from '/@/lib/dialogs/Dialog.svelte';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
-import type { KubeContext } from '/@api/kubernetes-context';
 
 interface Props {
   detailed?: boolean;

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { onMount } from 'svelte';
 
 import Onboarding from '/@/lib/onboarding/Onboarding.svelte';
@@ -6,7 +7,6 @@ import ExperimentalPage from '/@/lib/preferences/ExperimentalPage.svelte';
 import PreferencesContainerConnectionEdit from '/@/lib/preferences/PreferencesContainerConnectionEdit.svelte';
 import Route from '/@/Route.svelte';
 import { configurationProperties } from '/@/stores/configurationProperties';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 import CertificateList from './certificate/CertificateList.svelte';
 import PreferencesDockerCompatibilityRendering from './docker-compat/PreferencesDockerCompatibilityRendering.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
-
-import type { ProviderInfo } from '/@api/provider-info';
 
 import PreferencesProviderInstallationModal from './PreferencesProviderInstallationModal.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderInstallationModal.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import { faCircleXmark } from '@fortawesome/free-solid-svg-icons';
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 import { Button, CloseButton, Modal } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 interface Props {
   providerToBeInstalled: { provider: ProviderInfo; displayName: string };

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import * as PreferencesConnectionCreationRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
 import PreferencesProviderRendering from './PreferencesProviderRendering.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { faHistory, faPlay, faStop } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Button, ErrorMessage, Modal } from '@podman-desktop/ui-svelte';
 import type { Terminal } from '@xterm/xterm';
 import { onMount } from 'svelte';
@@ -10,8 +12,6 @@ import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
 import Route from '/@/Route.svelte';
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
 import { providerInfos } from '/@/stores/providers';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import type { ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import PreferencesConnectionCreationRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
 import { writeToTerminal } from './Util';

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -18,13 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { PROXY_CONFIG_KEYS, ProxyState } from '@podman-desktop/core-api';
 import { Dropdown } from '@podman-desktop/ui-svelte';
 import { fireEvent, render } from '@testing-library/svelte';
 import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import PreferencesProxiesRendering from '/@/lib/preferences/PreferencesProxiesRendering.svelte';
 import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
-import { PROXY_CONFIG_KEYS, ProxyState } from '/@api/proxy';
 
 // mock the ui library
 vi.mock(import('@podman-desktop/ui-svelte'), async importOriginal => {

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 import { faPen } from '@fortawesome/free-solid-svg-icons';
+import { PROXY_CONFIG_KEYS, ProxyState } from '@podman-desktop/core-api';
 import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import { PROXY_LABELS } from '/@/lib/preferences/proxy-state-labels';
-import { PROXY_CONFIG_KEYS, ProxyState } from '/@api/proxy';
 
 import PreferencesManagedInput from './PreferencesManagedInput.svelte';
 import SettingsPage from './SettingsPage.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { faPlusCircle, faTrash, faUser, faUserPen } from '@fortawesome/free-solid-svg-icons';
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import { PreferredRegistriesSettings } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Button, DropdownMenu, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
@@ -9,8 +11,6 @@ import Dialog from '/@/lib/dialogs/Dialog.svelte';
 import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { registriesInfos, registriesSuggestedInfos } from '/@/stores/registries';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
-import { PreferredRegistriesSettings } from '/@api/prefered-registries-info';
 
 import PreferencesRenderingItem from './PreferencesRenderingItem.svelte';
 import SettingsPage from './SettingsPage.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
@@ -22,14 +22,14 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
 import { context } from '/@/stores/context';
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import PreferencesRendering from './PreferencesRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { SearchInput } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { type Unsubscriber } from 'svelte/store';
@@ -6,7 +7,6 @@ import { type Unsubscriber } from 'svelte/store';
 import type { ContextUI } from '/@/lib/context/context';
 import Route from '/@/Route.svelte';
 import { context } from '/@/stores/context';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 import PreferencesRenderingItem from './PreferencesRenderingItem.svelte';
 import SettingsPage from './SettingsPage.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import PreferencesRenderingItem from '/@/lib/preferences/PreferencesRenderingItem.svelte';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 const EXPERIMENTAL_RECORD: IConfigurationPropertyRecordedSchema = {
   id: 'hello.world.fooBar',

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faArrowUpRightFromSquare, faFlask } from '@fortawesome/free-solid-svg-icons';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
@@ -7,7 +8,6 @@ import Markdown from '/@/lib/markdown/Markdown.svelte';
 import { getInitialValue } from '/@/lib/preferences/Util';
 import Label from '/@/lib/ui/Label.svelte';
 import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 import PreferencesManagedLabel from './PreferencesManagedLabel.svelte';
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -22,6 +22,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -29,7 +30,6 @@ import { beforeAll, expect, test, vi } from 'vitest';
 
 import { getInitialValue } from '/@/lib/preferences/Util';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { ErrorMessage } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
@@ -10,7 +11,6 @@ import NumberItem from '/@/lib/preferences/item-formats/NumberItem.svelte';
 import SliderItem from '/@/lib/preferences/item-formats/SliderItem.svelte';
 import StringItem from '/@/lib/preferences/item-formats/StringItem.svelte';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 import PasswordStringItem from './item-formats/PasswordStringItem.svelte';
 import { getInitialValue, getNormalizedDefaultNumberValue } from './Util';

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -19,6 +19,8 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderConnectionStatus } from '@podman-desktop/api';
+import type { Menu, OnboardingInfo, ProviderInfo } from '@podman-desktop/core-api';
+import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import { render, screen, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
@@ -27,10 +29,6 @@ import { assert, beforeAll, beforeEach, describe, expect, test, vi } from 'vites
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
-import type { Menu } from '/@api/menu.js';
-import type { OnboardingInfo } from '/@api/onboarding';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import PreferencesResourcesRendering from './PreferencesResourcesRendering.svelte';
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 import { faCircleInfo, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import type { ContainerProviderConnection } from '@podman-desktop/api';
+import type { CheckStatus, Menu, ProviderConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import { MenuContext } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { DropdownMenu, EmptyScreen, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { Buffer } from 'buffer';
@@ -25,10 +28,6 @@ import { configurationProperties } from '/@/stores/configurationProperties';
 import { context } from '/@/stores/context';
 import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import type { Menu } from '/@api/menu.js';
-import { MenuContext } from '/@api/menu-context.js';
-import type { CheckStatus, ProviderConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import { PeerProperties } from './PeerProperties';
 import { eventCollect } from './preferences-connection-rendering-task';

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
@@ -18,13 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
 import { assert, beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import * as preferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesVmConnectionRendering from './PreferencesVmConnectionRendering.svelte';

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import type { ProviderConnectionInfo, ProviderInfo, ProviderVmConnectionInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -12,8 +14,6 @@ import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { providerInfos } from '/@/stores/providers';
-import { NavigationPage } from '/@api/navigation-page';
-import type { ProviderConnectionInfo, ProviderInfo, ProviderVmConnectionInfo } from '/@api/provider-info';
 
 import { eventCollect } from './preferences-connection-rendering-task';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
@@ -25,7 +26,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ContextUI } from '/@/lib/context/context';
 import ProviderUpdateButton from '/@/lib/dashboard/ProviderUpdateButton.svelte';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import ProviderActionButtons from './ProviderActionButtons.svelte';
 

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import { faGear } from '@fortawesome/free-solid-svg-icons';
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 import { Button, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
 
 import type { ContextUI } from '/@/lib/context/context';
 import ProviderUpdateButton from '/@/lib/dashboard/ProviderUpdateButton.svelte';
-import type { CheckStatus, ProviderInfo } from '/@api/provider-info';
 
 interface Props {
   provider: ProviderInfo;

--- a/packages/renderer/src/lib/preferences/Util.spec.ts
+++ b/packages/renderer/src/lib/preferences/Util.spec.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import type { Terminal } from '@xterm/xterm';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import {
   calcHalfCpuCores,

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -17,18 +17,18 @@
  ***********************************************************************/
 
 import type { ConfigurationScope } from '@podman-desktop/api';
-import type { Terminal } from '@xterm/xterm';
-
-import type { ContextUI } from '/@/lib/context/context';
-import { ContextKeyExpr } from '/@/lib/context/contextKey';
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 import type {
   ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+} from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
+import type { Terminal } from '@xterm/xterm';
+
+import type { ContextUI } from '/@/lib/context/context';
+import { ContextKeyExpr } from '/@/lib/context/contextKey';
 
 export interface IProviderConnectionConfigurationPropertyRecorded extends IConfigurationPropertyRecordedSchema {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/renderer/src/lib/preferences/certificate/CertificateColumnExpires.spec.ts
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateColumnExpires.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { CertificateInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { describe, expect, test } from 'vitest';
-
-import type { CertificateInfo } from '/@api/certificate-info';
 
 import { formatExpirationDate } from './certificate-util';
 import CertificateColumnExpires from './CertificateColumnExpires.svelte';

--- a/packages/renderer/src/lib/preferences/certificate/CertificateColumnExpires.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateColumnExpires.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { CertificateInfo } from '/@api/certificate-info';
+import type { CertificateInfo } from '@podman-desktop/core-api';
 
 import { formatExpirationDate, isExpired } from './certificate-util';
 import CertificateExpirationIcon from './CertificateExpirationIcon.svelte';

--- a/packages/renderer/src/lib/preferences/certificate/CertificateColumnIssuer.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateColumnIssuer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { CertificateInfo } from '/@api/certificate-info';
+import type { CertificateInfo } from '@podman-desktop/core-api';
 
 import { getIssuerDisplayNameWithSelfSigned } from './certificate-util';
 

--- a/packages/renderer/src/lib/preferences/certificate/CertificateColumnSubject.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateColumnSubject.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { CertificateInfo } from '/@api/certificate-info';
+import type { CertificateInfo } from '@podman-desktop/core-api';
 
 import { getSubjectDisplayName } from './certificate-util';
 

--- a/packages/renderer/src/lib/preferences/certificate/CertificateExpirationIcon.spec.ts
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateExpirationIcon.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { CertificateInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { describe, expect, test } from 'vitest';
-
-import type { CertificateInfo } from '/@api/certificate-info';
 
 import CertificateExpirationIcon from './CertificateExpirationIcon.svelte';
 

--- a/packages/renderer/src/lib/preferences/certificate/CertificateExpirationIcon.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateExpirationIcon.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import { faCircleCheck, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import type { CertificateInfo } from '@podman-desktop/core-api';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
-
-import type { CertificateInfo } from '/@api/certificate-info';
 
 import { isExpired } from './certificate-util';
 

--- a/packages/renderer/src/lib/preferences/certificate/CertificateList.spec.ts
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateList.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { CertificateInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { certificatesInfos, searchPattern } from '/@/stores/certificates';
-import type { CertificateInfo } from '/@api/certificate-info';
 
 import CertificateList from './CertificateList.svelte';
 

--- a/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
+++ b/packages/renderer/src/lib/preferences/certificate/CertificateList.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+import type { CertificateInfo } from '@podman-desktop/core-api';
 import { FilteredEmptyScreen, SearchInput, Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 import { onDestroy } from 'svelte';
 
 import SettingsPage from '/@/lib/preferences/SettingsPage.svelte';
 import { certificatesInfos, filtered, searchPattern } from '/@/stores/certificates';
-import type { CertificateInfo } from '/@api/certificate-info';
 
 import { getIssuerDisplayNameWithSelfSigned, getSubjectDisplayName } from './certificate-util';
 import CertificateColumnExpires from './CertificateColumnExpires.svelte';

--- a/packages/renderer/src/lib/preferences/certificate/certificate-util.ts
+++ b/packages/renderer/src/lib/preferences/certificate/certificate-util.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { CertificateInfo } from '/@api/certificate-info';
+import type { CertificateInfo } from '@podman-desktop/core-api';
 
 /**
  * Get display name for certificate subject (CN → Full DN → 'Unknown')

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ExtensionInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -26,7 +27,6 @@ import { ContextUI } from '/@/lib/context/context';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { context } from '/@/stores/context';
 import { extensionInfos } from '/@/stores/extensions';
-import type { ExtensionInfo } from '/@api/extension-info';
 
 import PreferencesDockerCompatibilityContributions from './PreferencesDockerCompatibilityContributions.svelte';
 

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilityContributions.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 /* eslint-disable import/no-duplicates */
+import type { ExtensionInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Dropdown } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { get, type Unsubscriber, type Writable } from 'svelte/store';
@@ -12,8 +14,6 @@ import { isPropertyValidInContext } from '/@/lib/preferences/Util';
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { context } from '/@/stores/context';
 import { extensionInfos } from '/@/stores/extensions';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
-import type { ExtensionInfo } from '/@api/extension-info';
 
 const DOCKER_COMPAT_SCOPE = 'DockerCompatibility';
 

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { beforeEach, expect, type Mock, test, vi } from 'vitest';
-
-import type { DockerSocketMappingStatusInfo, DockerSocketServerInfoType } from '/@api/docker-compatibility-info';
 
 import PreferencesDockerCompatibilitySocketMappingStatus from './PreferencesDockerCompatibilitySocketMappingStatus.svelte';
 

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faCircleInfo } from '@fortawesome/free-solid-svg-icons';
+import type { DockerSocketMappingStatusInfo } from '@podman-desktop/core-api';
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
@@ -8,7 +9,6 @@ import { router } from 'tinro';
 import Label from '/@/lib/ui/Label.svelte';
 import ProviderInfoCircle from '/@/lib/ui/ProviderInfoCircle.svelte';
 import RefreshButton from '/@/lib/ui/RefreshButton.svelte';
-import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info';
 
 let isMac = $state(false);
 let isWindows = $state(false);

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import BooleanItem from './BooleanItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+
 import SlideToggle from '/@/lib/ui/SlideToggle.svelte';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let checked = false;

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import EditableConnectionResourceItem from './EditableConnectionResourceItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { filesize } from 'filesize';
 
 import { getNormalizedDefaultNumberValue } from '/@/lib/preferences/Util';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import EditableItem from './EditableItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import EditableItem from './EditableItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 import { faCheck, faPencil, faXmark } from '@fortawesome/free-solid-svg-icons';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 import FloatNumberItem from './FloatNumberItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import EnumItem from './EnumItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Dropdown } from '@podman-desktop/ui-svelte';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string | undefined;

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import FileItem from './FileItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { OpenDialogOptions } from '@podman-desktop/api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 
 import FileInput from '/@/lib/ui/FileInput.svelte';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string = '';

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import FloatNumberItem from './FloatNumberItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import { uncertainStringToNumber } from '/@/lib/preferences/Util';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import { checkNumericValueValid } from './NumberItemUtils';
 

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { afterEach, expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import NumberItem from './NumberItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { NumberInput, Tooltip } from '@podman-desktop/ui-svelte';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: number | undefined;

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItemUtils.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItemUtils.spec.ts
@@ -18,9 +18,8 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { expect, test } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import { checkNumericValueValid } from './NumberItemUtils';
 

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItemUtils.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItemUtils.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 
 export interface NumericValue {
   valid: boolean;

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import PasswordStringItem from './PasswordStringItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/PasswordStringItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+
 import PasswordInput from '/@/lib/ui/PasswordInput.svelte';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 interface Props {
   record: IConfigurationPropertyRecordedSchema;

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import SliderItem from './SliderItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+
 import { uncertainStringToNumber } from '/@/lib/preferences/Util';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: number;

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import StringItem from './StringItem.svelte';
 

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Input } from '@podman-desktop/ui-svelte';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 export let record: IConfigurationPropertyRecordedSchema;
 export let value: string | undefined;

--- a/packages/renderer/src/lib/preferences/proxy-state-labels.ts
+++ b/packages/renderer/src/lib/preferences/proxy-state-labels.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { ProxyState } from '/@api/proxy';
+import { ProxyState } from '@podman-desktop/core-api';
 
 export const PROXY_LABELS: Map<ProxyState, string> = new Map([
   [ProxyState.PROXY_SYSTEM, 'System'],

--- a/packages/renderer/src/lib/pvc/PVCDetails.svelte
+++ b/packages/renderer/src/lib/pvc/PVCDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { KubernetesObject, V1PersistentVolumeClaim } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -14,7 +15,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextPersistentVolumeClaims } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable';
 
 import { PVCUtils } from './pvc-utils';
 import PVCActions from './PVCActions.svelte';

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.spec.ts
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ExtensionBanner as IExtensionBanner } from '@podman-desktop/core-api/recommendations';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import ExtensionBanner from '/@/lib/recommendation/ExtensionBanner.svelte';
-import type { ExtensionBanner as IExtensionBanner } from '/@api/recommendations/recommendations';
 
 const baseBanner: IExtensionBanner = {
   extensionId: 'extension.banner',

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { MessageBoxReturnValue } from '@podman-desktop/core-api';
+import { type ExtensionBanner } from '@podman-desktop/core-api/recommendations';
 import { CloseButton } from '@podman-desktop/ui-svelte';
 
 import FeaturedExtension from '/@/lib/featured/FeaturedExtension.svelte';
-import type { MessageBoxReturnValue } from '/@api/dialog';
-import { type ExtensionBanner } from '/@api/recommendations/recommendations';
 
 // Pass in the theme appearance colour of PD to the banner, we do it here so we don't have to do multiple isDark checks when rendering multiple banners.
 interface Props {

--- a/packages/renderer/src/lib/recommendation/ExtensionBanners.spec.ts
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanners.spec.ts
@@ -16,15 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
+import type { ExtensionBanner } from '@podman-desktop/core-api/recommendations';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
 import ExtensionBanners from '/@/lib/recommendation/ExtensionBanners.svelte';
 import { extensionBannerInfos } from '/@/stores/extensionBanners';
 import { providerInfos } from '/@/stores/providers';
-import type { FeaturedExtension } from '/@api/featured/featured-api';
-import type { ProviderInfo } from '/@api/provider-info';
-import type { ExtensionBanner } from '/@api/recommendations/recommendations';
 
 test('multiple banners should be rendered', async () => {
   const banners: ExtensionBanner[] = Array.from({ length: 10 }, (_, i) => ({

--- a/packages/renderer/src/lib/recommendation/ExtensionBanners.svelte
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanners.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+import type { ExtensionBanner as ExtensionBannerInfo } from '@podman-desktop/core-api/recommendations';
+
 import { ContextUI } from '/@/lib/context/context';
 import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import ExtensionBanner from '/@/lib/recommendation/ExtensionBanner.svelte';
 import { isDark } from '/@/stores/appearance';
 import { extensionBannerInfos } from '/@/stores/extensionBanners';
 import { providerInfos } from '/@/stores/providers';
-import type { ExtensionBanner as ExtensionBannerInfo } from '/@api/recommendations/recommendations';
 
 let banners: ExtensionBannerInfo[] = $derived.by(() =>
   $extensionBannerInfos.filter(banner => !banner.when || isBannerVisible(banner)),

--- a/packages/renderer/src/lib/service/ServiceDetails.svelte
+++ b/packages/renderer/src/lib/service/ServiceDetails.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { CoreV1Event, KubernetesObject, V1Service } from '@kubernetes/client-node';
+import type { IDisposable } from '@podman-desktop/core-api';
 import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
@@ -15,7 +16,6 @@ import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { kubernetesCurrentContextEvents, kubernetesCurrentContextServices } from '/@/stores/kubernetes-contexts-state';
-import type { IDisposable } from '/@api/disposable.js';
 
 import { ServiceUtils } from './service-utils';
 import ServiceActions from './ServiceActions.svelte';

--- a/packages/renderer/src/lib/statusbar/PinActions.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinActions.spec.ts
@@ -18,6 +18,8 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import { STATUS_BAR_PIN_CONSTANTS } from '@podman-desktop/core-api/status-bar';
 import { fireEvent, render, type RenderResult, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import type { Component, ComponentProps } from 'svelte';
@@ -27,8 +29,6 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import PinActions from '/@/lib/statusbar/PinActions.svelte';
 import { providerInfos } from '/@/stores/providers';
 import { statusBarPinned } from '/@/stores/statusbar-pinned';
-import type { ProviderInfo } from '/@api/provider-info';
-import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
 
 const CONTAINER_CONNECTION_PROVIDER = {
   name: 'podman',

--- a/packages/renderer/src/lib/statusbar/PinActions.svelte
+++ b/packages/renderer/src/lib/statusbar/PinActions.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import { STATUS_BAR_PIN_CONSTANTS } from '@podman-desktop/core-api/status-bar';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import ProviderButton from '/@/lib/statusbar/ProviderButton.svelte';
 import { providerInfos } from '/@/stores/providers';
 import { statusBarPinned } from '/@/stores/statusbar-pinned';
-import type { ProviderInfo } from '/@api/provider-info';
-import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
 
 import PinMenu from './PinMenu.svelte';
 

--- a/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.spec.ts
@@ -18,13 +18,13 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import ProviderButton from '/@/lib/statusbar/ProviderButton.svelte';
 import ProviderButtonStatus from '/@/lib/statusbar/ProviderButtonStatus.svelte';
-import type { ProviderInfo } from '/@api/provider-info';
 
 vi.mock(import('/@/lib/statusbar/ProviderButtonStatus.svelte'));
 

--- a/packages/renderer/src/lib/statusbar/ProviderButton.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButton.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import type { Snippet } from 'svelte';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import ProviderButtonStatus from './ProviderButtonStatus.svelte';
 

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -18,17 +18,16 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderStatus } from '@podman-desktop/api';
-import { fireEvent, render, screen } from '@testing-library/svelte';
-import userEvent from '@testing-library/user-event';
-import { router } from 'tinro';
-import { beforeEach, expect, test, vi } from 'vitest';
-
 import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
   ProviderVmConnectionInfo,
-} from '/@api/provider-info';
+} from '@podman-desktop/core-api';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import ProviderWidget from './ProviderWidget.svelte';
 

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import ProviderButton from '/@/lib/statusbar/ProviderButton.svelte';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import ProviderWidgetStatus from './ProviderWidgetStatus.svelte';
 import ProviderWidgetStatusStyle from './ProviderWidgetStatusStyle.svelte';

--- a/packages/renderer/src/lib/statusbar/Providers.spec.ts
+++ b/packages/renderer/src/lib/statusbar/Providers.spec.ts
@@ -17,6 +17,12 @@
  ***********************************************************************/
 import '@testing-library/jest-dom/vitest';
 
+import type {
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+} from '@podman-desktop/core-api';
+import { STATUS_BAR_PIN_CONSTANTS } from '@podman-desktop/core-api/status-bar';
 import { fireEvent, render } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -24,12 +30,6 @@ import Providers from '/@/lib/statusbar/Providers.svelte';
 import ProviderWidget from '/@/lib/statusbar/ProviderWidget.svelte';
 import { providerInfos } from '/@/stores/providers';
 import { statusBarPinned } from '/@/stores/statusbar-pinned';
-import type {
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
-import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
 
 // mock provider widget
 vi.mock(import('./ProviderWidget.svelte'));

--- a/packages/renderer/src/lib/statusbar/Providers.svelte
+++ b/packages/renderer/src/lib/statusbar/Providers.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import { STATUS_BAR_PIN_CONSTANTS } from '@podman-desktop/core-api/status-bar';
+
 import ProviderWidget from '/@/lib/statusbar/ProviderWidget.svelte';
 import { providerInfos } from '/@/stores/providers';
 import { statusBarPinned } from '/@/stores/statusbar-pinned';
-import type { ProviderInfo } from '/@api/provider-info';
-import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
 
 let pinned: Set<string> = $derived(
   new Set($statusBarPinned.filter(option => option.pinned).map(option => option.value)),

--- a/packages/renderer/src/lib/statusbar/StatusBar.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBar.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { ExperimentalTasksSettings } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -27,7 +28,6 @@ import StatusBar from '/@/lib/statusbar/StatusBar.svelte';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import { statusBarEntries } from '/@/stores/statusbar';
 import { tasksInfo } from '/@/stores/tasks';
-import { ExperimentalTasksSettings } from '/@api/tasks-preferences';
 
 // mock providers component
 vi.mock(import('./Providers.svelte'));

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+import type { StatusBarEntry } from '@podman-desktop/core-api';
+import { ExperimentalTasksSettings } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 
 import TaskIndicator from '/@/lib/statusbar/TaskIndicator.svelte';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import { statusBarEntries } from '/@/stores/statusbar';
-import type { StatusBarEntry } from '/@api/status-bar';
-import { ExperimentalTasksSettings } from '/@api/tasks-preferences';
 
 import Providers from './Providers.svelte';
 import StatusBarItem from './StatusBarItem.svelte';

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { StatusBarEntry } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-
-import type { StatusBarEntry } from '/@api/status-bar';
 
 import { iconClass } from './StatusBarItem';
 import StatusBarItem from './StatusBarItem.svelte';

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { StatusBarEntry } from '/@api/status-bar';
+import type { StatusBarEntry } from '@podman-desktop/core-api';
 
 import { iconClass } from './StatusBarItem';
 

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { StatusBarEntry } from '/@api/status-bar';
+import type { StatusBarEntry } from '@podman-desktop/core-api';
 
 export function iconClass(entry: StatusBarEntry): string | undefined {
   let iconClass = undefined;

--- a/packages/renderer/src/lib/style/ColorsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/ColorsStyle.spec.ts
@@ -20,11 +20,11 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ColorInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { colorsInfos } from '/@/stores/colors';
-import type { ColorInfo } from '/@api/color-info';
 
 import ColorsStyle from './ColorsStyle.svelte';
 

--- a/packages/renderer/src/lib/style/ColorsStyle.svelte
+++ b/packages/renderer/src/lib/style/ColorsStyle.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { ColorInfo } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
 import { colorsInfos } from '/@/stores/colors';
-import type { ColorInfo } from '/@api/color-info';
 
 let style: HTMLStyleElement;
 

--- a/packages/renderer/src/lib/style/IconsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/IconsStyle.spec.ts
@@ -20,12 +20,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { IconInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { iconsInfos } from '/@/stores/icons';
-import type { IconInfo } from '/@api/icon-info';
 
 import IconsStyle from './IconsStyle.svelte';
 

--- a/packages/renderer/src/lib/style/IconsStyle.svelte
+++ b/packages/renderer/src/lib/style/IconsStyle.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+import type { FontDefinition, IconInfo } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 
 import { iconsInfos } from '/@/stores/icons';
-import type { FontDefinition } from '/@api/font-info';
-import type { IconInfo } from '/@api/icon-info';
 
 let style: HTMLStyleElement;
 

--- a/packages/renderer/src/lib/table/columns/ContainerEngineEnvironmentColumn.spec.ts
+++ b/packages/renderer/src/lib/table/columns/ContainerEngineEnvironmentColumn.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { readable, writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -26,7 +27,6 @@ import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
 import EnvironmentColumn from '/@/lib/table/columns/ContainerEngineEnvironmentColumn.svelte';
 import * as providers from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 vi.mock(import('/@/stores/providers'));
 

--- a/packages/renderer/src/lib/task-manager/TaskManagerTabs.spec.ts
+++ b/packages/renderer/src/lib/task-manager/TaskManagerTabs.spec.ts
@@ -18,10 +18,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { TASK_STATUSES } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { expect, test, vi } from 'vitest';
-
-import { TASK_STATUSES } from '/@api/taskInfo';
 
 import TaskManagerTabs from './TaskManagerTabs.svelte';
 

--- a/packages/renderer/src/lib/task-manager/TaskManagerTabs.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerTabs.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import { TASK_STATUSES } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 
 import { IS_TASK_STATUSES } from '/@/stores/tasks';
-import { TASK_STATUSES } from '/@api/taskInfo';
 
 interface Props {
   searchTerm: string;

--- a/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.spec.ts
@@ -18,11 +18,10 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { TaskInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { toast } from '@zerodevx/svelte-toast';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { TaskInfo } from '/@api/taskInfo';
 
 import ToastCustomUi from './ToastCustomUi.svelte';
 

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 import { faCheckCircle, faCircleExclamation, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import type { TaskInfo } from '@podman-desktop/core-api';
 import { CloseButton, Spinner } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { toast } from '@zerodevx/svelte-toast';
-
-import type { TaskInfo } from '/@api/taskInfo';
 
 interface Props {
   toastId: number;

--- a/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
@@ -18,12 +18,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { TaskInfo } from '@podman-desktop/core-api';
 import { render, waitFor } from '@testing-library/svelte';
 import { toast } from '@zerodevx/svelte-toast';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { tasksInfo } from '/@/stores/tasks';
-import type { TaskInfo } from '/@api/taskInfo';
 
 import ToastTaskNotifications from './ToastTaskNotifications.svelte';
 

--- a/packages/renderer/src/lib/toast/ToastTaskNotifications.svelte
+++ b/packages/renderer/src/lib/toast/ToastTaskNotifications.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+import type { TaskInfo } from '@podman-desktop/core-api';
+import { ExperimentalTasksSettings } from '@podman-desktop/core-api';
 import { type SvelteToastOptions, toast } from '@zerodevx/svelte-toast';
 import { type ComponentType, onMount } from 'svelte';
 
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import { tasksInfo } from '/@/stores/tasks';
-import type { TaskInfo } from '/@api/taskInfo';
-import { ExperimentalTasksSettings } from '/@api/tasks-preferences';
 
 import ToastCustomUi from './ToastCustomUi.svelte';
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.spec.ts
@@ -20,10 +20,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 import TroubleshootingContainerEngine from './TroubleshootingContainerEngine.svelte';
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 
 import TroubleshootingContainerEngineGrabContainers from './TroubleshootingContainerEngineGrabContainers.svelte';
 import TroubleshootingContainerEnginePing from './TroubleshootingContainerEnginePing.svelte';

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.spec.ts
@@ -20,10 +20,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 import TroubleshootingContainerEngineGrabContainers from './TroubleshootingContainerEngineGrabContainers.svelte';
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import { faSignal } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { Button, ErrorMessage } from '@podman-desktop/ui-svelte';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 interface Props {
   providerContainerEngine: ProviderContainerConnectionInfo;

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.spec.ts
@@ -20,10 +20,9 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 import TroubleshootingContainerEnginePing from './TroubleshootingContainerEnginePing.svelte';
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 import { faSignal } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { Button, ErrorMessage } from '@podman-desktop/ui-svelte';
 import { Buffer } from 'buffer';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 interface Props {
   providerContainerEngine: ProviderContainerConnectionInfo;

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.spec.ts
@@ -20,15 +20,14 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
-
 import type {
   ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+} from '@podman-desktop/core-api';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
 
 import TroubleshootingContainerEngines from './TroubleshootingContainerEngines.svelte';
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngines.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
-
-import type { ProviderInfo } from '/@api/provider-info';
 
 import TroubleshootingContainerEngine from './TroubleshootingContainerEngine.svelte';
 import TroubleshootingContainerEngineReconnect from './TroubleshootingContainerEngineReconnect.svelte';

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageKubernetes.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageKubernetes.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 import { faDatabase, faRefresh } from '@fortawesome/free-solid-svg-icons';
+import type { KubernetesTroubleshootingInformation } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
-
-import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting';
 
 let info = $state<KubernetesTroubleshootingInformation>();
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageProviders.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageProviders.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 import { type Unsubscriber } from 'svelte/store';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import TroubleshootingContainerEngines from './TroubleshootingContainerEngines.svelte';
 import TroubleshootingRepair from './TroubleshootingRepair.svelte';

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepair.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 import { faWrench } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
-
-import type { ProviderInfo } from '/@api/provider-info';
 
 import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte';
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 import { faBroom, faWarning } from '@fortawesome/free-solid-svg-icons';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
-
-import type { ProviderInfo } from '/@api/provider-info';
 
 interface Props {
   providers?: ProviderInfo[];

--- a/packages/renderer/src/lib/ui/KubernetesCheckConnection.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCheckConnection.spec.ts
@@ -18,14 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContextGeneralState, KubeContext } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import { expect, test, vi } from 'vitest';
 
 import * as kubernetesContextsStore from '/@/stores/kubernetes-contexts';
 import * as kubernetesContextsStateStore from '/@/stores/kubernetes-contexts-state';
-import type { KubeContext } from '/@api/kubernetes-context';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import KubernetesCheckConnection from './KubernetesCheckConnection.svelte';
 

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -20,6 +20,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ContextGeneralState, ContextHealth, KubeContext } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { readable, type Writable, writable } from 'svelte/store';
@@ -30,9 +31,6 @@ import KubernetesCurrentContextConnectionBadge from '/@/lib/ui/KubernetesCurrent
 import * as health from '/@/stores/kubernetes-context-health';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts';
 import * as states from '/@/stores/kubernetes-contexts-state';
-import type { KubeContext } from '/@api/kubernetes-context';
-import type { ContextHealth } from '/@api/kubernetes-contexts-healths';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 vi.mock('/@/stores/kubernetes-contexts-state');
 vi.mock('/@/stores/kubernetes-contexts');

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { ContextGeneralState, ContextHealth } from '@podman-desktop/core-api';
 import { Spinner } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
@@ -10,8 +11,6 @@ import {
   kubernetesContextsCheckingStateDelayed,
   kubernetesCurrentContextState,
 } from '/@/stores/kubernetes-contexts-state';
-import type { ContextHealth } from '/@api/kubernetes-contexts-healths';
-import type { ContextGeneralState } from '/@api/kubernetes-contexts-states';
 
 import Label from './Label.svelte';
 

--- a/packages/renderer/src/lib/ui/ProviderResultPage.svelte
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.svelte
@@ -7,12 +7,11 @@ import {
   type IconDefinition,
 } from '@fortawesome/free-solid-svg-icons';
 import type { ImageCheck } from '@podman-desktop/api';
+import type { ImageCheckerInfo } from '@podman-desktop/core-api';
 import { Spinner } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import type { Snippet } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
-
-import type { ImageCheckerInfo } from '/@api/image-checker-info';
 
 import type { ProviderUI } from './ProviderResultPage';
 import SlideToggle from './SlideToggle.svelte';

--- a/packages/renderer/src/lib/ui/ProviderResultPage.ts
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.ts
@@ -17,8 +17,7 @@
  ***********************************************************************/
 
 import type { ImageCheck } from '@podman-desktop/api';
-
-import type { ImageCheckerInfo } from '/@api/image-checker-info';
+import type { ImageCheckerInfo } from '@podman-desktop/core-api';
 
 export interface ProviderUI {
   info: ImageCheckerInfo;

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
 
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import TerminalSearchControls from '/@/lib/ui/TerminalSearchControls.svelte';
-import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 interface Props {
   terminal?: Terminal;

--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { render } from '@testing-library/svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
@@ -25,7 +26,6 @@ import { writable } from 'svelte/store';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
-import { TerminalSettings } from '/@api/terminal/terminal-settings';
 
 vi.mock(import('@xterm/xterm'));
 vi.mock(import('@xterm/addon-fit'));

--- a/packages/renderer/src/lib/volume/CreateVolume.spec.ts
+++ b/packages/renderer/src/lib/volume/CreateVolume.spec.ts
@@ -20,12 +20,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
 
 import CreateVolume from './CreateVolume.svelte';
 

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -2,6 +2,8 @@
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+/* eslint-enable import/no-duplicates */
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { get } from 'svelte/store';
@@ -10,8 +12,6 @@ import { router } from 'tinro';
 import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import { providerInfos } from '/@/stores/providers';
-/* eslint-enable import/no-duplicates */
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 let providers: ProviderInfo[] = [];
 let providerConnections: ProviderContainerConnectionInfo[] = [];

--- a/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { VolumeListInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
@@ -25,7 +26,6 @@ import { beforeAll, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
 import { volumeListInfos } from '/@/stores/volumes';
-import type { VolumeListInfo } from '/@api/volume-info';
 
 import VolumeDetails from './VolumeDetails.svelte';
 

--- a/packages/renderer/src/lib/volume/VolumeDetailsInspect.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetailsInspect.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
+import type { VolumeInspectInfo } from '@podman-desktop/core-api';
 import { onMount } from 'svelte';
 
 import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
-import type { VolumeInspectInfo } from '/@api/volume-info';
 
 import type { VolumeInfoUI } from './VolumeInfoUI';
 

--- a/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetailsSummary.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
 import { Link } from '@podman-desktop/ui-svelte';
 
 import DetailsCell from '/@/lib/details/DetailsCell.svelte';
 import DetailsTable from '/@/lib/details/DetailsTable.svelte';
 import DetailsTitle from '/@/lib/details/DetailsTitle.svelte';
 import { handleNavigation } from '/@/navigation';
-import { NavigationPage } from '/@api/navigation-page';
 
 import type { VolumeInfoUI } from './VolumeInfoUI';
 

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -20,6 +20,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { type ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 /* eslint-disable import/no-duplicates */
@@ -30,7 +31,6 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 import { volumeListInfos, volumesEventStore } from '/@/stores/volumes';
-import { type ProviderInfo } from '/@api/provider-info';
 
 import VolumesList from './VolumesList.svelte';
 

--- a/packages/renderer/src/lib/volume/volume-utils.spec.ts
+++ b/packages/renderer/src/lib/volume/volume-utils.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { VolumeInfo } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { VolumeInfo } from '/@api/volume-info';
 
 import { VolumeUtils } from './volume-utils';
 

--- a/packages/renderer/src/lib/volume/volume-utils.ts
+++ b/packages/renderer/src/lib/volume/volume-utils.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { VolumeInfo } from '@podman-desktop/core-api';
 import { filesize } from 'filesize';
 import humanizeDuration from 'humanize-duration';
 import moment from 'moment';
-
-import type { VolumeInfo } from '/@api/volume-info';
 
 import type { VolumeInfoUI } from './VolumeInfoUI';
 

--- a/packages/renderer/src/lib/webview/Webview.spec.ts
+++ b/packages/renderer/src/lib/webview/Webview.spec.ts
@@ -20,12 +20,12 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { WebviewInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { webviews } from '/@/stores/webviews';
-import type { WebviewInfo } from '/@api/webview-info';
 
 import Webview from './Webview.svelte';
 

--- a/packages/renderer/src/lib/webview/Webview.svelte
+++ b/packages/renderer/src/lib/webview/Webview.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
+import type { WebviewInfo } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 import { get, type Unsubscriber } from 'svelte/store';
 
 import Route from '/@/Route.svelte';
 import { webviews } from '/@/stores/webviews';
-import type { WebviewInfo } from '/@api/webview-info';
 
 import { webviewLifecycle } from './webview-directive';
 

--- a/packages/renderer/src/lib/webview/webview-directive.spec.ts
+++ b/packages/renderer/src/lib/webview/webview-directive.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { WebviewInfo } from '@podman-desktop/core-api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { WebviewInfo } from '/@api/webview-info';
 
 import {
   createWindowIpcApi,

--- a/packages/renderer/src/lib/webview/webview-directive.ts
+++ b/packages/renderer/src/lib/webview/webview-directive.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { WebviewInfo } from '/@api/webview-info';
+import type { WebviewInfo } from '@podman-desktop/core-api';
 
 import { type IpcApi, type WebviewElement, WebviewLifecycleManager } from './webview-lifecycle-manager';
 

--- a/packages/renderer/src/lib/webview/webview-lifecycle-manager.spec.ts
+++ b/packages/renderer/src/lib/webview/webview-lifecycle-manager.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { WebviewInfo } from '@podman-desktop/core-api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { WebviewInfo } from '/@api/webview-info';
 
 import type { IpcApi, WebviewElement } from './webview-lifecycle-manager';
 import { WebviewLifecycleManager } from './webview-lifecycle-manager';

--- a/packages/renderer/src/lib/webview/webview-lifecycle-manager.ts
+++ b/packages/renderer/src/lib/webview/webview-lifecycle-manager.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { WebviewInfo } from '/@api/webview-info';
+import type { WebviewInfo } from '@podman-desktop/core-api';
 
 interface WebviewEventMap {
   'dom-ready': Event;

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo, TelemetryMessages } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 /* eslint-disable import/no-duplicates */
 import { tick } from 'svelte';
@@ -27,8 +28,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
-import type { ProviderInfo } from '/@api/provider-info';
-import type { TelemetryMessages } from '/@api/telemetry';
 
 import WelcomePage from './WelcomePage.svelte';
 

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { OnboardingInfo, TelemetryMessages, WelcomeMessages } from '@podman-desktop/core-api';
 import { Button, Checkbox, Link, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
@@ -7,9 +8,6 @@ import IconImage from '/@/lib/appearance/IconImage.svelte';
 import DesktopIcon from '/@/lib/images/DesktopIcon.svelte';
 import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
-import type { OnboardingInfo } from '/@api/onboarding';
-import type { TelemetryMessages } from '/@api/telemetry';
-import type { WelcomeMessages } from '/@api/welcome-info';
 
 import bgImage from './background.png';
 import { WelcomeUtils } from './welcome-utils';

--- a/packages/renderer/src/lib/welcome/welcome-utils.spec.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.spec.ts
@@ -18,9 +18,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { WelcomeSettings } from '@podman-desktop/core-api/welcome';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import { WelcomeSettings } from '/@api/welcome/welcome-settings';
 
 import { WelcomeUtils } from './welcome-utils';
 

--- a/packages/renderer/src/lib/welcome/welcome-utils.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
-import { TelemetrySettings } from '/@api/telemetry/telemetry-settings';
-import { WelcomeSettings } from '/@api/welcome/welcome-settings';
+import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
+import { TelemetrySettings } from '@podman-desktop/core-api/telemetry';
+import { WelcomeSettings } from '@podman-desktop/core-api/welcome';
 
 export class WelcomeUtils {
   async getVersion(): Promise<string | undefined> {

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { NavigationPage } from '@podman-desktop/core-api';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import { NavigationPage } from '/@api/navigation-page';
 
 import { handleNavigation } from './navigation';
 

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -16,12 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NavigationRequest } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import { Buffer } from 'buffer';
 import { router } from 'tinro';
-
-import { NavigationPage } from '/@api/navigation-page';
-import type { NavigationRequest } from '/@api/navigation-request';
 
 // help method to ensure the handleNavigation is able to infer type properly through the switch
 // ref https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types

--- a/packages/renderer/src/stores/all-installed-extensions.ts
+++ b/packages/renderer/src/stores/all-installed-extensions.ts
@@ -17,9 +17,8 @@
  ***********************************************************************/
 
 // Combine PD and DD extensions being installed
+import type { ExtensionInfo } from '@podman-desktop/core-api';
 import { derived, type Readable } from 'svelte/store';
-
-import type { ExtensionInfo } from '/@api/extension-info';
 
 import { contributions } from './contribs';
 import { extensionInfos } from './extensions';

--- a/packages/renderer/src/stores/authenticationProviders.ts
+++ b/packages/renderer/src/stores/authenticationProviders.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { AuthenticationProviderInfo } from '@podman-desktop/core-api/authentication';
 import { type Writable, writable } from 'svelte/store';
 
 import KeyIcon from '/@/lib/images/KeyIcon.svelte';
-import type { AuthenticationProviderInfo } from '/@api/authentication/authentication';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/build-images.ts
+++ b/packages/renderer/src/stores/build-images.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import type { Terminal } from '@xterm/xterm';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info';
 
 export interface BuildArg {
   key: string;

--- a/packages/renderer/src/stores/catalog-extensions.spec.ts
+++ b/packages/renderer/src/stores/catalog-extensions.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api';
 
 import {
   catalogExtensionEventStore,

--- a/packages/renderer/src/stores/catalog-extensions.ts
+++ b/packages/renderer/src/stores/catalog-extensions.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
 import { type Writable, writable } from 'svelte/store';
-
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/certificates.spec.ts
+++ b/packages/renderer/src/stores/certificates.spec.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CertificateInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { CertificateInfo } from '/@api/certificate-info';
 
 import { certificatesEventStore, certificatesInfos, filtered, searchPattern } from './certificates';
 

--- a/packages/renderer/src/stores/certificates.ts
+++ b/packages/renderer/src/stores/certificates.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CertificateInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { derived, writable } from 'svelte/store';
-
-import type { CertificateInfo } from '/@api/certificate-info';
 
 import { EventStore } from './event-store';
 import { findMatchInLeaves } from './search-util';

--- a/packages/renderer/src/stores/cli-tools.ts
+++ b/packages/renderer/src/stores/cli-tools.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CliToolInfo } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { CliToolInfo } from '/@api/cli-tool-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/colors.spec.ts
+++ b/packages/renderer/src/stores/colors.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { ColorInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { ColorInfo } from '/@api/color-info';
 
 import { colorsEventStore, colorsInfos } from './colors';
 

--- a/packages/renderer/src/stores/colors.ts
+++ b/packages/renderer/src/stores/colors.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ColorInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 import { EventStore } from '/@/stores/event-store';
-import type { ColorInfo } from '/@api/color-info';
 
 const windowEvents = ['color-updated', 'extension-stopped', 'extensions-started'];
 const windowListeners = ['appearance-changed', 'extensions-already-started', 'system-ready'];

--- a/packages/renderer/src/stores/commands.spec.ts
+++ b/packages/renderer/src/stores/commands.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { CommandInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { CommandInfo } from '/@api/command-info';
 
 import { commandsEventStore, commandsEventStoreInfo, commandsInfos } from './commands';
 

--- a/packages/renderer/src/stores/commands.ts
+++ b/packages/renderer/src/stores/commands.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CommandInfo } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { CommandInfo } from '/@api/command-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/configurationProperties.spec.ts
+++ b/packages/renderer/src/stores/configurationProperties.spec.ts
@@ -18,9 +18,8 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { IConfigurationChangeEvent } from '@podman-desktop/core-api/configuration';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { IConfigurationChangeEvent } from '/@api/configuration/models';
 
 import { onDidChangeConfiguration, setupConfigurationChange } from './configurationProperties';
 

--- a/packages/renderer/src/stores/configurationProperties.ts
+++ b/packages/renderer/src/stores/configurationProperties.ts
@@ -16,9 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type {
+  IConfigurationChangeEvent,
+  IConfigurationPropertyRecordedSchema,
+} from '@podman-desktop/core-api/configuration';
 import { type Writable, writable } from 'svelte/store';
-
-import type { IConfigurationChangeEvent, IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/containers.spec.ts
+++ b/packages/renderer/src/stores/containers.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { ContainerInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ContainerInfo } from '/@api/container-info';
 
 import { containersEventStore, containersInfos } from './containers';
 

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContainerInfo } from '@podman-desktop/core-api';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ContainerInfo } from '/@api/container-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/contribs.ts
+++ b/packages/renderer/src/stores/contribs.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContributionInfo } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ContributionInfo } from '/@api/contribution-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/explore-features.ts
+++ b/packages/renderer/src/stores/explore-features.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ExploreFeature } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-
-import type { ExploreFeature } from '/@api/explore-feature';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/extensionBanners.ts
+++ b/packages/renderer/src/stores/extensionBanners.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ExtensionBanner } from '@podman-desktop/core-api/recommendations';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ExtensionBanner } from '/@api/recommendations/recommendations';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/extensionDevelopmentFolders.spec.ts
+++ b/packages/renderer/src/stores/extensionDevelopmentFolders.spec.ts
@@ -18,10 +18,9 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { IDisposable } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-
-import type { IDisposable } from '/@api/disposable.js';
 
 import {
   extensionDevelopmentFolders,

--- a/packages/renderer/src/stores/extensionDevelopmentFolders.ts
+++ b/packages/renderer/src/stores/extensionDevelopmentFolders.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ExtensionDevelopmentFolderInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-
-import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/extensions.ts
+++ b/packages/renderer/src/stores/extensions.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ExtensionInfo } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ExtensionInfo } from '/@api/extension-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/featuredExtensions.ts
+++ b/packages/renderer/src/stores/featuredExtensions.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 import { type Writable, writable } from 'svelte/store';
-
-import type { FeaturedExtension } from '/@api/featured/featured-api';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/icons.ts
+++ b/packages/renderer/src/stores/icons.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IconInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-
-import type { IconInfo } from '/@api/icon-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/image-checker-providers.ts
+++ b/packages/renderer/src/stores/image-checker-providers.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ImageCheckerInfo } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ImageCheckerInfo } from '/@api/image-checker-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/image-files-providers.ts
+++ b/packages/renderer/src/stores/image-files-providers.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ImageFilesInfo } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ImageFilesInfo } from '/@api/image-files-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/images.spec.ts
+++ b/packages/renderer/src/stores/images.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { ImageInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, describe, expect, test, vi } from 'vitest';
-
-import type { ImageInfo } from '/@api/image-info';
 
 import { filtered, imagesEventStore, imagesInfos } from './images';
 

--- a/packages/renderer/src/stores/images.ts
+++ b/packages/renderer/src/stores/images.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ImageInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { derived, writable } from 'svelte/store';
 
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
-import type { ImageInfo } from '/@api/image-info';
 
 import { EventStore } from './event-store';
 import { findMatchInLeaves } from './search-util';

--- a/packages/renderer/src/stores/kubernetes-context-health.ts
+++ b/packages/renderer/src/stores/kubernetes-context-health.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContextHealth } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ContextHealth } from '/@api/kubernetes-contexts-healths';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/kubernetes-context-permission-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-permission-experimental.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContextPermission } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
 
 import { kubernetesContextsPermissions, kubernetesContextsPermissionsStore } from './kubernetes-context-permission';
 

--- a/packages/renderer/src/stores/kubernetes-context-permission-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-context-permission-non-experimental.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContextPermission } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
 
 import { kubernetesContextsPermissions, kubernetesContextsPermissionsStore } from './kubernetes-context-permission';
 

--- a/packages/renderer/src/stores/kubernetes-context-permission.ts
+++ b/packages/renderer/src/stores/kubernetes-context-permission.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContextPermission } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/kubernetes-contexts-state.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.spec.ts
@@ -19,11 +19,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { ResourceName } from '@podman-desktop/core-api';
 import type { Readable } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ResourceName } from '/@api/kubernetes-contexts-states';
 
 import {
   kubernetesCurrentContextCronJobs,

--- a/packages/renderer/src/stores/kubernetes-contexts-state.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts-state.ts
@@ -17,10 +17,8 @@
  ***********************************************************************/
 
 import type { CoreV1Event, KubernetesObject } from '@kubernetes/client-node';
+import type { CheckingState, ContextGeneralState, ForwardConfig } from '@podman-desktop/core-api';
 import { derived, type Readable, readable, writable } from 'svelte/store';
-
-import type { CheckingState, ContextGeneralState } from '/@api/kubernetes-contexts-states';
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import { findMatchInLeaves } from './search-util';
 

--- a/packages/renderer/src/stores/kubernetes-contexts.ts
+++ b/packages/renderer/src/stores/kubernetes-contexts.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { KubeContext } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
 
 import { addIconToContexts } from '/@/lib/kube/KubeContextUI';
-import type { KubeContext } from '/@api/kubernetes-context';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/kubernetes-resources-count-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count-experimental.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ResourceCount } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
 import { kubernetesResourcesCount, kubernetesResourcesCountStore } from './kubernetes-resources-count';
 

--- a/packages/renderer/src/stores/kubernetes-resources-count-non-experimental.spec.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count-non-experimental.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ResourceCount } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
 import { kubernetesResourcesCount, kubernetesResourcesCountStore } from './kubernetes-resources-count';
 

--- a/packages/renderer/src/stores/kubernetes-resources-count.ts
+++ b/packages/renderer/src/stores/kubernetes-resources-count.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ResourceCount } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import type { ResourceCount } from '/@api/kubernetes-resource-count';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContainerInfo } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { containersInfos } from '/@/stores/containers';
-import type { ContainerInfo } from '/@api/container-info';
 
 import { createNavigationContainerEntry } from './navigation-registry-container.svelte';
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-extension.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-extension.svelte.ts
@@ -17,12 +17,11 @@
  ***********************************************************************/
 
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+import type { ContributionInfo, WebviewInfo } from '@podman-desktop/core-api';
 
 import ExtensionIcon from '/@/lib/images/ExtensionIcon.svelte';
 import { contributions } from '/@/stores/contribs';
 import { webviews } from '/@/stores/webviews';
-import type { ContributionInfo } from '/@api/contribution-info';
-import type { WebviewInfo } from '/@api/webview-info';
 
 import type { NavigationRegistryEntry } from './navigation-registry';
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-image.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-image.svelte.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ImageInfo } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { imagesInfos } from '/@/stores/images';
-import type { ImageInfo } from '/@api/image-info';
 
 import { createNavigationImageEntry } from './navigation-registry-image.svelte';
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-image.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-image.svelte.ts
@@ -16,10 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ImageInfo } from '@podman-desktop/core-api';
+
 import { ImageUtils } from '/@/lib/image/image-utils';
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
 import { imagesInfos } from '/@/stores/images';
-import type { ImageInfo } from '/@api/image-info';
 
 import type { NavigationRegistryEntry } from './navigation-registry';
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -17,14 +17,13 @@
  ***********************************************************************/
 
 import type { KubernetesObject } from '@kubernetes/client-node';
+import type { ContextGeneralState, ForwardConfig } from '@podman-desktop/core-api';
 import { readable, writable } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
-import { type ContextGeneralState } from '/@api/kubernetes-contexts-states';
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model';
 
 import { createNavigationKubernetesGroup } from './navigation-registry-kubernetes.svelte';
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-network.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-network.svelte.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NetworkInspectInfo } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { networksListInfo } from '/@/stores/networks';
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 import { createNavigationNetworkEntry } from './navigation-registry-network.svelte';
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { PodInfo } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { podsInfos } from '/@/stores/pods';
-import type { PodInfo } from '/@api/pod-info';
 
 import { createNavigationPodEntry } from './navigation-registry-pod.svelte';
 

--- a/packages/renderer/src/stores/navigation/navigation-registry-volume.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-volume.svelte.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { VolumeListInfo } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { volumeListInfos } from '/@/stores/volumes';
-import type { VolumeListInfo } from '/@api/volume-info';
 
 import { createNavigationVolumeEntry } from './navigation-registry-volume.svelte';
 

--- a/packages/renderer/src/stores/networks.spec.ts
+++ b/packages/renderer/src/stores/networks.spec.ts
@@ -18,11 +18,9 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { IDisposable, NetworkInspectInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { IDisposable } from '/@api/disposable';
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 import { networksEventStore, networksListInfo } from './networks';
 

--- a/packages/renderer/src/stores/networks.ts
+++ b/packages/renderer/src/stores/networks.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NetworkInspectInfo } from '@podman-desktop/core-api';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import type { Writable } from 'svelte/store';
 import { derived, writable } from 'svelte/store';
-
-import type { NetworkInspectInfo } from '/@api/network-info';
 
 import { EventStore } from './event-store';
 import { findMatchInLeaves } from './search-util';

--- a/packages/renderer/src/stores/notifications.spec.ts
+++ b/packages/renderer/src/stores/notifications.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { NotificationCard } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { NotificationCard } from '/@api/notification';
 
 import { fetchNotifications, notificationEventStore, notificationQueue } from './notifications';
 

--- a/packages/renderer/src/stores/notifications.ts
+++ b/packages/renderer/src/stores/notifications.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NotificationCard } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-
-import type { NotificationCard } from '/@api/notification';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/onboarding.spec.ts
+++ b/packages/renderer/src/stores/onboarding.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { OnboardingInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { OnboardingInfo } from '/@api/onboarding';
 
 import { fetchOnboarding, onboardingEventStore, onboardingList } from './onboarding';
 

--- a/packages/renderer/src/stores/onboarding.ts
+++ b/packages/renderer/src/stores/onboarding.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { OnboardingInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-
-import type { OnboardingInfo } from '/@api/onboarding';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/operation-connections.ts
+++ b/packages/renderer/src/stores/operation-connections.ts
@@ -16,15 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Writable } from 'svelte/store';
-import { writable } from 'svelte/store';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models';
 import type {
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info';
+} from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import type { Writable } from 'svelte/store';
+import { writable } from 'svelte/store';
 
 interface OperationConnectionInfo {
   operationKey: symbol;

--- a/packages/renderer/src/stores/pods.spec.ts
+++ b/packages/renderer/src/stores/pods.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { PodInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { PodInfo } from '/@api/pod-info';
 
 import { podsEventStore, podsInfos } from './pods';
 

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { PodInfo } from '@podman-desktop/core-api';
 import { derived, type Writable, writable } from 'svelte/store';
 
 import PodIcon from '/@/lib/images/PodIcon.svelte';
-import type { PodInfo } from '/@api/pod-info';
 
 import { EventStore } from './event-store';
 import { findMatchInLeaves } from './search-util';

--- a/packages/renderer/src/stores/providers.spec.ts
+++ b/packages/renderer/src/stores/providers.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, describe, expect, test, vi } from 'vitest';
-
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info';
 
 import { containerConnectionCount, eventStore, providerInfos } from './providers';
 

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
 import { derived } from 'svelte/store';
-
-import type { ProviderInfo } from '/@api/provider-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/recommendedRegistries.spec.ts
+++ b/packages/renderer/src/stores/recommendedRegistries.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { RecommendedRegistry } from '@podman-desktop/core-api/recommendations';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { RecommendedRegistry } from '/@api/recommendations/recommendations';
 
 import {
   fetchRecommendedRegistries,

--- a/packages/renderer/src/stores/recommendedRegistries.ts
+++ b/packages/renderer/src/stores/recommendedRegistries.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { RecommendedRegistry } from '@podman-desktop/core-api/recommendations';
+import { RecommendationsSettings } from '@podman-desktop/core-api/recommendations';
 import { type Writable, writable } from 'svelte/store';
-
-import type { RecommendedRegistry } from '/@api/recommendations/recommendations';
-import { RecommendationsSettings } from '/@api/recommendations/recommendations-settings';
 
 import { EventStore, fineGrainedEvents } from './event-store';
 

--- a/packages/renderer/src/stores/statusbar-pinned.ts
+++ b/packages/renderer/src/stores/statusbar-pinned.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { PinOption } from '@podman-desktop/core-api/status-bar';
+import { STATUS_BAR_PIN_CONSTANTS } from '@podman-desktop/core-api/status-bar';
 import { type Writable, writable } from 'svelte/store';
-
-import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants';
-import type { PinOption } from '/@api/status-bar/pin-option';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/statusbar.ts
+++ b/packages/renderer/src/stores/statusbar.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { STATUS_BAR_UPDATED_EVENT_NAME, type StatusBarEntryDescriptor } from '@podman-desktop/core-api';
 import { type Writable, writable } from 'svelte/store';
-
-import { STATUS_BAR_UPDATED_EVENT_NAME, type StatusBarEntryDescriptor } from '/@api/status-bar';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/tasks.spec.ts
+++ b/packages/renderer/src/stores/tasks.spec.ts
@@ -16,11 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IDisposable, type NotificationTaskInfo, TASK_STATUSES, type TaskInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { IDisposable } from '/@api/disposable';
-import { type NotificationTaskInfo, TASK_STATUSES, type TaskInfo } from '/@api/taskInfo';
 
 import {
   clearNotifications,

--- a/packages/renderer/src/stores/tasks.ts
+++ b/packages/renderer/src/stores/tasks.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type NotificationTaskInfo, TASK_STATUSES, type TaskInfo, type TaskStatus } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { derived, writable } from 'svelte/store';
-
-import { type NotificationTaskInfo, TASK_STATUSES, type TaskInfo, type TaskStatus } from '/@api/taskInfo';
 
 import { findMatchInLeaves } from './search-util';
 

--- a/packages/renderer/src/stores/view.spec.ts
+++ b/packages/renderer/src/stores/view.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { ViewInfoUI } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ViewInfoUI } from '/@api/view-info';
 
 import { fetchViews, viewsContributions, viewsEventStore } from './views';
 

--- a/packages/renderer/src/stores/views.spec.ts
+++ b/packages/renderer/src/stores/views.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { ViewInfoUI } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ViewInfoUI } from '/@api/view-info';
 
 import { fetchViews, viewsContributions, viewsEventStore } from './views';
 

--- a/packages/renderer/src/stores/views.ts
+++ b/packages/renderer/src/stores/views.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ViewInfoUI } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-
-import type { ViewInfoUI } from '/@api/view-info';
 
 import { EventStore } from './event-store';
 

--- a/packages/renderer/src/stores/volumes.spec.ts
+++ b/packages/renderer/src/stores/volumes.spec.ts
@@ -18,11 +18,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import type { VolumeInspectInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { VolumeInspectInfo } from '/@api/volume-info';
 
 import { fetchVolumesWithData, volumeListInfos, volumesEventStore } from './volumes';
 

--- a/packages/renderer/src/stores/volumes.ts
+++ b/packages/renderer/src/stores/volumes.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { VolumeListInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { derived, writable } from 'svelte/store';
 
 import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
-import type { VolumeListInfo } from '/@api/volume-info';
 
 import { EventStore } from './event-store';
 import { findMatchInLeaves } from './search-util';

--- a/packages/renderer/src/stores/webviews.ts
+++ b/packages/renderer/src/stores/webviews.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { WebviewInfo } from '@podman-desktop/core-api';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
-
-import type { WebviewInfo } from '/@api/webview-info';
 
 import { EventStore } from './event-store';
 


### PR DESCRIPTION
### What does this PR do?
instead of using typescript alias `/@api` use the new `@podman-desktop/core-api` dependency


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15496


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
