### PR TITLE
refactor(api-sender): make the data parameter optional

### DIFF
--- a/packages/main/src/plugin/commands-init.ts
+++ b/packages/main/src/plugin/commands-init.ts
@@ -53,13 +53,13 @@ export class CommandsInit implements IDisposable {
     const commandRegistry = this.getCommandRegistry();
     this.#disposables.push(
       commandRegistry.registerCommand('feedback', () => {
-        this.getApiSender().send('display-feedback', '');
+        this.getApiSender().send('display-feedback');
       }),
     );
 
     this.#disposables.push(
       commandRegistry.registerCommand('help', () => {
-        this.getApiSender().send('toggle-help-menu', '');
+        this.getApiSender().send('toggle-help-menu');
       }),
     );
 

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -256,7 +256,7 @@ test('waitForAContainerConnection', async () => {
   await new Promise(resolve => setTimeout(resolve, 100));
 
   // now send the 'extension-started' event
-  apiSender.send('extensions-started', {});
+  apiSender.send('extensions-started');
 
   await promise;
 });
@@ -276,7 +276,7 @@ test('waitForAContainerConnection delayed', async () => {
   await new Promise(resolve => setTimeout(resolve, 500));
 
   // now send the 'extension-started' event
-  apiSender.send('extensions-started', {});
+  apiSender.send('extensions-started');
 
   // and now the provider-change event (failing)
   apiSender.send('provider-change', {});
@@ -302,7 +302,7 @@ test('waitForAContainerConnection delayed twice', async () => {
   await new Promise(resolve => setTimeout(resolve, 500));
 
   // now send the 'extension-started' event
-  apiSender.send('extensions-started', {});
+  apiSender.send('extensions-started');
 
   // and now the provider-change event (failing)
   apiSender.send('provider-change', {});

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -326,7 +326,7 @@ export class ExtensionLoader implements IAsyncDisposable {
     });
     if (!extension.error) {
       await this.loadExtension(extension);
-      this.apiSender.send('extension-started', {});
+      this.apiSender.send('extension-started');
       this._onDidChange.fire();
     }
   }
@@ -1730,7 +1730,7 @@ export class ExtensionLoader implements IAsyncDisposable {
   async activateExtension(extension: AnalyzedExtension, extensionMain: any | undefined): Promise<void> {
     this.extensionState.set(extension.id, 'starting');
     this.extensionStateErrors.delete(extension.id);
-    this.apiSender.send('extension-starting', {});
+    this.apiSender.send('extension-starting');
 
     const subscriptions: containerDesktopAPI.Disposable[] = extension.subscriptions;
 

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -138,7 +138,7 @@ test('should install an image if labels are correct', async () => {
   expect(sendEnd).toHaveBeenCalledWith('Extension Successfully installed.');
 
   // extension started
-  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started', {});
+  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started');
 });
 
 test('should install an image (dd extensions) if labels are correct', async () => {
@@ -366,7 +366,7 @@ test('should install an image with extension pack', async () => {
   expect(sendEnd).toHaveBeenCalledWith('Extension Successfully installed.');
 
   // extension started
-  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started', {});
+  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started');
 
   // should have been called to load two extensions (current + extension pack)
   // expect to have 2 arguments in array
@@ -444,7 +444,7 @@ test('should install an image with transitive dependencies', async () => {
   expect(sendEnd).toHaveBeenCalledWith('Extension Successfully installed.');
 
   // extension started
-  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started', {});
+  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started');
 
   // should have been called to load two extensions (current + extension pack)
   // expect to have 2 arguments in array
@@ -517,7 +517,7 @@ test('should install an image with extension pack with an existing dependency al
   expect(sendEnd).toHaveBeenCalledWith('Extension Successfully installed.');
 
   // extension started
-  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started', {});
+  expect(apiSenderSendMock).toHaveBeenCalledWith('extension-started');
 
   // should have been called to load two extensions (current + extension pack)
   // expect to have 2 arguments in array

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -351,7 +351,7 @@ export class ExtensionInstaller {
     await this.extensionLoader.loadExtensions(analyzedExtensions);
 
     sendEnd('Extension Successfully installed.');
-    this.apiSender.send('extension-started', {});
+    this.apiSender.send('extension-started');
   }
 
   async init(): Promise<void> {

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -63,13 +63,13 @@ export class NavigationManager {
   init(): void {
     this.#disposables.push(
       this.commandRegistry.registerCommand('navigation.goBack', () => {
-        this.apiSender.send('navigation-go-back', '');
+        this.apiSender.send('navigation-go-back');
       }),
     );
 
     this.#disposables.push(
       this.commandRegistry.registerCommand('navigation.goForward', () => {
-        this.apiSender.send('navigation-go-forward', '');
+        this.apiSender.send('navigation-go-forward');
       }),
     );
 

--- a/packages/main/src/plugin/statusbar/statusbar-registry.ts
+++ b/packages/main/src/plugin/statusbar/statusbar-registry.ts
@@ -35,7 +35,7 @@ export class StatusBarRegistry implements IDisposable {
     const entry = this.entries.get(id);
     if (entry) {
       this.entries.delete(id);
-      this.apiSender.send(STATUS_BAR_UPDATED_EVENT_NAME, undefined);
+      this.apiSender.send(STATUS_BAR_UPDATED_EVENT_NAME);
     }
   }
 
@@ -89,7 +89,7 @@ export class StatusBarRegistry implements IDisposable {
       entryToUpdate.highlight = highlight;
     }
 
-    this.apiSender.send(STATUS_BAR_UPDATED_EVENT_NAME, undefined);
+    this.apiSender.send(STATUS_BAR_UPDATED_EVENT_NAME);
   }
 
   dispose(): void {

--- a/packages/main/src/plugin/tasks/task-manager.ts
+++ b/packages/main/src/plugin/tasks/task-manager.ts
@@ -52,7 +52,7 @@ export class TaskManager {
     this.setStatusBarEntry(false);
 
     this.commandRegistry.registerCommand('show-task-manager', () => {
-      this.apiSender.send('toggle-task-manager', '');
+      this.apiSender.send('toggle-task-manager');
       this.setStatusBarEntry(false);
     });
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -158,7 +158,7 @@ export const buildApiSender = (): ApiSenderType => {
   const eventEmitter = new EventEmitter();
 
   return {
-    send: (channel: string, data: unknown): void => {
+    send: (channel: string, data?: unknown): void => {
       eventEmitter.emit(channel, data);
     },
     receive: (channel: string, func: (...args: unknown[]) => void): IDisposable => {


### PR DESCRIPTION
### What does this PR do?
avoid to send empty string or empty object, can just send the event name

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15632

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
