### PR TITLE
chore(api): declare menu interface with Zod

### DIFF
--- a/packages/api/src/menu.ts
+++ b/packages/api/src/menu.ts
@@ -16,10 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface Menu {
-  command: string;
-  title: string;
-  when?: string;
-  disabled?: string;
-  icon?: string;
-}
+import { z } from 'zod';
+
+export const MenuSchema = z.object({
+  command: z.string(),
+  title: z.string(),
+  when: z.string().optional(),
+  disabled: z.string().optional(),
+  icon: z.string().optional(),
+});
+
+export type Menu = z.output<typeof MenuSchema>;


### PR DESCRIPTION
### What does this PR do?

This PR declares the menu interface with Zod instead of Typescript interface. It is needed for declaring the schema of extension package.json.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16050

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
