### PR TITLE
chore(deps): update devalue from 5.6.3 to 5.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,8 @@
       "serialize-javascript": "^7.0.4",
       "ajv@^6": "^6.14.0",
       "ajv@^8": "^8.18.0",
-      "electron-builder-squirrel-windows": "^26.8.2"
+      "electron-builder-squirrel-windows": "^26.8.2",
+      "svelte>devalue": "^5.6.4"
     },
     "patchedDependencies": {
       "docker-modem": "patches/docker-modem.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   ajv@^6: ^6.14.0
   ajv@^8: ^8.18.0
   electron-builder-squirrel-windows: ^26.8.2
+  svelte>devalue: ^5.6.4
 
 patchedDependencies:
   docker-modem:
@@ -6400,8 +6401,8 @@ packages:
     engines: {node: '>= 4.0.0'}
     hasBin: true
 
-  devalue@5.6.3:
-    resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
+  devalue@5.6.4:
+    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -18716,7 +18717,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  devalue@5.6.3: {}
+  devalue@5.6.4: {}
 
   devlop@1.1.0:
     dependencies:
@@ -24428,7 +24429,7 @@ snapshots:
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.3
+      devalue: 5.6.4
       esm-env: 1.2.2
       esrap: 2.2.3
       is-reference: 3.0.3


### PR DESCRIPTION
### What does this PR do?
update to a non-CVE one

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/advisories/GHSA-cfw5-2vxh-hr84
fixes https://github.com/advisories/GHSA-mwv9-gp5h-frr4

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
