### PR TITLE
chore(main): hide experimental enhanced dashboard setting

### DIFF
--- a/packages/main/src/plugin/dashboard/dashboard-service.ts
+++ b/packages/main/src/plugin/dashboard/dashboard-service.ts
@@ -39,6 +39,7 @@ export class DashboardService {
           description: 'Enhanced dashboard with more features and improved user experience',
           type: 'object',
           default: false,
+          hidden: true,
           experimental: {
             githubDiscussionLink: 'https://github.com/podman-desktop/podman-desktop/discussions/16055',
           },


### PR DESCRIPTION
### What does this PR do?

The enhanced dashboard feature is not yet ready: enabling the toggle results in an empty dashboard. Mark the configuration as hidden so it does not appear in the Experimental Features page until the dashboard content is implemented.

### Screenshot / video of UI

<img width="1459" height="957" alt="Screenshot 2026-03-18 at 17 49 07" src="https://github.com/user-attachments/assets/16e4b3da-29d1-44af-9e73-04ea32a643a8" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16551#issuecomment-4083599463

Requires a rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/16687 is merged

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Check on the experimental page that the experimental dashboard is not showing.

NB: I did not add UT as this is a temporary band aid.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
