### PR TITLE
fix(podman): clear reconnect timeout on disconnect

### DIFF
--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
@@ -126,12 +126,19 @@ test('should be able to connect', async () => {
 test('disconnect should clear pending reconnect timeout', () => {
   vi.useFakeTimers();
 
-  const clientConnectSpy = vi.spyOn(Client.prototype, 'connect').mockImplementation(function () {
+  const clientConnectSpy = vi.spyOn(Client.prototype, 'connect').mockImplementation(function (this: Client) {
     return this;
   });
 
   try {
-    const podmanRemoteSshTunnel = new PodmanRemoteSshTunnel('localhost', 22, 'foo', '', '/tmp/remote.sock', '/tmp/local.sock');
+    const podmanRemoteSshTunnel = new PodmanRemoteSshTunnel(
+      'localhost',
+      22,
+      'foo',
+      '',
+      '/tmp/remote.sock',
+      '/tmp/local.sock',
+    );
     const connectSpy = vi.spyOn(podmanRemoteSshTunnel, 'connect');
 
     podmanRemoteSshTunnel.connect();

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
@@ -23,12 +23,17 @@ import { join } from 'node:path';
 
 import { Client, Server } from 'ssh2';
 import { generatePrivateKey } from 'sshpk';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 class TestPodmanRemoteSshTunnel extends PodmanRemoteSshTunnel {
@@ -125,30 +130,22 @@ test('should be able to connect', async () => {
 
 test('disconnect should clear pending reconnect timeout', () => {
   vi.useFakeTimers();
+  vi.spyOn(Client.prototype, 'connect').mockReturnThis();
 
-  const clientConnectSpy = vi.spyOn(Client.prototype, 'connect').mockImplementation(function (this: Client) {
-    return this;
-  });
+  const podmanRemoteSshTunnel = new PodmanRemoteSshTunnel(
+    'localhost',
+    22,
+    'foo',
+    '',
+    '/tmp/remote.sock',
+    '/tmp/local.sock',
+  );
+  const connectSpy = vi.spyOn(podmanRemoteSshTunnel, 'connect');
 
-  try {
-    const podmanRemoteSshTunnel = new PodmanRemoteSshTunnel(
-      'localhost',
-      22,
-      'foo',
-      '',
-      '/tmp/remote.sock',
-      '/tmp/local.sock',
-    );
-    const connectSpy = vi.spyOn(podmanRemoteSshTunnel, 'connect');
+  podmanRemoteSshTunnel.connect();
+  podmanRemoteSshTunnel.handleReconnect();
+  podmanRemoteSshTunnel.disconnect();
 
-    podmanRemoteSshTunnel.connect();
-    podmanRemoteSshTunnel.handleReconnect();
-    podmanRemoteSshTunnel.disconnect();
-
-    vi.advanceTimersByTime(30000);
-    expect(connectSpy).toHaveBeenCalledTimes(1);
-  } finally {
-    clientConnectSpy.mockRestore();
-    vi.useRealTimers();
-  }
+  vi.advanceTimersByTime(30000);
+  expect(connectSpy).toHaveBeenCalledTimes(1);
 });

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
@@ -166,6 +166,10 @@ export class PodmanRemoteSshTunnel {
   disconnect(): void {
     // Set the reconnect flag to false to prevent reconnecting
     this.#reconnect = false;
+    if (this.#reconnectTimeout) {
+      clearTimeout(this.#reconnectTimeout);
+      this.#reconnectTimeout = undefined;
+    }
     this.#client?.end();
     this.#server?.close();
   }


### PR DESCRIPTION
### What does this PR do?

Clears any pending reconnect timeout when `disconnect()` is called, so we don't schedule a reconnect after an explicit disconnect.

Also adds a unit test for the timeout cleanup behavior.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #16042

### How to test this PR?

- `pnpm -C extensions/podman/packages/extension test`

- [x] Tests are covering the bug fix or the new feature
