### PR TITLE
chore(preload): import api using package rather than alias

### DIFF
--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -19,12 +19,11 @@
 /* eslint-disable sonarjs/no-unused-collection */
 
 import type { OpenDialogOptions, SaveDialogOptions } from '@podman-desktop/api';
+import type { ForwardConfig } from '@podman-desktop/core-api';
+import { WorkloadKind } from '@podman-desktop/core-api';
 import type { IpcRenderer, IpcRendererEvent } from 'electron';
 import { contextBridge, ipcRenderer } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model.js';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 import { buildApiSender, initExposure } from './index.js';
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -41,101 +41,112 @@ import type {
   V1Service,
 } from '@kubernetes/client-node';
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { contextBridge, ipcRenderer } from 'electron';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { AuthenticationProviderInfo } from '/@api/authentication/authentication.js';
-import type { CertificateInfo } from '/@api/certificate-info.js';
-import type { CliToolInfo } from '/@api/cli-tool-info.js';
-import type { ColorInfo } from '/@api/color-info.js';
-import type { CommandInfo } from '/@api/command-info.js';
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 import type {
+  CertificateInfo,
+  CliToolInfo,
+  ColorInfo,
+  CommandInfo,
   ContainerCreateOptions,
   ContainerExportOptions,
+  ContainerfileInfo,
   ContainerImportOptions,
   ContainerInfo,
+  ContainerInspectInfo,
+  ContainerStatsInfo,
+  ContextGeneralState,
+  ContextHealth,
+  ContextPermission,
+  ContributionInfo,
+  DockerSocketMappingStatusInfo,
+  DocumentationInfo,
+  ExploreFeature,
+  ExtensionDevelopmentFolderInfo,
+  ExtensionInfo,
+  FeedbackMessages,
+  FeedbackProperties,
+  ForwardConfig,
+  ForwardOptions,
+  GitHubIssue,
+  HistoryInfo,
+  IconInfo,
+  IDisposable,
+  ImageCheckerInfo,
+  ImageFilesInfo,
+  ImageFilesystemLayersUI,
+  ImageInfo,
+  ImageInspectInfo,
   ImageLoadOptions,
-  ImagesSaveOptions,
-  NetworkCreateOptions,
-  NetworkCreateResult,
-  SimpleContainerInfo,
-  VolumeCreateOptions,
-} from '/@api/container-info.js';
-import type { ContainerInspectInfo } from '/@api/container-inspect-info.js';
-import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
-import type { ContainerfileInfo } from '/@api/containerfile-info.js';
-import type { ContextInfo } from '/@api/context/context.js';
-import type { ContributionInfo } from '/@api/contribution-info.js';
-import type { MessageBoxOptions, MessageBoxReturnValue } from '/@api/dialog.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info.js';
-import type { DocumentationInfo } from '/@api/documentation-info.js';
-import type { ExploreFeature } from '/@api/explore-feature.js';
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api.js';
-import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
-import type { FeaturedExtension } from '/@api/featured/featured-api.js';
-import type { FeedbackMessages, FeedbackProperties, GitHubIssue } from '/@api/feedback.js';
-import type { ItemInfo } from '/@api/help-menu.js';
-import type { HistoryInfo } from '/@api/history-info.js';
-import type { IconInfo } from '/@api/icon-info.js';
-import type { ImageCheckerInfo } from '/@api/image-checker-info.js';
-import type { ImageFilesInfo } from '/@api/image-files-info.js';
-import type { ImageFilesystemLayersUI } from '/@api/image-filesystem-layers.js';
-import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info.js';
-import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
-import type {
   ImageSearchOptions,
   ImageSearchResult,
+  ImagesSaveOptions,
   ImageTagsListOptions,
   ImageUpdateStatus,
-} from '/@api/image-registry.js';
-import type {
-  GenerateKubeResult,
-  KubernetesGeneratorArgument,
-  KubernetesGeneratorInfo,
-  KubernetesGeneratorSelector,
-} from '/@api/kubernetes/kubernetes-generator-api.js';
-import type { KubeContext } from '/@api/kubernetes-context.js';
-import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
-import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
-import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
-import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
-import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
-import type { Guide } from '/@api/learning-center/guide.js';
-import type { ContainerCreateOptions as PodmanContainerCreateOptions, PlayKubeInfo } from '/@api/libpod/libpod.js';
-import type { ListOrganizerItem } from '/@api/list-organizer.js';
-import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
-import type { Menu } from '/@api/menu.js';
-import { NavigationPage } from '/@api/navigation-page.js';
-import type { NavigationRequest } from '/@api/navigation-request.js';
-import type { NetworkInspectInfo } from '/@api/network-info.js';
-import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
-import type { OnboardingInfo, OnboardingStatus } from '/@api/onboarding.js';
-import type { V1Route } from '/@api/openshift-types.js';
-import type { PodCreateOptions, PodInfo, PodInspectInfo } from '/@api/pod-info.js';
-import type {
+  ItemInfo,
+  KubeContext,
+  KubernetesContextResources,
+  KubernetesTroubleshootingInformation,
+  ListOrganizerItem,
+  ManifestCreateOptions,
+  ManifestInspectInfo,
+  ManifestPushOptions,
+  Menu,
+  MessageBoxOptions,
+  MessageBoxReturnValue,
+  NavigationRequest,
+  NetworkCreateOptions,
+  NetworkCreateResult,
+  NetworkInspectInfo,
+  NotificationCard,
+  NotificationCardOptions,
+  OnboardingInfo,
+  OnboardingStatus,
+  PodCreateOptions,
+  PodInfo,
+  PodInspectInfo,
+  PodmanListImagesOptions,
   PreflightCheckEvent,
   PreflightChecksCallback,
   ProviderConnectionInfo,
   ProviderContainerConnectionInfo,
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info.js';
-import type { ProxyState } from '/@api/proxy.js';
-import type { PullEvent } from '/@api/pull-event.js';
-import type { ExtensionBanner, RecommendedRegistry } from '/@api/recommendations/recommendations.js';
-import type { ReleaseNotesInfo } from '/@api/release-notes-info.js';
-import type { StatusBarEntryDescriptor } from '/@api/status-bar.js';
-import type { PinOption } from '/@api/status-bar/pin-option.js';
-import type { TelemetryMessages } from '/@api/telemetry.js';
-import type { ViewInfoUI } from '/@api/view-info.js';
-import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
-import type { WebviewInfo } from '/@api/webview-info.js';
-import type { WelcomeMessages } from '/@api/welcome-info.js';
+  ProxyState,
+  PullEvent,
+  ReleaseNotesInfo,
+  ResourceCount,
+  ResourceName,
+  SimpleContainerInfo,
+  StatusBarEntryDescriptor,
+  TelemetryMessages,
+  V1Route,
+  ViewInfoUI,
+  VolumeCreateOptions,
+  VolumeInspectInfo,
+  VolumeListInfo,
+  WebviewInfo,
+  WelcomeMessages,
+} from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { AuthenticationProviderInfo } from '@podman-desktop/core-api/authentication';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import type { ContextInfo } from '@podman-desktop/core-api/context';
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
+import type {
+  GenerateKubeResult,
+  KubernetesGeneratorArgument,
+  KubernetesGeneratorInfo,
+  KubernetesGeneratorSelector,
+} from '@podman-desktop/core-api/kubernetes';
+import type { Guide } from '@podman-desktop/core-api/learning-center';
+import type {
+  ContainerCreateOptions as PodmanContainerCreateOptions,
+  PlayKubeInfo,
+} from '@podman-desktop/core-api/libpod';
+import type { ExtensionBanner, RecommendedRegistry } from '@podman-desktop/core-api/recommendations';
+import type { PinOption } from '@podman-desktop/core-api/status-bar';
+import { contextBridge, ipcRenderer } from 'electron';
 
 export type OpenSaveDialogResultCallback = (result: string | string[] | undefined) => void;
 


### PR DESCRIPTION

### What does this PR do?

depends on:
- [x] https://github.com/podman-desktop/podman-desktop/pull/16201

instead of using typescript alias `/@api` use the new `@podman-desktop/core-api` dependency

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to #15496

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
