### PR TITLE
fix(renderer): make correct corners' radius

### DIFF
--- a/packages/renderer/src/lib/dialogs/CustomPick.svelte
+++ b/packages/renderer/src/lib/dialogs/CustomPick.svelte
@@ -186,9 +186,11 @@ function dragMe(node: HTMLElement): void {
                   <div
                     class="px-4 pt-4 pb-2 bg-[var(--pd-invert-content-card-bg)] group-hover:bg-[var(--pd-modal-dropdown-highlight)] hover:bg-[var(--pd-modal-dropdown-highlight)] group-hover:border-[var(--pd-tab-highlight)] hover:border-[var(--pd-tab-highlight)] rounded-t-md group-[.is-selected]:bg-[var(--pd-modal-dropdown-highlight)] border-t-2 border-x-2 border-transparent"
                     class:border-b-2={usePopperForDetails ||
-                      itemSectionHiddenStatus.get((i / colsPerRow) * colsPerRow + j)}
+                      (itemSectionHiddenStatus.get((i / colsPerRow) * colsPerRow + j) ?? false) ||
+                      (innerItem.sections?.length ?? 0) === 0}
                     class:rounded-b-md={usePopperForDetails ||
-                      itemSectionHiddenStatus.get((i / colsPerRow) * colsPerRow + j)}
+                      (itemSectionHiddenStatus.get((i / colsPerRow) * colsPerRow + j) ?? false) ||
+                      (innerItem.sections?.length ?? 0) === 0}
                     class:bg-[var(--pd-modal-dropdown-highlight)]={innerItem.selected}>
                     <div class="flex flex-row mb-1 gap-x-1">
                       <span class="text-md font-bold">{innerItem.title}</span>


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

### Screenshot / video of UI

**Before:**
<img width="685" height="245" alt="image" src="https://github.com/user-attachments/assets/c2995ef2-7e96-45e6-979a-26389158c816" />

**After:**
<img width="667" height="231" alt="image" src="https://github.com/user-attachments/assets/fe1b1132-f31d-48a7-b54f-e218ea8ee1c4" />


### What issues does this PR fix or reference?

Closes #16144 

### How to test this PR?

Create extension command that opens CustomPick and provide 2-3 items. All corners should be rounded

- [x] Tests are covering the bug fix or the new feature
