### PR TITLE
feat(extension-point): add extension point for certificates synchronization

### DIFF
--- a/packages/api/src/certificate-sync-target.ts
+++ b/packages/api/src/certificate-sync-target.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CertificateSyncTarget } from '@podman-desktop/api';
+
+/**
+ * Extended target with extension info for UI display.
+ * Returned by the registry (only includes trusted extensions).
+ */
+export interface CertificateSyncTargetInfo extends CertificateSyncTarget {
+  /** ID of the extension that registered the provider */
+  extensionId: string;
+  /** Display name of the extension */
+  extensionName: string;
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -19,6 +19,7 @@
 // Top-level API files
 export * from './async-disposable.js';
 export * from './certificate-info.js';
+export * from './certificate-sync-target.js';
 export * from './cli-tool-info.js';
 export * from './color-info.js';
 export * from './command-info.js';

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4370,6 +4370,148 @@ declare module '@podman-desktop/api' {
   }
 
   /**
+   * A target for certificate synchronization contributed by an extension.
+   */
+  export interface CertificateSyncTarget {
+    /**
+     * Unique identifier for the target within the extension.
+     */
+    id: string;
+
+    /**
+     * Display name for the target.
+     */
+    name: string;
+  }
+
+  /**
+   * Information about a certificate sync target provider.
+   */
+  export interface CertificateSyncTargetProviderInformation {
+    /**
+     * Extension identifier that registered this provider.
+     */
+    readonly extensionId: string;
+
+    /**
+     * Human-readable label for the provider (extension display name).
+     */
+    readonly label: string;
+  }
+
+  /**
+   * Event fired when a certificate sync target provider's targets change.
+   */
+  export interface CertificateSyncTargetProviderChangeEvent {
+    /**
+     * Information about the provider whose targets changed.
+     */
+    provider: CertificateSyncTargetProviderInformation;
+  }
+
+  /**
+   * Provider interface for extensions that contribute certificate sync targets.
+   */
+  export interface CertificateSyncTargetProvider {
+    /**
+     * Get all available sync targets from this provider.
+     * @returns A promise that resolves to an array of sync targets.
+     */
+    getTargets(): Promise<CertificateSyncTarget[]>;
+
+    /**
+     * Synchronize certificates to a specific target.
+     * @param targetId The ID of the target to synchronize to.
+     * @param certificates Array of PEM-encoded certificates to synchronize.
+     */
+    synchronize(targetId: string, certificates: string[]): Promise<void>;
+
+    /**
+     * Event fired when the available targets change.
+     * Extensions must fire this event when targets are added, removed, or modified.
+     */
+    onDidChangeTargets: Event<CertificateSyncTargetProviderChangeEvent>;
+  }
+
+  /**
+   * Information about a certificate from the host system.
+   */
+  export interface CertificateInfo {
+    /**
+     * The certificate subject's common name (CN) with fallback to O or full DN.
+     */
+    subjectCommonName: string;
+
+    /**
+     * The full subject distinguished name (DN).
+     * Example: "CN=example.com, O=Example Inc, C=US"
+     */
+    subject: string;
+
+    /**
+     * The certificate issuer's common name (CN) with fallback to O or full DN.
+     */
+    issuerCommonName: string;
+
+    /**
+     * The full issuer distinguished name (DN).
+     * Example: "CN=DigiCert Global Root CA, O=DigiCert Inc, C=US"
+     */
+    issuer: string;
+
+    /**
+     * The certificate serial number in hexadecimal format.
+     */
+    serialNumber: string;
+
+    /**
+     * The date from which the certificate is valid (notBefore).
+     * ISO 8601 string format.
+     */
+    validFrom?: string;
+
+    /**
+     * The date until which the certificate is valid (notAfter).
+     * ISO 8601 string format.
+     */
+    validTo?: string;
+
+    /**
+     * Indicates whether this is a Certificate Authority (CA) certificate.
+     */
+    isCA: boolean;
+  }
+
+  /**
+   * Namespace for certificate management and synchronization.
+   */
+  export namespace certificates {
+    /**
+     * Register a certificate sync target provider.
+     *
+     * Extensions can use this to contribute sync targets (e.g., VMs, remote hosts)
+     * where host certificates can be synchronized.
+     *
+     * Each extension can register at most one provider. Attempting to register a
+     * second provider from the same extension will throw an error.
+     *
+     * Note: Only preinstalled extensions (bundled with Podman Desktop) can register
+     * sync targets. User-installed extensions will have their targets excluded from
+     * the UI entirely for security reasons.
+     *
+     * @param provider The certificate sync target provider.
+     * @returns A [disposable](#Disposable) that unregisters this provider when being disposed.
+     */
+    export function registerSyncTargetProvider(provider: CertificateSyncTargetProvider): Disposable;
+
+    /**
+     * An event that fires when a provider's available sync targets change.
+     * Extensions can listen to this event to refresh their UI when targets are added, removed, or modified.
+     */
+    export const onDidChangeTargets: Event<CertificateSyncTargetProviderChangeEvent>;
+  }
+
+  /**
    * Namespace for authentication.
    */
   export namespace authentication {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4385,31 +4385,6 @@ declare module '@podman-desktop/api' {
   }
 
   /**
-   * Information about a certificate sync target provider.
-   */
-  export interface CertificateSyncTargetProviderInformation {
-    /**
-     * Extension identifier that registered this provider.
-     */
-    readonly extensionId: string;
-
-    /**
-     * Human-readable label for the provider (extension display name).
-     */
-    readonly label: string;
-  }
-
-  /**
-   * Event fired when a certificate sync target provider's targets change.
-   */
-  export interface CertificateSyncTargetProviderChangeEvent {
-    /**
-     * Information about the provider whose targets changed.
-     */
-    provider: CertificateSyncTargetProviderInformation;
-  }
-
-  /**
    * Provider interface for extensions that contribute certificate sync targets.
    */
   export interface CertificateSyncTargetProvider {
@@ -4429,8 +4404,9 @@ declare module '@podman-desktop/api' {
     /**
      * Event fired when the available targets change.
      * Extensions must fire this event when targets are added, removed, or modified.
+     * The registry determines the source extension automatically.
      */
-    onDidChangeTargets: Event<CertificateSyncTargetProviderChangeEvent>;
+    onDidChangeTargets: Event<void>;
   }
 
   /**
@@ -4508,7 +4484,7 @@ declare module '@podman-desktop/api' {
      * An event that fires when a provider's available sync targets change.
      * Extensions can listen to this event to refresh their UI when targets are added, removed, or modified.
      */
-    export const onDidChangeTargets: Event<CertificateSyncTargetProviderChangeEvent>;
+    export const onDidChangeTargets: Event<void>;
   }
 
   /**

--- a/packages/main/src/plugin/certificate-sync-target-registry.spec.ts
+++ b/packages/main/src/plugin/certificate-sync-target-registry.spec.ts
@@ -160,9 +160,7 @@ describe('CertificateSyncTargetRegistry', () => {
       registry.registerProvider(extensionInfo, provider);
 
       await vi.waitFor(() => {
-        expect(eventHandler).toHaveBeenCalledWith({
-          provider: { extensionId: 'trusted-ext', label: 'Trusted Extension' },
-        });
+        expect(eventHandler).toHaveBeenCalled();
       });
     });
   });
@@ -437,9 +435,7 @@ describe('CertificateSyncTargetRegistry', () => {
       eventHandler.mockClear();
       disposable.dispose();
 
-      expect(eventHandler).toHaveBeenCalledWith({
-        provider: { extensionId: 'trusted-ext', label: 'Trusted Extension' },
-      });
+      expect(eventHandler).toHaveBeenCalled();
     });
 
     test('should discard stale targets when disposed during in-flight getTargets', async () => {

--- a/packages/main/src/plugin/certificate-sync-target-registry.spec.ts
+++ b/packages/main/src/plugin/certificate-sync-target-registry.spec.ts
@@ -1,0 +1,576 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { CertificateSyncTarget, CertificateSyncTargetProvider, Disposable } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
+
+import type { IPCHandle } from './api.js';
+import {
+  type CertificateSyncExtensionInfo,
+  CertificateSyncTargetRegistry,
+} from './certificate-sync-target-registry.js';
+import type { Certificates } from './certificates.js';
+
+// Mock provider factory
+function createMockProvider(targets: CertificateSyncTarget[] = []): CertificateSyncTargetProvider {
+  let listener: (() => void) | undefined;
+  return {
+    getTargets: vi.fn().mockResolvedValue(targets),
+    synchronize: vi.fn().mockResolvedValue(undefined),
+    onDidChangeTargets: vi.fn().mockImplementation((callback: () => void) => {
+      listener = callback;
+      return { dispose: vi.fn() } as Disposable;
+    }),
+    _fireChangeEvent: (): void => listener?.(),
+  } as CertificateSyncTargetProvider & { _fireChangeEvent: () => void };
+}
+
+// Mock certificates service
+function createMockCertificates(certs: string[] = []): Certificates {
+  return {
+    getAllCertificates: vi.fn().mockReturnValue(certs),
+  } as unknown as Certificates;
+}
+
+// Extension info factories
+function createTrustedExtension(id = 'trusted-ext', name = 'Trusted Extension'): CertificateSyncExtensionInfo {
+  return { id, name, removable: false };
+}
+
+function createUntrustedExtension(id = 'untrusted-ext', name = 'Untrusted Extension'): CertificateSyncExtensionInfo {
+  return { id, name, removable: true };
+}
+
+describe('CertificateSyncTargetRegistry', () => {
+  let registry: CertificateSyncTargetRegistry;
+  let mockCertificates: Certificates;
+  let mockIpcHandle: IPCHandle;
+  let mockApiSender: ApiSenderType;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCertificates = createMockCertificates(['cert1', 'cert2']);
+    mockIpcHandle = vi.fn();
+    mockApiSender = { send: vi.fn(), receive: vi.fn() } as unknown as ApiSenderType;
+    registry = new CertificateSyncTargetRegistry(mockCertificates, mockIpcHandle, mockApiSender);
+  });
+
+  describe('init', () => {
+    test('should register certificates:getSyncTargets IPC handle', () => {
+      registry.init();
+
+      expect(mockIpcHandle).toHaveBeenCalledWith('certificates:getSyncTargets', expect.any(Function));
+    });
+
+    test('should register certificates:synchronizeToTargets IPC handle', () => {
+      registry.init();
+
+      expect(mockIpcHandle).toHaveBeenCalledWith('certificates:synchronizeToTargets', expect.any(Function));
+    });
+
+    test('should notify renderer via apiSender when targets change', async () => {
+      registry.init();
+
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      registry.registerProvider(createTrustedExtension(), provider);
+
+      await vi.waitFor(() => {
+        expect(mockApiSender.send).toHaveBeenCalledWith('certificate-sync-targets-update');
+      });
+    });
+  });
+
+  describe('registerProvider', () => {
+    test('should register a provider successfully', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+
+      expect(disposable).toBeDefined();
+      expect(provider.getTargets).toHaveBeenCalled();
+    });
+
+    test('should throw error when same extension registers twice', () => {
+      const provider1 = createMockProvider();
+      const provider2 = createMockProvider();
+      const extensionInfo = createTrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider1);
+
+      expect(() => registry.registerProvider(extensionInfo, provider2)).toThrow(
+        `Extension 'trusted-ext' has already registered a certificate sync target provider`,
+      );
+    });
+
+    test('should allow different extensions to register', () => {
+      const provider1 = createMockProvider();
+      const provider2 = createMockProvider();
+      const ext1 = createTrustedExtension('ext1', 'Extension 1');
+      const ext2 = createTrustedExtension('ext2', 'Extension 2');
+
+      expect(() => {
+        registry.registerProvider(ext1, provider1);
+        registry.registerProvider(ext2, provider2);
+      }).not.toThrow();
+    });
+
+    test('should subscribe to provider onDidChangeTargets', () => {
+      const provider = createMockProvider();
+      const extensionInfo = createTrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider);
+
+      expect(provider.onDidChangeTargets).toHaveBeenCalled();
+    });
+
+    test('should fetch targets on registration', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(provider.getTargets).toHaveBeenCalled();
+      });
+    });
+
+    test('should fire onDidChangeTargets event after initial fetch', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+      const eventHandler = vi.fn();
+
+      registry.onDidChangeTargets(eventHandler);
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(eventHandler).toHaveBeenCalledWith({
+          provider: { extensionId: 'trusted-ext', label: 'Trusted Extension' },
+        });
+      });
+    });
+  });
+
+  describe('trust model', () => {
+    test('should include targets from trusted extensions (removable === false)', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets).toHaveLength(1);
+        expect(targets[0]?.name).toBe('Target 1');
+      });
+    });
+
+    test('should exclude targets from untrusted extensions (removable === true)', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createUntrustedExtension();
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(provider.getTargets).not.toHaveBeenCalled();
+      });
+
+      const targets = registry.getTargets();
+      expect(targets).toHaveLength(0);
+    });
+  });
+
+  describe('getTargets', () => {
+    test('should return empty array when no providers registered', () => {
+      const targets = registry.getTargets();
+      expect(targets).toEqual([]);
+    });
+
+    test('should return targets with composite ID as id', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('my-ext');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets).toHaveLength(1);
+        expect(targets[0]?.id).toBe('my-ext:target1');
+      });
+    });
+
+    test('should include extension info in targets', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext-id', 'Extension Name');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets[0]).toMatchObject({
+          extensionId: 'ext-id',
+          extensionName: 'Extension Name',
+        });
+      });
+    });
+
+    test('should aggregate targets from multiple extensions', async () => {
+      const provider1 = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const provider2 = createMockProvider([{ id: 'target2', name: 'Target 2' }]);
+      const ext1 = createTrustedExtension('ext1');
+      const ext2 = createTrustedExtension('ext2');
+
+      registry.registerProvider(ext1, provider1);
+      registry.registerProvider(ext2, provider2);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('synchronize', () => {
+    test('should synchronize to target successfully', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      await registry.synchronize('ext1:target1');
+
+      expect(provider.synchronize).toHaveBeenCalledWith('target1', ['cert1', 'cert2']);
+    });
+
+    test('should throw error for non-existent target', async () => {
+      await expect(registry.synchronize('non-existent')).rejects.toThrow(`Target 'non-existent' not found`);
+    });
+
+    test('should pass certificates from Certificates service', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      await registry.synchronize('ext1:target1');
+
+      expect(mockCertificates.getAllCertificates).toHaveBeenCalled();
+      expect(provider.synchronize).toHaveBeenCalledWith('target1', ['cert1', 'cert2']);
+    });
+
+    test('should use original targetId when calling provider', async () => {
+      const provider = createMockProvider([{ id: 'my-original-id', name: 'Target' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      await registry.synchronize('ext1:my-original-id');
+
+      expect(provider.synchronize).toHaveBeenCalledWith('my-original-id', expect.any(Array));
+    });
+  });
+
+  describe('synchronizeToTargets', () => {
+    test('should sync to multiple targets in parallel', async () => {
+      const provider = createMockProvider([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+      ]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(2);
+      });
+
+      const result = await registry.synchronizeToTargets(['ext1:target1', 'ext1:target2']);
+
+      expect(result.errors).toHaveLength(0);
+      expect(provider.synchronize).toHaveBeenCalledTimes(2);
+    });
+
+    test('should return empty errors array on success', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      const result = await registry.synchronizeToTargets(['ext1:target1']);
+
+      expect(result.errors).toEqual([]);
+    });
+
+    test('should collect errors from failed targets', async () => {
+      const provider = createMockProvider([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+      ]);
+      (provider.synchronize as Mock).mockImplementation((targetId: string) => {
+        if (targetId === 'target2') {
+          return Promise.reject(new Error('Sync failed'));
+        }
+        return Promise.resolve();
+      });
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(2);
+      });
+
+      const result = await registry.synchronizeToTargets(['ext1:target1', 'ext1:target2']);
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toEqual({
+        targetId: 'ext1:target2',
+        error: 'Sync failed',
+      });
+    });
+
+    test('should continue syncing other targets when one fails', async () => {
+      const provider = createMockProvider([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+        { id: 'target3', name: 'Target 3' },
+      ]);
+      (provider.synchronize as Mock).mockImplementation((targetId: string) => {
+        if (targetId === 'target2') {
+          return Promise.reject(new Error('Sync failed'));
+        }
+        return Promise.resolve();
+      });
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(3);
+      });
+
+      await registry.synchronizeToTargets(['ext1:target1', 'ext1:target2', 'ext1:target3']);
+
+      expect(provider.synchronize).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('dispose behavior', () => {
+    test('should remove provider on dispose', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      disposable.dispose();
+
+      const targets = registry.getTargets();
+      expect(targets).toHaveLength(0);
+    });
+
+    test('should clear cached targets on dispose', async () => {
+      const provider = createMockProvider([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+      ]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(2);
+      });
+
+      disposable.dispose();
+
+      expect(registry.getTargets()).toHaveLength(0);
+    });
+
+    test('should fire onDidChangeTargets on dispose', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]);
+      const extensionInfo = createTrustedExtension();
+      const eventHandler = vi.fn();
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+      registry.onDidChangeTargets(eventHandler);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      eventHandler.mockClear();
+      disposable.dispose();
+
+      expect(eventHandler).toHaveBeenCalledWith({
+        provider: { extensionId: 'trusted-ext', label: 'Trusted Extension' },
+      });
+    });
+
+    test('should discard stale targets when disposed during in-flight getTargets', async () => {
+      let resolveGetTargets: (targets: CertificateSyncTarget[]) => void;
+      const provider: CertificateSyncTargetProvider & { _fireChangeEvent: () => void } = {
+        getTargets: vi.fn().mockReturnValue(
+          new Promise<CertificateSyncTarget[]>(resolve => {
+            resolveGetTargets = resolve;
+          }),
+        ),
+        synchronize: vi.fn(),
+        onDidChangeTargets: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+        _fireChangeEvent: vi.fn(),
+      };
+      const extensionInfo = createTrustedExtension('ext1');
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+
+      // Dispose while getTargets() is still pending
+      disposable.dispose();
+
+      // Now resolve the in-flight getTargets — results should be discarded
+      resolveGetTargets!([{ id: 'target1', name: 'Stale Target' }]);
+      await vi.waitFor(() => {
+        expect(provider.getTargets).toHaveBeenCalled();
+      });
+
+      expect(registry.getTargets()).toHaveLength(0);
+    });
+
+    test('should allow re-registration after dispose', () => {
+      const provider1 = createMockProvider();
+      const provider2 = createMockProvider();
+      const extensionInfo = createTrustedExtension();
+
+      const disposable = registry.registerProvider(extensionInfo, provider1);
+      disposable.dispose();
+
+      expect(() => registry.registerProvider(extensionInfo, provider2)).not.toThrow();
+    });
+
+    test('should unsubscribe from provider event on dispose', async () => {
+      const disposeEventSub = vi.fn();
+      const provider: CertificateSyncTargetProvider = {
+        getTargets: vi.fn().mockResolvedValue([]),
+        synchronize: vi.fn(),
+        onDidChangeTargets: vi.fn().mockReturnValue({ dispose: disposeEventSub }),
+      };
+      const extensionInfo = createTrustedExtension();
+
+      const disposable = registry.registerProvider(extensionInfo, provider);
+      disposable.dispose();
+
+      expect(disposeEventSub).toHaveBeenCalled();
+    });
+  });
+
+  describe('provider onDidChangeTargets refresh', () => {
+    test('should refresh targets when provider fires onDidChangeTargets', async () => {
+      const provider = createMockProvider([{ id: 'target1', name: 'Target 1' }]) as CertificateSyncTargetProvider & {
+        _fireChangeEvent: () => void;
+      };
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(1);
+      });
+
+      // Update mock to return new targets
+      (provider.getTargets as Mock).mockResolvedValue([
+        { id: 'target1', name: 'Target 1' },
+        { id: 'target2', name: 'Target 2' },
+      ]);
+
+      // Fire the change event
+      provider._fireChangeEvent();
+
+      await vi.waitFor(() => {
+        expect(registry.getTargets()).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    test('should handle provider.getTargets() error gracefully', async () => {
+      const provider = createMockProvider();
+      (provider.getTargets as Mock).mockRejectedValue(new Error('Failed to get targets'));
+      const extensionInfo = createTrustedExtension();
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        expect(consoleSpy).toHaveBeenCalled();
+      });
+
+      const targets = registry.getTargets();
+      expect(targets).toHaveLength(0);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('composite key handling', () => {
+    test('should build correct composite key format', async () => {
+      const provider = createMockProvider([{ id: 'my-target', name: 'Target' }]);
+      const extensionInfo = createTrustedExtension('my-extension');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets[0]?.id).toBe('my-extension:my-target');
+      });
+    });
+
+    test('should handle targets with colons in their IDs', async () => {
+      const provider = createMockProvider([{ id: 'target:with:colons', name: 'Target' }]);
+      const extensionInfo = createTrustedExtension('ext1');
+
+      registry.registerProvider(extensionInfo, provider);
+
+      await vi.waitFor(() => {
+        const targets = registry.getTargets();
+        expect(targets[0]?.id).toBe('ext1:target:with:colons');
+      });
+
+      await registry.synchronize('ext1:target:with:colons');
+      expect(provider.synchronize).toHaveBeenCalledWith('target:with:colons', expect.any(Array));
+    });
+  });
+});

--- a/packages/main/src/plugin/certificate-sync-target-registry.ts
+++ b/packages/main/src/plugin/certificate-sync-target-registry.ts
@@ -1,0 +1,285 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type * as containerDesktopAPI from '@podman-desktop/api';
+import type { CertificateSyncTargetInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { inject, injectable } from 'inversify';
+
+import { IPCHandle } from './api.js';
+import { Certificates } from './certificates.js';
+import { Emitter } from './events/emitter.js';
+import { Disposable } from './types/disposable.js';
+
+/**
+ * Minimal extension info needed for the certificate sync registry.
+ */
+export interface CertificateSyncExtensionInfo {
+  id: string;
+  name: string;
+  removable: boolean;
+}
+
+/**
+ * Internal representation of a registered provider with extension metadata.
+ */
+interface RegisteredProvider {
+  extensionInfo: CertificateSyncExtensionInfo;
+  provider: containerDesktopAPI.CertificateSyncTargetProvider;
+}
+
+/**
+ * Internal target info with composite ID for unique lookup.
+ * The `id` field keeps the original target ID from the provider.
+ * The `compositeId` is used as the map key and returned to UI for unique identification.
+ */
+interface InternalCertificateSyncTargetInfo extends CertificateSyncTargetInfo {
+  /** Composite key: extensionId:targetId */
+  compositeId: string;
+}
+
+/**
+ * Registry for certificate sync target providers.
+ *
+ * Implements a trust model where only preinstalled extensions (bundled with
+ * Podman Desktop) can register synchronization targets. User-installed
+ * extensions will have their targets not shown in the UI for security reasons.
+ */
+@injectable()
+export class CertificateSyncTargetRegistry {
+  private providers: Map<string, RegisteredProvider> = new Map();
+  // Flat map with composite keys: extensionId:targetId -> target
+  private targetsCache: Map<string, InternalCertificateSyncTargetInfo> = new Map();
+
+  private readonly _onDidChangeTargets = new Emitter<containerDesktopAPI.CertificateSyncTargetProviderChangeEvent>();
+  readonly onDidChangeTargets: containerDesktopAPI.Event<containerDesktopAPI.CertificateSyncTargetProviderChangeEvent> =
+    this._onDidChangeTargets.event;
+
+  constructor(
+    @inject(Certificates)
+    private certificates: Certificates,
+    @inject(IPCHandle)
+    private readonly ipcHandle: IPCHandle,
+    @inject(ApiSenderType)
+    private readonly apiSender: ApiSenderType,
+  ) {}
+
+  init(): void {
+    this.ipcHandle('certificates:getSyncTargets', async (): Promise<CertificateSyncTargetInfo[]> => {
+      return this.getTargets();
+    });
+
+    this.ipcHandle(
+      'certificates:synchronizeToTargets',
+      async (_listener, targetIds: string[]): Promise<{ errors: { targetId: string; error: string }[] }> => {
+        return this.synchronizeToTargets(targetIds);
+      },
+    );
+
+    this.onDidChangeTargets(() => {
+      this.apiSender.send('certificate-sync-targets-update');
+    });
+  }
+
+  /**
+   * Build a composite key for a target.
+   */
+  private buildTargetKey(extensionId: string, targetId: string): string {
+    return `${extensionId}:${targetId}`;
+  }
+
+  /**
+   * Clear all cached targets for a specific extension.
+   */
+  private clearProviderTargets(extensionId: string): void {
+    for (const [key, target] of this.targetsCache) {
+      if (target.extensionId === extensionId) {
+        this.targetsCache.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Update the cached targets for the provider registered by the given extension.
+   * Only caches targets from trusted (preinstalled) extensions.
+   */
+  private async updateProviderTargets(extensionId: string, registered: RegisteredProvider): Promise<void> {
+    const { extensionInfo } = registered;
+
+    // Clear existing targets for this extension
+    this.clearProviderTargets(extensionId);
+
+    // Skip untrusted (user-installed) extensions
+    if (extensionInfo.removable) {
+      return;
+    }
+
+    try {
+      const targets = await registered.provider.getTargets();
+
+      // Guard: if disposed during the await, the provider map entry will be
+      // gone or replaced by a new instance — discard the stale results.
+      if (this.providers.get(extensionId) !== registered) {
+        return;
+      }
+
+      for (const target of targets) {
+        const compositeId = this.buildTargetKey(extensionId, target.id);
+        this.targetsCache.set(compositeId, {
+          ...target,
+          compositeId,
+          extensionId,
+          extensionName: extensionInfo.name,
+        });
+      }
+    } catch (error) {
+      console.error(`Error getting targets from provider (${extensionId}):`, error);
+    }
+  }
+
+  /**
+   * Register a certificate sync target provider.
+   *
+   * Each extension can register at most one provider. Attempting to register a
+   * second provider from the same extension will throw an error.
+   *
+   * @param extensionInfo Information about the extension registering the provider.
+   * @param provider The provider implementation.
+   * @returns A disposable that unregisters the provider when disposed.
+   */
+  registerProvider(
+    extensionInfo: CertificateSyncExtensionInfo,
+    provider: containerDesktopAPI.CertificateSyncTargetProvider,
+  ): Disposable {
+    const extensionId = extensionInfo.id;
+
+    if (this.providers.has(extensionId)) {
+      throw new Error(`Extension '${extensionId}' has already registered a certificate sync target provider`);
+    }
+
+    const registered: RegisteredProvider = {
+      extensionInfo,
+      provider,
+    };
+
+    this.providers.set(extensionId, registered);
+
+    const providerInfo: containerDesktopAPI.CertificateSyncTargetProviderInformation = {
+      extensionId,
+      label: extensionInfo.name,
+    };
+
+    // Fetch targets and notify listeners
+    const refreshTargets = (): void => {
+      this.updateProviderTargets(extensionId, registered)
+        .catch((err: unknown) => {
+          console.error(`Error updating targets for provider (${extensionId}):`, err);
+        })
+        .finally(() => {
+          this._onDidChangeTargets.fire({ provider: providerInfo });
+        });
+    };
+
+    // Subscribe to provider's onDidChangeTargets event
+    const providerEventSubscription = provider.onDidChangeTargets(refreshTargets);
+
+    // Initial fetch of targets
+    refreshTargets();
+
+    return Disposable.create((): void => {
+      // Unsubscribe from provider event
+      providerEventSubscription.dispose();
+      this.providers.delete(extensionId);
+      // Clear cached targets for this extension
+      this.clearProviderTargets(extensionId);
+      // Notify listeners that targets have changed
+      this._onDidChangeTargets.fire({ provider: providerInfo });
+    });
+  }
+
+  /**
+   * Get all sync targets from trusted (preinstalled) providers only.
+   *
+   * Returns cached targets that are updated when providers fire onDidChangeTargets.
+   * Target IDs returned to UI are composite keys (extensionId:targetId) to ensure uniqueness.
+   *
+   * Applies the trust model:
+   * - Preinstalled extensions (removable === false): targets are included
+   * - User-installed extensions (removable === true): targets are excluded
+   *
+   * @returns An array of sync targets with extension info, using compositeId as id.
+   */
+  getTargets(): CertificateSyncTargetInfo[] {
+    // Return targets with compositeId as the id for UI usage
+    return Array.from(this.targetsCache.values()).map(target => ({
+      ...target,
+      id: target.compositeId,
+    }));
+  }
+
+  /**
+   * Synchronize certificates to a specific target.
+   * O(1) lookup using the composite target ID.
+   *
+   * @param compositeId The composite target ID (extensionId:originalTargetId).
+   * @throws Error if the target is not found.
+   */
+  async synchronize(compositeId: string): Promise<void> {
+    const target = this.targetsCache.get(compositeId);
+    if (!target) {
+      throw new Error(`Target '${compositeId}' not found`);
+    }
+
+    const registered = this.providers.get(target.extensionId);
+    if (!registered) {
+      throw new Error(`Provider for target '${compositeId}' not found`);
+    }
+
+    const certificatePems = this.certificates.getAllCertificates();
+    await registered.provider.synchronize(target.id, certificatePems);
+  }
+
+  /**
+   * Synchronize certificates to multiple targets in parallel.
+   *
+   * Each target runs independently - errors in one target don't affect others.
+   *
+   * @param targetIds Array of composite target IDs to synchronize to.
+   * @returns Object containing an array of errors for failed targets.
+   */
+  async synchronizeToTargets(targetIds: string[]): Promise<{ errors: { targetId: string; error: string }[] }> {
+    // Run all targets in parallel - each target has its own cancellation handling
+    const results = await Promise.allSettled(targetIds.map(id => this.synchronize(id)));
+
+    // Collect errors from failed targets
+    const errors: { targetId: string; error: string }[] = [];
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        const targetId = targetIds[index];
+        if (targetId) {
+          errors.push({
+            targetId,
+            error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+          });
+        }
+      }
+    });
+
+    return { errors };
+  }
+}

--- a/packages/main/src/plugin/certificate-sync-target-registry.ts
+++ b/packages/main/src/plugin/certificate-sync-target-registry.ts
@@ -66,9 +66,8 @@ export class CertificateSyncTargetRegistry {
   // Flat map with composite keys: extensionId:targetId -> target
   private targetsCache: Map<string, InternalCertificateSyncTargetInfo> = new Map();
 
-  private readonly _onDidChangeTargets = new Emitter<containerDesktopAPI.CertificateSyncTargetProviderChangeEvent>();
-  readonly onDidChangeTargets: containerDesktopAPI.Event<containerDesktopAPI.CertificateSyncTargetProviderChangeEvent> =
-    this._onDidChangeTargets.event;
+  private readonly _onDidChangeTargets = new Emitter<void>();
+  readonly onDidChangeTargets: containerDesktopAPI.Event<void> = this._onDidChangeTargets.event;
 
   constructor(
     @inject(Certificates)
@@ -179,11 +178,6 @@ export class CertificateSyncTargetRegistry {
 
     this.providers.set(extensionId, registered);
 
-    const providerInfo: containerDesktopAPI.CertificateSyncTargetProviderInformation = {
-      extensionId,
-      label: extensionInfo.name,
-    };
-
     // Fetch targets and notify listeners
     const refreshTargets = (): void => {
       this.updateProviderTargets(extensionId, registered)
@@ -191,7 +185,7 @@ export class CertificateSyncTargetRegistry {
           console.error(`Error updating targets for provider (${extensionId}):`, err);
         })
         .finally(() => {
-          this._onDidChangeTargets.fire({ provider: providerInfo });
+          this._onDidChangeTargets.fire();
         });
     };
 
@@ -208,7 +202,7 @@ export class CertificateSyncTargetRegistry {
       // Clear cached targets for this extension
       this.clearProviderTargets(extensionId);
       // Notify listeners that targets have changed
-      this._onDidChangeTargets.fire({ provider: providerInfo });
+      this._onDidChangeTargets.fire();
     });
   }
 

--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -268,7 +268,8 @@ export class Certificates {
       }
 
       // Convert serial number to hex string
-      const serialNumber = Array.from(cert.serialNumber.valueBlock.valueHexView)
+      const hexView = cert.serialNumber.valueBlock.valueHexView;
+      const serialNumber = Array.from(new Uint8Array(hexView))
         .map(b => b.toString(16).padStart(2, '0').toUpperCase())
         .join('');
 

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -36,6 +36,7 @@ import { app } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { AuthenticationImpl } from '/@/plugin/authentication.js';
+import type { CertificateSyncTargetRegistry } from '/@/plugin/certificate-sync-target-registry.js';
 import type { Certificates } from '/@/plugin/certificates.js';
 import type { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import type { ColorRegistry } from '/@/plugin/color-registry.js';
@@ -282,6 +283,7 @@ const dialogRegistry: DialogRegistry = {
 } as unknown as DialogRegistry;
 
 const certificates: Certificates = {} as unknown as Certificates;
+const certificateSyncTargetRegistry: CertificateSyncTargetRegistry = {} as unknown as CertificateSyncTargetRegistry;
 
 const extensionApiVersion: ExtensionApiVersion = {
   getApiVersion: vi.fn(),
@@ -380,6 +382,7 @@ beforeEach(() => {
     dialogRegistry,
     safeStorageRegistry,
     certificates,
+    certificateSyncTargetRegistry,
     extensionWatcher,
     extensionDevelopmentFolder,
     extensionAnalyzer,

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -36,6 +36,7 @@ import { inject, injectable, preDestroy } from 'inversify';
 
 import { AuthenticationImpl } from '/@/plugin/authentication.js';
 import { CancellationTokenSource } from '/@/plugin/cancellation-token.js';
+import { CertificateSyncTargetRegistry } from '/@/plugin/certificate-sync-target-registry.js';
 import { Certificates } from '/@/plugin/certificates.js';
 import { CliToolRegistry } from '/@/plugin/cli-tool-registry.js';
 import { ColorRegistry } from '/@/plugin/color-registry.js';
@@ -214,6 +215,8 @@ export class ExtensionLoader implements IAsyncDisposable {
     private safeStorageRegistry: SafeStorageRegistry,
     @inject(Certificates)
     private certificates: Certificates,
+    @inject(CertificateSyncTargetRegistry)
+    private certificateSyncTargetRegistry: CertificateSyncTargetRegistry,
     @inject(ExtensionWatcher)
     private extensionWatcher: ExtensionWatcher,
     @inject(ExtensionDevelopmentFolders)
@@ -1405,6 +1408,23 @@ export class ExtensionLoader implements IAsyncDisposable {
       },
     };
 
+    // Certificate sync target registry with extension info for trust model
+    const certificateSyncTargetRegistry = this.certificateSyncTargetRegistry;
+    const certificateSyncExtensionInfo = {
+      id: extensionInfo.id,
+      name: extensionInfo.name,
+      removable: analyzedExtension.removable,
+    };
+
+    const certificates: typeof containerDesktopAPI.certificates = {
+      registerSyncTargetProvider: provider => {
+        const registration = certificateSyncTargetRegistry.registerProvider(certificateSyncExtensionInfo, provider);
+        disposables.push(registration);
+        return registration;
+      },
+      onDidChangeTargets: certificateSyncTargetRegistry.onDidChangeTargets,
+    };
+
     const authenticationProviderRegistry = this.authenticationProviderRegistry;
 
     const authentication: typeof containerDesktopAPI.authentication = {
@@ -1678,6 +1698,7 @@ export class ExtensionLoader implements IAsyncDisposable {
       InputBoxValidationSeverity,
       QuickPickItemKind,
       authentication,
+      certificates,
       context: contextAPI,
       cli,
       imageChecker,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -174,6 +174,7 @@ import { AppearanceInit } from './appearance-init.js';
 import { AuthenticationImpl } from './authentication.js';
 import { AutostartEngine } from './autostart-engine.js';
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
+import { CertificateSyncTargetRegistry } from './certificate-sync-target-registry.js';
 import { Certificates } from './certificates.js';
 import { CliToolRegistry } from './cli-tool-registry.js';
 import { CloseBehavior } from './close-behavior.js';
@@ -546,17 +547,6 @@ export class PluginSystem {
     const colorRegistry = container.get<ColorRegistry>(ColorRegistry);
     colorRegistry.init();
 
-    container.bind<Certificates>(Certificates).toSelf().inSingletonScope();
-    const certificates = container.get<Certificates>(Certificates);
-    await certificates.init();
-
-    container.bind<Proxy>(Proxy).toSelf().inSingletonScope();
-    const proxy = container.get<Proxy>(Proxy);
-    await proxy.init();
-
-    const exec = new Exec(proxy);
-    container.bind<Exec>(Exec).toConstantValue(exec);
-
     container.bind<Telemetry>(Telemetry).toSelf().inSingletonScope();
     const telemetry = container.get<Telemetry>(Telemetry);
     await telemetry.init();
@@ -567,6 +557,20 @@ export class PluginSystem {
     container.bind<TaskManager>(TaskManager).toSelf().inSingletonScope();
     const taskManager = container.get<TaskManager>(TaskManager);
     taskManager.init();
+
+    // Certificates must be bound after TaskManager (dependency) and before Proxy (dependent)
+    container.bind<Certificates>(Certificates).toSelf().inSingletonScope();
+    const certificates = container.get<Certificates>(Certificates);
+    await certificates.init();
+
+    container.bind<CertificateSyncTargetRegistry>(CertificateSyncTargetRegistry).toSelf().inSingletonScope();
+
+    container.bind<Proxy>(Proxy).toSelf().inSingletonScope();
+    const proxy = container.get<Proxy>(Proxy);
+    await proxy.init();
+
+    const exec = new Exec(proxy);
+    container.bind<Exec>(Exec).toConstantValue(exec);
 
     container.bind<NotificationRegistry>(NotificationRegistry).toSelf().inSingletonScope();
     container.bind<MenuRegistry>(MenuRegistry).toSelf().inSingletonScope();
@@ -2449,6 +2453,9 @@ export class PluginSystem {
     this.ipcHandle('certificates:listCertificates', async (): Promise<CertificateInfo[]> => {
       return certificates.getAllCertificateInfos();
     });
+
+    const certificateSyncTargetRegistry = container.get<CertificateSyncTargetRegistry>(CertificateSyncTargetRegistry);
+    certificateSyncTargetRegistry.init();
 
     this.ipcHandle(
       'provider-registry:startProviderConnectionLifecycle',


### PR DESCRIPTION
### What does this PR do?

This commit introduces a new extension API that allows extensions to contribute certificate synchronization targets. Extensions can register providers that expose targets (e.g., container runtimes, VMs) where host system certificates can be synchronized.

New API in the certificates namespace:
- registerSyncTargetProvider(id, provider) - Register a sync target provider
- onDidChangeTargets - Event fired when sync targets change

The CertificateSyncTargetProvider interface requires:
- getTargets() - Return available sync targets
- synchronize(targetId, certificates) - Sync PEM certificates to a target
- onDidChangeTargets - Event for dynamic target updates

Usage example:

  import * as podmanDesktopAPI from '@podman-desktop/api';

  const targetChangeEmitter = new podmanDesktopAPI.EventEmitter();

  const provider: podmanDesktopAPI.CertificateSyncTargetProvider = { async getTargets() { return [ { id: 'podman-machine-default', name: 'Podman Machine (default)' }, { id: 'podman-machine-dev', name: 'Podman Machine (dev)' }, ]; },

    async synchronize(targetId: string, certificates: string[]) {
      // Write certificates to the target machine
      await writeCertsToMachine(targetId, certificates);
    },

    onDidChangeTargets: targetChangeEmitter.event,
  };

  // Register the provider (returns a Disposable) const disposable = podmanDesktopAPI.certificates.registerSyncTargetProvider( 'podman-cert-sync', provider );

  // When machines change, notify the registry targetChangeEmitter.fire({ provider: { id: 'podman-cert-sync', label: 'Podman' } });

  // Cleanup on extension deactivation context.subscriptions.push(disposable);

Security: Implements a trust model where only preinstalled extensions (bundled with Podman Desktop) can have their targets displayed in the UI. User-installed extensions are excluded for security reasons.

The new CertificateSyncTargetRegistry manages providers with composite IDs (extensionId:providerId:targetId) for unique identification and O(1) lookup.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #16278.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
