### PR TITLE
feat(extensions): add support menu context contributions for networks

### DIFF
--- a/packages/api/src/menu-context.ts
+++ b/packages/api/src/menu-context.ts
@@ -22,4 +22,5 @@ export enum MenuContext {
   DASHBOARD_POD = 'dashboard/pod',
   DASHBOARD_COMPOSE = 'dashboard/compose',
   DASHBOARD_CONTAINER_CONNECTION = 'dashboard/container-connection',
+  DASHBOARD_NETWORK = 'dashboard/network',
 }

--- a/packages/renderer/src/lib/network/NetworkActions.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkActions.spec.ts
@@ -26,6 +26,8 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import NetworkActions from './NetworkActions.svelte';
 import type { NetworkInfoUI } from './NetworkInfoUI';
 
+const getContributedMenusMock = vi.fn();
+
 const network1: NetworkInfoUI = {
   engineId: 'engine1',
   engineName: 'Engine 1',
@@ -58,6 +60,8 @@ const network2: NetworkInfoUI = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock, writable: true });
+  getContributedMenusMock.mockResolvedValue([]);
 });
 
 test('Expect non-podman unused network to have delete option and disabled edit', async () => {

--- a/packages/renderer/src/lib/network/NetworkActions.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkActions.spec.ts
@@ -26,8 +26,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import NetworkActions from './NetworkActions.svelte';
 import type { NetworkInfoUI } from './NetworkInfoUI';
 
-const getContributedMenusMock = vi.fn();
-
 const network1: NetworkInfoUI = {
   engineId: 'engine1',
   engineName: 'Engine 1',
@@ -60,8 +58,7 @@ const network2: NetworkInfoUI = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock, writable: true });
-  getContributedMenusMock.mockResolvedValue([]);
+  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
 });
 
 test('Expect non-podman unused network to have delete option and disabled edit', async () => {

--- a/packages/renderer/src/lib/network/NetworkActions.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkActions.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { MenuContext } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -65,11 +66,14 @@ test('Expect non-podman unused network to have delete option and disabled edit',
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(NetworkActions, { object: network1 });
 
-  expect(screen.queryByTitle('Delete Network')).toBeInTheDocument();
-  expect(screen.queryByTitle('Update Network')).toBeInTheDocument();
-  expect(screen.queryByTitle('Update Network')).toBeDisabled();
+  // Wait for async $derived to complete
+  const deleteButton = await screen.findByTitle('Delete Network');
+  const updateButton = await screen.findByTitle('Update Network');
 
-  const deleteButton = screen.getByTitle('Delete Network');
+  expect(deleteButton).toBeInTheDocument();
+  expect(updateButton).toBeInTheDocument();
+  expect(updateButton).toBeDisabled();
+
   await fireEvent.click(deleteButton);
   expect(window.removeNetwork).toHaveBeenCalledWith(network1.engineId, network1.id);
 });
@@ -77,11 +81,14 @@ test('Expect non-podman unused network to have delete option and disabled edit',
 test('Expect podman used network to have edit option and disabled delete', async () => {
   render(NetworkActions, { object: network2 });
 
-  expect(screen.queryByTitle('Delete Network')).toBeInTheDocument();
-  expect(screen.queryByTitle('Delete Network')).toBeDisabled();
-  expect(screen.queryByTitle('Update Network')).toBeInTheDocument();
+  // Wait for async $derived to complete
+  const deleteButton = await screen.findByTitle('Delete Network');
+  const updateButton = await screen.findByTitle('Update Network');
 
-  const updateButton = screen.getByTitle('Update Network');
+  expect(deleteButton).toBeInTheDocument();
+  expect(deleteButton).toBeDisabled();
+  expect(updateButton).toBeInTheDocument();
+
   await fireEvent.click(updateButton);
 
   await tick();
@@ -104,4 +111,12 @@ test('Expect podman used network to have edit option and disabled delete', async
 
   expect(window.updateNetwork).toBeCalledWith('podman2', '123456789123456', ['0.0.0.1', '2.1.1.2'], ['1.1.1.1']);
   expect(screen.queryByText('Edit Network Network 2')).not.toBeInTheDocument();
+});
+
+test('Expect getContributedMenus to be called with DASHBOARD_NETWORK context', async () => {
+  render(NetworkActions, { object: network1 });
+
+  await vi.waitFor(() => {
+    expect(window.getContributedMenus).toHaveBeenCalledWith(MenuContext.DASHBOARD_NETWORK);
+  });
 });

--- a/packages/renderer/src/lib/network/NetworkActions.svelte
+++ b/packages/renderer/src/lib/network/NetworkActions.svelte
@@ -22,7 +22,12 @@ let showUpdateNetworkDialog = $state(false);
 let contributions = $state<Menu[]>([]);
 
 onMount(async () => {
-  contributions = await window.getContributedMenus(MenuContext.DASHBOARD_NETWORK);
+  try {
+    contributions = await window.getContributedMenus(MenuContext.DASHBOARD_NETWORK);
+  } catch (error) {
+    console.error(`error while fetching contributed menus for network ${object.name}`, error);
+    handleError(String(error));
+  }
 });
 
 async function removeNetwork(): Promise<void> {

--- a/packages/renderer/src/lib/network/NetworkActions.svelte
+++ b/packages/renderer/src/lib/network/NetworkActions.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
+import type { Menu } from '@podman-desktop/core-api';
+import { MenuContext } from '@podman-desktop/core-api';
+import { onMount } from 'svelte';
 
+import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 
@@ -15,6 +19,11 @@ interface Props {
 let { object, detailed = false }: Props = $props();
 
 let showUpdateNetworkDialog = $state(false);
+let contributions = $state<Menu[]>([]);
+
+onMount(async () => {
+  contributions = await window.getContributedMenus(MenuContext.DASHBOARD_NETWORK);
+});
 
 async function removeNetwork(): Promise<void> {
   const oldStatus = object.status;
@@ -31,6 +40,10 @@ async function removeNetwork(): Promise<void> {
 function closeUpdateDialog(): void {
   showUpdateNetworkDialog = false;
 }
+
+function handleError(error: string): void {
+  console.error(`error in network actions for ${object.name}`, error);
+}
 </script>
 
 <ListItemButtonIcon
@@ -46,6 +59,14 @@ function closeUpdateDialog(): void {
   icon={faTrash}
   detailed={detailed}
   enabled={object.status === 'UNUSED'} />
+
+<ContributionActions
+  args={[object]}
+  contextPrefix="networkItem"
+  dropdownMenu={false}
+  contributions={contributions}
+  detailed={detailed}
+  onError={handleError} />
 
 {#if showUpdateNetworkDialog}
   <UpdateNetworkDialog network={object} onClose={closeUpdateDialog} />

--- a/packages/renderer/src/lib/network/NetworkActions.svelte
+++ b/packages/renderer/src/lib/network/NetworkActions.svelte
@@ -2,7 +2,6 @@
 import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { Menu } from '@podman-desktop/core-api';
 import { MenuContext } from '@podman-desktop/core-api';
-import { onMount } from 'svelte';
 
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
@@ -19,16 +18,18 @@ interface Props {
 let { object, detailed = false }: Props = $props();
 
 let showUpdateNetworkDialog = $state(false);
-let contributions = $state<Menu[]>([]);
 
-onMount(async () => {
+async function getContributionsWithErrorHandling(): Promise<Menu[]> {
   try {
-    contributions = await window.getContributedMenus(MenuContext.DASHBOARD_NETWORK);
+    return await window.getContributedMenus(MenuContext.DASHBOARD_NETWORK);
   } catch (error) {
     console.error(`error while fetching contributed menus for network ${object.name}`, error);
     handleError(String(error));
+    return [];
   }
-});
+}
+
+const contributions = $derived(await getContributionsWithErrorHandling());
 
 async function removeNetwork(): Promise<void> {
   const oldStatus = object.status;
@@ -47,7 +48,8 @@ function closeUpdateDialog(): void {
 }
 
 function handleError(error: string): void {
-  console.error(`error in network actions for ${object.name}`, error);
+  object.actionError = error;
+  object.status = 'ERROR';
 }
 </script>
 

--- a/packages/renderer/src/lib/network/NetworkActions.svelte
+++ b/packages/renderer/src/lib/network/NetworkActions.svelte
@@ -24,7 +24,6 @@ async function getContributionsWithErrorHandling(): Promise<Menu[]> {
     return await window.getContributedMenus(MenuContext.DASHBOARD_NETWORK);
   } catch (error) {
     console.error(`error while fetching contributed menus for network ${object.name}`, error);
-    handleError(String(error));
     return [];
   }
 }

--- a/packages/renderer/src/lib/network/NetworkInfoUI.ts
+++ b/packages/renderer/src/lib/network/NetworkInfoUI.ts
@@ -29,6 +29,7 @@ export interface NetworkInfoUI {
   status: string;
   containers: NetworkContainer[];
   ipv6_enabled: boolean;
+  actionError?: string;
 }
 
 export interface NetworkContainer {

--- a/website/docs/extensions/developing/menu.md
+++ b/website/docs/extensions/developing/menu.md
@@ -56,6 +56,7 @@ This example shows how to integrate a menu into the Podman Desktop extension thr
 - 'dashboard/container': Item menu on container actions
 - 'dashboard/pod': Item menu on pod actions
 - 'dashboard/compose': Item menu on compose actions
+- 'dashboard/network': Item menu on network actions
 
 ### Verification
 


### PR DESCRIPTION
### What does this PR do?

Adds support for extension menu context contribution for networks, enabling extensions to contribute custom menu items to network actions in the dashboard.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #16286

### How to test this PR?

1. Create an extension that contributes a menu item to the `dashboard/network` context
2. Navigate to the Networks dashboard in Podman Desktop
3. Verify that the contributed menu item appears in the network actions
4. Click the menu item and verify it executes the associated command

- [x] Tests are covering the bug fix or the new feature