### PR TITLE
fix(renderer): save previously typed title and description in GitHubFeedback

### DIFF
--- a/packages/api/src/feedback.ts
+++ b/packages/api/src/feedback.ts
@@ -17,8 +17,9 @@
  ***********************************************************************/
 
 export type DirectFeedbackCategory = 'developers' | 'design';
+export type GitHubFeedbackCategory = 'feature' | 'bug';
 
-export type FeedbackCategory = DirectFeedbackCategory | 'feature' | 'bug';
+export type FeedbackCategory = DirectFeedbackCategory | GitHubFeedbackCategory;
 
 export interface FeedbackProperties {
   category: FeedbackCategory;

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -148,7 +148,7 @@ test('Expect GitHubIssue feedback form to be rendered if category is not develop
   await userEvent.keyboard('[ArrowDown]');
   const featureCategory = screen.getByRole('button', { name: /Feature/ });
   await fireEvent.click(featureCategory);
-  expect(vi.mocked(GitHubIssueFeedback)).toHaveBeenNthCalledWith(2, expect.anything(), {
+  expect(vi.mocked(GitHubIssueFeedback)).toHaveBeenNthCalledWith(1, expect.anything(), {
     onCloseForm: expect.any(Function),
     category: 'feature',
     contentChange: expect.any(Function),

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -71,10 +71,8 @@ function handleUpdate(e: boolean): void {
 
     {#if category === 'developers' || category === 'design'}
       <DirectFeedback onCloseForm={hideModal} category={category} contentChange={handleUpdate}/>
-    {:else if category === 'bug'}
-      <GitHubIssueFeedback onCloseForm={hideModal} category="bug" contentChange={handleUpdate}/>
-    {:else if category === 'feature'}
-      <GitHubIssueFeedback onCloseForm={hideModal} category="feature" contentChange={handleUpdate}/>
+    {:else if category === 'bug' || category === 'feature'}
+      <GitHubIssueFeedback onCloseForm={hideModal} category={category} contentChange={handleUpdate}/>
     {/if}
   </Modal>
 </div>

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { FeedbackCategory } from '@podman-desktop/core-api';
+import type { GitHubFeedbackCategory } from '@podman-desktop/core-api';
 import { render, type RenderResult } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { type Component, type ComponentProps } from 'svelte';
@@ -146,7 +146,7 @@ test.each([
   },
 ])('$category should have specific placeholders', async ({ category, placeholders }) => {
   const { title, description } = renderGitHubIssueFeedback({
-    category: category as FeedbackCategory,
+    category: category as GitHubFeedbackCategory,
     onCloseForm: vi.fn(),
     contentChange: vi.fn(),
   });
@@ -166,7 +166,7 @@ test.each([
   },
 ])('$category should have specific issues link', async ({ category, link }) => {
   const { getByLabelText } = renderGitHubIssueFeedback({
-    category: category as FeedbackCategory,
+    category: category as GitHubFeedbackCategory,
     onCloseForm: vi.fn(),
     contentChange: vi.fn(),
   });
@@ -178,9 +178,12 @@ test.each([
   expect(openExternalMock).toHaveBeenCalledWith(link);
 });
 
-test.each(['bug', 'feature'])('Expect %s to be included in previewOnGitHub call', async category => {
+test.each<GitHubFeedbackCategory>([
+  'bug',
+  'feature',
+])('Expect %s to be included in previewOnGitHub call', async category => {
   const { preview, title, description } = renderGitHubIssueFeedback({
-    category: category as FeedbackCategory,
+    category: category,
     onCloseForm: vi.fn(),
     contentChange: vi.fn(),
   });
@@ -302,7 +305,10 @@ describe('includeExtensionInfo', () => {
   });
 });
 
-test.each<FeedbackCategory>(['bug', 'feature'])('Expect %s to have specific telemetry track events', async category => {
+test.each<GitHubFeedbackCategory>([
+  'bug',
+  'feature',
+])('Expect %s to have specific telemetry track events', async category => {
   const { title, description, preview } = renderGitHubIssueFeedback({
     category: category,
     onCloseForm: vi.fn(),
@@ -320,7 +326,7 @@ test.each<FeedbackCategory>(['bug', 'feature'])('Expect %s to have specific tele
   );
 });
 
-test.each<FeedbackCategory>([
+test.each<GitHubFeedbackCategory>([
   'bug',
   'feature',
 ])('Expect %s to have specific telemetry track events with error if the preview on GitHub fails', async category => {

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { FeedbackCategory, GitHubIssue } from '@podman-desktop/core-api';
+import type { GitHubFeedbackCategory, GitHubIssue } from '@podman-desktop/core-api';
 import { Button, Checkbox, ErrorMessage, Link } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
@@ -7,7 +7,7 @@ import FeedbackForm from '/@/lib/feedback/FeedbackForm.svelte';
 
 interface Props {
   onCloseForm: (confirm: boolean) => void;
-  category: FeedbackCategory;
+  category: GitHubFeedbackCategory;
   contentChange: (e: boolean) => void;
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes feedback dialog where switching category from "Feature request" to "Bug" erases title and description

*Technical Details*: Replace two conditions by one so the Feedback form component is the same instance and avoid duplicates. This prevents the typed text from being erased when the user switches categories.

### What issues does this PR fix or reference?

Closes #14748 

### How to test this PR?

Choose Category "Feature request"/"Bug" and start typing title and description. Switch between 2 categories and all data should be saved

- [x] Tests are covering the bug fix or the new feature
