### PR TITLE
fix(frontend): remove async from getImage which is not async

### DIFF
--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
 });
 
 test('Expect valid source and alt text with dark mode', async () => {
-  getImageMock.mockResolvedValue('dark.png');
+  getImageMock.mockReturnValue('dark.png');
 
   const image = render(IconImage, { image: { light: 'light.png', dark: 'dark.png' }, alt: 'this is alt text' });
 
@@ -64,7 +64,7 @@ test('Expect valid source and alt text with dark mode', async () => {
 });
 
 test('Expect valid source and alt text with light mode', async () => {
-  getImageMock.mockResolvedValue('light.png');
+  getImageMock.mockReturnValue('light.png');
 
   const image = render(IconImage, { image: { light: 'light.png', dark: 'dark.png' }, alt: 'this is alt text' });
 
@@ -85,7 +85,7 @@ test('Expect valid source and alt text with light mode', async () => {
 
 test('Expect no alt attribute if missing and default image', async () => {
   getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
-  getImageMock.mockResolvedValue('image.png');
+  getImageMock.mockReturnValue('image.png');
 
   const image = render(IconImage, { image: 'image.png' });
 
@@ -103,7 +103,7 @@ test('Expect no alt attribute if missing and default image', async () => {
 });
 
 test('Expect string as image', async () => {
-  getImageMock.mockResolvedValue('image1');
+  getImageMock.mockReturnValue('image1');
   const image = render(IconImage, { image: 'image1', alt: 'this is alt text' });
 
   // wait for image to be loaded

--- a/packages/renderer/src/lib/appearance/IconImage.svelte
+++ b/packages/renderer/src/lib/appearance/IconImage.svelte
@@ -13,7 +13,7 @@ interface Props {
 let { image, alt, class: className = '', children }: Props = $props();
 
 const appearanceUtil = new AppearanceUtil();
-let imgSrc: string | undefined = $derived(await appearanceUtil.getImage(image));
+let imgSrc: string | undefined = $derived(appearanceUtil.getImage(image));
 </script>
 
 {#if imgSrc}

--- a/packages/renderer/src/lib/appearance/appearance-util.ts
+++ b/packages/renderer/src/lib/appearance/appearance-util.ts
@@ -43,7 +43,7 @@ export class AppearanceUtil {
   /**
    * Helper function that returns the correct image to use based on icon and current light vs dark setting.
    */
-  async getImage(icon: string | { light: string; dark: string } | undefined): Promise<string | undefined> {
+  getImage(icon: string | { light: string; dark: string } | undefined): string | undefined {
     if (!icon) {
       return undefined;
     }

--- a/packages/renderer/src/lib/appearance/appearance-utils.spec.ts
+++ b/packages/renderer/src/lib/appearance/appearance-utils.spec.ts
@@ -44,14 +44,14 @@ test('Expect standard icon using dark configuration', async () => {
   const img = 'icon.png';
   vi.mocked(window.getConfigurationValue).mockResolvedValue(AppearanceSettings.DarkEnumValue);
 
-  expect(await appearanceUtil.getImage(img)).toBe(img);
+  expect(appearanceUtil.getImage(img)).toBe(img);
 });
 
 test('Expect standard icon using light configuration', async () => {
   const img = 'icon.png';
   vi.mocked(window.getConfigurationValue).mockResolvedValue(AppearanceSettings.LightEnumValue);
 
-  expect(await appearanceUtil.getImage(img)).toBe(img);
+  expect(appearanceUtil.getImage(img)).toBe(img);
 });
 
 test('Expect dark icon using dark configuration', async () => {
@@ -59,7 +59,7 @@ test('Expect dark icon using dark configuration', async () => {
   vi.mocked(window.getConfigurationValue).mockResolvedValue(AppearanceSettings.DarkEnumValue);
   configurationProperties.set([]);
 
-  await vi.waitFor(async () => expect(await appearanceUtil.getImage(img)).toBe(img.dark));
+  await vi.waitFor(async () => expect(appearanceUtil.getImage(img)).toBe(img.dark));
 });
 
 test('Expect light icon using light configuration', async () => {
@@ -67,7 +67,7 @@ test('Expect light icon using light configuration', async () => {
   vi.mocked(window.getConfigurationValue).mockResolvedValue(AppearanceSettings.LightEnumValue);
   configurationProperties.set([]);
 
-  await vi.waitFor(async () => expect(await appearanceUtil.getImage(img)).toBe(img.light));
+  await vi.waitFor(async () => expect(appearanceUtil.getImage(img)).toBe(img.light));
 });
 
 describe('getTheme', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -237,7 +237,7 @@ test('Expects images.icon option to be used when no themes are present', async (
       sessionRequests: [],
     },
   ];
-  vi.mocked(AppearanceUtil.prototype.getImage).mockResolvedValue('./icon.png');
+  vi.mocked(AppearanceUtil.prototype.getImage).mockReturnValue('./icon.png');
   authenticationProviders.set(providerWithImageIcon);
   render(PreferencesAuthenticationProvidersRendering, {});
 
@@ -264,7 +264,7 @@ test('Expects images.icon.dark option to be used when theme is dark', async () =
       sessionRequests: [],
     },
   ];
-  vi.mocked(AppearanceUtil.prototype.getImage).mockResolvedValue('./icon-dark.png');
+  vi.mocked(AppearanceUtil.prototype.getImage).mockReturnValue('./icon-dark.png');
   authenticationProviders.set(providerWithImageIcon);
 
   configMock.mockReturnValue('dark');

--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -13,7 +13,7 @@ onMount(async () => {
   const appearanceUtil = new AppearanceUtil();
 
   // get the color
-  let singleColor = await appearanceUtil.getImage(color);
+  let singleColor = appearanceUtil.getImage(color);
   singleColor ??= '';
 
   if (singleColor?.startsWith('#')) {


### PR DESCRIPTION
### What does this PR do?

Removes the async from appareanceUtils.getImage, which is not really async

It seems that this makes svelte 5 crazy when such function is called with async from a svelte component

Fixes #16656 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Check #16656 

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
