### PR TITLE
fix: support Docker API v1.52+ event format

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3116,8 +3116,15 @@ declare module '@podman-desktop/api' {
 
   interface ContainerJSONEvent {
     type: string;
-    status: string;
-    id: string;
+    // Podman events use top-level status/id.
+    // Docker Engine API v1.52+ events use Action/Actor.ID.
+    status?: string;
+    id?: string;
+    Action?: string;
+    Actor?: {
+      ID?: string;
+      Attributes?: Record<string, string>;
+    };
     Type?: string;
   }
 

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3663,6 +3663,41 @@ test('check handleEvents with loadArchive', async () => {
   expect(consoleLogSpy).toBeCalledWith('event is', content);
 });
 
+test('check handleEvents with Docker API v1.52+ event shape', async () => {
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  // Docker API v1.52+ no longer sends top-level status/id.
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      Type: 'container',
+      Action: 'start',
+      Actor: {
+        ID: 'abc123',
+      },
+    }),
+  );
+
+  await vi.waitFor(() => expect(apiSender.send).toBeCalledWith('container-started-event', 'abc123'));
+});
+
 test('check handleEvents is not calling the console.log for health_status event', async () => {
   const consoleLogSpy = vi.spyOn(console, 'log');
   consoleLogSpy.mockClear();
@@ -3693,6 +3728,43 @@ test('check handleEvents is not calling the console.log for health_status event'
   await vi.waitFor(() => expect(eventsMockCallback).toBeDefined());
 
   // check we didn't call the console.log method
+  expect(consoleLogSpy).not.toBeCalled();
+});
+
+test('check handleEvents does not log Docker compound health_status actions', async () => {
+  const consoleLogSpy = vi.spyOn(console, 'log');
+  consoleLogSpy.mockClear();
+
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      Type: 'container',
+      Action: 'health_status: healthy',
+      Actor: {
+        ID: 'abc123',
+      },
+    }),
+  );
+
+  await vi.waitFor(() => expect(eventsMockCallback).toBeDefined());
   expect(consoleLogSpy).not.toBeCalled();
 });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -107,8 +107,12 @@ export interface InternalContainerProvider {
 
 interface JSONEvent {
   type: string;
-  status: string;
-  id: string;
+  // Podman uses 'status'. Docker API v1.52+ uses 'Action'.
+  status?: string;
+  Action?: string;
+  // Podman uses top-level 'id'. Docker API v1.52+ uses 'Actor.ID'.
+  id?: string;
+  Actor?: { ID?: string; Attributes?: Record<string, string> };
   Type?: string;
 }
 
@@ -165,60 +169,66 @@ export class ContainerProviderRegistry {
       nbEvents++;
       // reconnected
       this.notify = true;
+
+      // Podman uses top-level `status` and `id`, while Docker API v1.52+ uses `Action` and `Actor.ID`.
+      // Docker can emit compound Action values like "health_status: healthy"; for Docker we keep only the base action.
+      const status = jsonEvent.status ?? jsonEvent.Action?.split(':')[0]?.trim();
+      const id = jsonEvent.id ?? jsonEvent.Actor?.ID;
+
       // do not log healthcheck(health_status) events
       // as it's too verbose/repeating a lot
-      if (jsonEvent.status !== 'health_status') {
+      if (status !== 'health_status') {
         console.log('event is', jsonEvent);
       }
       this._onEvent.fire(jsonEvent);
-      if (jsonEvent.status === 'stop' && jsonEvent?.Type === 'container') {
+      if (status === 'stop' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been stopped
-        this.apiSender.send('container-stopped-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'init' && jsonEvent?.Type === 'container') {
+        this.apiSender.send('container-stopped-event', id);
+      } else if (status === 'init' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been started
-        this.apiSender.send('container-init-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'create' && jsonEvent?.Type === 'container') {
+        this.apiSender.send('container-init-event', id);
+      } else if (status === 'create' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been created
-        this.apiSender.send('container-created-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'start' && jsonEvent?.Type === 'container') {
+        this.apiSender.send('container-created-event', id);
+      } else if (status === 'start' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been started
-        this.apiSender.send('container-started-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'destroy' && jsonEvent?.Type === 'container') {
+        this.apiSender.send('container-started-event', id);
+      } else if (status === 'destroy' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been destroyed
-        this.apiSender.send('container-stopped-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'die' && jsonEvent?.Type === 'container') {
-        this.apiSender.send('container-die-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'kill' && jsonEvent?.Type === 'container') {
-        this.apiSender.send('container-kill-event', jsonEvent.id);
+        this.apiSender.send('container-stopped-event', id);
+      } else if (status === 'die' && jsonEvent?.Type === 'container') {
+        this.apiSender.send('container-die-event', id);
+      } else if (status === 'kill' && jsonEvent?.Type === 'container') {
+        this.apiSender.send('container-kill-event', id);
       } else if (jsonEvent?.Type === 'pod') {
         this.apiSender.send('pod-event');
       } else if (jsonEvent?.Type === 'volume') {
         this.apiSender.send('volume-event');
       } else if (jsonEvent?.Type === 'network') {
         this.apiSender.send('network-event');
-      } else if (jsonEvent.status === 'remove' && jsonEvent?.Type === 'container') {
-        this.apiSender.send('container-removed-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'pull' && jsonEvent?.Type === 'image') {
+      } else if (status === 'remove' && jsonEvent?.Type === 'container') {
+        this.apiSender.send('container-removed-event', id);
+      } else if (status === 'pull' && jsonEvent?.Type === 'image') {
         // need to notify that image are being pulled
-        this.apiSender.send('image-pull-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'tag' && jsonEvent?.Type === 'image') {
+        this.apiSender.send('image-pull-event', id);
+      } else if (status === 'tag' && jsonEvent?.Type === 'image') {
         // need to notify that image are being tagged
-        this.apiSender.send('image-tag-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'untag' && jsonEvent?.Type === 'image') {
+        this.apiSender.send('image-tag-event', id);
+      } else if (status === 'untag' && jsonEvent?.Type === 'image') {
         // need to notify that image are being untagged
-        this.apiSender.send('image-untag-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'remove' && jsonEvent?.Type === 'image') {
+        this.apiSender.send('image-untag-event', id);
+      } else if (status === 'remove' && jsonEvent?.Type === 'image') {
         // need to notify that image are being pulled
-        this.apiSender.send('image-remove-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'delete' && jsonEvent?.Type === 'image') {
+        this.apiSender.send('image-remove-event', id);
+      } else if (status === 'delete' && jsonEvent?.Type === 'image') {
         // need to notify that image are being pulled
-        this.apiSender.send('image-remove-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'build' && jsonEvent?.Type === 'image') {
+        this.apiSender.send('image-remove-event', id);
+      } else if (status === 'build' && jsonEvent?.Type === 'image') {
         // need to notify that image are being pulled
-        this.apiSender.send('image-build-event', jsonEvent.id);
-      } else if (jsonEvent.status === 'loadfromarchive' && jsonEvent?.Type === 'image') {
+        this.apiSender.send('image-build-event', id);
+      } else if (status === 'loadfromarchive' && jsonEvent?.Type === 'image') {
         // need to notify that image are being pulled
-        this.apiSender.send('image-loadfromarchive-event', jsonEvent.id);
+        this.apiSender.send('image-loadfromarchive-event', id);
       }
     });
 


### PR DESCRIPTION
## Summary
- fix Docker event compatibility for API v1.52+ where `/events` no longer includes top-level `status` / `id`
- normalize event handling to use Podman-style fields when present, and Docker `Action` / `Actor.ID` fallback otherwise
- keep event routing behavior unchanged while making the parser forward-compatible

## Changes
- update `ContainerProviderRegistry.handleEvents` to derive local `status` and `id` values from either shape
- update `ContainerJSONEvent` typing in extension API to represent both old and new event payloads
- add regression tests for Docker v1.52+ event shape and compound actions such as `health_status: healthy`

## Validation
- verified targeted test passes:
  - `check handleEvents with Docker API v1.52+ event shape`