### PR TITLE
chore(ui): change volume to secondary buttons

### DIFF
--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -95,4 +95,4 @@ async function prune(type: string, selectedItemLabel: string): Promise<void> {
 }
 </script>
 
-<Button on:click={openPruneDialog} title="Remove unused {type}" icon={faTrash}>Prune</Button>
+<Button type="secondary" on:click={openPruneDialog} title="Remove unused {type}" icon={faTrash}>Prune</Button>

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -200,6 +200,7 @@ function label(obj: VolumeInfoUI): string {
       <Prune type="volumes" engines={enginesList} />
 
       <Button
+        type="secondary"
         inProgress={fetchDataInProgress}
         on:click={fetchUsageData}
         title="Gather sizes for volumes. It can take a while..."
@@ -207,7 +208,7 @@ function label(obj: VolumeInfoUI): string {
         aria-label="Gather volume sizes">Gather volume sizes</Button>
     {/if}
     {#if providerConnections.length > 0}
-      <Button on:click={gotoCreateVolume} icon={faPlusCircle} title="Create a volume" aria-label="Create"
+      <Button type="primary" on:click={gotoCreateVolume} icon={faPlusCircle} title="Create a volume" aria-label="Create"
         >Create</Button>
     {/if}
   {/snippet}


### PR DESCRIPTION
chore(ui): change volume to secondary buttons

### What does this PR do?

Moves the Prune & Gather volume sizes buttons to use the "secondary"
style now as the Create button is considered the "primary" button of
that section.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:

<img width="2274" height="1570" alt="image" src="https://github.com/user-attachments/assets/b87c565f-ce5e-478c-83a1-339be4a26fb0" />


After:

<img width="2274" height="1570" alt="image" src="https://github.com/user-attachments/assets/858c025e-2343-4cec-b652-4a5528fca4ea" />


### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/16358

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Go see the buttons on the volume page :)

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
