### PR TITLE
feat: handle high contrast themes in appearance init and isDark store

### DIFF
--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -165,6 +165,20 @@ test('Expect native theme to be set to system', async () => {
   expect(nativeTheme.themeSource).toEqual('system');
 });
 
+test('Expect native theme to be set to light for hc-light', async () => {
+  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
+  appearanceInit.updateNativeTheme('hc-light');
+
+  expect(nativeTheme.themeSource).toEqual('light');
+});
+
+test('Expect native theme to be set to dark for hc-dark', async () => {
+  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
+  appearanceInit.updateNativeTheme('hc-dark');
+
+  expect(nativeTheme.themeSource).toEqual('dark');
+});
+
 test('Expect unknown theme to be set to system', async () => {
   const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
   appearanceInit.updateNativeTheme('unknown');

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -42,7 +42,7 @@ export class AppearanceInit {
         [APPEARANCE_FULL_KEY]: {
           description: 'Select between light or dark mode, or use your system setting.',
           type: 'string',
-          enum: ['system', 'dark', 'light'],
+          enum: ['system', 'dark', 'light', 'hc-dark', 'hc-light'],
           default: 'system',
         },
         [`${AppearanceSettings.SectionName}.${AppearanceSettings.ZoomLevel}`]: {
@@ -78,9 +78,9 @@ export class AppearanceInit {
 
   updateNativeTheme(appearance: string): void {
     // appearance config values match the enum values for themeSource, but lets be expicit
-    if (appearance === AppearanceSettings.LightEnumValue) {
+    if (appearance === AppearanceSettings.LightEnumValue || appearance === AppearanceSettings.LightHCEnumValue) {
       nativeTheme.themeSource = 'light';
-    } else if (appearance === AppearanceSettings.DarkEnumValue) {
+    } else if (appearance === AppearanceSettings.DarkEnumValue || appearance === AppearanceSettings.DarkHCEnumValue) {
       nativeTheme.themeSource = 'dark';
     } else {
       nativeTheme.themeSource = 'system';

--- a/packages/main/src/plugin/appearance-init.ts
+++ b/packages/main/src/plugin/appearance-init.ts
@@ -40,7 +40,7 @@ export class AppearanceInit {
       type: 'object',
       properties: {
         [APPEARANCE_FULL_KEY]: {
-          description: 'Select between light or dark mode, or use your system setting.',
+          description: 'Select light, dark, high-contrast light, high-contrast dark, or use your system setting.',
           type: 'string',
           enum: ['system', 'dark', 'light', 'hc-dark', 'hc-light'],
           default: 'system',

--- a/packages/renderer/src/stores/appearance.spec.ts
+++ b/packages/renderer/src/stores/appearance.spec.ts
@@ -76,3 +76,17 @@ test('Expect dark mode using dark configuration', async () => {
 
   await vi.waitFor(() => expect(get(isDark)).toBe(true));
 });
+
+test('Expect light mode using hc-light configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightHCEnumValue);
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isDark)).toBe(false));
+});
+
+test('Expect dark mode using hc-dark configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkHCEnumValue);
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isDark)).toBe(true));
+});

--- a/packages/renderer/src/stores/appearance.ts
+++ b/packages/renderer/src/stores/appearance.ts
@@ -45,9 +45,9 @@ function updateIsDark(appearance: string): void {
   if (appearance === AppearanceSettings.SystemEnumValue) {
     // need to read the system default theme using the window.matchMedia
     isDark.set(window.matchMedia('(prefers-color-scheme: dark)').matches);
-  } else if (appearance === AppearanceSettings.LightEnumValue) {
+  } else if (appearance === AppearanceSettings.LightEnumValue || appearance === AppearanceSettings.LightHCEnumValue) {
     isDark.set(false);
-  } else if (appearance === AppearanceSettings.DarkEnumValue) {
+  } else if (appearance === AppearanceSettings.DarkEnumValue || appearance === AppearanceSettings.DarkHCEnumValue) {
     isDark.set(true);
   }
 }


### PR DESCRIPTION
### What does this PR do?

The following changes request extends the appearance configuration enum with hc-dark and hc-light values. 

Map hc variants to their base Electron native theme (hc-light → light, hc-dark → dark). Update the renderer isDark store to treat hc variants the same as their base counterparts.

This is a part of complex changes which is split to a smaller change set. Original plan is described here: https://github.com/podman-desktop/podman-desktop/issues/14166#issuecomment-4029644023

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

part of #14166 

### How to test this PR?

- `pnpm test:main` should pass with no errors (2 new tests for `updateNativeTheme`)
- `pnpm test:renderer` should pass with no errors (2 new tests for `isDark` store)
- Withing these changes, `hc-dark` and `hc-light` themes appear in Settings → Preferences → Appearance and the OS-level theme switching works correctly. `hc-dark` and `hc-light` fallback to their particular parent themes. Colors configuration will be provided in the separate PRs.

- [x] Tests are covering the bug fix or the new feature
