### PR TITLE
feat: uapi specification

### DIFF
--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -61,10 +61,10 @@ vi.mock(import('./locked-configuration.js'), () => ({
 let configurationRegistry: ConfigurationRegistry;
 
 const getConfigurationDirectoryMock = vi.fn();
-const getManagedDefaultsDirectoryMock = vi.fn();
+const getManagedDefaultsDirectoriesMock = vi.fn();
 const directories = {
   getConfigurationDirectory: getConfigurationDirectoryMock,
-  getManagedDefaultsDirectory: getManagedDefaultsDirectoryMock,
+  getManagedDefaultsDirectories: getManagedDefaultsDirectoriesMock,
 } as unknown as Directories;
 const apiSender = {
   send: vi.fn(),
@@ -90,7 +90,7 @@ beforeEach(async () => {
   vi.resetAllMocks();
   vi.clearAllMocks();
   getConfigurationDirectoryMock.mockReturnValue('/my-config-dir');
-  getManagedDefaultsDirectoryMock.mockReturnValue('/usr/share/podman-desktop');
+  getManagedDefaultsDirectoriesMock.mockReturnValue(['/usr/share/podman-desktop']);
 
   // Mock basic fs functions needed for initialization
   const readFileSync = vi.mocked(fs.readFileSync);

--- a/packages/main/src/plugin/default-configuration.spec.ts
+++ b/packages/main/src/plugin/default-configuration.spec.ts
@@ -27,9 +27,9 @@ import type { Directories } from './directories.js';
 vi.mock('node:fs/promises');
 
 let defaultConfiguration: DefaultConfiguration;
-const getManagedDefaultsDirectoryMock = vi.fn();
+const getManagedDefaultsDirectoriesMock = vi.fn();
 const directories = {
-  getManagedDefaultsDirectory: getManagedDefaultsDirectoryMock,
+  getManagedDefaultsDirectories: getManagedDefaultsDirectoriesMock,
 } as unknown as Directories;
 
 beforeEach(() => {
@@ -40,7 +40,7 @@ beforeEach(() => {
 
 describe('DefaultConfiguration', () => {
   test('should load managed defaults when file exists', async () => {
-    getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue(['/test/path']);
     const managedDefaults = { 'managed.setting': 'managedValue' };
     vi.mocked(readFile).mockResolvedValue(JSON.stringify(managedDefaults));
 
@@ -55,7 +55,7 @@ describe('DefaultConfiguration', () => {
   });
 
   test('should handle missing managed defaults file gracefully', async () => {
-    getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue(['/test/path']);
     const error = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
     error.code = 'ENOENT';
     vi.mocked(readFile).mockRejectedValue(error);
@@ -70,7 +70,7 @@ describe('DefaultConfiguration', () => {
   });
 
   test('should handle corrupted managed defaults file gracefully', async () => {
-    getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue(['/test/path']);
     vi.mocked(readFile).mockResolvedValue('invalid json');
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -90,7 +90,7 @@ describe('DefaultConfiguration', () => {
   });
 
   test('should load managed defaults configuration with valid JSON', async () => {
-    getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue(['/test/path']);
     const managedDefaults = { 'managed.setting': 'managedValue', 'another.setting': 'anotherValue' };
     vi.mocked(readFile).mockResolvedValue(JSON.stringify(managedDefaults));
 

--- a/packages/main/src/plugin/default-configuration.ts
+++ b/packages/main/src/plugin/default-configuration.ts
@@ -39,29 +39,48 @@ export class DefaultConfiguration {
   ) {}
 
   public async getContent(): Promise<{ [key: string]: unknown }> {
-    // Get the managed defaults file path from directories
-    const managedDefaultsFile = path.join(this.directories.getManagedDefaultsDirectory(), SYSTEM_DEFAULTS_FILENAME);
-    let managedDefaultsData = {};
+    let foundAnyConfig = false;
+    let hadParseError = false;
 
-    // It's important that we at least log to console what is happening here, as it's common for logs
-    // to be shared when there are issues loading "managed-by" defaults, so having this information in the logs is useful.
-    try {
-      const managedDefaultsContent = await readFile(managedDefaultsFile, 'utf-8');
-      managedDefaultsData = JSON.parse(managedDefaultsContent);
-      console.log(`[Managed-by]: Loaded managed defaults from: ${managedDefaultsFile}`);
-      this.telemetryInfo = { event: 'managedConfigurationEnabled' };
-    } catch (error) {
-      // Handle file-not-found errors gracefully - this is expected when no managed config exists
-      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-        console.debug(`[Managed-by]: No managed defaults file found at ${managedDefaultsFile}`);
-      } else {
-        // For other errors (like JSON parse errors), log as error
-        console.error(`[Managed-by]: Failed to parse managed defaults from ${managedDefaultsFile}:`, error);
-        this.telemetryInfo = { event: 'managedConfigurationStartupFailed', eventProperties: error };
+    // Get the managed defaults file path from directories
+    const managedDefaultsDirectories = this.directories.getManagedDefaultsDirectories();
+    let mergedConfig: { [key: string]: unknown } = {};
+
+    // Process paths in reverse order (lowest priority first)
+    // so higher priority sources override lower ones
+    for (const managedDefaultsDirectory of [...managedDefaultsDirectories].reverse()) {
+      const managedDefaultsFile = path.join(managedDefaultsDirectory, SYSTEM_DEFAULTS_FILENAME);
+      // It's important that we at least log to console what is happening here, as it's common for logs
+      // to be shared when there are issues loading "managed-by" defaults, so having this information in the logs is useful.
+      try {
+        const managedDefaultsContent = await readFile(managedDefaultsFile, 'utf-8');
+        const managedDefaultsData = JSON.parse(managedDefaultsContent);
+
+        // Merge with existing config, higher priority sources override lower ones
+        mergedConfig = { ...mergedConfig, ...managedDefaultsData };
+        console.log(`[Managed-by]: Loaded managed defaults from: ${managedDefaultsFile}`);
+        foundAnyConfig = true;
+      } catch (error) {
+        // Handle file-not-found errors gracefully - this is expected when no managed config exists
+        if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+          console.debug(`[Managed-by]: No managed defaults file found at ${managedDefaultsFile}`);
+        } else {
+          // For other errors (like JSON parse errors), log as error
+          console.error(`[Managed-by]: Failed to parse managed defaults from ${managedDefaultsFile}:`, error);
+          hadParseError = true;
+        }
       }
     }
-
-    return managedDefaultsData;
+    // Set telemetry after loop
+    if (hadParseError) {
+      this.telemetryInfo = {
+        event: 'managedConfigurationStartupFailed',
+        eventProperties: 'Parse error in one or more files',
+      };
+    } else if (foundAnyConfig) {
+      this.telemetryInfo = { event: 'managedConfigurationEnabled' };
+    }
+    return mergedConfig;
   }
 
   public getTelemetryInfo(): TelemetryInfo | undefined {

--- a/packages/main/src/plugin/directories-legacy.spec.ts
+++ b/packages/main/src/plugin/directories-legacy.spec.ts
@@ -161,7 +161,7 @@ describe('LegacyDirectories', () => {
       expect(paths[1]).toBe(product.paths.managed.linux);
     });
 
-    test('should return /etc first, then flatpak path on Linux in Flatpak', () => {
+    test('should return /run/host/etc first, then flatpak path on Linux in Flatpak', () => {
       vi.mocked(isMac).mockReturnValue(false);
       vi.mocked(isWindows).mockReturnValue(false);
       vi.mocked(isLinux).mockReturnValue(true);
@@ -173,7 +173,7 @@ describe('LegacyDirectories', () => {
       const paths = provider.getManagedDefaultsDirectories();
 
       expect(paths).toHaveLength(2);
-      expect(paths[0]).toBe('/etc/podman-desktop');
+      expect(paths[0]).toBe(`/run/host/etc/${product.artifactName}`);
       expect(paths[1]).toBe(product.paths.managed.flatpak);
     });
 

--- a/packages/main/src/plugin/directories-legacy.ts
+++ b/packages/main/src/plugin/directories-legacy.ts
@@ -111,7 +111,7 @@ export class LegacyDirectories implements Directories {
       // /etc always comes first (admin overrides)
       paths.push('/etc/podman-desktop');
 
-      // Then vendor defaults (Flatpak or standard Linux)
+      // Then managed defaults (Flatpak or standard Linux)
       // biome-ignore lint/complexity/useLiteralKeys: FLATPAK_ID comes from an index signature
       paths.push(process.env['FLATPAK_ID'] ? product.paths.managed.flatpak : product.paths.managed.linux);
     } else {

--- a/packages/main/src/plugin/directories-linux-xdg.spec.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.spec.ts
@@ -131,7 +131,7 @@ describe('LinuxXDGDirectories', () => {
       expect(paths[1]).toBe(product.paths.managed.linux);
     });
 
-    test('should return /etc first, then flatpak path when running in Flatpak', () => {
+    test('should return /run/host/etc first, then flatpak path when running in Flatpak', () => {
       // biome-ignore lint/complexity/useLiteralKeys: FLATPAK_ID comes from an index signature
       process.env['FLATPAK_ID'] = 'io.podman_desktop.PodmanDesktop';
 
@@ -140,7 +140,7 @@ describe('LinuxXDGDirectories', () => {
       const paths = provider.getManagedDefaultsDirectories();
 
       expect(paths).toHaveLength(2);
-      expect(paths[0]).toBe('/etc/podman-desktop');
+      expect(paths[0]).toBe(`/run/host/etc/${product.artifactName}`);
       expect(paths[1]).toBe(product.paths.managed.flatpak);
     });
 

--- a/packages/main/src/plugin/directories-linux-xdg.spec.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.spec.ts
@@ -120,20 +120,38 @@ describe('LinuxXDGDirectories', () => {
     });
   });
 
-  describe('getManagedDefaultsDirectory', () => {
-    test('should return linux managed folder path when not running in Flatpak', () => {
+  describe('getManagedDefaultsDirectories', () => {
+    test('should return /etc first, then /usr/share on standard Linux', () => {
       provider = new LinuxXDGDirectories();
 
-      expect(provider.getManagedDefaultsDirectory()).toBe(product.paths.managed.linux);
+      const paths = provider.getManagedDefaultsDirectories();
+
+      expect(paths).toHaveLength(2);
+      expect(paths[0]).toBe('/etc/podman-desktop');
+      expect(paths[1]).toBe(product.paths.managed.linux);
     });
 
-    test('should return flatpak managed folder path when running in Flatpak', () => {
+    test('should return /etc first, then flatpak path when running in Flatpak', () => {
       // biome-ignore lint/complexity/useLiteralKeys: FLATPAK_ID comes from an index signature
       process.env['FLATPAK_ID'] = 'io.podman_desktop.PodmanDesktop';
 
       provider = new LinuxXDGDirectories();
 
-      expect(provider.getManagedDefaultsDirectory()).toBe(product.paths.managed.flatpak);
+      const paths = provider.getManagedDefaultsDirectories();
+
+      expect(paths).toHaveLength(2);
+      expect(paths[0]).toBe('/etc/podman-desktop');
+      expect(paths[1]).toBe(product.paths.managed.flatpak);
+    });
+
+    test('should have /etc with higher priority than /usr/share (first in array)', () => {
+      provider = new LinuxXDGDirectories();
+
+      const paths = provider.getManagedDefaultsDirectories();
+
+      // First element = highest priority (will be checked/merged last)
+      expect(paths[0]).toBe('/etc/podman-desktop');
+      expect(paths.indexOf('/etc/podman-desktop')).toBeLessThan(paths.indexOf(product.paths.managed.linux));
     });
   });
 });

--- a/packages/main/src/plugin/directories-linux-xdg.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.ts
@@ -91,10 +91,10 @@ export class LinuxXDGDirectories implements Directories {
 
     // Priority order (highest to lowest):
     // 1. /etc - Admin overrides (writable even on immutable systems)
-    // 2. /usr or /run/host/usr - Vendor defaults (read-only on immutable systems)
+    // 2. /usr or /run/host/usr - Managed defaults (read-only on immutable systems)
     // /etc always comes first on Linux
     paths.push('/etc/podman-desktop');
-    // Then add the vendor defaults path (differs between Flatpak and standard Linux)
+    // Then add the managed defaults path (differs between Flatpak and standard Linux)
     // biome-ignore lint/complexity/useLiteralKeys: FLATPAK_ID comes from an index signature
     paths.push(process.env['FLATPAK_ID'] ? product.paths.managed.flatpak : product.paths.managed.linux);
     return paths;

--- a/packages/main/src/plugin/directories-linux-xdg.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.ts
@@ -86,11 +86,17 @@ export class LinuxXDGDirectories implements Directories {
     return this.dataDirectory;
   }
 
-  getManagedDefaultsDirectory(): string {
+  getManagedDefaultsDirectories(): string[] {
+    const paths: string[] = [];
+
+    // Priority order (highest to lowest):
+    // 1. /etc - Admin overrides (writable even on immutable systems)
+    // 2. /usr or /run/host/usr - Vendor defaults (read-only on immutable systems)
+    // /etc always comes first on Linux
+    paths.push('/etc/podman-desktop');
+    // Then add the vendor defaults path (differs between Flatpak and standard Linux)
     // biome-ignore lint/complexity/useLiteralKeys: FLATPAK_ID comes from an index signature
-    if (process.env['FLATPAK_ID']) {
-      return product.paths.managed.flatpak;
-    }
-    return product.paths.managed.linux;
+    paths.push(process.env['FLATPAK_ID'] ? product.paths.managed.flatpak : product.paths.managed.linux);
+    return paths;
   }
 }

--- a/packages/main/src/plugin/directories-linux-xdg.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.ts
@@ -88,15 +88,14 @@ export class LinuxXDGDirectories implements Directories {
 
   getManagedDefaultsDirectories(): string[] {
     const paths: string[] = [];
-
-    // Priority order (highest to lowest):
-    // 1. /etc - Admin overrides (writable even on immutable systems)
-    // 2. /usr or /run/host/usr - Managed defaults (read-only on immutable systems)
-    // /etc always comes first on Linux
-    paths.push('/etc/podman-desktop');
-    // Then add the managed defaults path (differs between Flatpak and standard Linux)
     // biome-ignore lint/complexity/useLiteralKeys: FLATPAK_ID comes from an index signature
-    paths.push(process.env['FLATPAK_ID'] ? product.paths.managed.flatpak : product.paths.managed.linux);
+    const isFlatpak = !!process.env['FLATPAK_ID'];
+    // Priority order (highest to lowest):
+    // 1. /etc (or /run/host/etc in Flatpak) - Admin overrides
+    // 2. /usr/share (or /run/host/usr/share in Flatpak) - Managed defaults
+    // In Flatpak, host paths are accessed via /run/host/ prefix
+    paths.push(isFlatpak ? `/run/host/etc/${product.artifactName}` : `/etc/${product.artifactName}`);
+    paths.push(isFlatpak ? product.paths.managed.flatpak : product.paths.managed.linux);
     return paths;
   }
 }

--- a/packages/main/src/plugin/directories.ts
+++ b/packages/main/src/plugin/directories.ts
@@ -25,5 +25,13 @@ export interface Directories {
   getContributionStorageDir(): string;
   getSafeStorageDirectory(): string;
   getDataDirectory(): string;
-  getManagedDefaultsDirectory(): string;
+  /**
+   * Get managed configuration directories in precedence order (highest priority first).
+   * On Linux, this returns ['/etc/podman-desktop', '/usr/share/podman-desktop']
+   * allowing admin overrides in /etc to take precedence over vendor defaults in /usr/share.
+   * This follows the UAPI Configuration Files Specification.
+   *
+   * @returns Array of paths to check for managed configuration files
+   */
+  getManagedDefaultsDirectories(): string[];
 }

--- a/packages/main/src/plugin/directories.ts
+++ b/packages/main/src/plugin/directories.ts
@@ -28,7 +28,7 @@ export interface Directories {
   /**
    * Get managed configuration directories in precedence order (highest priority first).
    * On Linux, this returns ['/etc/podman-desktop', '/usr/share/podman-desktop']
-   * allowing admin overrides in /etc to take precedence over vendor defaults in /usr/share.
+   * allowing admin overrides in /etc to take precedence over managed defaults in /usr/share.
    * This follows the UAPI Configuration Files Specification.
    *
    * @returns Array of paths to check for managed configuration files

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -339,6 +339,7 @@ test('configurationRegistry propagated', async () => {
   const apiSenderMock = {} as unknown as ApiSenderType;
   const directoriesMock = {
     getConfigurationDirectory: vi.fn().mockReturnValue(tmpdir()),
+    getManagedDefaultsDirectories: vi.fn().mockReturnValue(['/test/managed/path']),
   } as unknown as Directories;
   const defaultConfigurationMock = {
     getContent: vi.fn().mockResolvedValue({}),

--- a/packages/main/src/plugin/locked-configuration.spec.ts
+++ b/packages/main/src/plugin/locked-configuration.spec.ts
@@ -27,9 +27,9 @@ import { LockedConfiguration } from './locked-configuration.js';
 vi.mock('node:fs/promises');
 
 let lockedConfiguration: LockedConfiguration;
-const getManagedDefaultsDirectoryMock = vi.fn();
+const getManagedDefaultsDirectoriesMock = vi.fn();
 const directories = {
-  getManagedDefaultsDirectory: getManagedDefaultsDirectoryMock,
+  getManagedDefaultsDirectories: getManagedDefaultsDirectoriesMock,
 } as unknown as Directories;
 
 beforeEach(() => {
@@ -40,7 +40,7 @@ beforeEach(() => {
 
 describe('LockedConfiguration', () => {
   test('should load managed locked when file exists', async () => {
-    getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue('/test/path');
     const managedLocked = { locked: ['telemetry.enabled', 'some.other.setting'] };
     vi.mocked(readFile).mockResolvedValue(JSON.stringify(managedLocked));
 
@@ -55,7 +55,7 @@ describe('LockedConfiguration', () => {
   });
 
   test('should handle missing managed locked file gracefully', async () => {
-    getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue('/test/path');
     const error = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
     error.code = 'ENOENT';
     vi.mocked(readFile).mockRejectedValue(error);
@@ -70,7 +70,7 @@ describe('LockedConfiguration', () => {
   });
 
   test('should handle corrupted managed locked file gracefully', async () => {
-    getManagedDefaultsDirectoryMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue('/test/path');
     vi.mocked(readFile).mockResolvedValue('invalid json');
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/main/src/plugin/locked-configuration.spec.ts
+++ b/packages/main/src/plugin/locked-configuration.spec.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
 
 describe('LockedConfiguration', () => {
   test('should load managed locked when file exists', async () => {
-    getManagedDefaultsDirectoriesMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue(['/test/path']);
     const managedLocked = { locked: ['telemetry.enabled', 'some.other.setting'] };
     vi.mocked(readFile).mockResolvedValue(JSON.stringify(managedLocked));
 
@@ -55,7 +55,7 @@ describe('LockedConfiguration', () => {
   });
 
   test('should handle missing managed locked file gracefully', async () => {
-    getManagedDefaultsDirectoriesMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue(['/test/path']);
     const error = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException;
     error.code = 'ENOENT';
     vi.mocked(readFile).mockRejectedValue(error);
@@ -70,7 +70,7 @@ describe('LockedConfiguration', () => {
   });
 
   test('should handle corrupted managed locked file gracefully', async () => {
-    getManagedDefaultsDirectoriesMock.mockReturnValue('/test/path');
+    getManagedDefaultsDirectoriesMock.mockReturnValue(['/test/path']);
     vi.mocked(readFile).mockResolvedValue('invalid json');
 
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -79,7 +79,7 @@ const directories = {
   getContributionStorageDir: () => '/fake-contribution-storage-directory',
   getSafeStorageDirectory: () => '/fake-safe-storage-directory',
   getDataDirectory: () => '/fake-data-directory',
-  getManagedDefaultsDirectory: () => ['/fake-managed-defaults-directory'],
+  getManagedDefaultsDirectories: () => ['/fake-managed-defaults-directory'],
 } as unknown as Directories;
 
 const defaultConfiguration = {

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -79,7 +79,7 @@ const directories = {
   getContributionStorageDir: () => '/fake-contribution-storage-directory',
   getSafeStorageDirectory: () => '/fake-safe-storage-directory',
   getDataDirectory: () => '/fake-data-directory',
-  getManagedDefaultsDirectory: () => '/fake-managed-defaults-directory',
+  getManagedDefaultsDirectory: () => ['/fake-managed-defaults-directory'],
 } as unknown as Directories;
 
 const defaultConfiguration = {

--- a/website/docs/configuration/managed-configuration-troubleshooting.md
+++ b/website/docs/configuration/managed-configuration-troubleshooting.md
@@ -58,6 +58,28 @@ To verify in the GUI if a value is locked by your managed-by configuration:
 
 4. Confirm that it has the **Managed** label applied.
 
+## Configuration from `/etc` not overriding `/usr/share` (Linux)
+
+On Linux, Podman Desktop reads managed configuration from two locations: `/usr/share/podman-desktop/` (managed defaults) and `/etc/podman-desktop/` (admin overrides). If your `/etc` overrides are not taking effect:
+
+1. Verify the file names are exactly `default-settings.json` and `locked.json` (same as in `/usr/share`).
+2. Ensure the JSON content is valid (use a JSON validator).
+3. Check the startup logs. You should see separate log entries for each location:
+   ```
+   [Managed-by]: Loaded managed defaults from: /usr/share/podman-desktop/default-settings.json
+   [Managed-by]: Loaded managed defaults from: /etc/podman-desktop/default-settings.json
+   ```
+4. If you only see one log entry, the other file is missing or has a syntax error.
+5. Remember that `/etc` values only override keys that are present in the `/etc` file. Keys not listed in the `/etc` file will keep their `/usr/share` values.
+
+## Managed defaults not applied after restart
+
+If the log message `Applied default settings for: ...` does not appear after a restart:
+
+1. The settings may already exist in the user's `settings.json`. Managed defaults are only applied once per setting, when the key does not yet exist in the user's configuration.
+2. Check the user's `settings.json` file at `~/.local/share/containers/podman-desktop/configuration/settings.json` or `~/.config/containers/podman-desktop/settings.json`.
+3. To re-apply managed defaults, remove the specific key from the user's `settings.json` and restart Podman Desktop.
+
 ## File permission issues
 
 On Linux and macOS, managed configuration files must have appropriate permissions:

--- a/website/docs/configuration/managed-configuration-use-cases.md
+++ b/website/docs/configuration/managed-configuration-use-cases.md
@@ -104,6 +104,43 @@ This configuration maps to the [registries.conf](https://github.com/containers/i
 }
 ```
 
+## Deploying on immutable Linux systems
+
+On image-based Linux systems, the `/usr/share` directory is read-only and cannot be modified after the image is built. Podman Desktop supports an alternative configuration path at `/etc/podman-desktop/` for these environments.
+
+### Managed defaults baked into the OS image
+
+If you build custom OS images, include managed defaults in the image:
+
+```json title="/usr/share/podman-desktop/default-settings.json"
+{
+  "proxy.http": "http://default-proxy.example.com:8080",
+  "telemetry.enabled": false
+}
+```
+
+### Admin overrides applied at deployment time
+
+After the image is deployed, administrators can add site-specific overrides in `/etc/podman-desktop/`. Values in `/etc` take precedence over `/usr/share`:
+
+```json title="/etc/podman-desktop/default-settings.json"
+{
+  "proxy.http": "http://site-specific-proxy.example.com:3128"
+}
+```
+
+```json title="/etc/podman-desktop/locked.json"
+{
+  "locked": ["proxy.http", "telemetry.enabled"]
+}
+```
+
+In this example:
+
+- `proxy.http` is overridden to the site-specific proxy (`/etc` wins over `/usr/share`)
+- `telemetry.enabled` keeps the default value `false` from `/usr/share` (no override in `/etc`)
+- Both keys are locked and cannot be changed by the user
+
 ## Additional resources
 
 - [Configuring a managed user environment](/docs/configuration/managed-configuration)


### PR DESCRIPTION
### What does this PR do?
## Add /etc override support for managed configuration on Linux (UAPI compliance)
On image-based/immutable Linux systems (Fedora CoreOS, bootc, RHEL Image Mode), /usr/share is read-only, preventing administrators from placing managed configuration files there.
This PR adds support for reading managed configuration from /etc/podman-desktop/ in addition to /usr/share/podman-desktop/, following the UAPI Configuration Files Specification. When both locations contain configuration files, values from /etc take precedence over /usr/share.
Changes:
* Add getManagedDefaultsDirectories() method to the Directories interface, returning paths in precedence order
* Update DefaultConfiguration and LockedConfiguration to iterate over multiple paths and merge configurations
* Remove the singular getManagedDefaultsDirectory() method (only used internally)
* Update documentation with multi-path examples, immutable systems use case, and troubleshooting guidance
Behavior:
*Existing deployments using only /usr/share continue working unchanged
*macOS and Windows are not affected (single managed path)

### Screenshot / video of UI

### What issues does this PR fix or reference?
Closes #15366 

### How to test this PR?
### Prerequisites

- A Linux machine or VM (tested on Fedora)
- Root access to create files in `/usr/share` and `/etc`

### Setup

```bash
# Clean user settings before each scenario
rm -f ~/.local/share/containers/podman-desktop/configuration/settings.json
rm -f ~/.config/containers/podman-desktop/settings.json
```

### Scenario 1: Only managed defaults (`/usr/share`) — backward compatibility

```bash
sudo rm -rf /etc/podman-desktop
sudo mkdir -p /usr/share/podman-desktop
sudo tee /usr/share/podman-desktop/default-settings.json << 'EOF'
{
  "preferences.appearance": "light",
  "telemetry.enabled": false
}
EOF
sudo rm -f /usr/share/podman-desktop/locked.json
```

**Expected:**
- Log: `Loaded managed defaults from: /usr/share/podman-desktop/default-settings.json`
- Log: `Applied default settings for: preferences.appearance, telemetry.enabled`
- Theme is **light**
- Telemetry is disabled but **modifiable**

### Scenario 2: Only admin overrides (`/etc`) — immutable systems

```bash
sudo rm -rf /usr/share/podman-desktop
sudo mkdir -p /etc/podman-desktop
sudo tee /etc/podman-desktop/default-settings.json << 'EOF'
{
  "preferences.appearance": "dark",
  "telemetry.enabled": false
}
EOF
sudo tee /etc/podman-desktop/locked.json << 'EOF'
{
  "locked": ["telemetry.enabled"]
}
EOF
```

**Expected:**
- Log: `Loaded managed defaults from: /etc/podman-desktop/default-settings.json`
- Log: `Loaded managed locked from: /etc/podman-desktop/locked.json`
- Log: `Applied default settings for: preferences.appearance, telemetry.enabled`
- Theme is **dark**
- Telemetry is disabled, **locked** (grayed out with "Managed" label, no reset button)

### Scenario 3: No managed configuration — clean install

```bash
sudo rm -rf /usr/share/podman-desktop
sudo rm -rf /etc/podman-desktop
```

**Expected:**
- No `[Managed-by]` log messages
- Default system theme
- Telemetry is **modifiable**

### Scenario 4: Both paths — merge with `/etc` taking precedence

```bash
sudo mkdir -p /usr/share/podman-desktop
sudo tee /usr/share/podman-desktop/default-settings.json << 'EOF'
{
  "preferences.appearance": "light",
  "telemetry.enabled": false
}
EOF
sudo mkdir -p /etc/podman-desktop
sudo tee /etc/podman-desktop/default-settings.json << 'EOF'
{
  "preferences.appearance": "dark"
}
EOF
sudo tee /etc/podman-desktop/locked.json << 'EOF'
{
  "locked": ["telemetry.enabled"]
}
EOF
```

**Expected:**
- Log: `Loaded managed defaults from: /usr/share/podman-desktop/default-settings.json`
- Log: `Loaded managed defaults from: /etc/podman-desktop/default-settings.json`
- Log: `Loaded managed locked from: /etc/podman-desktop/locked.json`
- Log: `Applied default settings for: preferences.appearance, telemetry.enabled`
- Theme is **dark** (`/etc` overrides `/usr/share`)
- Telemetry is disabled, **locked** (grayed out with "Managed" label)

### Scenario 5: Existing user settings are preserved

```bash
sudo rm -rf /usr/share/podman-desktop
sudo mkdir -p /etc/podman-desktop
sudo tee /etc/podman-desktop/default-settings.json << 'EOF'
{
  "preferences.appearance": "dark",
  "telemetry.enabled": false
}
EOF

# Create a pre-existing user settings file
mkdir -p ~/.local/share/containers/podman-desktop/configuration/
echo '{"preferences.appearance": "light"}' > ~/.local/share/containers/podman-desktop/configuration/settings.json
```

**Expected:**
- Log: `Applied default settings for: telemetry.enabled` (only telemetry, **not** appearance)
- Theme is **light** (user's existing preference is respected)
- Telemetry is disabled but **modifiable**


- [ ] Tests are covering the bug fix or the new feature

- Assisted-by: <claude-4.6-opus-high>