### PR TITLE
chore(test): refactor filepicker methods and add save/load image e2e test

### DIFF
--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -24,6 +24,7 @@ export * from './setupFiles/setup-registry';
 export * from './utility/auth-utils';
 export * from './utility/cleanup';
 export * from './utility/cluster-operations';
+export * from './utility/dialog';
 export * from './utility/fixtures';
 export * from './utility/kubernetes';
 export * from './utility/operations';

--- a/tests/playwright/src/model/pages/create-kind-cluster-page.ts
+++ b/tests/playwright/src/model/pages/create-kind-cluster-page.ts
@@ -19,6 +19,7 @@
 import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
 import type { KindClusterOptions } from '/@/model/core/types';
+import { withMockedOpenFileDialog } from '/@/utility/dialog';
 import { fillTextbox } from '/@/utility/operations';
 
 import { CreateClusterBasePage } from './cluster-creation-base-page';
@@ -31,6 +32,7 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
   readonly httpsPort: Locator;
   readonly containerImage: Locator;
   readonly configFileInput: Locator;
+  readonly configFileBrowseButton: Locator;
   readonly warning: Locator;
 
   constructor(page: Page) {
@@ -50,6 +52,7 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
       name: 'Custom path to Kind config file (Default is blank)',
       exact: true,
     });
+    this.configFileBrowseButton = this.clusterPropertiesInformation.getByRole('button', { name: 'browse' });
     this.warning = this.page.getByRole('alert', { name: 'warning' });
   }
 
