### PR TITLE
chore(e2e): move manifest push scenario to simple containerfile block

### DIFF
--- a/tests/playwright/src/model/pages/images-page.ts
+++ b/tests/playwright/src/model/pages/images-page.ts
@@ -279,6 +279,16 @@ export class ImagesPage extends MainPage {
     });
   }
 
+  async getImageArch(name: string): Promise<string> {
+    return test.step(`Get architecture for image: ${name}`, async () => {
+      const imageRow = await this.getImageRowByName(name);
+      if (imageRow === undefined) {
+        throw Error(`Image: '${name}' does not exist`);
+      }
+      return (await imageRow.getByRole('cell').nth(7).innerText()).trim().toLowerCase();
+    });
+  }
+
   async getAllImageBadges(name: string): Promise<string[]> {
     return test.step(`Get all badges for image: ${name}`, async () => {
       const locators = await this.getAllBadgeLocators(name);

--- a/tests/playwright/src/model/pages/images-page.ts
+++ b/tests/playwright/src/model/pages/images-page.ts
@@ -259,7 +259,7 @@ export class ImagesPage extends MainPage {
     await handleConfirmationDialog(this.page, 'Delete Manifest?', true, 'Delete');
   }
 
-  async pushManifest(manifestName: string): Promise<void> {
+  async pushManifest(manifestName: string, timeout = 120_000): Promise<void> {
     return test.step(`Push manifest: ${manifestName}`, async () => {
       const manifest = await this.getImageRowByName(manifestName);
       if (!manifest) {
@@ -275,7 +275,7 @@ export class ImagesPage extends MainPage {
       await playExpect(pushManifestButton).toBeVisible();
       await pushManifestButton.click();
 
-      await handleConfirmationDialog(this.page, 'Push manifest', true, 'Push manifest', '', 120_000, true);
+      await handleConfirmationDialog(this.page, 'Push manifest', true, 'Push manifest', '', timeout, true);
     });
   }
 

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -105,7 +105,7 @@ test.describe
           const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
 
           imagesPage = await buildImagePage.buildImage(
-            imageNameSimple,
+            manifestLabelSimple,
             dockerfilePath,
             contextDirectory,
             architectures,

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -30,8 +30,8 @@ import { SettingsBar } from '/@/model/pages/settings-bar';
 import { NavigationBar } from '/@/model/workbench/navigation';
 import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
 import { expect as playExpect, test } from '/@/utility/fixtures';
-import { deleteRegistry, ensureNoImagesPresentCLI } from '/@/utility/operations';
-import { isWindows } from '/@/utility/platform';
+import { deleteImage, deleteRegistry, ensureNoImagesPresentCLI } from '/@/utility/operations';
+import { archType, isWindows } from '/@/utility/platform';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const architectures: string[] = [ArchitectureType.AMD64, ArchitectureType.ARM64];
@@ -175,6 +175,11 @@ test.describe
           await playExpect
             .poll(async () => await imagesPage.waitForImageExists(manifestLabelSimple, 15_000), { timeout: 0 })
             .toBeTruthy();
+
+          const expectedArch = archType === 'arm64' ? ArchitectureType.ARM64 : ArchitectureType.AMD64;
+          const imageDetailsPage = await imagesPage.openImageDetails(manifestLabelSimple);
+          await playExpect(imageDetailsPage.tabContent).toContainText(expectedArch);
+          await imageDetailsPage.backLink.click();
         });
 
         test('Remove registry after manifest push', async ({ page, navigationBar }) => {
@@ -193,7 +198,13 @@ test.describe
 
         test('Delete Manifest', async ({ page }) => {
           test.setTimeout(120_000);
-          await deleteImageManifest(page, manifestLabelSimple);
+          if (canTestRegistry()) {
+            // Verify test pulled the manifest back as a single-platform image,
+            // so it's a regular image now — not a manifest.
+            await deleteImage(page, manifestLabelSimple);
+          } else {
+            await deleteImageManifest(page, manifestLabelSimple);
+          }
         });
       });
     test.describe

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -37,7 +37,7 @@ import { waitForPodmanMachineStartup } from '/@/utility/wait';
 const architectures: string[] = [ArchitectureType.AMD64, ArchitectureType.ARM64];
 const imageNameSimple: string = 'manifest-test-simple';
 const imageNameComplex: string = 'manifest-test-complex';
-const manifestLabelSimple: string = `localhost/${imageNameSimple}`;
+let manifestLabelSimple: string;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,7 +48,7 @@ let provider: string | undefined;
 let registryUrl: string;
 let registryUsername: string;
 let registryPswdSecret: string;
-let manifestLabelComplex: string;
+const manifestLabelComplex: string = `localhost/${imageNameComplex}`;
 
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(180_000);
@@ -65,13 +65,10 @@ test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
 
   [registryUrl, registryUsername, registryPswdSecret] = setupRegistry();
 
-  // Determine manifest name based on whether registry tests are enabled
-  // If registry tests are enabled, use the full registry path; otherwise use localhost
-  if (canTestRegistry()) {
-    manifestLabelComplex = `${registryUrl}/${registryUsername}/${imageNameComplex}`;
-  } else {
-    manifestLabelComplex = `localhost/${imageNameComplex}`;
-  }
+  // Simple manifest uses the full registry path when registry tests are enabled (it gets pushed)
+  manifestLabelSimple = canTestRegistry()
+    ? `${registryUrl}/${registryUsername}/${imageNameSimple}`
+    : `localhost/${imageNameSimple}`;
 
   await deleteRegistry(page, 'GitHub').catch((error: unknown) => {
     console.log('Error deleting registry:', error);
@@ -95,9 +92,10 @@ test.describe
   .serial('Image Manifest E2E Validation', { tag: '@smoke' }, () => {
     test.describe
       .serial('Image Manifest Validation - Simple Containerfile', () => {
-        test('Build the image using cross-arch build (simple )', async () => {
+        test('Build the image using cross-arch build (simple)', async ({ navigationBar }) => {
           test.setTimeout(120_000);
 
+          imagesPage = await navigationBar.openImages();
           await playExpect(imagesPage.heading).toBeVisible();
           const alreadyPresentImagesCount = await imagesPage.countRowsFromTable();
 
@@ -113,7 +111,7 @@ test.describe
             architectures,
           );
           await playExpect
-            .poll(async () => imagesPage.waitForImageExists(manifestLabelSimple, 60_000), { timeout: 0 })
+            .poll(async () => await imagesPage.waitForImageExists(manifestLabelSimple, 60_000), { timeout: 0 })
             .toBeTruthy();
           await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 4);
           await imagesPage.toggleImageManifest(manifestLabelSimple);
@@ -131,17 +129,6 @@ test.describe
           await playExpect(imageDetailsPage.backLink).toBeVisible();
           await imageDetailsPage.backLink.click();
         });
-        test('Delete Manifest', async ({ page }) => {
-          test.setTimeout(180_000);
-          await deleteImageManifest(page, manifestLabelSimple);
-        });
-      });
-    test.describe
-      .serial('Image Manifest Validation - Complex Containerfile', () => {
-        test.skip(
-          () => isWindows && provider?.toLocaleLowerCase().trim() === 'wsl',
-          'Complex Containerfile uses RUN steps that require executing foreign-arch binaries, which fails on WSL without QEMU emulation. Simple Containerfile only defines CMD metadata and succeeds.',
-        );
 
         test('Add registry for manifest push', async ({ navigationBar, page }) => {
           test.skip(!canTestRegistry(), 'Registry tests are disabled');
@@ -158,6 +145,63 @@ test.describe
           await playExpect(username).toBeVisible();
         });
 
+        test('Push manifest to registry', async ({ navigationBar }) => {
+          test.skip(!canTestRegistry(), 'Registry tests are disabled');
+          test.setTimeout(120_000);
+
+          imagesPage = await navigationBar.openImages();
+          await playExpect(imagesPage.heading).toBeVisible();
+          try {
+            await imagesPage.pushManifest(manifestLabelSimple);
+          } catch (error: unknown) {
+            // On CI, the push dialog interaction can fail for small images.
+            // Push still completes; next test verifies by pulling from registry.
+            console.log('Push manifest dialog interaction failed:', error);
+          }
+        });
+
+        test('Verify manifest was pushed to registry', async ({ page, navigationBar }) => {
+          test.skip(!canTestRegistry(), 'Registry tests are disabled');
+          test.setTimeout(120_000);
+
+          await deleteImageManifest(page, manifestLabelSimple);
+
+          imagesPage = await navigationBar.openImages();
+          await playExpect(imagesPage.heading).toBeVisible();
+
+          const pullImagePage = await imagesPage.openPullImage();
+          imagesPage = await pullImagePage.pullImage(manifestLabelSimple);
+          await playExpect(imagesPage.heading).toBeVisible();
+          await playExpect
+            .poll(async () => await imagesPage.waitForImageExists(manifestLabelSimple, 15_000), { timeout: 0 })
+            .toBeTruthy();
+        });
+
+        test('Remove registry after manifest push', async ({ page, navigationBar }) => {
+          test.skip(!canTestRegistry(), 'Registry tests are disabled');
+
+          await navigationBar.openSettings();
+          const settingsBar = new SettingsBar(page);
+          const registryPage = await settingsBar.openTabPage(RegistriesPage);
+          await playExpect(registryPage.heading).toBeVisible();
+
+          await registryPage.removeRegistry('GitHub');
+          const registryBox = registryPage.registriesTable.getByLabel('GitHub');
+          const username = registryBox.getByText(registryUsername);
+          await playExpect(username).toBeHidden();
+        });
+
+        test('Delete Manifest', async ({ page }) => {
+          test.setTimeout(120_000);
+          await deleteImageManifest(page, manifestLabelSimple);
+        });
+      });
+    test.describe
+      .serial('Image Manifest Validation - Complex Containerfile', () => {
+        test.skip(
+          () => isWindows && provider?.toLocaleLowerCase().trim() === 'wsl',
+          'Complex Containerfile uses RUN steps that require executing foreign-arch binaries, which fails on WSL without QEMU emulation. Simple Containerfile only defines CMD metadata and succeeds.',
+        );
         test('Build the image using cross-arch build (complex)', async ({ navigationBar }) => {
           test.setTimeout(180_000);
 
@@ -205,30 +249,6 @@ test.describe
           );
           await playExpect(imageDetailsPage.backLink).toBeVisible();
           await imageDetailsPage.backLink.click();
-        });
-
-        test('Push manifest to registry', async ({ navigationBar }) => {
-          test.skip(!canTestRegistry(), 'Registry tests are disabled');
-          test.setTimeout(150_000);
-
-          imagesPage = await navigationBar.openImages();
-          await playExpect(imagesPage.heading).toBeVisible();
-
-          await imagesPage.pushManifest(manifestLabelComplex);
-        });
-
-        test('Remove registry after manifest push', async ({ page, navigationBar }) => {
-          test.skip(!canTestRegistry(), 'Registry tests are disabled');
-
-          await navigationBar.openSettings();
-          const settingsBar = new SettingsBar(page);
-          const registryPage = await settingsBar.openTabPage(RegistriesPage);
-          await playExpect(registryPage.heading).toBeVisible();
-
-          await registryPage.removeRegistry('GitHub');
-          const registryBox = registryPage.registriesTable.getByLabel('GitHub');
-          const username = registryBox.getByText(registryUsername);
-          await playExpect(username).toBeHidden();
         });
 
         test('Delete Manifest', async ({ page }) => {

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -176,10 +176,9 @@ test.describe
             .poll(async () => await imagesPage.waitForImageExists(manifestLabelSimple, 15_000), { timeout: 0 })
             .toBeTruthy();
 
+          // Pull resolves the manifest to the host platform — verify via the ARCH column
           const expectedArch = archType === 'arm64' ? ArchitectureType.ARM64 : ArchitectureType.AMD64;
-          const imageDetailsPage = await imagesPage.openImageDetails(manifestLabelSimple);
-          await playExpect(imageDetailsPage.tabContent).toContainText(expectedArch);
-          await imageDetailsPage.backLink.click();
+          await playExpect.poll(async () => await imagesPage.getImageArch(manifestLabelSimple)).toBe(expectedArch);
         });
 
         test('Remove registry after manifest push', async ({ page, navigationBar }) => {

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -140,7 +140,7 @@ test.describe
 
           await registryPage.createRegistry(registryUrl, registryUsername, registryPswdSecret);
 
-          const registryBox = registryPage.registriesTable.getByLabel('GitHub');
+          const registryBox = await registryPage.getRegistryRowByName('GitHub');
           const username = registryBox.getByText(registryUsername);
           await playExpect(username).toBeVisible();
         });
@@ -190,7 +190,7 @@ test.describe
           await playExpect(registryPage.heading).toBeVisible();
 
           await registryPage.removeRegistry('GitHub');
-          const registryBox = registryPage.registriesTable.getByLabel('GitHub');
+          const registryBox = await registryPage.getRegistryRowByName('GitHub');
           const username = registryBox.getByText(registryUsername);
           await playExpect(username).toBeHidden();
         });

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -152,7 +152,7 @@ test.describe
           imagesPage = await navigationBar.openImages();
           await playExpect(imagesPage.heading).toBeVisible();
           try {
-            await imagesPage.pushManifest(manifestLabelSimple);
+            await imagesPage.pushManifest(manifestLabelSimple, 60_000);
           } catch (error: unknown) {
             // On CI, the push dialog interaction can fail for small images.
             // Push still completes; next test verifies by pulling from registry.


### PR DESCRIPTION
### What does this PR do?
moves the push scenario into the Simple Containerfile block, which builds reliably on all platforms, including WSL.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/16891
https://github.com/podman-desktop/podman-desktop/issues/16636

### How to test this PR?

https://github.com/podman-desktop/e2e/actions/runs/25674410174
