### PR TITLE
chore(fix): fix provider dropdown height when adding a new provider

### DIFF
--- a/packages/renderer/src/lib/statusbar/PinMenu.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinMenu.spec.ts
@@ -18,22 +18,16 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render } from '@testing-library/svelte';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
 
 import PinMenu from '/@/lib/statusbar/PinMenu.svelte';
 
-beforeAll(() => {
-  Object.defineProperty(window, 'addEventListener', { value: vi.fn() });
-  Object.defineProperty(window, 'removeEventListener', { value: vi.fn() });
-});
-
-beforeEach(() => {
-  vi.resetAllMocks();
-});
-
-test('component on mount should resize listener', () => {
+test('component should render with fixed positioning above status bar', () => {
   render(PinMenu);
-  expect(window.addEventListener).toHaveBeenCalledOnce();
-  expect(window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+  const menu = screen.getByTestId('pin-menu');
+  expect(menu).toBeInTheDocument();
+  expect(menu.className).toContain('fixed');
+  expect(menu.className).toContain('bottom-[26px]');
+  expect(menu.className).toContain('left-px');
 });

--- a/packages/renderer/src/lib/statusbar/PinMenu.svelte
+++ b/packages/renderer/src/lib/statusbar/PinMenu.svelte
@@ -1,28 +1,5 @@
-<script lang="ts">
-import { onDestroy, onMount } from 'svelte';
-
-let dropDownHeight: number;
-let dropDownElement: HTMLElement;
-
-const STATUS_BAR_HEIGHT = 26;
-
-function updateMenuLocation(): void {
-  dropDownElement.style.top = `${window.innerHeight - dropDownHeight - STATUS_BAR_HEIGHT}px`;
-  dropDownElement.style.left = '1px';
-}
-
-onMount(() => {
-  updateMenuLocation();
-  window.addEventListener('resize', updateMenuLocation);
-});
-
-onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
-</script>
-
 <div
-  bind:offsetHeight={dropDownHeight}
-  bind:this={dropDownElement}
-  class="absolute z-10"
+  class="fixed z-10 bottom-[26px] left-px"
   data-testid="pin-menu">
   <div
     title="Pin Menu"


### PR DESCRIPTION
### What does this PR do?
Fixes the faulty behavior of the provider dropdown when a new entry is added while the menu is open.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/16704

### How to test this PR?
Check that issue https://github.com/podman-desktop/podman-desktop/issues/16704 no longer occurs.
