### PR TITLE
fix(ui): use TTY label for container tab

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -108,7 +108,7 @@ function getContainerInfoUI(cont: ContainerInfo | undefined): ContainerInfoUI | 
         selected={isTabSelected($router.path, 'terminal')}
         url={getTabUrl($router.path, 'terminal')} />
       {#if displayTty}
-        <Tab title="Tty" selected={isTabSelected($router.path, 'tty')} url={getTabUrl($router.path, 'tty')} />
+        <Tab title="TTY" selected={isTabSelected($router.path, 'tty')} url={getTabUrl($router.path, 'tty')} />
       {/if}
     {/snippet}
     {#snippet contentSnippet()}
@@ -127,7 +127,7 @@ function getContainerInfoUI(cont: ContainerInfo | undefined): ContainerInfoUI | 
       <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
         <ContainerDetailsTerminal container={container} />
       </Route>
-      <Route path="/tty" breadcrumb="Tty" navigationHint="tab">
+      <Route path="/tty" breadcrumb="TTY" navigationHint="tab">
         <ContainerDetailsTtyTerminal container={container} />
       </Route>
     {/snippet}

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -80,7 +80,7 @@ onMount(async () => {
   hidden={!closed && container.state !== 'RUNNING'}
   icon={NoLogIcon}
   title="No TTY"
-  message="Tty has stopped" />
+  message="TTY has stopped" />
 
 <EmptyScreen
   hidden={container.state === 'RUNNING'}


### PR DESCRIPTION
Fixes #15663.

- Updated the container details tab label and breadcrumb from 'Tty' to 'TTY'.
- Updated the stopped message to 'TTY has stopped'.

Test:
- pnpm vitest --run --project=renderer packages/renderer/src/lib/container/ContainerDetails.spec.ts