### PR TITLE
feat(main): add JSON Schema generation for extension manifest

### DIFF
--- a/packages/main/src/plugin/extension/extension-manifest-json-schema.spec.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-json-schema.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/extension/extension-manifest-json-schema.spec.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-json-schema.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import { generateExtensionManifestJsonSchema } from './extension-manifest-json-schema.js';
+
+function getExtensionSchema(): Record<string, unknown> {
+  const schema = generateExtensionManifestJsonSchema();
+  const allOf = schema['allOf'] as Record<string, unknown>[];
+  return allOf[1] as Record<string, unknown>;
+}
+
+describe('generateExtensionManifestJsonSchema', () => {
+  test('produces a valid JSON Schema with allOf composition', () => {
+    const schema = generateExtensionManifestJsonSchema();
+
+    expect(schema['$schema']).toBe('http://json-schema.org/draft-07/schema#');
+    expect(schema['title']).toBe('Podman Desktop Extension Manifest');
+    expect(schema['allOf']).toBeDefined();
+    expect(Array.isArray(schema['allOf'])).toBe(true);
+  });
+
+  test('references the SchemaStore package.json schema', () => {
+    const schema = generateExtensionManifestJsonSchema();
+    const allOf = schema['allOf'] as Record<string, unknown>[];
+
+    expect(allOf[0]).toEqual({ $ref: 'https://json.schemastore.org/package.json' });
+  });
+
+  test('includes extension-specific properties in the second allOf entry', () => {
+    const extensionSchema = getExtensionSchema();
+
+    expect(extensionSchema['type']).toBe('object');
+
+    const properties = extensionSchema['properties'] as Record<string, unknown>;
+    expect(properties).toHaveProperty('displayName');
+    expect(properties).toHaveProperty('publisher');
+    expect(properties).toHaveProperty('contributes');
+    expect(properties).toHaveProperty('engines');
+    expect(properties).toHaveProperty('extensionDependencies');
+    expect(properties).toHaveProperty('extensionPack');
+  });
+
+  test('does not set additionalProperties to false (loose schema)', () => {
+    const extensionSchema = getExtensionSchema();
+    expect(extensionSchema['additionalProperties']).not.toBe(false);
+  });
+
+  test('requires mandatory extension fields', () => {
+    const extensionSchema = getExtensionSchema();
+    const required = extensionSchema['required'] as string[];
+
+    expect(required).toContain('name');
+    expect(required).toContain('displayName');
+    expect(required).toContain('version');
+    expect(required).toContain('publisher');
+    expect(required).toContain('description');
+  });
+});

--- a/packages/main/src/plugin/extension/extension-manifest-json-schema.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-json-schema.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/extension/extension-manifest-json-schema.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-json-schema.ts
@@ -1,0 +1,36 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { z } from 'zod';
+
+import { ExtensionManifestSchema } from './extension-manifest-schema.js';
+
+const PACKAGE_JSON_SCHEMA_URL = 'https://json.schemastore.org/package.json';
+
+export function generateExtensionManifestJsonSchema(): Record<string, unknown> {
+  const extensionSchema = z.toJSONSchema(ExtensionManifestSchema, {
+    target: 'draft-07',
+  });
+
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'Podman Desktop Extension Manifest',
+    description: 'Schema for Podman Desktop extension package.json files',
+    allOf: [{ $ref: PACKAGE_JSON_SCHEMA_URL }, extensionSchema],
+  };
+}


### PR DESCRIPTION
### What does this PR do?

Generate a JSON Schema from the Zod ExtensionManifestSchema using z.toJSONSchema(), composed with the SchemaStore package.json schema via allOf for standard field validation.

### Screenshot / video of UI

Example application on boot-c extension

<img width="1171" height="945" alt="Screenshot 2026-03-16 at 13 05 50" src="https://github.com/user-attachments/assets/d7d0bc47-4536-42a3-94e9-adb17ca61a95" />

<img width="1171" height="945" alt="Screenshot 2026-03-16 at 13 05 39" src="https://github.com/user-attachments/assets/ccca8129-eeec-4d65-9a78-674ca36c47df" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/16051

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

At the top of your JSON file, add

```json
  "$schema": "https://github.com/simonrey1/podman-desktop/releases/download/extension-manifest-schema/extension-manifest-schema.json",
```

You might also need to allow the fetching in your vscode settings:
```json
  "json.schemas": [
    {
      "url": "https://github.com/simonrey1/podman-desktop/releases/download/extension-manifest-schema/extension-manifest-schema.json",
      "fileMatch": ["extensions/*/package.json", "extensions/*/packages/*/package.json"]
    }
  ]
```

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
