### PR TITLE
feat(spinner): Replace spinner in LoadingIcon.svelte

### DIFF
--- a/packages/renderer/src/lib/ui/LoadingIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/LoadingIcon.spec.ts
@@ -26,15 +26,11 @@ import LoadingIcon from './LoadingIcon.svelte';
 
 test('Expect default size', async () => {
   const icon = faPlayCircle;
-  const loadingWidthClass = 'w-10';
-  const loadingHeightClass = 'h-10';
   const loading = true;
   const iconSize = undefined;
   render(LoadingIcon, {
     icon,
     iconSize,
-    loadingHeightClass,
-    loadingWidthClass,
     loading,
   });
   const loadingIcon = screen.getByRole('img', { hidden: true, name: '' });
@@ -46,15 +42,11 @@ test('Expect default size', async () => {
 
 test('Expect specified size', async () => {
   const icon = faPlayCircle;
-  const loadingWidthClass = 'w-10';
-  const loadingHeightClass = 'h-10';
   const loading = true;
   const iconSize = '2x';
   render(LoadingIcon, {
     icon,
     iconSize,
-    loadingHeightClass,
-    loadingWidthClass,
     loading,
   });
   const loadingIcon = screen.getByRole('img', { hidden: true, name: '' });

--- a/packages/renderer/src/lib/ui/LoadingIcon.svelte
+++ b/packages/renderer/src/lib/ui/LoadingIcon.svelte
@@ -1,32 +1,20 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { Spinner } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import type { Component } from 'svelte';
 import type { IconSize } from 'svelte-fa';
 
 interface Props {
   icon: IconDefinition | Component | string;
-  loadingWidthClass?: string;
-  loadingHeightClass?: string;
   loading?: boolean;
   iconSize?: IconSize;
 }
 
-let {
-  icon,
-  loadingWidthClass = 'w-6',
-  loadingHeightClass = 'h-6',
-  loading = false,
-  iconSize = undefined,
-}: Props = $props();
+let { icon, loading = false, iconSize = undefined }: Props = $props();
 </script>
 
-<div>
-  <Icon size={iconSize} icon={icon} />
-  <div
-    aria-label="spinner"
-    class="{loading
-      ? ''
-      : 'hidden'} {loadingWidthClass} {loadingHeightClass} rounded-full animate-spin -translate-1/2 border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent absolute left-1/2 top-1/2">
-  </div>
-</div>
+<Icon size={iconSize} icon={icon} class={loading ? 'invisible' : ''}/>
+{#if loading}
+  <Spinner class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-1/2 h-1/2"/>
+{/if}

--- a/tests/playwright/src/model/pages/container-details-page.ts
+++ b/tests/playwright/src/model/pages/container-details-page.ts
@@ -67,7 +67,7 @@ export class ContainerDetailsPage extends DetailsPage {
 
   async getState(): Promise<string> {
     return test.step('Get container state', async () => {
-      const currentState = await this.header.getByRole('status').getAttribute('title');
+      const currentState = await this.header.locator('[role="status"][title]').getAttribute('title');
       for (const state of Object.values(ContainerState)) {
         if (currentState === state) return state;
       }

--- a/tests/playwright/src/model/pages/kubernetes-resource-details-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-details-page.ts
@@ -52,7 +52,7 @@ export class KubernetesResourceDetailsPage extends DetailsPage {
 
   async getState(): Promise<string> {
     return test.step('Get resource state', async () => {
-      const currentState = await this.header.getByRole('status').getAttribute('title');
+      const currentState = await this.header.locator('[role="status"][title]').getAttribute('title');
       return currentState ?? KubernetesResourceState.Unknown;
     });
   }

--- a/tests/playwright/src/model/pages/pods-details-page.ts
+++ b/tests/playwright/src/model/pages/pods-details-page.ts
@@ -54,7 +54,7 @@ export class PodDetailsPage extends DetailsPage {
 
   async getState(): Promise<string> {
     return test.step('Get Pod State', async () => {
-      const currentState = await this.header.getByRole('status').getAttribute('title');
+      const currentState = await this.header.locator('[role="status"][title]').getAttribute('title');
       for (const state of Object.values(PodState)) {
         if (currentState === state) return state;
       }


### PR DESCRIPTION
### What does this PR do?
Replaces old circle spinner around icons with the new Spinner from #16718.

Affected views for testing purposes:
Resources screen - start/stop providers
Extension install
List item button in tables (container start,...)
CLI tool preferences

### Screenshot / video of UI
Before:
<img width="221" height="49" alt="image" src="https://github.com/user-attachments/assets/f14ddb33-4754-4b9c-b6c1-1b524ccc4325" />

After:
<img width="202" height="69" alt="image" src="https://github.com/user-attachments/assets/ec40cb1f-ed5b-4ae0-9377-755a59b68c5e" />

Fixes https://github.com/podman-desktop/podman-desktop/issues/16241

- [x] Tests are covering the bug fix or the new feature
