### PR TITLE
feat(podman): detach machine start/stop process from parent [WIP]

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -881,6 +881,7 @@ test('if a machine is successfully started it changes its state to started', asy
       CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
     },
     logger: new LoggerDelegator(),
+    detached: true,
   });
 
   expect(spyUpdateStatus).toBeCalledWith('started');

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -876,6 +876,7 @@ export async function startMachine(
     // start the machine
     await execPodman(['machine', 'start', machineInfo.name], machineInfo.vmType, {
       logger: new LoggerDelegator(context, logger),
+      detached: true,
     });
     provider.updateStatus('started');
   } catch (err) {
@@ -907,6 +908,7 @@ export async function stopMachine(
   try {
     await execPodman(['machine', 'stop', machineInfo.name], machineInfo.vmType, {
       logger: new LoggerDelegator(context, logger),
+      detached: true,
     });
     provider.updateStatus('stopped');
   } catch (err: unknown) {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4545,6 +4545,13 @@ declare module '@podman-desktop/api' {
      * The encoding to use. Default utf8
      */
     encoding?: BufferEncoding;
+
+    /**
+     * If true, the child process will be detached from the parent and its stdio
+     * will be disconnected. The process will continue running independently even
+     * if Podman Desktop exits. Stdout/stderr will not be captured.
+     */
+    detached?: boolean;
   }
 
   /**

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -516,6 +516,60 @@ describe('exec', () => {
     expect(options?.env?.['MY(VAR']).not.toBeDefined();
   });
 
+  function mockDetachedProcess(event: string, eventArg: unknown): { spawnMock: Mock; unrefMock: Mock } {
+    const unrefMock = vi.fn();
+    const onMock = vi.fn().mockImplementation((evt: string, cb: (arg0: unknown) => void) => {
+      if (evt === event) {
+        cb(eventArg);
+      }
+    });
+    const spawnMock = vi.mocked(spawn).mockReturnValue({
+      unref: unrefMock,
+      on: onMock,
+      killed: false,
+    } as unknown as ChildProcess);
+    return { spawnMock, unrefMock };
+  }
+
+  test.each([
+    { description: 'without custom cwd', cwd: undefined },
+    { description: 'with custom cwd', cwd: '/opt/app' },
+  ])('should spawn a detached process and resolve $description', async ({ cwd }) => {
+    const command = 'my-daemon';
+    const args = ['--background'];
+    const { spawnMock, unrefMock } = mockDetachedProcess('close', 0);
+
+    const result = await exec.exec(command, args, { detached: true, cwd });
+
+    const expectedOpts: Record<string, unknown> = { detached: true, stdio: 'ignore' };
+    if (cwd) expectedOpts['cwd'] = cwd;
+    expect(spawnMock).toHaveBeenCalledWith(command, args, expect.objectContaining(expectedOpts));
+    expect(unrefMock).toHaveBeenCalled();
+    expect(result).toEqual({ command, stdout: '', stderr: '' });
+  });
+
+  test.each([
+    {
+      description: 'non-zero exit code',
+      event: 'close',
+      eventArg: 42,
+      expectedError: /Command execution failed with exit code 42/,
+    },
+    {
+      description: 'error event',
+      event: 'error',
+      eventArg: new Error('spawn ENOENT'),
+      expectedError: /Failed to execute command: spawn ENOENT/,
+    },
+  ])('should reject when detached process emits $description', async ({ event, eventArg, expectedError }) => {
+    mockDetachedProcess(event, eventArg);
+
+    const execResult = exec.exec('failing-command', [], { detached: true });
+
+    await expect(execResult).rejects.toThrowError(expectedError);
+    await expect(execResult).rejects.toThrowError(Error);
+  });
+
   test('should run the command and set specific encoding', async () => {
     const command = 'echo';
     const args = ['Hello, World!'];

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import type { ChildProcess, ChildProcessWithoutNullStreams } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import { homedir } from 'node:os';
 import { delimiter, join } from 'node:path';
@@ -150,9 +150,13 @@ export class Exec {
       command = 'flatpak-spawn';
     }
 
-    let cwd: string;
+    let cwd: string | undefined;
     if (options?.cwd) {
       cwd = options.cwd;
+    }
+
+    if (options?.detached) {
+      return this.execDetached(command, args ?? [], env, cwd);
     }
 
     return new Promise((resolve, reject) => {
@@ -240,6 +244,53 @@ export class Exec {
             childProcess.killed,
           );
           reject(errResult);
+        }
+      });
+    });
+  }
+
+  private execDetached(
+    command: string,
+    args: string[],
+    env: NodeJS.ProcessEnv,
+    cwd: string | undefined,
+  ): Promise<RunResult> {
+    return new Promise((resolve, reject) => {
+      const childProcess: ChildProcess = spawn(command, args, { env, cwd, detached: true, stdio: 'ignore' });
+
+      childProcess.unref();
+
+      childProcess.on('error', error => {
+        reject(
+          new RunErrorImpl(
+            error.name,
+            `Failed to execute command: ${error.message}`,
+            1,
+            command,
+            '',
+            '',
+            false,
+            childProcess.killed,
+          ),
+        );
+      });
+
+      childProcess.on('close', exitCode => {
+        if (exitCode === 0) {
+          resolve({ command, stdout: '', stderr: '' });
+        } else {
+          reject(
+            new RunErrorImpl(
+              `Command execution failed with exit code ${exitCode}`,
+              `Command execution failed with exit code ${exitCode}`,
+              exitCode ?? 1,
+              command,
+              '',
+              '',
+              false,
+              childProcess.killed,
+            ),
+          );
         }
       });
     });


### PR DESCRIPTION
### What does this PR do?

This PR is a WIP draft to collect feedback.

- Spawn podman machine start/stop with detached: true and stdio disconnected so the child process survives Podman Desktop exit. This prevents the machine from getting stuck in "Currently starting" state when PD is closed during a machine operation.

- Adds a detached option to RunOptions in the extension API and handles it in the Exec implementation.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/9670

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Hit Cmd+Q (Mac) when Podman Desktop is starting the machine, and see with the terminal CLI if the machine is in a good state after (either started or stopped but not starting).

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
