### PR TITLE
chore(main): import api using package rather than alias

### DIFF
--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -23,13 +23,13 @@ import { cp, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import minimist from 'minimist';
 
 import type { Certificates } from '/@/plugin/certificates.js';
 import { ImageRegistry } from '/@/plugin/image-registry.js';
 import type { Proxy } from '/@/plugin/proxy.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import product from '/@product.json' with { type: 'json' };
 
 /**

--- a/packages/main/src/development-mode-tracker.spec.ts
+++ b/packages/main/src/development-mode-tracker.spec.ts
@@ -17,9 +17,8 @@
  ***********************************************************************/
 
 import type { Configuration } from '@podman-desktop/api';
+import { ExtensionLoaderSettings } from '@podman-desktop/core-api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import { ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
 
 import { DevelopmentModeTracker } from './development-mode-tracker.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';

--- a/packages/main/src/development-mode-tracker.ts
+++ b/packages/main/src/development-mode-tracker.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
+import { ExtensionLoaderSettings } from '@podman-desktop/core-api';
 
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
 import { Emitter } from './plugin/events/emitter.js';

--- a/packages/main/src/index.spec.ts
+++ b/packages/main/src/index.spec.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IConfigurationChangeEvent, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import type { App } from 'electron';
 import { app, BrowserWindow, Menu } from 'electron';
 import { aboutMenuItem } from 'electron-util/main';
 import { afterEach, assert, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
-import type { IConfigurationChangeEvent, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import { mainWindowDeferred } from './index.js';
 import { Emitter } from './plugin/events/emitter.js';

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -15,11 +15,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { Event } from '@podman-desktop/core-api';
 import { app, ipcMain, Menu, Tray } from 'electron';
 
 import { restoreWindow } from '/@/mainWindow.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
-import type { Event } from '/@api/event.js';
 
 import { ApplicationMenuBuilder } from './application-menu-builder.js';
 import { type AdditionalData, Main } from './main.js';

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -15,6 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { IDisposable } from '@podman-desktop/core-api';
 import type { App as ElectronApp, BrowserWindow } from 'electron';
 
 import type { AppPlugin } from '/@/plugin/app-ready/app-plugin.js';
@@ -22,7 +23,6 @@ import { DefaultProtocolClient } from '/@/plugin/app-ready/default-protocol-clie
 import { WindowPlugin } from '/@/plugin/app-ready/window-plugin.js';
 import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isLinux, isMac, isWindows } from '/@/util.js';
-import type { IDisposable } from '/@api/disposable.js';
 import product from '/@product.json' with { type: 'json' };
 
 import { ProtocolLauncher } from './protocol-launcher.js';

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron';
-
-import { CONFIGURATION_DEFAULT_SCOPE } from '/@api/configuration/constants.js';
 
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
 

--- a/packages/main/src/plugin/app-ready/app-plugin.ts
+++ b/packages/main/src/plugin/app-ready/app-plugin.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IDisposable } from '/@api/disposable.js';
+import type { IDisposable } from '@podman-desktop/core-api';
 
 export interface AppPlugin extends IDisposable {
   onReady(): Promise<void>;

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IConfigurationChangeEvent } from '@podman-desktop/core-api/configuration';
 import { nativeTheme } from 'electron';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IConfigurationChangeEvent } from '/@api/configuration/models.js';
 
 import { AppearanceInit } from './appearance-init.js';
 import { AppearanceSettings } from './appearance-settings.js';

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { nativeTheme } from 'electron';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import { AppearanceSettings } from './appearance-settings.js';
 

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -23,9 +23,8 @@ import type {
   AuthenticationSessionAccountInformation,
   Event,
 } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { AuthenticationImpl } from './authentication.js';
 import { Emitter as EventEmitter } from './events/emitter.js';

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -25,10 +25,9 @@ import type {
   Disposable,
   Event,
 } from '@podman-desktop/api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { AuthenticationProviderInfo, SessionRequestInfo } from '@podman-desktop/core-api/authentication';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { AuthenticationProviderInfo, SessionRequestInfo } from '/@api/authentication/authentication.js';
 
 import { Emitter } from './events/emitter.js';
 import { MessageBox } from './message-box.js';

--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -17,11 +17,10 @@
  ***********************************************************************/
 
 import type { Configuration } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IConfigurationNode } from '@podman-desktop/core-api/configuration';
+import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '@podman-desktop/core-api/configuration';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
-import type { IConfigurationNode } from '/@api/configuration/models.js';
 
 import { AutostartEngine } from './autostart-engine.js';
 import { ConfigurationRegistry } from './configuration-registry.js';

--- a/packages/main/src/plugin/autostart-engine.ts
+++ b/packages/main/src/plugin/autostart-engine.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '@podman-desktop/core-api/configuration';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
 
-import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '/@api/configuration/constants.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import product from '/@product.json' with { type: 'json' };
 
 import { ProviderRegistry } from './provider-registry.js';

--- a/packages/main/src/plugin/cancellation-token.ts
+++ b/packages/main/src/plugin/cancellation-token.ts
@@ -17,8 +17,7 @@
  ***********************************************************************/
 
 import type * as extensionApi from '@podman-desktop/api';
-
-import type { IDisposable } from '/@api/disposable.js';
+import type { IDisposable } from '@podman-desktop/core-api';
 
 import { Emitter } from './events/emitter.js';
 

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -21,13 +21,13 @@ import * as https from 'node:https';
 import * as path from 'node:path';
 import * as tls from 'node:tls';
 
+import type { CertificateInfo } from '@podman-desktop/core-api';
 import * as asn1js from 'asn1js';
 import { injectable } from 'inversify';
 import * as pkijs from 'pkijs';
 import wincaAPI from 'win-ca/api';
 
 import { isLinux, isMac, isWindows } from '/@/util.js';
-import type { CertificateInfo } from '/@api/certificate-info.js';
 
 import { spawnWithPromise } from './util/spawn-promise.js';
 

--- a/packages/main/src/plugin/cli-tool-impl.spec.ts
+++ b/packages/main/src/plugin/cli-tool-impl.spec.ts
@@ -17,9 +17,8 @@
  ***********************************************************************/
 
 import type { CliToolOptions } from '@podman-desktop/api';
+import type { CliToolExtensionInfo } from '@podman-desktop/core-api';
 import { expect, test, vi } from 'vitest';
-
-import type { CliToolExtensionInfo } from '/@api/cli-tool-info.js';
 
 import { CliToolImpl } from './cli-tool-impl.js';
 import type { CliToolRegistry } from './cli-tool-registry.js';

--- a/packages/main/src/plugin/cli-tool-impl.ts
+++ b/packages/main/src/plugin/cli-tool-impl.ts
@@ -29,8 +29,7 @@ import type {
   Event,
   ProviderImages,
 } from '@podman-desktop/api';
-
-import type { CliToolExtensionInfo } from '/@api/cli-tool-info.js';
+import type { CliToolExtensionInfo } from '@podman-desktop/core-api';
 
 import type { CliToolRegistry } from './cli-tool-registry.js';
 import { Emitter } from './events/emitter.js';

--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -17,10 +17,9 @@
  ***********************************************************************/
 
 import type { CliToolInstaller, CliToolOptions, CliToolSelectUpdate, CliToolUpdate, Logger } from '@podman-desktop/api';
+import type { CliToolExtensionInfo } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { CliToolExtensionInfo } from '/@api/cli-tool-info.js';
 
 import type { CliToolImpl } from './cli-tool-impl.js';
 import { CliToolRegistry } from './cli-tool-registry.js';

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -25,11 +25,9 @@ import type {
   CliToolUpdate,
   Logger,
 } from '@podman-desktop/api';
+import type { CliToolExtensionInfo, CliToolInfo, Event } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { CliToolExtensionInfo, CliToolInfo } from '/@api/cli-tool-info.js';
-import type { Event } from '/@api/event.js';
 
 import { CliToolImpl } from './cli-tool-impl.js';
 import { Emitter } from './events/emitter.js';

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -15,9 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import * as util from '../util.js';
 import { CloseBehavior } from './close-behavior.js';

--- a/packages/main/src/plugin/close-behavior.ts
+++ b/packages/main/src/plugin/close-behavior.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import { isUnixLike } from '../util.js';
 

--- a/packages/main/src/plugin/color-registry-inject.spec.ts
+++ b/packages/main/src/plugin/color-registry-inject.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { Container } from 'inversify';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { InjectableColorRegistry } from './color-registry-inject.js';
 import { ConfigurationRegistry } from './configuration-registry.js';

--- a/packages/main/src/plugin/color-registry-inject.ts
+++ b/packages/main/src/plugin/color-registry-inject.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { ColorRegistry } from './color-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';

--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ColorDefinition, RawThemeContribution } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IConfigurationChangeEvent } from '@podman-desktop/core-api/configuration';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -23,10 +26,6 @@ import { AppearanceSettings } from '/@/plugin/appearance-settings.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ColorDefinition } from '/@api/color-info.js';
-import type { IConfigurationChangeEvent } from '/@api/configuration/models.js';
-import type { RawThemeContribution } from '/@api/theme-info.js';
 
 import tailwindColorPalette from '../../../../tailwind-color-palette.json' with { type: 'json' };
 import * as util from '../util.js';

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -17,11 +17,10 @@
  ***********************************************************************/
 
 import type * as extensionApi from '@podman-desktop/api';
+import type { ColorDefinition, ColorInfo, RawThemeContribution } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ColorDefinition, ColorInfo } from '/@api/color-info.js';
-import type { RawThemeContribution } from '/@api/theme-info.js';
 
 import tailwindColorPalette from '../../../../tailwind-color-palette.json' with { type: 'json' };
 import { isWindows } from '../util.js';

--- a/packages/main/src/plugin/command-registry.spec.ts
+++ b/packages/main/src/plugin/command-registry.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { CommandRegistry } from './command-registry.js';
 import type { Telemetry } from './telemetry/telemetry.js';

--- a/packages/main/src/plugin/command-registry.ts
+++ b/packages/main/src/plugin/command-registry.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CommandInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { CommandInfo } from '/@api/command-info.js';
 
 import { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';

--- a/packages/main/src/plugin/commands-init.spec.ts
+++ b/packages/main/src/plugin/commands-init.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import type { CommandRegistry } from './command-registry.js';
 import { CommandsInit } from './commands-init.js';

--- a/packages/main/src/plugin/commands-init.ts
+++ b/packages/main/src/plugin/commands-init.ts
@@ -17,14 +17,15 @@
  ***********************************************************************/
 
 import type { Uri } from '@podman-desktop/api';
+import type {
+  IDisposable,
+  KubernetesNavigationRequest,
+  ProviderContainerConnectionInfo,
+  PullEvent,
+} from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { shell } from 'electron';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { KubernetesNavigationRequest } from '/@api/kubernetes-navigation.js';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info.js';
-import type { PullEvent } from '/@api/pull-event.js';
 
 import { CommandRegistry } from './command-registry.js';
 import { ContainerProviderRegistry } from './container-registry.js';

--- a/packages/main/src/plugin/configuration-impl.spec.ts
+++ b/packages/main/src/plugin/configuration-impl.spec.ts
@@ -17,14 +17,13 @@
  ***********************************************************************/
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import {
   CONFIGURATION_DEFAULT_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
-} from '/@api/configuration/constants.js';
+} from '@podman-desktop/core-api/configuration';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ConfigurationImpl } from './configuration-impl.js';
 

--- a/packages/main/src/plugin/configuration-impl.ts
+++ b/packages/main/src/plugin/configuration-impl.ts
@@ -17,14 +17,13 @@
  ***********************************************************************/
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IConfigurationChangeEvent } from '@podman-desktop/core-api/configuration';
 import {
   CONFIGURATION_DEFAULT_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
-} from '/@api/configuration/constants.js';
-import type { IConfigurationChangeEvent } from '/@api/configuration/models.js';
+} from '@podman-desktop/core-api/configuration';
 
 import { LockedKeys } from './lock-configuration.js';
 

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -19,15 +19,14 @@
 // Import to access mocked functionionalities such as using vi.mock (we don't want to actually call node:fs methods)
 import * as fs from 'node:fs';
 
