### PR TITLE
fix(updater): show version in status bar even if app-update.yml is missing

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -401,6 +401,44 @@ test('expect default status entry when error No published versions on GitHub', (
   expect(setEntryMock).toHaveBeenCalled();
 });
 
+test('expect default status entry when error due to missing app-update.yml', () => {
+  const setEntryMock = vi.spyOn(statusBarRegistryMock, 'setEntry');
+  setEntryMock.mockImplementation(
+    (entryId, _alignLeft, _priority, text, tooltip, iconClass, enabled, command, _commandArgs, highlight) => {
+      expect(entryId).toBe('version');
+      expect(text).toBe('v@debug');
+      expect(tooltip).toBe('Using version v@debug');
+      expect(iconClass).toBe(undefined);
+      expect(enabled).toBe(true);
+      expect(command).toBe('version');
+      expect(highlight).toBeFalsy();
+    },
+  );
+
+  let mListener: ((error: Error) => void) | undefined;
+  vi.spyOn(autoUpdater, 'on').mockImplementation((channel: keyof AppUpdaterEvents, listener: unknown): AppUpdater => {
+    if (channel === 'error') mListener = listener as () => void;
+    return {} as unknown as AppUpdater;
+  });
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  // listener should exist
+  expect(mListener).toBeDefined();
+
+  // call the listener with a generic error (e.g. missing app-update.yml)
+  mListener?.(new Error('ENOENT: no such file or directory, open app-update.yml'));
+
+  expect(setEntryMock).toHaveBeenCalled();
+});
+
 test('expect command update to be called when configuration value on startup', () => {
   let mListener: (() => void) | undefined;
   vi.spyOn(autoUpdater, 'on').mockImplementation((channel: keyof AppUpdaterEvents, listener: unknown): AppUpdater => {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -427,10 +427,10 @@ export class Updater {
     // local build not pushed to GitHub so prevent any 'update'
     if (error?.message?.includes('No published versions on GitHub')) {
       console.log('Cannot check for updates, no published versions on GitHub');
-      this.defaultVersionEntry();
-      return;
+    } else {
+      console.error('unable to check for updates', error);
     }
-    console.error('unable to check for updates', error);
+    this.defaultVersionEntry();
     this.apiSender.send('app-update-available', false);
   }
 


### PR DESCRIPTION
fix(updater): show version in status bar even if app-update.yml is missing

### What does this PR do?

When `app-update.yml` is missing or any updater error occurs that is not
"No published versions on GitHub"... `defaultVersionEntry()` was never
called..

Resulting in erroring out and nothing on the bottom status bar regarding
the version.

Moved `defaultVersionEntry()` outside the conditional so it is called
regardless of error cases / the actual tray icon with the version shows
up if we don't have an `app-update.yml`.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/15990

### How to test this PR?

macOS:

1. `pnpm compile:current`
2. `codesign --force --deep --sign - "dist/mac-arm64/Podman Desktop.app"`
3. `rm "dist/mac-arm64/Podman Desktop.app/Contents/Resources/app-update.yml"`
4. Start Podman Desktop
5. See that the version now appears in the status bar.

Windows:

1. `pnpm compile:current`
2. Delete `dist\win-unpacked\resources\app-update.yml`
3. Start Podman Desktop
4. See that the version now appears in the status bar on the bottom
   right

**NOTE!!** You can also test this out against the `main` branch as well,
and see that if we edit / remove the `app-update.yml` from within the
app (in the case of macOS within the `Podman Desktop.app`, you can see
that the current bug exists across both mac and windows

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
