### PR TITLE
chore(renderer): ensure there is no relative `../` imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -320,6 +320,18 @@ export default [
 
       // reactive statements are not expressions
       'sonarjs/no-unused-expressions': 'off',
+
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['../*'],
+              message: 'Parent relative imports are not allowed. Use path aliases (e.g. /@/) instead.',
+            },
+          ],
+        },
+      ],
     },
   },
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.svelte
@@ -10,9 +10,9 @@ import { onDestroy, onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
+import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 import { getExistingTerminal, registerTerminal } from '/@/stores/container-terminal-store';
 
-import NoLogIcon from '../ui/NoLogIcon.svelte';
 import type { ContainerInfoUI } from './ContainerInfoUI';
 
 interface ContainerDetailsTerminalProps {

--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -9,8 +9,8 @@ import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
+import Steps from '/@/lib/ui/Steps.svelte';
 
-import Steps from '../ui/Steps.svelte';
 import PreflightChecks from './PreflightChecks.svelte';
 import ProviderCard from './ProviderCard.svelte';
 import { type InitializationContext, InitializationSteps, InitializeAndStartMode } from './ProviderInitUtils';

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.svelte
@@ -14,9 +14,8 @@ import SolidPodIcon from '/@/lib/images/SolidPodIcon.svelte';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { handleNavigation } from '/@/navigation';
+import { type PodCreation, podCreationHolder } from '/@/stores/creation-from-containers-store';
 import { providerInfos } from '/@/stores/providers';
-
-import { type PodCreation, podCreationHolder } from '../../stores/creation-from-containers-store';
 
 let podCreation: PodCreation;
 let createInProgress = false;


### PR DESCRIPTION
### What does this PR do?
we should use `/@` alias and not relative `../` imports in Podman Desktop
adds eslint rule to enforce that in renderer package

fixing new files that were not using proper imports

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
