### PR TITLE
refactor(macos): replace custom bash script by electron app.setLoginItemSettings

### DIFF
--- a/packages/main/src/system/macos-startup.spec.ts
+++ b/packages/main/src/system/macos-startup.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,11 @@
  ***********************************************************************/
 
 import { existsSync } from 'node:fs';
-import { unlink, writeFile } from 'node:fs/promises';
+import { unlink } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import type { Configuration } from '@podman-desktop/api';
 import { app } from 'electron';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
 
 import { MacosStartup } from './macos-startup.js';
 
@@ -34,6 +31,7 @@ vi.mock('electron', async () => {
   return {
     app: {
       getPath: vi.fn(),
+      setLoginItemSettings: vi.fn(),
     },
   };
 });
@@ -46,16 +44,10 @@ vi.mock('node:fs', async () => {
 vi.mock('node:fs/promises');
 vi.mock('node:path');
 
-const configurationRegistry = {
-  getConfiguration: vi.fn(),
-} as unknown as ConfigurationRegistry;
-
 let macosStartup: MacosStartup;
 
 const fakeAppExe = 'fakeAppExe';
 const fakeAppHome = 'fakeAppHome';
-
-const savedCommandLine = `/usr/bin/truncate -s 0 '${fakeAppHome}/Library/Logs/Podman Desktop/launchd-stdout.log'; /usr/bin/truncate -s 0 '${fakeAppHome}/Library/Logs/Podman Desktop/launchd-stderr.log'; '${fakeAppExe}' `;
 
 const originalConsoleInfo = console.info;
 const originalConsoleWarn = console.warn;
@@ -77,7 +69,7 @@ beforeEach(() => {
     }
     throw new Error('Unsupported path');
   });
-  macosStartup = new MacosStartup(configurationRegistry);
+  macosStartup = new MacosStartup();
 });
 
 afterEach(() => {
@@ -86,26 +78,41 @@ afterEach(() => {
 });
 
 describe('enable', () => {
-  test('check writing the plist file with the correct instruction', async () => {
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockReturnValue(true),
-    } as unknown as Configuration);
+  test('should call app.setLoginItemSettings with openAtLogin true', async () => {
+    await macosStartup.enable();
+
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true,
+    });
+
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Registered Podman Desktop as a login item'));
+  });
+
+  test('should remove legacy plist file if it exists', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
 
     await macosStartup.enable();
 
-    // check content being written
-    expect(writeFile).toHaveBeenCalledWith(
-      expect.stringContaining('fakeAppHome/Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist'),
-      expect.stringContaining(savedCommandLine),
-      'utf-8',
+    expect(unlink).toHaveBeenCalledWith(
+      expect.stringContaining('Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist'),
     );
-
-    // check console
-    expect(console.info).toHaveBeenCalledWith(expect.stringContaining('Installing Podman Desktop startup file at'));
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true,
+    });
   });
 
-  test('check unable to write the plist file if app is in /Volumes', async () => {
-    // change the app home to be in /Volumes
+  test('should not attempt to remove legacy plist if it does not exist', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await macosStartup.enable();
+
+    expect(unlink).not.toHaveBeenCalled();
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true,
+    });
+  });
+
+  test('should skip when running from a volume', async () => {
     vi.mocked(app.getPath).mockImplementation((name: AppGetPathParam) => {
       if (name === 'exe') {
         return `/Volumes/${fakeAppExe}`;
@@ -115,76 +122,48 @@ describe('enable', () => {
       }
       throw new Error('Unsupported path');
     });
-    // recreate the object to get correct resolve method
-    macosStartup = new MacosStartup(configurationRegistry);
-
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockReturnValue(true),
-    } as unknown as Configuration);
+    macosStartup = new MacosStartup();
 
     await macosStartup.enable();
 
-    // check no content has being written
-    expect(writeFile).not.toHaveBeenCalled();
-
-    // check console
-    expect(console.info).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalled();
-  });
-
-  test('check writing the plist file according to login.minimize configuration value', async () => {
-    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue({
-      get: vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false),
-    } as unknown as Configuration);
-
-    await macosStartup.enable();
-
-    // check content being written
-    expect(writeFile).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.stringContaining(`<string>${savedCommandLine}--minimize</string>`),
-      'utf-8',
-    );
-
-    vi.mocked(writeFile).mockReset();
-    await macosStartup.enable();
-
-    // check content being written
-    expect(writeFile).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.stringContaining(`<string>${savedCommandLine}</string>`),
-      'utf-8',
-    );
+    expect(app.setLoginItemSettings).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Cannot enable the start on login'));
   });
 });
 
 describe('disable', () => {
-  test('check remove if exists', async () => {
-    // mock as file exists
+  test('should call app.setLoginItemSettings with openAtLogin false', async () => {
+    await macosStartup.disable();
+
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: false,
+    });
+  });
+
+  test('should remove legacy plist file if it exists', async () => {
     vi.mocked(existsSync).mockReturnValue(true);
 
     await macosStartup.disable();
 
-    // check calls on fs
-    expect(existsSync).toHaveBeenCalled();
-    expect(unlink).toHaveBeenCalled();
+    expect(unlink).toHaveBeenCalledWith(
+      expect.stringContaining('Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist'),
+    );
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: false,
+    });
   });
 
