### PR TITLE
chore(extension/podman): prefer-import-in-mock

### DIFF
--- a/extensions/podman/packages/extension/src/certificate-detection/certificate-detection-service.spec.ts
+++ b/extensions/podman/packages/extension/src/certificate-detection/certificate-detection-service.spec.ts
@@ -26,8 +26,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { type CertificateDetectionConfig, CertificateDetectionService } from './certificate-detection-service';
 
-vi.mock('node:fs/promises');
-vi.mock('node:os');
+vi.mock(import('node:fs/promises'));
+vi.mock(import('node:os'));
 
 const mockTelemetryLogger: TelemetryLogger = {
   logUsage: vi.fn(),

--- a/extensions/podman/packages/extension/src/certificate-sync/podman-certificate-sync.spec.ts
+++ b/extensions/podman/packages/extension/src/certificate-sync/podman-certificate-sync.spec.ts
@@ -28,16 +28,6 @@ import * as util from '/@/utils/util';
 
 import { PodmanCertificateSync } from './podman-certificate-sync';
 
-vi.mock(import('@podman-desktop/api'), async () => ({
-  ProgressLocation: {
-    TASK_WIDGET: 1,
-  },
-  window: {
-    withProgress: vi.fn(),
-    showWarningMessage: vi.fn(),
-  },
-}));
-
 vi.mock(import('../utils/util'), () => ({
   execPodman: vi.fn(),
 }));

--- a/extensions/podman/packages/extension/src/certificate-sync/podman-certificate-sync.spec.ts
+++ b/extensions/podman/packages/extension/src/certificate-sync/podman-certificate-sync.spec.ts
@@ -28,7 +28,7 @@ import * as util from '/@/utils/util';
 
 import { PodmanCertificateSync } from './podman-certificate-sync';
 
-vi.mock('@podman-desktop/api', async () => ({
+vi.mock(import('@podman-desktop/api'), async () => ({
   ProgressLocation: {
     TASK_WIDGET: 1,
   },
@@ -38,11 +38,11 @@ vi.mock('@podman-desktop/api', async () => ({
   },
 }));
 
-vi.mock('../utils/util', () => ({
+vi.mock(import('../utils/util'), () => ({
   execPodman: vi.fn(),
 }));
 
-vi.mock('node:tls', () => ({
+vi.mock(import('node:tls'), () => ({
   getCACertificates: vi.fn(),
 }));
 

--- a/extensions/podman/packages/extension/src/checks/macos-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/macos-check.spec.ts
@@ -26,7 +26,7 @@ import { MacKrunkitPodmanMachineCreationCheck, MacVersionCheck, MINIMUM_VERSION 
 
 let macVersionCheck: MacVersionCheck;
 
-vi.mock('node:os', () => {
+vi.mock(import('node:os'), () => {
   return {
     release: vi.fn(),
     platform: vi.fn(),

--- a/extensions/podman/packages/extension/src/checks/windows/wsl2-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/wsl2-check.spec.ts
@@ -28,7 +28,7 @@ import { WSL2Check } from './wsl2-check';
 const userAdminCheck = { execute: vi.fn() } as unknown as UserAdminCheck;
 
 // mock ps-list
-vi.mock('ps-list', async () => {
+vi.mock(import('ps-list'), async () => {
   return {
     default: vi.fn(),
   };

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-abstract.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-abstract.spec.ts
@@ -39,15 +39,8 @@ class TestAbsPodmanCleanup extends AbsPodmanCleanup {
 let absPodmanCleanup: TestAbsPodmanCleanup;
 
 // mock exists sync
-vi.mock(import('node:fs'), async () => {
-  return {
-    existsSync: vi.fn(),
-    promises: {
-      readFile: vi.fn(),
-      rm: vi.fn(),
-    },
-  };
-});
+vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'));
 
 beforeEach(() => {
   absPodmanCleanup = new TestAbsPodmanCleanup();

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-abstract.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-abstract.spec.ts
@@ -39,7 +39,7 @@ class TestAbsPodmanCleanup extends AbsPodmanCleanup {
 let absPodmanCleanup: TestAbsPodmanCleanup;
 
 // mock exists sync
-vi.mock('node:fs', async () => {
+vi.mock(import('node:fs'), async () => {
   return {
     existsSync: vi.fn(),
     promises: {

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-macos.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-macos.spec.ts
@@ -25,15 +25,8 @@ import { PodmanCleanupMacOS } from './podman-cleanup-macos';
 let podmanCleanupMacOS: PodmanCleanupMacOS;
 
 // mock exists sync
-vi.mock(import('node:fs'), async () => {
-  return {
-    existsSync: vi.fn(),
-    promises: {
-      readFile: vi.fn(),
-      rm: vi.fn(),
-    },
-  };
-});
+vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'));
 
 // mock ps-list
 vi.mock(import('ps-list'), async () => {

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-macos.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-macos.spec.ts
@@ -25,7 +25,7 @@ import { PodmanCleanupMacOS } from './podman-cleanup-macos';
 let podmanCleanupMacOS: PodmanCleanupMacOS;
 
 // mock exists sync
-vi.mock('node:fs', async () => {
+vi.mock(import('node:fs'), async () => {
   return {
     existsSync: vi.fn(),
     promises: {
@@ -36,7 +36,7 @@ vi.mock('node:fs', async () => {
 });
 
 // mock ps-list
-vi.mock('ps-list', async () => {
+vi.mock(import('ps-list'), async () => {
   return {
     default: vi.fn(),
   };

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.spec.ts
@@ -24,7 +24,7 @@ import { PodmanCleanupWindows } from './podman-cleanup-windows';
 let podmanCleanupWindows: PodmanCleanupWindows;
 
 // mock exists sync
-vi.mock('node:fs', async () => {
+vi.mock(import('node:fs'), async () => {
   return {
     existsSync: vi.fn(),
     promises: {
@@ -35,7 +35,7 @@ vi.mock('node:fs', async () => {
 });
 
 // mock ps-list
-vi.mock('ps-list', async () => {
+vi.mock(import('ps-list'), async () => {
   return {
     default: vi.fn(),
   };

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.spec.ts
@@ -24,15 +24,8 @@ import { PodmanCleanupWindows } from './podman-cleanup-windows';
 let podmanCleanupWindows: PodmanCleanupWindows;
 
 // mock exists sync
-vi.mock(import('node:fs'), async () => {
-  return {
-    existsSync: vi.fn(),
-    promises: {
-      readFile: vi.fn(),
-      rm: vi.fn(),
-    },
-  };
-});
+vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'));
 
 // mock ps-list
 vi.mock(import('ps-list'), async () => {

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
@@ -29,11 +29,11 @@ import type { RegistryConfigurationFile } from './registry-configuration';
 import { ActionEnum, RegistryConfigurationImpl } from './registry-configuration';
 
 let registryConfiguration: RegistryConfigurationImpl;
-vi.mock('node:fs');
-vi.mock('node:fs/promises');
+vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'));
 
 // need to mock some functions due to exported function getJSONMachineList using os.homedir
-vi.mock('node:os', async () => {
+vi.mock(import('node:os'), async () => {
   return {
     tmpdir: vi.fn().mockReturnValue('fake-tmp'),
     homedir: vi.fn().mockReturnValue('fake-homedir'),

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -152,7 +152,7 @@ async function waitTelemetryLoggerUsage() {
   await vi.waitFor(() => expect((telemetryLogger.logUsage as Mock).mock.calls).not.toHaveLength(0));
 }
 
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 // mock fs.promises.readdir and use string[] as return type
 const fsPromisesReaddirMock = vi.mocked(
   fs.promises.readdir as (path: string, options?: { withFileTypes: false }) => Promise<string[]>,
@@ -161,7 +161,7 @@ const fsPromisesReaddirMock = vi.mocked(
 vi.mock(import('./inject/inversify-binding'));
 
 // mock ps-list
-vi.mock('ps-list', async () => {
+vi.mock(import('ps-list'), async () => {
   return {
     default: vi.fn(),
   };
@@ -282,7 +282,7 @@ beforeEach(async () => {
 const originalConsoleError = console.error;
 const consoleErrorMock = vi.fn();
 
-vi.mock('node:child_process', async () => {
+vi.mock(import('node:child_process'), async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const childProcessActual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
   return {
@@ -296,7 +296,7 @@ vi.mock('node:child_process', async () => {
   };
 });
 
-vi.mock('node:os', async () => {
+vi.mock(import('node:os'), async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const osActual = await vi.importActual<typeof import('node:os')>('node:os');
 
@@ -1160,7 +1160,7 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
   const spyPrompt = vi.mocked(extensionApi.window.showInformationMessage);
   spyPrompt.mockResolvedValue('Yes');
 
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
 
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
     return false;
@@ -3414,7 +3414,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
       },
     });
 
-    vi.mock('./utils/warnings');
+    vi.mock(import('./utils/warnings'));
   });
 
   test('do not show any notifications / messages if the provider is stopped', async () => {

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -18,6 +18,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import type * as proc from 'node:child_process';
+import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import { arch } from 'node:os';
 
@@ -282,17 +283,12 @@ beforeEach(async () => {
 const originalConsoleError = console.error;
 const consoleErrorMock = vi.fn();
 
-vi.mock(import('node:child_process'), async () => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  const childProcessActual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+vi.mock(import('node:child_process'), async importOriginal => {
+  const childProcessActual = await importOriginal();
   return {
     ...childProcessActual,
     env: vi.fn(),
-    spawn: () => {
-      return {
-        on: vi.fn(),
-      } as unknown as proc.ChildProcess;
-    },
+    spawn: vi.fn(),
   };
 });
 
@@ -329,6 +325,10 @@ beforeEach(() => {
   vi.mocked(extensionApi.env).isMac = false;
   vi.mocked(extensionApi.env).isLinux = false;
   vi.mocked(extensionApi.env).isWindows = false;
+
+  vi.mocked(spawn).mockReturnValue({
+    on: vi.fn(),
+  } as unknown as proc.ChildProcess);
 
   const mock = vi.spyOn(compatibilityModeLib, 'getSocketCompatibility');
   mock.mockReturnValue({

--- a/extensions/podman/packages/extension/src/installer/mac-os-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/mac-os-installer.spec.ts
@@ -26,7 +26,7 @@ import { getAssetsFolder } from '/@/utils/util';
 
 import { MacOSInstaller } from './mac-os-installer';
 
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 
 const extensionContext = {
   subscriptions: [],

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -79,17 +79,17 @@ const PODMAN_BINARY_MOCK: PodmanBinary = {
 } as unknown as PodmanBinary;
 
 // mock filesystem
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 
 // mock ps-list
-vi.mock('ps-list', async () => {
+vi.mock(import('ps-list'), async () => {
   return {
     default: vi.fn(),
   };
 });
 
 // mock release
-vi.mock('node:os', async () => {
+vi.mock(import('node:os'), async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await vi.importActual<typeof import('node:os')>('node:os');
   return {

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
@@ -24,7 +24,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { PodmanRemoteConnections } from './podman-remote-connections';
 import type { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
 
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 
 const extensionContext = {} as extensionApi.ExtensionContext;
 

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -32,7 +32,7 @@ const config: Configuration = {
   update: vi.fn(),
 };
 
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 
 const mockTelemetryLogger: extensionApi.TelemetryLogger = {
   logUsage: vi.fn(),
@@ -76,7 +76,7 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
       },
     });
 
-    vi.mock('./warnings');
+    vi.mock(import('./warnings'));
   });
 
   test('when isDisguisedPodman is true, error message should NOT be shown', async () => {

--- a/extensions/podman/packages/extension/src/utils/podman-binary.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-binary.spec.ts
@@ -27,7 +27,7 @@ import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 import { PodmanBinary } from '/@/utils/podman-binary';
 
 vi.mock(import('/@/utils/podman-cli'));
-vi.mock('@podman-desktop/api', () => ({
+vi.mock(import('@podman-desktop/api'), () => ({
   process: {
     exec: vi.fn(),
   },

--- a/extensions/podman/packages/extension/src/utils/podman-binary.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-binary.spec.ts
@@ -27,14 +27,6 @@ import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 import { PodmanBinary } from '/@/utils/podman-binary';
 
 vi.mock(import('/@/utils/podman-cli'));
-vi.mock(import('@podman-desktop/api'), () => ({
-  process: {
-    exec: vi.fn(),
-  },
-  configuration: {
-    onDidChangeConfiguration: vi.fn(),
-  },
-}));
 
 const disposableMock: Disposable = {
   dispose: vi.fn(),

--- a/extensions/podman/packages/extension/src/utils/podman-cli.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.spec.ts
@@ -30,7 +30,7 @@ const config: Configuration = {
 };
 
 // Mock fs module
-vi.mock('node:fs', () => {
+vi.mock(import('node:fs'), () => {
   return {
     default: {
       realpathSync: vi.fn(),

--- a/extensions/podman/packages/extension/src/utils/podman-cli.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-cli.spec.ts
@@ -30,14 +30,7 @@ const config: Configuration = {
 };
 
 // Mock fs module
-vi.mock(import('node:fs'), () => {
-  return {
-    default: {
-      realpathSync: vi.fn(),
-      statSync: vi.fn(),
-    },
-  };
-});
+vi.mock(import('node:fs'));
 
 describe('findPodmanInstallations', () => {
   beforeEach(() => {

--- a/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
@@ -65,7 +65,7 @@ memory = 4096
 });
 
 test('when enable rosetta is set to true and there is already a file with rosetta = false, remove it.', async () => {
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
   const configFileContent = `
 [machine]
 memory = 4096
@@ -87,7 +87,7 @@ rosetta = false
 });
 
 test('should disable Rosetta when useRosetta is false', async () => {
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
   const configFileContent = `
 [machine]
 memory = 4096
@@ -108,7 +108,7 @@ rosetta = true
 });
 
 test('if rosetta is set to true and the file does NOT exist, do not try and create the file.', async () => {
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
@@ -122,7 +122,7 @@ test('if rosetta is set to true and the file does NOT exist, do not try and crea
 
 describe('isRosettaEnabled', () => {
   test('check rosetta is enabled', async () => {
-    vi.mock('node:fs');
+    vi.mock(import('node:fs'));
     vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
     vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nrosetta=true');
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -133,7 +133,7 @@ describe('isRosettaEnabled', () => {
   });
 
   test('check rosetta is enabled if file is not containing rosetta setting (default value is true)', async () => {
-    vi.mock('node:fs');
+    vi.mock(import('node:fs'));
     vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
     vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -144,7 +144,7 @@ describe('isRosettaEnabled', () => {
   });
 
   test('check rosetta is disabled', async () => {
-    vi.mock('node:fs');
+    vi.mock(import('node:fs'));
     vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
     vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nrosetta=false');
 
@@ -157,7 +157,7 @@ describe('isRosettaEnabled', () => {
 });
 
 test('when provider is set to applehv provider and there is already a file with provider = libkrun, remove it.', async () => {
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nprovider = "libkrun"');
@@ -174,7 +174,7 @@ test('when provider is set to applehv provider and there is already a file with 
 });
 
 test('should update provider', async () => {
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nprovider = "applehv"');
@@ -191,7 +191,7 @@ test('should update provider', async () => {
 });
 
 test('if provider is set default one (on CLI) and the file does NOT exist, do not try and create the file.', async () => {
-  vi.mock('node:fs');
+  vi.mock(import('node:fs'));
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');

--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -43,7 +43,7 @@ export class TestRegistrySetup extends RegistrySetup {
 let registrySetup: TestRegistrySetup;
 
 // mock the fs module
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;

--- a/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
@@ -25,7 +25,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { PodmanConfiguration } from './podman-configuration';
 import { checkRosettaMacArm } from './rosetta';
 
-vi.mock('node:os', async () => {
+vi.mock(import('node:os'), async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const osActual = await vi.importActual<typeof import('node:os')>('node:os');
 


### PR DESCRIPTION
### What does this PR do?

Enabling `vitest/prefer-import-in-mock` rule in `extensions/podman`

```ts
// BAD
vi.mock('./path/to/module')

// GOOD
vi.mock(import('./path/to/module'))
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16503

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
