### PR TITLE
chore: build api module as a post-install step

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "storybook:dev": "pnpm run storybook:css && cd storybook && pnpm run dev",
     "storybook:build": "pnpm run build:ui && pnpm run storybook:css && cd storybook && pnpm run build",
     "prepare": "husky install",
-    "postinstall": "playwright install chromium"
+    "postinstall": "pnpm run build:core-api && playwright install chromium"
   },
   "lint-staged": {
     "*.{js,ts,tsx,svelte}": [


### PR DESCRIPTION
### What does this PR do?
on CI or other jobs, API is not found as it's never built build it at least once after we do install step

should probably require a system with dependencies and then it would execute pre-required steps


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15496

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
