### PR TITLE
fix(podman-windows-legacy-installer): remove unnecessary extension-api mock

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.spec.ts
@@ -31,24 +31,6 @@ import {
 } from '/@/utils/podman-windows-legacy-installer';
 
 vi.mock(import('winreg'));
-vi.mock(
-  import('@podman-desktop/api'),
-  () =>
-    ({
-      window: {
-        withProgress: vi.fn(),
-      },
-      commands: {
-        registerCommand: vi.fn(),
-      },
-      process: {
-        exec: vi.fn(),
-      },
-      ProgressLocation: {
-        TASK_WIDGET: 2,
-      },
-    }) as unknown as typeof extensionApi,
-);
 
 const TELEMETRY_LOGGER_MOCK = {
   logUsage: vi.fn(),


### PR DESCRIPTION
### What does this PR do?

Removing unnecessary mocked `@podman-desktop/api` in `extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.spec.ts`

### What issues does this PR fix or reference?

Might unblock https://github.com/podman-desktop/podman-desktop/pull/16606

### How to test this PR?
- [x] CI should be okay
