### PR TITLE
feat: allow selecting base for a connection value

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
@@ -63,7 +63,7 @@ $: providerContainerConfiguration = tmpProviderContainerConfiguration.filter(
               {@const peerValue = peerProperties.getPeerProperty(connectionSetting.id, providerContainerConfiguration)}
               <Donut
                 title={connectionSetting.description}
-                value={filesize(connectionSetting.value)}
+                value={filesize(connectionSetting.value, connectionSetting.base ? {base: connectionSetting.base} : {})}
                 percent={peerValue} />
             {/if}
           {:else}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -559,7 +559,7 @@ $effect(() => {
                         <div class="mr-4">
                           <Donut
                             title={connectionSetting.description}
-                            value={filesize(connectionSetting.value)}
+                            value={filesize(connectionSetting.value, connectionSetting.base ? {base: connectionSetting.base} : {})}
                             percent={peerValue} />
                         </div>
                       {/if}

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -33,6 +33,7 @@ import { ContextKeyExpr } from '/@/lib/context/contextKey';
 export interface IProviderConnectionConfigurationPropertyRecorded extends IConfigurationPropertyRecordedSchema {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value?: any;
+  base?: number;
   connection: string;
   providerId: string;
 }


### PR DESCRIPTION
Choose between the default 10 (decimal) or 2 (binary)

Depending on if you want to show "MB" or "MiB", etc.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #16790

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature

_There are no tests covering this section of the code_