### PR TITLE
feat(telemetry): add telemetry tracking when rootful switch was changed

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1819,6 +1819,69 @@ test('provider is registered with limited edit capabilities on (HyperV) Windows'
   );
 });
 
+test.each([
+  {
+    description: 'telemetry is tracked when rootful is set to true',
+    inspectRootful: false,
+    editParams: { 'podman.machine.rootful': true },
+    expectedTelemetry: { event: 'podman.machine.edit.rootful', data: { isRootful: true } },
+  },
+  {
+    description: 'telemetry is tracked when rootful is set to false',
+    inspectRootful: false,
+    editParams: { 'podman.machine.rootful': false },
+    expectedTelemetry: { event: 'podman.machine.edit.rootful', data: { isRootful: false } },
+  },
+  {
+    description: 'telemetry is not tracked when other settings are changed without rootful',
+    inspectRootful: true,
+    editParams: { 'podman.machine.cpus': '4', 'podman.machine.memory': '2048' },
+    expectedTelemetry: undefined,
+  },
+])('$description', async ({ inspectRootful, editParams, expectedTelemetry }) => {
+  vi.mocked(extensionApi.env).isMac = true;
+  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+  spyExecPromise.mockImplementation(
+    (_command, args) =>
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
+        if (args?.[0] === 'machine' && args?.[1] === 'list') {
+          resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
+        } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
+          resolve({
+            stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Rootful: inspectRootful }]),
+          } as extensionApi.RunResult);
+        } else if (args?.[0] === 'machine' && args?.[1] === 'set') {
+          resolve({
+            stdout: '',
+          } as extensionApi.RunResult);
+        } else {
+          reject(new Error('Unexpected command'));
+        }
+      }),
+  );
+
+  let registeredConnection: ContainerProviderConnection | undefined;
+  vi.mocked(provider.registerContainerProviderConnection).mockImplementation(connection => {
+    registeredConnection = connection;
+    return Disposable.from({ dispose: () => {} });
+  });
+
+  await extension.registerProviderFor(provider, podmanConfiguration, machineInfo, 'socket');
+  expect(registeredConnection).toBeDefined();
+  expect(registeredConnection?.lifecycle?.edit).toBeDefined();
+
+  vi.mocked(telemetryLogger.logUsage).mockClear();
+
+  await registeredConnection?.lifecycle?.edit?.({} as unknown as extensionApi.LifecycleContext, editParams);
+
+  if (expectedTelemetry) {
+    expect(telemetryLogger.logUsage).toHaveBeenCalledWith(expectedTelemetry.event, expectedTelemetry.data);
+  } else {
+    expect(telemetryLogger.logUsage).not.toHaveBeenCalled();
+  }
+});
+
 test('provider is registered without edit capabilities on Linux', async () => {
   vi.mocked(extensionApi.env).isLinux = true;
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -774,6 +774,8 @@ export async function registerProviderFor(
     lifecycle.edit = async (context, params, logger, _token): Promise<void> => {
       let effective = false;
       const args = ['machine', 'set', machineInfo.name];
+      let isRootful: boolean | undefined;
+
       for (const key of Object.keys(params)) {
         if (isEditCPUSupported && key === 'podman.machine.cpus') {
           args.push('--cpus', params[key]);
@@ -787,6 +789,7 @@ export async function registerProviderFor(
         } else if (isEditRootfulSupported && key === 'podman.machine.rootful') {
           args.push(`--rootful=${params[key]}`);
           effective = true;
+          isRootful = params[key];
         }
       }
       if (effective) {
@@ -798,6 +801,11 @@ export async function registerProviderFor(
           await execPodman(args, machineInfo.vmType, {
             logger: new LoggerDelegator(context, logger),
           });
+
+          // Track telemetry if rootful/rootless switch was changed
+          if (isRootful !== undefined) {
+            telemetryLogger.logUsage('podman.machine.edit.rootful', { isRootful });
+          }
         } finally {
           if (state === 'started') {
             await lifecycle.start?.(context, logger);


### PR DESCRIPTION
### What does this PR do?

This PR adds telemetry tracking for when users change the rootful/rootless mode of Podman machines. When the `podman.machine.rootful` setting is modified, the extension now logs a `podman.machine.edit.rootful` telemetry event with the `isRootful` property indicating the new state (true/false).

<img width="1200" height="457" alt="image" src="https://github.com/user-attachments/assets/14379a95-9c7e-4ee9-ad74-9f70e783d65b" />

### Screenshot / video of UI

### What issues does this PR fix or reference?

Closes #14402 

### How to test this PR?

1. On macOS or Windows, start a Podman machine
2. Open the machine's settings/edit dialog
3. Toggle the rootful setting from rootless to rootful (or vice versa)
4. Verify that the telemetry event `podman.machine.edit.rootful` is being tracked with the correct `isRootful` value
5. Verify that changing other machine settings (CPUs, memory) without touching rootful does NOT trigger this telemetry event

- [x] Tests are covering the bug fix or the new feature
  - Added test: `telemetry is tracked when rootful setting is changed`
  - Added test: `telemetry is not tracked when other settings are changed without rootful`
