### PR TITLE
feat(ui): add prefers-reduced-motion support to Spinner

### DIFF
--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -39,4 +39,10 @@ let { size = '2em', class: className, style, label = 'Loading' }: Props = $props
       transform: rotate(1turn);
     }
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    g {
+      animation: none;
+    }
+  }
 </style>


### PR DESCRIPTION
### What does this PR do?

Add `@media` (prefers-reduced-motion: reduce) CSS rule to disable the spinner animation when users prefer reduced motion.

### Screenshot / video of UI

The spinner becomes static:

<img width="241" height="112" alt="Screenshot 2026-03-30 at 15 14 37" src="https://github.com/user-attachments/assets/5666c62c-5cb3-4f64-955f-cee9655a7b1c" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Resolves #15806

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
-> I did not find a way to add a UT for this

1. Verify spinner animates normally

- Run pnpm watch
- Trigger any spinner in the app (e.g. start/stop a Podman machine, or use the Storybook: pnpm --filter storybook dev)
- Confirm the spinner rotates with the same discrete 8-step animation as before
 
2. Verify reduced motion disables animation

- macOS: System Settings > Accessibility > Display > enable "Reduce motion"
- Linux (GNOME): gsettings set org.gnome.desktop.interface enable-animations false
- Chrome DevTools shortcut: open DevTools > Rendering tab (Press Cmd+Shift+P (or Ctrl+Shift+P) to open the Command Menu, type "Rendering", select Show Rendering) > check "Emulate CSS media feature prefers-reduced-motion: reduce"
<img width="304" height="112" alt="Screenshot 2026-03-30 at 15 40 39" src="https://github.com/user-attachments/assets/85bc74e3-e2e6-4bd9-bed0-2787967a265f" />

- With reduced motion enabled, confirm the spinner is static (no rotation)

