### PR TITLE
chore: added status background colors

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -90,6 +90,10 @@ class TestColorRegistry extends ColorRegistry {
   override initCommon(): void {
     super.initCommon();
   }
+
+  override initStatusColors(): void {
+    super.initStatusColors();
+  }
 }
 
 const _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
@@ -886,6 +890,89 @@ describe('initCommon', () => {
     // verify the colors contain alpha information (0.4)
     expect(definition?.dark).toContain('0.4');
     expect(definition?.light).toContain('0.4');
+  });
+});
+
+describe('initStatusColors', () => {
+  beforeEach(() => {
+    vi.spyOn(colorRegistry, 'registerColor').mockReturnValue(undefined);
+    vi.spyOn(colorRegistry, 'registerColorDefinition').mockReturnValue(undefined);
+
+    colorRegistry.initStatusColors();
+  });
+
+  test('registers status-running-bg with green alpha background', () => {
+    const call = vi
+      .mocked(colorRegistry.registerColorDefinition)
+      .mock.calls.find(c => c?.[0]?.id === 'status-running-bg');
+    expect(call).toBeDefined();
+
+    const definition = call?.[0];
+    expect(definition?.id).toBe('status-running-bg');
+    expect(definition?.light).toBeDefined();
+    expect(definition?.dark).toBeDefined();
+    expect(definition?.light).toContain('0.2');
+    expect(definition?.dark).toContain('0.2');
+  });
+
+  test('registers status-stopped-bg with gray/charcoal alpha background', () => {
+    const call = vi
+      .mocked(colorRegistry.registerColorDefinition)
+      .mock.calls.find(c => c?.[0]?.id === 'status-stopped-bg');
+    expect(call).toBeDefined();
+
+    const definition = call?.[0];
+    expect(definition?.id).toBe('status-stopped-bg');
+    expect(definition?.light).toBeDefined();
+    expect(definition?.dark).toBeDefined();
+    expect(definition?.light).toContain('0.2');
+    expect(definition?.dark).toContain('0.2');
+  });
+
+  test('registers status-terminated-bg with red alpha background', () => {
+    const call = vi
+      .mocked(colorRegistry.registerColorDefinition)
+      .mock.calls.find(c => c?.[0]?.id === 'status-terminated-bg');
+    expect(call).toBeDefined();
+
+    const definition = call?.[0];
+    expect(definition?.id).toBe('status-terminated-bg');
+    expect(definition?.light).toBeDefined();
+    expect(definition?.dark).toBeDefined();
+    expect(definition?.light).toContain('0.2');
+    expect(definition?.dark).toContain('0.2');
+  });
+
+  test('registers status-starting-bg with green alpha background', () => {
+    const call = vi
+      .mocked(colorRegistry.registerColorDefinition)
+      .mock.calls.find(c => c?.[0]?.id === 'status-starting-bg');
+    expect(call).toBeDefined();
+
+    const definition = call?.[0];
+    expect(definition?.id).toBe('status-starting-bg');
+    expect(definition?.light).toBeDefined();
+    expect(definition?.dark).toBeDefined();
+    expect(definition?.light).toContain('0.2');
+    expect(definition?.dark).toContain('0.2');
+  });
+
+  test('registers status-unknown-bg with gray/charcoal alpha background', () => {
+    const call = vi
+      .mocked(colorRegistry.registerColorDefinition)
+      .mock.calls.find(c => c?.[0]?.id === 'status-unknown-bg');
+    expect(call).toBeDefined();
+
+    const definition = call?.[0];
+    expect(definition?.id).toBe('status-unknown-bg');
+    expect(definition?.light).toBeDefined();
+    expect(definition?.dark).toBeDefined();
+    expect(definition?.light).toContain('0.2');
+    expect(definition?.dark).toContain('0.2');
+  });
+
+  test('registers exactly 5 color definitions for status backgrounds', () => {
+    expect(vi.mocked(colorRegistry.registerColorDefinition)).toHaveBeenCalledTimes(5);
   });
 });
 

--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -901,70 +901,17 @@ describe('initStatusColors', () => {
     colorRegistry.initStatusColors();
   });
 