@@ -77,8 +80,10 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
 
       // Use the default cluster name if a custom config file is used; the default cluster name should be ignored in this case.
       if (configFilePath) {
-        await this.configFileInput.evaluate(node => node.removeAttribute('readonly'));
-        await this.configFileInput.fill(configFilePath);
+        await withMockedOpenFileDialog([configFilePath], async () => {
+          await this.configFileBrowseButton.click();
+        });
+        await playExpect(this.configFileInput).toHaveValue(configFilePath);
         await playExpect(this.warning).toBeVisible();
         await playExpect(this.warning).toContainText(
           'By specifying a config file, all other options will be ignored except for ingress controller deployment.',

--- a/tests/playwright/src/model/pages/image-details-page.ts
+++ b/tests/playwright/src/model/pages/image-details-page.ts
@@ -19,6 +19,7 @@
 import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
+import { withMockedSaveFileDialog } from '/@/utility/dialog';
 import { handleConfirmationDialog } from '/@/utility/operations';
 
 import { DetailsPage } from './details-page';
@@ -107,16 +108,16 @@ export class ImageDetailsPage extends DetailsPage {
     if (!outputPath) {
       throw Error('Path is incorrect or not provided!');
     }
-    // TODO: Will probably require refactoring when https://github.com/containers/podman-desktop/issues/7620 is done
     await playExpect(this.saveImagebutton).toBeEnabled();
     await this.saveImagebutton.click();
     await playExpect(this.saveImageInput).toBeVisible();
-    await playExpect(this.confirmSaveImages).toBeVisible();
+    await playExpect(this.browseButton).toBeVisible();
 
-    await this.saveImageInput.evaluate(node => node.removeAttribute('readonly'));
-    await this.confirmSaveImages.evaluate(node => node.removeAttribute('disabled'));
-
-    await this.saveImageInput.pressSequentially(outputPath, { delay: 10 });
+    await withMockedSaveFileDialog(outputPath, async () => {
+      await this.browseButton.click();
+    });
+    await playExpect(this.saveImageInput).toHaveValue(outputPath);
+    await playExpect(this.confirmSaveImages).toBeEnabled();
     await this.confirmSaveImages.click();
 
     return new ImagesPage(this.page);

--- a/tests/playwright/src/model/pages/images-page.ts
+++ b/tests/playwright/src/model/pages/images-page.ts
@@ -20,6 +20,7 @@ import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
 import type { ContainerInteractiveParams } from '/@/model/core/types';
+import { withMockedOpenFileDialog } from '/@/utility/dialog';
 import { handleConfirmationDialog } from '/@/utility/operations';
 import { waitUntil, waitWhile } from '/@/utility/wait';
 
@@ -48,7 +49,7 @@ export class ImagesPage extends MainPage {
     this.pruneConfirmationButton = this.page.getByRole('button', { name: 'All unused images', exact: true });
     this.loadImagesFromTarButton = this.additionalActions.getByLabel('Load Images', { exact: true });
     this.addArchiveButton = this.page.getByRole('button', { name: 'Add archive', exact: true });
-    this.confirmLoadImagesButton = this.page.getByRole('button', { name: 'Load Images', exact: true });
+    this.confirmLoadImagesButton = this.page.getByRole('button', { name: 'Load images', exact: true });
     this.deleteAllUnusedImagesCheckbox = this.page.getByRole('checkbox', { name: 'Toggle all', exact: true });
     this.deleteAllSelectedButton = this.bottomAdditionalActions.getByRole('button', { name: 'Delete' });
   }
@@ -171,16 +172,21 @@ export class ImagesPage extends MainPage {
     });
   }
 
-  async loadImages(archivePath: string): Promise<ImagesPage> {
-    // TODO: Will probably require refactoring when https://github.com/containers/podman-desktop/issues/7620 is done
+  async loadImages(archivePath: string, timeout = 60_000): Promise<ImagesPage> {
+    return test.step('Load images from tar archive', async () => {
+      await playExpect(this.loadImagesFromTarButton).toBeEnabled();
+      await this.loadImagesFromTarButton.click();
+      await playExpect(this.addArchiveButton).toBeEnabled();
 
-    await playExpect(this.loadImagesFromTarButton).toBeEnabled();
-    await this.loadImagesFromTarButton.click();
-    await playExpect(this.addArchiveButton).toBeEnabled();
-    await this.addArchiveButton.setInputFiles(archivePath);
-    await playExpect(this.confirmLoadImagesButton).toBeEnabled();
-    await this.confirmLoadImagesButton.click();
-    return this;
+      await withMockedOpenFileDialog([archivePath], async () => {
+        await this.addArchiveButton.click();
+      });
+
+      await playExpect(this.confirmLoadImagesButton).toBeEnabled();
+      await this.confirmLoadImagesButton.click();
+      await playExpect(this.heading).toBeVisible({ timeout });
+      return this;
+    });
   }
 
   async markAllUnusedImages(): Promise<boolean> {

--- a/tests/playwright/src/model/pages/podman-kube-play-page.ts
+++ b/tests/playwright/src/model/pages/podman-kube-play-page.ts
@@ -19,6 +19,7 @@ import test, { expect as playExpect, type Locator, type Page } from '@playwright
 
 import type { PlayYamlOptions } from '/@/model/core/types';
 import { PodmanKubePlayOptions } from '/@/model/core/types';
+import { withMockedOpenFileDialog } from '/@/utility/dialog';
 
 import { BasePage } from './base-page';
 import { PodsPage } from './pods-page';
@@ -32,6 +33,7 @@ export class PodmanKubePlayPage extends BasePage {
   readonly createYamlFromScratchButton: Locator;
   readonly customYamlEditor: Locator;
   readonly alertMessage: Locator;
+  readonly browseButton: Locator;
   readonly buildCheckbox: Locator;
   readonly replaceCheckbox: Locator;
 
@@ -44,6 +46,7 @@ export class PodmanKubePlayPage extends BasePage {
     this.selectYamlButton = page.getByRole('button', {
       name: 'Podman Container Engine Runtime',
     });
+    this.browseButton = page.getByRole('button', { name: 'browse' });
     this.createYamlFromScratchButton = page.getByRole('button', { name: 'Create a file from scratch' });
     this.customYamlEditor = page.locator('#custom-yaml-editor');
     this.playButton = page.getByRole('button', { name: 'Play' });
@@ -80,10 +83,11 @@ export class PodmanKubePlayPage extends BasePage {
     await playExpect(this.selectYamlButton).toBeEnabled();
     await this.selectYamlButton.click();
     await playExpect(this.selectYamlButton).toHaveAttribute('aria-pressed', 'true');
-    // TODO: evaluate() is required due to noninteractivity of fields currently, once https://github.com/containers/podman-desktop/issues/5479 is done they will no longer be needed
-    await this.yamlPathInput.evaluate(node => node.removeAttribute('readonly'));
-    await this.playButton.evaluate(node => node.removeAttribute('disabled'));
-    await this.yamlPathInput.fill(pathToYaml);
+
+    await withMockedOpenFileDialog([pathToYaml], async () => {
+      await this.browseButton.click();
+    });
+    await playExpect(this.yamlPathInput).toHaveValue(pathToYaml);
   }
 
   async playYaml(

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -75,7 +77,7 @@ test.describe
       const searchResults = await pullImagePage.getAllSearchResultsFor(imageToSearch, true);
       playExpect(searchResults.length).toBeGreaterThan(0);
 
-      imagesPage = await pullImagePage.pullImageFromSearchResults(imageToSearch + ':' + imageTagToSearch);
+      imagesPage = await pullImagePage.pullImageFromSearchResults(`${imageToSearch}:${imageTagToSearch}`);
       await playExpect(imagesPage.heading).toBeVisible();
       await playExpect.poll(async () => await imagesPage.waitForImageExists(imageToSearch)).toBeTruthy();
 
@@ -299,5 +301,44 @@ test.describe
       await playExpect
         .poll(async () => await imagesPage.waitForImageDelete(imageToSearch, 60_000), { timeout: 0 })
         .toBeTruthy();
+    });
+
+    test('Save image as tar, delete, load from tar', async ({ navigationBar }) => {
+      test.setTimeout(180_000);
+
+      const tarFilePath = path.join(tmpdir(), 'podman-desktop-e2e-hello.tar');
+
+      try {
+        let imagesPage = await navigationBar.openImages();
+        await playExpect(imagesPage.heading).toBeVisible();
+
+        imagesPage = await imagesPage.pullImage(helloContainer);
+        await playExpect(imagesPage.heading).toBeVisible();
+
+        await playExpect
+          .poll(async () => await imagesPage.waitForImageExists(helloContainer, 15_000), { timeout: 0 })
+          .toBeTruthy();
+
+        const imageDetailsPage = await imagesPage.openImageDetails(helloContainer);
+        await playExpect(imageDetailsPage.heading).toBeVisible();
+
+        imagesPage = await imageDetailsPage.saveImage(tarFilePath);
+        await playExpect(imagesPage.heading).toBeVisible({ timeout: 60_000 });
+
+        const imageDetailsPageForDelete = await imagesPage.openImageDetails(helloContainer);
+        await playExpect(imageDetailsPageForDelete.heading).toBeVisible();
+
+        imagesPage = await imageDetailsPageForDelete.deleteImage();
+        await playExpect
+          .poll(async () => await imagesPage.waitForImageDelete(helloContainer, 60_000), { timeout: 0 })
+          .toBeTruthy();
+
+        await imagesPage.loadImages(tarFilePath);
+        await playExpect
+          .poll(async () => await imagesPage.waitForImageExists(helloContainer, 30_000), { timeout: 0 })
+          .toBeTruthy();
+      } finally {
+        rmSync(tarFilePath, { force: true });
+      }
     });
   });

--- a/tests/playwright/src/utility/dialog.ts
+++ b/tests/playwright/src/utility/dialog.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/playwright/src/utility/dialog.ts
+++ b/tests/playwright/src/utility/dialog.ts
@@ -1,0 +1,76 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ElectronApplication } from '@playwright/test';
+
+import { Runner } from '/@/runner/podman-desktop-runner';
+
+async function getElectronApp(): Promise<ElectronApplication> {
+  const runner = await Runner.getInstance();
+  return runner.getElectronApp();
+}
+
+/**
+ * Replaces `dialog.showOpenDialog` with a stub that resolves to the given paths,
+ * executes the supplied action, and restores the original in a `finally` block.
+ */
+export async function withMockedOpenFileDialog(filePaths: string[], action: () => Promise<void>): Promise<void> {
+  const electronApp = await getElectronApp();
+  await electronApp.evaluate(({ dialog }, paths) => {
+    const d = dialog as unknown as Record<string, unknown>;
+    d._origShowOpenDialog = dialog.showOpenDialog;
+    dialog.showOpenDialog = (() =>
+      Promise.resolve({ canceled: false, filePaths: paths })) as typeof dialog.showOpenDialog;
+  }, filePaths);
+  try {
+    await action();
+  } finally {
+    await electronApp.evaluate(({ dialog }) => {
+      const d = dialog as unknown as Record<string, unknown>;
+      if (d._origShowOpenDialog) {
+        dialog.showOpenDialog = d._origShowOpenDialog as typeof dialog.showOpenDialog;
+        delete d._origShowOpenDialog;
+      }
+    });
+  }
+}
+
+/**
+ * Replaces `dialog.showSaveDialog` with a stub that resolves to the given path,
+ * executes the supplied action, and restores the original in a `finally` block.
+ */
+export async function withMockedSaveFileDialog(savePath: string, action: () => Promise<void>): Promise<void> {
+  const electronApp = await getElectronApp();
+  await electronApp.evaluate(({ dialog }, path) => {
+    const d = dialog as unknown as Record<string, unknown>;
+    d._origShowSaveDialog = dialog.showSaveDialog;
+    dialog.showSaveDialog = (() =>
+      Promise.resolve({ canceled: false, filePath: path })) as typeof dialog.showSaveDialog;
+  }, savePath);
+  try {
+    await action();
+  } finally {
+    await electronApp.evaluate(({ dialog }) => {
+      const d = dialog as unknown as Record<string, unknown>;
+      if (d._origShowSaveDialog) {
+        dialog.showSaveDialog = d._origShowSaveDialog as typeof dialog.showSaveDialog;
+        delete d._origShowSaveDialog;
+      }
+    });
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Refactors several methods in the test framework that are used to select files/path to load/save files.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/7647
https://github.com/podman-desktop/podman-desktop/issues/13315