### PR TITLE
test: add interactive MCP testing skill for Podman Desktop

### DIFF
--- a/.agents/skills/mcp-testing/SKILL.md
+++ b/.agents/skills/mcp-testing/SKILL.md
@@ -1,0 +1,598 @@
+---
+name: mcp-testing
+description: >-
+  Interactive testing of Podman Desktop UI using the electron-test MCP server.
+  Supports both production (installed app) and development (pnpm watch) modes.
+  Use for manually testing UI workflows, debugging UI issues, exploring features,
+  or quick acceptance testing.
+---
+
+# Podman Desktop MCP Testing
+
+Interactively test and explore Podman Desktop through automated browser commands, connected via Chrome DevTools Protocol (CDP).
+
+## When to use this skill
+
+- Manually testing Podman Desktop UI changes during development
+- Testing the production (installed) Podman Desktop app
+- Debugging specific user workflows or UI issues
+- Exploring new features interactively
+- Verifying functionality without writing test code
+- Quick acceptance testing
+
+## Prerequisites
+
+- MCP server `podman-desktop-mcp` configured via `.mcp.json` at the repo root (already done)
+- For dev mode: Node.js 24+ and pnpm 10+ installed
+- For production mode: Podman Desktop installed
+
+## Workflow
+
+### Phase 1: Detect Environment
+
+> **Always run detection yourself. Never ask the user to run scripts manually.**
+
+Detect the OS — run `uname -s` via the Bash tool:
+
+- Returns `Darwin` → macOS
+- Returns `Linux` → Linux
+- Starts with `MINGW`, `MSYS`, or `CYGWIN` → Windows (Git Bash)
+- Command unavailable or unrecognized → Windows (native PowerShell)
+
+Run the probe script to detect what's running:
+
+**Linux / macOS:**
+
+```bash
+bash .agents/skills/mcp-testing/probe.sh
+```
+
+**Windows:**
+
+```bash
+pwsh .agents/skills/mcp-testing/probe.ps1
+```
+
+Parse the key=value output. You will get six variables:
+
+- `PROD_RUNNING` — whether a production (installed) Podman Desktop is running
+- `PROD_CDP_PORT` — CDP port for production (`none` if CDP not available)
+- `PROD_APP_TITLE` — window title of production app (`none` if not available)
+- `DEV_RUNNING` — whether `pnpm watch` is running
+- `DEV_CDP_PORT` — CDP port for dev (`none` if not available)
+- `DEV_APP_TITLE` — window title of dev app (`none` if not available)
+
+### Phase 2: Choose Mode
+
+**Always ask the user which mode to use.** Use `AskUserQuestion` with options based on the probe results. Annotate each option with its current status.
+
+**Build the options based on probe output:**
+
+**Production mode option:**
+
+- If `PROD_RUNNING=true` and `PROD_CDP_PORT` is not `none`:
+  Label: `Production mode`
+  Description: `Connect to installed Podman Desktop on port {PROD_CDP_PORT} — changes affect your real environment`
+
+- If `PROD_RUNNING=true` and `PROD_CDP_PORT=none`:
+  Label: `Production mode`
+  Description: `Will relaunch Podman Desktop with CDP enabled — changes affect your real environment`
+
+- If `PROD_RUNNING=false`:
+  Label: `Production mode`
+  Description: `Will launch Podman Desktop with CDP enabled — changes affect your real environment`
+
+**Dev mode option:**
+
+- If `DEV_RUNNING=true` and `DEV_CDP_PORT` is not `none`:
+  Label: `Dev mode`
+  Description: `pnpm watch already running on port {DEV_CDP_PORT} — instant connect`
+
+- If `DEV_RUNNING=true` and `DEV_CDP_PORT=none`:
+  Label: `Dev mode`
+  Description: `pnpm watch is running but CDP is not responding — will restart pnpm watch`
+
+- If `DEV_RUNNING=false` and `PROD_RUNNING=false`:
+  Label: `Dev mode`
+  Description: `Start pnpm watch for isolated development testing (2-4 minutes first run)`
+
+- If `DEV_RUNNING=false` and `PROD_RUNNING=true`:
+  Label: `Dev mode`
+  Description: `Will close production app first, then start pnpm watch (2-4 minutes)`
+
+Use the `AskUserQuestion` tool with header `Mode` and these two options. The question should be: `Which mode would you like to use for testing?`
+
+### Phase 3: Start and Connect
+
+Based on the chosen mode and probe results, prepare the app and run the startup script.
+
+#### Production mode
+
+**If `DEV_RUNNING=true`** (dev holds the single-instance lock — must close it first):
+
+**Linux / macOS:**
+
+```bash
+kill $(lsof -ti :9223) 2>/dev/null && sleep 3
+```
+
+**Windows:**
+
+```powershell
+Get-NetTCPConnection -LocalPort 9223 -State Listen -ErrorAction SilentlyContinue |
+  ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+Start-Sleep 3
+```
+
+**If `PROD_RUNNING=true` and `PROD_CDP_PORT=none`** (running without CDP — must relaunch):
+
+Close the app, then relaunch with CDP:
+
+**macOS:**
+
+```bash
+osascript -e 'quit app "Podman Desktop"' && sleep 3
+open -a "Podman Desktop" --args --remote-debugging-port=9222
+```
+
+**Linux (Fedora/RHEL):**
+
+The executable name is `podman-desktop` (lowercase). It may be installed as:
+
+- Flatpak: `flatpak run io.podman_desktop.PodmanDesktop`
+- RPM/tar.gz: `/usr/bin/podman-desktop` or on `$PATH`
+
+```bash
+# Close running instance
+pkill -f podman-desktop && sleep 3
+
+# Relaunch — try direct binary first, fall back to flatpak
+if command -v podman-desktop &>/dev/null; then
+  podman-desktop --remote-debugging-port=9222 &
+elif flatpak list --app 2>/dev/null | grep -q podman_desktop; then
+  flatpak run io.podman_desktop.PodmanDesktop --remote-debugging-port=9222 &
+else
+  echo "ERROR: podman-desktop not found — install via RPM, Flatpak, or tar.gz"
+  exit 1
+fi
+```
+
+**Windows:**
+
+The process name is `Podman Desktop`. Installed via NSIS to `%LOCALAPPDATA%\Programs\Podman Desktop\`.
+
+```powershell
+Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue; Start-Sleep 3
+Start-Process "$env:LOCALAPPDATA\Programs\Podman Desktop\Podman Desktop.exe" -ArgumentList "--remote-debugging-port=9222"
+```
+
+Wait for CDP to become available (poll up to 30s):
+
+**Linux / macOS:**
+
+```bash
+for i in $(seq 1 30); do curl -s http://localhost:9222/json/version &>/dev/null && break; sleep 1; done
+```
+
+**Windows:**
+
+```powershell
+for ($i = 1; $i -le 30; $i++) {
+  try { $null = Invoke-WebRequest -Uri "http://localhost:9222/json/version" -UseBasicParsing -TimeoutSec 1 -ErrorAction Stop; break } catch { Start-Sleep 1 }
+}
+```
+
+**If `PROD_RUNNING=false`** (not running — launch with CDP):
+
+**macOS:**
+
+```bash
+open -a "Podman Desktop" --args --remote-debugging-port=9222
+```
+
+**Linux (Fedora/RHEL):**
+
+```bash
+if command -v podman-desktop &>/dev/null; then
+  podman-desktop --remote-debugging-port=9222 &
+elif flatpak list --app 2>/dev/null | grep -q podman_desktop; then
+  flatpak run io.podman_desktop.PodmanDesktop --remote-debugging-port=9222 &
+else
+  echo "ERROR: podman-desktop not found — install via RPM, Flatpak, or tar.gz"
+  exit 1
+fi
+```
+
+**Windows:**
+
+```powershell
+Start-Process "$env:LOCALAPPDATA\Programs\Podman Desktop\Podman Desktop.exe" -ArgumentList "--remote-debugging-port=9222"
+```
+
+Wait for CDP (same polling loops as above, up to 30s).
+
+**Once CDP is available** (or if `PROD_CDP_PORT` was already set), verify with the startup script. Use the probe's `PROD_CDP_PORT` if it was not `none`; otherwise use `9222` (the port you just launched with):
+
+```bash
+bash .agents/skills/mcp-testing/start.sh --mode prod {CDP_PORT}
+```
+
+```powershell
+pwsh .agents/skills/mcp-testing/start.ps1 -Mode prod -Port {CDP_PORT}
+```
+
+#### Dev mode
+
+**If `DEV_RUNNING=true` and `DEV_CDP_PORT` is not `none`** (already running):
+
+```bash
+bash .agents/skills/mcp-testing/start.sh --mode dev-fast
+```
+
+```powershell
+pwsh .agents/skills/mcp-testing/start.ps1 -Mode dev-fast
+```
+
+**If `DEV_RUNNING=true` and `DEV_CDP_PORT=none`** (pnpm watch alive but CDP not responding — treat as full restart):
+
+Use `--mode dev` (not `dev-fast`). The start script will kill the stale process and restart cleanly.
+
+**If `DEV_RUNNING=false`** (full startup):
+
+If `PROD_RUNNING=true`, close the production app first (Electron single-instance lock prevents both):
+
+**macOS:**
+
+```bash
+osascript -e 'quit app "Podman Desktop"' && sleep 3
+```
+
+**Linux:**
+
+```bash
+(pkill -f podman-desktop || flatpak kill io.podman_desktop.PodmanDesktop 2>/dev/null) && sleep 3
+```
+
+**Windows:**
+
+```powershell
+Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue; Start-Sleep 3
+```
+
+Then run the full startup — set Bash tool timeout to `600000` (10 minutes):
+
+```bash
+bash .agents/skills/mcp-testing/start.sh --mode dev
+```
+
+```powershell
+pwsh .agents/skills/mcp-testing/start.ps1 -Mode dev
+```
+
+#### Error handling
+
+If the start script exits with a non-zero code, report the error output to the user and refer to the **Troubleshooting** section below. Common failures:
+
+- Port still in use → suggest killing the process manually
+- `pnpm install` timeout → check network connectivity
+- CDP not available within 120s → check for single-instance lock (see Troubleshooting)
+
+Do not retry the script automatically — let the user decide after seeing the error.
+
+#### Connect and verify (both modes)
+
+When the start script prints `Ready — call mcp__podman-desktop-mcp__connect(...)`, connect via MCP. Use port `9223` for dev mode, or `PROD_CDP_PORT` for prod mode (`9222` if you just launched the app):
+
+```text
+mcp__podman-desktop-mcp__connect({ port: PORT })
+```
+
+After connecting, check the window title:
+
+```text
+mcp__podman-desktop-mcp__evaluate({ script: "document.title" })
+```
+
+The result should contain "Podman Desktop". If it contains "DevTools":
+
+1. Disconnect immediately: `mcp__podman-desktop-mcp__disconnect()`
+2. Close the DevTools targets via CDP:
+
+   **Linux / macOS:**
+
+   ```bash
+   curl -s "http://localhost:PORT/json" | CDP_PORT=PORT node -e '
+     const d = require("fs").readFileSync(0, "utf8");
+     const port = process.env.CDP_PORT;
+     (async () => {
+       for (const t of JSON.parse(d)) {
+         const u = (t.url || "").toLowerCase();
+         const l = (t.title || "").toLowerCase();
+         if (u.includes("devtools") || l === "devtools") {
+           try { await fetch("http://localhost:" + port + "/json/close/" + t.id); } catch {}
+         }
+       }
+     })();'
+   ```
+
+   **Windows:**
+
+   ```powershell
+   $targets = (Invoke-WebRequest -Uri "http://localhost:PORT/json" -UseBasicParsing).Content | ConvertFrom-Json
+   foreach ($t in $targets) {
+     $url = if ($t.url) { $t.url.ToLower() } else { "" }
+     $title = if ($t.title) { $t.title.ToLower() } else { "" }
+     if ($url -like "*devtools*" -or $title -eq "devtools") {
+       try { Invoke-WebRequest -Uri "http://localhost:PORT/json/close/$($t.id)" -UseBasicParsing | Out-Null } catch {}
+     }
+   }
+   ```
+
+   (Replace PORT with the actual port.)
+
+3. Wait 10 seconds, then reconnect: `mcp__podman-desktop-mcp__connect({ port: PORT })`
+4. Run `mcp__podman-desktop-mcp__evaluate({ script: "document.title" })` again to verify the title is now "Podman Desktop".
+5. If the title is still "DevTools", re-run the startup script (`start.sh` / `start.ps1`) — it will kill the old session and start fresh. Then reconnect.
+
+### Phase 4: Initial Setup (automatic)
+
+After connecting, perform these steps automatically without asking:
+
+**1. Handle Onboarding Dialog** (appears on first launch — disable telemetry but do NOT close it):
+
+```text
+mcp__podman-desktop-mcp__evaluate({
+  script: `
+    const skipButton = Array.from(document.querySelectorAll('button'))
+      .find(b => b.textContent.trim() === 'Skip');
+    if (skipButton) {
+      const telemetry = document.querySelector('input[aria-label="Enable telemetry"]');
+      if (telemetry?.checked) telemetry.click();
+      'Onboarding dialog present — telemetry disabled (dialog left open for testing)';
+    } else {
+      'No onboarding dialog found';
+    }
+  `
+})
+```
+
+> **Do not close the onboarding dialog automatically.** Some test scenarios need to interact with it. The task in Phase 5 will decide whether to skip it or test it.
+
+**2. Close Feedback Dialog** (appears after onboarding is completed — safe to run when absent):
+
+```text
+mcp__podman-desktop-mcp__evaluate({
+  script: `
+    const dialog = document.querySelector('[role="dialog"][aria-label="Share your feedback"]');
+    if (dialog) {
+      dialog.querySelector('button[aria-label="Close"]')?.click();
+      'Closed feedback dialog';
+    } else {
+      'No feedback dialog';
+    }
+  `
+})
+```
+
+**3. Take Initial Snapshot:**
+
+```text
+mcp__podman-desktop-mcp__snapshot()
+```
+
+Summarize what's visible on the current page to the user (including whether the onboarding dialog is showing).
+
+### Phase 5: Execute Task
+
+Execute the task provided when the skill was invoked. The task can be anything — exploring a page, testing a feature, verifying a workflow, checking UI state, etc. Work autonomously:
+
+- Use MCP tools (`snapshot`, `screenshot`, `evaluate`, `click`, `getText`, etc.) as needed — don't ask permission for individual actions.
+- Take screenshots and snapshots at your own judgment to verify state and gather information.
+- If something fails or is unexpected, investigate and retry before giving up.
+- When the task is complete, summarize what you found or did.
+
+**After completing the task**, use `AskUserQuestion`:
+
+- **Question:** `What would you like to do next?`
+- **Header:** `Next`
+- **Options:**
+  1. `Continue testing` — Provide another task (user enters free text via "Other")
+  2. `Done — finish testing` — Disconnect and clean up
+
+If the user continues, execute the new task the same way and ask again when done. If done, proceed to Phase 6.
+
+### Phase 6: Cleanup
+
+**Step 1 — Disconnect from MCP:**
+
+```text
+mcp__podman-desktop-mcp__disconnect()
+```
+
+**Step 2 — Ask about the app:**
+
+Use `AskUserQuestion`:
+
+- **Question:** `Disconnected from MCP. What should I do with the app?`
+- **Header:** `Cleanup`
+- **Options:**
+  1. `Leave running` — Keep the app alive so you can reconnect later
+  2. `Close it` — Stop the app and free the port
+
+If the user chooses "Close it":
+
+**Production mode:**
+
+macOS:
+
+```bash
+osascript -e 'quit app "Podman Desktop"'
+```
+
+Linux:
+
+```bash
+pkill -f podman-desktop || flatpak kill io.podman_desktop.PodmanDesktop 2>/dev/null
+```
+
+Windows:
+
+```powershell
+Stop-Process -Name "Podman Desktop" -Force
+```
+
+**Dev mode:**
+
+Linux / macOS:
+
+```bash
+kill $(lsof -ti :9223) 2>/dev/null && echo "App stopped"
+```
+
+Windows:
+
+```powershell
+Get-NetTCPConnection -LocalPort 9223 -State Listen -ErrorAction SilentlyContinue |
+  ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+```
+
+## Selector Strategy
+
+When interacting with elements, prefer in this order:
+
+1. **ARIA roles and accessible names** (most stable)
+
+   ```javascript
+   document.querySelector('button[aria-label="Create"]').click();
+   ```
+
+2. **Text content**
+
+   ```javascript
+   Array.from(document.querySelectorAll('button'))
+     .find(b => b.textContent.includes('Pull'))
+     .click();
+   ```
+
+3. **data-testid attributes**
+
+   ```javascript
+   document.querySelector('[data-testid="help-menu"]').click();
+   ```
+
+4. **CSS / href selectors** (last resort)
+
+   ```javascript
+   document.querySelector('a[href="/containers"]').click();
+   ```
+
+## Common Navigation URLs
+
+- Dashboard: `/`
+- Containers: `/containers`
+- Pods: `/pods`
+- Images: `/images`
+- Volumes: `/volumes`
+- Networks: `/networks`
+- Kubernetes: `/kubernetes`
+- Extensions: `/extensions`
+
+Navigate using JavaScript evaluation:
+
+```text
+mcp__podman-desktop-mcp__evaluate({
+  script: `document.querySelector('a[href="/containers"]').click(); 'Navigated to Containers';`
+})
+```
+
+## Troubleshooting
+
+### `pnpm: command not found`
+
+```bash
+npm install -g pnpm
+```
+
+Then re-open your terminal and verify with `pnpm --version`.
+
+### Connected to DevTools Instead of App
+
+**Symptom:** `connect` returns `Window title: DevTools`.
+
+**Fix:**
+
+1. `mcp__podman-desktop-mcp__disconnect()`
+2. Re-run `start.sh --mode dev` (kills the old session and starts fresh)
+3. `mcp__podman-desktop-mcp__connect({ port: 9223 })`
+
+### Production App Without CDP
+
+**Symptom:** Probe shows `PROD_RUNNING=true` but `PROD_CDP_PORT=none`.
+
+**Cause:** The production app was launched without the `--remote-debugging-port` flag.
+
+**Fix:** Close the production app and relaunch with:
+
+```bash
+podman-desktop --remote-debugging-port=9222
+```
+
+### Production Blocks Dev Instance
+
+**Symptom:** `start.sh --mode dev` times out after 120s with a hint about the single-instance lock.
+
+**Cause:** Electron allows only one instance via `requestSingleInstanceLock()`. The installed Podman Desktop holds the lock, so the dev Electron instance exits silently.
+
+**Fix:** Close the production app, then re-run in dev mode.
+
+### MCP Tools Become Unavailable Mid-Session
+
+**Symptom:** `mcp__podman-desktop-mcp__*` tools return errors.
+
+**Do not ask the user to restart the MCP server.** Try reconnecting:
+
+```text
+mcp__podman-desktop-mcp__connect({ port: PORT })
+```
+
+If the port is gone, re-run the startup script.
+
+### Element Not Found
+
+1. Use `snapshot()` to see current page structure
+2. Wait for page load: `mcp__podman-desktop-mcp__wait({ selector: 'main', timeout: 5000 })`
+3. Check if element is in a different frame or webview
+
+### Test Isolation (dev mode)
+
+Each `pnpm watch` session uses the same user data directory. For a clean state:
+
+```bash
+PODMAN_DESKTOP_HOME_DIR=/tmp/pd-dev-test pnpm watch
+```
+
+### "Too Many Open Files" Error (dev mode)
+
+```bash
+ulimit -n 65536
+```
+
+Add to `~/.bashrc` or `~/.zshrc` to make it permanent.
+
+## Quick Reference
+
+| Command                                                   | Purpose                                        |
+| --------------------------------------------------------- | ---------------------------------------------- |
+| `bash probe.sh`                                           | Detect environment (what's running, CDP ports) |
+| `bash start.sh --mode dev`                                | Full dev startup                               |
+| `bash start.sh --mode dev-fast`                           | Fast-path (dev already running)                |
+| `bash start.sh --mode prod PORT`                          | Connect to production CDP                      |
+| `mcp__podman-desktop-mcp__connect({ port: PORT })`        | Connect to app                                 |
+| `mcp__podman-desktop-mcp__disconnect()`                   | Disconnect from MCP                            |
+| `mcp__podman-desktop-mcp__snapshot()`                     | Get accessibility tree                         |
+| `mcp__podman-desktop-mcp__evaluate({ script: '...' })`    | Run JavaScript in renderer                     |
+| `mcp__podman-desktop-mcp__screenshot({ fullPage: true })` | Capture screenshot                             |
+
+## Additional Resources
+
+- **Example commands and selectors:** `examples.md` — Ready-to-use MCP command examples and selectors reference derived from Playwright Page Object Models

--- a/.agents/skills/mcp-testing/SKILL.md
+++ b/.agents/skills/mcp-testing/SKILL.md
@@ -53,7 +53,7 @@ bash .agents/skills/mcp-testing/probe.sh
 pwsh .agents/skills/mcp-testing/probe.ps1
 ```
 
