### PR TITLE
refactor(dd-extension): avoid to use Electron import in renderer part

### DIFF
--- a/packages/renderer/src/lib/docker-extension/DockerExtension.svelte
+++ b/packages/renderer/src/lib/docker-extension/DockerExtension.svelte
@@ -34,8 +34,8 @@ window.events?.receive('dev-tools:open-extension', (extensionId: unknown) => {
 
   // Check that the element contains "openDevTools" method, which is only available on Electron WebviewTag
   // we cannot use `instanceof` as Electron does not "contain" the WebviewTag class at run time.
-  if (extensionElement && 'openDevTools' in extensionElement) {
-    (extensionElement as Electron.WebviewTag).openDevTools();
+  if (extensionElement && 'openDevTools' in extensionElement && typeof extensionElement.openDevTools === 'function') {
+    extensionElement.openDevTools();
   } else {
     // Warn if unable
     console.warn(`Element with ID dd-webview-${extensionId} is not an Electron WebviewTag.`);


### PR DESCRIPTION
### What does this PR do?
I don't know if I'm the only one but as electron is no longer a dependency it looks like my renderer part typecheck is failing due to the usage of Electron import

remove this usage and do like it's done in WebView.svelte

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#15496 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
