### PR TITLE
refactor(startup): on macOS delay appeareance of Window if open at Login

### DIFF
--- a/packages/main/src/mainWindow.spec.ts
+++ b/packages/main/src/mainWindow.spec.ts
@@ -1,0 +1,253 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Configuration } from '@podman-desktop/api';
+import { app, BrowserWindow, ipcMain, screen } from 'electron';
+import { afterEach, assert, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DevelopmentModeTracker } from './development-mode-tracker.js';
+import { OpenDevTools } from './open-dev-tools.js';
+import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import * as util from './util.js';
+
+vi.mock(import('electron-context-menu'), async () => ({
+  default: vi.fn(),
+}));
+vi.mock(import('./development-menu-builder.js'));
+vi.mock(import('./development-mode-tracker.js'));
+vi.mock(import('./navigation-items-menu-builder.js'));
+vi.mock(import('./open-dev-tools.js'));
+
+vi.mock(import('./util.js'), async () => ({
+  isLinux: vi.fn().mockReturnValue(false),
+  isMac: vi.fn().mockReturnValue(false),
+  isWindows: vi.fn().mockReturnValue(false),
+  stoppedExtensions: { val: true },
+}));
+
+vi.mock('electron', async () => {
+  return {
+    autoUpdater: {
+      on: vi.fn(),
+    },
+    screen: {
+      getCursorScreenPoint: vi.fn(),
+      getDisplayNearestPoint: vi.fn().mockReturnValue({
+        workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+      }),
+    },
+    app: {
+      getPath: vi.fn().mockReturnValue('/Applications/Podman Desktop.app'),
+      dock: {
+        hide: vi.fn(),
+      },
+      getLoginItemSettings: vi.fn().mockReturnValue({ wasOpenedAtLogin: false }),
+      on: vi.fn(),
+      quit: vi.fn(),
+    },
+    ipcMain: {
+      on: vi.fn(),
+      handle: vi.fn(),
+    },
+    nativeTheme: {
+      shouldUseDarkColors: false,
+    },
+    BrowserWindow: Object.assign(vi.fn(), {
+      getAllWindows: vi.fn().mockReturnValue([]),
+    }),
+  };
+});
+
+let originalArgv: string[] = [];
+
+beforeEach(() => {
+  originalArgv = process.argv;
+  vi.resetAllMocks();
+  process.argv = [...originalArgv];
+
+  // Re-setup default mock implementations after reset
+  vi.mocked(app.getPath).mockReturnValue('/Applications/Podman Desktop.app');
+  vi.mocked(app.getLoginItemSettings).mockReturnValue({
+    wasOpenedAtLogin: false,
+  } as Electron.LoginItemSettings);
+  vi.mocked(util.isMac).mockReturnValue(false);
+  vi.mocked(util.isLinux).mockReturnValue(false);
+
+  vi.mocked(screen.getCursorScreenPoint).mockReturnValue({ x: 0, y: 0 });
+  vi.mocked(screen.getDisplayNearestPoint).mockReturnValue({
+    workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+  } as Electron.Display);
+
+  vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([]);
+
+  // Set up BrowserWindow instance methods via prototype
+  BrowserWindow.prototype.loadURL = vi.fn().mockResolvedValue(undefined);
+  BrowserWindow.prototype.setBounds = vi.fn();
+  BrowserWindow.prototype.on = vi.fn() as unknown as typeof BrowserWindow.prototype.on;
+  BrowserWindow.prototype.show = vi.fn();
+  BrowserWindow.prototype.focus = vi.fn();
+  BrowserWindow.prototype.isMinimized = vi.fn().mockReturnValue(false);
+  BrowserWindow.prototype.isDestroyed = vi.fn().mockReturnValue(false);
+  BrowserWindow.prototype.destroy = vi.fn();
+  BrowserWindow.prototype.hide = vi.fn();
+  Object.defineProperty(BrowserWindow.prototype, 'webContents', {
+    value: { send: vi.fn() },
+    configurable: true,
+  });
+
+  // Re-setup auto-mocked class prototypes after reset
+  DevelopmentModeTracker.prototype.onDidChangeDevelopmentMode = vi.fn();
+  DevelopmentModeTracker.prototype.init = vi.fn();
+  OpenDevTools.prototype.open = vi.fn();
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+});
+
+// Helper: extract an event handler registered via .on() by event name
+function getHandler(mockOnFn: ReturnType<typeof vi.fn>, eventName: string): (...args: unknown[]) => void {
+  const call = vi.mocked(mockOnFn).mock.calls.find((c: unknown[]) => c[0] === eventName);
+  assert(call, `Expected handler for '${eventName}' to be registered`);
+  return call[1] as (...args: unknown[]) => void;
+}
+
+describe('createNewWindow', () => {
+  test('should show window on normal launch', async () => {
+    const { createNewWindow } = await import('./mainWindow.js');
+
+    await createNewWindow();
+
+    const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+    assert(bwInstance);
+
+    const readyToShow = getHandler(bwInstance.on, 'ready-to-show');
+    readyToShow();
+
+    expect(bwInstance.show).toHaveBeenCalled();
+    expect(app.dock?.hide).not.toHaveBeenCalled();
+  });
+
+  test('should hide dock on macOS when started with --minimize flag', async () => {
+    vi.mocked(util.isMac).mockReturnValue(true);
+    process.argv = ['electron', '--minimize'];
+
+    const { createNewWindow } = await import('./mainWindow.js');
+
+    await createNewWindow();
+
+    const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+    assert(bwInstance);
+
+    const readyToShow = getHandler(bwInstance.on, 'ready-to-show');
+    readyToShow();
+
+    expect(bwInstance.show).not.toHaveBeenCalled();
+    expect(app.dock?.hide).toHaveBeenCalled();
+  });
+
+  test('should defer window show on macOS login item launch and show when minimize is false', async () => {
+    vi.mocked(util.isMac).mockReturnValue(true);
+    vi.mocked(app.getLoginItemSettings).mockReturnValue({
+      wasOpenedAtLogin: true,
+    } as Electron.LoginItemSettings);
+
+    const { createNewWindow } = await import('./mainWindow.js');
+
+    await createNewWindow();
+
+    const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+    assert(bwInstance);
+
+    const readyToShow = getHandler(bwInstance.on, 'ready-to-show');
+    readyToShow();
+
+    // Window should NOT have been shown yet (deferred)
+    expect(bwInstance.show).not.toHaveBeenCalled();
+
+    // Simulate configuration-registry IPC with minimize=false
+    const configHandler = getHandler(vi.mocked(ipcMain.on), 'configuration-registry');
+
+    const mockConfigRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: vi.fn().mockReturnValue(false),
+      } as unknown as Configuration),
+    } as unknown as ConfigurationRegistry;
+
+    configHandler({}, mockConfigRegistry);
+
+    // Now window should be shown
+    expect(bwInstance.show).toHaveBeenCalled();
+    expect(app.dock?.hide).not.toHaveBeenCalled();
+  });
+
+  test('should defer window show on macOS login item launch and hide dock when minimize is true', async () => {
+    vi.mocked(util.isMac).mockReturnValue(true);
+    vi.mocked(app.getLoginItemSettings).mockReturnValue({
+      wasOpenedAtLogin: true,
+    } as Electron.LoginItemSettings);
+
+    const { createNewWindow } = await import('./mainWindow.js');
+
+    await createNewWindow();
+
+    const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+    assert(bwInstance);
+
+    const readyToShow = getHandler(bwInstance.on, 'ready-to-show');
+    readyToShow();
+
+    // Window should NOT have been shown yet (deferred)
+    expect(bwInstance.show).not.toHaveBeenCalled();
+
+    // Simulate configuration-registry IPC with minimize=true
+    const configHandler = getHandler(vi.mocked(ipcMain.on), 'configuration-registry');
+
+    const mockConfigRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: vi.fn().mockReturnValue(true),
+      } as unknown as Configuration),
+    } as unknown as ConfigurationRegistry;
+
+    configHandler({}, mockConfigRegistry);
+
+    // Window should remain hidden, dock should be hidden
+    expect(bwInstance.show).not.toHaveBeenCalled();
+    expect(app.dock?.hide).toHaveBeenCalled();
+  });
+
+  test('should not defer on non-macOS even if wasOpenedAtLogin is true', async () => {
+    vi.mocked(util.isMac).mockReturnValue(false);
+    vi.mocked(app.getLoginItemSettings).mockReturnValue({
+      wasOpenedAtLogin: true,
+    } as Electron.LoginItemSettings);
+
+    const { createNewWindow } = await import('./mainWindow.js');
+
+    await createNewWindow();
+
+    const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+    assert(bwInstance);
+
+    const readyToShow = getHandler(bwInstance.on, 'ready-to-show');
+    readyToShow();
+
+    // Window should be shown immediately (no deferral on non-macOS)
+    expect(bwInstance.show).toHaveBeenCalled();
+  });
+});

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,12 +98,21 @@ async function createWindow(): Promise<BrowserWindow> {
    *
    * @see https://github.com/electron/electron/issues/25012
    */
+  // Track whether the window show is deferred (macOS login item launch).
+  // On macOS, app.setLoginItemSettings() does not support passing CLI args,
+  // so we defer showing the window until the configuration registry is available
+  // to check the preferences.login.minimize setting.
+  let deferredShow = false;
+
   browserWindow.on('ready-to-show', () => {
-    // If started with --minimize flag, don't show the window and hide the dock icon on macOS
+    // If started with --minimize flag (Windows login item or manual CLI), hide the window
     if (isStartedMinimize()) {
       if (isMac()) {
         app.dock?.hide();
       }
+    } else if (isMac() && app.getLoginItemSettings().wasOpenedAtLogin) {
+      // On macOS login item launch, defer showing until we can check the minimize preference
+      deferredShow = true;
     } else {
       browserWindow.show();
     }
@@ -112,6 +121,19 @@ async function createWindow(): Promise<BrowserWindow> {
   let configurationRegistry: ConfigurationRegistry;
   ipcMain.on('configuration-registry', (_, data) => {
     configurationRegistry = data;
+
+    // If the window show was deferred (macOS login item launch),
+    // check the minimize preference and show or hide accordingly
+    if (deferredShow) {
+      deferredShow = false;
+      const preferencesConfig = configurationRegistry.getConfiguration('preferences');
+      const minimize = preferencesConfig.get<boolean>('login.minimize');
+      if (minimize) {
+        app.dock?.hide();
+      } else {
+        browserWindow.show();
+      }
+    }
 
     // refresh the value of the development mode config property
     const developmentModeTracker = new DevelopmentModeTracker(configurationRegistry);


### PR DESCRIPTION
### What does this PR do?
for macOS, we need to replace the custom bash script by the electron `app.setLoginItemSettings` method
but the minimize or the fact to provide custom args is not possible
so we need to check when the app is started, to delay the appearance (minimize or not) until the configuration registry is available

pre-requisites to fix https://github.com/podman-desktop/podman-desktop/issues/15083

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/15083

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
