### PR TITLE
chore(imports): remove (or ignore) relative imports in main package

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -295,7 +295,7 @@ export default [
       ],
     },
   },
-   {
+  {
     files: ['packages/main/**'],
     rules: {
       'no-restricted-imports': [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -295,6 +295,22 @@ export default [
       ],
     },
   },
+   {
+    files: ['packages/main/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['../**'],
+              message: 'Parent relative imports are not allowed. Use path aliases (e.g. /@/) instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 
   {
     files: ['packages/renderer/**'],

--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -26,9 +26,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { Emitter } from '/@/plugin/events/emitter.js';
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
+import * as util from '/@/util.js';
 
+// eslint-disable-next-line no-restricted-imports
 import tailwindColorPalette from '../../../../tailwind-color-palette.json' with { type: 'json' };
-import * as util from '../util.js';
 import { ColorBuilder } from './color-builder.js';
 import { colorPaletteHelper } from './color-palette-helper.js';
 import { type ColorDefinitionWithId, ColorRegistry } from './color-registry.js';

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -22,9 +22,10 @@ import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
+import { isWindows } from '/@/util.js';
 
+// eslint-disable-next-line no-restricted-imports
 import tailwindColorPalette from '../../../../tailwind-color-palette.json' with { type: 'json' };
-import { isWindows } from '../util.js';
 import { ColorBuilder } from './color-builder.js';
 import { colorPaletteHelper } from './color-palette-helper.js';
 import type { ConfigurationRegistry } from './configuration-registry.js';

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -22,10 +22,13 @@ import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
-import { isWindows } from '/@/util.js';
 
 // eslint-disable-next-line no-restricted-imports
 import tailwindColorPalette from '../../../../tailwind-color-palette.json' with { type: 'json' };
+// use relative path as this file is embedded in the website build to generate css
+// and then type alias won't resolve it
+// eslint-disable-next-line no-restricted-imports
+import { isWindows } from '../util.js';
 import { ColorBuilder } from './color-builder.js';
 import { colorPaletteHelper } from './color-palette-helper.js';
 import type { ConfigurationRegistry } from './configuration-registry.js';

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2025 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,7 @@ import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, expect, t
 
 import type { DockerodeInternals, LibPod } from '/@/plugin/dockerode/libpod-dockerode.js';
 import { LibpodDockerode } from '/@/plugin/dockerode/libpod-dockerode.js';
-
-import podmanInfo from '../../../tests/resources/data/plugin/podman-info.json' with { type: 'json' };
+import podmanInfo from '/@tests/resources/data/plugin/podman-info.json' with { type: 'json' };
 
 let server: SetupServerApi | undefined = undefined;
 

--- a/packages/main/src/plugin/featured/featured.ts
+++ b/packages/main/src/plugin/featured/featured.ts
@@ -23,6 +23,7 @@ import { inject, injectable } from 'inversify';
 import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 
+// eslint-disable-next-line no-restricted-imports
 import featuredJSONFile from '../../../../../featured.json' with { type: 'json' };
 
 /**

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,18 +31,17 @@ import { setupServer, type SetupServerApi } from 'msw/node';
 import * as nodeTar from 'tar';
 import { afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
-import imageRegistryConfigJson from '../../tests/resources/data/plugin/image-registry-config.json' with {
+import imageRegistryConfigJson from '/@tests/resources/data/plugin/image-registry-config.json' with { type: 'json' };
+import imageRegistryManifestJson from '/@tests/resources/data/plugin/image-registry-manifest-index.json' with {
   type: 'json',
 };
-import imageRegistryManifestJson from '../../tests/resources/data/plugin/image-registry-manifest-index.json' with {
+import imageRegistryManifestZstdJson from '/@tests/resources/data/plugin/image-registry-manifest-index.zstd.json' with {
   type: 'json',
 };
-import imageRegistryManifestZstdJson from '../../tests/resources/data/plugin/image-registry-manifest-index.zstd.json' with {
+import imageRegistryManifestMultiArchJson from '/@tests/resources/data/plugin/image-registry-manifest-multi-arch-index.json' with {
   type: 'json',
 };
-import imageRegistryManifestMultiArchJson from '../../tests/resources/data/plugin/image-registry-manifest-multi-arch-index.json' with {
-  type: 'json',
-};
+
 import type { Certificates } from './certificates.js';
 import { ImageRegistry } from './image-registry.js';
 import type { Proxy } from './proxy.js';

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalo
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { Featured } from '/@/plugin/featured/featured.js';
 
+// eslint-disable-next-line no-restricted-imports
 import recommendations from '../../../../../recommendations.json' with { type: 'json' };
 
 @injectable()

--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -22,12 +22,12 @@ import { TelemetrySettings } from '@podman-desktop/core-api/telemetry';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 import type { DefaultConfiguration } from '/@/plugin/default-configuration.js';
 import type { LockedConfiguration } from '/@/plugin/locked-configuration.js';
+import { TelemetryTrustedValue } from '/@/plugin/types/telemetry.js';
 import product from '/@product.json' with { type: 'json' };
 
-import type { ConfigurationRegistry } from '../configuration-registry.js';
-import { TelemetryTrustedValue } from '../types/telemetry.js';
 import type { EventType } from './telemetry.js';
 import { Telemetry, TelemetryLoggerImpl } from './telemetry.js';
 

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -38,13 +38,14 @@ import { inject, injectable } from 'inversify';
 import * as osLocale from 'os-locale';
 
 import { DefaultConfiguration } from '/@/plugin/default-configuration.js';
+import { Emitter } from '/@/plugin/events/emitter.js';
 import { LockedConfiguration } from '/@/plugin/locked-configuration.js';
+import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '/@/plugin/types/telemetry.js';
+import { stoppedExtensions } from '/@/util.js';
 import product from '/@product.json' with { type: 'json' };
 
+// eslint-disable-next-line no-restricted-imports
 import telemetry from '../../../../../telemetry.json' with { type: 'json' };
-import { stoppedExtensions } from '../../util.js';
-import { Emitter } from '../events/emitter.js';
-import { TelemetryTrustedValue as TypeTelemetryTrustedValue } from '../types/telemetry.js';
 import { Identity } from './identity.js';
 import type { TelemetryRule } from './telemetry-api.js';
 

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -41,6 +41,7 @@ import { Disposable } from '/@/plugin/types/disposable.js';
 import { isLinux, isWindows } from '/@/util.js';
 import product from '/@product.json' with { type: 'json' };
 
+// eslint-disable-next-line no-restricted-imports
 import rootPackage from '../../../../package.json' with { type: 'json' };
 import { TaskManager } from './tasks/task-manager.js';
 


### PR DESCRIPTION
### What does this PR do?
some JSON are imported using relative paths. As it is a more per-case usage, ignore the rule for these one
For all others usecases, replace relative imports by path aliases

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/14361

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
