### PR TITLE
docs(storybook): update Spinner stories with a11y documentation

### DIFF
--- a/storybook/src/stories/progress/Spinner.stories.svelte
+++ b/storybook/src/stories/progress/Spinner.stories.svelte
@@ -5,7 +5,16 @@ import { defineMeta } from '@storybook/addon-svelte-csf';
 
 /**
  * These are the stories for the `Spinner` component.
- * Displays indeterminate progress through a circle/spinner.
+ * An SVG-based indeterminate loading spinner for ongoing processes with unknown duration.
+ *
+ * **Accessibility**: The wrapper element uses `role="status"` with `aria-live="polite"` so screen readers
+ * announce loading state changes. The SVG graphic is marked `aria-hidden="true"`. The `label` prop sets
+ * `aria-label` on the wrapper (default: `"Loading"`).
+ *
+ * **Color**: The spinner stroke uses `currentColor`, so it inherits the text color of its container.
+ *
+ * **Motion**: Support for `prefers-reduced-motion` is planned in
+ * [#15806](https://github.com/podman-desktop/podman-desktop/issues/15806).
  */
 const { Story } = defineMeta({
   component: Spinner,
@@ -13,6 +22,24 @@ const { Story } = defineMeta({
   title: 'Progress/Spinner',
   tags: ['autodocs'],
   argTypes: {
+    size: {
+      control: 'text',
+      description: 'CSS size value for SVG width and height',
+      defaultValue: '2em',
+    },
+    class: {
+      control: 'text',
+      description: 'Additional CSS classes on the wrapper element',
+    },
+    style: {
+      control: 'text',
+      description: 'Inline CSS styles on the wrapper element',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label for screen readers via aria-label',
+      defaultValue: 'Loading',
+    },
     kind: {
       table: { disable: true },
     },
@@ -27,6 +54,46 @@ const sizeVariants: { label: string; size?: string }[] = [
   { label: '1.5em', size: '1.5em' },
   { label: '12px', size: '12px' },
   { label: '16px', size: '16px' },
+];
+
+const accessibilityVariants: { heading: string; label?: string; containerClass?: string; aria: string }[] = [
+  {
+    heading: 'Default label',
+    aria: 'role="status" aria-label="Loading" aria-live="polite"',
+  },
+  {
+    heading: 'Custom label: Pulling image',
+    label: 'Pulling image',
+    aria: 'role="status" aria-label="Pulling image" aria-live="polite"',
+  },
+  {
+    heading: 'Custom label: Checking prerequisites',
+    label: 'Checking prerequisites',
+    aria: 'role="status" aria-label="Checking prerequisites" aria-live="polite"',
+  },
+  {
+    heading: 'Custom label: Building container',
+    label: 'Building container',
+    aria: 'role="status" aria-label="Building container" aria-live="polite"',
+  },
+  {
+    heading: 'Color inheritance: Info',
+    label: 'Loading info',
+    containerClass: 'text-(--pd-state-info)',
+    aria: 'Inherits currentColor from info context',
+  },
+  {
+    heading: 'Color inheritance: Warning',
+    label: 'Loading warning',
+    containerClass: 'text-(--pd-state-warning)',
+    aria: 'Inherits currentColor from warning context',
+  },
+  {
+    heading: 'Color inheritance: Muted',
+    label: 'Loading muted',
+    containerClass: 'text-(--pd-content-invert-text)',
+    aria: 'Inherits currentColor from muted context',
+  },
 ];
 </script>
 
@@ -47,6 +114,30 @@ const sizeVariants: { label: string; size?: string }[] = [
             {:else}
               <Spinner />
             {/if}
+          </div>
+        {/each}
+      </div>
+    </div>
+  {:else if args.kind === 'accessibility'}
+    <div class="flex flex-col gap-4">
+      <div class="text-sm text-(--pd-content-text)">
+        Accessibility features: ARIA attributes and color inheritance via <code>currentColor</code>.
+      </div>
+
+      <div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        {#each accessibilityVariants as variant (variant.heading)}
+          <div class="flex flex-col gap-2 rounded border border-(--pd-content-divider) p-3">
+            <div class="text-xs font-semibold text-(--pd-content-header)">{variant.heading}</div>
+
+            <div class="flex items-center justify-center py-2 {variant.containerClass ?? ''}">
+              {#if variant.label}
+                <Spinner label={variant.label} />
+              {:else}
+                <Spinner />
+              {/if}
+            </div>
+
+            <code class="text-[10px] text-(--pd-content-text) break-all">{variant.aria}</code>
           </div>
         {/each}
       </div>
@@ -127,6 +218,11 @@ const sizeVariants: { label: string; size?: string }[] = [
   name="Sizes"
   args={{
     kind: 'sizes',
+  }} />
+<Story
+  name="Accessibility"
+  args={{
+    kind: 'accessibility',
   }} />
 <Story
   name="Contexts"


### PR DESCRIPTION
Add documentation describing ARIA attributes, color inheritance, and planned `prefers-reduced-motion` support. Define `argTypes` for all public props (`size,` `class`, `style`, `label`) with controls and descriptions. Add a new Accessibility story showcasing custom labels and `currentColor` adaptation across different container contexts.

### What does this PR do?

Before:

<img width="1062" height="1799" alt="image" src="https://github.com/user-attachments/assets/074f3ad2-daf4-47f1-a771-2903ff29b80f" />

Now:

<img width="1062" height="2528" alt="image" src="https://github.com/user-attachments/assets/aff14714-9ecd-4807-83c0-96a7301bfec5" />

### What issues does this PR fix or reference?

Fixes #15809

### How to test this PR?

Use `pnpm run storybook:dev` to and navigate to Spinner.

Assisted by Claude Code