### PR TITLE
chore(test,hotfix): disable registries.conf verification for platforms other than linux

### DIFF
--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-registries.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-registries.spec.ts
@@ -25,6 +25,7 @@ import { expect as playExpect } from '@playwright/test';
 import { RegistriesPage } from '/@/model/pages/registries-page';
 import { RunnerOptions } from '/@/runner/runner-options';
 import { test } from '/@/utility/fixtures';
+import { isLinux } from '/@/utility/platform';
 
 let registriesPage: RegistriesPage;
 
@@ -73,6 +74,10 @@ test.describe
     test.describe
       .serial('Registries configuration file verification', () => {
         test('registries.conf contains expected default registries from managed configuration', async () => {
+          test.skip(
+            !isLinux,
+            'Skipping file content verification on Windows and Mac due to different config file handling',
+          );
           const homeDir = os.homedir();
           const registriesConfPath = path.join(homeDir, '.config', 'containers', 'registries.conf');
 


### PR DESCRIPTION
### What does this PR do?
* Disable `registries.conf` verification for platforms other than Linux

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Follow-up #16593 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
