### PR TITLE
feat(main/configuration): add telemetry tracking for experimental configuration

### DIFF
--- a/packages/main/src/plugin/experimental-configuration-manager.spec.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.spec.ts
@@ -21,17 +21,22 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ConfigurationRegistry } from './configuration-registry.js';
 import { ExperimentalConfigurationManager } from './experimental-configuration-manager.js';
+import type { Telemetry } from './telemetry/telemetry.js';
 
 const mockedConfigurationRegistry = {
   updateConfigurationValue: vi.fn(),
   getConfiguration: vi.fn(),
 } as unknown as ConfigurationRegistry;
 
+const mockedTelemetry = {
+  track: vi.fn(),
+} as unknown as Telemetry;
+
 let experimentalConfigurationManager: ExperimentalConfigurationManager;
 
 beforeEach(() => {
   vi.resetAllMocks();
-  experimentalConfigurationManager = new ExperimentalConfigurationManager(mockedConfigurationRegistry);
+  experimentalConfigurationManager = new ExperimentalConfigurationManager(mockedConfigurationRegistry, mockedTelemetry);
 });
 
 describe('ExperimentalConfigurationManager', () => {
@@ -127,6 +132,36 @@ describe('ExperimentalConfigurationManager', () => {
       await experimentalConfigurationManager.updateExperimentalConfigurationValue(key, config, scope);
 
       expect(mockedConfigurationRegistry.updateConfigurationValue).toHaveBeenCalledWith(key, undefined, scope);
+    });
+
+    test('should track telemetry with enabled=true when config is an object', async () => {
+      const key = 'kubernetes.statesExperimental';
+      await experimentalConfigurationManager.updateExperimentalConfigurationValue(key, {}, 'DEFAULT');
+
+      expect(mockedTelemetry.track).toHaveBeenCalledWith('experimentalConfigurationUpdate', {
+        key,
+        enabled: true,
+      });
+    });
+
+    test('should track telemetry with enabled=false when config is false', async () => {
+      const key = 'kubernetes.statesExperimental';
+      await experimentalConfigurationManager.updateExperimentalConfigurationValue(key, false, 'DEFAULT');
+
+      expect(mockedTelemetry.track).toHaveBeenCalledWith('experimentalConfigurationUpdate', {
+        key,
+        enabled: false,
+      });
+    });
+
+    test('should track telemetry with enabled=false when config is undefined', async () => {
+      const key = 'kubernetes.statesExperimental';
+      await experimentalConfigurationManager.updateExperimentalConfigurationValue(key, undefined, 'DEFAULT');
+
+      expect(mockedTelemetry.track).toHaveBeenCalledWith('experimentalConfigurationUpdate', {
+        key,
+        enabled: false,
+      });
     });
   });
 

--- a/packages/main/src/plugin/experimental-configuration-manager.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.ts
@@ -60,9 +60,9 @@ export class ExperimentalConfigurationManager {
     config: unknown,
     scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
   ): Promise<void> {
-    const enabled = typeof config === 'object' && config !== null;
-    this.telemetry.track('experimentalConfigurationUpdate', { key, enabled });
     await this.configurationRegistry.updateConfigurationValue(key, config, scope);
+    const enabled = typeof config === 'object' && !!config;
+    this.telemetry.track('experimentalConfigurationUpdate', { key, enabled });
   }
 
   /**

--- a/packages/main/src/plugin/experimental-configuration-manager.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.ts
@@ -20,10 +20,14 @@ import type * as containerDesktopAPI from '@podman-desktop/api';
 import { inject, injectable } from 'inversify';
 
 import { ConfigurationRegistry } from './configuration-registry.js';
+import { Telemetry } from './telemetry/telemetry.js';
 
 @injectable()
 export class ExperimentalConfigurationManager {
-  constructor(@inject(ConfigurationRegistry) private configurationRegistry: ConfigurationRegistry) {}
+  constructor(
+    @inject(ConfigurationRegistry) private configurationRegistry: ConfigurationRegistry,
+    @inject(Telemetry) private telemetry: Telemetry,
+  ) {}
 
   /**
    * Parse a configuration key into section and property
@@ -56,6 +60,8 @@ export class ExperimentalConfigurationManager {
     config: unknown,
     scope?: containerDesktopAPI.ConfigurationScope | containerDesktopAPI.ConfigurationScope[],
   ): Promise<void> {
+    const enabled = typeof config === 'object' && config !== null;
+    this.telemetry.track('experimentalConfigurationUpdate', { key, enabled });
     await this.configurationRegistry.updateConfigurationValue(key, config, scope);
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -537,11 +537,6 @@ export class PluginSystem {
       configurationRegistryEmitter,
     );
 
-    container.bind<ExperimentalConfigurationManager>(ExperimentalConfigurationManager).toSelf().inSingletonScope();
-    const experimentalConfigurationManager = container.get<ExperimentalConfigurationManager>(
-      ExperimentalConfigurationManager,
-    );
-
     container.bind<ColorRegistry>(ColorRegistry).to(InjectableColorRegistry).inSingletonScope();
     const colorRegistry = container.get<ColorRegistry>(ColorRegistry);
     colorRegistry.init();
@@ -560,6 +555,11 @@ export class PluginSystem {
     container.bind<Telemetry>(Telemetry).toSelf().inSingletonScope();
     const telemetry = container.get<Telemetry>(Telemetry);
     await telemetry.init();
+
+    container.bind<ExperimentalConfigurationManager>(ExperimentalConfigurationManager).toSelf().inSingletonScope();
+    const experimentalConfigurationManager = container.get<ExperimentalConfigurationManager>(
+      ExperimentalConfigurationManager,
+    );
 
     container.bind<CommandRegistry>(CommandRegistry).toSelf().inSingletonScope();
     const commandRegistry = container.get<CommandRegistry>(CommandRegistry);


### PR DESCRIPTION
### What does this PR do?

Adds telemetry tracking to `ExperimentalConfigurationManager.updateExperimentalConfigurationValue` so that toggling experimental features emits an `experimentalConfigurationUpdate` event to Amplitude with the configuration key and whether the feature was enabled or disabled.

Changes:
- Inject `Telemetry` into `ExperimentalConfigurationManager` and call `telemetry.track('experimentalConfigurationUpdate', { key, enabled })` on each update
- Move `ExperimentalConfigurationManager` DI binding after `Telemetry` initialization in `index.ts` to satisfy the new dependency
- Add 3 unit tests covering the telemetry call for object (enabled), `false` (disabled), and `undefined` (disabled) config values


### Screenshot / video of UI

<img width="1816" height="998" alt="Screenshot 2026-03-09 at 12 25 26" src="https://github.com/user-attachments/assets/0b46a5f6-1cb0-462a-80b6-0c63f11fcf63" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/16471
Closes https://github.com/podman-desktop/podman-desktop/issues/14989

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Run with `pnpm watch`, go to the Amplitude dashboard (https://app.amplitude.com/analytics/redhat/users), select "Podman Desktop Dev", get your user id (`cat ~/.redhat/anonymousId`), and see the new event logged.




<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
