### PR TITLE
chore(extension/kubectl-cli): prefer-import-in-mock

### DIFF
--- a/extensions/kubectl-cli/src/cli-run.spec.ts
+++ b/extensions/kubectl-cli/src/cli-run.spec.ts
@@ -25,7 +25,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { installBinaryToSystem } from './cli-run';
 
 // mock exists sync
-vi.mock('node:fs', async () => {
+vi.mock(import('node:fs'), async () => {
   return {
     existsSync: vi.fn(),
   };

--- a/extensions/kubectl-cli/src/detect.spec.ts
+++ b/extensions/kubectl-cli/src/detect.spec.ts
@@ -34,7 +34,7 @@ const osMock: OS = {
 
 let detect: Detect;
 
-vi.mock('shell-path', () => {
+vi.mock(import('shell-path'), () => {
   return {
     shellPath: vi.fn(),
   };
@@ -101,7 +101,7 @@ describe('Check storage path', async () => {
   });
 
   test('found', async () => {
-    vi.mock('node:fs');
+    vi.mock(import('node:fs'));
     const existSyncSpy = vi.spyOn(fs, 'existsSync');
     existSyncSpy.mockImplementation(() => true);
 

--- a/extensions/kubectl-cli/src/download.spec.ts
+++ b/extensions/kubectl-cli/src/download.spec.ts
@@ -124,7 +124,7 @@ test('test download of kubectl passes and that mkdir and executable mocks are ca
   const downloadReleaseAssetMock = vi.spyOn(kubectlGitHubReleasesMock, 'downloadReleaseAsset');
 
   // Mock that the storage path does not exist
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
     return false;
   });

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -37,15 +37,7 @@ const extensionContext = {
 
 vi.mock(import('./cli-run'));
 vi.mock(import('./kubectl-github-releases'));
-
-vi.mock('node:fs', () => ({
-  promises: {
-    chmod: vi.fn(),
-    mkdir: vi.fn(),
-    unlink: vi.fn(),
-  },
-  existsSync: vi.fn(),
-}));
+vi.mock(import('node:fs'));
 
 beforeEach(() => {
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -116,7 +116,7 @@ describe('Grab asset id for a given release id', async () => {
 });
 
 test('should download the file if parent folder does exist', async () => {
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
 
   getReleaseAssetMock.mockImplementation(() => {
     return { data: 'foo' };
@@ -140,7 +140,7 @@ test('should download the file if parent folder does exist', async () => {
 });
 
 test('should download the file if parent folder does not exist', async () => {
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
 
   getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 


### PR DESCRIPTION
### What does this PR do?

Enabling `vitest/prefer-import-in-mock` rule in `extensions/kubectl-cli`

```ts
// BAD
vi.mock('./path/to/module')

// GOOD
vi.mock(import('./path/to/module'))
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16503

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
