### PR TITLE
fix(ui): use TTY label for container tab

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -108,7 +108,7 @@ function getContainerInfoUI(cont: ContainerInfo | undefined): ContainerInfoUI | 
         selected={isTabSelected($router.path, 'terminal')}
         url={getTabUrl($router.path, 'terminal')} />
       {#if displayTty}
-        <Tab title="Tty" selected={isTabSelected($router.path, 'tty')} url={getTabUrl($router.path, 'tty')} />
+        <Tab title="TTY" selected={isTabSelected($router.path, 'tty')} url={getTabUrl($router.path, 'tty')} />
       {/if}
     {/snippet}
     {#snippet contentSnippet()}
@@ -127,7 +127,7 @@ function getContainerInfoUI(cont: ContainerInfo | undefined): ContainerInfoUI | 
       <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
         <ContainerDetailsTerminal container={container} />
       </Route>
-      <Route path="/tty" breadcrumb="Tty" navigationHint="tab">
+      <Route path="/tty" breadcrumb="TTY" navigationHint="tab">
         <ContainerDetailsTtyTerminal container={container} />
       </Route>
     {/snippet}

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -80,7 +80,7 @@ onMount(async () => {
   hidden={!closed && container.state !== 'RUNNING'}
   icon={NoLogIcon}
   title="No TTY"
-  message="Tty has stopped" />
+  message="TTY has stopped" />
 
 <EmptyScreen
   hidden={container.state === 'RUNNING'}


### PR DESCRIPTION
### What does this PR do?

Updates the container details UI label capitalization from "Tty" to "TTY" for consistency.

### Screenshot / video of UI

Text-only change. I can't attach runtime screenshots from this terminal-only environment.

### What issues does this PR fix or reference?

Fixes #15663

### How to test this PR?

- Open a container details page and verify the tab label and empty state message now use "TTY".

- [ ] Tests are covering the bug fix or the new feature (N/A - label-only change)
