### PR TITLE
feat(ui): replace spinner with 8-tick activity indicator

### DIFF
--- a/packages/renderer/src/lib/markdown/component/micromark-spinner.ts
+++ b/packages/renderer/src/lib/markdown/component/micromark-spinner.ts
@@ -94,52 +94,25 @@ function toggleElementSpinner(ownerId: string, enabled: boolean): void {
 function generateSpinnerIcon(id: string): string {
   return `
         <i id='${id}' class='flex justify-center items-center mr-2' style='display: none;'>
-            <svg width='1em' height='1em' viewBox='0 0 100 100'>
-            <defs>
-                <linearGradient id='grad1' x1='0%' y1='0%' x2='0%' y2='100%'>
-                <stop offset='0%' style='stop-color:rgb(0,0,0);stop-opacity:1'></stop>
-                <stop offset='60%' style='stop-color:rgb(0,0,0);stop-opacity:1'></stop>
-                <stop offset='100%' style='stop-color:rgb(255,255,255);stop-opacity:1'></stop>
-                </linearGradient>
-            </defs>
-            <mask id='myMask'>
-                <rect x='0' y='0' width='100' height='100' fill='white'></rect>
-                <rect x='-25' y='-25' width='150' height='75' fill='black'></rect>
-                <g transform='translate(50,50)' style='width='1em'; height='1em''>
-                <g>
-                    <rect x='-75' y='-75' width='150' height='75' fill='url(#grad1)'></rect>
-                    <rect x='-75' y='-70' width='100' height='75' fill='black'></rect>
-                    <animateTransform
-                    attributeName='transform'
-                    type='rotate'
-                    dur='1.5s'
-                    from='0'
-                    to='180'
-                    values='0; 140;180; 140; 0'
-                    keyTimes='0; 0.25;0.5; 0.75;1'
-                    repeatCount='indefinite'></animateTransform>
-                </g>
-                </g>
-            </mask>
-            <circle
-                cx='50'
-                cy='50'
-                r='46'
-                stroke='currentColor'
-                opacity='0.8'
-                stroke-width='10'
-                fill='transparent'
-                mask='url(#myMask)'></circle>
-            <animateTransform
+            <svg width='1em' height='1em' viewBox='0 0 64 64' aria-hidden='true'>
+            <g>
+                <line x1='32' y1='4' x2='32' y2='16' transform='rotate(0, 32, 32)' stroke='currentColor' stroke-width='8' stroke-linecap='round' opacity='0.4' />
+                <line x1='32' y1='4' x2='32' y2='16' transform='rotate(45, 32, 32)' stroke='currentColor' stroke-width='8' stroke-linecap='round' opacity='0.08' />
+                <line x1='32' y1='4' x2='32' y2='16' transform='rotate(90, 32, 32)' stroke='currentColor' stroke-width='8' stroke-linecap='round' opacity='0.16' />
+                <line x1='32' y1='4' x2='32' y2='16' transform='rotate(135, 32, 32)' stroke='currentColor' stroke-width='8' stroke-linecap='round' opacity='0.24' />
+                <line x1='32' y1='4' x2='32' y2='16' transform='rotate(180, 32, 32)' stroke='currentColor' stroke-width='8' stroke-linecap='round' opacity='0.32' />
+                <line x1='32' y1='4' x2='32' y2='16' transform='rotate(225, 32, 32)' stroke='currentColor' stroke-width='8' stroke-linecap='round' opacity='0.36' />
+                <line x1='32' y1='4' x2='32' y2='16' transform='rotate(270, 32, 32)' stroke='currentColor' stroke-width='8' stroke-linecap='round' opacity='0.4' />
+                <line x1='32' y1='4' x2='32' y2='16' transform='rotate(315, 32, 32)' stroke='currentColor' stroke-width='8' stroke-linecap='round' opacity='0.4' />
+                <animateTransform
                 attributeName='transform'
                 type='rotate'
-                dur='3s'
-                from='0'
-                to='360'
-                repeatCount='indefinite'
-                values='0;90;180;270;360;450;540;630;720;810;900;990;1080;1170;1260;1350;1440;1530;1620;1710;1800'
-                keyTimes='0; 0.02;0.08;0.18;0.32;0.375;0.42;0.455;0.48;0.495;0.5;0.52;0.58;0.68;0.82;0.875;0.92;0.955;0.98;0.995;1'
-            ></animateTransform>
+                calcMode='discrete'
+                values='0 32 32;45 32 32;90 32 32;135 32 32;180 32 32;225 32 32;270 32 32;315 32 32'
+                keyTimes='0;0.125;0.25;0.375;0.5;0.625;0.75;0.875'
+                dur='720ms'
+                repeatCount='indefinite' />
+            </g>
             </svg>
         </i>`;
 }

--- a/packages/ui/src/lib/progress/Spinner.spec.ts
+++ b/packages/ui/src/lib/progress/Spinner.spec.ts
@@ -53,3 +53,30 @@ test('should use custom label', () => {
   const { getByRole } = render(Spinner, { label: 'Custom Loading' });
   getByRole('status', { name: 'Custom Loading' });
 });
+
+describe('spinner SVG structure', () => {
+  test('should have 8 line elements', () => {
+    render(Spinner);
+    const spinner = screen.getByRole('status', { name: 'Loading' });
+    const svg = spinner.querySelector('svg');
+    expect(svg).toBeDefined();
+    const lines = svg?.querySelectorAll('line');
+    expect(lines?.length).toBe(8);
+  });
+
+  test('should have viewBox 0 0 64 64', () => {
+    render(Spinner);
+    const spinner = screen.getByRole('status', { name: 'Loading' });
+    const svg = spinner.querySelector('svg');
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 64 64');
+  });
+
+  test('should have animateTransform element', () => {
+    render(Spinner);
+    const spinner = screen.getByRole('status', { name: 'Loading' });
+    const svg = spinner.querySelector('svg');
+    const animateTransform = svg?.querySelector('animateTransform');
+    expect(animateTransform).toBeDefined();
+    expect(animateTransform?.getAttribute('calcMode')).toBe('discrete');
+  });
+});

--- a/packages/ui/src/lib/progress/Spinner.spec.ts
+++ b/packages/ui/src/lib/progress/Spinner.spec.ts
@@ -59,24 +59,26 @@ describe('spinner SVG structure', () => {
     render(Spinner);
     const spinner = screen.getByRole('status', { name: 'Loading' });
     const svg = spinner.querySelector('svg');
-    expect(svg).toBeDefined();
-    const lines = svg?.querySelectorAll('line');
-    expect(lines?.length).toBe(8);
+    expect(svg).not.toBeNull();
+    const lines = svg!.querySelectorAll('line');
+    expect(lines.length).toBe(8);
   });
 
   test('should have viewBox 0 0 64 64', () => {
     render(Spinner);
     const spinner = screen.getByRole('status', { name: 'Loading' });
     const svg = spinner.querySelector('svg');
-    expect(svg?.getAttribute('viewBox')).toBe('0 0 64 64');
+    expect(svg).not.toBeNull();
+    expect(svg!.getAttribute('viewBox')).toBe('0 0 64 64');
   });
 
   test('should have animateTransform element', () => {
     render(Spinner);
     const spinner = screen.getByRole('status', { name: 'Loading' });
     const svg = spinner.querySelector('svg');
-    const animateTransform = svg?.querySelector('animateTransform');
-    expect(animateTransform).toBeDefined();
-    expect(animateTransform?.getAttribute('calcMode')).toBe('discrete');
+    expect(svg).not.toBeNull();
+    const animateTransform = svg!.querySelector('animateTransform');
+    expect(animateTransform).not.toBeNull();
+    expect(animateTransform!.getAttribute('calcMode')).toBe('discrete');
   });
 });

