### PR TITLE
fix(Route): initialize the url field in metadata

### DIFF
--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -19,7 +19,7 @@ export let requestParser:
 
 let showContent = false;
 let params: Record<string, string> = {};
-let meta: TinroRouteMeta = {} as TinroRouteMeta;
+let meta: TinroRouteMeta = { url: '' } as TinroRouteMeta;
 let request: T | undefined = undefined;
 
 const route = createRouteObject({


### PR DESCRIPTION
### What does this PR do?
recent svelte update improved blocker calculation
https://github.com/sveltejs/svelte/pull/17676

but on our end we're in svelte files checking values of meta.url field with startWith, etc

as url field is not there, then the startsWith method is failing

initialize the field with an empty value


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/pull/16223

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
