### PR TITLE
fix: pass options when listing images with Docker API fallback

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4796,6 +4796,31 @@ test('expect to fall back to compat api images if podman provider does not have 
   expect(images[0]?.Id).toBe('dummyImageId2');
 });
 
+test('pass options to compat api when using podmanListImages', async () => {
+  const imagesList = [{ Id: 'dummyImageId' }];
+  server = setupServer(http.get('http://localhost/images/json', () => HttpResponse.json(imagesList)));
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+  const listImagesSpy = vi.spyOn(api, 'listImages');
+
+  containerRegistry.addInternalProvider('podman', {
+    name: 'podman',
+    id: 'podman1',
+    api,
+    connection: {
+      type: 'podman',
+    },
+  } as unknown as InternalContainerProvider);
+
+  await containerRegistry.podmanListImages({ all: true, filters: { dangling: ['false'] } });
+
+  expect(vi.mocked(listImagesSpy)).toHaveBeenCalledWith({
+    all: true,
+    filters: { dangling: ['false'] },
+  });
+});
+
 test('expect a blank array if there is no api or libpod API when doing podmanListImages', async () => {
   containerRegistry.addInternalProvider('podman', {
     name: 'podman',

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4813,11 +4813,11 @@ test('pass options to compat api when using podmanListImages', async () => {
     },
   } as unknown as InternalContainerProvider);
 
-  await containerRegistry.podmanListImages({ all: true, filters: { dangling: ['false'] } });
+  await containerRegistry.podmanListImages({ all: true, filters: '{"dangling":["false"]}' });
 
   expect(vi.mocked(listImagesSpy)).toHaveBeenCalledWith({
     all: true,
-    filters: { dangling: ['false'] },
+    filters: '{"dangling":["false"]}',
   });
 });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -710,20 +710,23 @@ export class ContainerProviderRegistry {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           let fetchedImages: any[] = [];
 
+          // Create list options with explicit defaults
+          const listOptions = {
+            all: options?.all ?? false,
+            filters: options?.filters,
+          };
+
           // If libpod API is available AND the configuration is set to use libpodApi, use podmanListImages API call.
           if (provider.libpodApi && this.useLibpodApiForImageList()) {
             fetchedImages = await withTimeout(
-              provider.libpodApi.podmanListImages({
-                all: options?.all,
-                filters: options?.filters,
-              }),
+              provider.libpodApi.podmanListImages(listOptions),
               providerTimeoutMs,
               provider.name,
               provider.id,
             );
           } else if (provider.api) {
             fetchedImages = await withTimeout(
-              provider.api.listImages({ all: false }),
+              provider.api.listImages(listOptions),
               providerTimeoutMs,
               provider.name,
               provider.id,


### PR DESCRIPTION
### What does this PR do?
When listing images with options like `{ all: true }`, the Docker API fallback was ignoring these options and hardcoding `{ all: false }`. This meant intermediate images were hidden unexpectedly. Now options are properly passed through, so image listing works consistently across all providers.

### What issues does this PR fix or reference?

Fixes #16422 

### How to test this PR?

unit test

- [x] Tests are covering the bug fix or the new feature
