### PR TITLE
fix(settings): scope feedback dialog preferences to its own section

### DIFF
--- a/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
@@ -130,7 +130,7 @@ describe('init', () => {
     expect(registerConfigurationsMock).toHaveBeenCalledTimes(1);
     expect(registerConfigurationsMock).toHaveBeenCalledWith([
       {
-        id: 'preferences',
+        id: 'preferences.feedback',
         title: 'Feedback dialog',
         type: 'object',
         properties: {

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -72,7 +72,7 @@ export class ExperimentalFeatureFeedbackHandler {
 
   async init(): Promise<void> {
     const feedbackConfiguration: IConfigurationNode = {
-      id: 'preferences',
+      id: 'preferences.feedback',
       title: 'Feedback dialog',
       type: 'object',
       properties: {


### PR DESCRIPTION
### What does this PR do?

Fixes the Feedback dialog preferences page showing all preference settings instead of only the feedback-related ones.

### Screenshot / video of UI

**Before:**

<img width="961" height="1157" alt="image" src="https://github.com/user-attachments/assets/9f616508-ad90-4bcf-abed-d7075895171b" />

**After:**

<img width="960" height="1154" alt="image" src="https://github.com/user-attachments/assets/522fc4b5-9d98-4d10-bc32-8d763003709f" />


### What issues does this PR fix or reference?

Closes #14121 

### How to test this PR?

1. Open Settings -> Preferences -> Feedback dialog
2. There should be only settings that are related to feedback dialog

- [x] Tests are covering the bug fix or the new feature
