### PR TITLE
refactor(logtype): move declaration of LogType to api package

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -60,6 +60,7 @@ export * from './kubernetes-resource-count.js';
 export * from './kubernetes-resources.js';
 export * from './kubernetes-troubleshooting.js';
 export * from './list-organizer.js';
+export * from './log-type.js';
 export * from './manifest-info.js';
 export * from './menu.js';
 export * from './menu-context.js';

--- a/packages/api/src/log-type.ts
+++ b/packages/api/src/log-type.ts
@@ -1,0 +1,19 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -84,6 +84,7 @@ import type {
   KubernetesContextResources,
   KubernetesTroubleshootingInformation,
   ListOrganizerItem,
+  LogType,
   ManifestCreateOptions,
   ManifestInspectInfo,
   ManifestPushOptions,
@@ -252,8 +253,6 @@ import { WelcomeInit } from './welcome/welcome-init.js';
 const checkDiskSpace: (path: string) => Promise<{ free: number }> = checkDiskSpacePkg as unknown as (
   path: string,
 ) => Promise<{ free: number }>;
-
-type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
 export const UPDATER_UPDATE_AVAILABLE_ICON = 'fa fa-exclamation-triangle';
 

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -18,9 +18,10 @@
 
 import * as fs from 'node:fs';
 
+import type { LogType } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import type { LogType, TroubleshootingFileMap } from './troubleshooting.js';
+import type { TroubleshootingFileMap } from './troubleshooting.js';
 import { Troubleshooting } from './troubleshooting.js';
 
 const writeZipMock = vi.fn();

--- a/packages/main/src/plugin/troubleshooting.ts
+++ b/packages/main/src/plugin/troubleshooting.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 
+import { LogType } from '@podman-desktop/core-api';
 import AdmZip from 'adm-zip';
 import { injectable } from 'inversify';
 import moment from 'moment';
@@ -29,8 +30,6 @@ export interface TroubleshootingFileMap {
   filename: string;
   content: string;
 }
-
-export type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 
 @injectable()
 export class Troubleshooting {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -86,6 +86,7 @@ import type {
   KubernetesContextResources,
   KubernetesTroubleshootingInformation,
   ListOrganizerItem,
+  LogType,
   ManifestCreateOptions,
   ManifestInspectInfo,
   ManifestPushOptions,
@@ -150,7 +151,6 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 export type OpenSaveDialogResultCallback = (result: string | string[] | undefined) => void;
 
-export type LogType = 'log' | 'warn' | 'trace' | 'debug' | 'error';
 const originalConsole = console;
 const memoryLogs: { logType: LogType; date: Date; message: string }[] = [];
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
 import { faFileLines, faPaste } from '@fortawesome/free-regular-svg-icons';
+import type { LogType } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy, onMount } from 'svelte';
 
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
-
-import type { LogType } from '../../../../preload/src';
 
 let logs: {
   logType: LogType;


### PR DESCRIPTION
### What does this PR do?
~~⚠️  for now it includes a commit from another PR. Will rebase once the PR has been merged~~
~~- [x] https://github.com/podman-desktop/podman-desktop/pull/16199~~
~~you can look only at the second commit about LogType~~

~~another failure is related to~~
~~- [x] https://github.com/podman-desktop/podman-desktop/pull/16210~~

Working on avoiding the usage of relative imports from external packages, one of the last remaining items is LogType
Another one is appearance-settings https://github.com/podman-desktop/podman-desktop/pull/15537

Here renderer was using a Type from preload package. It shouldn't
So move the definition to api package and reuse from there

Note that main package was duplicating at two places the definition, so I removed the definition and reuse also the one from api package

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/14361

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
