### PR TITLE
chore(api): enforce avoiding relative imports in api package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -372,4 +372,21 @@ export default [
       'sonarjs/no-unused-collection': 'off',
     },
   },
+
+  {
+    files: ['packages/api/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['../**'],
+              message: 'Parent relative imports are not allowed. Use path aliases (e.g. /@/) instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/api/src/api-sender/api-sender-type.ts
+++ b/packages/api/src/api-sender/api-sender-type.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { IDisposable } from '../disposable.js';
+import type { IDisposable } from '/@/disposable.js';
 
 export const ApiSenderType = Symbol.for('ApiSenderType');
 export type ApiSenderType = {

--- a/packages/api/src/configuration/models.ts
+++ b/packages/api/src/configuration/models.ts
@@ -22,8 +22,8 @@ import type {
   ConfigurationScope as PodmanDesktopApiConfigurationScope,
 } from '@podman-desktop/api';
 
-import type { IDisposable } from '../disposable.js';
-import type { Event } from '../event.js';
+import type { IDisposable } from '/@/disposable.js';
+import type { Event } from '/@/event.js';
 
 interface IExperimentalConfiguration {
   // href to the discussion

--- a/packages/api/src/recommendations/recommendations.ts
+++ b/packages/api/src/recommendations/recommendations.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { FeaturedExtension } from '../featured/featured-api.js';
+import type { FeaturedExtension } from '/@/featured/featured-api.js';
 
 export interface ExtensionBanner {
   extensionId: string;


### PR DESCRIPTION
### What does this PR do?
avoid the usage of relative imports in api/package
remove current relative imports and add eslint rule to avoid the usage of such imports


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
