### PR TITLE
fix: support Docker API v1.52+ event format

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -3114,12 +3114,21 @@ declare module '@podman-desktop/api' {
     };
   }
 
-  interface ContainerJSONEvent {
-    type: string;
-    status: string;
-    id: string;
-    Type?: string;
-  }
+  // Podman uses top-level `status` and `id`, while Docker API v1.52+ uses `Action` and `Actor.ID`.
+  type ContainerJSONEvent = {
+    Type: string;
+  } & (
+    | {
+        status: string;
+        id: string;
+      }
+    | {
+        Action: string;
+        Actor: {
+          ID: string;
+        };
+      }
+  );
 
   /**
    * Authentication credentials, used when pushing an image to a registry

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3696,6 +3696,114 @@ test('check handleEvents is not calling the console.log for health_status event'
   expect(consoleLogSpy).not.toBeCalled();
 });
 
+test('check handleEvents with Docker API v1.52+ event shape', async () => {
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  // Docker API v1.52+ no longer sends top-level status/id.
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      Type: 'container',
+      Action: 'start',
+      Actor: {
+        ID: 'abc123',
+      },
+    }),
+  );
+
+  await vi.waitFor(() => expect(apiSender.send).toBeCalledWith('container-started-event', 'abc123'));
+});
+
+test('check handleEvents does not log Docker compound health_status actions', async () => {
+  const consoleLogSpy = vi.spyOn(console, 'log');
+  consoleLogSpy.mockClear();
+
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      Type: 'container',
+      Action: 'health_status: healthy',
+      Actor: {
+        ID: 'abc123',
+      },
+    }),
+  );
+
+  await vi.waitFor(() => expect(eventsMockCallback).toBeDefined());
+  expect(consoleLogSpy).not.toBeCalled();
+});
+
+test('check handleEvents prefers Podman-style fields over Docker-style fields', async () => {
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  // Both shapes present — Podman-style fields must win
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      status: 'stop',
+      id: 'podman-id',
+      Type: 'container',
+      Action: 'start',
+      Actor: { ID: 'docker-id' },
+    }),
+  );
+
+  await vi.waitFor(() => expect(apiSender.send).toBeCalledWith('container-stopped-event', 'podman-id'));
+  expect(apiSender.send).not.toBeCalledWith('container-started-event', 'docker-id');
+});
+
 test('check volume mounted is replicated when executing replicatePodmanContainer with named volume', async () => {
   const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -105,17 +105,10 @@ export interface InternalContainerProvider {
   libpodApi?: LibPod;
 }
 
-interface JSONEvent {
-  type: string;
-  status: string;
-  id: string;
-  Type?: string;
-}
-
 @injectable()
 export class ContainerProviderRegistry {
-  private readonly _onEvent = new Emitter<JSONEvent>();
-  readonly onEvent: Event<JSONEvent> = this._onEvent.event;
+  private readonly _onEvent = new Emitter<containerDesktopAPI.ContainerJSONEvent>();
+  readonly onEvent: Event<containerDesktopAPI.ContainerJSONEvent> = this._onEvent.event;
 
   private readonly _onApiAttached = new Emitter<string>();
   readonly onApiAttached: Event<string> = this._onApiAttached.event;
@@ -161,7 +154,7 @@ export class ContainerProviderRegistry {
     const startDate = performance.now();
     const eventEmitter = new EventEmitter();
 
-    eventEmitter.on('event', (jsonEvent: JSONEvent) => {
+    eventEmitter.on('event', (jsonEvent: containerDesktopAPI.ContainerJSONEvent) => {
       nbEvents++;
       // reconnected
       this.notify = true;

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -159,8 +159,10 @@ export class ContainerProviderRegistry {
       // reconnected
       this.notify = true;
 
-      const status = jsonEvent.status;
-      const id = jsonEvent.id;
+      // Podman uses top-level `status` and `id`, while Docker API v1.52+ uses `Action` and `Actor.ID`.
+      // Docker can emit compound Action values like "health_status: healthy"; keep only the base action.
+      const status = 'status' in jsonEvent ? jsonEvent.status : jsonEvent.Action?.split(':')[0]?.trim();
+      const id = 'id' in jsonEvent ? jsonEvent.id : jsonEvent.Actor?.ID;
 
       // do not log healthcheck(health_status) events
       // as it's too verbose/repeating a lot


### PR DESCRIPTION
## What issue does this PR fix?

Fixes #16405

Users running Docker Engine 29+ experience that containers in the container dashboard no longer update automatically. Docker Engine 29 updated the API version to v1.52, which changed the `/events` endpoint format: events no longer include top-level `status` and `id` fields, using `Action` and `Actor.ID` instead.

## Summary
- Replace `ContainerJSONEvent` interface with a discriminated union type supporting both Podman-style (`status`/`id`) and Docker v1.52+ (`Action`/`Actor.ID`) event shapes
- Make `Type` required (uppercase) — it has always been uppercase in the actual API response
- Remove internal `JSONEvent` interface in favor of the shared `ContainerJSONEvent` from the extension API
- Normalize event handling with nullish coalescing fallback; Docker compound actions like `health_status: healthy` are split to extract the base action

Depends on #16387 and #16403

## Changes
- **`packages/extension-api/src/extension-api.d.ts`**: Replace `ContainerJSONEvent` interface with discriminated union type
- **`packages/main/src/plugin/container-registry.ts`**: Remove internal `JSONEvent`, use `ContainerJSONEvent` from extension API, derive `status` and `id` with fallback to Docker-style fields
- **`packages/main/src/plugin/container-registry.spec.ts`**: Add 3 regression tests for Docker v1.52+ event shape, compound `health_status` actions, and Podman-style field precedence

## Validation
- All 173 tests pass (170 existing + 3 new)