### PR TITLE
feat: add hc-dark theme color overrides to ColorRegistry

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -368,6 +368,7 @@ export class ColorRegistry {
     this.registerColor(`${def}text`, {
       dark: white,
       light: charcoal[900],
+      hcDark: white,
     });
   }
 
@@ -385,14 +386,17 @@ export class ColorRegistry {
     this.registerColor(`${glNav}bg`, {
       dark: charcoal[600],
       light: gray[100],
+      hcDark: black,
     });
     this.registerColor(`${glNav}bg-border`, {
       dark: charcoal[500],
       light: gray[300],
+      hcDark: gray[300],
     });
     this.registerColor(`${glNav}icon`, {
       dark: gray[600],
       light: charcoal[200],
+      hcDark: white,
     });
     this.registerColor(`${glNav}icon-hover`, {
       dark: gray[600],
@@ -401,22 +405,27 @@ export class ColorRegistry {
     this.registerColor(`${glNav}icon-hover-bg`, {
       dark: transparent,
       light: transparent,
+      hcDark: '#7E60E6',
     });
     this.registerColor(`${glNav}icon-inset-bg`, {
       dark: charcoal[800],
       light: gray[300],
+      hcDark: black,
     });
     this.registerColor(`${glNav}icon-selected`, {
       dark: white,
       light: accent1[500],
+      hcDark: white,
     });
     this.registerColor(`${glNav}icon-selected-bg`, {
       dark: charcoal[500],
       light: gray[250],
+      hcDark: '#7E60E6',
     });
     this.registerColor(`${glNav}icon-selected-highlight`, {
       dark: accent1[400],
       light: accent1[500],
+      hcDark: purple[600],
     });
   }
 
@@ -424,21 +433,25 @@ export class ColorRegistry {
     this.registerColor('titlebar-bg', {
       dark: isWindows() ? '#202020' : charcoal[900],
       light: gray[50],
+      hcDark: black,
     });
 
     this.registerColor('titlebar-text', {
       dark: white,
       light: accent1[500],
+      hcDark: white,
     });
 
     this.registerColor('titlebar-icon', {
       dark: white,
       light: accent1[500],
+      hcDark: white,
     });
 
     this.registerColor('titlebar-hover-bg', {
       dark: charcoal[300],
       light: gray[300],
+      hcDark: charcoal[500],
     });
 
     this.registerColor('titlebar-windows-hover-exit-bg', {
@@ -458,46 +471,55 @@ export class ColorRegistry {
     this.registerColor(`${sNav}bg`, {
       dark: charcoal[700],
       light: gray[100],
+      hcDark: black,
     });
 
     this.registerColor(`${sNav}header-text`, {
       dark: white,
       light: charcoal[900],
+      hcDark: white,
     });
 
     this.registerColor(`${sNav}text`, {
       dark: gray[300],
       light: charcoal[700],
+      hcDark: white,
     });
 
     this.registerColor(`${sNav}text-hover`, {
       dark: gray[275],
       light: charcoal[750],
+      hcDark: white,
     });
 
     this.registerColor(`${sNav}text-hover-bg`, {
       dark: transparent,
       light: transparent,
+      hcDark: '#7E60E6',
     });
 
     this.registerColor(`${sNav}text-selected`, {
       dark: white,
       light: black,
+      hcDark: white,
     });
 
     this.registerColor(`${sNav}selected-bg`, {
       dark: charcoal[500],
       light: gray[250],
+      hcDark: '#7E60E6',
     });
 
     this.registerColor(`${sNav}selected-highlight`, {
       dark: accent1[400],
       light: accent1[500],
+      hcDark: purple[600],
     });
 
     this.registerColor(`${sNav}expander`, {
       dark: white,
       light: charcoal[700],
+      hcDark: white,
     });
   }
 
@@ -505,6 +527,7 @@ export class ColorRegistry {
     this.registerColor(`card-bg`, {
       dark: charcoal[800],
       light: gray[300],
+      hcDark: black,
     });
 
     this.registerColor(`card-header-text`, {
@@ -523,6 +546,7 @@ export class ColorRegistry {
     this.registerColor(`${invCt}bg`, {
       dark: charcoal[800],
       light: gray[25],
+      hcDark: black,
     });
 
     this.registerColor(`${invCt}header-text`, {
@@ -538,6 +562,7 @@ export class ColorRegistry {
     this.registerColor(`${invCt}card-bg`, {
       dark: charcoal[600],
       light: gray[100],
+      hcDark: charcoal[900],
     });
 
     this.registerColor(`${invCt}card-header-text`, {
@@ -571,6 +596,7 @@ export class ColorRegistry {
     this.registerColor(`${ct}breadcrumb`, {
       dark: accent1[400],
       light: accent1[500],
+      hcDark: gray[300],
     });
 
     this.registerColor(`${ct}breadcrumb-2`, {
@@ -581,11 +607,13 @@ export class ColorRegistry {
     this.registerColor(`${ct}header`, {
       dark: white,
       light: charcoal[900],
+      hcDark: white,
     });
 
     this.registerColor(`${ct}text`, {
       dark: gray[700],
       light: charcoal[250],
+      hcDark: white,
     });
 
     this.registerColor(`${ct}sub-header`, {
@@ -606,16 +634,19 @@ export class ColorRegistry {
     this.registerColor(`${ct}card-bg`, {
       dark: charcoal[800],
       light: gray[25],
+      hcDark: black,
     });
 
     this.registerColor(`${ct}card-hover-bg`, {
       dark: charcoal[800],
       light: gray[25],
+      hcDark: charcoal[800],
     });
 
     this.registerColor(`${ct}card-selected-bg`, {
       dark: charcoal[400],
       light: accent1[100],
+      hcDark: charcoal[700],
     });
 
     this.registerColor(`${ct}card-text`, {
@@ -636,16 +667,19 @@ export class ColorRegistry {
     this.registerColor(`${ct}card-inset-bg`, {
       dark: black,
       light: white,
+      hcDark: black,
     });
 
     this.registerColor(`${ct}card-hover-inset-bg`, {
       dark: black,
       light: white,
+      hcDark: charcoal[900],
     });
 
     this.registerColor(`${ct}bg`, {
       dark: charcoal[700],
       light: gray[100],
+      hcDark: black,
     });
 
     this.registerColor(`${ct}card-icon`, {
@@ -656,16 +690,19 @@ export class ColorRegistry {
     this.registerColor(`${ct}divider`, {
       dark: charcoal[400],
       light: gray[700],
+      hcDark: gray[300],
     });
 
     this.registerColor(`${ct}card-carousel-card-bg`, {
       dark: charcoal[600],
       light: gray[100],
+      hcDark: charcoal[900],
     });
 
     this.registerColor(`${ct}card-carousel-card-hover-bg`, {
       dark: charcoal[600],
       light: gray[100],
+      hcDark: charcoal[800],
     });
 
     this.registerColor(`${ct}card-carousel-card-header-text`, {
@@ -696,16 +733,19 @@ export class ColorRegistry {
     this.registerColor(`${ct}card-border`, {
       dark: charcoal[800],
       light: gray[200],
+      hcDark: gray[300],
     });
 
     this.registerColor(`${ct}card-border-selected`, {
       dark: accent1[400],
       light: accent1[500],
+      hcDark: '#7E60E6',
     });
 
     this.registerColor(`${ct}table-border`, {
       dark: charcoal[400],
       light: gray[300],
+      hcDark: gray[300],
     });
   }
 
@@ -720,6 +760,7 @@ export class ColorRegistry {
     this.registerColor(`${sNav}focused-bg`, {
       dark: charcoal[900],
       light: gray[100],
+      hcDark: black,
     });
     this.registerColor(`${sNav}disabled-bg`, {
       dark: transparent,
@@ -752,10 +793,12 @@ export class ColorRegistry {
     this.registerColor(`${sNav}stroke`, {
       dark: charcoal[400],
       light: gray[700],
+      hcDark: gray[300],
     });
     this.registerColor(`${sNav}hover-stroke`, {
       dark: white,
       light: accent1[500],
+      hcDark: '#7E60E6',
     });
     this.registerColor(`${sNav}stroke-error`, {
       dark: red[550],
@@ -764,6 +807,7 @@ export class ColorRegistry {
     this.registerColor(`${sNav}stroke-readonly`, {
       dark: charcoal[100],
       light: charcoal[100],
+      hcDark: charcoal[50],
     });
     this.registerColor(`${sNav}icon`, {
       dark: gray[700],
@@ -927,6 +971,7 @@ export class ColorRegistry {
     this.registerColor(`${details}empty-cmdline-bg`, {
       dark: charcoal[900],
       light: gray[200],
+      hcDark: black,
     });
     this.registerColor(`${details}empty-cmdline-text`, {
       dark: gray[400],
@@ -935,10 +980,12 @@ export class ColorRegistry {
     this.registerColor(`${details}bg`, {
       dark: charcoal[900],
       light: gray[50],
+      hcDark: black,
     });
     this.registerColor(`${details}card-bg`, {
       dark: charcoal[600],
       light: gray[300],
+      hcDark: charcoal[900],
     });
     this.registerColor(`${details}card-header`, {
       dark: gray[700],
@@ -955,6 +1002,7 @@ export class ColorRegistry {
     this.registerColor(`${tab}text`, {
       dark: gray[600],
       light: charcoal[200],
+      hcDark: white,
     });
     this.registerColor(`${tab}text-highlight`, {
       dark: white,
@@ -963,6 +1011,7 @@ export class ColorRegistry {
     this.registerColor(`${tab}highlight`, {
       dark: gray[275],
       light: accent1[500],
+      hcDark: '#7E60E6',
     });
     this.registerColor(`${tab}hover`, {
       dark: charcoal[75],
@@ -989,14 +1038,17 @@ export class ColorRegistry {
     this.registerColor(`${modal}bg`, {
       dark: charcoal[800],
       light: gray[50],
+      hcDark: black,
     });
     this.registerColor(`${modal}border`, {
       dark: charcoal[500],
       light: gray[500],
+      hcDark: gray[300],
     });
     this.registerColor(`${modal}header-bg`, {
       dark: black,
       light: gray[100],
+      hcDark: black,
     });
     this.registerColor(`${modal}header-text`, {
       dark: gray[150],
@@ -1232,18 +1284,22 @@ export class ColorRegistry {
     this.registerColor(`${dropdown}bg`, {
       dark: charcoal[600],
       light: gray[100],
+      hcDark: charcoal[900],
     });
     this.registerColor(`${select}bg`, {
       dark: charcoal[800],
       light: gray[300],
+      hcDark: black,
     });
     this.registerColor(`${dropdown}ring`, {
       dark: accent1[800],
       light: accent1[500],
+      hcDark: gray[300],
     });
     this.registerColor(`${dropdown}hover-ring`, {
       dark: accent1[700],
       light: accent1[500],
+      hcDark: '#7E60E6',
     });
     this.registerColor(`${dropdown}divider`, {
       dark: charcoal[600],
@@ -1257,6 +1313,7 @@ export class ColorRegistry {
     this.registerColor(`${dropdown}item-hover-bg`, {
       dark: accent1[900],
       light: accent1[50],
+      hcDark: black,
     });
     this.registerColor(`${dropdown}item-hover-text`, {
       dark: gray[400],
@@ -1431,11 +1488,13 @@ export class ColorRegistry {
     this.registerColor(`${statusbar}bg`, {
       dark: black,
       light: black,
+      hcDark: purple[900],
     });
 
     this.registerColor(`${statusbar}hover-bg`, {
       dark: accent1[500],
       light: accent1[500],
+      hcDark: '#7E60E6',
     });
 
     this.registerColor(`${statusbar}text`, {


### PR DESCRIPTION
### What does this PR do?

The following change request defines explicit color values for the dark high contrast theme across all UI sections: pure black backgrounds, light gray borders, vivid purple selected states and white text on selected items.

Adds `hcDark` color overrides throughout `ColorRegistry` for all UI sections.

Design principles (per Figma HC Dark mockup):
- Backgrounds → `black` (pure black)
- Borders / dividers → `gray[300]` (high contrast on black)
- Selected nav / card items → `#7E60E6` (vivid purple)
- Text on selected items → `white`

Sections covered: global nav, secondary nav, titlebar, content, invert-content, card, details, input, modal, dropdown, tab, status bar.

### Screenshot / video of UI

<img width="1247" height="975" alt="Screenshot 2026-03-25 at 22 25 40" src="https://github.com/user-attachments/assets/b1ee2e7b-5f4f-4bf3-b90d-96ddc66abaa3" />

### What issues does this PR fix or reference?

part of #14166

### How to test this PR?

Switch to `hc-dark` in Settings → Preferences → Appearance.
Verify that elements described above have pure black backgrounds, light borders, vivid purple selected items.

- [ ] Tests are covering the bug fix or the new feature
