### PR TITLE
chore(preload-webview): use nodenext as module(resolution) in tsconfig

### DIFF
--- a/packages/preload-webview/src/index.spec.ts
+++ b/packages/preload-webview/src/index.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@
 
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { init } from '.';
-import * as webviewPreload from './webview-preload';
-import { WebviewPreload } from './webview-preload';
+import { init } from './index.js';
+import * as webviewPreload from './webview-preload.js';
+import { WebviewPreload } from './webview-preload.js';
 
-vi.mock(import('./webview-preload'));
+vi.mock(import('./webview-preload.js'));
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/preload-webview/src/index.ts
+++ b/packages/preload-webview/src/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { WebviewPreload } from './webview-preload';
+import { WebviewPreload } from './webview-preload.js';
 
 /**
  * @module preload

--- a/packages/preload-webview/src/webview-preload.spec.ts
+++ b/packages/preload-webview/src/webview-preload.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ import { contextBridge, ipcRenderer } from 'electron';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { ColorInfo } from '/@api/color-info';
-import type { WebviewInfo } from '/@api/webview-info';
+import type { ColorInfo } from '/@api/color-info.js';
+import type { WebviewInfo } from '/@api/webview-info.js';
 
-import { WebviewPreload } from './webview-preload';
+import { WebviewPreload } from './webview-preload.js';
 
 let webviewPreload: TestWebwiewPreload;
 

--- a/packages/preload-webview/src/webview-preload.ts
+++ b/packages/preload-webview/src/webview-preload.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ import type { WebviewApi } from '@podman-desktop/webview-api';
 import type { IpcRendererEvent } from 'electron';
 import { contextBridge, ipcRenderer } from 'electron';
 
-import { AppearanceSettings } from '/@api/appearance/appearance-settings';
-import type { ColorInfo } from '/@api/color-info';
-import type { WebviewInfo } from '/@api/webview-info';
+import { AppearanceSettings } from '/@api/appearance/appearance-settings.js';
+import type { ColorInfo } from '/@api/color-info.js';
+import type { WebviewInfo } from '/@api/webview-info.js';
 
 interface ErrorMessage {
   name: string;

--- a/packages/preload-webview/tsconfig.json
+++ b/packages/preload-webview/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "module": "esnext",
+    "module": "nodenext",
     "target": "esnext",
     "sourceMap": false,
-    "moduleResolution": "Node",
+    "moduleResolution": "nodenext",
     "skipLibCheck": true,
     "strict": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
### What does this PR do?
allow to import from @podman-desktop/core-api module side effect: add .js suffix


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15496

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
