### PR TITLE
fix(tests): add specific aria label to StatusIcon

### DIFF
--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -195,8 +195,9 @@ describe('expect display usage of an image', () => {
     });
 
     //  now check that we have the image saying it's in used
-    const usage = screen.getByRole('status', { name: 'USED' });
+    const usage = screen.getByRole('status', { name: 'Status Icon State' });
     expect(usage).toBeInTheDocument();
+    expect(usage).toHaveAttribute('title', 'USED');
   });
 
   test('expect unused', async () => {
@@ -226,9 +227,10 @@ describe('expect display usage of an image', () => {
       base64RepoTag: Buffer.from('<none>', 'binary').toString('base64'),
     });
 
-    //  now check that we have the image saying it's in used
-    const usage = screen.getByRole('status', { name: 'UNUSED' });
+    //  now check that we have the image saying it's unused
+    const usage = screen.getByRole('status', { name: 'Status Icon State' });
     expect(usage).toBeInTheDocument();
+    expect(usage).toHaveAttribute('title', 'UNUSED');
   });
 });
 
@@ -332,7 +334,7 @@ test.each([
   });
 
   // grab status icon of the image
-  const statusElement = screen.getByRole('status', { name: 'UNUSED' });
+  const statusElement = screen.getByRole('status', { name: 'Status Icon State' });
   expect(statusElement).toBeInTheDocument();
 
   // now assert status item contains the icon

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -342,7 +342,7 @@ describe('Contributions', () => {
     expect(fedoraOld).toBeInTheDocument();
 
     // now check that there is a custom icon for status column
-    const statusElement = screen.getByRole('status', { name: 'UNUSED' });
+    const statusElement = screen.getByRole('status', { name: 'Status Icon State' });
 
     // now assert status item contains the icon
     const subElement = statusElement.getElementsByClassName('podman-desktop-icon-my-custom-icon');

--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -59,7 +59,7 @@ test('Expect degraded styling', async () => {
 test('Expect deleting styling', async () => {
   const status = 'DELETING';
   render(StatusIcon, { status });
-  const icon = screen.getByRole('status', { name: status });
+  const icon = screen.getByRole('status', { name: 'Status Icon State' });
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
   expect(icon).not.toHaveAttribute('border');
@@ -72,7 +72,7 @@ test('Expect deleting styling', async () => {
 test('Expect updating styling', async () => {
   const status = 'UPDATING';
   render(StatusIcon, { status });
-  const icon = screen.getByRole('status', { name: status });
+  const icon = screen.getByRole('status', { name: 'Status Icon State' });
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
   expect(icon).not.toHaveAttribute('border');

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -31,6 +31,7 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
     class:text-[var(--pd-status-not-running)]={!solid}
     class:text-[var(--pd-status-contrast)]={solid}
     role="status"
+    aria-label="Status Icon State"
     title={status}>
     {#if status === 'DELETING' || status === 'UPDATING'}
       <Spinner size="1.4em" />

--- a/tests/playwright/src/model/pages/container-details-page.ts
+++ b/tests/playwright/src/model/pages/container-details-page.ts
@@ -67,7 +67,7 @@ export class ContainerDetailsPage extends DetailsPage {
 
   async getState(): Promise<string> {
     return test.step('Get container state', async () => {
-      const currentState = await this.header.getByRole('status').getAttribute('title');
+      const currentState = await this.header.getByRole('status', { name: 'Status Icon State' }).getAttribute('title');
       for (const state of Object.values(ContainerState)) {
         if (currentState === state) return state;
       }

--- a/tests/playwright/src/model/pages/kubernetes-resource-details-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-details-page.ts
@@ -52,7 +52,7 @@ export class KubernetesResourceDetailsPage extends DetailsPage {
 
   async getState(): Promise<string> {
     return test.step('Get resource state', async () => {
-      const currentState = await this.header.getByRole('status').getAttribute('title');
+      const currentState = await this.header.getByRole('status', { name: 'Status Icon State' }).getAttribute('title');
       return currentState ?? KubernetesResourceState.Unknown;
     });
   }

--- a/tests/playwright/src/model/pages/pods-details-page.ts
+++ b/tests/playwright/src/model/pages/pods-details-page.ts
@@ -54,7 +54,7 @@ export class PodDetailsPage extends DetailsPage {
 
   async getState(): Promise<string> {
     return test.step('Get Pod State', async () => {
-      const currentState = await this.header.getByRole('status').getAttribute('title');
+      const currentState = await this.header.getByRole('status', { name: 'Status Icon State' }).getAttribute('title');
       for (const state of Object.values(PodState)) {
         if (currentState === state) return state;
       }


### PR DESCRIPTION
### What does this PR do?

This adjusts the tests so that StatusIcon is locatable by more specific name, not just role. 

Needed to make https://github.com/podman-desktop/podman-desktop/pull/16823 pass e2e. 
