### PR TITLE
feat(renderer): replace CSS border spinner with Spinner component in ProviderWidgetStatus

### DIFF
--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.spec.ts
@@ -40,9 +40,7 @@ test('Expect to have different status icon based on provider status', async () =
   await renderObject.rerender({ status: 'stopping' });
   statusIcon = screen.getByLabelText('Connection Status Icon');
   expect(statusIcon).toBeInTheDocument();
-  expect(statusIcon).toHaveClass(
-    'animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent',
-  );
+  expect(statusIcon).toHaveAttribute('role', 'status');
 });
 
 test('Expect to have Update available icon status when an Update available status is passed', () => {

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
@@ -1,5 +1,7 @@
 
 <script lang="ts">
+import { Spinner } from '@podman-desktop/ui-svelte';
+
 interface Props {
   status?: string;
   class?: string;
@@ -12,7 +14,7 @@ const faRegularIconStatus: string[] = ['ready', 'started', 'stopped', 'error', '
 
 {#if status}
   {#if status === 'starting' || status === 'stopping'}
-    <div aria-label="Connection Status Icon" class="h-3 w-3 rounded-full animate-spin border border-solid border-[var(--pd-action-button-spinner)] border-t-transparent {className}"></div>
+    <Spinner size="12px" label="Connection Status Icon" class={className} />
   {:else}
     <div aria-label="Connection Status Icon" class="max-h-3 {className}"
       class:fa-regular={faRegularIconStatus.includes(status)}


### PR DESCRIPTION
### What does this PR do?

Replaces the custom animate-spin border trick with the official Spinner component from @podman-desktop/ui-svelte for consistency with the refreshed spinner design.

### Screenshot / video of UI

<img width="330" height="218" alt="Screenshot 2026-03-30 at 09 48 15" src="https://github.com/user-attachments/assets/c1f10109-a830-4895-8dc4-48f433e59884" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Resolves #16240

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
