### PR TITLE
chore(api): declare theme interface with Zod

### DIFF
--- a/packages/api/src/theme-info.ts
+++ b/packages/api/src/theme-info.ts
@@ -16,10 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export interface RawThemeContribution {
-  id: string;
-  name: string;
-  parent: string;
+import { z } from 'zod';
+
+export const RawThemeContributionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  parent: z.string(),
   // definition of colors
-  colors: { [key: string]: string };
-}
+  colors: z.record(z.string(), z.string()),
+});
+
+export type RawThemeContribution = z.output<typeof RawThemeContributionSchema>;


### PR DESCRIPTION
### What does this PR do?

This PR declares the theme interface with Zod instead of Typescript interface. It is needed for declaring the schema of extension package.json.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16050

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
