### PR TITLE
feat(kubernetes): support multiple KUBECONFIG paths

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -127,6 +127,10 @@ class TestKubernetesClient extends KubernetesClient {
     return super.createWatchObject();
   }
 
+  public testGetKubeconfigPaths(kubeconfigPath: string): string[] {
+    return this.getKubeconfigPaths(kubeconfigPath);
+  }
+
   public setInitialNamespace(namespace: string): void {
     this.currentNamespace = namespace;
   }
@@ -328,11 +332,16 @@ const execMock = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(fs.existsSync).mockReset();
+  KubeConfig.prototype.loadFromFile = vi.fn();
   KubeConfig.prototype.loadFromString = vi.fn();
+  KubeConfig.prototype.mergeConfig = vi.fn();
   KubeConfig.prototype.exportConfig = vi.fn();
   KubeConfig.prototype.makeApiClient = makeApiClientMock;
   KubeConfig.prototype.getContextObject = getContextObjectMock;
+  KubeConfig.prototype.getCurrentContext = vi.fn().mockReturnValue('context');
   KubeConfig.prototype.currentContext = 'context';
+  KubeConfig.prototype.contexts = [];
   Exec.prototype.exec = execMock;
   Health.prototype.readyz = vi.fn();
 });
@@ -514,6 +523,7 @@ test('Check update with empty kubeconfig file', async () => {
   const consoleErrorSpy = vi.spyOn(console, 'error');
 
   // provide empty kubeconfig file
+  vi.mocked(fs.existsSync).mockReturnValue(true);
   readFileMock.mockResolvedValue('');
 
   const client = new KubernetesClient(
@@ -525,26 +535,34 @@ test('Check update with empty kubeconfig file', async () => {
     featureRegistry,
   );
   await client.refresh();
-  expect(consoleErrorSpy).toBeCalledWith(expect.stringContaining('is empty. Skipping'));
+  expect(consoleErrorSpy).toBeCalledWith(expect.stringContaining('are empty. Skipping'));
 });
 
 test('test that blank kubeconfig path will be set to default one', async () => {
-  const client = createTestClient('fooNS');
-  vi.spyOn(client, 'refresh').mockResolvedValue(undefined);
-  const setKubeconfigSpy = vi.spyOn(client, 'setKubeconfig');
+  const savedKubeconfig = process.env['KUBECONFIG'];
+  delete process.env['KUBECONFIG'];
+  try {
+    const client = createTestClient('fooNS');
+    vi.spyOn(client, 'refresh').mockResolvedValue(undefined);
+    const setKubeconfigSpy = vi.spyOn(client, 'setKubeconfig');
 
-  await client.init();
+    await client.init();
 
-  // Set empty path
-  _onDidChangeConfiguration.fire({
-    key: 'kubernetes.Kubeconfig',
-    value: '',
-    scope: 'DEFAULT',
-  });
+    // Set empty path
+    _onDidChangeConfiguration.fire({
+      key: 'kubernetes.Kubeconfig',
+      value: '',
+      scope: 'DEFAULT',
+    });
 
-  const kubeconfigPath = Uri.file(resolve(homedir(), '.kube', 'config'));
-  // Should be default kubeconfigpath
-  expect(setKubeconfigSpy).toBeCalledWith(kubeconfigPath);
+    const kubeconfigPath = Uri.file(resolve(homedir(), '.kube', 'config'));
+    // Should be default kubeconfigpath
+    expect(setKubeconfigSpy).toBeCalledWith(kubeconfigPath);
+  } finally {
+    if (savedKubeconfig !== undefined) {
+      process.env['KUBECONFIG'] = savedKubeconfig;
+    }
+  }
 });
 
 test('test that setting current namespace updates namespace but not kubeconfig', async () => {
@@ -2712,4 +2730,76 @@ test('useInternalKubernetes configuration is set to true when internal manager i
   await client.init();
   await client.KubernetesManagerStart();
   expect(configurationRegistry.updateConfigurationValue).toHaveBeenCalledWith('kubernetes.useInternalKubernetes', true);
+});
+
+describe('multi-path KUBECONFIG support', () => {
+  test('refresh loads and merges multiple kubeconfig files', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('non-empty');
+
+    const client = createTestClient('default');
+    vi.spyOn(client, 'checkConnection').mockResolvedValue(false);
+
+    await client.setKubeconfig(Uri.file('/path/a:/path/b'));
+
+    expect(KubeConfig.prototype.loadFromFile).toHaveBeenCalledWith('/path/a');
+    // Second file should also be loaded (into a separate KubeConfig for merging)
+    expect(KubeConfig.prototype.loadFromFile).toHaveBeenCalledWith('/path/b');
+  });
+
+  test('refresh skips non-existent paths in multi-path kubeconfig', async () => {
+    vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
+      return p === '/path/a';
+    });
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('non-empty');
+
+    const client = createTestClient('default');
+    vi.spyOn(client, 'checkConnection').mockResolvedValue(false);
+
+    await client.setKubeconfig(Uri.file('/path/a:/path/nonexistent'));
+
+    // Only the existing path should be loaded
+    expect(KubeConfig.prototype.loadFromFile).toHaveBeenCalledWith('/path/a');
+    // Second (nonexistent) path should not be loaded
+    expect(KubeConfig.prototype.loadFromFile).not.toHaveBeenCalledWith('/path/nonexistent');
+  });
+
+  test('refresh logs error when no kubeconfig files exist in multi-path', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error');
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const client = createTestClient('default');
+    await client.setKubeconfig(Uri.file('/nonexistent/a:/nonexistent/b'));
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('No kubeconfig files found'));
+  });
+
+  test('getKubeconfigPaths splits paths by platform delimiter', () => {
+    const client = createTestClient('default');
+    const paths = client.testGetKubeconfigPaths('/path/a:/path/b');
+    // On Unix, delimiter is ':', so this should split into two paths
+    // On Windows, it would be ';' — the test value uses ':' which matches Unix
+    if (process.platform !== 'win32') {
+      expect(paths).toEqual(['/path/a', '/path/b']);
+    }
+  });
+
+  test('setupWatcher creates watchers for all paths in multi-path kubeconfig', () => {
+    const createWatcherMock = vi.spyOn(fileSystemMonitoring, 'createFileSystemWatcher').mockReturnValue({
+      onDidChange: vi.fn(),
+      onDidCreate: vi.fn(),
+      onDidDelete: vi.fn(),
+      dispose: vi.fn(),
+    } as unknown as FileSystemWatcher);
+
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const client = createTestClient('default');
+    client.setupWatcher('/path/a:/path/b');
+
+    if (process.platform !== 'win32') {
+      expect(createWatcherMock).toHaveBeenCalledTimes(2);
+      expect(createWatcherMock).toHaveBeenCalledWith('/path/a');
+      expect(createWatcherMock).toHaveBeenCalledWith('/path/b');
+    }
+  });
 });

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.ts
@@ -19,7 +19,7 @@
 import * as fs from 'node:fs';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { resolve } from 'node:path';
