### PR TITLE
feat: hide Settings > Kubernetes menu when kubernetes-contexts-manager feature is declared

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -22,14 +22,16 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import { configurationProperties } from './stores/configurationProperties';
+import { onDidChangeRegisteredFeatures, registeredFeatures } from './stores/registered-features';
 
 // fake the window.events object
 beforeEach(() => {
   vi.resetAllMocks();
+  registeredFeatures.set([]);
   Object.defineProperty(global, 'window', {
     value: {
       getConfigurationValue: vi.fn(),
@@ -217,5 +219,71 @@ test('experimental configuration should be visible if one property has experimen
   await vi.waitFor(() => {
     const experimental = getByRole('link', { name: 'Experimental' });
     expect(experimental).toBeDefined();
+  });
+});
+
+describe('Kubernetes menu visibility based on kubernetes-contexts-manager feature', () => {
+  test('should be visible by default', async () => {
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Kubernetes' })).toBeVisible();
+    });
+  });
+
+  test('should be hidden when kubernetes-contexts-manager feature is already registered', async () => {
+    registeredFeatures.set(['kubernetes-contexts-manager']);
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'Kubernetes' })).toBeNull();
+    });
+  });
+
+  test('should be hidden when kubernetes-contexts-manager feature is added via event', async () => {
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Kubernetes' })).toBeVisible();
+    });
+
+    onDidChangeRegisteredFeatures.dispatchEvent(new CustomEvent('kubernetes-contexts-manager', { detail: true }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'Kubernetes' })).toBeNull();
+    });
+  });
+
+  test('should reappear when kubernetes-contexts-manager feature is removed via event', async () => {
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Kubernetes' })).toBeVisible();
+    });
+
+    onDidChangeRegisteredFeatures.dispatchEvent(new CustomEvent('kubernetes-contexts-manager', { detail: true }));
+    await vi.waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'Kubernetes' })).toBeNull();
+    });
+
+    onDidChangeRegisteredFeatures.dispatchEvent(new CustomEvent('kubernetes-contexts-manager', { detail: false }));
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Kubernetes' })).toBeVisible();
+    });
   });
 });

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -10,6 +10,7 @@ import ShortcutArrowIcon from '/@/lib/images/ShortcutArrowIcon.svelte';
 import { type NavItem, settingsNavigationEntries, type SettingsNavItemConfig } from '/@/PreferencesNavigation';
 
 import { configurationProperties } from './stores/configurationProperties';
+import { onDidChangeRegisteredFeatures, registeredFeatures } from './stores/registered-features';
 
 interface Props {
   meta: TinroRouteMeta;
@@ -47,8 +48,27 @@ function sortItems(items: NavItem[]): NavItem[] {
   return items.toSorted((a, b) => a.title.localeCompare(b.title));
 }
 
+const kubernetesContextsManagerFeature = 'kubernetes-contexts-manager';
+
+function updateKubernetesVisibility(enabled: boolean): void {
+  const kubernetesIndex = settingsNavigationItems.findIndex(entry => entry.title === 'Kubernetes');
+  if (kubernetesIndex !== -1) {
+    settingsNavigationItems[kubernetesIndex].visible = !enabled;
+  }
+}
+
+const featureListener = (event: Event): void => {
+  updateKubernetesVisibility((event as CustomEvent<boolean>).detail);
+};
+
 onMount(() => {
-  return configurationProperties.subscribe(value => {
+  onDidChangeRegisteredFeatures.addEventListener(kubernetesContextsManagerFeature, featureListener);
+
+  const unsubFeatures = registeredFeatures.subscribe(features => {
+    updateKubernetesVisibility(features.includes(kubernetesContextsManagerFeature));
+  });
+
+  const unsubConfig = configurationProperties.subscribe(value => {
     // update compatibility
     updateDockerCompatibility();
 
@@ -78,6 +98,12 @@ onMount(() => {
       return map;
     }, new Map<string, NavItem[]>());
   });
+
+  return (): void => {
+    unsubConfig();
+    unsubFeatures();
+    onDidChangeRegisteredFeatures.removeEventListener(kubernetesContextsManagerFeature, featureListener);
+  };
 });
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Subscribe to the registered features store and listen for onDidChangeRegisteredFeatures events so the Kubernetes navigation entry is dynamically hidden when an extension declares the "kubernetes-contexts-manager" feature.

### Screenshot / video of UI

Watch how the "Kubernetes" entry in the Settings menu appears and disappears when I start or stop the extension.

https://github.com/user-attachments/assets/c711db51-0961-48a8-bf47-01e6bfce9378


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16528

Closes https://github.com/podman-desktop/podman-desktop/issues/16361 (epic)

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Install the https://github.com/podman-desktop/extension-kubernetes-contexts extension

Open the settings menu and in the console:

```ts
await window.startExtension('podman-desktop.kubernetes-contexts');

await window.stopExtension('podman-desktop.kubernetes-contexts');
```

Check that the Kubernetes submenu appears/disappears.

Also test to disable the extension from the extension page and go back to settings.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
