### PR TITLE
feat(alert): remove aria-label in WarningMessage.svelte

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -366,7 +366,7 @@ test('Expect latest tag warning is displayed when the image does not have latest
   await userEvent.keyboard('my-registry/image-without-latest[Enter]');
 
   // expect that the warning message is displayed
-  const errorMessage = screen.getByRole('alert', { name: 'Warning Message Content' });
+  const errorMessage = screen.getByRole('alert');
   expect(errorMessage).toBeInTheDocument();
   expect(errorMessage).toHaveTextContent('"latest" tag not found');
 });
@@ -378,7 +378,7 @@ test('Expect latest tag warning is not displayed when the image has latest tag',
   await userEvent.keyboard('my-registry/image-without-latest[Enter]');
 
   // expect that the warning message is not displayed
-  const errorMessage = screen.queryByRole('alert', { name: 'Warning Message Content' });
+  const errorMessage = screen.queryByRole('alert');
   expect(errorMessage).toBeNull();
 });
 

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -259,7 +259,7 @@ test('Show warning if multiple containers use the same port', async () => {
   podCreationHolder.set(podCreationSamePortContainers);
 
   render(PodCreateFromContainers, {});
-  const warningLabel = await screen.findByLabelText('Warning Message Content');
+  const warningLabel = await screen.findByRole('alert');
   expect(warningLabel).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -18,6 +18,6 @@ export let icon = false;
     class="text-[var(--pd-state-warning)] p-1 flex flex-row items-center {$$props.class}"
     class:opacity-0={error === undefined || error === ''}>
     <Icon size="1.125x" class="cursor-pointer text-[var(--pd-state-warning)]" icon={faTriangleExclamation} />
-    <div role="alert" aria-label="Warning Message Content" class="ml-2">{error}</div>
+    <div role="alert" class="ml-2">{error}</div>
   </div>
 {/if}


### PR DESCRIPTION
### What does this PR do?
Removes the hardcoded aria-label present in ([WarningMessage.svelte](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/ui/WarningMessage.svelte#L21)) which stops screen readers from reading the actual warning message.
### Screenshot / video of UI
none

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
closes #16473 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
`pnpm test:renderer`

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
