### PR TITLE
refactor(ui): replace SMIL animateTransform with CSS @keyframes in Spinner

### DIFF
--- a/packages/ui/src/lib/progress/Spinner.spec.ts
+++ b/packages/ui/src/lib/progress/Spinner.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { describe, expect, test } from 'vitest';
+import { assert, describe, expect, test } from 'vitest';
 
 import Spinner from './Spinner.svelte';
 
@@ -72,13 +72,14 @@ describe('spinner SVG structure', () => {
     expect(svg!.getAttribute('viewBox')).toBe('0 0 64 64');
   });
 
-  test('should have animateTransform element', () => {
+  test('should have a g element wrapping all lines as the animation target', () => {
     render(Spinner);
     const spinner = screen.getByRole('status', { name: 'Loading' });
     const svg = spinner.querySelector('svg');
-    expect(svg).not.toBeNull();
-    const animateTransform = svg!.querySelector('animateTransform');
-    expect(animateTransform).not.toBeNull();
-    expect(animateTransform!.getAttribute('calcMode')).toBe('discrete');
+    assert(svg);
+    const g = svg.querySelector('g');
+    assert(g);
+    expect(g.querySelectorAll('line').length).toBe(8);
+    expect(g.children.length).toBe(8);
   });
 });

--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -24,14 +24,19 @@ let { size = '2em', class: className, style, label = 'Loading' }: Props = $props
       <line x1="32" y1="4" x2="32" y2="16" transform="rotate(225, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.36" />
       <line x1="32" y1="4" x2="32" y2="16" transform="rotate(270, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.4" />
       <line x1="32" y1="4" x2="32" y2="16" transform="rotate(315, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.4" />
-      <animateTransform
-        attributeName="transform"
-        type="rotate"
-        calcMode="discrete"
-        values="0 32 32;45 32 32;90 32 32;135 32 32;180 32 32;225 32 32;270 32 32;315 32 32"
-        keyTimes="0;0.125;0.25;0.375;0.5;0.625;0.75;0.875"
-        dur="720ms"
-        repeatCount="indefinite" />
     </g>
   </svg>
 </i>
+
+<style>
+  g {
+    animation: spinner-rotate 720ms steps(8) infinite;
+    transform-origin: 32px 32px;
+  }
+
+  @keyframes spinner-rotate {
+    to {
+      transform: rotate(1turn);
+    }
+  }
+</style>


### PR DESCRIPTION
### What does this PR do?

SMIL animations (animateTransform) cannot be controlled by CSS media queries such as `@media` (prefers-reduced-motion: reduce). This makes it impossible to respect user motion accessibility preferences via CSS.

Replace the SMIL animation with an equivalent CSS `@keyframes` animation using steps(8) discrete rotation at 720ms (visually identical behavior) so that future CSS-based accessibility rules can control it.

Converting to CSS `@keyframes` is the standard approach and follows the same pattern used by LinearProgress.svelte in the same package.

### Screenshot / video of UI

Should not do any change

https://github.com/user-attachments/assets/094fa08c-0dee-48fa-b5d3-e1f15ce5fea1


https://github.com/user-attachments/assets/07d8dc66-eee8-47cb-98b1-0a9b75eeaddc


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/15806

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Test some spinners are unchanged

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature


cc @vancura 
