### PR TITLE
feat(renderer): add Cancel button in PullImage

### DIFF
--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -423,11 +423,46 @@ test('Pull image creates a task', async () => {
   expect(registeredCallback).not.equal(defaultCallback);
   registeredCallback({ id: 'pullEvent1' } as PullEvent);
   expect(createTaskSpy).toHaveBeenCalledOnce();
-  expect(createTaskSpy).toHaveBeenCalledWith({ title: `Pulling registry.com/repo/image:latest`, action: undefined });
+  expect(createTaskSpy).toHaveBeenCalledWith({
+    title: 'Pulling registry.com/repo/image:latest',
+    cancellable: false,
+    cancellationTokenSourceId: undefined,
+  });
   expect(webContents.send).toBeCalledWith('container-provider-registry:pullImage-onData', 1, {
     id: 'pullEvent1',
   } as PullEvent);
   expect(createTaskSpy.mock.results[0]?.value.status).toBe('success');
+});
+
+test('Pull image creates a cancellable task and marks task as canceled on cancellation', async () => {
+  const createTaskSpy = vi.spyOn(TaskManager.prototype, 'createTask');
+  const createTokenHandler: () => Promise<number | { result: number }> = handlers.get('cancellableTokenSource:create');
+  const cancelTokenHandler: (_event: unknown, id: number) => Promise<void> = handlers.get('cancellableToken:cancel');
+  const handle = handlers.get('container-provider-registry:pullImage');
+  expect(handle).not.equal(undefined);
+
+  const tokenCreationResult = await createTokenHandler();
+  const tokenId = typeof tokenCreationResult === 'number' ? tokenCreationResult : tokenCreationResult.result;
+  const pullImageSpy = vi
+    .spyOn(ContainerProviderRegistry.prototype, 'pullImage')
+    .mockImplementation(async (_engine, _imageName, _callback, _platform, abortController) => {
+      await Promise.resolve();
+      abortController?.abort();
+      throw new Error('aborted');
+    });
+
+  await cancelTokenHandler(undefined, tokenId);
+  const handleReturn = await handle(undefined, 'podman', 'registry.com/repo/image:latest', 1, undefined, tokenId);
+  expect(handleReturn.error).toBeInstanceOf(Error);
+  expect(handleReturn.error.message).toBe('aborted');
+
+  expect(pullImageSpy).toHaveBeenCalled();
+  expect(createTaskSpy).toHaveBeenCalledWith({
+    title: 'Pulling registry.com/repo/image:latest',
+    cancellable: true,
+    cancellationTokenSourceId: tokenId,
+  });
+  expect(createTaskSpy.mock.results[0]?.value.status).toBe('canceled');
 });
 
 test('ipcMain.handle returns caught error as is if it is instance of Error', async () => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1295,16 +1295,40 @@ export class PluginSystem {
         imageName: string,
         callbackId: number,
         platform?: string,
+        cancellableTokenId?: number,
       ): Promise<void> => {
-        return commandRegistry.executeCommand(
-          'pullImage',
-          providerContainerConnectionInfo,
-          imageName,
-          (event: PullEvent) => {
-            this.getWebContentsSender().send('container-provider-registry:pullImage-onData', callbackId, event);
-          },
-          platform,
+        const abortController = this.createAbortControllerOnCancellationToken(
+          cancellationTokenRegistry,
+          cancellableTokenId,
         );
+        const task = taskManager.createTask({
+          title: `Pulling ${imageName}`,
+          cancellable: cancellableTokenId !== undefined,
+          cancellationTokenSourceId: cancellableTokenId,
+        });
+
+        try {
+          await containerProviderRegistry.pullImage(
+            providerContainerConnectionInfo,
+            imageName,
+            (event: PullEvent) => {
+              this.getWebContentsSender().send('container-provider-registry:pullImage-onData', callbackId, event);
+            },
+            platform,
+            abortController,
+          );
+          task.status = 'success';
+        } catch (error: unknown) {
+          const cancellationToken = cancellableTokenId
+            ? cancellationTokenRegistry.getCancellationTokenSource(cancellableTokenId)?.token
+            : undefined;
+          if (cancellationToken?.isCancellationRequested) {
+            task.status = 'canceled';
+          } else {
+            task.error = `Something went wrong while trying to pull ${imageName}: ${String(error)};`;
+          }
+          throw error;
+        }
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -477,6 +477,7 @@ export function initExposure(): void {
       imageName: string,
       callback: (event: PullEvent) => void,
       platform?: string,
+      cancellableTokenId?: number,
     ): Promise<void> => {
       onDataCallbacksPullImageId++;
       onDataCallbacksPullImage.set(onDataCallbacksPullImageId, callback);
@@ -486,6 +487,7 @@ export function initExposure(): void {
         imageName,
         onDataCallbacksPullImageId,
         platform,
+        cancellableTokenId,
       );
     },
   );

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -82,6 +82,8 @@ beforeEach(() => {
   });
   console.error = vi.fn();
   vi.mocked(window.resolveShortnameImage).mockResolvedValue(['docker.io/test1']);
+  vi.mocked(window.getCancellableTokenSource).mockResolvedValue(1234);
+  vi.mocked(window.cancelToken).mockResolvedValue(undefined);
   vi.mocked(window.pullImage).mockResolvedValue(undefined);
   vi.mocked(window.listImageTagsInRegistry).mockResolvedValue(['latest', 'other']);
   vi.mocked(window.listImages).mockResolvedValue([]);
@@ -245,6 +247,47 @@ describe('PullImage', () => {
     const proposal = screen.getByRole('button', { name: 'Install myExtension.id Extension' });
     expect(proposal).toBeInTheDocument();
     expect(proposal).toBeEnabled();
+  });
+
+  test('Expect cancel to request cancellation while pull is in progress', async () => {
+    const pendingPull = Promise.withResolvers<void>();
+    vi.mocked(window.getCancellableTokenSource).mockResolvedValue(9876);
+    vi.mocked(window.pullImage).mockReturnValue(pendingPull.promise);
+
+    render(PullImage, { imageToPull: 'some-valid-image' });
+
+    const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
+    await userEvent.click(pullImagebutton);
+
+    expect(window.pullImage).toHaveBeenCalledWith(
+      CONTAINER_CONNECTION_MOCK,
+      'some-valid-image',
+      expect.any(Function),
+      undefined,
+      9876,
+    );
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancelButton);
+    expect(window.cancelToken).toHaveBeenCalledWith(9876);
+
+    pendingPull.reject(new Error('The operation was aborted'));
+    await vi.waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Pull image' })).toBeInTheDocument();
+    });
+  });
+
+  test('Expect cancellation errors are not displayed as pull errors', async () => {
+    vi.mocked(window.pullImage).mockRejectedValueOnce(new Error('Request aborted'));
+    render(PullImage, { imageToPull: 'some-valid-image' });
+
+    const pullImagebutton = screen.getByRole('button', { name: 'Pull image' });
+    await userEvent.click(pullImagebutton);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Pull image' })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('alert', { name: 'Error Message Content' })).toBeNull();
   });
 });
 
