### PR TITLE
chore(podman/tsconfig): switch to bundler for moduleResolution in extension

### DIFF
--- a/extensions/podman/packages/extension/scripts/podman-download.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.ts
@@ -19,7 +19,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Octokit } from 'octokit';
-import type { OctokitOptions } from '@octokit/core/dist-types/types';
+import type { OctokitOptions } from '@octokit/core/types';
 import { hashFile } from 'hasha';
 import { fileURLToPath } from 'node:url';
 import { Writable } from 'node:stream';

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -21,7 +21,7 @@ import type * as proc from 'node:child_process';
 import * as fs from 'node:fs';
 import { arch } from 'node:os';
 
-import type { ServiceIdentifier } from '@inversifyjs/common/lib/esm';
+import type { ServiceIdentifier } from '@inversifyjs/common';
 import type { Configuration, ContainerEngineInfo, ContainerProviderConnection } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { Disposable } from '@podman-desktop/api';

--- a/extensions/podman/packages/extension/tsconfig.json
+++ b/extensions/podman/packages/extension/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDirs": ["src", "scripts"],
     "outDir": "dist",
     "target": "esnext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
### What does this PR do?
I had the choices with
> this result could not be resolved under your current 'moduleResolution' setting
>. Consider updating to 'node16', 'nodenext', or 'bundler'.

using node16 or nodenext would result in many .js imports suffix missing in the src/ folder. I picked up then bundler to have the smallest changes

I also need this change
- [x] https://github.com/podman-desktop/podman-desktop/pull/16874

as fixing typing was raising a condition error

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

inversify v8 is ESM only and without any changes I have the error 
>this result could not be resolved under your current 'moduleResolution' setting
https://github.com/podman-desktop/podman-desktop/actions/runs/23731960691/job/69127600224?pr=16872



### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
