### PR TITLE
fix(container-registry): handle provider failures gracefully in podmanListImages

### DIFF
--- a/packages/api/src/container-registry-settings.ts
+++ b/packages/api/src/container-registry-settings.ts
@@ -16,9 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-export const DEFAULT_PROVIDER_TIMEOUT = 30;
-
 export enum ContainerRegistrySettings {
-  SectionName = 'container',
+  SectionName = 'container-registry',
   ProviderTimeout = 'providerTimeout',
 }

--- a/packages/api/src/container-registry-settings.ts
+++ b/packages/api/src/container-registry-settings.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export const DEFAULT_PROVIDER_TIMEOUT = 30;
+
+export enum ContainerRegistrySettings {
+  SectionName = 'container',
+  ProviderTimeout = 'providerTimeout',
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -24,6 +24,7 @@ export * from './color-info.js';
 export * from './command-info.js';
 export * from './container-info.js';
 export * from './container-inspect-info.js';
+export * from './container-registry-settings.js';
 export * from './container-stats-info.js';
 export * from './containerfile-info.js';
 export * from './contribution-info.js';

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6336,11 +6336,11 @@ describe('ContainerRegistrySettings', () => {
 
     expect(registerConfigurationsMock).toHaveBeenCalledOnce();
     const registeredConfig = registerConfigurationsMock.mock.calls[0]?.[0]?.[0] as IConfigurationNode | undefined;
-    expect(registeredConfig?.id).toBe('preferences.container');
-    expect(registeredConfig?.properties?.['container.providerTimeout']).toBeDefined();
-    expect(registeredConfig?.properties?.['container.providerTimeout']?.type).toBe('number');
-    expect(registeredConfig?.properties?.['container.providerTimeout']?.default).toBe(30);
-    expect(registeredConfig?.properties?.['container.providerTimeout']?.minimum).toBe(5);
-    expect(registeredConfig?.properties?.['container.providerTimeout']?.maximum).toBe(120);
+    expect(registeredConfig?.id).toBe('preferences.container-registry');
+    expect(registeredConfig?.properties?.['container-registry.providerTimeout']).toBeDefined();
+    expect(registeredConfig?.properties?.['container-registry.providerTimeout']?.type).toBe('number');
+    expect(registeredConfig?.properties?.['container-registry.providerTimeout']?.default).toBe(30);
+    expect(registeredConfig?.properties?.['container-registry.providerTimeout']?.minimum).toBe(5);
+    expect(registeredConfig?.properties?.['container-registry.providerTimeout']?.maximum).toBe(120);
   });
 });

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -32,6 +32,7 @@ import type {
   ProviderContainerConnectionInfo,
 } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IConfigurationNode } from '@podman-desktop/core-api/configuration';
 import type { ContainerCreateOptions as PodmanContainerCreateOptions } from '@podman-desktop/core-api/libpod';
 import Dockerode from 'dockerode';
 import moment from 'moment';
