### PR TITLE
chore(webview-registry): cleanup connections on dispose

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -258,6 +258,7 @@ const contributionManager: ContributionManager = {
 const webviewRegistry: WebviewRegistry = {
   listSimpleWebviews: vi.fn(),
   listWebviews: vi.fn(),
+  stop: vi.fn(),
 } as unknown as WebviewRegistry;
 
 const navigationManager: NavigationManager = new NavigationManager(

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -236,6 +236,9 @@ export class ExtensionLoader implements IAsyncDisposable {
   async asyncDispose(): Promise<void> {
     await this.stopAllExtensions();
 
+    // stop the webview HTTP server
+    await this.webviewRegistry.stop();
+
     // clear maps
     this.activatedExtensions.clear();
     this.analyzedExtensions.clear();

--- a/packages/main/src/plugin/webview/webview-registry.ts
+++ b/packages/main/src/plugin/webview/webview-registry.ts
@@ -66,6 +66,8 @@ export class HttpServer {
     if (!this.#instance) {
       return;
     }
+    // Force-close all keep-alive connections so close() can complete
+    this.#instance.closeAllConnections();
     return new Promise<void>((resolve, reject) => {
       this.#instance?.close((err: unknown) => {
         if (err) {


### PR DESCRIPTION
### What does this PR do?
some network connections may be still pending, holding the stop of Podman Desktop with recent versions of electrong

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

electron 40.0.5+ update

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