+import { delimiter, resolve } from 'node:path';
 import { PassThrough } from 'node:stream';
 
 import type {
@@ -177,7 +177,7 @@ export interface PodCreationSource {
 export class KubernetesClient {
   protected kubeConfig;
 
-  private static readonly DEFAULT_KUBECONFIG_PATH = resolve(homedir(), '.kube', 'config');
+  private static readonly DEFAULT_KUBECONFIG_PATH = process.env['KUBECONFIG'] ?? resolve(homedir(), '.kube', 'config');
 
   // Custom path to the location of the kubeconfig file
   private kubeconfigPath: string = KubernetesClient.DEFAULT_KUBECONFIG_PATH;
@@ -185,7 +185,7 @@ export class KubernetesClient {
   protected currentNamespace: string | undefined;
   protected currentContextName: string | undefined;
 
-  private kubeConfigWatcher: containerDesktopAPI.FileSystemWatcher | undefined;
+  private kubeConfigWatchers: containerDesktopAPI.FileSystemWatcher[] = [];
 
   private apiGroups = new Array<V1APIGroup>();
 
@@ -232,8 +232,8 @@ export class KubernetesClient {
   }
 
   async init(): Promise<void> {
-    // default
-    const defaultKubeconfigPath = resolve(homedir(), '.kube', 'config');
+    // default: respect KUBECONFIG env var if set, otherwise ~/.kube/config
+    const defaultKubeconfigPath = process.env['KUBECONFIG'] ?? resolve(homedir(), '.kube', 'config');
 
     // add configuration
     const kubeconfigConfigurationNode: IConfigurationNode = {
@@ -270,8 +270,9 @@ export class KubernetesClient {
     if (userKubeconfigPath) {
       this.kubeconfigPath = userKubeconfigPath;
       this.setupWatcher(userKubeconfigPath);
-      // check if path exists
-      if (existsSync(userKubeconfigPath)) {
+      // check if any path in the (possibly multi-path) value exists
+      const paths = this.getKubeconfigPaths(userKubeconfigPath);
+      if (paths.some(p => existsSync(p))) {
         this.refresh().catch(() => console.error('Refresh of kube resources on startup failed'));
       } else {
         console.error(`Kubeconfig path ${userKubeconfigPath} provided does not exist. Skipping.`);
@@ -323,41 +324,52 @@ export class KubernetesClient {
   // help send information to the renderer process to notify any
   // stores (in particular kube context store) as well as extensions (extensions/kube-context)
   setupWatcher(kubeconfigFile: string): void {
-    // cancel the previous one (if any)
-    this.kubeConfigWatcher?.dispose();
+    // cancel the previous watchers (if any)
+    for (const watcher of this.kubeConfigWatchers) {
+      watcher.dispose();
+    }
+    this.kubeConfigWatchers = [];
 
-    // monitor the kube config file for changes
-    this.kubeConfigWatcher = this.fileSystemMonitoring.createFileSystemWatcher(kubeconfigFile);
+    const paths = this.getKubeconfigPaths(kubeconfigFile);
 
-    const location = Uri.file(kubeconfigFile);
-    const notifyKubeConfigExist = async (): Promise<void> => {
-      await this.refresh();
-      this._onDidUpdateKubeconfig.fire({ type: 'CREATE', location });
-      this.apiSender.send('kubernetes-context-update');
-    };
-
-    if (fs.existsSync(kubeconfigFile)) {
-      notifyKubeConfigExist().catch((error: unknown) => {
-        console.error('Error while checking kubeconfig', error);
-      });
+    // trigger initial load if any path exists
+    const anyExists = paths.some(p => fs.existsSync(p));
+    if (anyExists) {
+      this.refresh()
+        .then(() => {
+          this._onDidUpdateKubeconfig.fire({ type: 'CREATE', location: Uri.file(paths[0]!) });
+          this.apiSender.send('kubernetes-context-update');
+        })
+        .catch((error: unknown) => {
+          console.error('Error while checking kubeconfig', error);
+        });
     }
 
-    // needs to refresh
-    this.kubeConfigWatcher.onDidChange(async () => {
-      await this.refresh();
-      this._onDidUpdateKubeconfig.fire({ type: 'UPDATE', location });
-      this.apiSender.send('kubernetes-context-update');
-    });
+    // set up a watcher for each file path
+    for (const filePath of paths) {
+      const watcher = this.fileSystemMonitoring.createFileSystemWatcher(filePath);
+      const location = Uri.file(filePath);
 
-    this.kubeConfigWatcher.onDidCreate(async () => {
-      await notifyKubeConfigExist();
-    });
+      watcher.onDidChange(async () => {
+        await this.refresh();
+        this._onDidUpdateKubeconfig.fire({ type: 'UPDATE', location });
+        this.apiSender.send('kubernetes-context-update');
+      });
 
-    this.kubeConfigWatcher.onDidDelete(() => {
-      this.kubeConfig = new KubeConfig();
-      this._onDidUpdateKubeconfig.fire({ type: 'DELETE', location });
-      this.apiSender.send('kubernetes-context-update');
-    });
+      watcher.onDidCreate(async () => {
+        await this.refresh();
+        this._onDidUpdateKubeconfig.fire({ type: 'CREATE', location });
+        this.apiSender.send('kubernetes-context-update');
+      });
+
+      watcher.onDidDelete(() => {
+        this.kubeConfig = new KubeConfig();
+        this._onDidUpdateKubeconfig.fire({ type: 'DELETE', location });
+        this.apiSender.send('kubernetes-context-update');
+      });
+
+      this.kubeConfigWatchers.push(watcher);
+    }
   }
 
   protected createWatchObject(): Watch {
@@ -613,17 +625,77 @@ export class KubernetesClient {
     return namespace;
   }
 
+  // Split a kubeconfig path string into individual file paths using the platform delimiter
+  protected getKubeconfigPaths(kubeconfigPath: string): string[] {
+    return kubeconfigPath.split(delimiter).filter(p => p.length > 0);
+  }
+
+  // Load kubeconfig from one or more files (supports colon-separated paths on Unix, semicolon on Windows).
+  // Uses first-wins dedup strategy for clusters/users/contexts, matching kubectl behavior.
+  private loadKubeConfigFromPaths(kubeconfigPath: string): void {
+    const paths = this.getKubeconfigPaths(kubeconfigPath).filter(p => existsSync(p));
+    if (paths.length === 0) {
+      throw new Error('No kubeconfig paths provided');
+    }
+    this.kubeConfig.loadFromFile(paths[0]!);
+    for (let i = 1; i < paths.length; i++) {
+      const additional = new KubeConfig();
+      additional.loadFromFile(paths[i]!);
+      this.mergeKubeConfigs(this.kubeConfig, additional);
+    }
+  }
+
+  // Merge source KubeConfig into target, skipping duplicate names (first-wins).
+  // This avoids the "Duplicate user/cluster/context" errors from KubeConfig.mergeConfig().
+  private mergeKubeConfigs(target: KubeConfig, source: KubeConfig): void {
+    const existingClusters = new Set(target.clusters.map(c => c.name));
+    const existingUsers = new Set(target.users.map(u => u.name));
+    const existingContexts = new Set(target.contexts.map(c => c.name));
+
+    for (const cluster of source.clusters) {
+      if (!existingClusters.has(cluster.name)) {
+        target.clusters.push(cluster);
+      }
+    }
+    for (const user of source.users) {
+      if (!existingUsers.has(user.name)) {
+        target.users.push(user);
+      }
+    }
+    for (const ctx of source.contexts) {
+      if (!existingContexts.has(ctx.name)) {
+        target.contexts.push(ctx);
+      }
+    }
+  }
+
   async refresh(): Promise<void> {
-    // check the file is empty
-    const fileContent = await fs.promises.readFile(this.kubeconfigPath);
-    if (fileContent.length === 0) {
-      console.error(`Kubeconfig file at ${this.kubeconfigPath} is empty. Skipping.`);
+    const paths = this.getKubeconfigPaths(this.kubeconfigPath);
+
+    // check that at least one file exists and is non-empty
+    const existingPaths = paths.filter(p => existsSync(p));
+    if (existingPaths.length === 0) {
+      console.error(`No kubeconfig files found in path ${this.kubeconfigPath}. Skipping.`);
+      return;
+    }
+
+    // check the files are not all empty
+    let allEmpty = true;
+    for (const p of existingPaths) {
+      const content = await fs.promises.readFile(p);
+      if (content.length > 0) {
+        allEmpty = false;
+        break;
+      }
+    }
+    if (allEmpty) {
+      console.error(`All kubeconfig files in ${this.kubeconfigPath} are empty. Skipping.`);
       return;
     }
 
     // perform it under a try/catch block as the file may not be valid for the kubernetes-javascript client library
     try {
-      this.kubeConfig.loadFromFile(this.kubeconfigPath);
+      this.loadKubeConfigFromPaths(this.kubeconfigPath);
     } catch (error) {
       console.error(`An error happened when loading kubeconfig file at ${this.kubeconfigPath}`, error);
       return;
@@ -1206,7 +1278,10 @@ export class KubernetesClient {
   }
 
   async stop(): Promise<void> {
-    this.kubeConfigWatcher?.dispose();
+    for (const watcher of this.kubeConfigWatchers) {
+      watcher.dispose();
+    }
+    this.kubeConfigWatchers = [];
   }
 
   getTags(tags: Tags): Tags {
@@ -1458,7 +1533,10 @@ export class KubernetesClient {
   }
 
   public dispose(): void {
-    this.kubeConfigWatcher?.dispose();
+    for (const watcher of this.kubeConfigWatchers) {
+      watcher.dispose();
+    }
+    this.kubeConfigWatchers = [];
     this.contextsState?.dispose();
     this.contextsStatesDispatcher?.dispose();
     this.#portForwardService?.dispose();


### PR DESCRIPTION
### What does this PR do?

Adds support for the `KUBECONFIG` environment variable containing multiple colon-separated paths (or semicolon-separated on Windows), per the [Kubernetes specification](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#the-kubeconfig-environment-variable).

Previously, Podman Desktop only loaded a single kubeconfig file (`~/.kube/config`), ignoring the `KUBECONFIG` env var entirely. With this change:

- The `KUBECONFIG` env var is respected as the default kubeconfig path
- Multi-path values are split by the platform delimiter (`:` on Unix, `;` on Windows)
- All kubeconfig files are loaded and merged using `KubeConfig.mergeConfig()`
- Each file is watched independently for changes
- Non-existent paths in the list are gracefully skipped

### Screenshot / video of UI

| Before | After |
| - | - |
| <img width="1052" height="701" alt="Screenshot 2026-03-22 at 10 23 38 PM" src="https://github.com/user-attachments/assets/40239a78-6131-4586-b67a-149e6db06b11" />|<img width="797" height="531" alt="Screenshot 2026-03-22 at 10 35 02 PM" src="https://github.com/user-attachments/assets/ac66d9c4-8e6f-4d63-af06-66709b896a3d" /> |

No UI changes — contexts from all kubeconfig files now appear in Settings > Kubernetes.

### What issues does this PR fix or reference?

Fixes the issue where `KUBECONFIG` env var with multiple paths (e.g. `/path/a:/path/b`) was not picked up in the Settings/Kubernetes screen.

### How to test this PR?

1. Set `KUBECONFIG` to multiple colon-separated paths: `export KUBECONFIG=/path/to/config1:/path/to/config2`
2. Launch Podman Desktop
3. Navigate to Settings > Kubernetes
4. Verify that contexts from **all** kubeconfig files are displayed
5. Modify one of the kubeconfig files and verify the UI updates

- [x] Tests are covering the bug fix or the new feature