### PR TITLE
chore(preload-docker-extension): use nodenext resolution in tsconfig

### DIFF
--- a/packages/preload-docker-extension/src/exec-result-helper.spec.ts
+++ b/packages/preload-docker-extension/src/exec-result-helper.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { lines, parseJsonLines, parseJsonObject } from './exec-result-helper';
+import { lines, parseJsonLines, parseJsonObject } from './exec-result-helper.js';
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/preload-docker-extension/src/exec-result-helper.ts
+++ b/packages/preload-docker-extension/src/exec-result-helper.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/preload-docker-extension/src/index.ts
+++ b/packages/preload-docker-extension/src/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,14 +22,18 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { v1 as dockerDesktopAPI } from '@docker/extension-api-client-types';
-import type { ExecStreamOptions, NavigationIntents, RequestConfig } from '@docker/extension-api-client-types/dist/v1';
-import type { Dialog, OpenDialogResult } from '@docker/extension-api-client-types/dist/v1/dialog';
+import type { Dialog, OpenDialogResult } from '@docker/extension-api-client-types/dist/v1/dialog.js';
+import type {
+  ExecStreamOptions,
+  NavigationIntents,
+  RequestConfig,
+} from '@docker/extension-api-client-types/dist/v1/index.js';
 import { contextBridge, ipcRenderer } from 'electron';
 
-import type { SimpleContainerInfo } from '/@api/container-info';
-import type { ImageInfo } from '/@api/image-info';
+import type { SimpleContainerInfo } from '/@api/container-info.js';
+import type { ImageInfo } from '/@api/image-info.js';
 
-import { lines, parseJsonLines, parseJsonObject } from './exec-result-helper';
+import { lines, parseJsonLines, parseJsonObject } from './exec-result-helper.js';
 
 interface ErrorMessage {
   name: string;

--- a/packages/preload-docker-extension/tsconfig.json
+++ b/packages/preload-docker-extension/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "esnext",
+    "module": "nodenext",
     "target": "esnext",
     "sourceMap": false,
-    "moduleResolution": "Node",
+    "moduleResolution": "nodenext",
     "skipLibCheck": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
### What does this PR do?
without that, I'm unable to import from '@podman-desktop/core-api'

As of this, need to use .js suffix

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15496

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
