### PR TITLE
feat(storybook): add high contrast light and dark theme options

### DIFF
--- a/storybook/.storybook/main.css
+++ b/storybook/.storybook/main.css
@@ -15,6 +15,16 @@ body.dark {
   color: #fff;
 }
 
+body.hc-light {
+  background-color: #fff;
+  color: #000;
+}
+
+body.hc-dark {
+  background-color: #000;
+  color: #fff;
+}
+
 /* Docs page story preview containers */
 body.light .docs-story {
   background-color: #f6f6f6;
@@ -24,6 +34,14 @@ body.dark .docs-story {
   background-color: #222222;
 }
 
+body.hc-light .docs-story {
+  background-color: #fff;
+}
+
+body.hc-dark .docs-story {
+  background-color: #000;
+}
+
 /* Storybook's canvas background */
 body.light .sb-show-main {
   background-color: #f6f6f6;
@@ -31,4 +49,12 @@ body.light .sb-show-main {
 
 body.dark .sb-show-main {
   background-color: #222222;
+}
+
+body.hc-light .sb-show-main {
+  background-color: #fff;
+}
+
+body.hc-dark .sb-show-main {
+  background-color: #000;
 }

--- a/storybook/.storybook/preview.ts
+++ b/storybook/.storybook/preview.ts
@@ -35,6 +35,8 @@ const preview: Preview = {
       themes: {
         light: 'light',
         dark: 'dark',
+        'hc-light': 'hc-light',
+        'hc-dark': 'hc-dark',
       },
       defaultTheme: 'light',
       parentSelector: 'body',


### PR DESCRIPTION
### What does this PR do?

Register `hc-light` and `hc-dark` in the theme switcher toolbar and add matching body/docs-story/sb-show-main background styles.

The generated themes.css already contains the `@scope` blocks.

- Register `hc-light` and `hc-dark` in the Storybook theme switcher toolbar
- Add body, docs-story, and canvas background styles for both HC themes

### Screenshot / video of UI

<img width="1268" height="472" alt="CleanShot 2026-04-01 at 15 22 08@2x" src="https://github.com/user-attachments/assets/995386ad-c22b-40e2-951f-6f9109959756" />

### What issues does this PR fix or reference?

Resolves #16922

### How to test this PR?

1. Run `pnpm storybook:css && pnpm storybook:dev`
2. Open the theme switcher in the Storybook toolbar
3. Verify all four options appear: light, dark, hc-light, hc-dark
4. Switch to hc-light -- background should be white, text black
5. Switch to hc-dark -- background should be black, text white
6. Confirm components render with their HC color overrides in both themes

- [ ] Tests are covering the bug fix or the new feature

No new tests -- configuration-only change with no logic.

Co-Authored-By: Claude <noreply@anthropic.com>