### PR TITLE
fix(ui): changed wording within darwin socket disconnect ui popup

### DIFF
--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
@@ -26,7 +26,7 @@ import { execPodman } from '/@/utils/util';
 
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.
-  details = 'the podman-mac-helper binary will be run, disconnecting the Docker socket to Podman.';
+  details = 'the podman-mac-helper binary will be run, unlinking the Docker socket from Podman.';
 
   // This will show the "opposite" of what the current state is
   // "Enable" if it's currently disabled, "Disable" if it's currently enabled

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
@@ -27,7 +27,7 @@ import { execPodman } from '/@/utils/util';
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.
   details =
-    'Administrative privlileges are required to start the podman-mac-helper binary to toggle the Docker socket compatibility mode for Podman.';
+    'Administrative privileges are required to start the podman-mac-helper binary to toggle the Docker socket compatibility mode for Podman.';
 
   // This will show the "opposite" of what the current state is
   // "Enable" if it's currently disabled, "Disable" if it's currently enabled

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
@@ -27,7 +27,7 @@ import { execPodman } from '/@/utils/util';
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.
   details =
-    'The podman-mac-helper binary will be run, linking the Docker socket to Podman. This requires administrative privileges.';
+    'The podman-mac-helper binary will be run, disconnecting the Docker socket from Podman. This requires administrative privileges.';
 
   // This will show the "opposite" of what the current state is
   // "Enable" if it's currently disabled, "Disable" if it's currently enabled

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
@@ -27,7 +27,7 @@ import { execPodman } from '/@/utils/util';
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.
   details =
-    'The podman-mac-helper binary will be run, disconnecting the Docker socket from Podman. This requires administrative privileges.';
+    'Administrative privileges are required to enable or disable the Docker socket compatibility mode for Podman.';
 
   // This will show the "opposite" of what the current state is
   // "Enable" if it's currently disabled, "Disable" if it's currently enabled

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
@@ -26,8 +26,7 @@ import { execPodman } from '/@/utils/util';
 
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.
-  details =
-    'Administrative privileges are required to start the podman-mac-helper binary to toggle the Docker socket compatibility mode for Podman.';
+  details = 'the podman-mac-helper binary will be run, disconnecting the Docker socket to Podman.';
 
   // This will show the "opposite" of what the current state is
   // "Enable" if it's currently disabled, "Disable" if it's currently enabled

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.ts
@@ -27,7 +27,7 @@ import { execPodman } from '/@/utils/util';
 export class DarwinSocketCompatibility extends SocketCompatibility {
   // Shows the details of the compatibility mode on what we do.
   details =
-    'Administrative privileges are required to enable or disable the Docker socket compatibility mode for Podman.';
+    'Administrative privlileges are required to start the podman-mac-helper binary to toggle the Docker socket compatibility mode for Podman.';
 
   // This will show the "opposite" of what the current state is
   // "Enable" if it's currently disabled, "Disable" if it's currently enabled


### PR DESCRIPTION
Signed-off-by: Gregory McNutt <amcnutt1996@gmail.com>

### What does this PR do?

Changed the wording in the UI pop-up when disabling the Docker socket compatibility mode from the UI.
Previous: `the podman-mac-helper binary will be run, linking the Docker socket to Podman`
Changed: `the podman-mac-helper binary will be run, unlinking the Docker socket from Podman.`


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

#11098 


<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