-  test('check do not remove if not exists', async () => {
-    // mock as file not existing
+  test('should not attempt to remove legacy plist if it does not exist', async () => {
     vi.mocked(existsSync).mockReturnValue(false);
 
     await macosStartup.disable();
 
-    // check calls on fs
-    expect(existsSync).toHaveBeenCalled();
     expect(unlink).not.toHaveBeenCalled();
   });
 });
 
 describe('shouldEnable', () => {
-  test('check shouldEnable being true', async () => {
-    // change the app folder to be in /Applications
+  test('should return true when running from /Applications', async () => {
     vi.mocked(app.getPath).mockImplementation((name: AppGetPathParam) => {
       if (name === 'exe') {
         return `/Applications/${fakeAppExe}`;
@@ -195,14 +174,30 @@ describe('shouldEnable', () => {
       throw new Error('Unsupported path');
     });
 
-    // recreate the object to get correct resolve method
-    macosStartup = new MacosStartup(configurationRegistry);
+    macosStartup = new MacosStartup();
 
     const result = macosStartup.shouldEnable();
     expect(result).toBeTruthy();
   });
 
-  test('check shouldEnable being false', async () => {
+  test('should return true when running from ~/Applications', async () => {
+    vi.mocked(app.getPath).mockImplementation((name: AppGetPathParam) => {
+      if (name === 'exe') {
+        return `${fakeAppHome}/Applications/${fakeAppExe}`;
+      }
+      if (name === 'home') {
+        return fakeAppHome;
+      }
+      throw new Error('Unsupported path');
+    });
+
+    macosStartup = new MacosStartup();
+
+    const result = macosStartup.shouldEnable();
+    expect(result).toBeTruthy();
+  });
+
+  test('should return false when not running from Applications folder', async () => {
     const result = macosStartup.shouldEnable();
 
     expect(console.warn).toHaveBeenCalledWith(

--- a/packages/main/src/system/macos-startup.ts
+++ b/packages/main/src/system/macos-startup.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-20265 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/system/macos-startup.ts
+++ b/packages/main/src/system/macos-startup.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-20265 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,30 +17,33 @@
  ***********************************************************************/
 
 import { existsSync } from 'node:fs';
-import { mkdir, unlink, writeFile } from 'node:fs/promises';
+import { unlink } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { app } from 'electron';
 
 /**
- * On macOS, startup on login is done via a plist file
- * that is installed in ~/Library/LaunchAgents
- * This class manages the creation and deletion of the plist file
+ * On macOS, startup on login is done via app.setLoginItemSettings().
+ * This uses the macOS SMAppService API, which properly registers
+ * the app bundle so that "Podman Desktop" is displayed in
+ * Login Items & Extensions (rather than "bash").
+ *
+ * Legacy installs used a LaunchAgent plist file — this class
+ * cleans it up when enabling or disabling.
  */
 export class MacosStartup {
-  private podmanDesktopBinaryPath;
-  private plistFile;
-  private configurationRegistry: IConfigurationRegistry;
+  private podmanDesktopBinaryPath: string;
+  private legacyPlistFile: string;
 
-  constructor(configurationRegistry: IConfigurationRegistry) {
-    this.configurationRegistry = configurationRegistry;
-
+  constructor() {
     // grab current path of the binary
     this.podmanDesktopBinaryPath = app.getPath('exe');
 
-    // Check if we already have a plist file ?
-    this.plistFile = path.resolve(app.getPath('home'), 'Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist');
+    // legacy plist file path (used before switching to app.setLoginItemSettings)
+    this.legacyPlistFile = path.resolve(
+      app.getPath('home'),
+      'Library/LaunchAgents/io.podman_desktop.PodmanDesktop.plist',
+    );
   }
 
   shouldEnable(): boolean {
@@ -57,60 +60,34 @@ export class MacosStartup {
   }
 
   async enable(): Promise<void> {
-    // Check the preferences for login.minimize has been enabled
-    // as this may change each time it's enabled (changed from true to false, etc.)
-    // it's also to make sure that settings weren't changed while async function was running
-    // so we check the configuration within the function
-    const preferencesConfig = this.configurationRegistry.getConfiguration('preferences');
-    const minimize = preferencesConfig.get<boolean>('login.minimize');
-    const minimizeSettings = minimize ? '--minimize' : '';
-
     // comes from a volume ? do nothing
     if (this.podmanDesktopBinaryPath.startsWith('/Volumes/')) {
       console.warn(`Cannot enable the start on login, running from a volume ${this.podmanDesktopBinaryPath}`);
       return;
     }
 
-    const stdoutPath = `${app.getPath('home')}/Library/Logs/Podman Desktop/launchd-stdout.log`;
-    const stderrPath = `${app.getPath('home')}/Library/Logs/Podman Desktop/launchd-stderr.log`;
+    // clean up legacy LaunchAgent plist file if it exists
+    await this.removeLegacyPlist();
 
-    // write the file
-    const plistContent = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>io.podman_desktop.PodmanDesktop</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>/bin/bash</string>
-        <string>-c</string>
-        <string>/usr/bin/truncate -s 0 '${stdoutPath}'; /usr/bin/truncate -s 0 '${stderrPath}'; '${this.podmanDesktopBinaryPath}' ${minimizeSettings}</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>StandardOutPath</key>
-    <string>${stdoutPath}</string>
-    <key>StandardErrorPath</key>
-    <string>${stderrPath}</string>
-</dict>
-</plist>
-`;
+    app.setLoginItemSettings({
+      openAtLogin: true,
+    });
 
-    // ensure the parent directory of the plist file exists
-    await mkdir(path.dirname(this.plistFile), { recursive: true });
-
-    // write the file
-    await writeFile(this.plistFile, plistContent, 'utf-8');
-    console.info(
-      `Installing Podman Desktop startup file at ${this.plistFile} using ${this.podmanDesktopBinaryPath} location.`,
-    );
+    console.info(`Registered Podman Desktop as a login item using ${this.podmanDesktopBinaryPath} location.`);
   }
 
   async disable(): Promise<void> {
-    // remove the file at this.podmanDesktopBinaryPath only if it exists
-    if (existsSync(this.plistFile)) {
-      await unlink(this.plistFile);
+    // clean up legacy LaunchAgent plist file if it exists
+    await this.removeLegacyPlist();
+
+    app.setLoginItemSettings({
+      openAtLogin: false,
+    });
+  }
+
+  private async removeLegacyPlist(): Promise<void> {
+    if (existsSync(this.legacyPlistFile)) {
+      await unlink(this.legacyPlistFile);
     }
   }
 }

--- a/packages/main/src/system/startup-install.ts
+++ b/packages/main/src/system/startup-install.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ export class StartupInstall {
   constructor(private configurationRegistry: IConfigurationRegistry) {
     // macos ?
     if (os.platform() === 'darwin') {
-      this.osStartup = new MacosStartup(configurationRegistry);
+      this.osStartup = new MacosStartup();
     } else if (os.platform() === 'win32') {
       this.osStartup = new WindowsStartup(configurationRegistry);
     }


### PR DESCRIPTION

### What does this PR do?
depends on 
- [x] https://github.com/podman-desktop/podman-desktop/pull/16481

on macOS, replace custom bash script by the electron method

then, it means that we don't have a bash script in the LoginItems on macOS
delete the bash script if detected as well when upgrading

as it's not possible to start with "minimized" mode, check that at startup time (this is done by https://github.com/podman-desktop/podman-desktop/pull/16481)

### Screenshot / video of UI

<img width="729" height="261" alt="image" src="https://github.com/user-attachments/assets/a3eb62fe-c2de-4c03-af0b-0b3ccf6b7f1c" />


### What issues does this PR fix or reference?


fixes https://github.com/podman-desktop/podman-desktop/issues/15083

### How to test this PR?

1. cherry-pick https://github.com/podman-desktop/podman-desktop/pull/16481
2. create a .dmg file and install the app into /Applications folder (ensuring code signing works)
3. launch the app and check 'start at login' is available and enabled
4. go to system settings and check Podman Desktop is there in Login items
<img width="729" height="261" alt="image" src="https://github.com/user-attachments/assets/58c619ec-66fa-4fe0-9891-d4c41a1d0aa7" />
5. logout and reconnect
6. you should see Podman Desktop restarting
7. disable the option from Podman Desktop, it should be removed from the system settings



- [x] Tests are covering the bug fix or the new feature