@@ -550,7 +593,13 @@ describe('container connections', () => {
     pullImagebutton.click();
 
     await vi.waitFor(() => {
-      expect(window.pullImage).toHaveBeenCalledWith(connectionTarget, 'test1', expect.any(Function));
+      expect(window.pullImage).toHaveBeenCalledWith(
+        connectionTarget,
+        'test1',
+        expect.any(Function),
+        undefined,
+        expect.any(Number),
+      );
     });
   });
 });

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -459,10 +459,10 @@ async function searchFunction(value: string): Promise<void> {
         {#if !pullFinished}
           <Button
             icon={faArrowCircleDown}
-            disabled={imageNameIsInvalid}
+            disabled={imageNameIsInvalid || pullInProgress}
             on:click={pullImage}
             inProgress={pullInProgress}>
-            Pull image
+            {pullInProgress ? 'Pulling image' : 'Pull image'}
           </Button>
         {:else}
         <div class="space-x-2 flex flex-nowrap text-[var(--pd-content-text)]">

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowCircleDown, faCog, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleDown, faBan, faCog, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import type { ImageSearchOptions, ProviderContainerConnectionInfo, PullEvent } from '@podman-desktop/core-api';
 import { PreferredRegistriesSettings } from '@podman-desktop/core-api';
 import { Button, Checkbox, ErrorMessage, Link, Tooltip } from '@podman-desktop/ui-svelte';
@@ -33,6 +33,8 @@ let logsPull = $state<Terminal>();
 let pullError = $state('');
 let pullInProgress = $state(false);
 let pullFinished = $state(false);
+let pullCancellableTokenId = $state<number | undefined>();
+let pullCancellationRequested = $state(false);
 let shortnameImages: string[] = [];
 let podmanFQN = $state('');
 let usePodmanFQN = $state(false);
@@ -145,21 +147,51 @@ async function pullImage(): Promise<void> {
 
   pullInProgress = true;
   try {
+    pullCancellationRequested = false;
+    pullCancellableTokenId = await window.getCancellableTokenSource();
     const selectedProviderConnectionSnapshot = $state.snapshot(selectedProviderConnection);
     if (podmanFQN) {
       usePodmanFQN
-        ? await window.pullImage(selectedProviderConnectionSnapshot, podmanFQN.trim(), callback)
-        : await window.pullImage(selectedProviderConnectionSnapshot, `docker.io/${imageToPull.trim()}`, callback);
+        ? await window.pullImage(
+            selectedProviderConnectionSnapshot,
+            podmanFQN.trim(),
+            callback,
+            undefined,
+            pullCancellableTokenId,
+          )
+        : await window.pullImage(
+            selectedProviderConnectionSnapshot,
+            `docker.io/${imageToPull.trim()}`,
+            callback,
+            undefined,
+            pullCancellableTokenId,
+          );
     } else {
-      await window.pullImage(selectedProviderConnectionSnapshot, imageToPull.trim(), callback);
+      await window.pullImage(
+        selectedProviderConnectionSnapshot,
+        imageToPull.trim(),
+        callback,
+        undefined,
+        pullCancellableTokenId,
+      );
     }
-    pullInProgress = false;
     pullFinished = true;
   } catch (error: unknown) {
     const errorMessage =
       error && typeof error === 'object' && 'message' in error && error.message ? error.message : error;
-    pullError = `Error while pulling image from ${selectedProviderConnection.name}: ${errorMessage}`;
+    const normalizedErrorMessage = String(errorMessage).toLowerCase();
+    const pullCanceled =
+      pullCancellationRequested ||
+      normalizedErrorMessage.includes('aborted') ||
+      normalizedErrorMessage.includes('cancelled') ||
+      normalizedErrorMessage.includes('canceled');
+    if (!pullCanceled) {
+      pullError = `Error while pulling image from ${selectedProviderConnection.name}: ${errorMessage}`;
+    }
+  } finally {
+    pullCancellableTokenId = undefined;
     pullInProgress = false;
+    pullCancellationRequested = false;
   }
 }
 
@@ -201,6 +233,13 @@ async function gotoImageRun(): Promise<void> {
     runImageInfo.set(image);
     router.goto('/images/run/basic');
   }
+}
+async function cancelPullImage(): Promise<void> {
+  if (pullCancellableTokenId === undefined) {
+    return;
+  }
+  pullCancellationRequested = true;
+  await window.cancelToken(pullCancellableTokenId);
 }
 
 async function gotoManageRegistries(): Promise<void> {
@@ -457,13 +496,18 @@ async function searchFunction(value: string): Promise<void> {
     <footer>
       <div class="w-full flex flex-col justify-end">
         {#if !pullFinished}
-          <Button
-            icon={faArrowCircleDown}
-            disabled={imageNameIsInvalid || pullInProgress}
-            on:click={pullImage}
-            inProgress={pullInProgress}>
-            {pullInProgress ? 'Pulling image' : 'Pull image'}
-          </Button>
+          <div class="space-x-2 flex flex-nowrap text-[var(--pd-content-text)]">
+            <Button
+              icon={faArrowCircleDown}
+              disabled={imageNameIsInvalid || pullInProgress}
+              on:click={pullImage}
+              inProgress={pullInProgress}>
+              {pullInProgress ? 'Pulling image' : 'Pull image'}
+            </Button>
+            {#if pullInProgress}
+              <Button icon={faBan} disabled={!pullInProgress} on:click={cancelPullImage} type="secondary">Cancel</Button>
+            {/if}
+          </div>
         {:else}
         <div class="space-x-2 flex flex-nowrap text-[var(--pd-content-text)]">
           <Button type='secondary' on:click={pullImageFinished}>Close</Button>


### PR DESCRIPTION
### What does this PR do?

This PR adds functional `Cancel` button while image pulling

### Screenshot / video of UI

Before:
<img width="1170" height="565" alt="Image" src="https://github.com/user-attachments/assets/3845cb2f-6e9d-4625-9a8b-a0823912ecad" />

After:
<img width="1160" height="558" alt="Image" src="https://github.com/user-attachments/assets/47241570-202f-42c8-aaa6-ee959e41f63f" />

### What issues does this PR fix or reference?

Closes #15490 

### How to test this PR?

Start to pull Image and you should see `Cancel` button

- [x] Tests are covering the bug fix or the new feature
