### PR TITLE
fix(ci): checkout repo before running PR labeler

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -29,6 +29,11 @@ jobs:
   labeler:
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
       - name: Labeler
         uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
         with:


### PR DESCRIPTION
### What does this PR do?

Adds an explicit checkout step to the PR labeler workflow so the labeler has repository content available when it runs.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #14443

### How to test this PR?

- Open a PR and confirm the "PR labeler" workflow can read its config and apply labels.
- Inspect a workflow run: checkout runs before `actions/labeler`.

- [x] Tests are covering the bug fix or the new feature (N/A - workflow-only change)
