### PR TITLE
fix(renderer): respect hidden property in ExperimentalPage

### DIFF
--- a/packages/renderer/src/lib/preferences/ExperimentalPage.spec.ts
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.spec.ts
@@ -61,6 +61,24 @@ test('only experimental configuration should be displayed', async () => {
   });
 });
 
+test('hidden experimental configuration should not be displayed', async () => {
+  const hiddenExperimentalConfig: IConfigurationPropertyRecordedSchema = {
+    ...EXPERIMENTAL_CONFIG,
+    id: 'hidden-experimental-config',
+    title: 'Hidden Experimental Config',
+    hidden: true,
+  };
+
+  const { queryByText } = render(ExperimentalPage, {
+    properties: [hiddenExperimentalConfig, EXPERIMENTAL_CONFIG],
+  });
+
+  await vi.waitFor(() => {
+    expect(queryByText(hiddenExperimentalConfig.title)).toBeNull();
+    expect(queryByText(EXPERIMENTAL_CONFIG.title)).toBeDefined();
+  });
+});
+
 test('Enable all should update all configuration', async () => {
   const generated: IConfigurationPropertyRecordedSchema[] = Array.from({ length: 10 }, (_, index) => ({
     ...EXPERIMENTAL_CONFIG,

--- a/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
+++ b/packages/renderer/src/lib/preferences/ExperimentalPage.svelte
@@ -14,7 +14,7 @@ interface Props {
 let { properties = [] }: Props = $props();
 
 let experimental: IConfigurationPropertyRecordedSchema[] = $derived(
-  properties.filter(property => !!property.experimental),
+  properties.filter(property => !!property.experimental && !property.hidden),
 );
 
 let values: Record<string, boolean> = $state({});


### PR DESCRIPTION
### What does this PR do?

The ExperimentalPage filtered properties only by `!!property.experimental` but did not check `property.hidden`, unlike PreferencesRendering and PreferencesResourcesRendering. This meant setting `hidden: true` on an experimental configuration had no effect on the Experimental Features page.

### Screenshot / video of UI

For example, I can now hide the experimental dashboard feature (will be pushed in a separate PR).

<img width="1459" height="957" alt="Screenshot 2026-03-18 at 17 49 07" src="https://github.com/user-attachments/assets/16e4b3da-29d1-44af-9e73-04ea32a643a8" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/16551

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
