### PR TITLE
feat(api): add logFile option for detached process execution

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4547,11 +4547,15 @@ declare module '@podman-desktop/api' {
     encoding?: BufferEncoding;
 
     /**
-     * If true, the child process will be detached from the parent and its stdio
-     * will be disconnected. The process will continue running independently even
-     * if Podman Desktop exits. Stdout/stderr will not be captured.
+     * If set, the child process will be detached from the parent and will
+     * continue running independently even if Podman Desktop exits.
+     *
+     * @property logFile - Path to a file where stdout and stderr will be
+     * appended. When omitted, stdio is discarded.
      */
-    detached?: boolean;
+    detached?: {
+      logFile?: string;
+    };
   }
 
   /**

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -18,6 +18,7 @@
 
 import type { ChildProcess, ChildProcessWithoutNullStreams } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import { open } from 'node:fs/promises';
 import { homedir, platform } from 'node:os';
 import { delimiter, join } from 'node:path';
 import type { Readable } from 'node:stream';
@@ -39,6 +40,8 @@ vi.mock(import('@expo/sudo-prompt'), async () => {
 });
 
 vi.mock(import('/@/util.js'));
+
+vi.mock(import('node:fs/promises'));
 
 vi.mock('child_process', () => {
   return {
@@ -539,9 +542,9 @@ describe('exec', () => {
     const args = ['--background'];
     const { spawnMock, unrefMock } = mockDetachedProcess('close', 0);
 
-    const result = await exec.exec(command, args, { detached: true, cwd });
+    const result = await exec.exec(command, args, { detached: {}, cwd });
 
-    const expectedOpts: Record<string, unknown> = { detached: true, stdio: 'ignore' };
+    const expectedOpts: Record<string, unknown> = { detached: true, stdio: ['ignore'] };
     if (cwd) expectedOpts['cwd'] = cwd;
     expect(spawnMock).toHaveBeenCalledWith(command, args, expect.objectContaining(expectedOpts));
     expect(unrefMock).toHaveBeenCalled();
@@ -564,10 +567,31 @@ describe('exec', () => {
   ])('should reject when detached process emits $description', async ({ event, eventArg, expectedError }) => {
     mockDetachedProcess(event, eventArg);
 
-    const execResult = exec.exec('failing-command', [], { detached: true });
+    const execResult = exec.exec('failing-command', [], { detached: {} });
 
     await expect(execResult).rejects.toThrowError(expectedError);
     await expect(execResult).rejects.toThrowError(Error);
+  });
+
+  test('should spawn a detached process with logFile and redirect stdio to the file', async () => {
+    const logFilePath = '/tmp/detached.log';
+    const fakeFd = 42;
+    const closeMock = vi.fn();
+    vi.mocked(open).mockResolvedValue({ fd: fakeFd, close: closeMock } as unknown as Awaited<ReturnType<typeof open>>);
+
+    const { spawnMock, unrefMock } = mockDetachedProcess('close', 0);
+
+    const result = await exec.exec('my-daemon', ['--run'], { detached: { logFile: logFilePath } });
+
+    expect(open).toHaveBeenCalledWith(logFilePath, 'a');
+    expect(spawnMock).toHaveBeenCalledWith(
+      'my-daemon',
+      ['--run'],
+      expect.objectContaining({ detached: true, stdio: ['ignore', fakeFd, fakeFd] }),
+    );
+    expect(unrefMock).toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+    expect(result).toEqual({ command: 'my-daemon', stdout: '', stderr: '' });
   });
 
   test('should run the command and set specific encoding', async () => {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -16,8 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ChildProcess } from 'node:child_process';
+import type { ChildProcess, StdioOptions } from 'node:child_process';
 import { spawn } from 'node:child_process';
+import type { FileHandle } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { delimiter, join } from 'node:path';
 
@@ -153,8 +155,24 @@ export class Exec {
     const cwd = options?.cwd;
 
     if (options?.detached) {
-      const childProcess = spawn(command, args ?? [], { env, cwd, detached: true, stdio: 'ignore' });
+      // If passed as an array, the first element is used for `stdin`, the second for `stdout`, and the third for `stderr`.
+      const stdio: StdioOptions = ['ignore'];
+      let fileHandle: FileHandle | undefined;
+
+      if (options.detached.logFile) {
+        fileHandle = await open(options.detached.logFile, 'a');
+        // Stdout and stderr are redirected to the log file
+        stdio.push(fileHandle.fd);
+        stdio.push(fileHandle.fd);
+      }
+
+      const childProcess = spawn(command, args ?? [], { env, cwd, detached: true, stdio });
       childProcess.unref();
+
+      // The child holds its own duplicate of the fd; closing the parent's
+      // copy just releases our reference — the child keeps writing.
+      await fileHandle?.close();
+
       return this.awaitChildProcess(childProcess, command, { stdout: '', stderr: '' });
     }
 


### PR DESCRIPTION
### What does this PR do?

When running a process in detached mode, stdout/stderr are discarded (`stdio: 'ignore'`). Add a `logFile` option to `RunOptions` that redirects both streams to a file (opened in append mode) so callers can capture output from long-running detached processes.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/9670 since we want to detach "podman machine start" (and stop) during autostart, but still have the logs somewhere.

Needs a rebase after:
- #16911 is merged

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

You can try this option in WIP PR https://github.com/podman-desktop/podman-desktop/pull/16909, see instructions there.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
