### PR TITLE
feat(main): send features through apiSender event

### DIFF
--- a/packages/main/src/plugin/feature-registry.spec.ts
+++ b/packages/main/src/plugin/feature-registry.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { FeatureRegistry } from '/@/plugin/feature-registry.js';
@@ -25,6 +26,10 @@ class TestFeatureRegistry extends FeatureRegistry {
     return super.listFeatures();
   }
 }
+const apiSenderMock: ApiSenderType = {
+  send: vi.fn(),
+  receive: vi.fn(),
+};
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -34,7 +39,7 @@ describe('FeatureRegistry', () => {
   let featureRegistry: TestFeatureRegistry;
 
   beforeEach(() => {
-    featureRegistry = new TestFeatureRegistry();
+    featureRegistry = new TestFeatureRegistry(apiSenderMock);
   });
 
   test('should list registered features', () => {
@@ -46,6 +51,13 @@ describe('FeatureRegistry', () => {
     expect(featureRegistry.listFeatures()).toEqual(['feature3', 'feature4']);
     dispose2.dispose();
     expect(featureRegistry.listFeatures()).toEqual([]);
+  });
+
+  test('init sends apiSender events on feature changes', () => {
+    featureRegistry.init();
+
+    featureRegistry.registerFeatures('ext1', ['feat1']);
+    expect(apiSenderMock.send).toHaveBeenCalledWith('feature-registry:features-updated', ['feat1']);
   });
 
   test('handler passed to onFeaturesUpdated is called when features are registered and unregistered', () => {

--- a/packages/main/src/plugin/feature-registry.ts
+++ b/packages/main/src/plugin/feature-registry.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { Event } from '@podman-desktop/core-api';
-import { injectable } from 'inversify';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { inject, injectable } from 'inversify';
 
 import { Emitter } from '/@/plugin/events/emitter.js';
 
@@ -29,8 +30,17 @@ export class FeatureRegistry {
   private readonly _onFeaturesUpdated = new Emitter<string[]>();
   readonly onFeaturesUpdated: Event<string[]> = this._onFeaturesUpdated.event;
 
-  constructor() {
+  constructor(
+    @inject(ApiSenderType)
+    private readonly apiSender: ApiSenderType,
+  ) {
     this.extFeaturesContribution = new Map();
+  }
+
+  init(): void {
+    this.onFeaturesUpdated(features => {
+      this.apiSender.send('feature-registry:features-updated', features);
+    });
   }
 
   registerFeatures(extensionId: string, features: string[]): Disposable {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -577,6 +577,9 @@ export class PluginSystem {
     container.bind<CustomPickRegistry>(CustomPickRegistry).toSelf().inSingletonScope();
     container.bind<OnboardingRegistry>(OnboardingRegistry).toSelf().inSingletonScope();
     container.bind<FeatureRegistry>(FeatureRegistry).toSelf().inSingletonScope();
+    const featureRegistry = container.get<FeatureRegistry>(FeatureRegistry);
+    featureRegistry.init();
+
     container.bind<KubernetesClient>(KubernetesClient).toSelf().inSingletonScope();
     const kubernetesClient = container.get<KubernetesClient>(KubernetesClient);
     await kubernetesClient.init();


### PR DESCRIPTION
### What does this PR do?

This PR exposes the registered features through an `apiSender` event to be consumed by the renderer in the next PR. It is required to hide the Settings menu for Kubernetes during the migration to an extension.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/16361

Fixes https://github.com/podman-desktop/podman-desktop/issues/16396

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
