### PR TITLE
chore(test): disable fail fast for e2e test matrix

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -311,6 +311,7 @@ jobs:
     name: smoke e2e tests
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         mode: [production, development]
     steps:


### PR DESCRIPTION
### What does this PR do?
Disables fail fast setting in GHA so that the e2e tests may finish even if some other test run from the same matrix already failed.

### What issues does this PR fix or reference?
