### PR TITLE
chore(ui): export Icon component from main ui library

### DIFF
--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -25,6 +25,7 @@ import Checkbox from './checkbox/Checkbox.svelte';
 import Dropdown from './dropdown/Dropdown.svelte';
 import DropdownMenu from './dropdownMenu';
 import ChevronExpander from './icons/ChevronExpander.svelte';
+import Icon from './icons/Icon.svelte';
 import Input from './inputs/Input.svelte';
 import NumberInput from './inputs/NumberInput.svelte';
 import SearchInput from './inputs/SearchInput.svelte';
@@ -66,6 +67,7 @@ export {
   Expandable,
   FilteredEmptyScreen,
   FormPage,
+  Icon,
   Input,
   LinearProgress,
   Link,


### PR DESCRIPTION
fixes #16141

the Icon component exists in packages/ui/src/lib/icons/Icon.svelte and is exported from the icons submodule but wasn't re-exported from the main ui library index. this adds it to the main export list so it can be imported like other ui components.

## changes

- added Icon import to packages/ui/src/lib/index.ts
- added Icon to the export block in alphabetical order

## testing

no test changes needed — this just exposes an existing component through the main export path