### PR TITLE
refactor(main): avoid in-place mutation of extension configuration

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -798,11 +798,14 @@ export class ExtensionLoader implements IAsyncDisposable {
     const extensionConfiguration = extension.manifest?.contributes?.configuration;
     if (extensionConfiguration) {
       // add information about the current extension
-      extensionConfiguration.extension = extension;
-      extensionConfiguration.title = `Extension: ${extensionConfiguration.title}`;
-      extensionConfiguration.id = 'preferences.' + extension.id;
-
-      this.configurationRegistry.registerConfigurations([extensionConfiguration]);
+      this.configurationRegistry.registerConfigurations([
+        {
+          ...extensionConfiguration,
+          id: 'preferences.' + extension.id,
+          extension,
+          title: `Extension: ${extensionConfiguration.title}`,
+        },
+      ]);
     }
 
     const extensionCommands = extension.manifest?.contributes?.commands;


### PR DESCRIPTION
### What does this PR do?

Refactors `ExtensionLoader.activateExtension` to avoid mutating the `extensionConfiguration` object in-place. Instead of assigning `id`, `extension`, and `title` directly on the manifest's configuration object, this uses an object spread when passing it to `registerConfigurations`. This prevents unintended side effects from modifying the manifest data.

### Screenshot / video of UI

N/A — no visual change, internal refactor only.

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Pre-requisite for #16134
See comment https://github.com/podman-desktop/podman-desktop/pull/16134#discussion_r2910807740

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

1. Load extensions that contribute configuration
2. Verify their settings still appear correctly under `Extension: <name>` in preferences
3. Verify no regressions in extension loading

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
