### PR TITLE
test(main): add tests for ExtensionManifestSchema and loadManifest

### DIFF
--- a/packages/main/src/plugin/extension/extension-analyzer.spec.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.spec.ts
@@ -169,3 +169,75 @@ describe('analyze extension and main', () => {
     expect(extension?.devMode).toBeTruthy();
   });
 });
+
+describe('loadManifest', () => {
+  test('returns parsed manifest when schema validation succeeds', async () => {
+    const validManifest = {
+      name: 'my-ext',
+      displayName: 'My Extension',
+      version: '1.0.0',
+      publisher: 'test',
+      description: 'desc',
+      main: 'index.js',
+    };
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(validManifest));
+
+    const result = await extensionAnalyzer.loadManifest('/some/path');
+
+    expect(result.name).toBe('my-ext');
+    expect(result.version).toBe('1.0.0');
+    expect(result.main).toBe('index.js');
+  });
+
+  test('returns raw manifest and logs error when schema validation fails', async () => {
+    const invalidManifest = { name: 123 };
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(invalidManifest));
+    const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await extensionAnalyzer.loadManifest('/bad/extension');
+
+    const expectedError =
+      'Error while parsing manifest for extension /bad/extension. ' +
+      '✖ Invalid input: expected string, received number\n  → at name\n' +
+      '✖ Invalid input: expected string, received undefined\n  → at displayName\n' +
+      '✖ Invalid input: expected string, received undefined\n  → at version\n' +
+      '✖ Invalid input: expected string, received undefined\n  → at publisher\n' +
+      '✖ Invalid input: expected string, received undefined\n  → at description';
+    expect(consoleErrorMock).toHaveBeenCalledWith(expectedError);
+    expect(result).toEqual(invalidManifest);
+  });
+
+  test('preserves unknown fields from the manifest', async () => {
+    const manifestWithExtras = {
+      name: 'my-ext',
+      displayName: 'My Extension',
+      version: '1.0.0',
+      publisher: 'test',
+      description: 'desc',
+      scripts: { build: 'tsc' },
+      license: 'MIT',
+    };
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(manifestWithExtras));
+
+    const result = await extensionAnalyzer.loadManifest('/some/path');
+
+    expect(result.name).toBe('my-ext');
+    expect((result as Record<string, unknown>)['scripts']).toEqual({ build: 'tsc' });
+    expect((result as Record<string, unknown>)['license']).toBe('MIT');
+  });
+
+  test('reads package.json from the given extension path', async () => {
+    const validManifest = {
+      name: 'my-ext',
+      displayName: 'My Extension',
+      version: '1.0.0',
+      publisher: 'test',
+      description: 'desc',
+    };
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify(validManifest));
+
+    await extensionAnalyzer.loadManifest('/extensions/my-ext');
+
+    expect(readFile).toHaveBeenCalledWith(path.join('/extensions/my-ext', 'package.json'), 'utf8');
+  });
+});

--- a/packages/main/src/plugin/extension/extension-manifest-schema.spec.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-schema.spec.ts
@@ -1,0 +1,169 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { assert, describe, expect, test } from 'vitest';
+import { z } from 'zod';
+
+import { ExtensionManifestSchema } from './extension-manifest-schema.js';
+
+const minimalValidManifest = {
+  name: 'my-extension',
+  displayName: 'My Extension',
+  version: '1.0.0',
+  publisher: 'test-publisher',
+  description: 'A test extension',
+};
+
+describe('ExtensionManifestSchema', () => {
+  test('accepts a minimal valid manifest', () => {
+    const result = ExtensionManifestSchema.safeParse(minimalValidManifest);
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts a manifest with optional main field', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      main: 'dist/extension.js',
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.main).toBe('dist/extension.js');
+  });
+
+  test('accepts icon as a string', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      icon: 'icon.png',
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.icon).toBe('icon.png');
+  });
+
+  test('accepts icon as a light/dark object', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      icon: { light: 'icon-light.png', dark: 'icon-dark.png' },
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.icon).toEqual({ light: 'icon-light.png', dark: 'icon-dark.png' });
+  });
+
+  test('accepts engines with podman-desktop version', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      engines: { 'podman-desktop': '>=1.0.0' },
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.engines?.['podman-desktop']).toBe('>=1.0.0');
+  });
+
+  test('accepts extensionDependencies and extensionPack', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      extensionDependencies: ['publisher.dep1', 'publisher.dep2'],
+      extensionPack: ['publisher.pack1'],
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.extensionDependencies).toEqual(['publisher.dep1', 'publisher.dep2']);
+    expect(result.data.extensionPack).toEqual(['publisher.pack1']);
+  });
+
+  test('accepts contributes with features', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      contributes: {
+        features: ['kubernetes-contexts-manager'],
+      },
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.contributes?.features).toEqual(['kubernetes-contexts-manager']);
+  });
+
+  test('accepts contributes with commands', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      contributes: {
+        commands: [{ command: 'my.command', title: 'My Command' }],
+      },
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.contributes?.commands).toHaveLength(1);
+  });
+
+  test('accepts contributes with menus', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      contributes: {
+        menus: {
+          'dashboard/image': [{ command: 'my.command', title: 'Run' }],
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('allows unknown top-level fields due to .loose()', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      scripts: { build: 'tsc' },
+      devDependencies: { typescript: '^5.0.0' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test.each([
+    'name',
+    'displayName',
+    'version',
+    'publisher',
+    'description',
+  ] as const)('rejects manifest missing required %s field', field => {
+    const incomplete = { ...minimalValidManifest };
+    delete (incomplete as Record<string, unknown>)[field];
+    const result = ExtensionManifestSchema.safeParse(incomplete);
+    expect(result.success).toBe(false);
+    assert(result.error);
+    expect(z.prettifyError(result.error)).toBe(`✖ Invalid input: expected string, received undefined\n  → at ${field}`);
+  });
+
+  test('rejects manifest with wrong type for name', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      name: 123,
+    });
+    expect(result.success).toBe(false);
+    assert(result.error);
+    expect(z.prettifyError(result.error)).toBe('✖ Invalid input: expected string, received number\n  → at name');
+  });
+
+  test('rejects manifest with invalid icon type', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      icon: 42,
+    });
+    expect(result.success).toBe(false);
+    assert(result.error);
+    expect(z.prettifyError(result.error)).toBe('✖ Invalid input\n  → at icon');
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Add unit tests for the ExtensionManifestSchema Zod schema and the loadManifest method in ExtensionAnalyzer, as a follow-up to https://github.com/podman-desktop/podman-desktop/pull/16134#pullrequestreview-3930752843

- extension-manifest-schema.spec.ts (17 tests)
- extension-analyzer.spec.ts (4 new tests)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Follow-up to #16497


<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
