### PR TITLE
chore(e2e): remove unreliable xterm log validation/modify test skip condition

### DIFF
--- a/tests/playwright/src/model/pages/build-image-page.ts
+++ b/tests/playwright/src/model/pages/build-image-page.ts
@@ -80,7 +80,6 @@ export class BuildImagePage extends BasePage {
       await this.fillBuildImageForm(imageName, containerFilePath, contextDirectory, archType, target);
 
       await playExpect(this.doneButton).toBeEnabled({ timeout: timeout });
-      await this.validateBuildLogs();
       await this.doneButton.scrollIntoViewIfNeeded();
       await this.doneButton.click();
       console.log(`Image ${imageName} has been built successfully!`);
@@ -173,18 +172,6 @@ export class BuildImagePage extends BasePage {
     } else {
       await playExpect(this.archLessOptionsButton).toBeEnabled();
     }
-  }
-
-  async validateBuildLogs(): Promise<void> {
-    const logs = this.page.locator('.xterm-rows');
-    await playExpect(logs).toBeVisible();
-    const logRows = await logs.locator('div:has(span)').all();
-
-    await Promise.all(
-      logRows.map(async logRow => {
-        await playExpect.poll(async () => logRow.textContent()).not.toContain('Error');
-      }),
-    );
   }
 
   private async fillBuildImageForm(

--- a/tests/playwright/src/model/pages/build-image-page.ts
+++ b/tests/playwright/src/model/pages/build-image-page.ts
@@ -80,6 +80,7 @@ export class BuildImagePage extends BasePage {
       await this.fillBuildImageForm(imageName, containerFilePath, contextDirectory, archType, target);
 
       await playExpect(this.doneButton).toBeEnabled({ timeout: timeout });
+      await playExpect(this.terminalContent).toBeVisible();
       await this.doneButton.scrollIntoViewIfNeeded();
       await this.doneButton.click();
       console.log(`Image ${imageName} has been built successfully!`);

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -140,7 +140,7 @@ test.describe
       .serial('Image Manifest Validation - Complex Containerfile', () => {
         test.skip(
           isWindows && provider?.toLocaleLowerCase().trim() === 'wsl',
-          'Building cross-architecture images with the WSL hypervisor is not working yet',
+          'Complex Containerfile uses RUN steps that require executing foreign-arch binaries, which fails on WSL without QEMU emulation. Simple Containerfile only defines CMD metadata and succeeds.',
         );
 
         test('Add registry for manifest push', async ({ navigationBar, page }) => {

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,7 +139,7 @@ test.describe
     test.describe
       .serial('Image Manifest Validation - Complex Containerfile', () => {
         test.skip(
-          isWindows && provider?.toLocaleLowerCase().trim() === 'wsl',
+          () => isWindows && provider?.toLocaleLowerCase().trim() === 'wsl',
           'Complex Containerfile uses RUN steps that require executing foreign-arch binaries, which fails on WSL without QEMU emulation. Simple Containerfile only defines CMD metadata and succeeds.',
         );
 

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -42,7 +42,6 @@ const manifestLabelSimple: string = `localhost/${imageNameSimple}`;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 let imagesPage: ImagesPage;
-let skipTests = false;
 
 let provider: string | undefined;
 
@@ -139,6 +138,11 @@ test.describe
       });
     test.describe
       .serial('Image Manifest Validation - Complex Containerfile', () => {
+        test.skip(
+          isWindows && provider?.toLocaleLowerCase().trim() === 'wsl',
+          'Building cross-architecture images with the WSL hypervisor is not working yet',
+        );
+
         test('Add registry for manifest push', async ({ navigationBar, page }) => {
           test.skip(!canTestRegistry(), 'Registry tests are disabled');
 
@@ -154,7 +158,7 @@ test.describe
           await playExpect(username).toBeVisible();
         });
 
-        test('Build the image using cross-arch build (complex)', async ({ page, navigationBar }) => {
+        test('Build the image using cross-arch build (complex)', async ({ navigationBar }) => {
           test.setTimeout(180_000);
 
           imagesPage = await navigationBar.openImages();
@@ -163,6 +167,7 @@ test.describe
 
           const buildImagePage = await imagesPage.openBuildImage();
           await playExpect(buildImagePage.heading).toBeVisible();
+
           const dockerfilePath = path.resolve(
             __dirname,
             '..',
@@ -173,21 +178,12 @@ test.describe
           );
           const contextDirectory = path.resolve(__dirname, '..', '..', 'resources', 'alphine-hello');
 
-          try {
-            imagesPage = await buildImagePage.buildImage(
-              manifestLabelComplex,
-              dockerfilePath,
-              contextDirectory,
-              architectures,
-            );
-          } catch (error) {
-            skipTests = true;
-            await deleteImageManifest(page, manifestLabelComplex);
-            if (!!isWindows && provider?.toLocaleLowerCase().trim() === 'wsl') {
-              test.skip(true, 'Building cross-architecture images with the WSL hypervisor is not working yet');
-            }
-            throw error;
-          }
+          imagesPage = await buildImagePage.buildImage(
+            manifestLabelComplex,
+            dockerfilePath,
+            contextDirectory,
+            architectures,
+          );
 
           await playExpect
             .poll(async () => await imagesPage.waitForImageExists(manifestLabelComplex, 60_000), { timeout: 0 })
@@ -198,8 +194,6 @@ test.describe
         });
 
         test('Check Manifest details', async ({ navigationBar }) => {
-          test.skip(skipTests, 'Build manifest failed, manifest should be already deleted, skipping the test');
-
           imagesPage = await navigationBar.openImages();
           await playExpect(imagesPage.heading).toBeVisible();
 
@@ -215,7 +209,6 @@ test.describe
 
         test('Push manifest to registry', async ({ navigationBar }) => {
           test.skip(!canTestRegistry(), 'Registry tests are disabled');
-          test.skip(skipTests, 'Build manifest failed, skipping the test');
           test.setTimeout(150_000);
 
           imagesPage = await navigationBar.openImages();
@@ -239,7 +232,6 @@ test.describe
         });
 
         test('Delete Manifest', async ({ page }) => {
-          test.skip(skipTests, 'Build manifest failed, manifest should be already deleted, skipping the test');
           test.setTimeout(180_000);
           await deleteImageManifest(page, manifestLabelComplex);
         });


### PR DESCRIPTION
### What this PR does

Removes `validateBuildLogs()` from `BuildImagePage`. The method attempted to detect failures by scanning `.xterm-rows` for `"Error"`, but xterm.js only renders the visible viewport, so any errors that scroll out of view aren’t in the DOM and could be missed. On top of that, error messages don’t always follow a consistent format, the check assumed a specific string, which wouldn’t catch differently worded failures from other build steps or container engines.

Other approaches were considered but proved unreliable: checking for `"Successfully built"` can give a false sense of success—each platform (when building the manifest) prints its own message, and with long manifest logs, not all of them may be visible at once. Reading the xterm buffer via `page.evaluate()` depends on the private `_xterm` property, which is fragile and could break on any xterm upgrade.

So let’s stick with a simpler build verification: confirming that the built image appears on the images page along with the expected row count. If a build fails, the image never appears and the test fails clearly at that point.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/16636