-Parse the key=value output. You will get six variables:
+Parse the key=value output. You will get eleven variables:
 
 - `PROD_RUNNING` — whether a production (installed) Podman Desktop is running
 - `PROD_CDP_PORT` — CDP port for production (`none` if CDP not available)
@@ -61,6 +61,38 @@ Parse the key=value output. You will get six variables:
 - `DEV_RUNNING` — whether `pnpm watch` is running
 - `DEV_CDP_PORT` — CDP port for dev (`none` if not available)
 - `DEV_APP_TITLE` — window title of dev app (`none` if not available)
+- `STALE_SESSION` — `true` if a previous session left a state file without cleaning up
+- `PORT_9222_NAME` / `PORT_9222_PID` — process on port 9222 (`none` if free)
+- `PORT_9223_NAME` / `PORT_9223_PID` — process on port 9223 (`none` if free)
+
+**Stale session:** If `STALE_SESSION=true`, run the stop script immediately — no confirmation needed — then re-run the probe to get fresh state:
+
+**Linux / macOS:**
+
+```bash
+bash .agents/skills/mcp-testing/stop.sh
+```
+
+**Windows:**
+
+```powershell
+pwsh .agents/skills/mcp-testing/stop.ps1
+```
+
+**Port conflict:** For each port where `PORT_<port>_NAME` is not `none`, `electron`, `node`, or `Podman Desktop`, use `AskUserQuestion`:
+
+- **Question:** `Port {PORT} is in use by "{NAME}" (PID {PID}), which doesn't look like Podman Desktop. Kill it to free the port?`
+- **Header:** `Port conflict`
+- **Options:**
+  1. `Kill it` — Stop the process and free the port
+  2. `Skip` — Leave it running (choose a different mode or abort)
+
+If the user chooses "Kill it", kill the process using the PID from the probe output:
+
+**Linux / macOS:** `kill <PID>`
+**Windows:** `Stop-Process -Id <PID> -Force`
+
+If the user chooses Skip and neither port is usable, report the conflict and stop — do not run the start script.
 
 ### Phase 2: Choose Mode
 
@@ -108,117 +140,18 @@ Based on the chosen mode and probe results, prepare the app and run the startup 
 
 #### Production mode
 
-**If `DEV_RUNNING=true`** (dev holds the single-instance lock — must close it first):
+Run the startup script — it handles detecting the current state (including stopping any dev instance that holds the single-instance lock), relaunching with CDP if needed, waiting for the app, and verifying the connection:
 
 **Linux / macOS:**
 
 ```bash
-kill $(lsof -ti :9223) 2>/dev/null && sleep 3
+bash .agents/skills/mcp-testing/start.sh --mode prod
 ```
 
 **Windows:**
 
 ```powershell
-Get-NetTCPConnection -LocalPort 9223 -State Listen -ErrorAction SilentlyContinue |
-  ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
-Start-Sleep 3
-```
-
-**If `PROD_RUNNING=true` and `PROD_CDP_PORT=none`** (running without CDP — must relaunch):
-
-Close the app, then relaunch with CDP:
-
-**macOS:**
-
-```bash
-osascript -e 'quit app "Podman Desktop"' && sleep 3
-open -a "Podman Desktop" --args --remote-debugging-port=9222
-```
-
-**Linux (Fedora/RHEL):**
-
-The executable name is `podman-desktop` (lowercase). It may be installed as:
-
-- Flatpak: `flatpak run io.podman_desktop.PodmanDesktop`
-- RPM/tar.gz: `/usr/bin/podman-desktop` or on `$PATH`
-
-```bash
-# Close running instance
-pkill -f podman-desktop && sleep 3
-
-# Relaunch — try direct binary first, fall back to flatpak
-if command -v podman-desktop &>/dev/null; then
-  podman-desktop --remote-debugging-port=9222 &
-elif flatpak list --app 2>/dev/null | grep -q podman_desktop; then
-  flatpak run io.podman_desktop.PodmanDesktop --remote-debugging-port=9222 &
-else
-  echo "ERROR: podman-desktop not found — install via RPM, Flatpak, or tar.gz"
-  exit 1
-fi
-```
-
-**Windows:**
-
-The process name is `Podman Desktop`. Installed via NSIS to `%LOCALAPPDATA%\Programs\Podman Desktop\`.
-
-```powershell
-Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue; Start-Sleep 3
-Start-Process "$env:LOCALAPPDATA\Programs\Podman Desktop\Podman Desktop.exe" -ArgumentList "--remote-debugging-port=9222"
-```
-
-Wait for CDP to become available (poll up to 30s):
-
-**Linux / macOS:**
-
-```bash
-for i in $(seq 1 30); do curl -s http://localhost:9222/json/version &>/dev/null && break; sleep 1; done
-```
-
-**Windows:**
-
-```powershell
-for ($i = 1; $i -le 30; $i++) {
-  try { $null = Invoke-WebRequest -Uri "http://localhost:9222/json/version" -UseBasicParsing -TimeoutSec 1 -ErrorAction Stop; break } catch { Start-Sleep 1 }
-}
-```
-
-**If `PROD_RUNNING=false`** (not running — launch with CDP):
-
-**macOS:**
-
-```bash
-open -a "Podman Desktop" --args --remote-debugging-port=9222
-```
-
-**Linux (Fedora/RHEL):**
-
-```bash
-if command -v podman-desktop &>/dev/null; then
-  podman-desktop --remote-debugging-port=9222 &
-elif flatpak list --app 2>/dev/null | grep -q podman_desktop; then
-  flatpak run io.podman_desktop.PodmanDesktop --remote-debugging-port=9222 &
-else
-  echo "ERROR: podman-desktop not found — install via RPM, Flatpak, or tar.gz"
-  exit 1
-fi
-```
-
-**Windows:**
-
-```powershell
-Start-Process "$env:LOCALAPPDATA\Programs\Podman Desktop\Podman Desktop.exe" -ArgumentList "--remote-debugging-port=9222"
-```
-
-Wait for CDP (same polling loops as above, up to 30s).
-
-**Once CDP is available** (or if `PROD_CDP_PORT` was already set), verify with the startup script. Use the probe's `PROD_CDP_PORT` if it was not `none`; otherwise use `9222` (the port you just launched with):
-
-```bash
-bash .agents/skills/mcp-testing/start.sh --mode prod {CDP_PORT}
-```
-
-```powershell
-pwsh .agents/skills/mcp-testing/start.ps1 -Mode prod -Port {CDP_PORT}
+pwsh .agents/skills/mcp-testing/start.ps1 -Mode prod
 ```
 
 #### Dev mode
@@ -237,29 +170,7 @@ pwsh .agents/skills/mcp-testing/start.ps1 -Mode dev-fast
 
 Use `--mode dev` (not `dev-fast`). The start script will kill the stale process and restart cleanly.
 
-**If `DEV_RUNNING=false`** (full startup):
-
-If `PROD_RUNNING=true`, close the production app first (Electron single-instance lock prevents both):
-
-**macOS:**
-
-```bash
-osascript -e 'quit app "Podman Desktop"' && sleep 3
-```
-
-**Linux:**
-
-```bash
-(pkill -f podman-desktop || flatpak kill io.podman_desktop.PodmanDesktop 2>/dev/null) && sleep 3
-```
-
-**Windows:**
-
-```powershell
-Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue; Start-Sleep 3
-```
-
-Then run the full startup — set Bash tool timeout to `600000` (10 minutes):
+**If `DEV_RUNNING=false`** (full startup) — set Bash tool timeout to `600000` (10 minutes):
 
 ```bash
 bash .agents/skills/mcp-testing/start.sh --mode dev
@@ -281,7 +192,7 @@ Do not retry the script automatically — let the user decide after seeing the e
 
 #### Connect and verify (both modes)
 
-When the start script prints `Ready — call mcp__podman-desktop-mcp__connect(...)`, connect via MCP. Use port `9223` for dev mode, or `PROD_CDP_PORT` for prod mode (`9222` if you just launched the app):
+When the start script prints `Ready — call mcp__podman-desktop-mcp__connect(...)`, extract the port number from that line and connect:
 
 ```text
 mcp__podman-desktop-mcp__connect({ port: PORT })
@@ -296,43 +207,7 @@ mcp__podman-desktop-mcp__evaluate({ script: "document.title" })
 The result should contain "Podman Desktop". If it contains "DevTools":
 
 1. Disconnect immediately: `mcp__podman-desktop-mcp__disconnect()`
-2. Close the DevTools targets via CDP:
-
-   **Linux / macOS:**
-
-   ```bash
-   curl -s "http://localhost:PORT/json" | CDP_PORT=PORT node -e '
-     const d = require("fs").readFileSync(0, "utf8");
-     const port = process.env.CDP_PORT;
-     (async () => {
-       for (const t of JSON.parse(d)) {
-         const u = (t.url || "").toLowerCase();
-         const l = (t.title || "").toLowerCase();
-         if (u.includes("devtools") || l === "devtools") {
-           try { await fetch("http://localhost:" + port + "/json/close/" + t.id); } catch {}
-         }
-       }
-     })();'
-   ```
-
-   **Windows:**
-
-   ```powershell
-   $targets = (Invoke-WebRequest -Uri "http://localhost:PORT/json" -UseBasicParsing).Content | ConvertFrom-Json
-   foreach ($t in $targets) {
-     $url = if ($t.url) { $t.url.ToLower() } else { "" }
-     $title = if ($t.title) { $t.title.ToLower() } else { "" }
-     if ($url -like "*devtools*" -or $title -eq "devtools") {
-       try { Invoke-WebRequest -Uri "http://localhost:PORT/json/close/$($t.id)" -UseBasicParsing | Out-Null } catch {}
-     }
-   }
-   ```
-
-   (Replace PORT with the actual port.)
-
-3. Wait 10 seconds, then reconnect: `mcp__podman-desktop-mcp__connect({ port: PORT })`
-4. Run `mcp__podman-desktop-mcp__evaluate({ script: "document.title" })` again to verify the title is now "Podman Desktop".
-5. If the title is still "DevTools", re-run the startup script (`start.sh` / `start.ps1`) — it will kill the old session and start fresh. Then reconnect.
+2. Re-run the startup script — it closes any DevTools targets automatically via `close_devtools_targets`, then reconnect.
 
 ### Phase 4: Initial Setup (automatic)
 
@@ -419,41 +294,23 @@ Use `AskUserQuestion`:
   1. `Leave running` — Keep the app alive so you can reconnect later
   2. `Close it` — Stop the app and free the port
 
-If the user chooses "Close it":
+If the user chooses **"Leave running"** — remove the session file so the next invocation finds the app cleanly via probe (no process killing):
 
-**Production mode:**
+**Linux / macOS:** `bash .agents/skills/mcp-testing/stop.sh --session-only`
+**Windows:** `pwsh .agents/skills/mcp-testing/stop.ps1 -SessionOnly`
 
-macOS:
+If the user chooses **"Close it"** — run the stop script, which reads the session state and kills the right processes:
 
-```bash
-osascript -e 'quit app "Podman Desktop"'
-```
-
-Linux:
+**Linux / macOS:**
 
 ```bash
-pkill -f podman-desktop || flatpak kill io.podman_desktop.PodmanDesktop 2>/dev/null
+bash .agents/skills/mcp-testing/stop.sh
 ```
 
-Windows:
+**Windows:**
 
 ```powershell
