### PR TITLE
chore(package.json): remove deprecated `@types/tar` package

### DIFF
--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -28,7 +28,6 @@
     "@types/node": "^24",
     "@types/semver": "^7.7.1",
     "@types/stream-json": "^1.7.8",
-    "@types/tar": "^7.0.87",
     "@types/tar-fs": "^2.0.4",
     "@types/validator": "^13.15.10",
     "@types/winreg": "^1.2.36",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,9 +671,6 @@ importers:
       '@types/stream-json':
         specifier: ^1.7.8
         version: 1.7.8
-      '@types/tar':
-        specifier: ^7.0.87
-        version: 7.0.87
       '@types/tar-fs':
         specifier: ^2.0.4
         version: 2.0.4
@@ -4476,10 +4473,6 @@ packages:
 
   '@types/tar-stream@3.1.3':
     resolution: {integrity: sha512-Zbnx4wpkWBMBSu5CytMbrT5ZpMiF55qgM+EpHzR4yIDu7mv52cej8hTkOc6K+LzpkOAbxwn/m7j3iO+/l42YkQ==}
-
-  '@types/tar@7.0.87':
-    resolution: {integrity: sha512-3IxNBV8LeY5oi2ZFpvAhOtW1+mHswkzM7BuisVrwJgPv67GBO2rkLPQlEKtzfHuLdhDDczhkCZeT+RuizMay4A==}
-    deprecated: This is a stub types definition. tar provides its own type definitions, so you do not need this installed.
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -16566,10 +16559,6 @@ snapshots:
   '@types/tar-stream@3.1.3':
     dependencies:
       '@types/node': 24.10.11
-
-  '@types/tar@7.0.87':
-    dependencies:
-      tar: 7.5.12
 
   '@types/trusted-types@2.0.7': {}
 


### PR DESCRIPTION
### What does this PR do?
Remove the deprecated `@types/tar` devDependency from `packages/main/package.json`.
The `tar` package now ships its own type definitions, making `@types/tar` unnecessary.

### What issues does this PR fix or reference?
Closes #16716

### How to test this PR?
- [x] Run `pnpm install` — no deprecation warning for `@types/tar`
- [x] Run `pnpm run typecheck` — no type errors