### PR TITLE
feat(renderer/settings): route experimental config updates through dedicated API

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -23,18 +23,18 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getInitialValue } from '/@/lib/preferences/Util';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 
-beforeAll(() => {
-  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(undefined);
+beforeEach(() => {
+  vi.resetAllMocks();
 });
 
 async function awaitRender(record: IConfigurationPropertyRecordedSchema, customProperties: any): Promise<void> {
@@ -511,4 +511,69 @@ test('Expect a password input when record is type string and format is password'
   // check that the name is properly set and the value too
   expect(passwordInput).toHaveAttribute('name', 'record');
   expect(passwordInput).toHaveValue('foobar');
+});
+
+describe('experimental configuration update', () => {
+  test('Expect updateExperimentalConfigurationValue to be called for experimental records', async () => {
+    const record: IConfigurationPropertyRecordedSchema = {
+      id: 'experimental.record',
+      title: 'Experimental feature',
+      parentId: 'parent.record',
+      description: 'experimental-description',
+      type: 'boolean',
+      default: false,
+      scope: 'DEFAULT',
+      experimental: { githubDiscussionLink: 'https://github.com/test' },
+    };
+
+    render(PreferencesRenderingItemFormat, {
+      record,
+      initialValue: getInitialValue(record),
+      enableAutoSave: true,
+    });
+
+    const checkbox = screen.getByRole('checkbox');
+    await fireEvent.click(checkbox);
+
+    await vi.waitFor(
+      () => {
+        expect(window.updateExperimentalConfigurationValue).toHaveBeenCalledWith(
+          'experimental.record',
+          expect.anything(),
+          'DEFAULT',
+        );
+      },
+      { timeout: 3000 },
+    );
+    expect(window.updateConfigurationValue).not.toHaveBeenCalled();
+  });
+
+  test('Expect updateConfigurationValue to be called for non-experimental records', async () => {
+    const record: IConfigurationPropertyRecordedSchema = {
+      id: 'regular.record',
+      title: 'Regular feature',
+      parentId: 'parent.record',
+      description: 'regular-description',
+      type: 'boolean',
+      default: false,
+      scope: 'DEFAULT',
+    };
+
+    render(PreferencesRenderingItemFormat, {
+      record,
+      initialValue: getInitialValue(record),
+      enableAutoSave: true,
+    });
+
+    const checkbox = screen.getByRole('checkbox');
+    await fireEvent.click(checkbox);
+
+    await vi.waitFor(
+      () => {
+        expect(window.updateConfigurationValue).toHaveBeenCalledWith('regular.record', expect.anything(), 'DEFAULT');
+      },
+      { timeout: 3000 },
+    );
+    expect(window.updateExperimentalConfigurationValue).not.toHaveBeenCalled();
+  });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -109,7 +109,11 @@ async function update(record: IConfigurationPropertyRecordedSchema): Promise<voi
       if (typeof recordValue === 'object') {
         settings = JSON.parse(JSON.stringify(recordValue));
       }
-      await window.updateConfigurationValue(record.id, settings, record.scope);
+      if (record.experimental) {
+        await window.updateExperimentalConfigurationValue(record.id, settings, record.scope);
+      } else {
+        await window.updateConfigurationValue(record.id, settings, record.scope);
+      }
     } catch (error) {
       invalidText = String(error);
       invalidRecord(invalidText);


### PR DESCRIPTION
### What does this PR do?

Use `updateExperimentalConfigurationValue` for records with the `experimental` property set, falling back to `updateConfigurationValue` for standard records. Add tests covering both paths.

This PR also replaces the `beforeAll` with 

```ts
beforeEach(() => {
  vi.resetAllMocks();
});
```

in the test file which is standard and helps the tests to pass.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16470

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Check that the toggle of settings still work.

<img width="1459" height="838" alt="Screenshot 2026-03-06 at 15 01 02" src="https://github.com/user-attachments/assets/daf4435b-c6ac-44d0-946f-57d6bd4d1ce4" />
<img width="1459" height="838" alt="Screenshot 2026-03-06 at 15 00 20" src="https://github.com/user-attachments/assets/1b740611-4e34-4652-a6ea-c39b20eed308" />


<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
