### PR TITLE
chore(extension/docker): prefer-import-in-mock

### DIFF
--- a/extensions/docker/packages/extension/src/docker-context-handler.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-context-handler.spec.ts
@@ -41,7 +41,7 @@ class TestDockerContextHandler extends DockerContextHandler {
 }
 
 // mock exists sync
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 
 const originalConsoleError = console.error;
 let dockerContextHandler: TestDockerContextHandler;


### PR DESCRIPTION
### What does this PR do?

Preparing code in `extensions/docker` to enable `vitest/prefer-import-in-mock` rule 

```ts
// BAD
vi.mock('./path/to/module')

// GOOD
vi.mock(import('./path/to/module'))
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16503

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