@@ -6299,5 +6300,47 @@ describe('getNetworkDrivers', () => {
     await expect(containerRegistry.getNetworkDrivers(nonexistentConnectionInfo)).rejects.toThrow(
       'no running provider for the matching container',
     );
+  });
+});
+
+describe('ContainerRegistrySettings', () => {
+  test('init should register provider timeout configuration', () => {
+    const registerConfigurationsMock = vi.fn();
+    const configRegistry = {
+      registerConfigurations: registerConfigurationsMock,
+    } as unknown as ConfigurationRegistry;
+
+    const proxy: Proxy = {
+      onDidStateChange: vi.fn(),
+      onDidUpdateProxy: vi.fn(),
+      isEnabled: vi.fn(),
+    } as unknown as Proxy;
+
+    const imageRegistry = new ImageRegistry(
+      {} as ApiSenderType,
+      { track: vi.fn() } as unknown as Telemetry,
+      {} as Certificates,
+      proxy,
+    );
+
+    const apiSender: ApiSenderType = {
+      send: vi.fn(),
+      receive: vi.fn(),
+    };
+
+    const containerProviderRegistry = new TestContainerProviderRegistry(apiSender, configRegistry, imageRegistry, {
+      track: vi.fn(),
+    } as unknown as Telemetry);
+
+    containerProviderRegistry.init();
+
+    expect(registerConfigurationsMock).toHaveBeenCalledOnce();
+    const registeredConfig = registerConfigurationsMock.mock.calls[0]?.[0]?.[0] as IConfigurationNode | undefined;
+    expect(registeredConfig?.id).toBe('preferences.container');
+    expect(registeredConfig?.properties?.['container.providerTimeout']).toBeDefined();
+    expect(registeredConfig?.properties?.['container.providerTimeout']?.type).toBe('number');
+    expect(registeredConfig?.properties?.['container.providerTimeout']?.default).toBe(30);
+    expect(registeredConfig?.properties?.['container.providerTimeout']?.minimum).toBe(5);
+    expect(registeredConfig?.properties?.['container.providerTimeout']?.maximum).toBe(120);
   });
 });

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4778,6 +4778,68 @@ test('expect to get get zero images if podman provider has neither libpod API no
   expect(images).toHaveLength(0);
 });
 
