### PR TITLE
chore(main): declare command interface with Zod

### DIFF
--- a/packages/main/src/plugin/command-registry.ts
+++ b/packages/main/src/plugin/command-registry.ts
@@ -19,19 +19,30 @@
 import type { CommandInfo } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
+import { z } from 'zod';
 
 import { Telemetry } from './telemetry/telemetry.js';
 import { Disposable } from './types/disposable.js';
 
-export interface RawCommand {
-  command?: string;
-  title?: string;
-  category?: string;
-  description?: string;
-  icon?: string | { light: string; dark: string };
-  keybinding?: string;
-  enablement?: string;
-}
+export const RawCommandSchema = z.object({
+  command: z.string().optional(),
+  title: z.string().optional(),
+  category: z.string().optional(),
+  description: z.string().optional(),
+  icon: z
+    .union([
+      z.string(),
+      z.object({
+        light: z.string(),
+        dark: z.string(),
+      }),
+    ])
+    .optional(),
+  keybinding: z.string().optional(),
+  enablement: z.string().optional(),
+});
+
+export type RawCommand = z.output<typeof RawCommandSchema>;
 
 export interface CommandHandler {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### What does this PR do?

This PR declares the `RawCommand` interface with Zod instead of Typescript interface. It is needed for declaring the schema of extension package.json.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16050

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
