### PR TITLE
feat: introduce @svelte-ui alias for ui and renderer packages

### DIFF
--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -11,7 +11,8 @@
     "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src/*"]
+      "/@api/*": ["../api/src/*"],
+      "/@svelte-ui/*": ["../ui/dist/*"]
     },
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -36,6 +36,7 @@ export default defineConfig({
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
       '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
+      '/@svelte-ui/': join(PACKAGE_ROOT, '../ui/dist') + '/',
     },
   },
   plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js', hot: !process.env.VITEST }), svelteTesting()],

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -8,7 +8,8 @@
     "preserveValueImports": false,
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"]
+      "/@/*": ["./src/*"],
+      "/@svelte-ui/*": ["./src/lib/*"]
     },
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.

--- a/packages/ui/vite.config.js
+++ b/packages/ui/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@svelte-ui/': join(PACKAGE_ROOT, 'src/lib') + '/',
     },
   },
   plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js', hot: !process.env.VITEST }), svelteTesting()],

--- a/storybook/vite.config.js
+++ b/storybook/vite.config.js
@@ -36,6 +36,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@svelte-ui/': join(PACKAGE_ROOT, '../packages/ui/dist') + '/',
     },
   },
   plugins: [tailwindcss(), svelte(), svelteTesting()],


### PR DESCRIPTION
### What does this PR do?

Adds @svelte-ui alias to reference svelte-ui package components the same way in the UI package iself and in the renderer package.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #14729.

### How to test this PR?

1. Switch to the branch
2. Run `pnpm build` from podman-desktop root folder
3. Open `packages/ui/src/lib/buttons/Button.svelte` and replace import with relatives imports to
``` typescript
import Icon from '/@svelte-ui/icons/Icon.svelte';
import Spinner from '/@svelte-ui/progress/Spinner.svelte';
```
4. Run `pnpm build` again and there should be no errors
5. Run `npx electron .` and podman desktop should still have icons in buttons.