### PR TITLE
chore(test): increase test timeout in order to not be flaky in cicd

### DIFF
--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -169,6 +169,8 @@ test.describe.serial('Image workflow verification', { tag: '@smoke' }, () => {
   });
 
   test('Build image with stage2 target from staged Containerfile', async ({ navigationBar }) => {
+    test.setTimeout(180_000);
+
     let imagesPage = await navigationBar.openImages();
     await playExpect(imagesPage.heading).toBeVisible();
 


### PR DESCRIPTION
### What does this PR do?
Increases the test runtime for an image build test which sometimes expires when running in cicd during network lag.

### What issues does this PR fix or reference?
