### PR TITLE
chore(api): declare view info interface with Zod

### DIFF
--- a/packages/api/src/view-info.ts
+++ b/packages/api/src/view-info.ts
@@ -15,22 +15,41 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-export type ViewContribution = ViewContributionIcon | ViewContributionBadge;
 
-export interface ViewContributionIcon {
-  when: string | undefined;
-  icon: string;
-}
+import { z } from 'zod';
 
-export interface ViewContributionBadge {
-  when: string | undefined;
-  badge: ViewContributionBadgeValue;
-}
+export const ViewContributionBadgeValueSchema = z.object({
+  label: z.string(),
+  color: z
+    .union([
+      z.string(),
+      z.object({
+        light: z.string(),
+        dark: z.string(),
+      }),
+    ])
+    .optional(),
+});
 
-export interface ViewContributionBadgeValue {
-  label: string;
-  color?: string | { light: string; dark: string };
-}
+export type ViewContributionBadgeValue = z.output<typeof ViewContributionBadgeValueSchema>;
+
+export const ViewContributionIconSchema = z.object({
+  when: z.string().optional(),
+  icon: z.string(),
+});
+
+export type ViewContributionIcon = z.output<typeof ViewContributionIconSchema>;
+
+export const ViewContributionBadgeSchema = z.object({
+  when: z.string().optional(),
+  badge: ViewContributionBadgeValueSchema,
+});
+
+export type ViewContributionBadge = z.output<typeof ViewContributionBadgeSchema>;
+
+export const ViewContributionSchema = z.union([ViewContributionIconSchema, ViewContributionBadgeSchema]);
+
+export type ViewContribution = z.output<typeof ViewContributionSchema>;
 
 export interface ViewInfoUI {
   extensionId: string;


### PR DESCRIPTION
### What does this PR do?

This PR declares the view interface with Zod instead of Typescript interface. It is needed for declaring the schema of extension package.json.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16050

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
