### PR TITLE
chore(extensions/compose): prefer-import-in-mock

### DIFF
--- a/extensions/compose/src/cli-run.spec.ts
+++ b/extensions/compose/src/cli-run.spec.ts
@@ -25,15 +25,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { getSystemBinaryPath, installBinaryToSystem, localBinDir } from './cli-run';
 
 // mock exists sync
-vi.mock('node:fs', async () => {
-  return {
-    existsSync: vi.fn(),
-    copyFileSync: vi.fn(),
-    promises: {
-      copyFile: vi.fn(),
-    },
-  };
-});
+vi.mock(import('node:fs'));
 
 const previousPath = process.env.PATH;
 

--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -24,6 +24,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ComposeGitHubReleases } from './compose-github-releases';
 
+vi.mock(import('node:fs'));
+
 let composeGitHubReleases: ComposeGitHubReleases;
 
 const listReleaseAssetsMock = vi.fn();
@@ -154,8 +156,6 @@ describe.each([
 });
 
 test('should download the file if parent folder does exist', async () => {
-  vi.mock('node:fs');
-
   getReleaseAssetMock.mockImplementation(() => {
     return { data: 'foo' };
   });
@@ -178,8 +178,6 @@ test('should download the file if parent folder does exist', async () => {
 });
 
 test('should download the file if parent folder does not exist', async () => {
-  vi.mock('node:fs');
-
   getReleaseAssetMock.mockImplementation(() => {
     return { data: 'foo' };
   });

--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -37,11 +37,9 @@ const osMock: OS = {
 
 let detect: Detect;
 
-vi.mock('shell-path', () => {
-  return {
-    shellPath: vi.fn(),
-  };
-});
+vi.mock(import('shell-path'));
+vi.mock(import('node:fs'));
+vi.mock(import('node:http'));
 
 const originalConsoleDebug = console.debug;
 
@@ -117,7 +115,6 @@ describe('Check storage path', async () => {
   });
 
   test('found', async () => {
-    vi.mock('node:fs');
     const existSyncSpy = vi.mocked(fs.existsSync);
     existSyncSpy.mockImplementation(() => true);
 
@@ -225,14 +222,6 @@ describe('Check docker socket', async () => {
     const socketPathMock = vi.spyOn(detect, 'getSocketPath');
     socketPathMock.mockResolvedValue('/foo/docker.sock');
 
-    // mock http request
-
-    vi.mock('node:http', () => {
-      return {
-        get: vi.fn(),
-      };
-    });
-
     const spyGet: MockInstance<HttpGet> = vi.spyOn(http, 'get');
     const clientRequestEmitter = new EventEmitter();
     const myRequest = clientRequestEmitter as http.ClientRequest;
@@ -258,14 +247,6 @@ describe('Check docker socket', async () => {
     const socketPathMock = vi.spyOn(detect, 'getSocketPath');
     socketPathMock.mockResolvedValue('/foo/docker.sock');
 
-    // mock http request
-
-    vi.mock('node:http', () => {
-      return {
-        get: vi.fn(),
-      };
-    });
-
     const spyGet: MockInstance<HttpGet> = vi.spyOn(http, 'get');
     const clientRequestEmitter = new EventEmitter();
     const myRequest = clientRequestEmitter as http.ClientRequest;
@@ -287,14 +268,6 @@ describe('Check docker socket', async () => {
   test('test error', async () => {
     const socketPathMock = vi.spyOn(detect, 'getSocketPath');
     socketPathMock.mockResolvedValue('/foo/docker.sock');
-
-    // mock http request
-
-    vi.mock('node:http', () => {
-      return {
-        get: vi.fn(),
-      };
-    });
 
     const spyGet: MockInstance<HttpGet> = vi.spyOn(http, 'get');
     const clientRequestEmitter = new EventEmitter();

--- a/extensions/compose/src/download.spec.ts
+++ b/extensions/compose/src/download.spec.ts
@@ -27,6 +27,8 @@ import { ComposeDownload } from './download';
 import { OS } from './os';
 import * as utils from './utils';
 
+vi.mock(import('node:fs'));
+
 // Create the OS class as well as fake extensionContext
 const os = new OS();
 const extensionContext: extensionApi.ExtensionContext = {
@@ -112,7 +114,6 @@ test('test download of compose passes and that mkdir and executable mocks are ca
   const downloadReleaseAssetMock = vi.spyOn(composeGitHubReleasesMock, 'downloadReleaseAsset');
 
   // Mock that the storage path does not exist
-  vi.mock('node:fs');
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
     return false;
   });

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -27,12 +27,7 @@ import { Detect } from './detect';
 import { ComposeDownload } from './download';
 import { activate, deactivate } from './extension';
 
-vi.mock('node:fs', () => ({
-  promises: {
-    unlink: vi.fn(),
-  },
-  existsSync: vi.fn(),
-}));
+vi.mock(import('node:fs'));
 
 const cliToolMock = {
   registerUpdate: vi.fn(),

--- a/extensions/compose/src/handler.spec.ts
+++ b/extensions/compose/src/handler.spec.ts
@@ -22,7 +22,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import * as detect from './detect';
 import * as handler from './handler';
 
-vi.mock('./detect');
+vi.mock(import('./detect'));
 
 const extensionContextMock: extensionApi.ExtensionContext = {
   storagePath: '/storage-path',


### PR DESCRIPTION
### What does this PR do?

Enabling `vitest/prefer-import-in-mock` rule in `extensions/compose`

```ts
// BAD
vi.mock('./path/to/module')

// GOOD
vi.mock(import('./path/to/module'))
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16503

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
