### PR TITLE
feat(Dialogs): standardize cancel button types

### DIFF
--- a/packages/renderer/src/lib/image/PushImageModal.svelte
+++ b/packages/renderer/src/lib/image/PushImageModal.svelte
@@ -129,7 +129,7 @@ $effect(() => {
   {#snippet buttons()}
   
       {#if !pushInProgress && !pushFinished}
-        <Button class="w-auto" type="secondary" on:click={closeCallback}>Cancel</Button>
+        <Button class="w-auto" type="link" on:click={closeCallback}>Cancel</Button>
       {/if}
       {#if !pushFinished}
         <Button

--- a/packages/renderer/src/lib/image/PushManifestModal.svelte
+++ b/packages/renderer/src/lib/image/PushManifestModal.svelte
@@ -74,7 +74,7 @@ async function pushManifestFinished(): Promise<void> {
   {#snippet buttons()}
   
       {#if !pushInProgress && !pushFinished}
-        <Button class="w-auto" type="secondary" on:click={closeCallback}>Cancel</Button>
+        <Button class="w-auto" type="link" on:click={closeCallback}>Cancel</Button>
       {/if}
       {#if !pushFinished}
         <Button


### PR DESCRIPTION
### What does this PR do?
There are two dialogs:
- Push image ([PushImageModal](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/image/PushImageModal.svelte#L132C32-L132C48))
- Push manifest ([PushManifestModal](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/image/PushManifestModal.svelte#L77)
having `cancel` button with `type="secondary"` according to #15952 this should be standardized to `type="link"`.
### Screenshot / video of UI
Before:
<img width="1920" height="1140" alt="before" src="https://github.com/user-attachments/assets/057b6891-4dcb-4dfc-b37c-33af0804bc88" />
After:
<img width="1920" height="1140" alt="after" src="https://github.com/user-attachments/assets/49b28120-1b31-4a54-a461-f9a3b3a0d047" />

### What issues does this PR fix or reference?
closes #15952 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Tests for this feature are yet to be added.

- [ ] Tests are covering the bug fix or the new feature