-Stop-Process -Name "Podman Desktop" -Force
-```
-
-**Dev mode:**
-
-Linux / macOS:
-
-```bash
-kill $(lsof -ti :9223) 2>/dev/null && echo "App stopped"
-```
-
-Windows:
-
-```powershell
-Get-NetTCPConnection -LocalPort 9223 -State Listen -ErrorAction SilentlyContinue |
-  ForEach-Object { Stop-Process -Id $_.OwningProcess -Force }
+pwsh .agents/skills/mcp-testing/stop.ps1
 ```
 
 ## Selector Strategy
@@ -522,8 +379,8 @@ Then re-open your terminal and verify with `pnpm --version`.
 **Fix:**
 
 1. `mcp__podman-desktop-mcp__disconnect()`
-2. Re-run `start.sh --mode dev` (kills the old session and starts fresh)
-3. `mcp__podman-desktop-mcp__connect({ port: 9223 })`
+2. Re-run the startup script for your mode — it closes DevTools targets automatically via `close_devtools_targets`
+3. `mcp__podman-desktop-mcp__connect({ port: PORT })`
 
 ### Production App Without CDP
 
@@ -531,19 +388,13 @@ Then re-open your terminal and verify with `pnpm --version`.
 
 **Cause:** The production app was launched without the `--remote-debugging-port` flag.
 
-**Fix:** Close the production app and relaunch with:
-
-```bash
-podman-desktop --remote-debugging-port=9222
-```
+**Fix:** Run `start.sh --mode prod` (or `start.ps1 -Mode prod`) — it detects this case automatically, closes the running app, and relaunches it with CDP enabled.
 
 ### Production Blocks Dev Instance
 
-**Symptom:** `start.sh --mode dev` times out after 120s with a hint about the single-instance lock.
+`start.sh --mode dev` (and `start.ps1 -Mode dev`) automatically detects and closes a running production Podman Desktop before starting the dev instance — no manual action is needed.
 
-**Cause:** Electron allows only one instance via `requestSingleInstanceLock()`. The installed Podman Desktop holds the lock, so the dev Electron instance exits silently.
-
-**Fix:** Close the production app, then re-run in dev mode.
+**If startup still times out after 120s:** the production app may have restarted in the gap between detection and the kill, or a non-Podman-Desktop process holds port 9222. Run the stop script, verify port 9222 is free (`lsof -ti :9222`), then re-run the start script.
 
 ### MCP Tools Become Unavailable Mid-Session
 
@@ -586,7 +437,7 @@ Add to `~/.bashrc` or `~/.zshrc` to make it permanent.
 | `bash probe.sh`                                           | Detect environment (what's running, CDP ports) |
 | `bash start.sh --mode dev`                                | Full dev startup                               |
 | `bash start.sh --mode dev-fast`                           | Fast-path (dev already running)                |
-| `bash start.sh --mode prod PORT`                          | Connect to production CDP                      |
+| `bash start.sh --mode prod`                               | Launch/connect production app                  |
 | `mcp__podman-desktop-mcp__connect({ port: PORT })`        | Connect to app                                 |
 | `mcp__podman-desktop-mcp__disconnect()`                   | Disconnect from MCP                            |
 | `mcp__podman-desktop-mcp__snapshot()`                     | Get accessibility tree                         |

--- a/.agents/skills/mcp-testing/examples.md
+++ b/.agents/skills/mcp-testing/examples.md
@@ -1,0 +1,561 @@
+# MCP Test Command Examples
+
+Ready-to-use MCP command examples for testing Podman Desktop. Works in both development mode (`pnpm watch`, port 9223) and production mode (installed app, port 9222).
+
+## Connection
+
+### Connect to Podman Desktop
+
+```
+Connect to Podman Desktop using CDP at port 9223   # dev mode
+Connect to Podman Desktop using CDP at port 9222   # production mode
+```
+
+**Prerequisites:** Dev mode requires `pnpm watch` running. Production mode requires the app launched with `--remote-debugging-port=9222`.
+
+## Navigation Workflows
+
+### Navigate to Settings Page
+
+```
+Navigate to the Settings page in Podman Desktop
+```
+
+**Expected:** Settings page loads, showing Preferences, Resources, etc.
+
+### Navigate to Containers View
+
+```
+Click on the Containers link in the navigation sidebar
+```
+
+**Expected:** Containers view loads, showing list of containers (if any).
+
+### Open Dashboard
+
+```
+Navigate to the Dashboard page
+```
+
+**Expected:** Dashboard loads, showing provider status and quick actions.
+
+### Access Extensions Panel
+
+```
+Navigate to the Extensions page
+```
+
+**Expected:** Extensions page loads, showing installed and available extensions.
+
+### Navigate to Kubernetes Resources
+
+```
+Go to the Pods page
+```
+
+**Expected:** Pods view loads (if Kubernetes is enabled).
+
+## Form Interaction
+
+### Fill Configuration Form
+
+```
+Navigate to Settings > Preferences, toggle the "Enable experimental features" checkbox, and verify it's enabled
+```
+
+**Expected:** Checkbox state changes, setting is saved.
+
+### Submit Search Query
+
+```
+Navigate to Containers, fill in the search box with "nginx", and press Enter
+```
+
+**Expected:** Container list filters to show only containers matching "nginx".
+
+### Create Container Form
+
+```
+Navigate to Images, find the nginx image, click "Run Image", fill in container name as "test-nginx", and start the container
+```
+
+**Expected:** Container creation form appears, fields are filled, container starts.
+
+## Element Inspection
+
+### Get Text Content from Elements
+
+```
+What is the text of the main heading on the Dashboard page?
+```
+
+**Expected:** Returns heading text (e.g., "Dashboard").
+
+### Check Visibility of UI Components
+
+```
+Navigate to Settings and check if the "Kubernetes" tab is visible
+```
+
+**Expected:** Returns true/false based on visibility.
+
+### Count Elements (Container List)
+
+```
+Navigate to Containers and count how many container cards are displayed
+```
+
+**Expected:** Returns count of container elements in the list.
+
+### Get Element Attributes
+
+```
+Get the aria-label attribute of the navigation sidebar links
+```
+
+**Expected:** Returns accessible names like "Dashboard", "Containers", "Images", etc.
+
+### Check Button State
+
+```
+Navigate to Dashboard, find the Podman provider, and check if the "Start" button is enabled
+```
+
+**Expected:** Returns button enabled state.
+
+## Screenshot & Debugging
+
+### Capture Full-Page Screenshot
+
+```
+Take a screenshot of the current page and save it
+```
+
+**Expected:** Screenshot captured and saved to file.
+
+### Get Accessibility Snapshot
+
+```
+Get an accessibility snapshot of the Settings page to see the element tree
+```
+
+**Expected:** Returns accessibility tree structure showing headings, buttons, inputs, etc.
+
+## Advanced Scenarios
+
+### Complete Container Creation Workflow
+
+```
+1. Navigate to Images page
+2. Search for "redis" image
+3. Click "Pull Image" if not already available
+4. Wait for pull to complete
+5. Find the redis image and click "Run Image"
+6. Fill in container name as "test-redis"
+7. Set port mapping from 6379 to 6379
+8. Click "Start Container"
+9. Navigate to Containers and verify "test-redis" is running
+10. Take a screenshot of the running container
+```
+
+**Expected:** Complete workflow from image pull to running container with verification.
+
+### Test Extension Installation Flow
+
+```
+1. Navigate to Extensions page
+2. Get a snapshot to see available extensions
+3. Find the "Docker" extension
+4. Click "Install" if not already installed
+5. Wait for installation to complete
+6. Verify the extension appears in the installed list
+7. Take a screenshot
+```
+
+**Expected:** Extension installs successfully and appears in installed list.
+
+### Verify Provider Status Changes
+
+```
+1. Navigate to Dashboard
+2. Find the Podman provider card
+3. Check current status (should be "Running" or "Stopped")
+4. If running, click "Stop"; if stopped, click "Start"
+5. Wait 5 seconds for status change
+6. Verify the status changed
+7. Take a screenshot of the new status
+```
+
+**Expected:** Provider status changes as expected.
+
+### Container Lifecycle Test
+
+```
+1. Navigate to Containers
+2. Create a new container from nginx image named "lifecycle-test"
+3. Verify it starts successfully
+4. Stop the container
+5. Restart the container
+6. Delete the container
+7. Verify it's removed from the list
+```
+
+**Expected:** Full container lifecycle from creation to deletion.
+
+### Image Pull and Inspect
+
+```
+1. Navigate to Images
+2. Click "Pull Image" button
+3. Enter image name "alpine:latest"
+4. Click "Pull"
+5. Wait for pull to complete
+6. Find the alpine image in the list
+7. Click on it to view details
+8. Verify image size and tags are displayed
+```
+
+**Expected:** Image pulls successfully, details are visible.
+
+## Debugging Scenarios
+
+### Investigate Slow Page Load
+
+```
+1. Navigate to Containers page
+2. Take a screenshot immediately
+3. Wait 2 seconds
+4. Take another screenshot
+5. Compare to identify lazy-loading elements
+```
+
+**Expected:** Identifies elements that load asynchronously.
+
+### Test Keyboard Navigation
+
+```
+1. Navigate to Settings
+2. Press Tab key 5 times
+3. Take screenshot showing focus state
+4. Verify focus is visible and logical
+```
+
+**Expected:** Focus indicators are visible and follow logical tab order.
+
+## Continuous Testing Workflows
+
+### Daily Smoke Test
+
+```
+Run this daily to verify core functionality:
+
+1. Connect to running Podman Desktop (port 9223 for dev, 9222 for production)
+2. Navigate to Dashboard - verify it loads
+3. Navigate to Containers - count containers
+4. Navigate to Images - count images
+5. Navigate to Extensions - verify Podman extension is loaded
+6. Navigate to Settings - verify Preferences tab is accessible
+7. Take screenshot of Dashboard
+8. Disconnect
+```
+
+**Expected:** All pages load without errors.
+
+### Regression Testing After Changes
+
+```
+After making code changes:
+
+1. Verify pnpm watch is running (hot-reloaded with new code) or production app is running with CDP
+2. Connect via MCP to the appropriate port (9223 for dev, 9222 for production)
+3. Navigate to affected page/feature
+4. Test the specific functionality changed
+5. Test related functionality for regressions
+6. Verify no new errors appear
+7. Take before/after screenshots if UI changed
+```
+
+**Expected:** Changes work as intended, no regressions introduced.
+
+## Tips for Effective Testing
+
+### Start Every Session With:
+
+```
+Connect to Podman Desktop and get an accessibility snapshot of the current page
+```
+
+This gives you context about what's visible and available.
+
+### Use Accessible Names Over CSS:
+
+```
+Click the button labeled "Start Container"
+```
+
+ARIA roles and accessible names are the most stable selectors in Podman Desktop.
+
+### Wait for Dynamic Content:
+
+```
+Navigate to Containers, wait 3 seconds for the list to load, then count the containers
+```
+
+Prevents race conditions with async operations.
+
+### Verify After Actions:
+
+```
+Create a container named "test", then navigate to Containers and verify "test" appears in the list
+```
+
+Always confirm actions succeeded.
+
+## Selectors Reference
+
+Podman Desktop has very few `data-testid` attributes. Always use `snapshot()` to discover the actual element tree before interacting.
+
+Selectors below are derived from the project's Playwright Page Object Models (`tests/playwright/src/model/`). Use them as reliable starting points — always verify with `snapshot()` since the UI may evolve.
+
+### Page Regions
+
+The UI is structured around named regions. Start navigation from the top-level region, then drill into header/content:
+
+```javascript
+// Main navigation sidebar
+document.querySelector('[role="navigation"][aria-label="AppNavigation"]');
+
+// Page-level regions (Dashboard, Images, Containers, Pods, Volumes, Networks)
+document.querySelector('[role="region"][aria-label="Images"]');
+
+// Within a page region — header and content areas
+// region[aria-label="header"] — contains title, search, action buttons
+// region[aria-label="content"] — contains the data table or detail view
+```
+
+### Navigation Links
+
+```javascript
+// Sidebar links — use role="link" with exact name
+document.querySelector('[role="link"][aria-label="Dashboard"]'); // or: Images, Containers, Pods, Volumes, Networks, Settings, Extensions, Kubernetes
+```
+
+### Buttons — Common Actions
+
+```javascript
+// Resource actions (appear in headers and table rows)
+document.querySelector('button[aria-label="Create"]');
+document.querySelector('button[aria-label="Delete"]');
+document.querySelector('button[aria-label="Prune"]');
+
+// Container lifecycle
+document.querySelector('button[aria-label="Start Container"]');
+document.querySelector('button[aria-label="Stop Container"]');
+document.querySelector('button[aria-label="Delete Container"]');
+
+// Image actions
+document.querySelector('button[aria-label="Pull"]'); // exact: true in POM
+document.querySelector('button[aria-label="Build"]'); // exact: true in POM
+document.querySelector('button[aria-label="Run Image"]');
+document.querySelector('button[aria-label="Push Image"]');
+document.querySelector('button[aria-label="Save Image"]');
+document.querySelector('button[aria-label="Delete Image"]');
+
+// Volume / Network actions
+document.querySelector('button[aria-label="Delete Volume"]');
+document.querySelector('button[aria-label="Delete Network"]');
+document.querySelector('button[aria-label="Create Pod"]');
+
+// Provider actions
+document.querySelector('button[aria-label="Initialize and start"]'); // partial — provider name follows
+
+// Navigation buttons
+document.querySelector('button[aria-label="Back (hold for history)"]');
+document.querySelector('button[aria-label="Forward (hold for history)"]');
+
+// Kebab / overflow menu
+document.querySelector('button[aria-label="kebab menu"]');
+```
+
+### Button Groups
+
+Action buttons are organized in named groups:
+
+```javascript
+// Detail page control actions (Start, Stop, Delete, etc.)
+document.querySelector('[role="group"][aria-label="Control Actions"]');
+
+// Additional actions in headers
+document.querySelector('[role="group"][aria-label="additionalActions"]');
+document.querySelector('[role="group"][aria-label="bottomAdditionalActions"]');
+
+// Left/right action groups
+document.querySelector('[role="group"][aria-label="left actions"]');
+document.querySelector('[role="group"][aria-label="right actions"]');
+```
+
+### Headings
+
+```javascript
+// Page titles
+document.querySelector('[role="heading"][aria-label="Dashboard"]');
+document.querySelector('[role="heading"][aria-label="Images"]');
+document.querySelector('[role="heading"][aria-label="Containers"]');
+
+// Form/dialog headings
+document.querySelector('[role="heading"][aria-label="Pull Image From a Registry"]');
+document.querySelector('[role="heading"][aria-label="Build Image from Containerfile"]');
+document.querySelector('[role="heading"][aria-label="Copy containers to a pod"]');
+document.querySelector('[role="heading"][aria-label="Create a volume"]');
+
+// Empty state
+document.querySelector('[role="heading"][aria-label="No Container Engine"]');
+```
+
+### Tables and Rows
+
+```javascript
+// The resource table
+document.querySelector('[role="table"]');
+
+// All rows
+document.querySelectorAll('[role="row"]');
+
+// Cells within a row (0-indexed: checkbox, status, name, environment, image, ...)
+document.querySelectorAll('[role="cell"]'); // use nth-child for specific columns
+
+// Column headers — e.g. the "toggle all" checkbox
+document.querySelector('[role="columnheader"]');
+
+// Toggle all checkbox
+document.querySelector('[role="checkbox"][aria-label="Toggle all"]');
+```
+
+### Form Inputs
+
+```javascript
+// Pull image input
+document.querySelector('[aria-label="Image to Pull"]');
+
+// Container creation form
+document.querySelector('[aria-label="Container Name"]');
+document.querySelector('[aria-label="Entrypoint"]');
+document.querySelector('[aria-label="Command"]');
+document.querySelector('[aria-label="host port"]');
+document.querySelector('[aria-label="container port"]');
+document.querySelector('button[aria-label="Add custom port mapping"]');
+
+// Pod creation
+document.querySelector('[role="textbox"][aria-label="Pod name"]');
+
+// Volume creation
+document.querySelector('[role="textbox"][aria-label="Volume name"]');
+
+// Build image (use placeholder text)
+document.querySelector('[placeholder="Containerfile to build"]');
+document.querySelector('[placeholder="Directory to build in"]');
+document.querySelector('[placeholder="my-custom-image"]');
+
+// Search in preferences
+document.querySelector('[aria-label="search preferences"]');
+
+// Command palette
+document.querySelector('[aria-label="Command palette command input"]');
+```
+
+### Dialogs
+
+```javascript
+document.querySelector('[role="dialog"][aria-label="Create a new container"]');
+document.querySelector('[role="dialog"][aria-label="Install Custom Extension"]');
+document.querySelector('[role="dialog"][aria-label="Find / Replace"]');
+```
+
+### Provider Regions
+
+```javascript
+document.querySelector('[role="region"][aria-label="Podman Provider"]');
+document.querySelector('[role="region"][aria-label="Developer Sandbox Provider"]');
+document.querySelector('[role="region"][aria-label="OpenShift Local Provider"]');
+```
+
+### Status and Notifications
+
+```javascript
+// Status indicator (check title attribute for "Running", "Stopped", etc.)
+document.querySelector('[role="status"]');
+
+// Notifications panel
+document.querySelector('[role="region"][aria-label="Notifications Box"]');
+
+// Error messages
+document.querySelector('[role="alert"][aria-label="Error Message Content"]');
+
+// Extension status
+document.querySelector('[aria-label="Extension Status Label"]');
+document.querySelector('[aria-label="Connection Status Label"]');
+```
+
+### Tabs
+
+```javascript
+// Tab container
+document.querySelector('[role="region"][aria-label="Tabs"]');
+
+// Tab content area
+document.querySelector('[role="region"][aria-label="Tab Content"]');
+
+// Individual tabs — use role="link" with the tab name:
+// Summary, History, Inspect, Logs, Terminal, Kube
+```
+
+### Terminal (Container Logs / Terminal Tab)
+
+```javascript
+// Terminal content (xterm.js)
+document.querySelector('.xterm-rows');
+
+// Terminal input
+document.querySelector('[aria-label="Terminal input"]');
+
+// Clear logs button
+document.querySelector('[aria-label="Clear logs"]');
+
+// Find in terminal
+document.querySelector('[aria-label="Find"]');
+```
+
+### Extensions Page
+
+```javascript
+// Extension page tabs
+document.querySelector('button[aria-label="Installed"]');
+document.querySelector('button[aria-label="Catalog"]');
+document.querySelector('button[aria-label="Local Extensions"]');
+
+// Featured extensions region
+document.querySelector('[role="region"][aria-label="FeaturedExtensions"]');
+
+// Install custom extension
+document.querySelector('[aria-label="Install custom"]');
+
+// Extension actions group
+document.querySelector('[role="group"][aria-label="Extension Actions"]');
+```
+
+### Platform Selection (Build Image)
+
+```javascript
+document.querySelector('[role="region"][aria-label="Build Platform Options"]');
+document.querySelector('[aria-label="linux/arm64"]');
+document.querySelector('[aria-label="linux/amd64"]');
+document.querySelector('[aria-label="ARM® aarch64 systems"]');
+document.querySelector('[aria-label="Intel and AMD x86_64 systems"]');
+```
+
+### Preferences Navigation
+
+```javascript
+document.querySelector('[role="navigation"][aria-label="PreferencesNavigation"]');
+document.querySelector('[role="navigation"][aria-label="Breadcrumb"]');
+```

--- a/.agents/skills/mcp-testing/probe.ps1
+++ b/.agents/skills/mcp-testing/probe.ps1
@@ -1,0 +1,80 @@
+#!/usr/bin/env pwsh
+# probe.ps1 — Read-only environment detection for MCP testing (Windows).
+# Never starts, kills, or modifies anything. Prints structured key=value output.
+#
+# Output:
+#   PROD_RUNNING=true|false
+#   PROD_CDP_PORT=<port>|none
+#   PROD_APP_TITLE=<title>|none
+#   DEV_RUNNING=true|false
+#   DEV_CDP_PORT=<port>|none
+#   DEV_APP_TITLE=<title>|none
+
+function Get-CdpHealthyTitle {
+    param([int]$Port)
+    try {
+        $targets = (Invoke-WebRequest -Uri "http://localhost:$Port/json" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop).Content | ConvertFrom-Json
+        foreach ($t in $targets) {
+            $url   = if ($t.url)   { $t.url.ToLower()   } else { "" }
+            $title = if ($t.title) { $t.title.ToLower() } else { "" }
+            $ttype = if ($t.type)  { $t.type.ToLower()  } else { "" }
+            if ($url -notlike "*devtools*" -and $title -ne "devtools" -and $ttype -eq "page") {
+                return $t.title
+            }
+        }
+    } catch {}
+    return $null
+}
+
+# ── Production detection ──────────────────────────────────────────────────────
+$prodRunning = $false
+$procs = Get-Process -Name "Podman Desktop" -ErrorAction SilentlyContinue |
+         Where-Object { $_.Path -and $_.Path -notmatch 'node_modules' }
+if ($null -ne $procs -and @($procs).Count -gt 0) {
+    $prodRunning = $true
+}
+
+$prodCdpPort = "none"
+$prodAppTitle = "none"
+if ($prodRunning) {
+    foreach ($p in @(9222, 9223)) {
+        try {
+            $null = Invoke-WebRequest -Uri "http://localhost:$p/json/version" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
+            $title = Get-CdpHealthyTitle -Port $p
+            if ($title) {
+                $prodCdpPort = $p
+                $prodAppTitle = $title
+                break
+            }
+        } catch {}
+    }
+}
+
+# ── Dev detection ─────────────────────────────────────────────────────────────
+$devRunning = $false
+$devProcs = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandLine -match 'pnpm.*watch' }
+if ($null -ne $devProcs -and @($devProcs).Count -gt 0) {
+    $devRunning = $true
+}
+
+$devCdpPort = "none"
+$devAppTitle = "none"
+if ($devRunning) {
+    try {
+        $null = Invoke-WebRequest -Uri "http://localhost:9223/json/version" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
+        $title = Get-CdpHealthyTitle -Port 9223
+        if ($title) {
+            $devCdpPort = 9223
+            $devAppTitle = $title
+        }
+    } catch {}
+}
+
+# ── Output ────────────────────────────────────────────────────────────────────
+Write-Output "PROD_RUNNING=$($prodRunning.ToString().ToLower())"
+Write-Output "PROD_CDP_PORT=$prodCdpPort"
+Write-Output "PROD_APP_TITLE=$prodAppTitle"
+Write-Output "DEV_RUNNING=$($devRunning.ToString().ToLower())"
+Write-Output "DEV_CDP_PORT=$devCdpPort"
+Write-Output "DEV_APP_TITLE=$devAppTitle"

--- a/.agents/skills/mcp-testing/probe.ps1
+++ b/.agents/skills/mcp-testing/probe.ps1
@@ -9,6 +9,9 @@
 #   DEV_RUNNING=true|false
 #   DEV_CDP_PORT=<port>|none
 #   DEV_APP_TITLE=<title>|none
+#   STALE_SESSION=true|false
+#   PORT_9222_NAME=<name>|none   PORT_9222_PID=<pid>|none
+#   PORT_9223_NAME=<name>|none   PORT_9223_PID=<pid>|none
 
 function Get-CdpHealthyTitle {
     param([int]$Port)
@@ -37,7 +40,7 @@ if ($null -ne $procs -and @($procs).Count -gt 0) {
 $prodCdpPort = "none"
 $prodAppTitle = "none"
 if ($prodRunning) {
-    foreach ($p in @(9222, 9223)) {
+    foreach ($p in @(9222)) {
         try {
             $null = Invoke-WebRequest -Uri "http://localhost:$p/json/version" -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop
             $title = Get-CdpHealthyTitle -Port $p
@@ -71,6 +74,30 @@ if ($devRunning) {
     } catch {}
 }
 
+# ── Stale session check ───────────────────────────────────────────────────────
+# Only stale if session file exists AND no healthy CDP is reachable.
+# If the app is running and accessible, the file is from a "Leave running" exit — not an orphan.
+$staleSession = $false
+if (Test-Path "$env:TEMP\mcp-testing-session") {
+    if ($prodCdpPort -eq "none" -and $devCdpPort -eq "none") {
+        $staleSession = $true
+    }
+}
+
+# ── Port conflict check ───────────────────────────────────────────────────────
+$portNames = @{}
+$portPids  = @{}
+foreach ($port in @(9222, 9223)) {
+    $conn = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($conn) {
+        $portNames[$port] = (Get-Process -Id $conn.OwningProcess -ErrorAction SilentlyContinue).ProcessName ?? "unknown"
+        $portPids[$port]  = $conn.OwningProcess
+    } else {
+        $portNames[$port] = "none"
+        $portPids[$port]  = "none"
+    }
+}
+
 # ── Output ────────────────────────────────────────────────────────────────────
 Write-Output "PROD_RUNNING=$($prodRunning.ToString().ToLower())"
 Write-Output "PROD_CDP_PORT=$prodCdpPort"
@@ -78,3 +105,8 @@ Write-Output "PROD_APP_TITLE=$prodAppTitle"
 Write-Output "DEV_RUNNING=$($devRunning.ToString().ToLower())"
 Write-Output "DEV_CDP_PORT=$devCdpPort"
 Write-Output "DEV_APP_TITLE=$devAppTitle"
+Write-Output "STALE_SESSION=$($staleSession.ToString().ToLower())"
+Write-Output "PORT_9222_NAME=$($portNames[9222])"
+Write-Output "PORT_9222_PID=$($portPids[9222])"
+Write-Output "PORT_9223_NAME=$($portNames[9223])"
+Write-Output "PORT_9223_PID=$($portPids[9223])"

--- a/.agents/skills/mcp-testing/probe.ps1
+++ b/.agents/skills/mcp-testing/probe.ps1
@@ -90,7 +90,8 @@ $portPids  = @{}
 foreach ($port in @(9222, 9223)) {
     $conn = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($conn) {
-        $portNames[$port] = (Get-Process -Id $conn.OwningProcess -ErrorAction SilentlyContinue).ProcessName ?? "unknown"
+        $proc = Get-Process -Id $conn.OwningProcess -ErrorAction SilentlyContinue
+        $portNames[$port] = if ($proc) { $proc.ProcessName } else { "unknown" }
         $portPids[$port]  = $conn.OwningProcess
     } else {
         $portNames[$port] = "none"

--- a/.agents/skills/mcp-testing/probe.sh
+++ b/.agents/skills/mcp-testing/probe.sh
@@ -9,6 +9,9 @@
 #   DEV_RUNNING=true|false
 #   DEV_CDP_PORT=<port>|none
 #   DEV_APP_TITLE=<title>|none
+#   STALE_SESSION=true|false
+#   PORT_9222_NAME=<name>|none   PORT_9222_PID=<pid>|none
+#   PORT_9223_NAME=<name>|none   PORT_9223_PID=<pid>|none
 
 cdp_healthy_title() {
   local port=$1
@@ -40,13 +43,17 @@ case "$(uname -s)" in
         prod_running=true; break
       fi
     done < <(pgrep -af "podman-desktop" 2>/dev/null)
+    # Also detect Flatpak-installed PD (app ID uses underscores: io.podman_desktop.PodmanDesktop)
+    if ! $prod_running && pgrep -f "io.podman_desktop.PodmanDesktop" &>/dev/null; then
+      prod_running=true
+    fi
     ;;
 esac
 
 prod_cdp_port=none
 prod_app_title=none
 if $prod_running; then
-  for p in 9222 9223; do
+  for p in 9222; do
     if curl -s --connect-timeout 2 --max-time 5 "http://localhost:$p/json/version" &>/dev/null; then
       title=$(cdp_healthy_title "$p") && {
         prod_cdp_port=$p
@@ -72,6 +79,30 @@ if $dev_running; then
   fi
 fi
 
+# ── Stale session check ──────────────────────────────────────────────────────
+# Only stale if session file exists AND no healthy CDP is reachable.
+# If the app is running and accessible, the file is from a "Leave running" exit — not an orphan.
+stale_session=false
+if [ -f /tmp/mcp-testing-session ]; then
+  if [[ "$prod_cdp_port" == "none" && "$dev_cdp_port" == "none" ]]; then
+    stale_session=true
+  fi
+fi
+
+# ── Port conflict check ───────────────────────────────────────────────────────
+for port in 9222 9223; do
+  info=$(lsof -i ":$port" -n -P 2>/dev/null | awk '/LISTEN/ {print $1 ":" $2; exit}')
+  if [[ -n "$info" ]]; then
+    _name="${info%%:*}"
+    _pid="${info##*:}"
+    eval "port_${port}_name=\$_name"
+    eval "port_${port}_pid=\$_pid"
+  else
+    eval "port_${port}_name=none"
+    eval "port_${port}_pid=none"
+  fi
+done
+
 # ── Output ───────────────────────────────────────────────────────────────────
 echo "PROD_RUNNING=$prod_running"
 echo "PROD_CDP_PORT=$prod_cdp_port"
@@ -79,3 +110,8 @@ echo "PROD_APP_TITLE=$prod_app_title"
 echo "DEV_RUNNING=$dev_running"
 echo "DEV_CDP_PORT=$dev_cdp_port"
 echo "DEV_APP_TITLE=$dev_app_title"
+echo "STALE_SESSION=$stale_session"
+echo "PORT_9222_NAME=$port_9222_name"
+echo "PORT_9222_PID=$port_9222_pid"
+echo "PORT_9223_NAME=$port_9223_name"
+echo "PORT_9223_PID=$port_9223_pid"

--- a/.agents/skills/mcp-testing/probe.sh
+++ b/.agents/skills/mcp-testing/probe.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# probe.sh — Read-only environment detection for MCP testing.
+# Never starts, kills, or modifies anything. Prints structured key=value output.
+#
+# Output:
+#   PROD_RUNNING=true|false
+#   PROD_CDP_PORT=<port>|none
+#   PROD_APP_TITLE=<title>|none
+#   DEV_RUNNING=true|false
+#   DEV_CDP_PORT=<port>|none
+#   DEV_APP_TITLE=<title>|none
+
+cdp_healthy_title() {
+  local port=$1
+  curl -s --connect-timeout 2 "http://localhost:$port/json" 2>/dev/null | node -e '
+    const d = require("fs").readFileSync(0, "utf8");
+    try {
+      for (const t of JSON.parse(d)) {
+        const u = (t.url || "").toLowerCase();
+        const l = (t.title || "").toLowerCase();
+        if (!u.includes("devtools") && l !== "devtools" && t.type === "page") {
+          process.stdout.write(t.title || "unknown");
+          process.exit(0);
+        }
+      }
+    } catch {}
+    process.exit(1);
+  ' 2>/dev/null
+}
+
+# ── Production detection ─────────────────────────────────────────────────────
+prod_running=false
+case "$(uname -s)" in
+  Darwin)
+    pgrep -f "Podman Desktop.app/Contents" &>/dev/null && prod_running=true
+    ;;
+  Linux)
+    while IFS= read -r line; do
+      if ! echo "$line" | grep -qE 'node_modules|pnpm|scripts/watch'; then
+        prod_running=true; break
+      fi
+    done < <(pgrep -af "podman-desktop" 2>/dev/null)
+    ;;
+esac
+
+prod_cdp_port=none
+prod_app_title=none
+if $prod_running; then
+  for p in 9222 9223; do
+    if curl -s --connect-timeout 2 "http://localhost:$p/json/version" &>/dev/null; then
+      title=$(cdp_healthy_title "$p") && {
+        prod_cdp_port=$p
+        prod_app_title=$title
+        break
+      }
+    fi
+  done
+fi
+
+# ── Dev detection ────────────────────────────────────────────────────────────
+dev_running=false
+pgrep -f 'pnpm.*watch' &>/dev/null && dev_running=true
+
+dev_cdp_port=none
+dev_app_title=none
+if $dev_running; then
+  if curl -s --connect-timeout 2 "http://localhost:9223/json/version" &>/dev/null; then
+    title=$(cdp_healthy_title 9223) && {
+      dev_cdp_port=9223
+      dev_app_title=$title
+    }
+  fi
+fi
+
+# ── Output ───────────────────────────────────────────────────────────────────
+echo "PROD_RUNNING=$prod_running"
+echo "PROD_CDP_PORT=$prod_cdp_port"
+echo "PROD_APP_TITLE=$prod_app_title"
+echo "DEV_RUNNING=$dev_running"
+echo "DEV_CDP_PORT=$dev_cdp_port"
+echo "DEV_APP_TITLE=$dev_app_title"

--- a/.agents/skills/mcp-testing/probe.sh
+++ b/.agents/skills/mcp-testing/probe.sh
@@ -12,7 +12,7 @@
 
 cdp_healthy_title() {
   local port=$1
-  curl -s --connect-timeout 2 "http://localhost:$port/json" 2>/dev/null | node -e '
+  curl -s --connect-timeout 2 --max-time 5 "http://localhost:$port/json" 2>/dev/null | node -e '
     const d = require("fs").readFileSync(0, "utf8");
     try {
       for (const t of JSON.parse(d)) {
@@ -47,7 +47,7 @@ prod_cdp_port=none
 prod_app_title=none
 if $prod_running; then
   for p in 9222 9223; do
-    if curl -s --connect-timeout 2 "http://localhost:$p/json/version" &>/dev/null; then
+    if curl -s --connect-timeout 2 --max-time 5 "http://localhost:$p/json/version" &>/dev/null; then
       title=$(cdp_healthy_title "$p") && {
         prod_cdp_port=$p
         prod_app_title=$title
@@ -64,7 +64,7 @@ pgrep -f 'pnpm.*watch' &>/dev/null && dev_running=true
 dev_cdp_port=none
 dev_app_title=none
 if $dev_running; then
-  if curl -s --connect-timeout 2 "http://localhost:9223/json/version" &>/dev/null; then
+  if curl -s --connect-timeout 2 --max-time 5 "http://localhost:9223/json/version" &>/dev/null; then
     title=$(cdp_healthy_title 9223) && {
       dev_cdp_port=9223
       dev_app_title=$title

--- a/.agents/skills/mcp-testing/start.ps1
+++ b/.agents/skills/mcp-testing/start.ps1
@@ -198,23 +198,26 @@ if (Test-ProductionPDRunning) {
     Write-Host "      Production app stopped"
 }
 
-# Kill any existing pnpm watch
+# Kill any existing pnpm watch (tree kill to catch vite/svelte-package/esbuild children)
 Write-Host "[1/4] Stopping any running dev instance..."
-$killed = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
-          Where-Object { $_.CommandLine -match 'pnpm.*watch' }
-if ($killed) {
-    $killed | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-    Write-Host "      Stopped pnpm watch"
+$watchProcs = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+              Where-Object { $_.CommandLine -match 'pnpm.*watch' }
+foreach ($wp in $watchProcs) {
+    & taskkill /F /T /PID $wp.ProcessId 2>$null
+}
+if ($watchProcs) {
+    Write-Host "      Stopped pnpm watch tree"
     Start-Sleep -Seconds 3
 }
 
 # Also kill the Electron app if it is still listening on the dev CDP port
 $conn = Get-NetTCPConnection -LocalPort $DEV_PORT -State Listen -ErrorAction SilentlyContinue
 if ($conn) {
-    $procName = (Get-Process -Id $conn.OwningProcess -ErrorAction SilentlyContinue).ProcessName ?? "unknown"
+    $proc = Get-Process -Id $conn.OwningProcess -ErrorAction SilentlyContinue
+    $procName = if ($proc) { $proc.ProcessName } else { "unknown" }
     Write-Host "      Killing process on port $DEV_PORT ($procName)"
-    Stop-Process -Id $conn.OwningProcess -Force -ErrorAction SilentlyContinue
-    Write-Host "      Stopped process on port $DEV_PORT"
+    & taskkill /F /T /PID $conn.OwningProcess 2>$null
+    Write-Host "      Stopped process tree on port $DEV_PORT"
     Start-Sleep -Seconds 2
 }
 

--- a/.agents/skills/mcp-testing/start.ps1
+++ b/.agents/skills/mcp-testing/start.ps1
@@ -5,16 +5,14 @@
 # Usage:
 #   pwsh start.ps1 -Mode dev          # full startup (clean, install, pnpm watch)
 #   pwsh start.ps1 -Mode dev-fast     # fast-path (pnpm watch already running)
-#   pwsh start.ps1 -Mode prod -Port 9222  # connect to production CDP
+#   pwsh start.ps1 -Mode prod             # launch/connect production app
 #
 # After exit 0, call mcp__podman-desktop-mcp__connect({ port: <PORT> }).
 
 param(
     [Parameter(Mandatory = $true)]
     [ValidateSet("dev", "dev-fast", "prod")]
-    [string]$Mode,
-
-    [int]$Port = 0
+    [string]$Mode
 )
 
 $DEV_PORT = 9223
@@ -88,24 +86,79 @@ function Test-ProductionPDRunning {
 
 # ── Mode: prod ────────────────────────────────────────────────────────────────
 if ($Mode -eq "prod") {
-    if ($Port -eq 0) {
-        Write-Host "ERROR: -Mode prod requires -Port argument"
+    $PROD_PORT = 9222
+
+    # 1. Already running with CDP on the production port? (9223 is exclusively dev — never check it here)
+    foreach ($p in @(9222)) {
+        if (Test-CdpReady -CdpPort $p) {
+            $appTitle = $null
+            for ($j = 1; $j -le 10; $j++) {
+                $appTitle = Get-HealthyAppTitle -CdpPort $p
+                if ($appTitle) { break }
+                Start-Sleep -Seconds 1
+            }
+            if ($appTitle) {
+                "prod" | Out-File -FilePath "$env:TEMP\mcp-testing-session" -Encoding utf8 -NoNewline
+                Write-Host "Already running — $appTitle (port $p)"
+                Write-Host "Ready — call mcp__podman-desktop-mcp__connect({ port: $p })"
+                exit 0
+            }
+        }
+    }
+
+    # 2. Running but no CDP — relaunch with CDP flag
+    if (Test-ProductionPDRunning) {
+        Write-Host "Production Podman Desktop is running without CDP — relaunching with --remote-debugging-port=$PROD_PORT..."
+        Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 3
+    }
+
+    # 3. Kill dev instance if it holds the single-instance lock
+    if (Test-WatchRunning) {
+        Write-Host "      Dev instance (pnpm watch) running — stopping it to release the single-instance lock..."
+        Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandLine -match 'pnpm.*watch' } |
+            ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+        $devConn = Get-NetTCPConnection -LocalPort $DEV_PORT -State Listen -ErrorAction SilentlyContinue
+        if ($devConn) { Stop-Process -Id $devConn.OwningProcess -Force -ErrorAction SilentlyContinue }
+        Start-Sleep -Seconds 3
+        Write-Host "      Dev instance stopped"
+    }
+
+    # 4. Not running (or just closed) — launch with CDP
+    Write-Host "Launching production Podman Desktop with --remote-debugging-port=$PROD_PORT..."
+    Start-Process "$env:LOCALAPPDATA\Programs\Podman Desktop\Podman Desktop.exe" -ArgumentList "--remote-debugging-port=$PROD_PORT"
+
+    Write-Host "      Waiting for CDP on port $PROD_PORT..."
+    $ready = $false
+    for ($i = 1; $i -le 30; $i++) {
+        if (Test-CdpReady -CdpPort $PROD_PORT) {
+            Write-Host "      CDP ready after ${i}s"
+            $ready = $true
+            break
+        }
+        Start-Sleep -Seconds 1
+    }
+    if (-not $ready) {
+        Write-Host "ERROR: App did not expose CDP on port $PROD_PORT within 30s"
         exit 1
     }
 
-    if (-not (Test-CdpReady -CdpPort $Port)) {
-        Write-Host "ERROR: No CDP response on port $Port"
-        exit 1
+    # Window title may not be set immediately — retry for up to 10s
+    $appTitle = $null
+    for ($i = 1; $i -le 10; $i++) {
+        $appTitle = Get-HealthyAppTitle -CdpPort $PROD_PORT
+        if ($appTitle) { break }
+        Start-Sleep -Seconds 1
     }
-
-    $appTitle = Get-HealthyAppTitle -CdpPort $Port
     if (-not $appTitle) {
-        Write-Host "ERROR: CDP on port $Port has no healthy app window"
+        Write-Host "ERROR: CDP on port $PROD_PORT has no healthy app window"
         exit 1
     }
 
-    Write-Host "Connected to production Podman Desktop — $appTitle (port $Port)"
-    Write-Host "Ready — call mcp__podman-desktop-mcp__connect({ port: $Port })"
+    "prod" | Out-File -FilePath "$env:TEMP\mcp-testing-session" -Encoding utf8 -NoNewline
+    Write-Host "Connected to production Podman Desktop — $appTitle (port $PROD_PORT)"
+    Write-Host "Ready — call mcp__podman-desktop-mcp__connect({ port: $PROD_PORT })"
     exit 0
 }
 
@@ -129,6 +182,7 @@ if ($Mode -eq "dev-fast") {
 
     Close-DevToolsTargets
 
+    "dev" | Out-File -FilePath "$env:TEMP\mcp-testing-session" -Encoding utf8 -NoNewline
     Write-Host "pnpm watch already running — $appTitle"
     Write-Host "Ready — call mcp__podman-desktop-mcp__connect({ port: $DEV_PORT })"
     exit 0
@@ -136,22 +190,32 @@ if ($Mode -eq "dev-fast") {
 
 # ── Mode: dev (full startup) ─────────────────────────────────────────────────
 
-# Fail fast if a production Podman Desktop holds the single-instance lock
+# Close production Podman Desktop if it holds the single-instance lock
 if (Test-ProductionPDRunning) {
-    Write-Host "ERROR: A production Podman Desktop is running — it holds the"
-    Write-Host "       single-instance lock, preventing the dev instance from starting."
-    Write-Host "       Close it first, then re-run this script."
-    exit 1
+    Write-Host "      Production Podman Desktop running — closing it to release the single-instance lock..."
+    Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 3
+    Write-Host "      Production app stopped"
 }
 
 # Kill any existing pnpm watch
-Write-Host "[1/4] Stopping any running pnpm watch..."
+Write-Host "[1/4] Stopping any running dev instance..."
 $killed = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
           Where-Object { $_.CommandLine -match 'pnpm.*watch' }
 if ($killed) {
     $killed | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
     Write-Host "      Stopped pnpm watch"
     Start-Sleep -Seconds 3
+}
+
+# Also kill the Electron app if it is still listening on the dev CDP port
+$conn = Get-NetTCPConnection -LocalPort $DEV_PORT -State Listen -ErrorAction SilentlyContinue
+if ($conn) {
+    $procName = (Get-Process -Id $conn.OwningProcess -ErrorAction SilentlyContinue).ProcessName ?? "unknown"
+    Write-Host "      Killing process on port $DEV_PORT ($procName)"
+    Stop-Process -Id $conn.OwningProcess -Force -ErrorAction SilentlyContinue
+    Write-Host "      Stopped process on port $DEV_PORT"
+    Start-Sleep -Seconds 2
 }
 
 if (Test-CdpReady) {
@@ -174,6 +238,11 @@ foreach ($d in $distDirs) {
     Remove-Item -Recurse -Force $d.FullName
 }
 Write-Host "      Removed $($distDirs.Count) dist/ folder(s)"
+
+if (-not (Get-Command pnpm -ErrorAction SilentlyContinue)) {
+    Write-Host "ERROR: pnpm not found in PATH — install with: npm install -g pnpm"
+    exit 1
+}
 
 # Install deps (timeout after 5 minutes)
 Write-Host "[3/4] Installing dependencies..."
@@ -231,4 +300,5 @@ if (-not $ready) {
 
 Close-DevToolsTargets
 
+"dev" | Out-File -FilePath "$env:TEMP\mcp-testing-session" -Encoding utf8 -NoNewline
 Write-Host "Ready — call mcp__podman-desktop-mcp__connect({ port: $DEV_PORT })"

--- a/.agents/skills/mcp-testing/start.ps1
+++ b/.agents/skills/mcp-testing/start.ps1
@@ -1,0 +1,216 @@
+#!/usr/bin/env pwsh
+# start.ps1 — Start or connect to Podman Desktop for MCP testing (Windows).
+# Requires -Mode flag. Detection is handled by probe.ps1; this script executes.
+#
+# Usage:
+#   pwsh start.ps1 -Mode dev          # full startup (clean, install, pnpm watch)
+#   pwsh start.ps1 -Mode dev-fast     # fast-path (pnpm watch already running)
+#   pwsh start.ps1 -Mode prod -Port 9222  # connect to production CDP
+#
+# After exit 0, call mcp__podman-desktop-mcp__connect({ port: <PORT> }).
+
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("dev", "dev-fast", "prod")]
+    [string]$Mode,
+
+    [int]$Port = 0
+)
+
+$DEV_PORT = 9223
+$REPO = (Resolve-Path "$PSScriptRoot\..\..\..\").Path.TrimEnd('\')
+
+# VS Code (and other Electron-based editors) set ELECTRON_RUN_AS_NODE=1 in child
+# processes. This makes the Electron binary run as plain Node.js, breaking the
+# Electron API and Chromium flags like --remote-debugging-port. Remove it so that
+# pnpm watch can spawn Electron properly.
+if ($env:ELECTRON_RUN_AS_NODE) {
+    Remove-Item Env:\ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue
+}
+
+function Test-CdpReady {
+    param([int]$CdpPort = $DEV_PORT)
+    try {
+        $null = Invoke-WebRequest -Uri "http://localhost:$CdpPort/json/version" -UseBasicParsing -ErrorAction Stop
+        return $true
+    } catch { return $false }
+}
+
+function Get-HealthyAppTitle {
+    param([int]$CdpPort = $DEV_PORT)
+    try {
+        $targets = (Invoke-WebRequest -Uri "http://localhost:$CdpPort/json" -UseBasicParsing -ErrorAction Stop).Content | ConvertFrom-Json
+        foreach ($t in $targets) {
+            $url   = if ($t.url)   { $t.url.ToLower()   } else { "" }
+            $title = if ($t.title) { $t.title.ToLower() } else { "" }
+            $ttype = if ($t.type)  { $t.type.ToLower()  } else { "" }
+            if ($url -notlike "*devtools*" -and $title -ne "devtools" -and $ttype -eq "page") {
+                return $t.title
+            }
+        }
+    } catch {}
+    return $null
+}
+
+function Test-WatchRunning {
+    $procs = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+             Where-Object { $_.CommandLine -match 'pnpm.*watch' }
+    return ($null -ne $procs -and @($procs).Count -gt 0)
+}
+
+function Close-DevToolsTargets {
+    param([int]$CdpPort = $DEV_PORT)
+    try {
+        $targets = (Invoke-WebRequest -Uri "http://localhost:$CdpPort/json" -UseBasicParsing -ErrorAction Stop).Content | ConvertFrom-Json
+        $closed = 0
+        foreach ($t in $targets) {
+            $url   = if ($t.url)   { $t.url.ToLower()   } else { "" }
+            $title = if ($t.title) { $t.title.ToLower() } else { "" }
+            if ($url -like "*devtools*" -or $title -eq "devtools") {
+                try {
+                    Invoke-WebRequest -Uri "http://localhost:$CdpPort/json/close/$($t.id)" -UseBasicParsing | Out-Null
+                    $closed++
+                } catch {}
+            }
+        }
+        if ($closed -gt 0) {
+            Write-Host "      Closed $closed DevTools target(s) — waiting 10s for rendering surface..."
+            Start-Sleep -Seconds 10
+        }
+    } catch {}
+}
+
+function Test-ProductionPDRunning {
+    $procs = Get-Process -Name "Podman Desktop" -ErrorAction SilentlyContinue |
+             Where-Object { $_.Path -and $_.Path -notmatch 'node_modules' }
+    return ($null -ne $procs -and @($procs).Count -gt 0)
+}
+
+# ── Mode: prod ────────────────────────────────────────────────────────────────
+if ($Mode -eq "prod") {
+    if ($Port -eq 0) {
+        Write-Host "ERROR: -Mode prod requires -Port argument"
+        exit 1
+    }
+
+    if (-not (Test-CdpReady -CdpPort $Port)) {
+        Write-Host "ERROR: No CDP response on port $Port"
+        exit 1
+    }
+
+    $appTitle = Get-HealthyAppTitle -CdpPort $Port
+    if (-not $appTitle) {
+        Write-Host "ERROR: CDP on port $Port has no healthy app window"
+        exit 1
+    }
+
+    Write-Host "Connected to production Podman Desktop — $appTitle (port $Port)"
+    Write-Host "Ready — call mcp__podman-desktop-mcp__connect({ port: $Port })"
+    exit 0
+}
+
+# ── Mode: dev-fast ────────────────────────────────────────────────────────────
+if ($Mode -eq "dev-fast") {
+    if (-not (Test-WatchRunning)) {
+        Write-Host "ERROR: pnpm watch is not running"
+        exit 1
+    }
+
+    if (-not (Test-CdpReady)) {
+        Write-Host "ERROR: pnpm watch is running but CDP is not available on port $DEV_PORT"
+        exit 1
+    }
+
+    $appTitle = Get-HealthyAppTitle
+    if (-not $appTitle) {
+        Write-Host "ERROR: CDP on port $DEV_PORT has no healthy app window — restart pnpm watch"
+        exit 1
+    }
+
+    Close-DevToolsTargets
+
+    Write-Host "pnpm watch already running — $appTitle"
+    Write-Host "Ready — call mcp__podman-desktop-mcp__connect({ port: $DEV_PORT })"
+    exit 0
+}
+
+# ── Mode: dev (full startup) ─────────────────────────────────────────────────
+
+# Kill any existing pnpm watch
+Write-Host "[1/4] Stopping any running pnpm watch..."
+$killed = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+          Where-Object { $_.CommandLine -match 'pnpm.*watch' }
+if ($killed) {
+    $killed | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+    Write-Host "      Stopped pnpm watch"
+    Start-Sleep -Seconds 3
+}
+
+if (Test-CdpReady) {
+    Write-Host "ERROR: Port $DEV_PORT is still in use (not by pnpm watch) — stop it manually:"
+    Write-Host "  Get-NetTCPConnection -LocalPort $DEV_PORT -State Listen"
+    exit 1
+}
+Write-Host "      Port $DEV_PORT is free"
+
+# Clean stale artifacts
+Write-Host "[2/4] Cleaning stale artifacts..."
+if (Test-Path "$REPO\node_modules") {
+    Remove-Item -Recurse -Force "$REPO\node_modules"
+    Write-Host "      Removed node_modules/"
+}
+$distDirs = @()
+$distDirs += Get-ChildItem -Path "$REPO\packages","$REPO\extensions" -Directory -Recurse -Filter "dist" -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -notmatch '\\node_modules\\' }
+foreach ($d in $distDirs) {
+    Remove-Item -Recurse -Force $d.FullName
+}
+Write-Host "      Removed $($distDirs.Count) dist/ folder(s)"
+
+# Install deps (timeout after 5 minutes)
+Write-Host "[3/4] Installing dependencies..."
+$installJob = Start-Job -ScriptBlock { param($r) & pnpm --dir $r install } -ArgumentList $REPO
+$finished = $installJob | Wait-Job -Timeout 300
+if (-not $finished -or $installJob.State -ne 'Completed') {
+    $installJob | Stop-Job; $installJob | Remove-Job -Force
+    Write-Host "ERROR: pnpm install failed or timed out after 5 minutes"
+    exit 1
+}
+$installJob | Receive-Job
+$installJob | Remove-Job
+Write-Host "      Dependencies up to date"
+
+# Launch pnpm watch and wait for CDP
+$logOut = "$env:TEMP\pnpm-watch-out.log"
+$logErr = "$env:TEMP\pnpm-watch-err.log"
+Write-Host "[4/4] Launching pnpm watch..."
+$null = Start-Process -FilePath "pnpm" `
+    -ArgumentList "--dir", "`"$REPO`"", "watch" `
+    -RedirectStandardOutput $logOut `
+    -RedirectStandardError  $logErr `
+    -NoNewWindow -PassThru
+
+$ready = $false
+for ($i = 1; $i -le 120; $i++) {
+    if (Test-CdpReady) {
+        Write-Host "      CDP ready after ${i}s"
+        $ready = $true
+        break
+    }
+    Start-Sleep -Seconds 1
+}
+if (-not $ready) {
+    Write-Host "ERROR: App did not expose CDP within 120s"
+    if (Test-ProductionPDRunning) {
+        Write-Host "HINT: A production Podman Desktop is running — it holds the"
+        Write-Host "      single-instance lock, preventing the dev instance from starting."
+        Write-Host "      Either close it, or relaunch it with CDP:"
+        Write-Host "        podman-desktop --remote-debugging-port=9222"
+    }
+    Get-Content $logOut, $logErr -Tail 20 -ErrorAction SilentlyContinue
+    exit 1
+}
+
+Close-DevToolsTargets
+
+Write-Host "Ready — call mcp__podman-desktop-mcp__connect({ port: $DEV_PORT })"

