### PR TITLE
feat(spinner): replace CSS spinner with Spinner component

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderButtonStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderButtonStatus.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Spinner } from '@podman-desktop/ui-svelte';
+
 import IconImage from '/@/lib/appearance/IconImage.svelte';
 
 import arrowUp from './status-icons/arrow-up.svg';
@@ -13,7 +15,7 @@ let { status, class: className = '' }: Props = $props();
 
 
 {#if status === 'starting' || status === 'stopping'}
-  <div aria-label="Connection Status Icon" class="h-3 w-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent {className}"></div>
+  <Spinner size="12px" />
 {:else if status === 'ready' || status === 'started'}
   <div aria-label="Connection Status Icon" class="h-[7px] w-[7px] absolute top-[0px] right-[-2px] rounded-full bg-[var(--pd-status-contrast)] border-1 border-[var(--pd-statusbar-bg)] {className}"></div>
 {:else if status === 'error'}


### PR DESCRIPTION
### What does this PR do?
Part of  #16434,
The spinner used in ([ProviderButtonStatus.svelte](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/statusbar/ProviderButtonStatus.svelte#L16)) is based on css, this PR uses the Spinner component provided by the UI instead.

### Screenshot / video of UI
Before(css based spinner):

https://github.com/user-attachments/assets/6a3f833b-1920-4158-ab0e-d0ba46febe6e

After(Spinner component):

https://github.com/user-attachments/assets/9d0b95d1-d7d1-49f2-ba8f-aab863e15963



<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
closes #16239 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
none

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
