### PR TITLE
chore(ui): change image page to secondary buttons

### DIFF
--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -310,6 +310,7 @@ function label(item: ImageInfoUI): string {
       <Prune type="images" engines={enginesList} />
     {/if}
     <Button
+      type="secondary"
       on:click={loadImages}
       title="Load Images From Tar Archives"
       icon={faUpload}
@@ -317,14 +318,15 @@ function label(item: ImageInfoUI): string {
       Load
     </Button>
     <Button
+      type="secondary"
       on:click={importImage}
       title="Import Containers From Filesystem"
       icon={faArrowCircleDown}
       aria-label="Import Image">
       Import
     </Button>
-    <Button on:click={gotoPullImage} title="Pull Image From a Registry" icon={faArrowCircleDown}>Pull</Button>
-    <Button on:click={gotoBuildImage} title="Build Image From Containerfile" icon={faCube}>Build</Button>
+    <Button type="secondary" on:click={gotoPullImage} title="Pull Image From a Registry" icon={faArrowCircleDown}>Pull</Button>
+    <Button type="primary" on:click={gotoBuildImage} title="Build Image From Containerfile" icon={faCube}>Build</Button>
   {/snippet}
 
   {#snippet bottomAdditionalActions()}


### PR DESCRIPTION
chore(ui): change image page to secondary buttons

### What does this PR do?

Moves the Prune, Load, Import and Pull buttons to be secondary and the
Create button to be a primary button.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:

<img width="1137" height="785" alt="Screenshot 2026-02-26 at 11 43 10 AM" src="https://github.com/user-attachments/assets/e8e61cca-7887-42cb-aa2e-b94b90938f37" />


After:

<img width="1137" height="785" alt="Screenshot 2026-02-26 at 11 42 53 AM" src="https://github.com/user-attachments/assets/074bb9c2-ded0-4095-af97-ac20b7c9a4b6" />

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/16357

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

Go see the buttons on the image page

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