--- a/.agents/skills/mcp-testing/start.ps1
+++ b/.agents/skills/mcp-testing/start.ps1
@@ -31,7 +31,7 @@ if ($env:ELECTRON_RUN_AS_NODE) {
 function Test-CdpReady {
     param([int]$CdpPort = $DEV_PORT)
     try {
-        $null = Invoke-WebRequest -Uri "http://localhost:$CdpPort/json/version" -UseBasicParsing -ErrorAction Stop
+        $null = Invoke-WebRequest -Uri "http://localhost:$CdpPort/json/version" -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
         return $true
     } catch { return $false }
 }
@@ -39,7 +39,7 @@ function Test-CdpReady {
 function Get-HealthyAppTitle {
     param([int]$CdpPort = $DEV_PORT)
     try {
-        $targets = (Invoke-WebRequest -Uri "http://localhost:$CdpPort/json" -UseBasicParsing -ErrorAction Stop).Content | ConvertFrom-Json
+        $targets = (Invoke-WebRequest -Uri "http://localhost:$CdpPort/json" -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop).Content | ConvertFrom-Json
         foreach ($t in $targets) {
             $url   = if ($t.url)   { $t.url.ToLower()   } else { "" }
             $title = if ($t.title) { $t.title.ToLower() } else { "" }
@@ -61,14 +61,14 @@ function Test-WatchRunning {
 function Close-DevToolsTargets {
     param([int]$CdpPort = $DEV_PORT)
     try {
-        $targets = (Invoke-WebRequest -Uri "http://localhost:$CdpPort/json" -UseBasicParsing -ErrorAction Stop).Content | ConvertFrom-Json
+        $targets = (Invoke-WebRequest -Uri "http://localhost:$CdpPort/json" -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop).Content | ConvertFrom-Json
         $closed = 0
         foreach ($t in $targets) {
             $url   = if ($t.url)   { $t.url.ToLower()   } else { "" }
             $title = if ($t.title) { $t.title.ToLower() } else { "" }
             if ($url -like "*devtools*" -or $title -eq "devtools") {
                 try {
-                    Invoke-WebRequest -Uri "http://localhost:$CdpPort/json/close/$($t.id)" -UseBasicParsing | Out-Null
+                    Invoke-WebRequest -Uri "http://localhost:$CdpPort/json/close/$($t.id)" -UseBasicParsing -TimeoutSec 5 | Out-Null
                     $closed++
                 } catch {}
             }
@@ -177,14 +177,24 @@ Write-Host "      Removed $($distDirs.Count) dist/ folder(s)"
 
 # Install deps (timeout after 5 minutes)
 Write-Host "[3/4] Installing dependencies..."
-$installJob = Start-Job -ScriptBlock { param($r) & pnpm --dir $r install } -ArgumentList $REPO
+$installJob = Start-Job -ScriptBlock {
+    param($r)
+    & pnpm --dir $r install
+    if ($LASTEXITCODE -ne 0) { throw "pnpm install exited with code $LASTEXITCODE" }
+} -ArgumentList $REPO
 $finished = $installJob | Wait-Job -Timeout 300
-if (-not $finished -or $installJob.State -ne 'Completed') {
+if (-not $finished -or $installJob.State -eq 'Running') {
     $installJob | Stop-Job; $installJob | Remove-Job -Force
-    Write-Host "ERROR: pnpm install failed or timed out after 5 minutes"
+    Write-Host "ERROR: pnpm install timed out after 5 minutes"
     exit 1
 }
-$installJob | Receive-Job
+try {
+    $installJob | Receive-Job -ErrorAction Stop
+} catch {
+    $installJob | Remove-Job -Force
+    Write-Host "ERROR: pnpm install failed: $_"
+    exit 1
+}
 $installJob | Remove-Job
 Write-Host "      Dependencies up to date"
 

--- a/.agents/skills/mcp-testing/start.ps1
+++ b/.agents/skills/mcp-testing/start.ps1
@@ -136,6 +136,14 @@ if ($Mode -eq "dev-fast") {
 
 # ── Mode: dev (full startup) ─────────────────────────────────────────────────
 
+# Fail fast if a production Podman Desktop holds the single-instance lock
+if (Test-ProductionPDRunning) {
+    Write-Host "ERROR: A production Podman Desktop is running — it holds the"
+    Write-Host "       single-instance lock, preventing the dev instance from starting."
+    Write-Host "       Close it first, then re-run this script."
+    exit 1
+}
+
 # Kill any existing pnpm watch
 Write-Host "[1/4] Stopping any running pnpm watch..."
 $killed = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |

--- a/.agents/skills/mcp-testing/start.sh
+++ b/.agents/skills/mcp-testing/start.sh
@@ -59,7 +59,7 @@ close_devtools_targets() {
     })();
   ' 2>/dev/null || echo 0)
   if [[ "$closed" -gt 0 ]]; then
-    echo "      Closed $closed DevTools target(s) — waiting 10s for rendering surface…"
+    echo "      Closed ${closed} DevTools target(s) — waiting 10s for rendering surface…"
     sleep 10
   fi
 }
@@ -133,7 +133,7 @@ if [[ "$MODE" == "prod" ]]; then
 
   wait_cdp() {
     local port=$1
-    echo "      Waiting for CDP on port $port…"
+    echo "      Waiting for CDP on port ${port}…"
     for i in $(seq 1 30); do
       if cdp_ready "$port"; then
         echo "      CDP ready after ${i}s"
@@ -166,7 +166,7 @@ if [[ "$MODE" == "prod" ]]; then
 
   # 2. Running but no CDP — relaunch with CDP flag
   if detect_production_pd; then
-    echo "Production Podman Desktop is running without CDP — relaunching with --remote-debugging-port=$PROD_PORT…"
+    echo "Production Podman Desktop is running without CDP — relaunching with --remote-debugging-port=${PROD_PORT}…"
     case "$(uname -s)" in
       Darwin) osascript -e 'quit app "Podman Desktop"' 2>/dev/null || true ;;
       Linux)
@@ -187,7 +187,7 @@ if [[ "$MODE" == "prod" ]]; then
   fi
 
   # 4. Not running (or just closed) — launch with CDP
-  echo "Launching production Podman Desktop with --remote-debugging-port=$PROD_PORT…"
+  echo "Launching production Podman Desktop with --remote-debugging-port=${PROD_PORT}…"
   launch_prod
   wait_cdp "$PROD_PORT" || exit 1
 

--- a/.agents/skills/mcp-testing/start.sh
+++ b/.agents/skills/mcp-testing/start.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# start.sh — Start or connect to Podman Desktop for MCP testing.
+# Requires --mode flag. Detection is handled by probe.sh; this script executes.
+#
+# Usage:
+#   bash start.sh --mode dev          # full startup (clean, install, pnpm watch)
+#   bash start.sh --mode dev-fast     # fast-path (pnpm watch already running)
+#   bash start.sh --mode prod PORT    # connect to production CDP on PORT
+#
+# After exit 0, call mcp__podman-desktop-mcp__connect({ port: <PORT> }).
+
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
+DEV_PORT=9223
+
+# VS Code (and other Electron-based editors) set ELECTRON_RUN_AS_NODE=1 in child
+# processes. This makes the Electron binary run as plain Node.js, breaking the
+# Electron API and Chromium flags like --remote-debugging-port. Unset it so that
+# pnpm watch can spawn Electron properly.
+unset ELECTRON_RUN_AS_NODE
+
+cdp_ready() { curl -s "http://localhost:${1:-$DEV_PORT}/json/version" &>/dev/null; }
+watch_running() { pgrep -f 'pnpm.*watch' &>/dev/null; }
+
+cdp_healthy_title() {
+  local port=${1:-$DEV_PORT}
+  curl -s "http://localhost:$port/json" | node -e '
+    const d = require("fs").readFileSync(0, "utf8");
+    try {
+      for (const t of JSON.parse(d)) {
+        const u = (t.url || "").toLowerCase();
+        const l = (t.title || "").toLowerCase();
+        if (!u.includes("devtools") && l !== "devtools" && t.type === "page") {
+          process.stdout.write(t.title || "unknown");
+          process.exit(0);
+        }
+      }
+    } catch {}
+    process.exit(1);
+  ' 2>/dev/null
+}
+
+close_devtools_targets() {
+  local port=${1:-$DEV_PORT}
+  local closed
+  closed=$(curl -s "http://localhost:$port/json" | CDP_PORT=$port node -e '
+    const d = require("fs").readFileSync(0, "utf8");
+    const port = process.env.CDP_PORT;
+    let closed = 0;
+    (async () => {
+      for (const t of JSON.parse(d)) {
+        const u = (t.url || "").toLowerCase();
+        const l = (t.title || "").toLowerCase();
+        if (u.includes("devtools") || l === "devtools") {
+          try { await fetch("http://localhost:" + port + "/json/close/" + t.id); closed++; } catch {}
+        }
+      }
+      console.log(closed);
+    })();
+  ' 2>/dev/null || echo 0)
+  if [[ "$closed" -gt 0 ]]; then
+    echo "      Closed $closed DevTools target(s) — waiting 10s for rendering surface…"
+    sleep 10
+  fi
+}
+
+detect_production_pd() {
+  case "$(uname -s)" in
+    Darwin)
+      pgrep -f "Podman Desktop.app/Contents" &>/dev/null
+      ;;
+    Linux)
+      local found=false
+      while IFS= read -r line; do
+        if ! echo "$line" | grep -qE 'node_modules|pnpm|scripts/watch'; then
+          found=true; break
+        fi
+      done < <(pgrep -af "podman-desktop" 2>/dev/null)
+      $found
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+MODE=""
+PROD_PORT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="$2"; shift 2
+      if [[ "$MODE" == "prod" && $# -gt 0 && "$1" != --* ]]; then
+        PROD_PORT="$1"; shift
+      fi
+      ;;
+    *)
+      echo "Unknown argument: $1"; exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$MODE" ]]; then
+  echo "Usage:"
+  echo "  bash start.sh --mode dev          # full startup"
+  echo "  bash start.sh --mode dev-fast     # fast-path (already running)"
+  echo "  bash start.sh --mode prod PORT    # connect to production CDP"
+  exit 1
+fi
+
+# ── Mode: prod ───────────────────────────────────────────────────────────────
+if [[ "$MODE" == "prod" ]]; then
+  if [[ -z "$PROD_PORT" ]]; then
+    echo "ERROR: --mode prod requires a PORT argument"
+    exit 1
+  fi
+
+  if ! cdp_ready "$PROD_PORT"; then
+    echo "ERROR: No CDP response on port $PROD_PORT"
+    exit 1
+  fi
+
+  app_title=$(cdp_healthy_title "$PROD_PORT") || {
+    echo "ERROR: CDP on port $PROD_PORT has no healthy app window"
+    exit 1
+  }
+
+  echo "Connected to production Podman Desktop — $app_title (port $PROD_PORT)"
+  echo "Ready — call mcp__podman-desktop-mcp__connect({ port: $PROD_PORT })"
+  exit 0
+fi
+
+# ── Mode: dev-fast ───────────────────────────────────────────────────────────
+if [[ "$MODE" == "dev-fast" ]]; then
+  if ! watch_running; then
+    echo "ERROR: pnpm watch is not running"
+    exit 1
+  fi
+
+  if ! cdp_ready; then
+    echo "ERROR: pnpm watch is running but CDP is not available on port $DEV_PORT"
+    exit 1
+  fi
+
+  app_title=$(cdp_healthy_title) || {
+    echo "ERROR: CDP on port $DEV_PORT has no healthy app window — restart pnpm watch"
+    exit 1
+  }
+
+  close_devtools_targets
+
+  echo "pnpm watch already running — $app_title"
+  echo "Ready — call mcp__podman-desktop-mcp__connect({ port: $DEV_PORT })"
+  exit 0
+fi
+
+# ── Mode: dev (full startup) ────────────────────────────────────────────────
+if [[ "$MODE" != "dev" ]]; then
+  echo "ERROR: Unknown mode '$MODE'. Use: dev, dev-fast, or prod"
+  exit 1
+fi
+
+# Kill any existing dev instance on the dev CDP port
+echo "[1/4] Stopping any running dev instance…"
+if lsof -ti :$DEV_PORT &>/dev/null; then
+  kill $(lsof -ti :$DEV_PORT) 2>/dev/null || true
+  echo "      Stopped process on port $DEV_PORT"
+fi
+
+# Wait up to 5s for port to drain
+for i in $(seq 1 5); do
+  cdp_ready || break
+  sleep 1
+done
+
+if cdp_ready; then
+  echo "ERROR: Port $DEV_PORT is still in use (not by pnpm watch) — stop it manually:"
+  echo "  lsof -ti :$DEV_PORT | xargs kill"
+  exit 1
+fi
+echo "      Port $DEV_PORT is free"
+
+# Clean stale artifacts
+echo "[2/4] Cleaning stale artifacts…"
+rm -rf "$REPO/node_modules"
+echo "      Removed node_modules/"
+dist_count=0
+while IFS= read -r d; do
+  rm -rf "$d"
+  dist_count=$((dist_count + 1))
+done < <(find "$REPO/packages" "$REPO/extensions" -maxdepth 4 -name dist -type d 2>/dev/null)
+echo "      Removed $dist_count dist/ folder(s)"
+
+# Install deps (timeout after 5 minutes)
+echo "[3/4] Installing dependencies…"
+pnpm --dir "$REPO" install &
+INSTALL_PID=$!
+( sleep 300 && kill $INSTALL_PID 2>/dev/null ) &
+TIMER_PID=$!
+if wait $INSTALL_PID 2>/dev/null; then
+  kill $TIMER_PID 2>/dev/null; wait $TIMER_PID 2>/dev/null
+  echo "      Dependencies up to date"
+else
+  kill $TIMER_PID 2>/dev/null; wait $TIMER_PID 2>/dev/null
+  echo "ERROR: pnpm install failed or timed out after 5 minutes"
+  exit 1
+fi
+
+# Launch pnpm watch and wait for CDP
+echo "[4/4] Launching pnpm watch (output → /tmp/pnpm-watch.log)…"
+pnpm --dir "$REPO" watch &>/tmp/pnpm-watch.log &
+echo "      pnpm watch started (pid $!)"
+
+echo "      Waiting for CDP on port ${DEV_PORT}..."
+for i in $(seq 1 120); do
+  if cdp_ready; then
+    echo "      CDP ready after ${i}s"
+    break
+  fi
+  sleep 1
+done
+if ! cdp_ready; then
+  echo "ERROR: App did not expose CDP within 120s"
+  if detect_production_pd; then
+    echo "HINT: A production Podman Desktop is running — it holds the"
+    echo "      single-instance lock, preventing the dev instance from starting."
+    echo "      Either close it, or relaunch it with CDP:"
+    echo "        podman-desktop --remote-debugging-port=9222"
+  fi
+  tail -20 /tmp/pnpm-watch.log
+  exit 1
+fi
+
+close_devtools_targets
+
+echo "Ready — call mcp__podman-desktop-mcp__connect({ port: $DEV_PORT })"

--- a/.agents/skills/mcp-testing/start.sh
+++ b/.agents/skills/mcp-testing/start.sh
@@ -19,12 +19,12 @@ DEV_PORT=9223
 # pnpm watch can spawn Electron properly.
 unset ELECTRON_RUN_AS_NODE
 
-cdp_ready() { curl -s "http://localhost:${1:-$DEV_PORT}/json/version" &>/dev/null; }
+cdp_ready() { curl -s --connect-timeout 2 --max-time 5 "http://localhost:${1:-$DEV_PORT}/json/version" &>/dev/null; }
 watch_running() { pgrep -f 'pnpm.*watch' &>/dev/null; }
 
 cdp_healthy_title() {
   local port=${1:-$DEV_PORT}
-  curl -s "http://localhost:$port/json" | node -e '
+  curl -s --connect-timeout 2 --max-time 5 "http://localhost:$port/json" | node -e '
     const d = require("fs").readFileSync(0, "utf8");
     try {
       for (const t of JSON.parse(d)) {
@@ -43,7 +43,7 @@ cdp_healthy_title() {
 close_devtools_targets() {
   local port=${1:-$DEV_PORT}
   local closed
-  closed=$(curl -s "http://localhost:$port/json" | CDP_PORT=$port node -e '
+  closed=$(curl -s --connect-timeout 2 --max-time 5 "http://localhost:$port/json" | CDP_PORT=$port node -e '
     const d = require("fs").readFileSync(0, "utf8");
     const port = process.env.CDP_PORT;
     let closed = 0;

--- a/.agents/skills/mcp-testing/start.sh
+++ b/.agents/skills/mcp-testing/start.sh
@@ -5,7 +5,7 @@
 # Usage:
 #   bash start.sh --mode dev          # full startup (clean, install, pnpm watch)
 #   bash start.sh --mode dev-fast     # fast-path (pnpm watch already running)
-#   bash start.sh --mode prod PORT    # connect to production CDP on PORT
+#   bash start.sh --mode prod         # launch/connect production app (auto-detects state)
 #
 # After exit 0, call mcp__podman-desktop-mcp__connect({ port: <PORT> }).
 
@@ -76,6 +76,10 @@ detect_production_pd() {
           found=true; break
         fi
       done < <(pgrep -af "podman-desktop" 2>/dev/null)
+      # Also detect Flatpak-installed PD (app ID uses underscores: io.podman_desktop.PodmanDesktop)
+      if ! $found && pgrep -f "io.podman_desktop.PodmanDesktop" &>/dev/null; then
+        found=true
+      fi
       $found
       ;;
     *)
@@ -86,19 +90,11 @@ detect_production_pd() {
 
 # ── Argument parsing ─────────────────────────────────────────────────────────
 MODE=""
-PROD_PORT=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --mode)
-      MODE="$2"; shift 2
-      if [[ "$MODE" == "prod" && $# -gt 0 && "$1" != --* ]]; then
-        PROD_PORT="$1"; shift
-      fi
-      ;;
-    *)
-      echo "Unknown argument: $1"; exit 1
-      ;;
+    --mode) MODE="$2"; shift 2 ;;
+    *)      echo "Unknown argument: $1"; exit 1 ;;
   esac
 done
 
@@ -106,27 +102,107 @@ if [[ -z "$MODE" ]]; then
   echo "Usage:"
   echo "  bash start.sh --mode dev          # full startup"
   echo "  bash start.sh --mode dev-fast     # fast-path (already running)"
-  echo "  bash start.sh --mode prod PORT    # connect to production CDP"
+  echo "  bash start.sh --mode prod         # launch/connect production app"
   exit 1
 fi
 
 # ── Mode: prod ───────────────────────────────────────────────────────────────
 if [[ "$MODE" == "prod" ]]; then
-  if [[ -z "$PROD_PORT" ]]; then
-    echo "ERROR: --mode prod requires a PORT argument"
-    exit 1
-  fi
 
-  if ! cdp_ready "$PROD_PORT"; then
-    echo "ERROR: No CDP response on port $PROD_PORT"
-    exit 1
-  fi
-
-  app_title=$(cdp_healthy_title "$PROD_PORT") || {
-    echo "ERROR: CDP on port $PROD_PORT has no healthy app window"
-    exit 1
+  launch_prod() {
+    case "$(uname -s)" in
+      Darwin)
+        open -a "Podman Desktop" --args --remote-debugging-port=9222
+        ;;
+      Linux)
+        if command -v podman-desktop &>/dev/null; then
+          podman-desktop --remote-debugging-port=9222 &
+        elif flatpak list --app 2>/dev/null | grep -q podman_desktop; then
+          flatpak run io.podman_desktop.PodmanDesktop --remote-debugging-port=9222 &
+        else
+          echo "ERROR: podman-desktop not found — install via RPM, Flatpak, or tar.gz"
+          exit 1
+        fi
+        ;;
+      *)
+        echo "ERROR: Unsupported OS for auto-launch — launch Podman Desktop manually with --remote-debugging-port=9222"
+        exit 1
+        ;;
+    esac
   }
 
+  wait_cdp() {
+    local port=$1
+    echo "      Waiting for CDP on port $port…"
+    for i in $(seq 1 30); do
+      if cdp_ready "$port"; then
+        echo "      CDP ready after ${i}s"
+        return 0
+      fi
+      sleep 1
+    done
+    echo "ERROR: App did not expose CDP on port $port within 30s"
+    return 1
+  }
+
+  PROD_PORT=9222
+
+  # 1. Already running with CDP on the production port? (9223 is exclusively dev — never check it here)
+  for p in 9222; do
+    if cdp_ready "$p"; then
+      app_title=""
+      for _i in $(seq 1 10); do
+        app_title=$(cdp_healthy_title "$p") && break
+        sleep 1
+      done
+      if [[ -n "$app_title" ]]; then
+        echo "prod" > /tmp/mcp-testing-session
+        echo "Already running — $app_title (port $p)"
+        echo "Ready — call mcp__podman-desktop-mcp__connect({ port: $p })"
+        exit 0
+      fi
+    fi
+  done
+
+  # 2. Running but no CDP — relaunch with CDP flag
+  if detect_production_pd; then
+    echo "Production Podman Desktop is running without CDP — relaunching with --remote-debugging-port=$PROD_PORT…"
+    case "$(uname -s)" in
+      Darwin) osascript -e 'quit app "Podman Desktop"' 2>/dev/null || true ;;
+      Linux)
+        flatpak kill io.podman_desktop.PodmanDesktop 2>/dev/null || true
+        pkill -x podman-desktop 2>/dev/null || true
+        ;;
+    esac
+    sleep 3
+  fi
+
+  # 3. Kill dev instance if it holds the single-instance lock
+  if watch_running; then
+    echo "      Dev instance (pnpm watch) running — stopping it to release the single-instance lock…"
+    pgrep -f 'pnpm.*watch' | xargs kill 2>/dev/null || true
+    lsof -ti :$DEV_PORT | xargs kill 2>/dev/null || true
+    sleep 3
+    echo "      Dev instance stopped"
+  fi
+
+  # 4. Not running (or just closed) — launch with CDP
+  echo "Launching production Podman Desktop with --remote-debugging-port=$PROD_PORT…"
+  launch_prod
+  wait_cdp "$PROD_PORT" || exit 1
+
+  # Window title may not be set immediately — retry for up to 10s
+  app_title=""
+  for i in $(seq 1 10); do
+    app_title=$(cdp_healthy_title "$PROD_PORT") && break
+    sleep 1
+  done
+  if [[ -z "$app_title" ]]; then
+    echo "ERROR: CDP on port $PROD_PORT has no healthy app window"
+    exit 1
+  fi
+
+  echo "prod" > /tmp/mcp-testing-session
   echo "Connected to production Podman Desktop — $app_title (port $PROD_PORT)"
   echo "Ready — call mcp__podman-desktop-mcp__connect({ port: $PROD_PORT })"
   exit 0
@@ -151,6 +227,7 @@ if [[ "$MODE" == "dev-fast" ]]; then
 
   close_devtools_targets
 
+  echo "dev" > /tmp/mcp-testing-session
   echo "pnpm watch already running — $app_title"
   echo "Ready — call mcp__podman-desktop-mcp__connect({ port: $DEV_PORT })"
   exit 0
@@ -162,20 +239,36 @@ if [[ "$MODE" != "dev" ]]; then
   exit 1
 fi
 
-# Fail fast if a production Podman Desktop holds the single-instance lock
+# Close production Podman Desktop if it holds the single-instance lock
 if detect_production_pd; then
-  echo "ERROR: A production Podman Desktop is running — it holds the"
-  echo "       single-instance lock, preventing the dev instance from starting."
-  echo "       Close it first, then re-run this script."
-  exit 1
+  echo "      Production Podman Desktop running — closing it to release the single-instance lock…"
+  case "$(uname -s)" in
+    Darwin) osascript -e 'quit app "Podman Desktop"' 2>/dev/null || true ;;
+    Linux)
+      flatpak kill io.podman_desktop.PodmanDesktop 2>/dev/null || true
+      pkill -x podman-desktop 2>/dev/null || true
+      ;;
+  esac
+  sleep 3
+  echo "      Production app stopped"
 fi
 
 # Kill any existing dev instance on the dev CDP port
 echo "[1/4] Stopping any running dev instance…"
 if lsof -ti :$DEV_PORT &>/dev/null; then
+  proc_name=$(lsof -ti :$DEV_PORT | head -1 | xargs -I{} ps -p {} -o comm= 2>/dev/null || echo "unknown")
+  echo "      Killing process on port $DEV_PORT ($proc_name)"
   kill $(lsof -ti :$DEV_PORT) 2>/dev/null || true
   echo "      Stopped process on port $DEV_PORT"
 fi
+
+# Also kill any lingering pnpm watch process tree (port kill only hits the Electron app)
+if pgrep -f 'pnpm.*watch' &>/dev/null; then
+  pgrep -f 'pnpm.*watch' | xargs kill 2>/dev/null || true
+  sleep 2
+  echo "      Killed stale pnpm watch processes"
+fi
+rm -f /tmp/pnpm-watch.pid
 
 # Wait up to 5s for port to drain
 for i in $(seq 1 5); do
@@ -201,6 +294,11 @@ while IFS= read -r d; do
 done < <(find "$REPO/packages" "$REPO/extensions" -maxdepth 4 -name dist -type d 2>/dev/null)
 echo "      Removed $dist_count dist/ folder(s)"
 
+if ! command -v pnpm &>/dev/null; then
+  echo "ERROR: pnpm not found — install with: npm install -g pnpm"
+  exit 1
+fi
+
 # Install deps (timeout after 5 minutes)
 echo "[3/4] Installing dependencies…"
 pnpm --dir "$REPO" install &
@@ -218,8 +316,14 @@ fi
 
 # Launch pnpm watch and wait for CDP
 echo "[4/4] Launching pnpm watch (output → /tmp/pnpm-watch.log)…"
-pnpm --dir "$REPO" watch &>/tmp/pnpm-watch.log &
-echo "      pnpm watch started (pid $!)"
+if [[ "$(uname -s)" == "Linux" && -n "${WAYLAND_DISPLAY:-}" ]]; then
+  ELECTRON_OZONE_PLATFORM_HINT=x11 pnpm --dir "$REPO" watch &>/tmp/pnpm-watch.log &
+else
+  pnpm --dir "$REPO" watch &>/tmp/pnpm-watch.log &
+fi
+WATCH_PID=$!
+echo "$WATCH_PID" > /tmp/pnpm-watch.pid
+echo "      pnpm watch started (pid $WATCH_PID)"
 
 echo "      Waiting for CDP on port ${DEV_PORT}..."
 for i in $(seq 1 120); do
@@ -243,4 +347,5 @@ fi
 
 close_devtools_targets
 
+echo "dev" > /tmp/mcp-testing-session
 echo "Ready — call mcp__podman-desktop-mcp__connect({ port: $DEV_PORT })"

--- a/.agents/skills/mcp-testing/start.sh
+++ b/.agents/skills/mcp-testing/start.sh
@@ -162,6 +162,14 @@ if [[ "$MODE" != "dev" ]]; then
   exit 1
 fi
 
+# Fail fast if a production Podman Desktop holds the single-instance lock
+if detect_production_pd; then
+  echo "ERROR: A production Podman Desktop is running — it holds the"
+  echo "       single-instance lock, preventing the dev instance from starting."
+  echo "       Close it first, then re-run this script."
+  exit 1
+fi
+
 # Kill any existing dev instance on the dev CDP port
 echo "[1/4] Stopping any running dev instance…"
 if lsof -ti :$DEV_PORT &>/dev/null; then
@@ -200,10 +208,10 @@ INSTALL_PID=$!
 ( sleep 300 && kill $INSTALL_PID 2>/dev/null ) &
 TIMER_PID=$!
 if wait $INSTALL_PID 2>/dev/null; then
-  kill $TIMER_PID 2>/dev/null; wait $TIMER_PID 2>/dev/null
+  kill $TIMER_PID 2>/dev/null; wait $TIMER_PID 2>/dev/null || true
   echo "      Dependencies up to date"
 else
-  kill $TIMER_PID 2>/dev/null; wait $TIMER_PID 2>/dev/null
+  kill $TIMER_PID 2>/dev/null; wait $TIMER_PID 2>/dev/null || true
   echo "ERROR: pnpm install failed or timed out after 5 minutes"
   exit 1
 fi

--- a/.agents/skills/mcp-testing/stop.ps1
+++ b/.agents/skills/mcp-testing/stop.ps1
@@ -27,15 +27,32 @@ switch ($Mode) {
         # Kill Electron app listening on the dev CDP port
         $conn = Get-NetTCPConnection -LocalPort $DevPort -State Listen -ErrorAction SilentlyContinue
         if ($conn) {
-            Stop-Process -Id $conn.OwningProcess -Force -ErrorAction SilentlyContinue
-            Write-Host "  Killed Electron on port $DevPort"
+            # Use taskkill /T to kill the entire process tree (Electron + helpers)
+            & taskkill /F /T /PID $conn.OwningProcess 2>$null
+            Write-Host "  Killed Electron tree on port $DevPort"
         }
 
-        # Kill pnpm watch processes (Get-CimInstance needed to access CommandLine)
-        Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+        # Find pnpm watch root processes, then kill their entire trees
+        $watchPids = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
             Where-Object { $_.CommandLine -match 'pnpm.*watch' } |
-            ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
-        Write-Host "  Killed pnpm watch processes"
+            Select-Object -ExpandProperty ProcessId
+        foreach ($pid in $watchPids) {
+            & taskkill /F /T /PID $pid 2>$null
+        }
+        if ($watchPids) {
+            Write-Host "  Killed pnpm watch process tree(s)"
+        }
+
+        # Catch any orphaned node.exe children that escaped the tree kill
+        # (e.g., vite, svelte-package, esbuild spawned by pnpm watch)
+        $remaining = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandLine -match 'vite|svelte-package|esbuild|podman-desktop' }
+        foreach ($proc in $remaining) {
+            Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+        if ($remaining) {
+            Write-Host "  Killed $($remaining.Count) orphaned child process(es)"
+        }
 
         Remove-Item "$env:TEMP\pnpm-watch-out.log" -ErrorAction SilentlyContinue
         Remove-Item "$env:TEMP\pnpm-watch-err.log" -ErrorAction SilentlyContinue

--- a/.agents/skills/mcp-testing/stop.ps1
+++ b/.agents/skills/mcp-testing/stop.ps1
@@ -1,0 +1,60 @@
+# stop.ps1 — Stop everything started by the mcp-testing skill.
+# Reads $env:TEMP\mcp-testing-session to determine what to kill.
+# Safe to run even if nothing is running.
+
+param(
+    [switch]$SessionOnly
+)
+
+if ($SessionOnly) {
+    Remove-Item "$env:TEMP\mcp-testing-session" -ErrorAction SilentlyContinue
+    Write-Host "Session file removed — app left running"
+    exit 0
+}
+
+$StateFile = "$env:TEMP\mcp-testing-session"
+$DevPort = 9223
+
+$Mode = ""
+if (Test-Path $StateFile) {
+    $Mode = (Get-Content $StateFile -Raw).Trim()
+}
+
+switch ($Mode) {
+    "dev" {
+        Write-Host "Stopping dev session..."
+
+        # Kill Electron app listening on the dev CDP port
+        $conn = Get-NetTCPConnection -LocalPort $DevPort -State Listen -ErrorAction SilentlyContinue
+        if ($conn) {
+            Stop-Process -Id $conn.OwningProcess -Force -ErrorAction SilentlyContinue
+            Write-Host "  Killed Electron on port $DevPort"
+        }
+
+        # Kill pnpm watch processes (Get-CimInstance needed to access CommandLine)
+        Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandLine -match 'pnpm.*watch' } |
+            ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+        Write-Host "  Killed pnpm watch processes"
+
+        Remove-Item "$env:TEMP\pnpm-watch-out.log" -ErrorAction SilentlyContinue
+        Remove-Item "$env:TEMP\pnpm-watch-err.log" -ErrorAction SilentlyContinue
+    }
+
+    "prod" {
+        Write-Host "Stopping production session..."
+        Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue
+        Write-Host "  Production app stopped"
+    }
+
+    "" {
+        Write-Host "No active session found ($StateFile not present)"
+    }
+
+    default {
+        Write-Host "Unknown mode '$Mode' in $StateFile — skipping process kill"
+    }
+}
+
+if (Test-Path $StateFile) { Remove-Item $StateFile }
+Write-Host "Cleanup complete"

--- a/.agents/skills/mcp-testing/stop.sh
+++ b/.agents/skills/mcp-testing/stop.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# stop.sh — Stop everything started by the mcp-testing skill.
+# Reads /tmp/mcp-testing-session to determine what to kill.
+# Safe to run even if nothing is running.
+
+set -euo pipefail
+
+STATE=/tmp/mcp-testing-session
+DEV_PORT=9223
+
+SESSION_ONLY=false
+for arg in "$@"; do
+  [ "$arg" = "--session-only" ] && SESSION_ONLY=true
+done
+
+if $SESSION_ONLY; then
+  rm -f "$STATE"
+  echo "Session file removed — app left running"
+  exit 0
+fi
+
+MODE=""
+[ -f "$STATE" ] && MODE=$(cat "$STATE" | tr -d '[:space:]')
+
+case "$MODE" in
+  dev)
+    echo "Stopping dev session…"
+
+    # Kill pnpm watch process tree via PID file
+    if [ -f /tmp/pnpm-watch.pid ]; then
+      PID=$(cat /tmp/pnpm-watch.pid)
+      kill "$PID" 2>/dev/null || true
+      rm -f /tmp/pnpm-watch.pid
+      echo "  Killed pnpm watch (pid $PID)"
+    fi
+
+    # Kill any remaining pnpm watch processes (catches children not in PID file)
+    pkill -f 'pnpm.*watch' 2>/dev/null || true
+
+    # Kill the Electron app listening on the dev CDP port
+    if command -v lsof &>/dev/null; then
+      ELECTRON_PIDS=$(lsof -ti :"$DEV_PORT" 2>/dev/null || true)
+      if [ -n "$ELECTRON_PIDS" ]; then
+        echo "$ELECTRON_PIDS" | xargs kill 2>/dev/null || true
+        echo "  Killed Electron on port $DEV_PORT"
+      fi
+    fi
+
+    rm -f /tmp/pnpm-watch.log
+    ;;
+
+  prod)
+    echo "Stopping production session…"
+
+    case "$(uname -s)" in
+      Darwin)
+        osascript -e 'quit app "Podman Desktop"' 2>/dev/null || true
+        ;;
+      Linux)
+        flatpak kill io.podman_desktop.PodmanDesktop 2>/dev/null || true
+        pkill -x podman-desktop 2>/dev/null || true
+        ;;
+    esac
+    echo "  Production app stopped"
+    ;;
+
+  "")
+    echo "No active session found (/tmp/mcp-testing-session not present)"
+    ;;
+
+  *)
+    echo "Unknown mode '$MODE' in $STATE — skipping process kill"
+    ;;
+esac
+
+rm -f "$STATE"
+echo "Cleanup complete"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["mcp__podman-desktop-mcp__*"]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "podman-desktop-mcp": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["--yes", "electron-test-mcp"]
+    }
+  }
+}