-import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
+import type { IDisposable } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IConfigurationNode } from '@podman-desktop/core-api/configuration';
 import {
   CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
-} from '/@api/configuration/constants.js';
-import type { IConfigurationNode } from '/@api/configuration/models.js';
-import type { IDisposable } from '/@api/disposable.js';
+} from '@podman-desktop/core-api/configuration';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ConfigurationRegistry } from './configuration-registry.js';
 import type { DefaultConfiguration } from './default-configuration.js';

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -22,24 +22,21 @@ import * as path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import {
-  CONFIGURATION_DEFAULT_SCOPE,
-  CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
-  CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
-} from '/@api/configuration/constants.js';
+import type { Event, IDisposable, NotificationCardOptions } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type {
   ConfigurationScope,
   IConfigurationChangeEvent,
   IConfigurationNode,
   IConfigurationPropertyRecordedSchema,
   IConfigurationRegistry,
-} from '/@api/configuration/models.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { Event } from '/@api/event.js';
-import type { NotificationCardOptions } from '/@api/notification.js';
+} from '@podman-desktop/core-api/configuration';
+import {
+  CONFIGURATION_DEFAULT_SCOPE,
+  CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
+  CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
+} from '@podman-desktop/core-api/configuration';
+import { inject, injectable } from 'inversify';
 
 import { ConfigurationImpl } from './configuration-impl.js';
 import { DefaultConfiguration } from './default-configuration.js';

--- a/packages/main/src/plugin/confirmation-init.ts
+++ b/packages/main/src/plugin/confirmation-init.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 @injectable()
 export class ConfirmationInit {

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -24,6 +24,15 @@ import { PassThrough, Readable } from 'node:stream';
 import * as streamPromises from 'node:stream/promises';
 
 import type * as podmanDesktopAPI from '@podman-desktop/api';
+import type {
+  ContainerCreateOptions,
+  ContainerInspectInfo,
+  HostConfig,
+  ImageInfo,
+  ProviderContainerConnectionInfo,
+} from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { ContainerCreateOptions as PodmanContainerCreateOptions } from '@podman-desktop/core-api/libpod';
 import Dockerode from 'dockerode';
 import moment from 'moment';
 import { http, HttpResponse } from 'msw';
@@ -39,12 +48,6 @@ import { ImageRegistry } from '/@/plugin/image-registry.js';
 import { KubePlayContext } from '/@/plugin/podman/kube.js';
 import type { Proxy } from '/@/plugin/proxy.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ContainerCreateOptions, HostConfig } from '/@api/container-info.js';
-import type { ContainerInspectInfo } from '/@api/container-inspect-info.js';
-import type { ImageInfo } from '/@api/image-info.js';
-import type { ContainerCreateOptions as PodmanContainerCreateOptions } from '/@api/libpod/libpod.js';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info.js';
 
 import * as util from '../util.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -25,6 +25,51 @@ import { Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type {
+  BuildImageOptions,
+  ContainerCreateOptions,
+  ContainerExportOptions,
+  ContainerImportOptions,
+  ContainerInfo,
+  ContainerInspectInfo,
+  ContainerPortInfo,
+  ContainerStatsInfo,
+  Event,
+  HistoryInfo,
+  ImageInfo,
+  ImageInspectInfo,
+  ImageLoadOptions,
+  ImagesSaveOptions,
+  LibPodPodInfo,
+  ListImagesOptions,
+  ManifestCreateOptions,
+  ManifestInspectInfo,
+  ManifestPushOptions,
+  NetworkCreateOptions,
+  NetworkCreateResult,
+  NetworkInspectInfo,
+  PodCreateOptions,
+  PodInfo,
+  PodInspectInfo,
+  PodmanListImagesOptions,
+  ProviderContainerConnectionInfo,
+  PullEvent,
+  SimpleContainerInfo,
+  VolumeCreateOptions,
+  VolumeCreateResponseInfo,
+  VolumeInfo,
+  VolumeInspectInfo,
+  VolumeListInfo,
+} from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type {
+  ContainerCreateMountOption,
+  ContainerCreateNetNSOption,
+  ContainerCreateOptions as PodmanContainerCreateOptions,
+  ContainerCreatePortMappingOption,
+  PodmanDevice,
+} from '@podman-desktop/core-api/libpod';
+import { PlayKubeInfo } from '@podman-desktop/core-api/libpod';
 import datejs from 'date.js';
 import type { ContainerAttachOptions, ImageBuildOptions } from 'dockerode';
 import Dockerode from 'dockerode';
@@ -36,41 +81,6 @@ import type { Headers, Pack, PackOptions } from 'tar-fs';
 
 import { KubePlayContext } from '/@/plugin/podman/kube.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type {
-  ContainerCreateOptions,
-  ContainerExportOptions,
-  ContainerImportOptions,
-  ContainerInfo,
-  ContainerPortInfo,
-  ImageLoadOptions,
-  ImagesSaveOptions,
-  NetworkCreateOptions,
-  NetworkCreateResult,
-  SimpleContainerInfo,
-  VolumeCreateOptions,
-  VolumeCreateResponseInfo,
-} from '/@api/container-info.js';
-import type { ContainerInspectInfo } from '/@api/container-inspect-info.js';
-import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
-import type { Event } from '/@api/event.js';
-import type { HistoryInfo } from '/@api/history-info.js';
-import type { BuildImageOptions, ImageInfo, ListImagesOptions, PodmanListImagesOptions } from '/@api/image-info.js';
-import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
-import type {
-  ContainerCreateMountOption,
-  ContainerCreateNetNSOption,
-  ContainerCreateOptions as PodmanContainerCreateOptions,
-  ContainerCreatePortMappingOption,
-  PodmanDevice,
-} from '/@api/libpod/libpod.js';
-import { PlayKubeInfo } from '/@api/libpod/libpod.js';
-import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
-import type { NetworkInspectInfo } from '/@api/network-info.js';
-import type { LibPodPodInfo, PodCreateOptions, PodInfo, PodInspectInfo } from '/@api/pod-info.js';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info.js';
-import type { PullEvent } from '/@api/pull-event.js';
-import type { VolumeInfo, VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
 
 import { isWindows } from '../util.js';
 import { ConfigurationRegistry } from './configuration-registry.js';

--- a/packages/main/src/plugin/containerfile-parser.ts
+++ b/packages/main/src/plugin/containerfile-parser.ts
@@ -18,9 +18,8 @@
 
 import { readFile } from 'node:fs/promises';
 
+import type { ContainerfileInfo } from '@podman-desktop/core-api';
 import { inject, injectable } from 'inversify';
-
-import type { ContainerfileInfo } from '/@api/containerfile-info.js';
 
 import { IPCHandle } from './api.js';
 

--- a/packages/main/src/plugin/context/context.ts
+++ b/packages/main/src/plugin/context/context.ts
@@ -21,10 +21,9 @@
  *--------------------------------------------------------------------------------------------*/
 // based on https://github.com/microsoft/vscode/blob/3eed9319874b7ca037128962593b6a8630869253/src/vs/platform/contextkey/browser/contextKeyService.ts
 
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IContext } from '@podman-desktop/core-api/context';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IContext } from '/@api/context/context.js';
 
 @injectable()
 export class Context implements IContext {

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -20,13 +20,11 @@ import * as fs from 'node:fs';
 import type { FileHandle } from 'node:fs/promises';
 
 import type { RunResult } from '@podman-desktop/api';
+import type { ContributionInfo, IDisposable } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import * as jsYaml from 'js-yaml';
 import { EventEmitter } from 'stream-json/Assembler.js';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ContributionInfo } from '/@api/contribution-info.js';
-import type { IDisposable } from '/@api/disposable.js';
 
 import * as util from '../util.js';
 import type { ContainerProviderRegistry } from './container-registry.js';

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -20,11 +20,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import type { RunResult } from '@podman-desktop/api';
+import type { ContributionInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
 import * as jsYaml from 'js-yaml';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ContributionInfo } from '/@api/contribution-info.js';
 
 import { isMac, isUnixLike, isWindows } from '../util.js';
 import { ContainerProviderRegistry } from './container-registry.js';

--- a/packages/main/src/plugin/custompick/custompick-impl.spec.ts
+++ b/packages/main/src/plugin/custompick/custompick-impl.spec.ts
@@ -15,9 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { CustomPickImpl } from './custompick-impl.js';
 import { CustomPickRegistry } from './custompick-registry.js';

--- a/packages/main/src/plugin/custompick/custompick-impl.ts
+++ b/packages/main/src/plugin/custompick/custompick-impl.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { CustomPick, CustomPickItem, Event } from '@podman-desktop/api';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
+import type { IDisposable } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 
 import { Emitter } from '../events/emitter.js';
 import type { CustomPickRegistry } from './custompick-registry.js';

--- a/packages/main/src/plugin/custompick/custompick-registry.ts
+++ b/packages/main/src/plugin/custompick/custompick-registry.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { CustomPick, CustomPickItem } from '@podman-desktop/api';
+import { IDisposable } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { IDisposable } from '/@api/disposable.js';
 
 import { CustomPickImpl } from './custompick-impl.js';
 

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -19,15 +19,14 @@
 import * as fs from 'node:fs';
 
 import type { RequestConfig } from '@docker/extension-api-client-types/dist/v1/http-service.js';
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type Dockerode from 'dockerode';
 import type { IpcMainEvent } from 'electron';
 import type { Method } from 'got';
 import { http, HttpResponse } from 'msw';
 import { setupServer, type SetupServerApi } from 'msw/node';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ProviderContainerConnectionInfo } from '/@api/provider-info.js';
 
 import type { ContainerProviderRegistry } from '../container-registry.js';
 import type { ContributionManager } from '../contribution-manager.js';

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -22,15 +22,14 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import type { v1 } from '@docker/extension-api-client-types';
+import type { PullEvent } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type Dockerode from 'dockerode';
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { ipcMain } from 'electron';
 import type { Method, OptionsOfTextResponseBody } from 'got';
 import got, { RequestError } from 'got';
 import * as tarFs from 'tar-fs';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { PullEvent } from '/@api/pull-event.js';
 
 import type { ContainerProviderRegistry } from '../container-registry.js';
 import type { ContributionManager } from '../contribution-manager.js';

--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { SimpleContainerInfo } from '@podman-desktop/core-api';
 import type { IpcMainEvent } from 'electron';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { SimpleContainerInfo } from '/@api/container-info.js';
 
 import type { ContainerProviderRegistry } from '../container-registry.js';
 import type { ContributionManager } from '../contribution-manager.js';

--- a/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
+++ b/packages/main/src/plugin/docker-extension/docker-plugin-adapter.ts
@@ -19,10 +19,9 @@
 import { spawn } from 'node:child_process';
 import * as os from 'node:os';
 
+import type { SimpleContainerInfo } from '@podman-desktop/core-api';
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { ipcMain } from 'electron';
-
-import type { SimpleContainerInfo } from '/@api/container-info.js';
 
 import type { ContainerProviderRegistry } from '../container-registry.js';
 import type { ContributionManager } from '../contribution-manager.js';

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -20,11 +20,9 @@ import type { Stats } from 'node:fs';
 import { promises } from 'node:fs';
 
 import type { ProviderContainerConnection } from '@podman-desktop/api';
+import type { DockerSocketServerInfoType, ProviderInfo } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeAll, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { DockerSocketServerInfoType } from '/@api/docker-compatibility-info.js';
-import type { ProviderInfo } from '/@api/provider-info.js';
 
 import * as util from '../../util.js';
 import { ConfigurationRegistry } from '../configuration-registry.js';

--- a/packages/main/src/plugin/docker/docker-compatibility.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.ts
@@ -18,16 +18,16 @@
 
 import { promises } from 'node:fs';
 
-import Dockerode from 'dockerode';
-import { inject, injectable } from 'inversify';
-
-import { isMac, isWindows } from '/@/util.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import {
   DockerCompatibilitySettings,
   type DockerSocketMappingStatusInfo,
   type DockerSocketServerInfoType,
-} from '/@api/docker-compatibility-info.js';
+} from '@podman-desktop/core-api';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import Dockerode from 'dockerode';
+import { inject, injectable } from 'inversify';
+
+import { isMac, isWindows } from '/@/util.js';
 
 import type { LibPod } from '../dockerode/libpod-dockerode.js';
 import { ProviderRegistry } from '../provider-registry.js';

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -23,6 +23,8 @@ import type { RequestOptions } from 'node:http';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import type { PodmanListImagesOptions } from '@podman-desktop/core-api';
+import type { PlayKubeInfo } from '@podman-desktop/core-api/libpod';
 import type DockerModem from 'docker-modem';
 import Dockerode from 'dockerode';
 import type { DefaultBodyType, HttpResponseResolver, PathParams, ResponseResolverReturnType } from 'msw';
@@ -32,8 +34,6 @@ import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, t
 
 import type { DockerodeInternals, LibPod } from '/@/plugin/dockerode/libpod-dockerode.js';
 import { LibpodDockerode } from '/@/plugin/dockerode/libpod-dockerode.js';
