### PR TITLE
chore(main): replace function reference with Symbol for inversify v8 

### DIFF
--- a/packages/main/src/plugin/api.ts
+++ b/packages/main/src/plugin/api.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2024 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,3 +31,5 @@ export type IPCMainOn = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   listener: (event: IpcMainEvent, ...args: any[]) => void,
 ) => void;
+
+export const MainWindowDeferred = Symbol.for('MainWindowDeferred');

--- a/packages/main/src/plugin/dialog-registry.ts
+++ b/packages/main/src/plugin/dialog-registry.ts
@@ -23,6 +23,7 @@ import { inject, injectable } from 'inversify';
 
 import { isMac } from '/@/util.js';
 
+import { MainWindowDeferred } from './api.js';
 import { Uri } from './types/uri.js';
 
 /**
@@ -34,9 +35,7 @@ export class DialogRegistry {
 
   #mainWindowDeferred: PromiseWithResolvers<BrowserWindow>;
 
-  constructor(
-    @inject(Promise.withResolvers<BrowserWindow>) readonly mainWindowDeferred: PromiseWithResolvers<BrowserWindow>,
-  ) {
+  constructor(@inject(MainWindowDeferred) readonly mainWindowDeferred: PromiseWithResolvers<BrowserWindow>) {
     this.#mainWindowDeferred = mainWindowDeferred;
   }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -169,6 +169,7 @@ import { securityRestrictionCurrentHandler } from '/@/security-restrictions-hand
 import { TrayMenu } from '/@/tray-menu.js';
 import { createHash, isMac } from '/@/util.js';
 
+import { MainWindowDeferred } from './api.js';
 import { AppearanceInit } from './appearance-init.js';
 import { AuthenticationImpl } from './authentication.js';
 import { AutostartEngine } from './autostart-engine.js';
@@ -762,9 +763,7 @@ export class PluginSystem {
     const webviewRegistry = container.get<WebviewRegistry>(WebviewRegistry);
     await webviewRegistry.start();
 
-    container
-      .bind<PromiseWithResolvers<BrowserWindow>>(Promise.withResolvers<BrowserWindow>)
-      .toConstantValue(this.mainWindowDeferred);
+    container.bind<PromiseWithResolvers<BrowserWindow>>(MainWindowDeferred).toConstantValue(this.mainWindowDeferred);
     container.bind<DialogRegistry>(DialogRegistry).toSelf().inSingletonScope();
 
     const dialogRegistry = container.get<DialogRegistry>(DialogRegistry);


### PR DESCRIPTION
### What does this PR do?
Inversify 8 no longer accepts arbitrary values as service identifiers: only strings, symbols, or class constructors.

This replaces the Promise.withResolvers<BrowserWindow> function reference with a proper Symbol.for('MainWindowDeferred') token.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/16631

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
