### PR TITLE
feat(extensions): add support menu context contribution for volumes

### DIFF
--- a/packages/api/src/menu-context.ts
+++ b/packages/api/src/menu-context.ts
@@ -20,6 +20,7 @@ export enum MenuContext {
   DASHBOARD_IMAGE = 'dashboard/image',
   DASHBOARD_CONTAINER = 'dashboard/container',
   DASHBOARD_POD = 'dashboard/pod',
+  DASHBOARD_VOLUME = 'dashboard/volume',
   DASHBOARD_COMPOSE = 'dashboard/compose',
   DASHBOARD_CONTAINER_CONNECTION = 'dashboard/container-connection',
 }

--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -25,7 +25,6 @@ import VolumeActions from './VolumeActions.svelte';
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
 const removeVolumeMock = vi.fn();
-const getContributedMenusMock = vi.fn();
 
 class VolumeInfoUIImpl {
   #status: string;
@@ -46,11 +45,10 @@ class VolumeInfoUIImpl {
 
 beforeAll(() => {
   Object.defineProperty(window, 'removeVolume', { value: removeVolumeMock });
-  Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
 });
 
 test('Expect prompt dialog and deletion', async () => {
-  getContributedMenusMock.mockResolvedValue([]);
+  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
   // Mock the showMessageBox to return 0 (yes)
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 

--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -25,6 +25,7 @@ import VolumeActions from './VolumeActions.svelte';
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
 const removeVolumeMock = vi.fn();
+const getContributedMenusMock = vi.fn();
 
 class VolumeInfoUIImpl {
   #status: string;
@@ -45,9 +46,11 @@ class VolumeInfoUIImpl {
 
 beforeAll(() => {
   Object.defineProperty(window, 'removeVolume', { value: removeVolumeMock });
+  Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
 });
 
 test('Expect prompt dialog and deletion', async () => {
+  getContributedMenusMock.mockResolvedValue([]);
   // Mock the showMessageBox to return 0 (yes)
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -1,23 +1,60 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import { createEventDispatcher } from 'svelte';
+import type { Menu } from '@podman-desktop/core-api';
+import { MenuContext } from '@podman-desktop/core-api';
+import { DropdownMenu } from '@podman-desktop/ui-svelte';
+import { createEventDispatcher, onMount } from 'svelte';
 
+import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+import FlatMenu from '/@/lib/ui/FlatMenu.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
-export let volume: VolumeInfoUI;
-export let detailed = false;
+interface Props {
+  volume: VolumeInfoUI;
+  dropdownMenu?: boolean;
+  detailed?: boolean;
+  onUpdate?: (update: VolumeInfoUI) => void;
+}
+
+let {
+  volume = $bindable(),
+  dropdownMenu = false,
+  detailed = false,
+  onUpdate = (update): void => {
+    dispatch('update', update);
+  },
+}: Props = $props();
 
 const dispatch = createEventDispatcher<{ update: VolumeInfoUI }>();
 
+let contributions = $state<Menu[]>([]);
+onMount(async () => {
+  contributions = await window.getContributedMenus(MenuContext.DASHBOARD_VOLUME);
+});
+
+function handleError(errorMessage: string): void {
+  volume.actionError = errorMessage;
+  volume.status = 'ERROR';
+  onUpdate(volume);
+}
+
 async function removeVolume(): Promise<void> {
   volume.status = 'DELETING';
-  dispatch('update', volume);
+  onUpdate(volume);
 
-  await window.removeVolume(volume.engineId, volume.name);
+  try {
+    await window.removeVolume(volume.engineId, volume.name);
+  } catch (error) {
+    handleError(String(error));
+  }
 }
+
+// If dropdownMenu = true, we'll change style to the imported dropdownMenu style
+// otherwise, leave blank.
+const MenuComponent = $derived(dropdownMenu ? DropdownMenu : FlatMenu);
 </script>
 
 {#if volume.status === 'UNUSED'}
@@ -27,3 +64,13 @@ async function removeVolume(): Promise<void> {
     detailed={detailed}
     icon={faTrash} />
 {/if}
+
+<MenuComponent>
+  <ContributionActions
+    args={[volume]}
+    contextPrefix="volumeItem"
+    dropdownMenu={dropdownMenu}
+    contributions={contributions}
+    detailed={detailed}
+    onError={handleError} />
+</MenuComponent>

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -27,21 +27,11 @@ onMount(async () => {
   }
 });
 
-function handleError(errorMessage: string): void {
-  volume.actionError = errorMessage;
-  volume.status = 'ERROR';
-  dispatch('update', volume);
-}
-
 async function removeVolume(): Promise<void> {
   volume.status = 'DELETING';
   dispatch('update', volume);
 
-  try {
-    await window.removeVolume(volume.engineId, volume.name);
-  } catch (error) {
-    handleError(String(error));
-  }
+  await window.removeVolume(volume.engineId, volume.name);
 }
 
 // If dropdownMenu = true, we'll change style to the imported dropdownMenu style
@@ -64,5 +54,5 @@ $: MenuComponent = dropdownMenu ? DropdownMenu : FlatMenu;
     dropdownMenu={dropdownMenu}
     contributions={contributions}
     detailed={detailed}
-    onError={handleError} />
+    onError={(errorMessage: string): void => console.error(errorMessage)} />
 </MenuComponent>

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -12,25 +12,13 @@ import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
-interface Props {
-  volume: VolumeInfoUI;
-  dropdownMenu?: boolean;
-  detailed?: boolean;
-  onUpdate?: (update: VolumeInfoUI) => void;
-}
-
-let {
-  volume = $bindable(),
-  dropdownMenu = false,
-  detailed = false,
-  onUpdate = (update): void => {
-    dispatch('update', update);
-  },
-}: Props = $props();
+export let volume: VolumeInfoUI;
+export let dropdownMenu = false;
+export let detailed = false;
 
 const dispatch = createEventDispatcher<{ update: VolumeInfoUI }>();
 
-let contributions = $state<Menu[]>([]);
+let contributions: Menu[] = [];
 onMount(async () => {
   contributions = await window.getContributedMenus(MenuContext.DASHBOARD_VOLUME);
 });
@@ -38,12 +26,12 @@ onMount(async () => {
 function handleError(errorMessage: string): void {
   volume.actionError = errorMessage;
   volume.status = 'ERROR';
-  onUpdate(volume);
+  dispatch('update', volume);
 }
 
 async function removeVolume(): Promise<void> {
   volume.status = 'DELETING';
-  onUpdate(volume);
+  dispatch('update', volume);
 
   try {
     await window.removeVolume(volume.engineId, volume.name);
@@ -54,7 +42,7 @@ async function removeVolume(): Promise<void> {
 
 // If dropdownMenu = true, we'll change style to the imported dropdownMenu style
 // otherwise, leave blank.
-const MenuComponent = $derived(dropdownMenu ? DropdownMenu : FlatMenu);
+$: MenuComponent = dropdownMenu ? DropdownMenu : FlatMenu;
 </script>
 
 {#if volume.status === 'UNUSED'}

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -20,7 +20,11 @@ const dispatch = createEventDispatcher<{ update: VolumeInfoUI }>();
 
 let contributions: Menu[] = [];
 onMount(async () => {
-  contributions = await window.getContributedMenus(MenuContext.DASHBOARD_VOLUME);
+  try {
+    contributions = await window.getContributedMenus(MenuContext.DASHBOARD_VOLUME);
+  } catch (error) {
+    console.error('Error fetching contributed menus for volumes:', error);
+  }
 });
 
 function handleError(errorMessage: string): void {

--- a/website/docs/extensions/developing/menu.md
+++ b/website/docs/extensions/developing/menu.md
@@ -55,6 +55,7 @@ This example shows how to integrate a menu into the Podman Desktop extension thr
 - 'dashboard/image': Item menu on image actions
 - 'dashboard/container': Item menu on container actions
 - 'dashboard/pod': Item menu on pod actions
+- 'dashboard/volume': Item menu on volume actions
 - 'dashboard/compose': Item menu on compose actions
 
 ### Verification


### PR DESCRIPTION
### What does this PR do?

This PR adds support for extension menu context contribution for volumes, allowing extensions to provide custom menu entries in the volume context menu, following the same pattern used for pods, containers, and images.

### Screenshot / video of UI

<!-- No UI changes visible without an extension implementing volume menu contributions -->

### What issues does this PR fix or reference?

Fixes #16285

### How to test this PR?

1. Verify that the MenuContext enum includes DASHBOARD_VOLUME
2. Check that VolumeActions component properly loads and displays contributed menus
3. Test with an extension that contributes to the volume context menu
4. Run the unit tests to ensure the VolumeActions component works correctly with menu contributions

- [x] Tests are covering the bug fix or the new feature