### PR TITLE
feat(main): expose IPC to list registered features

### DIFF
--- a/packages/main/src/plugin/feature-registry.spec.ts
+++ b/packages/main/src/plugin/feature-registry.spec.ts
@@ -35,11 +35,13 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+const ipcHandleMock = vi.fn();
+
 describe('FeatureRegistry', () => {
   let featureRegistry: TestFeatureRegistry;
 
   beforeEach(() => {
-    featureRegistry = new TestFeatureRegistry(apiSenderMock);
+    featureRegistry = new TestFeatureRegistry(ipcHandleMock, apiSenderMock);
   });
 
   test('should list registered features', () => {
@@ -53,8 +55,10 @@ describe('FeatureRegistry', () => {
     expect(featureRegistry.listFeatures()).toEqual([]);
   });
 
-  test('init sends apiSender events on feature changes', () => {
+  test('init registers ipc handler and sends apiSender events on feature changes', () => {
     featureRegistry.init();
+
+    expect(ipcHandleMock).toHaveBeenCalledWith('feature-registry:getRegisteredFeatures', expect.any(Function));
 
     featureRegistry.registerFeatures('ext1', ['feat1']);
     expect(apiSenderMock.send).toHaveBeenCalledWith('feature-registry:features-updated', ['feat1']);

--- a/packages/main/src/plugin/feature-registry.ts
+++ b/packages/main/src/plugin/feature-registry.ts
@@ -19,6 +19,7 @@ import { Event } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
 
+import { IPCHandle } from '/@/plugin/api.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
 
 import { Disposable } from './types/disposable.js';
@@ -31,6 +32,8 @@ export class FeatureRegistry {
   readonly onFeaturesUpdated: Event<string[]> = this._onFeaturesUpdated.event;
 
   constructor(
+    @inject(IPCHandle)
+    private readonly ipcHandle: IPCHandle,
     @inject(ApiSenderType)
     private readonly apiSender: ApiSenderType,
   ) {
@@ -38,6 +41,10 @@ export class FeatureRegistry {
   }
 
   init(): void {
+    this.ipcHandle('feature-registry:getRegisteredFeatures', async (): Promise<string[]> => {
+      return this.listFeatures();
+    });
+
     this.onFeaturesUpdated(features => {
       this.apiSender.send('feature-registry:features-updated', features);
     });

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2659,6 +2659,10 @@ export function initExposure(): void {
     return ipcInvoke('help-menu:getItems');
   });
 
+  contextBridge.exposeInMainWorld('getRegisteredFeatures', async (): Promise<string[]> => {
+    return ipcInvoke('feature-registry:getRegisteredFeatures');
+  });
+
   contextBridge.exposeInMainWorld('contextCollectAllValues', async (): Promise<Record<string, unknown>> => {
     return ipcInvoke('context:collectAllValues');
   });


### PR DESCRIPTION
### What does this PR do?

This PR creates a new IPC to list the registered features.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16402

Requires a rebase after https://github.com/podman-desktop/podman-desktop/pull/16397 is merged

Required for https://github.com/podman-desktop/podman-desktop/issues/16361

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Try to install the Kubernetes Dashboard extension (ghcr.io/podman-desktop/podman-desktop-extension-kubernetes-dashboard:latest)
In the Chrome debugger, you can call `await getRegisteredFeatures()`
<img width="238" height="54" alt="Screenshot 2026-03-03 at 10 25 51" src="https://github.com/user-attachments/assets/5423f2cd-d648-41ad-96cd-798e89fb6f81" />

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
