### PR TITLE
fix(podman): clear reconnect timeout on disconnect

### DIFF
--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
@@ -166,6 +166,10 @@ export class PodmanRemoteSshTunnel {
   disconnect(): void {
     // Set the reconnect flag to false to prevent reconnecting
     this.#reconnect = false;
+    if (this.#reconnectTimeout) {
+      clearTimeout(this.#reconnectTimeout);
+      this.#reconnectTimeout = undefined;
+    }
     this.#client?.end();
     this.#server?.close();
   }


### PR DESCRIPTION
Fixes #16042.

- Clear any pending reconnect timer in PodmanRemoteSshTunnel.disconnect() so a scheduled reconnect cannot fire after disconnect.
- Add a unit test covering the pending reconnect timeout behavior.

Test:
- cd extensions/podman/packages/extension && pnpm vitest run src/remote/podman-remote-ssh-tunnel.spec.ts