### PR TITLE
fix(main): check icon type before converting to base64 in onboarding registry

### DIFF
--- a/packages/main/src/plugin/onboarding-registry.ts
+++ b/packages/main/src/plugin/onboarding-registry.ts
@@ -74,7 +74,7 @@ export class OnboardingRegistry {
       if (base64Image) {
         onboarding.media.path = base64Image;
       }
-    } else if (extension.manifest?.icon) {
+    } else if (extension.manifest?.icon && typeof extension.manifest.icon === 'string') {
       const base64Image = getBase64Image(path.resolve(extension.path, extension.manifest.icon));
       if (base64Image) {
         // if no image has been set for the onboarding, it uses the extension icon


### PR DESCRIPTION
### What does this PR do?

In `OnboardingRegistry.convertImages`, the `extension.manifest.icon` field is not typed but it can be either a `string` (single icon path) or an object (with `light`/`dark` variants). The code passes the icon directly to `path.resolve` and `getBase64Image`, which only works for string icons. This adds a `typeof extension.manifest.icon === 'string'` guard so that object-typed icons are not incorrectly passed to `getBase64Image`.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Pre-requisite for #16134

See comment https://github.com/podman-desktop/podman-desktop/pull/16134#discussion_r2910802122.

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Load an extension that has a light/dark icon object in its manifest
2. Verify onboarding images still load correctly
3. Load an extension with a string icon, verify it still works as before


<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