-import type { PodmanListImagesOptions } from '/@api/image-info.js';
-import type { PlayKubeInfo } from '/@api/libpod/libpod.js';
 
 import podmanInfo from '../../../tests/resources/data/plugin/podman-info.json' with { type: 'json' };
 

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -19,14 +19,12 @@
 import type { RequestOptions } from 'node:http';
 
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '@podman-desktop/api';
+import type { ImageInfo, LibPodPodInfo, LibPodPodInspectInfo, PodmanListImagesOptions } from '@podman-desktop/core-api';
+import type { ContainerCreateOptions, PlayKubeInfo, PodCreatePortOptions } from '@podman-desktop/core-api/libpod';
 import type DockerModem from 'docker-modem';
 import type { DialOptions } from 'docker-modem';
 import type { VolumeCreateOptions, VolumeCreateResponse } from 'dockerode';
 import Dockerode from 'dockerode';
-
-import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info.js';
-import type { ContainerCreateOptions, PlayKubeInfo, PodCreatePortOptions } from '/@api/libpod/libpod.js';
-import type { LibPodPodInfo, LibPodPodInspectInfo } from '/@api/pod-info.js';
 
 export interface PodCreateOptions {
   name?: string;

--- a/packages/main/src/plugin/documentation/documentation-service.spec.ts
+++ b/packages/main/src/plugin/documentation/documentation-service.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { DocumentationService } from '/@/plugin/documentation/documentation-service.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 const originalConsoleError = console.error;
 

--- a/packages/main/src/plugin/documentation/documentation-service.ts
+++ b/packages/main/src/plugin/documentation/documentation-service.ts
@@ -18,10 +18,9 @@
 
 import { createHash } from 'node:crypto';
 
+import { DocumentationBaseInfo, DocumentationInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { DocumentationBaseInfo, DocumentationInfo } from '/@api/documentation-info.js';
 
 import fallbackDocumentation from '../../assets/fallback-documentation.json' with { type: 'json' };
 import { Disposable } from '../types/disposable.js';

--- a/packages/main/src/plugin/editor-init.ts
+++ b/packages/main/src/plugin/editor-init.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import { EditorSettings } from '@podman-desktop/core-api/editor';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { EditorSettings } from '/@api/editor/editor-settings.js';
 
 @injectable()
 export class EditorInit {

--- a/packages/main/src/plugin/events/emitter.ts
+++ b/packages/main/src/plugin/events/emitter.ts
@@ -18,9 +18,7 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
 
-import type { IDisposable } from '/@api/disposable.js';
-import type { DisposableGroup } from '/@api/disposable-group.js';
-import type { Event } from '/@api/event.js';
+import type { DisposableGroup, Event, IDisposable } from '@podman-desktop/core-api';
 
 type Callback = (...args: unknown[]) => unknown;
 class CallbackList implements Iterable<Callback> {

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
@@ -17,10 +17,9 @@
  ***********************************************************************/
 
 import type { Configuration } from '@podman-desktop/api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { shell } from 'electron';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { IConfigurationPropertyRecordedSchema } from '/@api/configuration/models.js';
 
 import type { ConfigurationRegistry } from './configuration-registry.js';
 import type { ExperimentalConfiguration, Timestamp } from './experimental-feature-feedback-handler.js';

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IDisposable } from '@podman-desktop/core-api';
+import { IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { shell } from 'electron';
 import { inject, injectable } from 'inversify';
-
-import { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { IDisposable } from '/@api/disposable.js';
 
 import { formatName } from '../util.js';
 import { ConfigurationRegistry } from './configuration-registry.js';

--- a/packages/main/src/plugin/explore-features/explore-features.spec.ts
+++ b/packages/main/src/plugin/explore-features/explore-features.spec.ts
@@ -20,13 +20,16 @@ import { existsSync, promises } from 'node:fs';
 import path from 'node:path';
 
 import type { Configuration } from '@podman-desktop/api';
+import type {
+  ContainerInfo,
+  ExploreFeature,
+  ExtensionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+} from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { Context } from '/@/plugin/context/context.js';
-import type { ContainerInfo } from '/@api/container-info.js';
-import type { ExploreFeature } from '/@api/explore-feature.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
-import type { ProviderInfo, ProviderKubernetesConnectionInfo } from '/@api/provider-info.js';
 
 import type { ConfigurationRegistry } from '../configuration-registry.js';
 import type { ContainerProviderRegistry } from '../container-registry.js';

--- a/packages/main/src/plugin/explore-features/explore-features.ts
+++ b/packages/main/src/plugin/explore-features/explore-features.ts
@@ -19,13 +19,13 @@
 import { existsSync, promises } from 'node:fs';
 import path from 'node:path';
 
+import { ExploreFeature } from '@podman-desktop/core-api';
+import { IConfigurationNode } from '@podman-desktop/core-api/configuration';
 import { app } from 'electron';
 import { inject, injectable } from 'inversify';
 
 import { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import { Context } from '/@/plugin/context/context.js';
-import { IConfigurationNode } from '/@api/configuration/models.js';
-import { ExploreFeature } from '/@api/explore-feature.js';
 
 import { ContainerProviderRegistry } from '../container-registry.js';
 import { ExtensionLoader } from '../extension/extension-loader.js';

--- a/packages/main/src/plugin/extension/catalog/extensions-catalog.spec.ts
+++ b/packages/main/src/plugin/extension/catalog/extensions-catalog.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { Configuration, ProxySettings } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { delay, http, HttpResponse } from 'msw';
 import { setupServer, type SetupServerApi } from 'msw/node';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
@@ -26,7 +27,6 @@ import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js'
 import { Emitter } from '/@/plugin/events/emitter.js';
 import type { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import type { Proxy } from '/@/plugin/proxy.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { ExtensionsCatalog } from './extensions-catalog.js';
 

--- a/packages/main/src/plugin/extension/catalog/extensions-catalog.ts
+++ b/packages/main/src/plugin/extension/catalog/extensions-catalog.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import { CatalogExtension, CatalogFetchableExtension } from '@podman-desktop/core-api/extension-catalog';
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
 import got from 'got';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
@@ -25,9 +28,6 @@ import { coerce, satisfies } from 'semver';
 import { Certificates } from '/@/plugin/certificates.js';
 import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import { Proxy } from '/@/plugin/proxy.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { CatalogExtension, CatalogFetchableExtension } from '/@api/extension-catalog/extensions-catalog-api.js';
 import product from '/@product.json' with { type: 'json' };
 
 import { ExtensionsCatalogSettings } from './extensions-catalog-settings.js';

--- a/packages/main/src/plugin/extension/extension-development-folders.spec.ts
+++ b/packages/main/src/plugin/extension/extension-development-folders.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { Configuration } from '@podman-desktop/api';
+import { ExtensionDevelopmentFolderInfoSettings } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { ExtensionDevelopmentFolderInfoSettings } from '/@api/extension-development-folders-info.js';
 
 import type { ConfigurationRegistry } from '../configuration-registry.js';
 import type { AnalyzedExtension, ExtensionAnalyzer } from './extension-analyzer.js';

--- a/packages/main/src/plugin/extension/extension-development-folders.ts
+++ b/packages/main/src/plugin/extension/extension-development-folders.ts
@@ -19,13 +19,13 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import type { ExtensionDevelopmentFolderInfo } from '@podman-desktop/core-api';
+import { ExtensionDevelopmentFolderInfoSettings } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
 
 import { Emitter } from '/@/plugin/events/emitter.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info.js';
-import { ExtensionDevelopmentFolderInfoSettings } from '/@api/extension-development-folders-info.js';
 
 import { type AnalyzedExtension, ExtensionAnalyzer } from './extension-analyzer.js';
 

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -22,6 +22,16 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type {
+  BuildImageOptions as InternalBuildImageOptions,
+  ContributionInfo,
+  IDisposable,
+  OnboardingInfo,
+  PodInspectInfo,
+  WebviewInfo,
+} from '@podman-desktop/core-api';
+import { ExtensionLoaderSettings, NavigationPage } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { app } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -32,15 +42,6 @@ import type { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import type { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ContributionInfo } from '/@api/contribution-info.js';
-import type { IDisposable } from '/@api/disposable.js';
-import { ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
-import type { BuildImageOptions as InternalBuildImageOptions } from '/@api/image-info.js';
-import { NavigationPage } from '/@api/navigation-page.js';
-import type { OnboardingInfo } from '/@api/onboarding.js';
-import type { PodInspectInfo } from '/@api/pod-info.js';
-import type { WebviewInfo } from '/@api/webview-info.js';
 import product from '/@product.json' with { type: 'json' };
 
 import { getBase64Image } from '../../util.js';

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -20,6 +20,16 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type {
+  Event,
+  ExtensionError,
+  ExtensionInfo,
+  ExtensionUpdateInfo,
+  ImageInspectInfo,
+} from '@podman-desktop/core-api';
+import { DEFAULT_TIMEOUT, ExtensionLoaderSettings, IAsyncDisposable, PodInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import AdmZip from 'adm-zip';
 import { app, clipboard as electronClipboard } from 'electron';
 import { inject, injectable, preDestroy } from 'inversify';
@@ -34,14 +44,6 @@ import {
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { IAsyncDisposable } from '/@api/async-disposable.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { Event } from '/@api/event.js';
-import type { ExtensionError, ExtensionInfo, ExtensionUpdateInfo } from '/@api/extension-info.js';
-import { DEFAULT_TIMEOUT, ExtensionLoaderSettings } from '/@api/extension-loader-settings.js';
-import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
-import { PodInfo } from '/@api/pod-info.js';
 import product from '/@product.json' with { type: 'json' };
 
 import { securityRestrictionCurrentHandler } from '../../security-restrictions-handler.js';

--- a/packages/main/src/plugin/extension/extension-watcher.ts
+++ b/packages/main/src/plugin/extension/extension-watcher.ts
@@ -17,11 +17,10 @@
  ***********************************************************************/
 
 import type { FileSystemWatcher, Uri } from '@podman-desktop/api';
+import type { Event } from '@podman-desktop/core-api';
+import { IDisposable } from '@podman-desktop/core-api';
 import type { FileMatcher } from 'get-tsconfig';
 import { inject, injectable } from 'inversify';
-
-import { IDisposable } from '/@api/disposable.js';
-import type { Event } from '/@api/event.js';
 
 import { Emitter } from '../events/emitter.js';
 import { FilesystemMonitoring } from '../filesystem-monitoring.js';

--- a/packages/main/src/plugin/extension/updater/extensions-updater.spec.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ExtensionInfo } from '@podman-desktop/core-api';
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
@@ -23,8 +25,6 @@ import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-c
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { ExtensionInstaller } from '/@/plugin/install/extension-installer.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
 
 import { ExtensionsUpdater } from './extensions-updater.js';
 

--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ExtensionUpdateInfo } from '@podman-desktop/core-api';
+import type { IConfigurationNode } from '@podman-desktop/core-api/configuration';
+import { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
 import { compare } from 'semver';
 
@@ -24,9 +27,6 @@ import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionsUpdaterSettings } from '/@/plugin/extension/updater/extensions-updater-settings.js';
 import { ExtensionInstaller } from '/@/plugin/install/extension-installer.js';
 import { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-import type { IConfigurationNode } from '/@api/configuration/models.js';
-import { IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { ExtensionUpdateInfo } from '/@api/extension-info.js';
 
 @injectable()
 export class ExtensionsUpdater {

--- a/packages/main/src/plugin/feature-registry.ts
+++ b/packages/main/src/plugin/feature-registry.ts
@@ -15,10 +15,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { Event } from '@podman-desktop/core-api';
 import { injectable } from 'inversify';
 
 import { Emitter } from '/@/plugin/events/emitter.js';
-import { Event } from '/@api/event.js';
 
 import { Disposable } from './types/disposable.js';
 

--- a/packages/main/src/plugin/featured/featured.ts
+++ b/packages/main/src/plugin/featured/featured.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { CatalogFetchableExtension } from '@podman-desktop/core-api/extension-catalog';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 import { inject, injectable } from 'inversify';
 
 import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
-import type { CatalogFetchableExtension } from '/@api/extension-catalog/extensions-catalog-api.js';
-import type { FeaturedExtension } from '/@api/featured/featured-api.js';
 
 import featuredJSONFile from '../../../../../featured.json' with { type: 'json' };
 

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -18,13 +18,12 @@
 
 import { release } from 'node:os';
 
+import type { ExtensionInfo, GitHubIssue } from '@podman-desktop/core-api';
 import { shell } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { isLinux, isMac, isWindows } from '/@/util.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
-import type { GitHubIssue } from '/@api/feedback.js';
 import productJSONFile from '/@product.json' with { type: 'json' };
 
 import { FeedbackHandler } from './feedback-handler.js';

--- a/packages/main/src/plugin/feedback-handler.ts
+++ b/packages/main/src/plugin/feedback-handler.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { FeedbackMessages, GitHubIssue } from '@podman-desktop/core-api';
 import { shell } from 'electron';
 import { inject, injectable } from 'inversify';
 
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { SystemInfo } from '/@/plugin/util/sys-info.js';
 import { getSystemInfo } from '/@/plugin/util/sys-info.js';
-import type { FeedbackMessages, GitHubIssue } from '/@api/feedback.js';
 import productJSONFile from '/@product.json' with { type: 'json' };
 
 @injectable()

--- a/packages/main/src/plugin/help-menu/help-menu.ts
+++ b/packages/main/src/plugin/help-menu/help-menu.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ActionKind, ItemInfo } from '@podman-desktop/core-api';
 import { inject, injectable } from 'inversify';
 
 import { IPCHandle } from '/@/plugin/api.js';
-import { ActionKind, ItemInfo } from '/@api/help-menu.js';
 import product from '/@product.json' with { type: 'json' };
 
 @injectable()

--- a/packages/main/src/plugin/icon-registry.spec.ts
+++ b/packages/main/src/plugin/icon-registry.spec.ts
@@ -18,10 +18,10 @@
 
 import path from 'node:path';
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { IconRegistry } from './icon-registry.js';
 

--- a/packages/main/src/plugin/icon-registry.ts
+++ b/packages/main/src/plugin/icon-registry.ts
@@ -18,12 +18,11 @@
 
 import { join } from 'node:path';
 
+import type { FontDefinition, IconDefinition, IconInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
 
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { FontDefinition } from '/@api/font-info.js';
-import type { IconDefinition, IconInfo } from '/@api/icon-info.js';
 
 import { isWindows } from '../util.js';
 

--- a/packages/main/src/plugin/image-checker.spec.ts
+++ b/packages/main/src/plugin/image-checker.spec.ts
@@ -17,10 +17,9 @@
  ***********************************************************************/
 
 import type { CancellationToken, ImageChecks, ImageInfo, ProviderResult } from '@podman-desktop/api';
+import type { ImageCheckerExtensionInfo } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ImageCheckerExtensionInfo } from '/@api/image-checker-info.js';
 
 import { ImageCheckerImpl } from './image-checker.js';
 

--- a/packages/main/src/plugin/image-checker.ts
+++ b/packages/main/src/plugin/image-checker.ts
@@ -24,10 +24,9 @@ import type {
   ImageChecks,
   ImageInfo,
 } from '@podman-desktop/api';
+import type { ImageCheckerExtensionInfo, ImageCheckerInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ImageCheckerExtensionInfo, ImageCheckerInfo } from '/@api/image-checker-info.js';
 
 export interface ImageCheckerProviderWithMetadata {
   id: string;

--- a/packages/main/src/plugin/image-details-files.ts
+++ b/packages/main/src/plugin/image-details-files.ts
@@ -17,9 +17,8 @@
  ***********************************************************************/
 
 import type { ImageFile, ImageFilesystemLayer } from '@podman-desktop/api';
-
-import { FilesystemTree } from '/@api/filesystem-tree.js';
-import type { ImageFilesystemLayerUI } from '/@api/image-filesystem-layers.js';
+import type { ImageFilesystemLayerUI } from '@podman-desktop/core-api';
+import { FilesystemTree } from '@podman-desktop/core-api';
 
 export function toImageFilesystemLayerUIs(layers: ImageFilesystemLayer[]): ImageFilesystemLayerUI[] {
   const result: ImageFilesystemLayerUI[] = [];

--- a/packages/main/src/plugin/image-files-registry.spec.ts
+++ b/packages/main/src/plugin/image-files-registry.spec.ts
@@ -24,10 +24,9 @@ import type {
   ImageInfo,
   ProviderResult,
 } from '@podman-desktop/api';
+import type { ImageFilesExtensionInfo } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { afterEach, beforeEach, expect, suite, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ImageFilesExtensionInfo } from '/@api/image-files-info.js';
 
 import type { ConfigurationRegistry } from './configuration-registry.js';
 import type { Context } from './context/context.js';

--- a/packages/main/src/plugin/image-files-registry.ts
+++ b/packages/main/src/plugin/image-files-registry.ts
@@ -23,12 +23,10 @@ import type {
   ImageFilesProviderMetadata,
   ImageInfo,
 } from '@podman-desktop/api';
+import type { ImageFilesExtensionInfo, ImageFilesInfo, ImageFilesystemLayersUI } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { ImageFilesExtensionInfo, ImageFilesInfo } from '/@api/image-files-info.js';
-import type { ImageFilesystemLayersUI } from '/@api/image-filesystem-layers.js';
 
 import { Context } from './context/context.js';
 import { toImageFilesystemLayerUIs } from './image-details-files.js';

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -24,13 +24,12 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import type { Registry } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import * as fzstd from 'fzstd';
 import { http, HttpResponse } from 'msw';
 import { setupServer, type SetupServerApi } from 'msw/node';
 import * as nodeTar from 'tar';
 import { afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import imageRegistryConfigJson from '../../tests/resources/data/plugin/image-registry-config.json' with {
   type: 'json',

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -24,6 +24,13 @@ import * as path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type {
+  ImageSearchOptions,
+  ImageSearchResult,
+  ImageTagsListOptions,
+  ImageUpdateStatus,
+} from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type * as Dockerode from 'dockerode';
 import * as fzstd from 'fzstd';
 import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
@@ -32,14 +39,6 @@ import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import { inject, injectable } from 'inversify';
 import * as nodeTar from 'tar';
 import validator from 'validator';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type {
-  ImageSearchOptions,
-  ImageSearchResult,
-  ImageTagsListOptions,
-  ImageUpdateStatus,
-} from '/@api/image-registry.js';
 
 import { isMac, isWindows } from '../util.js';
 import { Certificates } from './certificates.js';

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -21,6 +21,9 @@ import { EventEmitter } from 'node:events';
 import { tmpdir } from 'node:os';
 
 import type { PullEvent } from '@podman-desktop/api';
+import type { NotificationCardOptions, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { PlayKubeInfo } from '@podman-desktop/core-api/libpod';
 import type { IpcMainInvokeEvent, WebContents } from 'electron';
 import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import { Container as InversifyContainer } from 'inversify';
@@ -29,10 +32,6 @@ import { afterEach, assert, beforeAll, beforeEach, describe, expect, test, vi } 
 
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { Updater } from '/@/plugin/updater.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { PlayKubeInfo } from '/@api/libpod/libpod.js';
-import type { NotificationCardOptions } from '/@api/notification.js';
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info.js';
 
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import type { TrayMenu } from '../tray-menu.js';

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -42,6 +42,107 @@ import type {
   V1Service,
 } from '@kubernetes/client-node';
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type {
+  CertificateInfo,
+  CliToolInfo,
+  ColorInfo,
+  CommandInfo,
+  ContainerCreateOptions,
+  ContainerExportOptions,
+  ContainerImportOptions,
+  ContainerInfo,
+  ContainerInspectInfo,
+  ContainerStatsInfo,
+  ContextGeneralState,
+  ContextHealth,
+  ContextPermission,
+  ContributionInfo,
+  DockerSocketMappingStatusInfo,
+  DocumentationInfo,
+  ExtensionDevelopmentFolderInfo,
+  ExtensionInfo,
+  FeedbackMessages,
+  FeedbackProperties,
+  ForwardConfig,
+  ForwardOptions,
+  GitHubIssue,
+  HistoryInfo,
+  IconInfo,
+  IDisposable,
+  ImageCheckerInfo,
+  ImageFilesInfo,
+  ImageFilesystemLayersUI,
+  ImageInfo,
+  ImageInspectInfo,
+  ImageLoadOptions,
+  ImageSearchOptions,
+  ImageSearchResult,
+  ImagesSaveOptions,
+  ImageTagsListOptions,
+  ImageUpdateStatus,
+  KubeContext,
+  KubernetesContextResources,
+  KubernetesTroubleshootingInformation,
+  ListOrganizerItem,
+  ManifestCreateOptions,
+  ManifestInspectInfo,
+  ManifestPushOptions,
+  Menu,
+  MessageBoxOptions,
+  MessageBoxReturnValue,
+  NetworkCreateOptions,
+  NetworkCreateResult,
+  NetworkInspectInfo,
+  NotificationCard,
+  NotificationCardOptions,
+  OnboardingInfo,
+  OnboardingStatus,
+  PodInfo,
+  PodInspectInfo,
+  PodmanListImagesOptions,
+  PreflightCheckEvent,
+  PreflightChecksCallback,
+  ProviderConnectionInfo,
+  ProviderContainerConnectionInfo,
+  ProviderInfo,
+  ProviderKubernetesConnectionInfo,
+  ProxyState,
+  PullEvent,
+  ReleaseNotesInfo,
+  ResourceCount,
+  ResourceName,
+  SimpleContainerInfo,
+  StatusBarEntryDescriptor,
+  TelemetryMessages,
+  V1Route,
+  ViewInfoUI,
+  VolumeCreateOptions,
+  VolumeCreateResponseInfo,
+  VolumeInspectInfo,
+  VolumeListInfo,
+  WebviewInfo,
+  WelcomeMessages,
+} from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { AuthenticationProviderInfo } from '@podman-desktop/core-api/authentication';
+import {
+  type IConfigurationPropertyRecordedSchema,
+  IConfigurationRegistry,
+} from '@podman-desktop/core-api/configuration';
+import type { CatalogExtension } from '@podman-desktop/core-api/extension-catalog';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
+import type {
+  GenerateKubeResult,
+  KubernetesGeneratorArgument,
+  KubernetesGeneratorInfo,
+  KubernetesGeneratorSelector,
+} from '@podman-desktop/core-api/kubernetes';
+import type {
+  ContainerCreateOptions as PodmanContainerCreateOptions,
+  PlayKubeInfo,
+} from '@podman-desktop/core-api/libpod';
+import type { ExtensionBanner, RecommendedRegistry } from '@podman-desktop/core-api/recommendations';
+import type { PinOption } from '@podman-desktop/core-api/status-bar';
 import checkDiskSpacePkg from 'check-disk-space';
 import type Dockerode from 'dockerode';
 import type { IpcMainEvent, WebContents } from 'electron';
@@ -63,93 +164,6 @@ import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Uri } from '/@/plugin/types/uri.js';
 import { Updater } from '/@/plugin/updater.js';
 import { Welcome } from '/@/plugin/welcome.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { AuthenticationProviderInfo } from '/@api/authentication/authentication.js';
-import type { CertificateInfo } from '/@api/certificate-info.js';
-import type { CliToolInfo } from '/@api/cli-tool-info.js';
-import type { ColorInfo } from '/@api/color-info.js';
-import type { CommandInfo } from '/@api/command-info.js';
-import { type IConfigurationPropertyRecordedSchema, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type {
-  ContainerCreateOptions,
-  ContainerExportOptions,
-  ContainerImportOptions,
-  ContainerInfo,
-  ImageLoadOptions,
-  ImagesSaveOptions,
-  NetworkCreateOptions,
-  NetworkCreateResult,
-  SimpleContainerInfo,
-  VolumeCreateOptions,
-  VolumeCreateResponseInfo,
-} from '/@api/container-info.js';
-import type { ContainerInspectInfo } from '/@api/container-inspect-info.js';
-import type { ContainerStatsInfo } from '/@api/container-stats-info.js';
-import type { ContributionInfo } from '/@api/contribution-info.js';
-import type { MessageBoxOptions, MessageBoxReturnValue } from '/@api/dialog.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { DockerSocketMappingStatusInfo } from '/@api/docker-compatibility-info.js';
-import type { DocumentationInfo } from '/@api/documentation-info.js';
-import type { CatalogExtension } from '/@api/extension-catalog/extensions-catalog-api.js';
-import type { ExtensionDevelopmentFolderInfo } from '/@api/extension-development-folders-info.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
-import type { FeaturedExtension } from '/@api/featured/featured-api.js';
-import type { FeedbackMessages, FeedbackProperties, GitHubIssue } from '/@api/feedback.js';
-import type { HistoryInfo } from '/@api/history-info.js';
-import type { IconInfo } from '/@api/icon-info.js';
-import type { ImageCheckerInfo } from '/@api/image-checker-info.js';
-import type { ImageFilesInfo } from '/@api/image-files-info.js';
-import type { ImageFilesystemLayersUI } from '/@api/image-filesystem-layers.js';
-import type { ImageInfo, PodmanListImagesOptions } from '/@api/image-info.js';
-import type { ImageInspectInfo } from '/@api/image-inspect-info.js';
-import type {
-  ImageSearchOptions,
-  ImageSearchResult,
-  ImageTagsListOptions,
-  ImageUpdateStatus,
-} from '/@api/image-registry.js';
-import type {
-  GenerateKubeResult,
-  KubernetesGeneratorArgument,
-  KubernetesGeneratorInfo,
-  KubernetesGeneratorSelector,
-} from '/@api/kubernetes/kubernetes-generator-api.js';
-import type { KubeContext } from '/@api/kubernetes-context.js';
-import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
-import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
-import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
-import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
-import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
-import type { ContainerCreateOptions as PodmanContainerCreateOptions, PlayKubeInfo } from '/@api/libpod/libpod.js';
-import type { ListOrganizerItem } from '/@api/list-organizer.js';
-import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '/@api/manifest-info.js';
-import type { Menu } from '/@api/menu.js';
-import type { NetworkInspectInfo } from '/@api/network-info.js';
-import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
-import type { OnboardingInfo, OnboardingStatus } from '/@api/onboarding.js';
-import type { V1Route } from '/@api/openshift-types.js';
-import type { PodInfo, PodInspectInfo } from '/@api/pod-info.js';
-import type {
-  PreflightCheckEvent,
-  PreflightChecksCallback,
-  ProviderConnectionInfo,
-  ProviderContainerConnectionInfo,
-  ProviderInfo,
-  ProviderKubernetesConnectionInfo,
-} from '/@api/provider-info.js';
-import type { ProxyState } from '/@api/proxy.js';
-import type { PullEvent } from '/@api/pull-event.js';
-import type { ExtensionBanner, RecommendedRegistry } from '/@api/recommendations/recommendations.js';
-import type { ReleaseNotesInfo } from '/@api/release-notes-info.js';
-import type { StatusBarEntryDescriptor } from '/@api/status-bar.js';
-import type { PinOption } from '/@api/status-bar/pin-option.js';
-import type { TelemetryMessages } from '/@api/telemetry.js';
-import type { ViewInfoUI } from '/@api/view-info.js';
-import type { VolumeInspectInfo, VolumeListInfo } from '/@api/volume-info.js';
-import type { WebviewInfo } from '/@api/webview-info.js';
-import type { WelcomeMessages } from '/@api/welcome-info.js';
 
 import { securityRestrictionCurrentHandler } from '../security-restrictions-handler.js';
 import { TrayMenu } from '../tray-menu.js';

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.spec.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.spec.ts
@@ -15,9 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeAll, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { InputQuickPickRegistry } from './input-quickpick-registry.js';
 

--- a/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
+++ b/packages/main/src/plugin/input-quickpick/input-quickpick-registry.ts
@@ -22,9 +22,8 @@ import type {
   InputBoxValidationMessage,
   QuickPickOptions,
 } from '@podman-desktop/api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 @injectable()
 export class InputQuickPickRegistry {

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -19,15 +19,15 @@
 import { rmSync } from 'node:fs';
 import * as path from 'node:path';
 
+import type { ExtensionInfo } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { CatalogFetchableExtension } from '@podman-desktop/core-api/extension-catalog';
 import type { IpcMain, IpcMainEvent } from 'electron';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { CatalogFetchableExtension } from '/@api/extension-catalog/extensions-catalog-api.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
 
 import type { ContributionManager } from '../contribution-manager.js';
 import type { Directories } from '../directories.js';

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -21,6 +21,8 @@ import { cp } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import type { ExtensionInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { IpcMainEvent } from 'electron';
 import { inject, injectable } from 'inversify';
 
@@ -29,8 +31,6 @@ import { Directories } from '/@/plugin/directories.js';
 import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
 
 import { ContributionManager } from '../contribution-manager.js';
 import { DockerDesktopContribution, DockerDesktopInstaller } from '../docker-extension/docker-desktop-installer.js';

--- a/packages/main/src/plugin/kubernetes/context-health-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-health-checker.ts
@@ -18,8 +18,7 @@
 
 import { Health } from '@kubernetes/client-node';
 import type { Disposable } from '@podman-desktop/api';
-
-import type { Event } from '/@api/event.js';
+import type { Event } from '@podman-desktop/core-api';
 
 import { Emitter } from '../events/emitter.js';
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';

--- a/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
+++ b/packages/main/src/plugin/kubernetes/context-permissions-checker.ts
@@ -23,8 +23,7 @@ import type {
 } from '@kubernetes/client-node';
 import { AuthorizationV1Api } from '@kubernetes/client-node';
 import type { Disposable } from '@podman-desktop/api';
-
-import type { Event } from '/@api/event.js';
+import type { Event } from '@podman-desktop/core-api';
 
 import { Emitter } from '../events/emitter.js';
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';

--- a/packages/main/src/plugin/kubernetes/contexts-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-dispatcher.ts
@@ -17,8 +17,7 @@
  ***********************************************************************/
 
 import type { KubeConfig } from '@kubernetes/client-node';
-
-import type { Event } from '/@api/event.js';
+import type { Event } from '@podman-desktop/core-api';
 
 import { Emitter } from '../events/emitter.js';
 import { KubeConfigSingleContext } from './kubeconfig-single-context.js';

--- a/packages/main/src/plugin/kubernetes/contexts-informers-registry.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-informers-registry.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ResourceName } from '/@api/kubernetes-contexts-states.js';
+import type { ResourceName } from '@podman-desktop/core-api';
 
 import type { CancellableInformer, ContextInternalState } from './contexts-states-registry.js';
 import { isSecondaryResourceName } from './contexts-states-registry.js';

--- a/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager-experimental.ts
@@ -17,13 +17,15 @@
  ***********************************************************************/
 
 import type { KubeConfig, KubernetesObject, ObjectCache } from '@kubernetes/client-node';
-
-import type { Event } from '/@api/event.js';
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
-import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
-import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
-import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
+import type {
+  ContextGeneralState,
+  ContextPermission,
+  Event,
+  KubernetesContextResources,
+  KubernetesTroubleshootingInformation,
+  ResourceCount,
+  ResourceName,
+} from '@podman-desktop/core-api';
 
 import { Emitter } from '../events/emitter.js';
 import { ConfigmapsResourceFactory } from './configmaps-resource-factory.js';

--- a/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
@@ -18,11 +18,9 @@
 
 import * as kubeclient from '@kubernetes/client-node';
 import { KubeConfig, makeInformer } from '@kubernetes/client-node';
+import type { CheckingState, ContextGeneralState, KubeContext, ResourceName } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { KubeContext } from '/@api/kubernetes-context.js';
-import type { CheckingState, ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
 
 import type { ContextsInformersRegistry } from './contexts-informers-registry.js';
 import { ContextsManager } from './contexts-manager.js';

--- a/packages/main/src/plugin/kubernetes/contexts-manager.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.ts
@@ -53,12 +53,9 @@ import {
   makeInformer,
   NetworkingV1Api,
 } from '@kubernetes/client-node';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { KubeContext } from '/@api/kubernetes-context.js';
-import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import { secondaryResources } from '/@api/kubernetes-contexts-states.js';
-import type { V1Route } from '/@api/openshift-types.js';
+import type { ContextGeneralState, KubeContext, ResourceName, V1Route } from '@podman-desktop/core-api';
+import { secondaryResources } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 
 import { Backoff } from './backoff.js';
 import {

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.spec.ts
@@ -16,11 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ContextPermission, IDisposable } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
 
 import type { ContextHealthState } from './context-health-checker.js';
 import type { ContextPermissionResult } from './context-permissions-checker.js';

--- a/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-dispatcher.ts
@@ -16,13 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
-import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
-import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
-import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
+import type {
+  ContextHealth,
+  ContextPermission,
+  IDisposable,
+  KubernetesContextResources,
+  KubernetesTroubleshootingInformation,
+  ResourceCount,
+} from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 
 import type { ContextHealthState } from './context-health-checker.js';
 import type { ContextPermissionResult } from './context-permissions-checker.js';

--- a/packages/main/src/plugin/kubernetes/contexts-states-registry.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-registry.spec.ts
@@ -15,9 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { ContextsStatesRegistry, isSecondaryResourceName } from './contexts-states-registry.js';
 

--- a/packages/main/src/plugin/kubernetes/contexts-states-registry.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-states-registry.ts
@@ -17,15 +17,9 @@
  ***********************************************************************/
 
 import type { Informer, KubernetesObject } from '@kubernetes/client-node';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type {
-  CheckingState,
-  ContextGeneralState,
-  ResourceName,
-  SecondaryResourceName,
-} from '/@api/kubernetes-contexts-states.js';
-import { NO_CURRENT_CONTEXT_ERROR, secondaryResources } from '/@api/kubernetes-contexts-states.js';
+import type { CheckingState, ContextGeneralState, ResourceName, SecondaryResourceName } from '@podman-desktop/core-api';
+import { NO_CURRENT_CONTEXT_ERROR, secondaryResources } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 
 import { dispatchTimeout } from './contexts-constants.js';
 

--- a/packages/main/src/plugin/kubernetes/kube-generator-registry.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kube-generator-registry.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { KubernetesGeneratorSelector } from '@podman-desktop/core-api/kubernetes';
 import { expect, test, vi } from 'vitest';
-
-import type { KubernetesGeneratorSelector } from '/@api/kubernetes/kubernetes-generator-api.js';
 
 import { KubeGeneratorRegistry } from './kube-generator-registry.js';
 

--- a/packages/main/src/plugin/kubernetes/kube-generator-registry.ts
+++ b/packages/main/src/plugin/kubernetes/kube-generator-registry.ts
@@ -15,14 +15,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { injectable } from 'inversify';
-
 import type {
   GenerateKubeResult,
   KubernetesGeneratorArgument,
   KubernetesGeneratorInfo,
   KubernetesGeneratorSelector,
-} from '/@api/kubernetes/kubernetes-generator-api.js';
+} from '@podman-desktop/core-api/kubernetes';
+import { injectable } from 'inversify';
 
 import { Disposable } from '../types/disposable.js';
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client-kubeconfig.spec.ts
@@ -17,10 +17,10 @@
  ***********************************************************************/
 
 import type { Cluster, Context, KubeConfig, User } from '@kubernetes/client-node';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { FeatureRegistry } from '/@/plugin/feature-registry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import type { ConfigurationRegistry } from '../configuration-registry.js';
 import type { ExperimentalConfigurationManager } from '../experimental-configuration-manager.js';

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -45,7 +45,7 @@ import {
 } from '@kubernetes/client-node';
 import * as clientNode from '@kubernetes/client-node';
 import type { FileSystemWatcher } from '@podman-desktop/api';
-import type { type ForwardConfig, type ForwardOptions, V1Route, WorkloadKind } from '@podman-desktop/core-api';
+import { type ForwardConfig, type ForwardOptions, type V1Route, WorkloadKind } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { IConfigurationChangeEvent, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -45,15 +45,14 @@ import {
 } from '@kubernetes/client-node';
 import * as clientNode from '@kubernetes/client-node';
 import type { FileSystemWatcher } from '@podman-desktop/api';
+import type { type ForwardConfig, type ForwardOptions, V1Route, WorkloadKind } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IConfigurationChangeEvent, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
 import type { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IConfigurationChangeEvent, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { type ForwardConfig, type ForwardOptions, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
-import type { V1Route } from '/@api/openshift-types.js';
 
 import { Emitter } from '../events/emitter.js';
 import type { ExperimentalConfigurationManager } from '../experimental-configuration-manager.js';

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -66,6 +66,21 @@ import {
 } from '@kubernetes/client-node';
 import { PromiseMiddlewareWrapper } from '@kubernetes/client-node/dist/gen/middleware.js';
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type {
+  ContextGeneralState,
+  ContextHealth,
+  ContextPermission,
+  ForwardConfig,
+  ForwardOptions,
+  KubeContext,
+  KubernetesContextResources,
+  KubernetesTroubleshootingInformation,
+  ResourceCount,
+  ResourceName,
+  V1Route,
+} from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
 import * as jsYaml from 'js-yaml';
 import type { WebSocket } from 'ws';
@@ -75,17 +90,6 @@ import { parseAllDocuments } from 'yaml';
 import { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import type { KubernetesPortForwardService } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import { KubernetesPortForwardServiceProvider } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { KubeContext } from '/@api/kubernetes-context.js';
-import type { ContextHealth } from '/@api/kubernetes-contexts-healths.js';
-import type { ContextPermission } from '/@api/kubernetes-contexts-permissions.js';
-import type { ContextGeneralState, ResourceName } from '/@api/kubernetes-contexts-states.js';
-import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
-import type { ResourceCount } from '/@api/kubernetes-resource-count.js';
-import type { KubernetesContextResources } from '/@api/kubernetes-resources.js';
-import type { KubernetesTroubleshootingInformation } from '/@api/kubernetes-troubleshooting.js';
-import type { V1Route } from '/@api/openshift-types.js';
 
 import { Emitter } from '../events/emitter.js';
 import { ExperimentalConfigurationManager } from '../experimental-configuration-manager.js';

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
@@ -29,7 +29,7 @@ import {
 } from '@kubernetes/client-node';
 import type { ApiType } from '@kubernetes/client-node/dist/config.js';
 import type { V1PodList } from '@kubernetes/client-node/dist/gen/models/V1PodList.js';
-import type { type ForwardConfig, IDisposable, type PortMapping, WorkloadKind } from '@podman-desktop/core-api';
+import { type ForwardConfig, type IDisposable, type PortMapping, WorkloadKind } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { WebSocket } from 'isomorphic-ws';
 import { afterEach, beforeEach, describe, expect, type MockedFunction, test, vi } from 'vitest';

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.spec.ts
@@ -29,6 +29,8 @@ import {
 } from '@kubernetes/client-node';
 import type { ApiType } from '@kubernetes/client-node/dist/config.js';
 import type { V1PodList } from '@kubernetes/client-node/dist/gen/models/V1PodList.js';
+import type { type ForwardConfig, IDisposable, type PortMapping, WorkloadKind } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { WebSocket } from 'isomorphic-ws';
 import { afterEach, beforeEach, describe, expect, type MockedFunction, test, vi } from 'vitest';
 
@@ -41,9 +43,6 @@ import {
   PortForwardConnectionService,
 } from '/@/plugin/kubernetes/kubernetes-port-forward-connection.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
-import { type ForwardConfig, type PortMapping, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 import type { ExperimentalConfigurationManager } from '../experimental-configuration-manager.js';
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-connection.ts
@@ -19,14 +19,13 @@ import net from 'node:net';
 
 import type { V1Deployment, V1Pod, V1Service } from '@kubernetes/client-node';
 import { PortForward } from '@kubernetes/client-node';
+import type { ForwardConfig, IDisposable, PortMapping } from '@podman-desktop/core-api';
+import { WorkloadKind } from '@podman-desktop/core-api';
 
 import type { KubernetesClient } from '/@/plugin/kubernetes/kubernetes-client.js';
 import type { ForwardConfigRequirements } from '/@/plugin/kubernetes/kubernetes-port-forward-validation.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
 import { requireNonUndefined } from '/@/util.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { ForwardConfig, PortMapping } from '/@api/kubernetes-port-forward-model.js';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 /**
  * Internal type for holding forwarding setup information.

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.spec.ts
@@ -20,6 +20,9 @@ import type { UUID } from 'node:crypto';
 import { randomUUID } from 'node:crypto';
 
 import type { KubeConfig } from '@kubernetes/client-node';
+import type { ForwardConfig, IDisposable } from '@podman-desktop/core-api';
+import { WorkloadKind } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { PortForwardConnectionService } from '/@/plugin/kubernetes/kubernetes-port-forward-connection.js';
@@ -28,10 +31,6 @@ import {
   KubernetesPortForwardServiceProvider,
 } from '/@/plugin/kubernetes/kubernetes-port-forward-service.js';
 import type { ConfigManagementService } from '/@/plugin/kubernetes/kubernetes-port-forward-storage.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model.js';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-connection.js');
 vi.mock('/@/plugin/kubernetes/kubernetes-port-forward-storage.js');

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-service.ts
@@ -18,6 +18,8 @@
 import { randomUUID } from 'node:crypto';
 
 import type { KubeConfig } from '@kubernetes/client-node';
+import type { ForwardConfig, ForwardOptions, IDisposable } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 
 import type { KubernetesClient } from '/@/plugin/kubernetes/kubernetes-client.js';
 import { PortForwardConnectionService } from '/@/plugin/kubernetes/kubernetes-port-forward-connection.js';
@@ -25,9 +27,6 @@ import { ConfigManagementService, MemoryBasedStorage } from '/@/plugin/kubernete
 import { ForwardConfigRequirements } from '/@/plugin/kubernetes/kubernetes-port-forward-validation.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
 import { isFreePort } from '/@/plugin/util/port.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
-import type { ForwardConfig, ForwardOptions } from '/@api/kubernetes-port-forward-model.js';
 
 /**
  * Service provider for Kubernetes port forwarding.

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.spec.ts
@@ -19,6 +19,8 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
+import type { ForwardConfig } from '@podman-desktop/core-api';
+import { WorkloadKind } from '@podman-desktop/core-api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { Directories } from '/@/plugin/directories.js';
@@ -30,8 +32,6 @@ import {
   MemoryBasedStorage,
   PreferenceFolderBasedStorage,
 } from '/@/plugin/kubernetes/kubernetes-port-forward-storage.js';
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model.js';
-import { WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn(),

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-storage.ts
@@ -18,8 +18,9 @@
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 
+import type { ForwardConfig } from '@podman-desktop/core-api';
+
 import type { Directories } from '/@/plugin/directories.js';
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model.js';
 
 /**
  * Interface for forward configuration storage.

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type ForwardConfig, WorkloadKind } from '@podman-desktop/core-api';
 import { describe, expect, test, vi } from 'vitest';
 
 import { ForwardConfigRequirements } from '/@/plugin/kubernetes/kubernetes-port-forward-validation.js';
-import { type ForwardConfig, WorkloadKind } from '/@api/kubernetes-port-forward-model.js';
 
 describe('ForwardConfigRequirements', () => {
   const validConfig: ForwardConfig = {

--- a/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-port-forward-validation.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { ForwardConfig } from '/@api/kubernetes-port-forward-model.js';
+import type { ForwardConfig } from '@podman-desktop/core-api';
 
 /**
  * Type representing a function that checks the availability of a port.

--- a/packages/main/src/plugin/kubernetes/resource-informer.ts
+++ b/packages/main/src/plugin/kubernetes/resource-informer.ts
@@ -25,8 +25,7 @@ import type {
 } from '@kubernetes/client-node';
 import { ADD, ApiException, DELETE, ERROR, ListWatch, UPDATE, Watch } from '@kubernetes/client-node';
 import type { Disposable } from '@podman-desktop/api';
-
-import type { Event } from '/@api/event.js';
+import type { Event } from '@podman-desktop/core-api';
 
 import { Emitter } from '../events/emitter.js';
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';

--- a/packages/main/src/plugin/kubernetes/routes-resource-factory.ts
+++ b/packages/main/src/plugin/kubernetes/routes-resource-factory.ts
@@ -18,8 +18,7 @@
 
 import type { KubernetesListObject } from '@kubernetes/client-node';
 import { CustomObjectsApi } from '@kubernetes/client-node';
-
-import type { V1Route } from '/@api/openshift-types.js';
+import type { V1Route } from '@podman-desktop/core-api';
 
 import type { KubeConfigSingleContext } from './kubeconfig-single-context.js';
 import type { ResourceFactory } from './resource-factory.js';

--- a/packages/main/src/plugin/learning-center-init.ts
+++ b/packages/main/src/plugin/learning-center-init.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 @injectable()
 export class LearningCenterInit {

--- a/packages/main/src/plugin/learning-center/learning-center.ts
+++ b/packages/main/src/plugin/learning-center/learning-center.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Guide } from '/@api/learning-center/guide.js';
+import type { Guide } from '@podman-desktop/core-api/learning-center';
 
 import guidesJson from './guides.json' with { type: 'json' };
 

--- a/packages/main/src/plugin/libpod-api-enable/libpod-api-init.ts
+++ b/packages/main/src/plugin/libpod-api-enable/libpod-api-init.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import { LibpodApiSettings } from './libpod-api-settings.js';
 

--- a/packages/main/src/plugin/list-organizer.spec.ts
+++ b/packages/main/src/plugin/list-organizer.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ListOrganizerItem, SavedListOrganizerConfig } from '@podman-desktop/core-api';
+import type { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { ListOrganizerItem, SavedListOrganizerConfig } from '/@api/list-organizer.js';
 
 import { ListOrganizerRegistry } from './list-organizer.js';
 

--- a/packages/main/src/plugin/list-organizer.ts
+++ b/packages/main/src/plugin/list-organizer.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ListOrganizerItem, SavedListOrganizerConfig } from '@podman-desktop/core-api';
+import { IDisposable } from '@podman-desktop/core-api';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { IDisposable } from '/@api/disposable.js';
-import type { ListOrganizerItem, SavedListOrganizerConfig } from '/@api/list-organizer.js';
 
 @injectable()
 export class ListOrganizerRegistry implements IDisposable {

--- a/packages/main/src/plugin/lock-configuration.spec.ts
+++ b/packages/main/src/plugin/lock-configuration.spec.ts
@@ -16,13 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { beforeEach, describe, expect, test } from 'vitest';
-
 import {
   CONFIGURATION_LOCKED_KEY,
   CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
-} from '/@api/configuration/constants.js';
+} from '@podman-desktop/core-api/configuration';
+import { beforeEach, describe, expect, test } from 'vitest';
 
 import { LockedKeys } from './lock-configuration.js';
 

--- a/packages/main/src/plugin/lock-configuration.ts
+++ b/packages/main/src/plugin/lock-configuration.ts
@@ -20,7 +20,7 @@ import {
   CONFIGURATION_LOCKED_KEY,
   CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
-} from '/@api/configuration/constants.js';
+} from '@podman-desktop/core-api/configuration';
 
 /**
  * Handles any "locked" configuration values managed by the managed-by configuration scopes.

--- a/packages/main/src/plugin/menu-registry.spec.ts
+++ b/packages/main/src/plugin/menu-registry.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
 
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { CommandRegistry } from './command-registry.js';
 import { MenuRegistry } from './menu-registry.js';

--- a/packages/main/src/plugin/menu-registry.ts
+++ b/packages/main/src/plugin/menu-registry.ts
@@ -15,9 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { Menu } from '@podman-desktop/core-api';
 import { inject, injectable } from 'inversify';
-
-import type { Menu } from '/@api/menu.js';
 
 import { CommandRegistry } from './command-registry.js';
 import { Disposable } from './types/disposable.js';

--- a/packages/main/src/plugin/message-box.spec.ts
+++ b/packages/main/src/plugin/message-box.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { DropdownType } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { DropdownType } from '/@api/dialog.js';
 
 import { MessageBox } from './message-box.js';
 

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -15,10 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { ButtonsType, DropdownType, MessageBoxOptions, MessageBoxReturnValue } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ButtonsType, DropdownType, MessageBoxOptions, MessageBoxReturnValue } from '/@api/dialog.js';
 
 type DialogType = 'none' | 'info' | 'error' | 'question' | 'warning';
 

--- a/packages/main/src/plugin/navigation-items-init.ts
+++ b/packages/main/src/plugin/navigation-items-init.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 @injectable()
 export class NavigationItemsInit {

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -17,14 +17,13 @@
  ***********************************************************************/
 
 import type { ProviderContainerConnection } from '@podman-desktop/api';
+import type { OnboardingInfo, WebviewInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
 import type { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { NavigationPage } from '/@api/navigation-page.js';
-import type { OnboardingInfo } from '/@api/onboarding.js';
-import type { WebviewInfo } from '/@api/webview-info.js';
 
 import type { ContainerProviderRegistry } from '../container-registry.js';
 import type { ContributionManager } from '../contribution-manager.js';

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -17,16 +17,15 @@
  ***********************************************************************/
 
 import type { NavigateToExtensionsCatalogOptions, ProviderContainerConnection } from '@podman-desktop/api';
+import type { NavigationRequest } from '@podman-desktop/core-api';
+import { IDisposable, NavigationPage } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 
 import { CommandRegistry } from '/@/plugin/command-registry.js';
 import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
 import { ContributionManager } from '/@/plugin/contribution-manager.js';
 import { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { IDisposable } from '/@api/disposable.js';
-import { NavigationPage } from '/@api/navigation-page.js';
-import type { NavigationRequest } from '/@api/navigation-request.js';
 
 import { ProviderRegistry } from '../provider-registry.js';
 import { Disposable } from '../types/disposable.js';

--- a/packages/main/src/plugin/onboarding-registry.spec.ts
+++ b/packages/main/src/plugin/onboarding-registry.spec.ts
@@ -18,11 +18,11 @@
 
 import * as fs from 'node:fs';
 
+import type { OnboardingState } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { OnboardingState } from '/@api/onboarding.js';
 
 import { Context } from './context/context.js';
 import { OnboardingRegistry } from './onboarding-registry.js';

--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -18,10 +18,10 @@
 
 import * as path from 'node:path';
 
+import type { Onboarding, OnboardingInfo, OnboardingStatus } from '@podman-desktop/core-api';
 import { inject, injectable } from 'inversify';
 
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
-import type { Onboarding, OnboardingInfo, OnboardingStatus } from '/@api/onboarding.js';
 import productJSONFile from '/@product.json' with { type: 'json' };
 
 import { getBase64Image } from '../util.js';

--- a/packages/main/src/plugin/open-devtools-init.ts
+++ b/packages/main/src/plugin/open-devtools-init.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
 
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 import product from '/@product.json' with { type: 'json' };
 
 @injectable()

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -39,8 +39,7 @@ import type {
   VmProviderConnection,
   VmProviderConnectionFactory,
 } from '@podman-desktop/api';
-
-import type { IDisposable } from '/@api/disposable.js';
+import type { IDisposable } from '@podman-desktop/core-api';
 
 import type { ContainerProviderRegistry } from './container-registry.js';
 import { Emitter } from './events/emitter.js';

--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -40,16 +40,15 @@ import type {
   UpdateVmConnectionEvent,
   VmProviderConnection,
 } from '@podman-desktop/api';
-import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import type {
   CheckStatus,
   PreflightChecksCallback,
   ProviderContainerConnectionInfo,
   ProviderKubernetesConnectionInfo,
   ProviderVmConnectionInfo,
-} from '/@api/provider-info.js';
+} from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { AutostartEngine } from './autostart-engine.js';
 import type { ContainerProviderRegistry } from './container-registry.js';

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -56,11 +56,8 @@ import type {
   UpdateVmConnectionEvent,
   VmProviderConnection,
 } from '@podman-desktop/api';
-import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { Event } from '/@api/event.js';
 import type {
+  Event,
   LifecycleMethod,
   PreflightChecksCallback,
   ProviderCleanupActionInfo,
@@ -69,7 +66,9 @@ import type {
   ProviderInfo,
   ProviderKubernetesConnectionInfo,
   ProviderVmConnectionInfo,
-} from '/@api/provider-info.js';
+} from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { inject, injectable } from 'inversify';
 
 import type { AutostartEngine } from './autostart-engine.js';
 import { ContainerProviderRegistry } from './container-registry.js';

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -21,15 +21,15 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import type { AddressInfo } from 'node:net';
 
+import type { IDisposable } from '@podman-desktop/core-api';
+import { ProxyState } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { createProxy, type ProxyServer } from 'proxy';
 import { beforeAll, describe, expect, test, vi } from 'vitest';
 
 import type { Certificates } from '/@/plugin/certificates.js';
 import { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import { ensureURL, Proxy } from '/@/plugin/proxy.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
-import { ProxyState } from '/@api/proxy.js';
 
 import type { DefaultConfiguration } from './default-configuration.js';
 import type { Directories } from './directories.js';

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -17,12 +17,12 @@
  ***********************************************************************/
 
 import type { Event, ProxySettings } from '@podman-desktop/api';
+import { PROXY_CONFIG_KEYS, ProxyState } from '@podman-desktop/core-api';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
 import { Agent, ProxyAgent } from 'undici';
 
 import { Certificates } from '/@/plugin/certificates.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { PROXY_CONFIG_KEYS, ProxyState } from '/@api/proxy.js';
 
 import { Emitter } from './events/emitter.js';
 import { getProxyUrl } from './proxy-resolver.js';

--- a/packages/main/src/plugin/recommendations/recommendations-registry.spec.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.spec.ts
@@ -16,15 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ExtensionInfo } from '@podman-desktop/core-api';
+import type { CatalogFetchableExtension } from '@podman-desktop/core-api/extension-catalog';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { Featured } from '/@/plugin/featured/featured.js';
-import type { CatalogFetchableExtension } from '/@api/extension-catalog/extensions-catalog-api.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
-import type { FeaturedExtension } from '/@api/featured/featured-api.js';
 
 import { RecommendationsRegistry } from './recommendations-registry.js';
 

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -16,19 +16,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
+import type {
+  ExtensionBanner,
+  RecommendedRegistry,
+  RecommendedRegistryExtensionDetails,
+} from '@podman-desktop/core-api/recommendations';
+import { RecommendationsSettings } from '@podman-desktop/core-api/recommendations';
 import { inject, injectable } from 'inversify';
 
 import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { Featured } from '/@/plugin/featured/featured.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { FeaturedExtension } from '/@api/featured/featured-api.js';
-import type {
-  ExtensionBanner,
-  RecommendedRegistry,
-  RecommendedRegistryExtensionDetails,
-} from '/@api/recommendations/recommendations.js';
-import { RecommendationsSettings } from '/@api/recommendations/recommendations-settings.js';
 
 import recommendations from '../../../../../recommendations.json' with { type: 'json' };
 

--- a/packages/main/src/plugin/registry-init.ts
+++ b/packages/main/src/plugin/registry-init.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { PreferredRegistriesSettings } from '@podman-desktop/core-api';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { PreferredRegistriesSettings } from '/@api/prefered-registries-info.js';
 
 @injectable()
 export class RegistryInit {

--- a/packages/main/src/plugin/release-notes-banner-init.ts
+++ b/packages/main/src/plugin/release-notes-banner-init.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 @injectable()
 export class ReleaseNotesBannerInit {

--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
@@ -20,13 +20,12 @@ import { cpSync, existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import type { Event, NotificationCardOptions } from '@podman-desktop/core-api';
 import { safeStorage } from 'electron';
 import { inject, injectable } from 'inversify';
 
 import { Directories } from '/@/plugin/directories.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
-import type { Event } from '/@api/event.js';
-import type { NotificationCardOptions } from '/@api/notification.js';
 
 /**
  * Manage the storage of string being encrypted on disk

--- a/packages/main/src/plugin/statusbar/pin-registry.spec.ts
+++ b/packages/main/src/plugin/statusbar/pin-registry.spec.ts
@@ -17,6 +17,9 @@
  ***********************************************************************/
 
 import type { Configuration } from '@podman-desktop/api';
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { STATUS_BAR_PIN_CONSTANTS } from '@podman-desktop/core-api/status-bar';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
@@ -24,9 +27,6 @@ import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js'
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { PIN_REGISTRY_TELEMETRY_EVENTS, PinRegistry } from '/@/plugin/statusbar/pin-registry.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ProviderInfo } from '/@api/provider-info.js';
-import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants.js';
 
 const COMMAND_REGISTRY_MOCK: CommandRegistry = {
   registerCommand: vi.fn(),

--- a/packages/main/src/plugin/statusbar/pin-registry.ts
+++ b/packages/main/src/plugin/statusbar/pin-registry.ts
@@ -16,16 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type containerDesktopAPI from '@podman-desktop/api';
+import type { IDisposable } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { PinOption } from '@podman-desktop/core-api/status-bar';
+import { STATUS_BAR_PIN_CONSTANTS } from '@podman-desktop/core-api/status-bar';
 import { inject, injectable } from 'inversify';
 
 import { CommandRegistry } from '/@/plugin/command-registry.js';
 import { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { Telemetry } from '/@/plugin/telemetry/telemetry.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { IDisposable } from '/@api/disposable.js';
-import { STATUS_BAR_PIN_CONSTANTS } from '/@api/status-bar/pin-constants.js';
-import type { PinOption } from '/@api/status-bar/pin-option.js';
 
 export enum PIN_REGISTRY_TELEMETRY_EVENTS {
   PIN = 'pin-registry:pin',

--- a/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-providers-init.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import statusbarImage from '../../assets/statusbarProviders.showProviders.webp';
 

--- a/packages/main/src/plugin/statusbar/statusbar-registry.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-registry.ts
@@ -16,11 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { IDisposable } from '@podman-desktop/core-api';
+import {
+  STATUS_BAR_UPDATED_EVENT_NAME,
+  type StatusBarEntry,
+  type StatusBarEntryDescriptor,
+} from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { IDisposable } from '/@api/disposable.js';
-import { STATUS_BAR_UPDATED_EVENT_NAME, type StatusBarEntry, type StatusBarEntryDescriptor } from '/@api/status-bar.js';
 
 @injectable()
 export class StatusBarRegistry implements IDisposable {

--- a/packages/main/src/plugin/tasks/notification-registry.spec.ts
+++ b/packages/main/src/plugin/tasks/notification-registry.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { assert, beforeEach, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { Disposable } from '../types/disposable.js';
 import { NotificationRegistry } from './notification-registry.js';

--- a/packages/main/src/plugin/tasks/notification-registry.ts
+++ b/packages/main/src/plugin/tasks/notification-registry.ts
@@ -17,11 +17,10 @@
  ***********************************************************************/
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type { NotificationCard, NotificationCardOptions } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { Notification } from 'electron';
 import { inject, injectable } from 'inversify';
-
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { NotificationCard, NotificationCardOptions } from '/@api/notification.js';
 
 import { Disposable } from '../types/disposable.js';
 import { TaskManager } from './task-manager.js';

--- a/packages/main/src/plugin/tasks/progress-impl.spec.ts
+++ b/packages/main/src/plugin/tasks/progress-impl.spec.ts
@@ -18,11 +18,11 @@
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
+import type { TaskState, TaskStatus } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
 import type { TaskAction } from '/@/plugin/tasks/tasks.js';
-import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
 
 import { CancellationTokenSource } from '../cancellation-token.js';
 import type { CancellationTokenRegistry } from '../cancellation-token-registry.js';

--- a/packages/main/src/plugin/tasks/task-impl.ts
+++ b/packages/main/src/plugin/tasks/task-impl.ts
@@ -16,8 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { Event } from '@podman-desktop/api';
-
-import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
+import type { TaskState, TaskStatus } from '@podman-desktop/core-api';
 
 import { Emitter } from '../events/emitter.js';
 import type { Task, TaskAction, TaskUpdateEvent } from './tasks.js';

--- a/packages/main/src/plugin/tasks/task-manager.spec.ts
+++ b/packages/main/src/plugin/tasks/task-manager.spec.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { CommandRegistry } from '/@/plugin/command-registry.js';
 import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import type { StatusBarRegistry } from '/@/plugin/statusbar/statusbar-registry.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { TaskManager } from './task-manager.js';
 

--- a/packages/main/src/plugin/tasks/task-manager.ts
+++ b/packages/main/src/plugin/tasks/task-manager.ts
@@ -17,16 +17,16 @@
  ***********************************************************************/
 
 import type { NotificationOptions } from '@podman-desktop/api';
+import type { NotificationTaskInfo, TaskInfo } from '@podman-desktop/core-api';
+import { ExperimentalTasksSettings } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
 
 import { NotificationImpl } from '/@/plugin/tasks/notification-impl.js';
 import type { NotificationTask } from '/@/plugin/tasks/notifications.js';
 import { TaskImpl } from '/@/plugin/tasks/task-impl.js';
 import type { Task, TaskAction, TaskUpdateEvent } from '/@/plugin/tasks/tasks.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { NotificationTaskInfo, TaskInfo } from '/@api/taskInfo.js';
-import { ExperimentalTasksSettings } from '/@api/tasks-preferences.js';
 
 import { CommandRegistry } from '../command-registry.js';
 import { StatusBarRegistry } from '../statusbar/statusbar-registry.js';

--- a/packages/main/src/plugin/tasks/tasks.ts
+++ b/packages/main/src/plugin/tasks/tasks.ts
@@ -17,8 +17,7 @@
  ***********************************************************************/
 
 import type { Disposable, Event } from '@podman-desktop/api';
-
-import type { TaskState, TaskStatus } from '/@api/taskInfo.js';
+import type { TaskState, TaskStatus } from '@podman-desktop/core-api';
 
 export interface TaskAction {
   name: string;

--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -17,14 +17,13 @@
  ***********************************************************************/
 
 import type { TelemetrySender } from '@podman-desktop/api';
+import type { ExtensionInfo, TelemetryMessages } from '@podman-desktop/core-api';
+import { TelemetrySettings } from '@podman-desktop/core-api/telemetry';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { DefaultConfiguration } from '/@/plugin/default-configuration.js';
 import type { LockedConfiguration } from '/@/plugin/locked-configuration.js';
-import type { ExtensionInfo } from '/@api/extension-info.js';
-import type { TelemetryMessages } from '/@api/telemetry.js';
-import { TelemetrySettings } from '/@api/telemetry/telemetry-settings.js';
 import product from '/@product.json' with { type: 'json' };
 
 import type { ConfigurationRegistry } from '../configuration-registry.js';

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -25,6 +25,10 @@ import type {
   TelemetrySender,
   TelemetryTrustedValue,
 } from '@podman-desktop/api';
+import type { Event, FeedbackProperties } from '@podman-desktop/core-api';
+import { TelemetryMessages } from '@podman-desktop/core-api';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import { TelemetrySettings } from '@podman-desktop/core-api/telemetry';
 import type { EventProperties } from '@segment/analytics-core';
 import { Analytics, type UserTraits } from '@segment/analytics-node';
 import { app } from 'electron';
@@ -35,11 +39,6 @@ import * as osLocale from 'os-locale';
 
 import { DefaultConfiguration } from '/@/plugin/default-configuration.js';
 import { LockedConfiguration } from '/@/plugin/locked-configuration.js';
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { Event } from '/@api/event.js';
-import type { FeedbackProperties } from '/@api/feedback.js';
-import { TelemetryMessages } from '/@api/telemetry.js';
-import { TelemetrySettings } from '/@api/telemetry/telemetry-settings.js';
 import product from '/@product.json' with { type: 'json' };
 
 import telemetry from '../../../../../telemetry.json' with { type: 'json' };

--- a/packages/main/src/plugin/temp-file-service.ts
+++ b/packages/main/src/plugin/temp-file-service.ts
@@ -20,9 +20,8 @@ import { unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { IAsyncDisposable } from '@podman-desktop/core-api';
 import { injectable, preDestroy } from 'inversify';
-
-import { IAsyncDisposable } from '/@api/async-disposable.js';
 
 /**
  * Service for managing temporary files (YAML, configuration files, etc.)

--- a/packages/main/src/plugin/terminal-init.ts
+++ b/packages/main/src/plugin/terminal-init.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { TerminalSettings } from '/@api/terminal/terminal-settings.js';
 
 @injectable()
 export class TerminalInit {

--- a/packages/main/src/plugin/tray-icon-color.ts
+++ b/packages/main/src/plugin/tray-icon-color.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 @injectable()
 export class TrayIconColor {

--- a/packages/main/src/plugin/tray-menu-registry.spec.ts
+++ b/packages/main/src/plugin/tray-menu-registry.spec.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { ipcMain } from 'electron';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-
-import type { ProviderInfo } from '/@api/provider-info.js';
 
 import type { TrayMenu } from '../tray-menu.js';
 import type { CommandRegistry } from './command-registry.js';

--- a/packages/main/src/plugin/tray-menu-registry.ts
+++ b/packages/main/src/plugin/tray-menu-registry.ts
@@ -16,11 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { MenuItem, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { dialog, ipcMain } from 'electron';
 import { inject, injectable } from 'inversify';
-
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info.js';
-import type { MenuItem } from '/@api/tray-menu-info.js';
 
 import { TrayMenu } from '../tray-menu.js';
 import { CommandRegistry } from './command-registry.js';

--- a/packages/main/src/plugin/types/disposable.ts
+++ b/packages/main/src/plugin/types/disposable.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { IDisposable } from '/@api/disposable.js';
+import type { IDisposable } from '@podman-desktop/core-api';
 
 export class Disposable implements IDisposable {
   private disposable: undefined | (() => void);

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -19,6 +19,7 @@
 import type { IncomingMessage } from 'node:http';
 
 import type { Configuration } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { app, shell } from 'electron';
 import { type AppUpdater, autoUpdater, type UpdateCheckResult, type UpdateDownloadedEvent } from 'electron-updater';
 import type { AppUpdaterEvents } from 'electron-updater/out/AppUpdater.js';
@@ -34,7 +35,6 @@ import { Disposable } from '/@/plugin/types/disposable.js';
 import { Updater } from '/@/plugin/updater.js';
 import * as util from '/@/util.js';
 import { isLinux, isMac, isWindows } from '/@/util.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 import product from '/@product.json' with { type: 'json' };
 
 import type { TaskManager } from './tasks/task-manager.js';

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -18,6 +18,8 @@
 
 import * as https from 'node:https';
 
+import type { ReleaseNotesInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { app, shell } from 'electron';
 import {
   autoUpdater,
@@ -37,8 +39,6 @@ import { StatusBarRegistry } from '/@/plugin/statusbar/statusbar-registry.js';
 import type { Task } from '/@/plugin/tasks/tasks.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
 import { isLinux, isWindows } from '/@/util.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { ReleaseNotesInfo } from '/@api/release-notes-info.js';
 import product from '/@product.json' with { type: 'json' };
 
 import rootPackage from '../../../../package.json' with { type: 'json' };

--- a/packages/main/src/plugin/util/manifest.spec.ts
+++ b/packages/main/src/plugin/util/manifest.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ImageInfo } from '@podman-desktop/core-api';
 import { describe, expect, test } from 'vitest';
-
-import type { ImageInfo } from '/@api/image-info.js';
 
 import { guessIsManifest } from './manifest.js';
 

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { ImageInfo } from '/@api/image-info.js';
+import type { ImageInfo } from '@podman-desktop/core-api';
 
 const KB = 1024;
 const GUESSED_MANIFEST_SIZE = 50 * KB;

--- a/packages/main/src/plugin/view-registry.spec.ts
+++ b/packages/main/src/plugin/view-registry.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ViewContributionIcon } from '@podman-desktop/core-api';
 import { beforeEach, expect, expectTypeOf, test, vi } from 'vitest';
-
-import type { ViewContributionIcon } from '/@api/view-info.js';
 
 import type { Disposable } from './types/disposable.js';
 import { ViewRegistry } from './view-registry.js';

--- a/packages/main/src/plugin/view-registry.ts
+++ b/packages/main/src/plugin/view-registry.ts
@@ -15,9 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { ViewContribution, ViewInfoUI } from '@podman-desktop/core-api';
 import { injectable } from 'inversify';
-
-import type { ViewContribution, ViewInfoUI } from '/@api/view-info.js';
 
 import { Disposable } from './types/disposable.js';
 

--- a/packages/main/src/plugin/webview/webview-impl.spec.ts
+++ b/packages/main/src/plugin/webview/webview-impl.spec.ts
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { Uri } from '/@/plugin/types/uri.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { WebviewImpl } from './webview-impl.js';
 

--- a/packages/main/src/plugin/webview/webview-impl.ts
+++ b/packages/main/src/plugin/webview/webview-impl.ts
@@ -19,10 +19,10 @@
 import { randomUUID } from 'node:crypto';
 
 import type { Event, Webview, WebviewOptions } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 
 import { Emitter } from '/@/plugin/events/emitter.js';
 import { Uri } from '/@/plugin/types/uri.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 export class WebviewImpl implements Webview {
   readonly #apiSender: ApiSenderType;

--- a/packages/main/src/plugin/webview/webview-panel-impl.spec.ts
+++ b/packages/main/src/plugin/webview/webview-panel-impl.spec.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import { Uri } from '../types/uri.js';
 import type { WebviewImpl } from './webview-impl.js';

--- a/packages/main/src/plugin/webview/webview-panel-impl.ts
+++ b/packages/main/src/plugin/webview/webview-panel-impl.ts
@@ -23,11 +23,11 @@ import type {
   WebviewPanel,
   WebviewPanelOnDidChangeViewStateEvent,
 } from '@podman-desktop/api';
+import type { NavigationRequest } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 
 import { Emitter } from '/@/plugin/events/emitter.js';
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import { NavigationPage } from '/@api/navigation-page.js';
-import type { NavigationRequest } from '/@api/navigation-request.js';
 
 import type { WebviewImpl } from './webview-impl.js';
 import type { WebviewRegistry } from './webview-registry.js';

--- a/packages/main/src/plugin/webview/webview-registry.spec.ts
+++ b/packages/main/src/plugin/webview/webview-registry.spec.ts
@@ -19,12 +19,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { Router } from 'express';
 import type express from 'express';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-
-import type { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
 
 import type { DevToolsManager } from './devtools-manager.js';
 import type { WebviewPanelImpl } from './webview-panel-impl.js';

--- a/packages/main/src/plugin/webview/webview-registry.ts
+++ b/packages/main/src/plugin/webview/webview-registry.ts
@@ -21,13 +21,13 @@ import type * as http from 'node:http';
 import { resolve } from 'node:path';
 
 import type * as podmanDesktopAPI from '@podman-desktop/api';
+import type { WebviewInfo, WebviewSimpleInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { Application } from 'express';
 import express from 'express';
 import { inject, injectable } from 'inversify';
 
 import { Uri } from '/@/plugin/types/uri.js';
-import { ApiSenderType } from '/@api/api-sender/api-sender-type.js';
-import type { WebviewInfo, WebviewSimpleInfo } from '/@api/webview-info.js';
 
 import { getFreePort } from '../util/port.js';
 import { DevToolsManager } from './devtools-manager.js';

--- a/packages/main/src/plugin/welcome.ts
+++ b/packages/main/src/plugin/welcome.ts
@@ -15,9 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import { WelcomeMessages } from '@podman-desktop/core-api';
 import { injectable } from 'inversify';
 
-import { WelcomeMessages } from '/@api/welcome-info.js';
 import productJSONFile from '/@product.json' with { type: 'json' };
 
 @injectable()

--- a/packages/main/src/plugin/welcome/welcome-init.ts
+++ b/packages/main/src/plugin/welcome/welcome-init.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import { WelcomeSettings } from '@podman-desktop/core-api/welcome';
 import { inject, injectable } from 'inversify';
-
-import { type IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
-import { WelcomeSettings } from '/@api/welcome/welcome-settings.js';
 
 @injectable()
 export class WelcomeInit {

--- a/packages/main/src/plugin/zoom-level-handler.spec.ts
+++ b/packages/main/src/plugin/zoom-level-handler.spec.ts
@@ -17,14 +17,13 @@
  ***********************************************************************/
 
 import type { Configuration } from '@podman-desktop/api';
-import type { BrowserWindow } from 'electron';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-
 import type {
   IConfigurationChangeEvent,
   IConfigurationPropertyRecordedSchema,
   IConfigurationRegistry,
-} from '/@api/configuration/models.js';
+} from '@podman-desktop/core-api/configuration';
+import type { BrowserWindow } from 'electron';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { AppearanceSettings } from './appearance-settings.js';
 import { Emitter } from './events/emitter.js';

--- a/packages/main/src/plugin/zoom-level-handler.ts
+++ b/packages/main/src/plugin/zoom-level-handler.ts
@@ -16,10 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IDisposable } from '@podman-desktop/core-api';
+import type { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import type { BrowserWindow } from 'electron';
-
-import type { IConfigurationRegistry } from '/@api/configuration/models.js';
-import type { IDisposable } from '/@api/disposable.js';
 
 import { AppearanceSettings } from './appearance-settings.js';
 

--- a/packages/main/src/system/macos-startup.ts
+++ b/packages/main/src/system/macos-startup.ts
@@ -20,9 +20,8 @@ import { existsSync } from 'node:fs';
 import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import type { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { app } from 'electron';
-
-import type { IConfigurationRegistry } from '/@api/configuration/models.js';
 
 /**
  * On macOS, startup on login is done via a plist file

--- a/packages/main/src/system/startup-install.ts
+++ b/packages/main/src/system/startup-install.ts
@@ -18,7 +18,8 @@
 
 import * as os from 'node:os';
 
-import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
+import type { IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+
 import product from '/@product.json' with { type: 'json' };
 
 import { MacosStartup } from './macos-startup.js';

--- a/packages/main/src/system/window/window-handler.ts
+++ b/packages/main/src/system/window/window-handler.ts
@@ -16,9 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { type BrowserWindow, type Rectangle, screen } from 'electron';
-
-import type { IConfigurationNode, IConfigurationRegistry } from '/@api/configuration/models.js';
 
 import { WindowSettings } from './window-settings.js';
 

--- a/packages/main/src/system/windows-startup.ts
+++ b/packages/main/src/system/windows-startup.ts
@@ -20,7 +20,7 @@
 import { existsSync, unlink } from 'node:fs';
 import path from 'node:path';
 import { app } from 'electron';
-import type { IConfigurationRegistry } from '/@api/configuration/models.js';
+import type { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 
 /**
  * On Windows, launching program automatically on startup is done via %APPDATA%\Roaming\Microsoft\Windows\Start Menu\Programs\Startup folder

--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -16,11 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import type { MenuItemConstructorOptions, Tray } from 'electron';
 import { ipcMain, Menu, nativeImage } from 'electron';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
-
-import type { ProviderInfo } from '/@api/provider-info.js';
 
 import statusStopped from './assets/status-stopped.png';
 import type { AnimatedTray } from './tray-animate-icon.js';

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -17,10 +17,9 @@
  ***********************************************************************/
 
 import type { ProviderStatus } from '@podman-desktop/api';
+import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import type { MenuItemConstructorOptions, NativeImage, Tray } from 'electron';
 import { app, ipcMain, Menu, nativeImage } from 'electron';
-
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '/@api/provider-info.js';
 
 import statusBusy from './assets/status-busy.png';
 import statusStarted from './assets/status-started.png';


### PR DESCRIPTION

### What does this PR do?
instead of using typescript alias `/@api` use the new `@podman-desktop/core-api` dependency

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to #15496


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
