### PR TITLE
feat(test): add text check in PodCreateFromContainers.spec.ts

### DIFF
--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -261,6 +261,7 @@ test('Show warning if multiple containers use the same port', async () => {
   render(PodCreateFromContainers, {});
   const warningLabel = await screen.findByRole('alert');
   expect(warningLabel).toBeInTheDocument();
+  expect(warningLabel).toHaveTextContent('Containers cont_1 and cont_1 use same port 80');
 });
 
 test('Do not show warning if multiple containers use different ports', async () => {


### PR DESCRIPTION
### What does this PR do?
The test present in [PodCreateFromContainers.spec.ts](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts#L262) only checks for warning component to be present in the document.
This PR extends the test, to check for the warning message to be present in the warning component.

### Screenshot / video of UI
none
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
closes #16903 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
`pnpm test:renderer`

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
