### PR TITLE
chore: update email label in feedback form

### DIFF
--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -241,3 +241,17 @@ test('Expect design category to be sent when design category is used', async () 
   // expect close to have been call with confirmation=false
   expect(closeMock).toHaveBeenCalledWith(false);
 });
+
+test('Expect email field has correct text', async () => {
+  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+
+  const emaillabel = await screen.findByLabelText(
+    'Share your email address if we can follow up with you regarding your feedback. We will only use your email address for this purpose:',
+  );
+  expect(emaillabel).toBeInTheDocument();
+
+  const emailPlaceholder = await screen.findByPlaceholderText(
+    'Enter email address, or leave blank for anonymous feedback',
+  );
+  expect(emailPlaceholder).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -128,8 +128,9 @@ async function openGitHub(): Promise<void> {
       class="w-full p-2 outline-hidden text-sm bg-[var(--pd-input-field-focused-bg)] rounded-xs text-[var(--pd-input-field-focused-text)] placeholder-[var(--pd-input-field-placeholder-text)]"
       placeholder="Please enter your feedback here, we appreciate and review all comments"></textarea>
 
-    <label for="contactInformation" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
-      >Share your contact information if you'd like us to answer you:</label>
+    <label for="contactInformation" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]">
+      Share your email address if we can follow up with you regarding your feedback. We will only use your email address for this purpose:
+    </label>
     <input
       type="email"
       name="contactInformation"


### PR DESCRIPTION
### What does this PR do?

Updates the text to be clearer on purpose and scope.

### Screenshot / video of UI

Before:

<img width="513" height="523" alt="feedback-original" src="https://github.com/user-attachments/assets/fbccb061-d410-46d2-95a0-b2a16ae16ba8" />

After:

<img width="513" height="523" alt="feedback-suggest" src="https://github.com/user-attachments/assets/b2639cc9-7084-492f-927c-82eb392adfbd" />

### What issues does this PR fix or reference?

Fixes #16530.

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature