### PR TITLE
feat(podman): use detached mode for machine autostart [WIP]

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -957,6 +957,54 @@ test('if a machine failed to start with a wsl distro not found error but the ski
   expect(console.error).toBeCalled();
 });
 
+test('autostart uses detached mode with logFile', async () => {
+  const fakeStoragePath = '/fake/storage/path';
+  extension.initExtensionContext({
+    subscriptions: [],
+    storagePath: fakeStoragePath,
+  } as unknown as extensionApi.ExtensionContext);
+
+  vi.spyOn(provider, 'updateStatus').mockImplementation(() => {});
+  vi.mocked(fs.mkdirSync).mockReturnValue(undefined);
+
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+
+  await extension.startMachine(provider, podmanConfiguration, machineInfo, undefined, undefined, undefined, true);
+
+  expect(fs.mkdirSync).toHaveBeenCalledWith(fakeStoragePath, { recursive: true });
+  expect(spyExecPromise).toHaveBeenCalledWith(
+    podmanCli.getPodmanCli(),
+    ['machine', 'start', 'name'],
+    expect.objectContaining({
+      detached: { logFile: `${fakeStoragePath}/machine-start-name.log` },
+    }),
+  );
+});
+
+test('manual start does not use detached mode', async () => {
+  vi.spyOn(provider, 'updateStatus').mockImplementation(() => {});
+
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+
+  await extension.startMachine(provider, podmanConfiguration, machineInfo);
+
+  expect(spyExecPromise).toHaveBeenCalledWith(
+    podmanCli.getPodmanCli(),
+    ['machine', 'start', 'name'],
+    expect.not.objectContaining({ detached: expect.anything() }),
+  );
+});
+
+test('getMachineStartLogPath returns correct path when extension context is set', () => {
+  extension.initExtensionContext({
+    subscriptions: [],
+    storagePath: '/test/storage',
+  } as unknown as extensionApi.ExtensionContext);
+
+  const result = extension.getMachineStartLogPath('my-machine');
+  expect(result).toBe('/test/storage/machine-start-my-machine.log');
+});
+
 test('test checkDefaultMachine - if there is no machine marked as default, take the default system connection to retrieve it. Prompt as it is not running', async () => {
   // Create fake of MachineJSON
   const fakeJSON: MachineJSON[] = fakeMachineJSON;

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -857,6 +857,13 @@ export async function registerProviderFor(
   storedExtensionContext?.subscriptions.push(disposable);
 }
 
+export function getMachineStartLogPath(machineName: string): string | undefined {
+  if (!storedExtensionContext) {
+    return undefined;
+  }
+  return path.join(storedExtensionContext.storagePath, `machine-start-${machineName}.log`);
+}
+
 export async function startMachine(
   provider: extensionApi.Provider,
   podmanConfiguration: PodmanConfiguration,
@@ -873,10 +880,19 @@ export async function startMachine(
   await checkRosettaMacArm(podmanConfiguration);
 
   try {
-    // start the machine
-    await execPodman(['machine', 'start', machineInfo.name], machineInfo.vmType, {
+    const runOptions: extensionApi.RunOptions = {
       logger: new LoggerDelegator(context, logger),
-    });
+    };
+
+    if (autoStart) {
+      const logFile = getMachineStartLogPath(machineInfo.name);
+      if (logFile) {
+        fs.mkdirSync(path.dirname(logFile), { recursive: true });
+      }
+      runOptions.detached = { logFile };
+    }
+
+    await execPodman(['machine', 'start', machineInfo.name], machineInfo.vmType, runOptions);
     provider.updateStatus('started');
   } catch (err) {
     telemetryRecords.error = err;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4547,11 +4547,15 @@ declare module '@podman-desktop/api' {
     encoding?: BufferEncoding;
 
     /**
-     * If true, the child process will be detached from the parent and its stdio
-     * will be disconnected. The process will continue running independently even
-     * if Podman Desktop exits. Stdout/stderr will not be captured.
+     * If set, the child process will be detached from the parent and will
+     * continue running independently even if Podman Desktop exits.
+     *
+     * @property logFile - Path to a file where stdout and stderr will be
+     * appended. When omitted, stdio is discarded.
      */
-    detached?: boolean;
+    detached?: {
+      logFile?: string;
+    };
   }
 
   /**

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -18,6 +18,7 @@
 
 import type { ChildProcess, ChildProcessWithoutNullStreams } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import { open } from 'node:fs/promises';
 import { homedir, platform } from 'node:os';
 import { delimiter, join } from 'node:path';
 import type { Readable } from 'node:stream';
@@ -39,6 +40,8 @@ vi.mock(import('@expo/sudo-prompt'), async () => {
 });
 
 vi.mock(import('/@/util.js'));
+
+vi.mock(import('node:fs/promises'));
 
 vi.mock('child_process', () => {
   return {
@@ -539,9 +542,9 @@ describe('exec', () => {
     const args = ['--background'];
     const { spawnMock, unrefMock } = mockDetachedProcess('close', 0);
 
-    const result = await exec.exec(command, args, { detached: true, cwd });
+    const result = await exec.exec(command, args, { detached: {}, cwd });
 
-    const expectedOpts: Record<string, unknown> = { detached: true, stdio: 'ignore' };
+    const expectedOpts: Record<string, unknown> = { detached: true, stdio: ['ignore'] };
     if (cwd) expectedOpts['cwd'] = cwd;
     expect(spawnMock).toHaveBeenCalledWith(command, args, expect.objectContaining(expectedOpts));
     expect(unrefMock).toHaveBeenCalled();
@@ -564,10 +567,31 @@ describe('exec', () => {
   ])('should reject when detached process emits $description', async ({ event, eventArg, expectedError }) => {
     mockDetachedProcess(event, eventArg);
 
-    const execResult = exec.exec('failing-command', [], { detached: true });
+    const execResult = exec.exec('failing-command', [], { detached: {} });
 
     await expect(execResult).rejects.toThrowError(expectedError);
     await expect(execResult).rejects.toThrowError(Error);
+  });
+
+  test('should spawn a detached process with logFile and redirect stdio to the file', async () => {
+    const logFilePath = '/tmp/detached.log';
+    const fakeFd = 42;
+    const closeMock = vi.fn();
+    vi.mocked(open).mockResolvedValue({ fd: fakeFd, close: closeMock } as unknown as Awaited<ReturnType<typeof open>>);
+
+    const { spawnMock, unrefMock } = mockDetachedProcess('close', 0);
+
+    const result = await exec.exec('my-daemon', ['--run'], { detached: { logFile: logFilePath } });
+
+    expect(open).toHaveBeenCalledWith(logFilePath, 'a');
+    expect(spawnMock).toHaveBeenCalledWith(
+      'my-daemon',
+      ['--run'],
+      expect.objectContaining({ detached: true, stdio: ['ignore', fakeFd, fakeFd] }),
+    );
+    expect(unrefMock).toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+    expect(result).toEqual({ command: 'my-daemon', stdout: '', stderr: '' });
   });
 
   test('should run the command and set specific encoding', async () => {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -16,8 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ChildProcess } from 'node:child_process';
+import type { ChildProcess, StdioOptions } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import type { FileHandle } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { delimiter, join } from 'node:path';
 
@@ -153,8 +155,24 @@ export class Exec {
     const cwd = options?.cwd;
 
     if (options?.detached) {
-      const childProcess = spawn(command, args ?? [], { env, cwd, detached: true, stdio: 'ignore' });
+      // If passed as an array, the first element is used for `stdin`, the second for `stdout`, and the third for `stderr`.
+      const stdio: StdioOptions = ['ignore'];
+      let fileHandle: FileHandle | undefined;
+
+      if (options.detached.logFile) {
+        fileHandle = await open(options.detached.logFile, 'a');
+        // Stdout and stderr are redirected to the log file
+        stdio.push(fileHandle.fd);
+        stdio.push(fileHandle.fd);
+      }
+
+      const childProcess = spawn(command, args ?? [], { env, cwd, detached: true, stdio });
       childProcess.unref();
+
+      // The child holds its own duplicate of the fd; closing the parent's
+      // copy just releases our reference — the child keeps writing.
+      await fileHandle?.close();
+
       return this.awaitChildProcess(childProcess, command, { stdout: '', stderr: '' });
     }
 


### PR DESCRIPTION
### What does this PR do?

When autostaring a podman machine, run `podman machine start` in detached mode so the process survives if Podman Desktop is closed before it finishes. Logs are written to the extension storage directory (`machine-start-<name>.log`) for later inspection.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Needs a rebase after:

- #16911 is merged
- #16910 is merged

Relates to https://github.com/podman-desktop/podman-desktop/issues/9670

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Enable autostart in the preferences of Podman extension.

Start Podman Desktop.
Check that the podman machine is running and logs (example MacOS path):

```zsh
srey@srey-mac podman-desktop % cat ~/.local/share/containers/podman-desktop/extensions-storage/podman-desktop.podman/machine-start-*.log
Starting machine "podman-machine-default"

This machine is currently configured in rootless mode. If your containers
require root permissions (e.g. ports < 1024), or if you run into compatibility
issues with non-podman clients, you can switch using the following command:

        podman machine set --rootful

API forwarding listening on: /var/run/docker.sock
Docker API clients default to this address. You do not need to set DOCKER_HOST.

Machine "podman-machine-default" started successfully
```

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
