### PR TITLE
feat(renderer): add new buttons to PullImage page

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -20,14 +20,16 @@ import '@testing-library/jest-dom/vitest';
 
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { PreferredRegistriesSettings } from '@podman-desktop/core-api';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { get } from 'svelte/store';
+import { router } from 'tinro';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 import { recommendedRegistries } from '/@/stores/recommendedRegistries';
+import { runImageInfo } from '/@/stores/run-image-store';
 
 import PullImage from './PullImage.svelte';
 
@@ -82,6 +84,7 @@ beforeEach(() => {
   vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
   vi.mocked(window.pullImage).mockResolvedValue(undefined);
   vi.mocked(window.listImageTagsInRegistry).mockResolvedValue(['latest', 'other']);
+  vi.mocked(window.listImages).mockResolvedValue([]);
 
   providerInfos.set([PROVIDER_INFO_MOCK]);
 });
@@ -333,6 +336,80 @@ test('Expect latest tag warning is not displayed when the image has latest tag',
   // expect that the warning message is not displayed
   const errorMesssage = screen.queryByRole('alert', { name: 'Warning Message Content' });
   expect(errorMesssage).toBeNull();
+});
+
+test('Expect done, details and run actions after a successful pull', async () => {
+  render(PullImage, { imageToPull: 'some-valid-image' });
+
+  const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
+  await userEvent.click(pullImagebutton);
+
+  const footer = await screen.findByRole('contentinfo');
+  expect(within(footer).getByRole('button', { name: 'View details' })).toBeInTheDocument();
+  expect(within(footer).getByRole('button', { name: 'Run' })).toBeInTheDocument();
+  expect(within(footer).getByRole('button', { name: 'Close' })).toBeInTheDocument();
+});
+
+test('Expect details action to open pulled image summary route', async () => {
+  const gotoSpy = vi.spyOn(router, 'goto');
+  vi.mocked(window.listImages).mockResolvedValue([
+    {
+      Id: 'sha256:1234567890123',
+      RepoTags: ['docker.io/library/alpine:latest'],
+      Created: 1644009612,
+      Size: 123,
+      engineId: 'podman',
+      engineName: 'podman',
+    } as never,
+  ]);
+  render(PullImage, { imageToPull: 'docker.io/alpine' });
+
+  const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
+  await userEvent.click(pullImagebutton);
+  const detailsButton = await screen.findByRole('button', { name: 'View details' });
+  await userEvent.click(detailsButton);
+
+  await vi.waitFor(() => {
+    expect(window.listImages).toHaveBeenCalledWith({
+      provider: CONTAINER_CONNECTION_MOCK,
+    });
+    expect(gotoSpy).toHaveBeenLastCalledWith(
+      '/images/sha256:1234567890123/podman/ZG9ja2VyLmlvL2xpYnJhcnkvYWxwaW5lOmxhdGVzdA==/summary',
+    );
+  });
+});
+
+test('Expect run action to set image info and go to run page', async () => {
+  const gotoSpy = vi.spyOn(router, 'goto');
+  const runImageInfoSetSpy = vi.spyOn(runImageInfo, 'set');
+  vi.mocked(window.listImages).mockResolvedValue([
+    {
+      Id: 'sha256:1234567890123',
+      RepoTags: ['docker.io/library/alpine:latest'],
+      Created: 1644009612,
+      Size: 123,
+      engineId: 'podman',
+      engineName: 'podman',
+    } as never,
+  ]);
+  render(PullImage, { imageToPull: 'docker.io/alpine' });
+
+  const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
+  await userEvent.click(pullImagebutton);
+  const runButton = await screen.findByRole('button', { name: 'Run' });
+  await userEvent.click(runButton);
+
+  await vi.waitFor(() => {
+    expect(runImageInfoSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'sha256:1234567890123',
+        engineId: 'podman',
+        name: 'docker.io/library/alpine',
+        tag: 'latest',
+      }),
+    );
+    expect(gotoSpy).toHaveBeenLastCalledWith('/images/run/basic');
+  });
 });
 
 test('input component should not raise an error when the input is valid', async () => {

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -10,13 +10,16 @@ import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { router } from 'tinro';
 
 import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
+import { ImageUtils } from '/@/lib/image/image-utils';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
 import type { TypeaheadItem } from '/@/lib/ui/Typeahead';
 import Typeahead from '/@/lib/ui/Typeahead.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { providerInfos } from '/@/stores/providers';
+import { runImageInfo } from '/@/stores/run-image-store';
 
+import type { ImageInfoUI } from './ImageInfoUI';
 import RecommendedRegistry from './RecommendedRegistry.svelte';
 
 const DOCKER_PREFIX = 'docker.io';
@@ -24,6 +27,7 @@ const DOCKER_PREFIX_WITH_SLASH = DOCKER_PREFIX + '/';
 
 // Get the preferred registries from configuration
 let preferredRegistries = $state<string[]>([DOCKER_PREFIX]);
+const imageUtils = new ImageUtils();
 
 let logsPull = $state<Terminal>();
 let pullError = $state('');
@@ -161,6 +165,42 @@ async function pullImage(): Promise<void> {
 
 async function pullImageFinished(): Promise<void> {
   router.goto('/images');
+}
+
+async function getFirstPulledImageInfo(): Promise<ImageInfoUI | undefined> {
+  const dockerLibraryImage =
+    imageToPull?.startsWith('docker.io/') && imageToPull.split('/').length === 2
+      ? `${imageToPull.split('/')[0]}/library/${imageToPull.split('/')[1]}`
+      : undefined;
+
+  const target = usePodmanFQN && podmanFQN ? podmanFQN : (dockerLibraryImage ?? imageToPull);
+  if (!target) return undefined;
+
+  const localImages = (
+    await window.listImages({
+      provider: $state.snapshot(selectedProviderConnection),
+    })
+  ).filter(image => (image.RepoTags ?? []).some(repoTag => repoTag.includes(target)));
+
+  if (localImages.length === 0) return undefined;
+
+  const [first] = imageUtils.getImagesInfoUI(localImages[0], []);
+  return first;
+}
+
+async function gotoImageDetails(): Promise<void> {
+  const image = await getFirstPulledImageInfo();
+  if (image) {
+    router.goto(`/images/${image.id}/${image.engineId}/${image.base64RepoTag}/summary`);
+  }
+}
+
+async function gotoImageRun(): Promise<void> {
+  const image = await getFirstPulledImageInfo();
+  if (image) {
+    runImageInfo.set(image);
+    router.goto('/images/run/basic');
+  }
 }
 
 async function gotoManageRegistries(): Promise<void> {
@@ -425,7 +465,11 @@ async function searchFunction(value: string): Promise<void> {
             Pull image
           </Button>
         {:else}
-          <Button on:click={pullImageFinished}>Done</Button>
+        <div class="space-x-2 flex flex-nowrap text-[var(--pd-content-text)]">
+          <Button type='secondary' on:click={pullImageFinished}>Close</Button>
+          <Button type='link' on:click={gotoImageDetails}>View details</Button>
+          <Button type='primary' on:click={gotoImageRun}>Run</Button>
+        </div>
         {/if}
         {#if pullError}
           <ErrorMessage error={pullError} />

--- a/tests/playwright/src/model/pages/pull-image-page.ts
+++ b/tests/playwright/src/model/pages/pull-image-page.ts
@@ -30,7 +30,7 @@ export class PullImagePage extends BasePage {
   readonly imageNameInput: Locator;
   readonly tabContent: Locator;
   readonly searchResultsTable: Locator;
-  readonly doneButton: Locator;
+  readonly closeButton: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -51,7 +51,7 @@ export class PullImagePage extends BasePage {
       exact: true,
     });
     this.searchResultsTable = this.tabContent.getByRole('row');
-    this.doneButton = page.getByRole('button', { name: 'Done', exact: true });
+    this.closeButton = this.tabContent.getByRole('button', { name: 'Close', exact: true });
   }
 
   async pullImage(imageName: string, tag = '', timeout = 60_000): Promise<ImagesPage> {
@@ -61,8 +61,8 @@ export class PullImagePage extends BasePage {
       await playExpect(this.pullImageButton).toBeEnabled();
       await this.pullImageButton.click();
 
-      await playExpect(this.doneButton).toBeEnabled({ timeout: timeout });
-      await this.doneButton.click();
+      await playExpect(this.closeButton).toBeEnabled({ timeout: timeout });
+      await this.closeButton.click();
       return new ImagesPage(this.page);
     });
   }
@@ -148,8 +148,8 @@ export class PullImagePage extends BasePage {
       await playExpect(this.pullImageButton).toBeEnabled();
       await this.pullImageButton.click();
 
-      await playExpect(this.doneButton).toBeEnabled({ timeout: timeout });
-      await this.doneButton.click();
+      await playExpect(this.closeButton).toBeEnabled({ timeout: timeout });
+      await this.closeButton.click();
       return new ImagesPage(this.page);
     });
   }


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

This PR add 2 new buttons after pulling image

### Screenshot / video of UI

Before: 
<img width="883" height="236" alt="Screenshot_20260217_111052" src="https://github.com/user-attachments/assets/70a7854d-bfb8-4753-8126-72dd29658c5f" />

After:
<img width="883" height="236" alt="Screenshot_20260217_110903" src="https://github.com/user-attachments/assets/f09e695f-b9d9-4f90-a38b-f674e8c7d2f5" />


### What issues does this PR fix or reference?

Closes #14652 

### How to test this PR?

- Pull Image and tap on "Details" button and Summary page of the pulled image should be opened 
- Pull Image and tap on "Run..." button and Creating container page should be opened

- [x] Tests are covering the bug fix or the new feature