+test('expect podmanListImages to return images from working providers even if one fails', async () => {
+  const consoleErrorSpy = vi.spyOn(console, 'error');
+
+  const workingProviderImages = [
+    {
+      Id: 'workingImageId',
+      Digest: 'fooDigest',
+    },
+  ];
+
+  // Setup working provider
+  server = setupServer(
+    http.get('http://localhost/v4.2.0/libpod/images/json', () => HttpResponse.json(workingProviderImages)),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const workingApi = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+  // Add working provider
+  containerRegistry.addInternalProvider('podman-working', {
+    name: 'podman-working',
+    id: 'podman-working',
+    api: workingApi,
+    libpodApi: workingApi,
+    connection: {
+      type: 'podman',
+    },
+  } as unknown as InternalContainerProvider);
+
+  // Add failing provider
+  const failingError = new Error('Connection failed');
+  const failingApi = {
+    podmanListImages: vi.fn().mockRejectedValue(failingError),
+    listImages: vi.fn().mockRejectedValue(failingError),
+  };
+
+  containerRegistry.addInternalProvider('podman-failing', {
+    name: 'podman-failing',
+    id: 'podman-failing',
+    api: failingApi,
+    libpodApi: failingApi,
+    connection: {
+      type: 'podman',
+    },
+  } as unknown as InternalContainerProvider);
+
+  const images = await containerRegistry.podmanListImages();
+
+  // Should return images from working provider despite the error
+  expect(images).toBeDefined();
+  expect(images).toHaveLength(1);
+  expect(images[0]?.Id).toBe('sha256:workingImageId');
+  expect(images[0]?.engineId).toBe('podman-working');
+  expect(images[0]?.engineName).toBe('podman-working');
+
+  // Should log error for failed provider with provider context
+  expect(consoleErrorSpy).toHaveBeenCalledWith(
+    'Error listing images from provider podman-failing (podman-failing):',
+    failingError,
+  );
+});
+
 test('listInfos without provider', async () => {
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -666,7 +666,7 @@ export class ContainerProviderRegistry {
     // Get timeout from configuration
     const timeoutSeconds = this.configurationRegistry
       .getConfiguration(ContainerRegistrySettings.SectionName)
-      .get<number>(ContainerRegistrySettings.ProviderTimeout, DEFAULT_PROVIDER_TIMEOUT);
+      .get<number>(ContainerRegistrySettings.ProviderTimeout);
     const PROVIDER_TIMEOUT_MS = timeoutSeconds * 1000;
 
     // Helper function to add timeout to provider operations

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -642,6 +642,30 @@ export class ContainerProviderRegistry {
   // Podman list images will prefer to use libpod API of the provider
   // before falling back to using the regular API
   async podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]> {
+    // Timeout for provider image listing (in milliseconds)
+    const PROVIDER_TIMEOUT_MS = 30_000; // 30 seconds
+
+    // Helper function to add timeout to provider operations
+    function withTimeout<T>(
+      promise: Promise<T>,
+      timeoutMs: number,
+      providerName: string,
+      providerId: string,
+    ): Promise<T> {
+      return Promise.race([
+        promise,
+        new Promise<T>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error(`Provider ${providerName} (${providerId}): listing images timed out after ${timeoutMs}ms`),
+              ),
+            timeoutMs,
+          ),
+        ),
+      ]);
+    }
+
     // This gets all the available providers if no provider has been specified
     let providers: InternalContainerProvider[];
     if (options?.provider === undefined) {
@@ -661,12 +685,22 @@ export class ContainerProviderRegistry {
 
           // If libpod API is available AND the configuration is set to use libpodApi, use podmanListImages API call.
           if (provider.libpodApi && this.useLibpodApiForImageList()) {
-            fetchedImages = await provider.libpodApi.podmanListImages({
-              all: options?.all,
-              filters: options?.filters,
-            });
+            fetchedImages = await withTimeout(
+              provider.libpodApi.podmanListImages({
+                all: options?.all,
+                filters: options?.filters,
+              }),
+              PROVIDER_TIMEOUT_MS,
+              provider.name,
+              provider.id,
+            );
           } else if (provider.api) {
-            fetchedImages = await provider.api.listImages({ all: false });
+            fetchedImages = await withTimeout(
+              provider.api.listImages({ all: false }),
+              PROVIDER_TIMEOUT_MS,
+              provider.name,
+              provider.id,
+            );
           } else {
             console.log('Engine does not have an API or a libpod API, returning empty array', provider.name);
             return fetchedImages;

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -61,7 +61,7 @@ import type {
   VolumeInspectInfo,
   VolumeListInfo,
 } from '@podman-desktop/core-api';
-import { ContainerRegistrySettings, DEFAULT_PROVIDER_TIMEOUT } from '@podman-desktop/core-api';
+import { ContainerRegistrySettings } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { IConfigurationNode } from '@podman-desktop/core-api/configuration';
 import type {
@@ -97,6 +97,8 @@ import { Disposable } from './types/disposable.js';
 import { guessIsManifest } from './util/manifest.js';
 
 const tar: { pack: (dir: string, opts?: PackOptions) => NodeJS.ReadableStream } = require('tar-fs');
+
+const DEFAULT_PROVIDER_TIMEOUT = 30;
 
 export interface InternalContainerProvider {
   name: string;
@@ -146,8 +148,8 @@ export class ContainerProviderRegistry {
 
   init(): void {
     const providerTimeoutConfiguration: IConfigurationNode = {
-      id: 'preferences.container',
-      title: 'Container',
+      id: 'preferences.container-registry',
+      title: 'Container registries',
       type: 'object',
       properties: {
         [`${ContainerRegistrySettings.SectionName}.${ContainerRegistrySettings.ProviderTimeout}`]: {
@@ -666,8 +668,8 @@ export class ContainerProviderRegistry {
     // Get timeout from configuration
     const timeoutSeconds = this.configurationRegistry
       .getConfiguration(ContainerRegistrySettings.SectionName)
-      .get<number>(ContainerRegistrySettings.ProviderTimeout);
-    const PROVIDER_TIMEOUT_MS = timeoutSeconds * 1000;
+      .get<number>(ContainerRegistrySettings.ProviderTimeout, DEFAULT_PROVIDER_TIMEOUT);
+    const providerTimeoutMs = timeoutSeconds * 1000;
 
     // Helper function to add timeout to provider operations
     function withTimeout<T>(
@@ -714,14 +716,14 @@ export class ContainerProviderRegistry {
                 all: options?.all,
                 filters: options?.filters,
               }),
-              PROVIDER_TIMEOUT_MS,
+              providerTimeoutMs,
               provider.name,
               provider.id,
             );
           } else if (provider.api) {
             fetchedImages = await withTimeout(
               provider.api.listImages({ all: false }),
-              PROVIDER_TIMEOUT_MS,
+              providerTimeoutMs,
               provider.name,
               provider.id,
             );

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -652,57 +652,62 @@ export class ContainerProviderRegistry {
 
     const images = await Promise.all(
       providers.map(async provider => {
-        // Initialize an empty array for the case where neither API is available
-        // ignore any warning as we are adding engineId and engineName to the image
-        // and as one of the API uses Dockerode, the other ImageInfo
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let fetchedImages: any[] = [];
+        try {
+          // Initialize an empty array for the case where neither API is available
+          // ignore any warning as we are adding engineId and engineName to the image
+          // and as one of the API uses Dockerode, the other ImageInfo
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let fetchedImages: any[] = [];
 
-        // If libpod API is available AND the configuration is set to use libpodApi, use podmanListImages API call.
-        if (provider.libpodApi && this.useLibpodApiForImageList()) {
-          fetchedImages = await provider.libpodApi.podmanListImages({
-            all: options?.all,
-            filters: options?.filters,
-          });
-        } else if (provider.api) {
-          fetchedImages = await provider.api.listImages({ all: false });
-        } else {
-          console.log('Engine does not have an API or a libpod API, returning empty array', provider.name);
-          return fetchedImages;
-        }
+          // If libpod API is available AND the configuration is set to use libpodApi, use podmanListImages API call.
+          if (provider.libpodApi && this.useLibpodApiForImageList()) {
+            fetchedImages = await provider.libpodApi.podmanListImages({
+              all: options?.all,
+              filters: options?.filters,
+            });
+          } else if (provider.api) {
+            fetchedImages = await provider.api.listImages({ all: false });
+          } else {
+            console.log('Engine does not have an API or a libpod API, returning empty array', provider.name);
+            return fetchedImages;
+          }
 
-        return Promise.all(
-          Array.from(fetchedImages).map(async image => {
-            // If image.isManifestList is NOT undefined (5.0.2+), we can use it to determine if the image is a manifest
-            // rather than guessing
-            const isManifest = image.isManifestList ?? guessIsManifest(image, provider.connection.type);
+          return Promise.all(
+            Array.from(fetchedImages).map(async image => {
+              // If image.isManifestList is NOT undefined (5.0.2+), we can use it to determine if the image is a manifest
+              // rather than guessing
+              const isManifest = image.isManifestList ?? guessIsManifest(image, provider.connection.type);
 
-            // Return the base image with the engineName and engineId as well as our isManifest parameter.
-            const baseImage = {
-              ...image,
-              engineName: provider.name,
-              engineId: provider.id,
-              isManifest,
-              Id: image.Digest ? `sha256:${image.Id}` : image.Id,
-              Digest: image.Digest ?? `sha256:${image.Id}`,
-            };
+              // Return the base image with the engineName and engineId as well as our isManifest parameter.
+              const baseImage = {
+                ...image,
+                engineName: provider.name,
+                engineId: provider.id,
+                isManifest,
+                Id: image.Digest ? `sha256:${image.Id}` : image.Id,
+                Digest: image.Digest ?? `sha256:${image.Id}`,
+              };
 
-            // If the image is a manifest, inspect the manifest to get the digests of the images part of the manifest
-            // however, we do not **ever** want this to block the UI / operation, so if this fails, output to console and continue
-            if (baseImage.isManifest && provider.libpodApi) {
-              try {
-                const manifestInspectInfo = await provider.libpodApi.podmanInspectManifest(image.Id);
-                if (manifestInspectInfo?.manifests) {
-                  baseImage.manifests = manifestInspectInfo.manifests;
+              // If the image is a manifest, inspect the manifest to get the digests of the images part of the manifest
+              // however, we do not **ever** want this to block the UI / operation, so if this fails, output to console and continue
+              if (baseImage.isManifest && provider.libpodApi) {
+                try {
+                  const manifestInspectInfo = await provider.libpodApi.podmanInspectManifest(image.Id);
+                  if (manifestInspectInfo?.manifests) {
+                    baseImage.manifests = manifestInspectInfo.manifests;
+                  }
+                } catch (error) {
+                  console.error('Error while inspecting manifest', error);
                 }
-              } catch (error) {
-                console.error('Error while inspecting manifest', error);
               }
-            }
 
-            return baseImage;
-          }),
-        );
+              return baseImage;
+            }),
+          );
+        } catch (error) {
+          console.error(`Error listing images from provider ${provider.name} (${provider.id}):`, error);
+          return [];
+        }
       }),
     );
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -61,7 +61,9 @@ import type {
   VolumeInspectInfo,
   VolumeListInfo,
 } from '@podman-desktop/core-api';
+import { ContainerRegistrySettings, DEFAULT_PROVIDER_TIMEOUT } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import type { IConfigurationNode } from '@podman-desktop/core-api/configuration';
 import type {
   ContainerCreateMountOption,
   ContainerCreateNetNSOption,
@@ -140,6 +142,25 @@ export class ContainerProviderRegistry {
 
     // setup listeners
     this.setupListeners();
+  }
+
+  init(): void {
+    const providerTimeoutConfiguration: IConfigurationNode = {
+      id: 'preferences.container',
+      title: 'Container',
+      type: 'object',
+      properties: {
+        [`${ContainerRegistrySettings.SectionName}.${ContainerRegistrySettings.ProviderTimeout}`]: {
+          description: 'Timeout in seconds for container provider image listing operations.',
+          type: 'number',
+          default: DEFAULT_PROVIDER_TIMEOUT,
+          minimum: 5,
+          maximum: 120,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([providerTimeoutConfiguration]);
   }
 
   protected containerProviders: Map<string, containerDesktopAPI.ContainerProviderConnection> = new Map();
@@ -642,8 +663,11 @@ export class ContainerProviderRegistry {
   // Podman list images will prefer to use libpod API of the provider
   // before falling back to using the regular API
   async podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]> {
-    // Timeout for provider image listing (in milliseconds)
-    const PROVIDER_TIMEOUT_MS = 30_000; // 30 seconds
+    // Get timeout from configuration
+    const timeoutSeconds = this.configurationRegistry
+      .getConfiguration(ContainerRegistrySettings.SectionName)
+      .get<number>(ContainerRegistrySettings.ProviderTimeout, DEFAULT_PROVIDER_TIMEOUT);
+    const PROVIDER_TIMEOUT_MS = timeoutSeconds * 1000;
 
     // Helper function to add timeout to provider operations
     function withTimeout<T>(

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -617,6 +617,7 @@ export class PluginSystem {
     Object.freeze(notifications);
     const kubeGeneratorRegistry = container.get<KubeGeneratorRegistry>(KubeGeneratorRegistry);
     const containerProviderRegistry = container.get<ContainerProviderRegistry>(ContainerProviderRegistry);
+    containerProviderRegistry.init();
     kubeGeneratorRegistry.registerDefaultKubeGenerator({
       name: 'PodmanKube',
       types: ['Compose', 'Container', 'Pod'],


### PR DESCRIPTION
### What does this PR do?
When one provider connection fails, podmanListImages now continues to return images from working providers instead of failing.

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes #16327 

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### How to test this PR?

- Added unit test: `expect podmanListImages to return images from working providers even if one fails.`

Tested locally with an SSH provider that was unreachable (simulated by blocking port 22 with iptables and killing the SSH tunnel):
 
```bash                                                                                                                        
[DEBUG] Processing provider: Podman (podman.mylocalSSH)
[DEBUG] Error listing images from provider Podman (podman.mylocalSSH): Error: connect ECONNREFUSED /tmp/podman-remote-mylocalSSH.sock
[DEBUG] Total images returned: 4
```
Images from the 3 working providers are displayed correctly.

- [x] Tests are covering the bug fix or the new feature