### PR TITLE
refactor: simplify troubleshooting zip export

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1779,19 +1779,8 @@ export class PluginSystem {
 
     this.ipcHandle(
       'troubleshooting:saveLogs',
-      async (
-        _listener,
-        consoleLogs: { logType: LogType; message: string }[],
-        destinaton: string,
-      ): Promise<string[]> => {
-        return troubleshooting.saveLogs(consoleLogs, destinaton);
-      },
-    );
-
-    this.ipcHandle(
-      'troubleshooting:generateLogFileName',
-      async (_listener, filename: string, prefix?: string): Promise<string> => {
-        return troubleshooting.generateLogFileName(filename, prefix);
+      async (_listener, consoleLogs: { logType: LogType; message: string }[]): Promise<string[]> => {
+        return troubleshooting.saveLogs(consoleLogs);
       },
     );
 

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -71,14 +71,13 @@ describe('saveLogs', () => {
     });
   });
 
-  test('should throw error if user cancelled save dialog', async () => {
+  test('should return empty array if user cancelled save dialog', async () => {
     vi.mocked(DIALOG_REGISTRY_MOCK.saveDialog).mockResolvedValue(undefined);
 
     const troubleshooting = new Troubleshooting(DIALOG_REGISTRY_MOCK);
 
-    await expect(async () => {
-      await troubleshooting.saveLogs([]);
-    }).rejects.toThrow('cannot save logs: save dialog returned undefined');
+    const result = await troubleshooting.saveLogs([]);
+    expect(result).toHaveLength(0);
   });
 });
 

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -19,10 +19,17 @@
 import * as fs from 'node:fs';
 
 import type { LogType } from '@podman-desktop/core-api';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { DialogRegistry } from '/@/plugin/dialog-registry.js';
+import { Uri } from '/@/plugin/types/uri.js';
 
 import type { TroubleshootingFileMap } from './troubleshooting.js';
 import { Troubleshooting } from './troubleshooting.js';
+
+const DIALOG_REGISTRY_MOCK: DialogRegistry = {
+  saveDialog: vi.fn(),
+} as unknown as DialogRegistry;
 
 const writeZipMock = vi.fn();
 const addFileMock = vi.fn();
