### PR TITLE
fix(ci): checkout repo before running PR labeler

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -29,6 +29,11 @@ jobs:
   labeler:
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
       - name: Labeler
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
         with:


### PR DESCRIPTION
Fixes #14443.

The PR labeler workflow runs actions/labeler with configuration-path set to .github/labeler.yml, but the job never checks out the repository, so the config file isn't present in the workspace.

This adds a pinned actions/checkout step (ref: base SHA) before running the labeler.