### PR TITLE
feat(alert): remove custom aria-label in DeployPodToKube.svelte

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -567,7 +567,7 @@ test('ImagePullBackOff error should be reported', async () => {
     expect(window.telemetryTrack).toBeCalledWith('deployToKube', {
       errorMessage: 'ImagePullBackOff',
     });
-    expect(screen.getByLabelText('Deploy Error Message')).toHaveTextContent(
+    expect(screen.getByRole('alert')).toHaveTextContent(
       'ImagePullBackOff error, please check that the image is accessible from the Kubernetes cluster',
     );
   });

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -552,10 +552,10 @@ function updateKubeResult(): void {
     {/if}
 
     {#if deployWarning}
-      <WarningMessage aria-label="Deploy Warning Message" class="text-sm" error={deployWarning} />
+      <WarningMessage class="text-sm" error={deployWarning} />
     {/if}
     {#if deployError}
-      <ErrorMessage aria-label="Deploy Error Message" class="text-sm" error={deployError} />
+      <ErrorMessage class="text-sm" error={deployError} />
     {/if}
 
     {#if !deployStarted}


### PR DESCRIPTION
### What does this PR do?
Removes custom `aria-label` applied to alert components like `Error Message` and `Warning Message`. Makes the actual "error" or "warning" message visible to screen readers.

### Screenshot / video of UI
none

### What issues does this PR fix or reference?
closes #16479 

### How to test this PR?
`pnpm test:renderer`

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
