### PR TITLE
chore(test): fixing some flakyness in compose download e2e test in case of quota hit

### DIFF
--- a/tests/playwright/src/model/pages/images-page.ts
+++ b/tests/playwright/src/model/pages/images-page.ts
@@ -153,6 +153,13 @@ export class ImagesPage extends MainPage {
     });
   }
 
+  async countImagesByName(name: string): Promise<number> {
+    return test.step(`Count images matching: ${name}`, async () => {
+      const locator = this.page.getByRole('row').and(this.page.getByLabel(name, { exact: true }));
+      return locator.count();
+    });
+  }
+
   async getCurrentStatusOfImage(name: string): Promise<string> {
     return test.step(`Get current status of image: ${name}`, async () => {
       let status = '';

--- a/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/compose-onboarding-smoke.spec.ts
@@ -108,7 +108,7 @@ test.describe
           hasText: 'Compose successfully Downloaded',
         })
         .first();
-      const rateLimitExceeded = page.getByText('API rate limit exceeded').first();
+      const rateLimitExceeded = page.getByRole('dialog').getByText('API rate limit exceeded');
 
       await playExpect(downloadSuccess.or(rateLimitExceeded)).toBeVisible({ timeout: 50_000 });
 

--- a/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
@@ -167,7 +167,14 @@ test.describe
         .then(() => true)
         .catch(() => false);
       if (!appeared) {
+        if (rateLimitReachedFlag) {
+          test.skip(true, 'Rate limit exceeded after clicking version selector; skipping');
+        }
         await welcomePage.otherVersionButton.click();
+      }
+
+      if (rateLimitReachedFlag) {
+        test.skip(true, 'Rate limit exceeded while loading version dropdown; skipping');
       }
 
       await playExpect(welcomePage.dropDownDialog).toBeVisible({ timeout: 10_000 });

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -131,6 +131,7 @@ test.describe
           await imageDetailsPage.backLink.click();
         });
         test('Delete Manifest', async ({ page }) => {
+          test.setTimeout(180_000);
           await deleteImageManifest(page, manifestLabelSimple);
         });
       });
@@ -152,7 +153,7 @@ test.describe
         });
 
         test('Build the image using cross-arch build (complex)', async ({ page, navigationBar }) => {
-          test.setTimeout(120_000);
+          test.setTimeout(180_000);
 
           imagesPage = await navigationBar.openImages();
           await playExpect(imagesPage.heading).toBeVisible();
@@ -237,6 +238,7 @@ test.describe
 
         test('Delete Manifest', async ({ page }) => {
           test.skip(skipTests, 'Build manifest failed, manifest should be already deleted, skipping the test');
+          test.setTimeout(180_000);
           await deleteImageManifest(page, manifestLabelComplex);
         });
       });
@@ -248,8 +250,8 @@ async function deleteImageManifest(page: Page, manifestName: string): Promise<vo
 
   await imagesPage.deleteImageManifest(manifestName);
   await playExpect
-    .poll(async () => await imagesPage.waitForImageDelete(manifestName, 30_000), { timeout: 0 })
+    .poll(async () => await imagesPage.waitForImageDelete(manifestName, 60_000), { timeout: 0 })
     .toBeTruthy();
   await imagesPage.deleteAllUnusedImages();
-  await playExpect.poll(async () => await imagesPage.countRowsFromTable(), { timeout: 30_000 }).toBe(0);
+  await playExpect.poll(async () => await imagesPage.countRowsFromTable(), { timeout: 90_000 }).toBe(0);
 }

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -234,6 +234,8 @@ test.describe
       const imagesPage = await navigationBar.openImages();
       await playExpect(imagesPage.heading).toBeVisible();
 
+      const baselineNoneCount = await imagesPage.countImagesByName('<none>');
+
       for (const image of imageList) {
         await imagesPage.pullImage(helloContainer);
         await playExpect(imagesPage.heading).toBeVisible();
@@ -256,14 +258,14 @@ test.describe
 
       await untagImagesFromPodman(imageList[0]);
       await playExpect
-        .poll(async () => await imagesPage.waitForImageExists('<none>', 60_000), { timeout: 0 })
-        .toBeTruthy();
+        .poll(async () => await imagesPage.countImagesByName('<none>'), { timeout: 60_000 })
+        .toBeGreaterThan(baselineNoneCount);
 
       await imagesPage.pruneUntaggedImages();
       await playExpect(imagesPage.heading).toBeVisible();
       await playExpect
-        .poll(async () => await imagesPage.waitForImageDelete('<none>', 60_000), { timeout: 0 })
-        .toBeTruthy();
+        .poll(async () => await imagesPage.countImagesByName('<none>'), { timeout: 60_000 })
+        .toBeLessThanOrEqual(baselineNoneCount);
       await playExpect
         .poll(async () => await imagesPage.waitForImageExists(imageToSearch, 60_000), { timeout: 0 })
         .toBeTruthy();


### PR DESCRIPTION
### What does this PR do?
Better handling for test skipping in case of API quota being reached during test run.

### What issues does this PR fix or reference?
