### PR TITLE
chore(test): make startup sequence be more robust to environment system lag

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   outputDir: 'tests/playwright/output/',
   workers: 1,
-  timeout: 60000,
+  timeout: 90_000,
 
   reporter: [
     ['list'],

--- a/tests/playwright/src/model/pages/welcome-page.ts
+++ b/tests/playwright/src/model/pages/welcome-page.ts
@@ -69,7 +69,7 @@ export class WelcomePage extends BasePage {
   async turnOffTelemetry(): Promise<void> {
     return test.step('Turn off Telemetry', async () => {
       // Extensions load sequentially (faster speed but can block ui)
-      await playExpect(this.startOnboarding).toBeEnabled({ timeout: 45_000 });
+      await playExpect(this.startOnboarding).toBeEnabled({ timeout: 60_000 });
 
       if (await this.telemetryConsent.isChecked()) {
         await playExpect(this.telemetryConsent).toBeChecked();
@@ -86,7 +86,7 @@ export class WelcomePage extends BasePage {
       await this.skipOnBoarding.click({ force: true });
       try {
         await waitWhile(async () => await this.skipOnBoarding.isVisible(), { timeout: 5_000, diff: 250 });
-      } catch (err) {
+      } catch (_err) {
         console.log('Skip Onboarding button is still visible, retrying to press the button');
         await this.skipOnBoarding.click({ force: true });
       }


### PR DESCRIPTION
### What does this PR do?
Increases the timers during the PD startup sequence for e2e tests.

### What issues does this PR fix or reference?