### PR TITLE
chore(watch): move core-api watcher first

### DIFF
--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -297,11 +297,11 @@ const setupExtensionApiWatcher = name => {
     for (const extension of extensions) {
       setupExtensionApiWatcher(extension);
     }
+    await setupCoreApiPackageWatcher(viteDevServer);
     await setupPreloadPackageWatcher(viteDevServer);
     await setupPreloadDockerExtensionPackageWatcher(viteDevServer);
     await setupPreloadWebviewPackageWatcher(viteDevServer);
     await setupUiPackageWatcher();
-    await setupCoreApiPackageWatcher(viteDevServer);
     await setupMainPackageWatcher(viteDevServer);
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
### What does this PR do?
main, preload, renderer, etc depend on api package move api first so it may avoid empty folder

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/16287

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