--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -14,51 +14,24 @@ let { size = '2em', class: className, style, label = 'Loading' }: Props = $props
   aria-live="polite"
   class="flex justify-center items-center {className}"
   style={style}>
-  <svg width={size} height={size} viewBox="0 0 100 100" aria-hidden="true">
-    <defs>
-      <linearGradient id="grad1" x1="0%" y1="0%" x2="0%" y2="100%">
-        <stop offset="0%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
-        <stop offset="60%" style="stop-color:rgb(0,0,0);stop-opacity:1"></stop>
-        <stop offset="100%" style="stop-color:rgb(255,255,255);stop-opacity:1"></stop>
-      </linearGradient>
-    </defs>
-    <mask id="myMask">
-      <rect x="0" y="0" width="100" height="100" fill="white"></rect>
-      <rect x="-25" y="-25" width="150" height="75" fill="black"></rect>
-      <g transform="translate(50,50)" style="width={size}; height={size}">
-        <g>
-          <rect x="-75" y="-75" width="150" height="75" fill="url(#grad1)"></rect>
-          <rect x="-75" y="-70" width="100" height="75" fill="black"></rect>
-          <animateTransform
-            attributeName="transform"
-            type="rotate"
-            dur="1.5s"
-            from="0"
-            to="180"
-            values="0; 140;180; 140; 0"
-            keyTimes="0; 0.25;0.5; 0.75;1"
-            repeatCount="indefinite"></animateTransform>
-        </g>
-      </g>
-    </mask>
-    <circle
-      cx="50"
-      cy="50"
-      r="46"
-      stroke="currentColor"
-      opacity="0.8"
-      stroke-width="10"
-      fill="transparent"
-      mask="url(#myMask)"></circle>
-    <animateTransform
-      attributeName="transform"
-      type="rotate"
-      dur="3s"
-      from="0"
-      to="360"
-      repeatCount="indefinite"
-      values="0;90;180;270;360;450;540;630;720;810;900;990;1080;1170;1260;1350;1440;1530;1620;1710;1800"
-      keyTimes="0; 0.02;0.08;0.18;0.32;0.375;0.42;0.455;0.48;0.495;0.5;0.52;0.58;0.68;0.82;0.875;0.92;0.955;0.98;0.995;1"
-    ></animateTransform>
+  <svg width={size} height={size} viewBox="0 0 64 64" aria-hidden="true">
+    <g>
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(0, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(45, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.08" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(90, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.16" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(135, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.24" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(180, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.32" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(225, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.36" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(270, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(315, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+      <animateTransform
+        attributeName="transform"
+        type="rotate"
+        calcMode="discrete"
+        values="0 32 32;45 32 32;90 32 32;135 32 32;180 32 32;225 32 32;270 32 32;315 32 32"
+        keyTimes="0;0.125;0.25;0.375;0.5;0.625;0.75;0.875"
+        dur="720ms"
+        repeatCount="indefinite" />
+    </g>
   </svg>
 </i>


### PR DESCRIPTION
### What does this PR do?

Replaces the gradient-mask circle spinner (Material Design style) with a macOS-style 8-tick activity indicator that uses discrete rotation animation.

- Rewrite `Spinner.svelte` SVG: 8 `<line>` ticks with graduated opacity inside a `<g>`, rotated via a single `<animateTransform>` with `calcMode="discrete"`
- Update hardcoded spinner HTML in `micromark-spinner.ts` to match the new design
- Add unit tests for the new SVG structure (8 lines, `viewBox`, `animateTransform`)
- Remove all SVG `id` attributes (`grad1`, `myMask`) that caused conflicts when multiple spinners existed on the same page
- Color remains `currentColor` (inherits from parent context)

### Screenshot / video of UI

- Current Spinner on podman-desktop.io Storybook page: https://podman-desktop.io/storybook?id=progress-spinner--docs
- New Spinner: https://vancura-gh-15172-spinner-design-implementation.podman-desktop-website-pr.pages.dev/storybook (the bot has some problems with the artifact, so no build yet - `no artifacts found`)

#### Before, light theme:

<img width="2120" height="5055" alt="image" src="https://github.com/user-attachments/assets/5e8155dc-7ffd-4c81-b193-2e91433e7eb1" />

#### Now:

<img width="2120" height="5055" alt="image" src="https://github.com/user-attachments/assets/fd122ee1-c17f-4814-93f0-7de78ac4b777" />

#### Before, dark theme:

<img width="2120" height="5055" alt="image" src="https://github.com/user-attachments/assets/ec0a5936-9f69-4635-89df-c4d59d8af9bc" />

#### Now:

<img width="2120" height="5055" alt="image" src="https://github.com/user-attachments/assets/1201284f-e267-4383-81cf-60168f3433a2" />

### What issues does this PR fix or reference?

Closes #15172

### How to test this PR?

1. `pnpm test:ui` -- Spinner unit tests pass (6 tests)
2. `pnpm test:renderer` -- micromark-spinner and micromark-button-directive tests pass
3. `pnpm --filter storybook dev` -- visual check of Spinner stories (Basic, Sizes, Accessibility, Contexts) in both light and dark
  themes
4. `pnpm watch` -- visual check in app (Button in progress, StatusIcon DELETING/UPDATING, toast in-progress)

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>