@@ -46,12 +53,38 @@ vi.mock('adm-zip', () => {
 });
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+});
+
+describe('saveLogs', () => {
+  test('should use DialogRegistry#saveDialog', async () => {
+    const output = Uri.file('foo.zip');
+    vi.mocked(DIALOG_REGISTRY_MOCK.saveDialog).mockResolvedValue(output);
+
+    const troubleshooting = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+
+    await troubleshooting.saveLogs([]);
+
+    expect(DIALOG_REGISTRY_MOCK.saveDialog).toHaveBeenCalledExactlyOnceWith({
+      defaultUri: expect.any(Uri),
+      title: 'Save Logs as .zip',
+    });
+  });
+
+  test('should throw error if user cancelled save dialog', async () => {
+    vi.mocked(DIALOG_REGISTRY_MOCK.saveDialog).mockResolvedValue(undefined);
+
+    const troubleshooting = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+
+    await expect(async () => {
+      await troubleshooting.saveLogs([]);
+    }).rejects.toThrow('cannot save logs: save dialog returned undefined');
+  });
 });
 
 // Test the saveLogsToZip function
 test('Should save a zip file with the correct content', async () => {
-  const zipFile = new Troubleshooting();
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
   const fileMaps = [
     {
       filename: 'file1',
@@ -73,7 +106,7 @@ test('Should save a zip file with the correct content', async () => {
 
 // Do not expect writeZipMock to have been called if fileMaps is empty
 test('Should not save a zip file if fileMaps is empty', async () => {
-  const zipFile = new Troubleshooting();
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
   const fileMaps: TroubleshootingFileMap[] = [];
 
   const zipSpy = vi.spyOn(zipFile, 'saveLogsToZip');
@@ -86,7 +119,7 @@ test('Should not save a zip file if fileMaps is empty', async () => {
 
 // Expect the file name to have a .txt extension
 test('Should have a .txt extension in the file name', async () => {
-  const zipFile = new Troubleshooting();
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
   const fileMaps = [
     {
       filename: 'file1',
@@ -109,7 +142,7 @@ test('Should have a .txt extension in the file name', async () => {
 
 // Expect getConsoleLogs to correctly format the console logs passed in
 test('Should correctly format console logs', async () => {
-  const zipFile = new Troubleshooting();
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
   const consoleLogs = [
     {
       logType: 'log' as LogType,
@@ -148,7 +181,7 @@ test('Should return getMacSystemLogs if the platform is darwin', async () => {
     return true;
   });
 
-  const zipFile = new Troubleshooting();
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
   const getSystemLogsSpy = vi.spyOn(zipFile, 'getSystemLogs');
 
   await zipFile.getSystemLogs();
@@ -183,7 +216,7 @@ test('Should return getWindowsSystemLogs if the platform is win32', async () => 
   const readFileMock = vi.spyOn(fs.promises, 'readFile');
   readFileMock.mockResolvedValue('content');
 
-  const zipFile = new Troubleshooting();
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
   const getSystemLogsSpy = vi.spyOn(zipFile, 'getSystemLogs');
 
   await zipFile.getSystemLogs();
@@ -206,7 +239,7 @@ test.each([
   { file: 'test.log', extension: undefined, expected: /test-\d{14}\.log/ }, // use extension from filename
   { file: 'test.log', extension: 'customExtension', expected: /test-\d{14}\.customExtension/ }, //use provided extension
 ])('test generateLogFileName, file: $file, extension: $extension', async ({ file, extension, expected }) => {
-  const ts = new Troubleshooting();
+  const ts = new Troubleshooting(DIALOG_REGISTRY_MOCK);
   const filename = ts.generateLogFileName(file, extension);
   // Check the format of "name"-"date(14digits)"-"extension"
   expect(filename).toMatch(new RegExp(expected));

--- a/packages/main/src/plugin/troubleshooting.ts
+++ b/packages/main/src/plugin/troubleshooting.ts
@@ -49,7 +49,7 @@ export class Troubleshooting {
     const uri = await this.dialogRegistry.saveDialog({ title: 'Save Logs as .zip', defaultUri: Uri.file(defaultUri) });
 
     if (!uri) {
-      throw new Error('cannot save logs: save dialog returned undefined');
+      return [];
     }
 
     const systemLogs = await this.getSystemLogs();

--- a/packages/main/src/plugin/troubleshooting.ts
+++ b/packages/main/src/plugin/troubleshooting.ts
@@ -21,8 +21,11 @@ import * as os from 'node:os';
 
 import { LogType } from '@podman-desktop/core-api';
 import AdmZip from 'adm-zip';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import moment from 'moment';
+
+import { DialogRegistry } from '/@/plugin/dialog-registry.js';
+import { Uri } from '/@/plugin/types/uri.js';
 
 const SYSTEM_FILENAME = 'system';
 
@@ -33,14 +36,26 @@ export interface TroubleshootingFileMap {
 
 @injectable()
 export class Troubleshooting {
+  constructor(
+    @inject(DialogRegistry)
+    private dialogRegistry: DialogRegistry,
+  ) {}
+
   // The "main" function that is exposes that is used to gather
   // all the logs and save them to a zip file.
   // this also takes in the console logs and adds them to the zip file (see preload/src/index.ts) regarding memoryLogs
-  async saveLogs(console: { logType: LogType; message: string }[], destination: string): Promise<string[]> {
+  async saveLogs(console: { logType: LogType; message: string }[]): Promise<string[]> {
+    const defaultUri = this.generateLogFileName('podman-desktop', 'zip');
+    const uri = await this.dialogRegistry.saveDialog({ title: 'Save Logs as .zip', defaultUri: Uri.file(defaultUri) });
+
+    if (!uri) {
+      throw new Error('cannot save logs: save dialog returned undefined');
+    }
+
     const systemLogs = await this.getSystemLogs();
     const consoleLogs = this.getConsoleLogs(console);
     const fileMaps = [...systemLogs, ...consoleLogs];
-    await this.saveLogsToZip(fileMaps, destination);
+    await this.saveLogsToZip(fileMaps, uri.fsPath);
     return fileMaps.map(fileMap => fileMap.filename);
   }
 
@@ -100,6 +115,7 @@ export class Troubleshooting {
     }
     return logs;
   }
+
   generateLogFileName(filename: string, extension?: string): string {
     // If the filename has an extension like .log, move it to the end ofthe generated name
     // otherwise just use .txt

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1448,18 +1448,9 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('troubleshootingSaveLogs', async (destinaton: string): Promise<string[]> => {
-    return ipcInvoke('troubleshooting:saveLogs', memoryLogs, destinaton);
+  contextBridge.exposeInMainWorld('troubleshootingSaveLogs', async (): Promise<string[]> => {
+    return ipcInvoke('troubleshooting:saveLogs', memoryLogs);
   });
-
-  contextBridge.exposeInMainWorld(
-    'troubleshootingGenerateLogFileUri',
-    async (filename: string, extension?: string): Promise<containerDesktopAPI.Uri> => {
-      const generatedFile = await ipcInvoke('troubleshooting:generateLogFileName', filename, extension);
-      // transform into URI Object
-      return { fsPath: generatedFile, scheme: 'file' } as containerDesktopAPI.Uri;
-    },
-  );
 
   contextBridge.exposeInMainWorld('getContributedMenus', async (context: string): Promise<Menu[]> => {
     return ipcInvoke('menu-registry:getContributedMenus', context);

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingGatherLogs.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingGatherLogs.spec.ts
@@ -1,0 +1,51 @@
+/*********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import TroubleshootingGatherLogs from '/@/lib/troubleshooting/TroubleshootingGatherLogs.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+
+  vi.mocked(window.troubleshootingSaveLogs).mockResolvedValue([]);
+});
+
+test('button should be enabled', async () => {
+  const { getByRole } = render(TroubleshootingGatherLogs);
+
+  const btn = getByRole('button', {
+    name: 'Collect and save logs as .zip',
+  });
+  expect(btn).toBeEnabled();
+});
+
+test('save button should call window#troubleshootingSaveLogs', async () => {
+  const { getByRole } = render(TroubleshootingGatherLogs);
+
+  const btn = getByRole('button', {
+    name: 'Collect and save logs as .zip',
+  });
+
+  await fireEvent.click(btn);
+
+  expect(window.troubleshootingSaveLogs).toHaveBeenCalledOnce();
+});

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingGatherLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingGatherLogs.svelte
@@ -3,18 +3,11 @@ import { faFileLines, faScroll } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
-import { Uri } from '/@/lib/uri/Uri';
-
 let logs = $state<string[]>([]);
 
 // Save files as a zip file (we first ask the user for the dialog, and then save the files to the filepath)
 async function saveLogsAsZip(): Promise<void> {
-  const defaultUri = await window.troubleshootingGenerateLogFileUri('podman-desktop', 'zip');
-  const filePath = await window.saveDialog({ title: 'Save Logs as .zip', defaultUri });
-  if (filePath) {
-    const filePathUri = Uri.revive(filePath);
-    logs = await window.troubleshootingSaveLogs(filePathUri.fsPath);
-  }
+  logs = await window.troubleshootingSaveLogs();
 }
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Simplify the troubleshooting zip logic, the main issue were the `troubleshooting:saveLogs` IPC taking as argument a destination file, allowing anyone using this IPC to write a file anywhere on the host system.

To avoid this issue, we remove the destination, and in the core prompt the user through the default file explorer where it wants to save the zip.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16661

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