--- a/tests/playwright/AGENTS.md
+++ b/tests/playwright/AGENTS.md
@@ -415,19 +415,18 @@ The repository provides specialized AI skills in [.agents/skills/](../../.agents
 These skills work together in the complete E2E testing lifecycle:
 
 ```
-Explore UI → Implement tests → Execution → Investigation → Fix
-     ↓              ↓             ↓            ↓           ↓
-    [4]            [1]           CI          [3]         [1]
-                                  ↓            ↓
-                            (if fails)      [2]
+Explore UI → Write tests → CI execution → Investigate failure → Fix
+     ↓             ↓            ↓                ↓               ↓
+mcp-testing   playwright-   (GitHub       investigate-gh-run  playwright-
+              testing       Actions)            ↓              testing
+                               ↓         playwright-trace-
+                          (if fails)      analysis
 ```
 
-1. **playwright-testing** - Implement tests following POM patterns
-2. CI execution (GitHub Actions)
-3. **investigate-gh-run** - Analyze CI failure, download artifacts (if tests fail)
-4. **playwright-trace-analysis** - Diagnose root cause from traces
-5. **playwright-testing** - Fix test or identify app bug
-6. **mcp-testing** - Interactively explore and test UI in dev or production mode
+- **mcp-testing** — Explore UI interactively in dev or production mode
+- **playwright-testing** — Write, update, and fix E2E tests
+- **investigate-gh-run** — Analyze CI failure, download artifacts
+- **playwright-trace-analysis** — Diagnose root cause from traces
 
 ### Quick Skill Selection Guide
 

--- a/tests/playwright/AGENTS.md
+++ b/tests/playwright/AGENTS.md
@@ -383,16 +383,43 @@ The repository provides specialized AI skills in [.agents/skills/](../../.agents
 - "Why did E2E tests fail on this PR?"
 - "Analyze GitHub Actions run #12345"
 
+#### 4. [mcp-testing](../../.agents/skills/mcp-testing/SKILL.md)
+
+**Purpose:** Interactively explore and test the Podman Desktop UI using the `podman-desktop-mcp` MCP server — supports both production (installed app) and development (`pnpm watch`) modes
+
+**Use when:**
+
+- Quickly verifying a UI change during development without writing test code
+- Testing the production (installed) Podman Desktop app interactively
+- Exploring new or unfamiliar UI flows before writing page objects
+- Debugging a specific user workflow or UI issue interactively
+- Manual acceptance testing in development or production
+
+**Provides:**
+
+- Automated startup of production app or `pnpm watch` (cross-platform, no manual steps)
+- Live connection to the running Electron app via CDP
+- Screenshot, snapshot, click, fill, evaluate — all MCP-driven
+- Cross-platform support (macOS, Linux/Fedora/RHEL, Windows)
+- Troubleshooting guidance for DevTools targets, port conflicts, and CDP issues
+
+**Example prompts:**
+
+- "Explore the pods page"
+- "Show me what the Settings > Resources page looks like"
+- "Verify the image pull dialog works"
+- "Test the onboarding flow on the production app"
+
 ### Skills Workflow Integration
 
 These skills work together in the complete E2E testing lifecycle:
 
 ```
-Implementation → Execution → Investigation → Fix
-       ↓             ↓            ↓           ↓
-      [1]           CI          [3]         [1]
-                     ↓            ↓
-               (if fails)      [2]
+Explore UI → Implement tests → Execution → Investigation → Fix
+     ↓              ↓             ↓            ↓           ↓
+    [4]            [1]           CI          [3]         [1]
+                                  ↓            ↓
+                            (if fails)      [2]
 ```
 
 1. **playwright-testing** - Implement tests following POM patterns
@@ -400,18 +427,21 @@ Implementation → Execution → Investigation → Fix
 3. **investigate-gh-run** - Analyze CI failure, download artifacts (if tests fail)
 4. **playwright-trace-analysis** - Diagnose root cause from traces
 5. **playwright-testing** - Fix test or identify app bug
+6. **mcp-testing** - Interactively explore and test UI in dev or production mode
 
 ### Quick Skill Selection Guide
 
-| Scenario                               | Use This Skill              |
-| -------------------------------------- | --------------------------- |
-| Writing or modifying test code         | `playwright-testing`        |
-| Test failed in CI, need to investigate | `investigate-gh-run`        |
-| Have trace.zip, need diagnosis         | `playwright-trace-analysis` |
-| Understanding why test is flaky        | `playwright-trace-analysis` |
-| Comparing passing vs failing traces    | `playwright-trace-analysis` |
-| Creating page objects                  | `playwright-testing`        |
-| Understanding test framework patterns  | `playwright-testing`        |
+| Scenario                                 | Use This Skill              |
+| ---------------------------------------- | --------------------------- |
+| Writing or modifying test code           | `playwright-testing`        |
+| Exploring UI before writing tests        | `mcp-testing`               |
+| Quick manual verification of a UI change | `mcp-testing`               |
+| Test failed in CI, need to investigate   | `investigate-gh-run`        |
+| Have trace.zip, need diagnosis           | `playwright-trace-analysis` |
+| Understanding why test is flaky          | `playwright-trace-analysis` |
+| Comparing passing vs failing traces      | `playwright-trace-analysis` |
+| Creating page objects                    | `playwright-testing`        |
+| Understanding test framework patterns    | `playwright-testing`        |
 
 ## Resources
 
@@ -421,6 +451,7 @@ Implementation → Execution → Investigation → Fix
   - [`playwright-testing`](../../.agents/skills/playwright-testing/SKILL.md) - Core patterns (POM, locators, assertions, waits)
   - [`playwright-trace-analysis`](../../.agents/skills/playwright-trace-analysis/SKILL.md) - Trace analysis and failure diagnosis
   - [`investigate-gh-run`](../../.agents/skills/investigate-gh-run/SKILL.md) - CI/CD failure investigation
+  - [`mcp-testing`](../../.agents/skills/mcp-testing/SKILL.md) - Interactive UI testing via MCP (dev and production modes)
 - **[Reference docs](../../.agents/skills/playwright-testing/reference.md)** - Advanced features (fixtures, network mocking, etc.)
 - **[Examples](../../.agents/skills/playwright-testing/examples.md)** - Complete test examples
 


### PR DESCRIPTION
## Summary

Adds an interactive MCP testing skill that connects to Podman Desktop via Chrome DevTools Protocol (CDP) for UI testing through Claude Code. Supports both development and production modes across macOS, Linux, and Windows.

- **Cross-platform:** Full macOS, Linux, and Windows support with OS-specific commands throughout
- **Production mode:** Connect to installed Podman Desktop (port 9222) — not just dev mode
- **Dev mode:** `pnpm watch` with hot reload (port 9223)
- **Probe-based detection:** Scripts detect what's already running before asking the user
- **Single-instance lock handling:** Automatically closes conflicting instances (dev↔prod)
- **DevTools remediation:** Detects and fixes CDP connecting to DevTools instead of the app
- **Grounded selectors:** All selector examples derived from actual Playwright POMs, not fabricated

### Files

- `.mcp.json` — electron-test MCP server config (stdio transport)
- `.claude/settings.json` — auto-allow MCP tool permissions
- `.agents/skills/mcp-testing/SKILL.md` — main workflow (Phases 1–6: detect → choose mode → start → setup → test → cleanup)
- `.agents/skills/mcp-testing/examples.md` — command examples and selectors reference derived from Playwright Page Object Models
- `.agents/skills/mcp-testing/probe.sh` / `probe.ps1` — read-only environment detection (what's running, CDP ports)
- `.agents/skills/mcp-testing/start.sh` / `start.ps1` — startup scripts (dev and production modes)
- `.agents/skills/mcp-testing/stop.sh` / `stop.ps1` — cleanup scripts (session-only or full stop)

### How it works

1. Probe detects OS, running instances, and CDP ports
2. User chooses production or dev mode
3. Skill handles launch/relaunch/connect automatically
4. Handles onboarding dialog (disables telemetry) and feedback dialog
5. Executes the testing task autonomously using MCP tools
6. Clean disconnect with option to leave app running or close it

### Testing

Invoke with `/mcp-testing <task>` in Claude Code, e.g.:
- checkout the branch
- `/mcp-testing navigate to Containers and count how many are running`
- `/mcp-testing check if the Podman provider is started on the Dashboard`

## How to test

Paste the following prompt into Claude Code on your machine (macOS, Linux, or Windows) to run the full test suite:

```text
Test the mcp-testing skill scripts end-to-end on this machine. Detect the platform (uname -s: Darwin=macOS, Linux=Linux, else Windows) and use .sh scripts for macOS/Linux or .ps1 for Windows. All scripts are in .agents/skills/mcp-testing/.

Run the following test scenarios in order. For each one: set up the pre-condition, run the command, verify the expected result, record PASS/FAIL. Fix any bugs you find and note them. Set Bash timeout to 600000 for --mode dev cases.

Probe detection (probe.sh / probe.ps1):
1. Clean state: Nothing running, no session file. Run probe. Expected: all false/none.
2. Stale session: Write dev to /tmp/mcp-testing-session ($env:TEMP\mcp-testing-session on Windows) with nothing running. Run probe. Expected: STALE_SESSION=true.
3. Port 9222 conflict: Start python3 -c "import http.server; s=http.server.HTTPServer(('127.0.0.1',9222),http.server.SimpleHTTPRequestHandler); s.serve_forever()" in background. Run probe. Expected: PORT_9222_NAME and PORT_9222_PID populated. Kill the python process after.
4. Port 9223 conflict: Same as above but on port 9223. Expected: PORT_9223_NAME and PORT_9223_PID populated. Kill after.
5. Both ports conflict: Occupy both 9222 and 9223 with python. Run probe. Expected: both PORT fields populated. Kill both after.

Stale session handling (stop.sh / stop.ps1):
6. Stale dev session: Write dev to session file, nothing running. Run stop.sh. Expected: prints "Stopping dev session", removes session file, exit 0.
7. Stale prod session: Write prod to session file, nothing running. Run stop.sh. Expected: prints "Stopping production session", removes session file, exit 0.
8. Garbage session file: Write garbage_xyz to session file. Run stop.sh. Expected: prints "Unknown mode", removes file, no crash.
9. No session file: Remove session file. Run stop.sh. Expected: prints "No active session found", exit 0.

Dev mode errors (start.sh / start.ps1):
10. pnpm not found: Run start.sh --mode dev with PATH stripped to exclude pnpm (e.g., PATH=/usr/bin:/bin bash .agents/skills/mcp-testing/start.sh --mode dev). Expected: error "pnpm not found", exit 1.
11. Dev-fast no pnpm watch: Run start.sh --mode dev-fast with nothing running. Expected: error "pnpm watch is not running", exit 1.
12. Unknown mode: Run start.sh --mode bogus. Expected: error "Unknown mode", exit 1.
13. No arguments: Run start.sh with no args. Expected: usage message, exit 1.

Dev full startup (start.sh --mode dev):
14. Clean state full startup: Ensure nothing running, no session file. Run start.sh --mode dev (timeout 600000). Expected: 4-step process completes, prints "Ready". Verify /tmp/mcp-testing-session contains dev and /tmp/pnpm-watch.pid exists.

Dev fast path (start.sh --mode dev-fast):
15. Happy path: With pnpm watch running from case 14, run start.sh --mode dev-fast. Expected: instant "Ready" message with port 9223.

Probe with dev running:
16. Dev running with CDP: Run probe. Expected: DEV_RUNNING=true, DEV_CDP_PORT=9223, DEV_APP_TITLE=Podman Desktop.
17. Session file + app running: Session file exists and app is running. Run probe. Expected: STALE_SESSION=false.

Connect and verify (MCP tools):
18. Connect to dev: Call mcp__podman-desktop-mcp__connect({ port: 9223 }). Expected: connected, title "Podman Desktop".
19. Verify title: Call mcp__podman-desktop-mcp__evaluate({ script: "document.title" }). Expected: contains "Podman Desktop".
20. Screenshot: Call mcp__podman-desktop-mcp__screenshot(). Expected: shows the PD UI.
21. Onboarding check: Run the onboarding dialog detection script from SKILL.md Phase 4. Expected: either "Onboarding dialog present" or "No onboarding dialog found".
22. Feedback dialog check: Run the feedback dialog detection script from SKILL.md Phase 4. Expected: either "Closed feedback dialog" or "No feedback dialog".
23. Disconnect: Call mcp__podman-desktop-mcp__disconnect().

Cleanup leave running:
24. Leave running: Run stop.sh --session-only. Expected: session file removed, pnpm watch still running.
25. Dev-fast reconnect after leave: Run start.sh --mode dev-fast. Expected: instant reconnect.

Cleanup full stop dev:
26. Full stop dev: Run stop.sh. Expected: pnpm watch killed, Electron on 9223 killed, session/PID/log files removed, port 9223 free.

Orphan cleanup:
27. Orphan without PID file: Start pnpm watch in background, write dev to session file, delete /tmp/pnpm-watch.pid. Run stop.sh. Expected: pkill fallback kills the orphan.

Production mode (skip if Podman Desktop is not installed):
Check if PD is installed: macOS=/Applications/Podman Desktop.app, Linux=command -v podman-desktop or flatpak list | grep podman_desktop. If not installed, skip cases 28-37.

28. Prod fresh launch: Nothing running. Run start.sh --mode prod. Expected: launches PD with CDP on 9222, prints "Ready".
29. Prod already running with CDP: Run start.sh --mode prod again. Expected: detects existing CDP, instant reconnect.
30. Probe with prod running: Run probe. Expected: PROD_RUNNING=true, PROD_CDP_PORT=9222.
31. Connect to prod: Call mcp__podman-desktop-mcp__connect({ port: 9222 }), verify title, screenshot, disconnect.
32. Leave prod running: Run stop.sh --session-only. Verify app still running.
33. Prod to Prod reconnect: Run start.sh --mode prod. Expected: instant reconnect.
34. Full stop prod: Run stop.sh. Expected: PD closed, session file removed.
35. Prod without CDP relaunch: Launch PD without CDP flag (macOS: open -a "Podman Desktop", Linux: podman-desktop &). Wait 5s. Run start.sh --mode prod. Expected: detects no CDP, closes app, relaunches with --remote-debugging-port=9222.
36. Prod with dev holding lock: Start pnpm watch (dev mode), then run start.sh --mode prod. Expected: kills dev instance first, then launches prod.
37. Full stop prod after case 36: Run stop.sh.

Cross-mode transitions:
38. Prod to Dev: Start prod (start.sh --mode prod), leave running (stop.sh --session-only), then run start.sh --mode dev (timeout 600000). Expected: closes prod, starts dev.
39. Dev to Prod: With dev running from case 38, run start.sh --mode prod. Expected: kills dev, launches prod.
40. Final cleanup: Run stop.sh.

Port won't drain:
41. Stubborn process: Start a python process on 9223 that ignores SIGTERM: python3 -c "import signal,http.server; signal.signal(signal.SIGTERM,signal.SIG_IGN); s=http.server.HTTPServer(('127.0.0.1',9223),http.server.SimpleHTTPRequestHandler); s.serve_forever()". Run start.sh --mode dev. Expected: error "Port 9223 is still in use". Kill the python process with kill -9 after.

Linux-specific (skip on macOS/Windows):
42. Flatpak detection: If PD is installed via Flatpak, verify probe detects PROD_RUNNING=true.
43. Wayland handling: If WAYLAND_DISPLAY is set, verify start.sh --mode dev launches Electron with ELECTRON_OZONE_PLATFORM_HINT=x11.

After all tests, produce a summary table with case number, name, PASS/FAIL, and notes. Include total count and list any bugs found/fixed.
```
