### PR TITLE
refactor(main+api): declare icon contribution interface with Zod

### DIFF
--- a/packages/api/src/icon-info.ts
+++ b/packages/api/src/icon-info.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { z } from 'zod';
+
 import type { FontDefinition } from './font-info.js';
 
 export interface IconDefinition {
@@ -28,3 +30,18 @@ export interface IconInfo {
   id: string;
   definition: IconDefinition;
 }
+
+export const IconsContributionSchema = z.record(
+  z.string(),
+  z.object({
+    description: z.string().optional(),
+    default: z
+      .object({
+        fontPath: z.string().optional(),
+        fontCharacter: z.string(),
+      })
+      .optional(),
+  }),
+);
+
+export type IconsContribution = z.output<typeof IconsContributionSchema>;

--- a/packages/main/src/plugin/icon-registry.ts
+++ b/packages/main/src/plugin/icon-registry.ts
@@ -18,7 +18,7 @@
 
 import { join } from 'node:path';
 
-import type { FontDefinition, IconDefinition, IconInfo } from '@podman-desktop/core-api';
+import type { FontDefinition, IconDefinition, IconInfo, IconsContribution } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
 
@@ -53,10 +53,7 @@ export class IconRegistry {
     this.apiSender.send('font-update');
   }
 
-  public registerIconContribution(
-    extension: AnalyzedExtension,
-    icons: { [key: string]: { description?: string; default?: { fontPath?: string; fontCharacter: string } } },
-  ): void {
+  public registerIconContribution(extension: AnalyzedExtension, icons: IconsContribution): void {
     // register each font and icon
     Object.entries(icons).forEach(([iconId, iconContribution]) => {
       // is there any default icon?


### PR DESCRIPTION
### What does this PR do?

This PR adds a zod schema and an interface for icon contributions that are registered. It is needed for declaring the schema of extension package.json.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16050

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
