### PR TITLE
chore(test): enhancing trace naming with workerIndex to distinguish between files with the same name

### DIFF
--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -400,9 +400,16 @@ export class Runner {
   public setVideoAndTraceName(name: string): void {
     this._videoAndTraceName = name;
 
-    if (test.info().retry > 0) {
+    if (test?.info()?.retry && test.info()?.retry > 0) {
       this._videoAndTraceName += `_retry-${test.info().retry}`;
+      return;
     }
+
+    this._videoAndTraceName += `_w${test?.info()?.workerIndex}`;
+  }
+
+  public getVideoAndTraceName(): string {
+    return this._videoAndTraceName ?? '';
   }
 
   public getTestOutput(): string {


### PR DESCRIPTION
### What does this PR do?
Enhances the naming of the trace/video files with the worker index in order to be able to distinguish between trace files from the same test file but from different workers.

### What issues does this PR fix or reference?
