### PR TITLE
chore(alias): remove api alias in main,preload & renderer packages

### DIFF
--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -18,7 +18,6 @@
     "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src/*"],
       "/@product.json": ["../../product.json"]
     }
   },

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -32,7 +32,6 @@ const config = {
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
       '/@product.json': `${join(PACKAGE_ROOT, '../../product.json')}`,
     },
   },

--- a/packages/preload/tsconfig.json
+++ b/packages/preload/tsconfig.json
@@ -15,8 +15,7 @@
 
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src/*"]
+      "/@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*.ts", "exposedInMainWorld.d.ts", "../../types/**/*.d.ts", "../api/src/**/*.ts"]

--- a/packages/preload/vite.config.js
+++ b/packages/preload/vite.config.js
@@ -33,7 +33,6 @@ const config = {
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
   /*plugins: [

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -10,8 +10,7 @@
     "emitDecoratorMetadata": true,
     "baseUrl": ".",
     "paths": {
-      "/@/*": ["./src/*"],
-      "/@api/*": ["../api/src/*"]
+      "/@/*": ["./src/*"]
     },
     /**
      * Typecheck JS in `.svelte` and `.js` files by default.

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -35,7 +35,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
-      '/@api/': join(PACKAGE_ROOT, '../api/src') + '/',
     },
   },
   plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js', hot: !process.env.VITEST }), svelteTesting()],


### PR DESCRIPTION
### What does this PR do?
now that these packages are using @podman-desktop/core-api import remove the alias

note: there are still 2 preload packages using the `/@api` alias that need to be fixed

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to #15496


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
