### PR TITLE
refactor(renderer): rewrite tests using automatic mocking

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -24,6 +24,7 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { afterEach, beforeAll, expect, test, vi } from 'vitest';
 
+import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 import { authenticationProviders } from '/@/stores/authenticationProviders';
 
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
@@ -35,15 +36,8 @@ class ResizeObserver {
 }
 
 const configMock = vi.fn();
-const getImageMock = vi.fn();
 
-vi.mock('../appearance/appearance-util', () => {
-  return {
-    AppearanceUtil: class {
-      getImage = getImageMock;
-    },
-  };
-});
+vi.mock(import('/@/lib/appearance/appearance-util'));
 
 beforeAll(() => {
   (window as any).ResizeObserver = ResizeObserver;
@@ -233,7 +227,7 @@ test('Expects images.icon option to be used when no themes are present', async (
       sessionRequests: [],
     },
   ];
-  getImageMock.mockResolvedValue('./icon.png');
+  vi.mocked(AppearanceUtil.prototype.getImage).mockResolvedValue('./icon.png');
   authenticationProviders.set(providerWithImageIcon);
   render(PreferencesAuthenticationProvidersRendering, {});
 
@@ -260,7 +254,7 @@ test('Expects images.icon.dark option to be used when theme is dark', async () =
       sessionRequests: [],
     },
   ];
-  getImageMock.mockResolvedValue('./icon-dark.png');
+  vi.mocked(AppearanceUtil.prototype.getImage).mockResolvedValue('./icon-dark.png');
   authenticationProviders.set(providerWithImageIcon);
 
   configMock.mockReturnValue('dark');

--- a/packages/renderer/src/stores/colors.spec.ts
+++ b/packages/renderer/src/stores/colors.spec.ts
@@ -23,6 +23,8 @@ import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
+
 import { colorsEventStore, colorsInfos } from './colors';
 
 const callbacks = new Map<string, any>();
@@ -32,13 +34,7 @@ const eventEmitter = {
   },
 };
 
-vi.mock('../lib/appearance/appearance-util', () => {
-  return {
-    AppearanceUtil: class {
-      getTheme = async (): Promise<string> => 'light';
-    },
-  };
-});
+vi.mock(import('/@/lib/appearance/appearance-util'));
 
 const listColorsMock: Mock<() => Promise<ColorInfo[]>> = vi.fn();
 
@@ -56,6 +52,7 @@ Object.defineProperty(global, 'window', {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(AppearanceUtil.prototype.getTheme).mockResolvedValue('light');
 });
 
 test('grab colors', async () => {


### PR DESCRIPTION


### What does this PR do?
rewrite test that were using relative imports.
but using import was leading issues to partial mocking
switch to use vi.mocked and prototype and automocking

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
