### PR TITLE
fix: openExternal command to use security handler

### DIFF
--- a/packages/main/src/plugin/commands-init.spec.ts
+++ b/packages/main/src/plugin/commands-init.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/commands-init.spec.ts
+++ b/packages/main/src/plugin/commands-init.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { assert, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { securityRestrictionCurrentHandler } from '/@/security-restrictions-handler.js';
 
@@ -118,8 +118,8 @@ describe('CommandsInit', () => {
 
     beforeEach(() => {
       const call = vi.mocked(commandRegistryMock.registerCommand).mock.calls.find(c => c[0] === 'openExternal');
-      expect(call).toBeDefined();
-      openExternalCallback = call![1] as typeof openExternalCallback;
+      assert(call);
+      openExternalCallback = call[1] as typeof openExternalCallback;
     });
 
     test('should route through securityRestrictionCurrentHandler', async () => {

--- a/packages/main/src/plugin/commands-init.spec.ts
+++ b/packages/main/src/plugin/commands-init.spec.ts
@@ -19,6 +19,8 @@
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { securityRestrictionCurrentHandler } from '/@/security-restrictions-handler.js';
+
 import type { CommandRegistry } from './command-registry.js';
 import { CommandsInit } from './commands-init.js';
 import type { ContainerProviderRegistry } from './container-registry.js';
@@ -109,5 +111,52 @@ describe('CommandsInit', () => {
 
   test('should register the openExternal command', () => {
     expect(commandRegistryMock.registerCommand).toBeCalledWith('openExternal', expect.anything());
+  });
+
+  describe('openExternal command', () => {
+    let openExternalCallback: (arg: { toString: () => string } | undefined) => Promise<void>;
+
+    beforeEach(() => {
+      const call = vi.mocked(commandRegistryMock.registerCommand).mock.calls.find(c => c[0] === 'openExternal');
+      expect(call).toBeDefined();
+      openExternalCallback = call![1] as typeof openExternalCallback;
+    });
+
+    test('should route through securityRestrictionCurrentHandler', async () => {
+      const handlerMock = vi.fn().mockResolvedValue(true);
+      securityRestrictionCurrentHandler.handler = handlerMock;
+
+      const uri = { toString: (): string => 'https://example.com' };
+      await openExternalCallback(uri);
+
+      expect(handlerMock).toHaveBeenCalledWith('https://example.com');
+    });
+
+    test('should not throw when handler is undefined', async () => {
+      securityRestrictionCurrentHandler.handler = undefined;
+
+      const uri = { toString: (): string => 'https://example.com' };
+      await expect(openExternalCallback(uri)).resolves.toBeUndefined();
+    });
+
+    test('should do nothing when arg is falsy', async () => {
+      const handlerMock = vi.fn().mockResolvedValue(true);
+      securityRestrictionCurrentHandler.handler = handlerMock;
+
+      await openExternalCallback(undefined);
+
+      expect(handlerMock).not.toHaveBeenCalled();
+    });
+
+    test('should log error when handler rejects', async () => {
+      const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const error = new Error('handler failed');
+      securityRestrictionCurrentHandler.handler = vi.fn().mockRejectedValue(error);
+
+      const uri = { toString: (): string => 'https://example.com' };
+      await openExternalCallback(uri);
+
+      expect(consoleErrorMock).toHaveBeenCalledWith('Unable to open external link https://example.com', error);
+    });
   });
 });

--- a/packages/main/src/plugin/commands-init.spec.ts
+++ b/packages/main/src/plugin/commands-init.spec.ts
@@ -148,15 +148,15 @@ describe('CommandsInit', () => {
       expect(handlerMock).not.toHaveBeenCalled();
     });
 
-    test('should log error when handler rejects', async () => {
+    test('should log and rethrow when handler rejects', async () => {
       const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const error = new Error('handler failed');
-      securityRestrictionCurrentHandler.handler = vi.fn().mockRejectedValue(error);
+      const cause = new Error('handler failed');
+      securityRestrictionCurrentHandler.handler = vi.fn().mockRejectedValue(cause);
 
       const uri = { toString: (): string => 'https://example.com' };
-      await openExternalCallback(uri);
+      await expect(openExternalCallback(uri)).rejects.toThrow('Unable to open external link https://example.com');
 
-      expect(consoleErrorMock).toHaveBeenCalledWith('Unable to open external link https://example.com', error);
+      expect(consoleErrorMock).toHaveBeenCalledWith('Unable to open external link https://example.com', cause);
     });
   });
 });

--- a/packages/main/src/plugin/commands-init.ts
+++ b/packages/main/src/plugin/commands-init.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/commands-init.ts
+++ b/packages/main/src/plugin/commands-init.ts
@@ -122,10 +122,11 @@ export class CommandsInit implements IDisposable {
     this.#disposables.push(
       commandRegistry.registerCommand('openExternal', async (arg: Uri) => {
         if (arg) {
+          const url = arg.toString();
           try {
-            await securityRestrictionCurrentHandler.handler?.(arg.toString());
+            await securityRestrictionCurrentHandler.handler?.(url);
           } catch (error: unknown) {
-            const message = `Unable to open external link ${arg.toString()}`;
+            const message = `Unable to open external link ${url}`;
             console.error(message, error);
             throw new Error(message, { cause: error });
           }

--- a/packages/main/src/plugin/commands-init.ts
+++ b/packages/main/src/plugin/commands-init.ts
@@ -125,7 +125,9 @@ export class CommandsInit implements IDisposable {
           try {
             await securityRestrictionCurrentHandler.handler?.(arg.toString());
           } catch (error: unknown) {
-            console.error(`Unable to open external link ${arg.toString()}`, error);
+            const message = `Unable to open external link ${arg.toString()}`;
+            console.error(message, error);
+            throw new Error(message, { cause: error });
           }
         }
       }),

--- a/packages/main/src/plugin/commands-init.ts
+++ b/packages/main/src/plugin/commands-init.ts
@@ -24,8 +24,9 @@ import type {
   PullEvent,
 } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
-import { shell } from 'electron';
 import { inject, injectable } from 'inversify';
+
+import { securityRestrictionCurrentHandler } from '/@/security-restrictions-handler.js';
 
 import { CommandRegistry } from './command-registry.js';
 import { ContainerProviderRegistry } from './container-registry.js';
@@ -121,7 +122,11 @@ export class CommandsInit implements IDisposable {
     this.#disposables.push(
       commandRegistry.registerCommand('openExternal', async (arg: Uri) => {
         if (arg) {
-          await shell.openExternal(arg.toString());
+          try {
+            await securityRestrictionCurrentHandler.handler?.(arg.toString());
+          } catch (error: unknown) {
+            console.error(`Unable to open external link ${arg.toString()}`, error);
+          }
         }
       }),
     );


### PR DESCRIPTION
### What does this PR do?

The openExternal command was calling Electron's shell.openExternal() directly, bypassing the security restriction handler that validates URLs and prompts the user before opening unknown domains. The fix routes it through securityRestrictionCurrentHandler instead, consistent with how env.openExternal() in the extension API already works.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #16421.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
