### PR TITLE
chore(test): prolong afterAll hook and runner.close timeout

### DIFF
--- a/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
+++ b/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
@@ -41,7 +41,8 @@ test.beforeAll(async ({ page, runner, welcomePage }) => {
 });
 
 test.afterAll(async ({ runner }) => {
-  await runner.close();
+  test.setTimeout(120_000);
+  await runner.close(45_000);
 });
 
 test.describe.serial('Podman installer integration in Podman Desktop', { tag: '@update-install' }, () => {

--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -49,7 +49,8 @@ test.beforeAll(async ({ runner, page, statusBar }) => {
 });
 
 test.afterAll(async ({ runner }) => {
-  await runner.close();
+  test.setTimeout(120_000);
+  await runner.close(45_000);
 });
 
 test.describe.serial('Podman Desktop Update installation', { tag: '@update-install' }, () => {


### PR DESCRIPTION
### What does this PR do?
Extends the timeout of the afterAll hook for update e2e test specs. Also extend a closing timeout for the electron app to 45 sec.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/16451
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
