### PR TITLE
chore(main/k8s): disable Kubernetes manager with feature kubernetes-contexts-manage

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -2658,7 +2658,10 @@ test('expect readNamespacedJob to return the job', async () => {
   expect(job?.metadata?.name).toEqual('foobar');
 });
 
-test('the internal monitoring is stopped when a kubernetes-dashboard feature is registered', async () => {
+test.each([
+  'kubernetes-dashboard',
+  'kubernetes-contexts-manager',
+])('the internal monitoring is stopped when a %s feature is registered', async (feature: string) => {
   const client = createTestClient('default');
   expect(featureRegistry.onFeaturesUpdated).not.toHaveBeenCalled();
 
@@ -2668,15 +2671,18 @@ test('the internal monitoring is stopped when a kubernetes-dashboard feature is 
   expect(callback).toBeDefined();
 
   vi.spyOn(client, 'KubernetesManagerStop').mockResolvedValue();
-  await callback!(['kubernetes-dashboard', 'other-feature']);
+  await callback!([feature, 'other-feature']);
   expect(client.KubernetesManagerStop).toHaveBeenCalledOnce();
 
   // should prevent stopping it twice before starting it
-  await callback!(['kubernetes-dashboard', 'other-feature']);
+  await callback!([feature, 'other-feature']);
   expect(client.KubernetesManagerStop).toHaveBeenCalledOnce();
 });
 
-test('the internal monitoring is started when a kubernetes-dashboard feature is unregistered, only once', async () => {
+test.each([
+  'kubernetes-dashboard',
+  'kubernetes-contexts-manager',
+])('the internal monitoring is started when a %s feature is unregistered, only once', async (feature: string) => {
   const client = createTestClient('default');
   expect(featureRegistry.onFeaturesUpdated).not.toHaveBeenCalled();
 
@@ -2687,7 +2693,7 @@ test('the internal monitoring is started when a kubernetes-dashboard feature is 
 
   // first stop the monitoring
   vi.spyOn(client, 'KubernetesManagerStop').mockResolvedValue();
-  await callback!(['other-feature', 'kubernetes-dashboard']);
+  await callback!(['other-feature', feature]);
   expect(client.KubernetesManagerStop).toHaveBeenCalledOnce();
 
   // then start the monitoring

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -304,8 +304,9 @@ export class KubernetesClient {
 
     this.#managerStarted = true;
     this.featureRegistry.onFeaturesUpdated(async features => {
-      const kubeDashboardRegistered = features.includes('kubernetes-dashboard');
-      if (kubeDashboardRegistered) {
+      const shouldDisableInternalManager =
+        features.includes('kubernetes-dashboard') || features.includes('kubernetes-contexts-manager');
+      if (shouldDisableInternalManager) {
         if (this.#managerStarted) {
           await this.KubernetesManagerStop();
           this.#managerStarted = false;


### PR DESCRIPTION
### What does this PR do?

This PR disables the Kubernetes manager when the feature "kubernetes-contexts-manager" is declared by an extension.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16389

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
