### PR TITLE
chore(ci): fix next build gha repo reference

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -85,8 +85,8 @@ jobs:
           name: ${{ steps.TAG_UTIL.outputs.githubTag }}
           draft: true
           prerelease: true
-          owner: containers
-          repo: podman-desktop-prereleases
+          owner: podman-desktop
+          repo: prereleases
           token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
 
   build:

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -174,5 +174,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
         with:
           id: ${{ needs.tag.outputs.releaseId}}
-          repo: podman-desktop-prereleases
+          repo: prereleases
           owner: podman-desktop


### PR DESCRIPTION
### What does this PR do?
Updates GHA owner and repo to podman-desktop/prereleases

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/16192