-  test('registers status-running-bg with green alpha background', () => {
-    const call = vi
-      .mocked(colorRegistry.registerColorDefinition)
-      .mock.calls.find(c => c?.[0]?.id === 'status-running-bg');
+  test.each([
+    { id: 'status-running-bg', description: 'green alpha background' },
+    { id: 'status-stopped-bg', description: 'gray/charcoal alpha background' },
+    { id: 'status-terminated-bg', description: 'red alpha background' },
+    { id: 'status-starting-bg', description: 'green alpha background' },
+    { id: 'status-unknown-bg', description: 'gray/charcoal alpha background' },
+  ])('registers $id with $description', ({ id }) => {
+    const call = vi.mocked(colorRegistry.registerColorDefinition).mock.calls.find(c => c?.[0]?.id === id);
     expect(call).toBeDefined();
-
     const definition = call?.[0];
-    expect(definition?.id).toBe('status-running-bg');
-    expect(definition?.light).toBeDefined();
-    expect(definition?.dark).toBeDefined();
-    expect(definition?.light).toContain('0.2');
-    expect(definition?.dark).toContain('0.2');
-  });
-
-  test('registers status-stopped-bg with gray/charcoal alpha background', () => {
-    const call = vi
-      .mocked(colorRegistry.registerColorDefinition)
-      .mock.calls.find(c => c?.[0]?.id === 'status-stopped-bg');
-    expect(call).toBeDefined();
-
-    const definition = call?.[0];
-    expect(definition?.id).toBe('status-stopped-bg');
-    expect(definition?.light).toBeDefined();
-    expect(definition?.dark).toBeDefined();
-    expect(definition?.light).toContain('0.2');
-    expect(definition?.dark).toContain('0.2');
-  });
-
-  test('registers status-terminated-bg with red alpha background', () => {
-    const call = vi
-      .mocked(colorRegistry.registerColorDefinition)
-      .mock.calls.find(c => c?.[0]?.id === 'status-terminated-bg');
-    expect(call).toBeDefined();
-
-    const definition = call?.[0];
-    expect(definition?.id).toBe('status-terminated-bg');
-    expect(definition?.light).toBeDefined();
-    expect(definition?.dark).toBeDefined();
-    expect(definition?.light).toContain('0.2');
-    expect(definition?.dark).toContain('0.2');
-  });
-
-  test('registers status-starting-bg with green alpha background', () => {
-    const call = vi
-      .mocked(colorRegistry.registerColorDefinition)
-      .mock.calls.find(c => c?.[0]?.id === 'status-starting-bg');
-    expect(call).toBeDefined();
-
-    const definition = call?.[0];
-    expect(definition?.id).toBe('status-starting-bg');
-    expect(definition?.light).toBeDefined();
-    expect(definition?.dark).toBeDefined();
-    expect(definition?.light).toContain('0.2');
-    expect(definition?.dark).toContain('0.2');
-  });
-
-  test('registers status-unknown-bg with gray/charcoal alpha background', () => {
-    const call = vi
-      .mocked(colorRegistry.registerColorDefinition)
-      .mock.calls.find(c => c?.[0]?.id === 'status-unknown-bg');
-    expect(call).toBeDefined();
-
-    const definition = call?.[0];
-    expect(definition?.id).toBe('status-unknown-bg');
+    expect(definition?.id).toBe(id);
     expect(definition?.light).toBeDefined();
     expect(definition?.dark).toBeDefined();
     expect(definition?.light).toContain('0.2');

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1534,6 +1534,37 @@ export class ColorRegistry {
       light: gray[100],
     });
 
+    this.registerColorDefinition(
+      this.color(`${status}running-bg`)
+        .withLight(colorPaletteHelper(green[200]).withAlpha(0.2))
+        .withDark(colorPaletteHelper(green[900]).withAlpha(0.2))
+        .build(),
+    );
+    this.registerColorDefinition(
+      this.color(`${status}stopped-bg`)
+        .withLight(colorPaletteHelper(gray[300]).withAlpha(0.2))
+        .withDark(colorPaletteHelper(charcoal[500]).withAlpha(0.2))
+        .build(),
+    );
+    this.registerColorDefinition(
+      this.color(`${status}terminated-bg`)
+        .withLight(colorPaletteHelper(red[200]).withAlpha(0.2))
+        .withDark(colorPaletteHelper(red[900]).withAlpha(0.2))
+        .build(),
+    );
+    this.registerColorDefinition(
+      this.color(`${status}starting-bg`)
+        .withLight(colorPaletteHelper(green[200]).withAlpha(0.2))
+        .withDark(colorPaletteHelper(green[900]).withAlpha(0.2))
+        .build(),
+    );
+    this.registerColorDefinition(
+      this.color(`${status}unknown-bg`)
+        .withLight(colorPaletteHelper(gray[300]).withAlpha(0.2))
+        .withDark(colorPaletteHelper(charcoal[500]).withAlpha(0.2))
+        .build(),
+    );
+
     // contrast color for the other status colors,
     // e.g. to use in status icons
     this.registerColor(`${status}contrast`, {


### PR DESCRIPTION
### What does this PR do?
Adds background colors for statuses that will be used in System Overview component in the dashbaord

### Screenshot / video of UI


### What issues does this PR fix or reference?
Part of https://github.com/podman-desktop/podman-desktop/issues/16018

### How to test this PR?
The whole feature can be tried out in https://github.com/podman-desktop/podman-desktop/pull/16111

- [x] Tests are covering the bug fix or the new feature
