### PR TITLE
feat: add pod log search functionality for kubernetes

### DIFF
--- a/packages/renderer/src/lib/kube/pods/PodDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsLogs.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { SearchAddon } from '@xterm/addon-search';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import PodDetailsLogs from '/@/lib/kube/pods/PodDetailsLogs.svelte';
+import type { PodUI } from '/@/lib/kube/pods/PodUI';
+
+vi.mock(import('@xterm/xterm'));
+vi.mock(import('@xterm/addon-search'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const POD: PodUI = {
+  name: 'pod-name',
+  namespace: 'default',
+  status: 'RUNNING',
+  selected: false,
+  containers: [
+    {
+      Id: 'container-id',
+      Names: 'container-name',
+      Status: 'Running',
+    },
+  ],
+};
+
+test('Kubernetes pod should use window#kubernetesReadPodLog', async () => {
+  render(PodDetailsLogs, {
+    pod: POD,
+  });
+
+  await vi.waitFor(() => {
+    expect(window.kubernetesReadPodLog).toHaveBeenCalledWith(POD.name, POD.containers[0].Names, expect.any(Function));
+  });
+});
+
+test('terminal used should have search enabled', async () => {
+  render(PodDetailsLogs, {
+    pod: POD,
+  });
+
+  await vi.waitFor(() => {
+    expect(SearchAddon).toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/kube/pods/PodDetailsLogs.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsLogs.svelte
@@ -106,5 +106,5 @@ onMount(async () => {
   class:invisible={noLogs === true}
   class:h-0={noLogs === true}
   class:h-full={noLogs === false}>
-  <TerminalWindow class="h-full" bind:terminal={logsTerminal} convertEol disableStdIn />
+  <TerminalWindow search class="h-full" bind:terminal={logsTerminal} convertEol disableStdIn />
 </div>

--- a/tests/playwright/resources/kubernetes/test-pod-log-search.yaml
+++ b/tests/playwright/resources/kubernetes/test-pod-log-search.yaml
@@ -1,0 +1,36 @@
+# /**********************************************************************
+#  * Copyright (C) 2026 Red Hat, Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ***********************************************************************/
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-log-search
+spec:
+  containers:
+    - name: logger
+      image: busybox
+      command:
+        - /bin/sh
+        - -c
+        - |
+          i=0
+          while true; do
+            echo "k8s-log-search-token line=${i}"
+            i=$((i+1))
+            sleep 1
+          done

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -47,6 +47,7 @@ const SECRET_NAME: string = 'test-secret-resource';
 const SECRET_POD_NAME: string = 'test-pod-configmaps-secrets';
 const DEPLOYMENT_NAME: string = 'test-deployment-resource';
 const CRON_JOB_NAME: string = 'test-cronjob-resource';
+const POD_LOG_SEARCH_NAME: string = 'test-pod-log-search';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -91,6 +92,14 @@ const CRON_JOB_YAML_PATH: string = path.resolve(
   'resources',
   'kubernetes',
   `${CRON_JOB_NAME}.yaml`,
+);
+const POD_LOG_SEARCH_YAML_PATH: string = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'resources',
+  'kubernetes',
+  `${POD_LOG_SEARCH_NAME}.yaml`,
 );
 
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
@@ -324,6 +333,39 @@ test.describe('Kubernetes resources End-to-End test', { tag: ['@k8s_e2e', '@k8s_
       });
       test('Delete CronJob resource', async ({ page }) => {
         await deleteKubernetesResource(page, KubernetesResources.Cronjobs, CRON_JOB_NAME);
+      });
+    });
+
+  test.describe
+    .serial('Pod logs search test', () => {
+      test('Create a pod with deterministic logs for search', async ({ page }) => {
+        await createKubernetesResource(page, KubernetesResources.Pods, POD_LOG_SEARCH_NAME, POD_LOG_SEARCH_YAML_PATH);
+        await checkKubernetesResourceState(
+          page,
+          KubernetesResources.Pods,
+          POD_LOG_SEARCH_NAME,
+          KubernetesResourceState.Running,
+        );
+      });
+
+      test('Find input and navigation controls are available in pod logs', async ({ navigationBar }) => {
+        const kubernetesBar = await navigationBar.openKubernetes();
+        const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);
+        const podDetails = await kubernetesPodsPage.openResourceDetails(POD_LOG_SEARCH_NAME, KubernetesResources.Pods);
+        await playExpect(podDetails.heading).toBeVisible();
+        await podDetails.activateTab('Logs');
+
+        const findInLogsInput = podDetails.tabContent.getByLabel('Find');
+        await playExpect(findInLogsInput).toBeVisible();
+        await findInLogsInput.fill('k8s-log-search-token');
+        await playExpect(findInLogsInput).toHaveValue('k8s-log-search-token');
+
+        await playExpect(podDetails.tabContent.getByRole('button', { name: 'Previous Match' })).toBeVisible();
+        await playExpect(podDetails.tabContent.getByRole('button', { name: 'Next Match' })).toBeVisible();
+      });
+
+      test('Delete pod log search fixture', async ({ page }) => {
+        await deleteKubernetesResource(page, KubernetesResources.Pods, POD_LOG_SEARCH_NAME);
       });
     });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes [#16359](https://github.com/podman-desktop/podman-desktop/issues/16359) by enabling log search controls in Kubernetes Pod Logs view.

This aligns Kubernetes pod logs behavior with existing log search support in other logs views.
### Screenshot / video of UI
(Pod name redacted for privacy)

Before:
<img width="2279" height="117" alt="Screenshot 2026-02-26 at 2 37 16 PM" src="https://github.com/user-attachments/assets/1aea51ff-29ac-4033-99c3-306adbee1f2e" />


After:

<img width="794" height="144" alt="Screenshot 2026-02-26 at 2 35 16 PM" src="https://github.com/user-attachments/assets/4ac38c18-cb87-492d-8528-7360195650cb" />

### What issues does this PR fix or reference?

Fixes [#16359](https://github.com/podman-desktop/podman-desktop/issues/16359)

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
