### PR TITLE
chore(extension/kind): prefer-import-in-mock

### DIFF
--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -32,7 +32,7 @@ vi.mock(import('./kind-cluster-watcher'));
 vi.mock(import('@kubernetes/client-node'));
 vi.mock(import('./util'));
 
-vi.mock('node:fs', () => ({
+vi.mock(import('node:fs'), () => ({
   promises: {
     writeFile: vi.fn(),
     readFile: vi.fn(),

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -31,16 +31,7 @@ import { getKindPath, getMemTotalInfo } from './util';
 vi.mock(import('./kind-cluster-watcher'));
 vi.mock(import('@kubernetes/client-node'));
 vi.mock(import('./util'));
-
-vi.mock(import('node:fs'), () => ({
-  promises: {
-    writeFile: vi.fn(),
-    readFile: vi.fn(),
-    mkdtemp: vi.fn(),
-    rm: vi.fn(),
-  },
-  readFileSync: vi.fn(),
-}));
+vi.mock(import('node:fs'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -28,7 +28,7 @@ import type { KindGithubReleaseArtifactMetadata } from './kind-installer';
 import { KindInstaller } from './kind-installer';
 import * as util from './util';
 
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 vi.mock(import('./util'));
 vi.mock(import('./image-handler'));
 vi.mock(import('./create-cluster'));

--- a/extensions/kind/src/image-handler.spec.ts
+++ b/extensions/kind/src/image-handler.spec.ts
@@ -27,7 +27,7 @@ import { getKindPath } from './util';
 
 let imageHandler: ImageHandler;
 
-vi.mock('./util', async () => {
+vi.mock(import('./util'), async () => {
   return {
     getKindPath: vi.fn(),
   };

--- a/extensions/kind/src/kind-cluster-watcher.spec.ts
+++ b/extensions/kind/src/kind-cluster-watcher.spec.ts
@@ -22,7 +22,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { KindClusterWatcher } from './kind-cluster-watcher';
 
-vi.mock('@kubernetes/client-node');
+vi.mock(import('@kubernetes/client-node'));
 
 describe('KindClusterWatcher', () => {
   let mockKubeConfig: KubeConfig;

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -31,7 +31,7 @@ import * as util from './util';
 
 let installer: KindInstaller;
 
-vi.mock('node:os', async () => {
+vi.mock(import('node:os'), async () => {
   return {
     platform: vi.fn(),
     arch: vi.fn(),
@@ -239,7 +239,7 @@ describe('install', () => {
     });
     vi.mocked(os.platform).mockReturnValue('win32');
     vi.mocked(os.arch).mockReturnValue('x64');
-    vi.mock('node:fs');
+    vi.mock(import('node:fs'));
     vi.mocked(fs.existsSync).mockReturnValue(true);
     const chmodMock = vi.spyOn(fs.promises, 'chmod');
     const downloadReleaseAssetMock = vi
@@ -264,7 +264,7 @@ describe('install', () => {
     });
     vi.mocked(os.platform).mockReturnValue('darwin');
     vi.mocked(os.arch).mockReturnValue('x64');
-    vi.mock('node:fs');
+    vi.mock(import('node:fs'));
     vi.mocked(fs.existsSync).mockReturnValue(true);
     const chmodMock = vi.spyOn(fs.promises, 'chmod').mockResolvedValue();
     const downloadReleaseAssetMock = vi
@@ -278,7 +278,7 @@ describe('install', () => {
 
 describe('downloadReleaseAsset', () => {
   test('should download the file if parent folder does exist', async () => {
-    vi.mock('node:fs');
+    vi.mock(import('node:fs'));
 
     getReleaseAssetMock.mockImplementation(() => {
       return { data: 'foo' };
@@ -302,7 +302,7 @@ describe('downloadReleaseAsset', () => {
   });
 
   test('should download the file if parent folder does not exist', async () => {
-    vi.mock('node:fs');
+    vi.mock(import('node:fs'));
 
     getReleaseAssetMock.mockImplementation(() => {
       return { data: 'foo' };


### PR DESCRIPTION
### What does this PR do?

Enabling `vitest/prefer-import-in-mock` rule in `extensions/kind`

```ts
// BAD
vi.mock('./path/to/module')

// GOOD
vi.mock(import('./path/to/module'))
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16503

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
