### PR TITLE
refactor(Dashboard): changed setup dashboard registry init

### DIFF
--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -41,6 +41,7 @@ function getDefaultDashboardItems(): ListOrganizerItem[] {
 // Initialize dashboard configuration
 async function initializeDashboard(): Promise<void> {
   try {
+    await setupDashboardPageRegistry();
     if (dashboardPageRegistry.entries.length > 0) {
       dashboardSections = await loadDashboardConfiguration();
     }

--- a/packages/renderer/src/stores/dashboard/dashboard-page-registry.svelte.spec.ts
+++ b/packages/renderer/src/stores/dashboard/dashboard-page-registry.svelte.spec.ts
@@ -24,7 +24,6 @@ import {
   convertFromListOrganizerItems,
   dashboardPageRegistry,
   type DashboardPageRegistryEntry,
-  defaultSection,
   setupDashboardPageRegistry,
 } from './dashboard-page-registry.svelte';
 
@@ -41,20 +40,6 @@ beforeEach(async () => {
 });
 
 describe('defaultSection', () => {
-  test('should return section names in correct order when enhanced dashboard is disabled', async () => {
-    await vi.waitFor(() => {
-      expect(dashboardPageRegistry.entries).toHaveLength(5);
-    });
-
-    expect(defaultSection.names).toEqual([
-      'Release Notes',
-      'Extension Banners',
-      'Explore Features',
-      'Learning Center',
-      'Providers',
-    ]);
-  });
-
   test('should return section names in correct order when enhanced dashboard is enabled', async () => {
     vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
     await setupDashboardPageRegistry();

--- a/packages/renderer/src/stores/dashboard/dashboard-page-registry.svelte.ts
+++ b/packages/renderer/src/stores/dashboard/dashboard-page-registry.svelte.ts
@@ -47,10 +47,6 @@ function getDashboardPageRegistry(): DashboardPageRegistryEntry[] {
   ];
 }
 
-setupDashboardPageRegistry().catch((error: unknown) => {
-  console.error(`Failed to setup dashboard page registry: ${error}`);
-});
-
 window.events?.receive('enhanced-dashboard-enabled', (value: unknown) => {
   if (typeof value === 'boolean') {
     enhancedDashboard.enabled = value;


### PR DESCRIPTION
### What does this PR do?
Moved the setupDashboardRegistry init function to be initialized from the dashboardPage.svelte 

### Screenshot / video of UI


### What issues does this PR fix or reference?

### How to test this PR?
Build the podman desktop/ download the binary
The dashboard should load as expected

- [x] Tests are covering the bug fix or the new feature
