### PR TITLE
fix(Roseta): fixed Roseta enablement on macOS Tahoe with Podman 5.6+

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -65,7 +65,7 @@ import type { UpdateCheck } from './installer/podman-install';
 import { PodmanInstall } from './installer/podman-install';
 import * as podmanCli from './utils/podman-cli';
 import type { PodmanConfiguration } from './utils/podman-configuration';
-import { needsRosettaEnableFile, provisionAndRestartForRosetta } from './utils/rosetta';
+import { RosettaProvisioner } from './utils/rosetta';
 import * as util from './utils/util';
 import { getAssetsFolder, LIBKRUN_LABEL, LoggerDelegator, VMTYPE } from './utils/util';
 import { isDisguisedPodman } from './utils/warnings';
@@ -194,6 +194,12 @@ const PODMAN_BINARY_MOCK: PodmanBinary = {
   getBinaryInfo: vi.fn(),
   invalidate: vi.fn(),
 } as unknown as PodmanBinary;
+const ROSETTA_PROVISIONER_MOCK: RosettaProvisioner = {
+  checkRosettaMacArm: vi.fn(),
+  needsRosettaEnableFile: vi.fn(),
+  enableRosettaInMachine: vi.fn(),
+  provisionAndRestartForRosetta: vi.fn(),
+} as unknown as RosettaProvisioner;
 
 beforeEach(async () => {
   fakeMachineJSON = [
@@ -268,6 +274,8 @@ beforeEach(async () => {
         return PODMAN_BINARY_MOCK;
       case PodmanProvider:
         return PODMAN_PROVIDER_MOCK;
+      case RosettaProvisioner:
+        return ROSETTA_PROVISIONER_MOCK;
     }
     throw new Error(`Unknown identifier ${String(identifier)}`);
   }
@@ -997,11 +1005,11 @@ describe('startMachine rosetta enable-file provisioning', () => {
   test('calls provisionAndRestartForRosetta after successful start', async () => {
     vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
     vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '5.7.0' } as InstalledPodman);
-    vi.mocked(provisionAndRestartForRosetta).mockResolvedValue(false);
+    vi.mocked(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).mockResolvedValue(false);
 
     await extension.startMachine(provider, podmanConfiguration, machineInfo);
 
-    expect(provisionAndRestartForRosetta).toHaveBeenCalledWith(
+    expect(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).toHaveBeenCalledWith(
       machineInfo.name,
       machineInfo.vmType,
       podmanConfiguration,
@@ -1014,7 +1022,7 @@ describe('startMachine rosetta enable-file provisioning', () => {
   test('does not report started when provisionAndRestartForRosetta throws (restart failed)', async () => {
     vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
     vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '5.7.0' } as InstalledPodman);
-    vi.mocked(provisionAndRestartForRosetta).mockRejectedValue(new Error('restart failed'));
+    vi.mocked(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).mockRejectedValue(new Error('restart failed'));
 
     await expect(
       extension.startMachine(provider, podmanConfiguration, machineInfo, undefined, undefined, true),
@@ -1029,7 +1037,7 @@ describe('startMachine rosetta enable-file provisioning', () => {
 
     await extension.startMachine(provider, podmanConfiguration, machineInfo);
 
-    expect(provisionAndRestartForRosetta).not.toHaveBeenCalled();
+    expect(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).not.toHaveBeenCalled();
     expect(provider.updateStatus).toHaveBeenCalledWith('started');
   });
 });
@@ -1049,14 +1057,14 @@ describe('createMachine rosetta enable-file provisioning', () => {
   });
 
   test('--now branch calls provisionAndRestartForRosetta', async () => {
-    vi.mocked(provisionAndRestartForRosetta).mockResolvedValue(false);
+    vi.mocked(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).mockResolvedValue(false);
 
     await extension.createMachine(
       { ...createMachineBaseParams, 'podman.factory.machine.now': true },
       podmanConfiguration,
     );
 
-    expect(provisionAndRestartForRosetta).toHaveBeenCalledWith(
+    expect(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).toHaveBeenCalledWith(
       'podman-machine-default',
       expect.any(String),
       podmanConfiguration,
@@ -1066,7 +1074,7 @@ describe('createMachine rosetta enable-file provisioning', () => {
   });
 
   test('--now branch catches error as warning', async () => {
-    vi.mocked(provisionAndRestartForRosetta).mockRejectedValue(new Error('rosetta ssh fail'));
+    vi.mocked(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).mockRejectedValue(new Error('rosetta ssh fail'));
 
     await extension.createMachine(
       { ...createMachineBaseParams, 'podman.factory.machine.now': true },
@@ -1079,16 +1087,20 @@ describe('createMachine rosetta enable-file provisioning', () => {
   });
 
   test('stopped branch calls needsRosettaEnableFile with vmType', async () => {
-    vi.mocked(needsRosettaEnableFile).mockResolvedValue(false);
+    vi.mocked(ROSETTA_PROVISIONER_MOCK.needsRosettaEnableFile).mockResolvedValue(false);
 
     await extension.createMachine(createMachineBaseParams, podmanConfiguration);
 
-    expect(needsRosettaEnableFile).toHaveBeenCalledWith(podmanConfiguration, '5.7.0', expect.any(String));
-    expect(provisionAndRestartForRosetta).not.toHaveBeenCalled();
+    expect(ROSETTA_PROVISIONER_MOCK.needsRosettaEnableFile).toHaveBeenCalledWith(
+      podmanConfiguration,
+      '5.7.0',
+      expect.any(String),
+    );
+    expect(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).not.toHaveBeenCalled();
   });
 
   test('stopped branch starts, touches file, then stops when setup is needed', async () => {
-    vi.mocked(needsRosettaEnableFile).mockResolvedValue(true);
+    vi.mocked(ROSETTA_PROVISIONER_MOCK.needsRosettaEnableFile).mockResolvedValue(true);
 
     await extension.createMachine(createMachineBaseParams, podmanConfiguration);
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -65,6 +65,7 @@ import type { UpdateCheck } from './installer/podman-install';
 import { PodmanInstall } from './installer/podman-install';
 import * as podmanCli from './utils/podman-cli';
 import type { PodmanConfiguration } from './utils/podman-configuration';
+import { needsRosettaEnableFile, provisionAndRestartForRosetta } from './utils/rosetta';
 import * as util from './utils/util';
 import { getAssetsFolder, LIBKRUN_LABEL, LoggerDelegator, VMTYPE } from './utils/util';
 import { isDisguisedPodman } from './utils/warnings';
@@ -281,6 +282,10 @@ beforeEach(async () => {
 
 const originalConsoleError = console.error;
 const consoleErrorMock = vi.fn();
+const originalConsoleWarn = console.warn;
+const consoleWarnMock = vi.fn();
+const originalConsoleTrace = console.trace;
+const consoleTraceMock = vi.fn();
 
 vi.mock(import('node:child_process'), async importOriginal => {
   const childProcessActual = await importOriginal();
@@ -307,6 +312,7 @@ vi.mock(import('./helpers/qemu-helper'));
 vi.mock(import('./helpers/krunkit-helper'));
 vi.mock(import('./helpers/podman-binary-location-helper'));
 vi.mock(import('./helpers/podman-info-helper'));
+vi.mock(import('./utils/rosetta'));
 
 vi.mock(import('./utils/util'), async importOriginal => {
   const original = await importOriginal();
@@ -320,6 +326,8 @@ vi.mock(import('./utils/util'), async importOriginal => {
 
 beforeEach(() => {
   console.error = consoleErrorMock;
+  console.warn = consoleWarnMock;
+  console.trace = consoleTraceMock;
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue(config);
   vi.mocked(extensionApi.env).isMac = false;
   vi.mocked(extensionApi.env).isLinux = false;
@@ -347,6 +355,8 @@ beforeEach(() => {
 
 afterEach(async () => {
   console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
+  console.trace = originalConsoleTrace;
   await extension.deactivate();
   vi.useRealTimers();
 });
@@ -977,6 +987,122 @@ test('if a machine failed to start with a wsl distro not found error but the ski
   ).rejects.toThrow('wsl bootstrap script failed: exit status 0xffffffff');
   expect(extensionApi.window.showInformationMessage).not.toHaveBeenCalled();
   expect(console.error).toBeCalled();
+});
+
+describe('startMachine rosetta enable-file provisioning', () => {
+  beforeEach(() => {
+    vi.spyOn(provider, 'updateStatus').mockImplementation(() => {});
+  });
+
+  test('calls provisionAndRestartForRosetta after successful start', async () => {
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '5.7.0' } as InstalledPodman);
+    vi.mocked(provisionAndRestartForRosetta).mockResolvedValue(false);
+
+    await extension.startMachine(provider, podmanConfiguration, machineInfo);
+
+    expect(provisionAndRestartForRosetta).toHaveBeenCalledWith(
+      machineInfo.name,
+      machineInfo.vmType,
+      podmanConfiguration,
+      '5.7.0',
+      expect.objectContaining({ logger: expect.anything() }),
+    );
+    expect(provider.updateStatus).toHaveBeenCalledWith('started');
+  });
+
+  test('does not report started when provisionAndRestartForRosetta throws (restart failed)', async () => {
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '5.7.0' } as InstalledPodman);
+    vi.mocked(provisionAndRestartForRosetta).mockRejectedValue(new Error('restart failed'));
+
+    await expect(
+      extension.startMachine(provider, podmanConfiguration, machineInfo, undefined, undefined, true),
+    ).rejects.toThrow('restart failed');
+
+    expect(provider.updateStatus).not.toHaveBeenCalledWith('started');
+  });
+
+  test('skips provisionAndRestartForRosetta when podman version is not available', async () => {
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue(undefined);
+
+    await extension.startMachine(provider, podmanConfiguration, machineInfo);
+
+    expect(provisionAndRestartForRosetta).not.toHaveBeenCalled();
+    expect(provider.updateStatus).toHaveBeenCalledWith('started');
+  });
+});
+
+describe('createMachine rosetta enable-file provisioning', () => {
+  const createMachineBaseParams = {
+    'podman.factory.machine.cpus': '2',
+    'podman.factory.machine.memory': '1048000000',
+    'podman.factory.machine.diskSize': '250000000000',
+    'podman.factory.machine.image': 'path',
+  };
+
+  beforeEach(() => {
+    vi.mocked(extensionApi.env).isMac = true;
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '5.7.0' } as InstalledPodman);
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+  });
+
+  test('--now branch calls provisionAndRestartForRosetta', async () => {
+    vi.mocked(provisionAndRestartForRosetta).mockResolvedValue(false);
+
+    await extension.createMachine(
+      { ...createMachineBaseParams, 'podman.factory.machine.now': true },
+      podmanConfiguration,
+    );
+
+    expect(provisionAndRestartForRosetta).toHaveBeenCalledWith(
+      'podman-machine-default',
+      expect.any(String),
+      podmanConfiguration,
+      '5.7.0',
+      expect.anything(),
+    );
+  });
+
+  test('--now branch catches error as warning', async () => {
+    vi.mocked(provisionAndRestartForRosetta).mockRejectedValue(new Error('rosetta ssh fail'));
+
+    await extension.createMachine(
+      { ...createMachineBaseParams, 'podman.factory.machine.now': true },
+      podmanConfiguration,
+    );
+
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to set up Rosetta enable file during machine creation: Error: rosetta ssh fail',
+    );
+  });
+
+  test('stopped branch calls needsRosettaEnableFile with vmType', async () => {
+    vi.mocked(needsRosettaEnableFile).mockResolvedValue(false);
+
+    await extension.createMachine(createMachineBaseParams, podmanConfiguration);
+
+    expect(needsRosettaEnableFile).toHaveBeenCalledWith(podmanConfiguration, '5.7.0', expect.any(String));
+    expect(provisionAndRestartForRosetta).not.toHaveBeenCalled();
+  });
+
+  test('stopped branch starts, touches file, then stops when setup is needed', async () => {
+    vi.mocked(needsRosettaEnableFile).mockResolvedValue(true);
+
+    await extension.createMachine(createMachineBaseParams, podmanConfiguration);
+
+    const execCalls = vi.mocked(extensionApi.process.exec).mock.calls;
+    const startCalls = execCalls.filter(c => (c[1] as string[]).includes('start'));
+    const stopCalls = execCalls.filter(c => (c[1] as string[]).includes('stop'));
+    const sshTouchCalls = execCalls.filter(
+      c => (c[1] as string[]).includes('ssh') && (c[1] as string[]).some(a => a.includes('enable-rosetta')),
+    );
+
+    expect(startCalls.length).toBeGreaterThanOrEqual(1);
+    expect(stopCalls.length).toBeGreaterThanOrEqual(1);
+    expect(sshTouchCalls.length).toBe(1);
+  });
 });
 
 test('test checkDefaultMachine - if there is no machine marked as default, take the default system connection to retrieve it. Prompt as it is not running', async () => {

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1065,7 +1065,7 @@ describe('createMachine rosetta enable-file provisioning', () => {
     );
 
     expect(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).toHaveBeenCalledWith(
-      'podman-machine-default',
+      '',
       expect.any(String),
       podmanConfiguration,
       '5.7.0',

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -71,7 +71,12 @@ import { getPodmanCli } from './utils/podman-cli';
 import { PodmanConfiguration } from './utils/podman-configuration';
 import { ProviderConnectionShellAccessImpl } from './utils/podman-machine-stream';
 import { RegistrySetup } from './utils/registry-setup';
-import { checkRosettaMacArm } from './utils/rosetta';
+import {
+  checkRosettaMacArm,
+  needsRosettaEnableFile,
+  provisionAndRestartForRosetta,
+  ROSETTA_ENABLE_FILE,
+} from './utils/rosetta';
 import {
   appConfigDir,
   appHomeDir,
@@ -883,6 +888,23 @@ export async function startMachine(
     }
 
     await execPodman(['machine', 'start', machineInfo.name], machineInfo.vmType, runOptions);
+
+    // Provision /etc/containers/enable-rosetta if needed (macOS Tahoe + AppleHV + Podman 5.6+).
+    // If the file was just created, restart the machine so the binfmt_misc handler registers.
+    // SSH/file-creation errors are caught inside provisionAndRestartForRosetta;
+    // stop/start errors propagate so the provider status stays accurate.
+    // https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
+    const podmanInstallation = await podmanBinary.getBinaryInfo();
+    if (podmanInstallation?.version) {
+      await provisionAndRestartForRosetta(
+        machineInfo.name,
+        machineInfo.vmType,
+        podmanConfiguration,
+        podmanInstallation.version,
+        { logger: new LoggerDelegator(context, logger) },
+      );
+    }
+
     provider.updateStatus('started');
   } catch (err) {
     telemetryRecords.error = err;
@@ -2134,7 +2156,9 @@ export async function createMachine(
   }
 
   // name at the end
+  let machineName = 'podman-machine-default';
   if (params['podman.factory.machine.name'] && typeof params['podman.factory.machine.name'] === 'string') {
+    machineName = params['podman.factory.machine.name'];
     parameters.push(params['podman.factory.machine.name']);
     telemetryRecords.customName = params['podman.factory.machine.name'];
     telemetryRecords.defaultName = false;
@@ -2178,6 +2202,31 @@ export async function createMachine(
     telemetryRecords.duration = endTime - startTime;
     sendTelemetryRecords('podman.machine.init', telemetryRecords, false);
   }
+  // On macOS Tahoe with AppleHV + Podman 5.6+, provision /etc/containers/enable-rosetta
+  // inside the VM as part of machine creation so Rosetta is active from first use.
+  // https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
+  if (extensionApi.env.isMac && version) {
+    try {
+      if (params['podman.factory.machine.now']) {
+        await provisionAndRestartForRosetta(machineName, provider, podmanConfiguration, version, { logger });
+      } else {
+        // Machine is stopped. Check conditions without SSH first; only start/stop
+        // the machine temporarily when actually needed.
+        const setupNeeded = await needsRosettaEnableFile(podmanConfiguration, version, provider);
+        if (setupNeeded) {
+          await execPodman(['machine', 'start', machineName], provider, { logger });
+          try {
+            await execPodman(['machine', 'ssh', machineName, `sudo touch ${ROSETTA_ENABLE_FILE}`], provider);
+          } finally {
+            await execPodman(['machine', 'stop', machineName], provider);
+          }
+        }
+      }
+    } catch (err) {
+      console.warn(`Failed to set up Rosetta enable file during machine creation: ${err}`);
+    }
+  }
+
   extensionApi.context.setValue('podmanMachineExists', true, 'onboarding');
   extensionNotifications.disposeNotification();
 }

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -2153,7 +2153,7 @@ export async function createMachine(
   }
 
   // name at the end
-  let machineName = 'podman-machine-default';
+  let machineName = '';
   if (params['podman.factory.machine.name'] && typeof params['podman.factory.machine.name'] === 'string') {
     machineName = params['podman.factory.machine.name'];
     parameters.push(params['podman.factory.machine.name']);

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -71,12 +71,7 @@ import { getPodmanCli } from './utils/podman-cli';
 import { PodmanConfiguration } from './utils/podman-configuration';
 import { ProviderConnectionShellAccessImpl } from './utils/podman-machine-stream';
 import { RegistrySetup } from './utils/registry-setup';
-import {
-  checkRosettaMacArm,
-  needsRosettaEnableFile,
-  provisionAndRestartForRosetta,
-  ROSETTA_ENABLE_FILE,
-} from './utils/rosetta';
+import { ROSETTA_ENABLE_FILE, RosettaProvisioner } from './utils/rosetta';
 import {
   appConfigDir,
   appHomeDir,
@@ -121,6 +116,7 @@ let telemetryLogger: extensionApi.TelemetryLogger;
 
 let winPlatform: WinPlatform;
 let podmanBinary: PodmanBinary;
+let rosettaProvisioner: RosettaProvisioner;
 
 let certificateDetectionService: CertificateDetectionService | undefined;
 let certificateDetectionInterval: NodeJS.Timeout | undefined;
@@ -875,7 +871,7 @@ export async function startMachine(
   telemetryRecords.provider = machineInfo.vmType;
   const startTime = performance.now();
 
-  await checkRosettaMacArm(podmanConfiguration);
+  await rosettaProvisioner.checkRosettaMacArm(podmanConfiguration);
 
   try {
     // start the machine
@@ -891,12 +887,12 @@ export async function startMachine(
 
     // Provision /etc/containers/enable-rosetta if needed (macOS Tahoe + AppleHV + Podman 5.6+).
     // If the file was just created, restart the machine so the binfmt_misc handler registers.
-    // SSH/file-creation errors are caught inside provisionAndRestartForRosetta;
+    // SSH/file-creation errors are caught inside rosettaProvisioner.provisionAndRestartForRosetta;
     // stop/start errors propagate so the provider status stays accurate.
     // https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
     const podmanInstallation = await podmanBinary.getBinaryInfo();
     if (podmanInstallation?.version) {
-      await provisionAndRestartForRosetta(
+      await rosettaProvisioner.provisionAndRestartForRosetta(
         machineInfo.name,
         machineInfo.vmType,
         podmanConfiguration,
@@ -1295,6 +1291,7 @@ export async function initInversify(
   const podmanInstall = inversifyContainer.get(PodmanInstall);
   winPlatform = inversifyContainer.get(WinPlatform);
   podmanBinary = inversifyContainer.get(PodmanBinary);
+  rosettaProvisioner = inversifyContainer.get(RosettaProvisioner);
   const podmanProvider = await inversifyContainer.getAsync(PodmanProvider);
 
   return { podmanInstall, winPlatform, podmanProvider };
@@ -2208,11 +2205,13 @@ export async function createMachine(
   if (extensionApi.env.isMac && version) {
     try {
       if (params['podman.factory.machine.now']) {
-        await provisionAndRestartForRosetta(machineName, provider, podmanConfiguration, version, { logger });
+        await rosettaProvisioner.provisionAndRestartForRosetta(machineName, provider, podmanConfiguration, version, {
+          logger,
+        });
       } else {
         // Machine is stopped. Check conditions without SSH first; only start/stop
         // the machine temporarily when actually needed.
-        const setupNeeded = await needsRosettaEnableFile(podmanConfiguration, version, provider);
+        const setupNeeded = await rosettaProvisioner.needsRosettaEnableFile(podmanConfiguration, version, provider);
         if (setupNeeded) {
           await execPodman(['machine', 'start', machineName], provider, { logger });
           try {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -2153,8 +2153,10 @@ export async function createMachine(
   }
 
   // name at the end
+  const args = [];
   let machineName = '';
   if (params['podman.factory.machine.name'] && typeof params['podman.factory.machine.name'] === 'string') {
+    args.push(params['podman.factory.machine.name']);
     machineName = params['podman.factory.machine.name'];
     parameters.push(params['podman.factory.machine.name']);
     telemetryRecords.customName = params['podman.factory.machine.name'];
@@ -2213,11 +2215,11 @@ export async function createMachine(
         // the machine temporarily when actually needed.
         const setupNeeded = await rosettaProvisioner.needsRosettaEnableFile(podmanConfiguration, version, provider);
         if (setupNeeded) {
-          await execPodman(['machine', 'start', machineName], provider, { logger });
+          await execPodman(['machine', 'start', ...args], provider, { logger });
           try {
-            await execPodman(['machine', 'ssh', machineName, `sudo touch ${ROSETTA_ENABLE_FILE}`], provider);
+            await execPodman(['machine', 'ssh', ...args, `sudo touch ${ROSETTA_ENABLE_FILE}`], provider);
           } finally {
-            await execPodman(['machine', 'stop', machineName], provider);
+            await execPodman(['machine', 'stop', ...args], provider);
           }
         }
       }

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.spec.ts
@@ -26,6 +26,7 @@ import { PodmanCleanupWindows } from '/@/cleanup/podman-cleanup-windows';
 import { Installer } from '/@/installer/installer';
 import { MacOSInstaller } from '/@/installer/mac-os-installer';
 import { WinInstaller } from '/@/installer/win-installer';
+import { RosettaProvisioner } from '/@/utils/rosetta';
 
 import { InversifyBinding } from './inversify-binding';
 import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from './symbols';
@@ -51,6 +52,13 @@ describe('inversifyBinding', () => {
 
     expect(container.get(ExtensionContextSymbol)).toBe(extensionContextMock);
     expect(container.get(TelemetryLoggerSymbol)).toBe(telemetryLoggerMock);
+  });
+
+  test('should bind RosettaProvisioner', async () => {
+    const container: InversifyContainer = await inversifyBinding.init();
+
+    const value = container.get(RosettaProvisioner);
+    expect(value).toBeInstanceOf(RosettaProvisioner);
   });
 
   describe('windows', () => {

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -42,6 +42,7 @@ import { WinPlatform } from '/@/platforms/win-platform';
 import { PodmanProvider } from '/@/providers/podman-provider';
 import { PodmanBinary } from '/@/utils/podman-binary';
 import { PodmanWindowsLegacyInstaller } from '/@/utils/podman-windows-legacy-installer';
+import { RosettaProvisioner } from '/@/utils/rosetta';
 
 import { ExtensionContextSymbol, ProviderCleanupSymbol, TelemetryLoggerSymbol } from './symbols';
 
@@ -79,6 +80,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(PodmanWindowsLegacyInstaller).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(PodmanDesktopElevatedCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(PodmanProvider).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(RosettaProvisioner).toSelf().inSingletonScope();
 
     if (envAPI.isWindows) {
       this.#inversifyContainer.bind(Installer).to(WinInstaller).inSingletonScope();

--- a/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
@@ -16,14 +16,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************/
 
-import { arch } from 'node:os';
+import { arch, release } from 'node:os';
 
-import type { RunError, RunResult } from '@podman-desktop/api';
+import type { RunError, RunOptions, RunResult } from '@podman-desktop/api';
 import { env as envAPI, process as processAPI, window as windowAPI } from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { PodmanConfiguration } from './podman-configuration';
-import { checkRosettaMacArm } from './rosetta';
+import {
+  checkRosettaMacArm,
+  enableRosettaInMachine,
+  needsRosettaEnableFile,
+  provisionAndRestartForRosetta,
+} from './rosetta';
+import { execPodman } from './util';
 
 vi.mock(import('node:os'), async () => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -36,6 +42,8 @@ vi.mock(import('node:os'), async () => {
     arch: vi.fn(),
   };
 });
+
+vi.mock(import('./util'));
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -103,5 +111,201 @@ describe('checkRosettaMacArm', async () => {
     expect(processAPI.exec).toBeCalled();
     expect(podmanConfiguration.isRosettaEnabled).toBeCalled();
     expect(windowAPI.showInformationMessage).toBeCalled();
+  });
+});
+
+describe('needsRosettaEnableFile', () => {
+  const podmanConfiguration = {
+    isRosettaEnabled: vi.fn(),
+  } as unknown as PodmanConfiguration;
+
+  // Darwin 25.x = macOS 26 (Tahoe), Darwin 24.x = macOS 15 (Sequoia)
+  const TAHOE = '25.3.0';
+  const SEQUOIA = '24.5.0';
+
+  test.each([
+    // [description, isMac, arch, darwinRelease, podmanVersion, rosettaEnabled, vmType, expected]
+    ['non-macOS', false, 'arm64', TAHOE, '5.6.0', true, 'applehv', false],
+    ['macOS Intel (x64)', true, 'x64', TAHOE, '5.6.0', true, 'applehv', false],
+    ['macOS Sequoia ARM64', true, 'arm64', SEQUOIA, '5.6.0', true, 'applehv', false],
+    ['macOS Tahoe, Podman 5.5.0 (too old)', true, 'arm64', TAHOE, '5.5.0', true, 'applehv', false],
+    ['macOS Tahoe, Podman 5.6.0, Rosetta disabled', true, 'arm64', TAHOE, '5.6.0', false, 'applehv', false],
+    ['macOS Tahoe, libkrun provider', true, 'arm64', TAHOE, '5.6.0', true, 'libkrun', false],
+    ['macOS Tahoe, no vmType', true, 'arm64', TAHOE, '5.6.0', true, undefined, false],
+    ['macOS Tahoe, Podman 5.6.0, Rosetta enabled', true, 'arm64', TAHOE, '5.6.0', true, 'applehv', true],
+    ['macOS Tahoe, Podman 5.6.1, Rosetta enabled', true, 'arm64', TAHOE, '5.6.1', true, 'applehv', true],
+    ['macOS Tahoe, Podman 6.0.0, Rosetta enabled', true, 'arm64', TAHOE, '6.0.0', true, 'applehv', true],
+  ] as const)('%s → %s', async (_desc, isMac, architecture, darwinRelease, podmanVersion, rosettaEnabled, vmType, expected) => {
+    vi.mocked(envAPI).isMac = isMac;
+    vi.mocked(arch).mockReturnValue(architecture);
+    vi.mocked(release).mockReturnValue(darwinRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(rosettaEnabled);
+
+    expect(await needsRosettaEnableFile(podmanConfiguration, podmanVersion, vmType)).toBe(expected);
+  });
+});
+
+describe('enableRosettaInMachine', () => {
+  const podmanConfiguration = {
+    isRosettaEnabled: vi.fn(),
+  } as unknown as PodmanConfiguration;
+
+  const machineName = 'podman-machine-default';
+  const vmType = 'applehv';
+  const podmanVersion = '5.6.0';
+  const tahoeRelease = '25.3.0';
+
+  test('returns false when conditions are not met (non-macOS)', async () => {
+    vi.mocked(envAPI).isMac = false;
+    const result = await enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
+    expect(result).toBe(false);
+    expect(execPodman).not.toBeCalled();
+  });
+
+  test('returns false when enable-rosetta file already exists in the VM', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    // test -f succeeds → file exists
+    vi.mocked(execPodman).mockResolvedValue({ stdout: '', stderr: '', command: '' } as RunResult);
+
+    const result = await enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
+    expect(result).toBe(false);
+    expect(execPodman).toHaveBeenCalledWith(
+      ['machine', 'ssh', machineName, 'test -f /etc/containers/enable-rosetta'],
+      vmType,
+    );
+    expect(execPodman).toHaveBeenCalledTimes(1);
+  });
+
+  test('creates enable-rosetta file and returns true when file is missing', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    // test -f fails → file missing; sudo touch succeeds
+    vi.mocked(execPodman)
+      .mockRejectedValueOnce(new Error('exit code 1'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult);
+
+    const result = await enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
+    expect(result).toBe(true);
+    expect(execPodman).toHaveBeenNthCalledWith(
+      1,
+      ['machine', 'ssh', machineName, 'test -f /etc/containers/enable-rosetta'],
+      vmType,
+    );
+    expect(execPodman).toHaveBeenNthCalledWith(
+      2,
+      ['machine', 'ssh', machineName, 'sudo touch /etc/containers/enable-rosetta'],
+      vmType,
+    );
+  });
+});
+
+describe('provisionAndRestartForRosetta', () => {
+  const podmanConfiguration = {
+    isRosettaEnabled: vi.fn(),
+  } as unknown as PodmanConfiguration;
+
+  const machineName = 'podman-machine-default';
+  const vmType = 'applehv';
+  const podmanVersion = '5.6.0';
+  const tahoeRelease = '25.3.0';
+
+  test('returns false when enableRosettaInMachine returns false (file already exists)', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    // test -f succeeds → file exists
+    vi.mocked(execPodman).mockResolvedValue({ stdout: '', stderr: '', command: '' } as RunResult);
+
+    const result = await provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion);
+    expect(result).toBe(false);
+    expect(execPodman).toHaveBeenCalledTimes(1);
+  });
+
+  test('stops and restarts the machine when file is created', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    // test -f fails → file missing; touch succeeds; stop succeeds; start succeeds
+    vi.mocked(execPodman)
+      .mockRejectedValueOnce(new Error('exit code 1'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult);
+
+    const result = await provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion);
+    expect(result).toBe(true);
+    // ssh test -f, ssh sudo touch, machine stop, machine start
+    expect(execPodman).toHaveBeenCalledTimes(4);
+    expect(execPodman).toHaveBeenNthCalledWith(3, ['machine', 'stop', machineName], vmType);
+    expect(execPodman).toHaveBeenNthCalledWith(4, ['machine', 'start', machineName], vmType, undefined);
+  });
+
+  test('passes options to the start command', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    vi.mocked(execPodman)
+      .mockRejectedValueOnce(new Error('exit code 1'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult);
+
+    const options = { logger: { log: vi.fn() } } as unknown as RunOptions;
+    await provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion, options);
+    expect(execPodman).toHaveBeenNthCalledWith(4, ['machine', 'start', machineName], vmType, options);
+  });
+
+  test('returns false when conditions are not met (non-AppleHV)', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+
+    const result = await provisionAndRestartForRosetta(machineName, 'libkrun', podmanConfiguration, podmanVersion);
+    expect(result).toBe(false);
+    expect(execPodman).not.toBeCalled();
+  });
+
+  test('catches SSH errors from enableRosettaInMachine and returns false', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    // test -f fails, then sudo touch also fails (SSH broken)
+    vi.mocked(execPodman)
+      .mockRejectedValueOnce(new Error('exit code 1'))
+      .mockRejectedValueOnce(new Error('SSH connection refused'));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion);
+    expect(result).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    // stop/start should not have been attempted
+    expect(execPodman).toHaveBeenCalledTimes(2);
+  });
+
+  test('propagates error when machine start fails after stop', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    // test -f fails, touch succeeds, stop succeeds, start fails
+    vi.mocked(execPodman)
+      .mockRejectedValueOnce(new Error('exit code 1'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
+      .mockRejectedValueOnce(new Error('start failed'));
+
+    await expect(
+      provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion),
+    ).rejects.toThrow('start failed');
   });
 });

--- a/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
@@ -218,6 +218,25 @@ describe('enableRosettaInMachine', () => {
       vmType,
     );
   });
+
+  test('omits machine name from ssh commands when machineName is empty', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    vi.mocked(execPodman)
+      .mockRejectedValueOnce(new Error('exit code 1'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult);
+
+    const result = await rosettaProvisioner.enableRosettaInMachine('', vmType, podmanConfiguration, podmanVersion);
+    expect(result).toBe(true);
+    expect(execPodman).toHaveBeenNthCalledWith(1, ['machine', 'ssh', 'test -f /etc/containers/enable-rosetta'], vmType);
+    expect(execPodman).toHaveBeenNthCalledWith(
+      2,
+      ['machine', 'ssh', 'sudo touch /etc/containers/enable-rosetta'],
+      vmType,
+    );
+  });
 });
 
 describe('provisionAndRestartForRosetta', () => {
@@ -332,6 +351,35 @@ describe('provisionAndRestartForRosetta', () => {
     expect(warnSpy).toHaveBeenCalled();
     // stop/start should not have been attempted
     expect(execPodman).toHaveBeenCalledTimes(2);
+  });
+
+  test('omits machine name from stop/start commands when machineName is empty', async () => {
+    vi.mocked(envAPI).isMac = true;
+    vi.mocked(arch).mockReturnValue('arm64');
+    vi.mocked(release).mockReturnValue(tahoeRelease);
+    vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
+    vi.mocked(execPodman)
+      .mockRejectedValueOnce(new Error('exit code 1'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
+      .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult);
+
+    const result = await rosettaProvisioner.provisionAndRestartForRosetta(
+      '',
+      vmType,
+      podmanConfiguration,
+      podmanVersion,
+    );
+    expect(result).toBe(true);
+    expect(execPodman).toHaveBeenCalledTimes(4);
+    expect(execPodman).toHaveBeenNthCalledWith(1, ['machine', 'ssh', 'test -f /etc/containers/enable-rosetta'], vmType);
+    expect(execPodman).toHaveBeenNthCalledWith(
+      2,
+      ['machine', 'ssh', 'sudo touch /etc/containers/enable-rosetta'],
+      vmType,
+    );
+    expect(execPodman).toHaveBeenNthCalledWith(3, ['machine', 'stop'], vmType);
+    expect(execPodman).toHaveBeenNthCalledWith(4, ['machine', 'start'], vmType, undefined);
   });
 
   test('propagates error when machine start fails after stop', async () => {

--- a/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.spec.ts
@@ -22,13 +22,9 @@ import type { RunError, RunOptions, RunResult } from '@podman-desktop/api';
 import { env as envAPI, process as processAPI, window as windowAPI } from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { PodmanBinary } from './podman-binary';
 import type { PodmanConfiguration } from './podman-configuration';
-import {
-  checkRosettaMacArm,
-  enableRosettaInMachine,
-  needsRosettaEnableFile,
-  provisionAndRestartForRosetta,
-} from './rosetta';
+import { RosettaProvisioner } from './rosetta';
 import { execPodman } from './util';
 
 vi.mock(import('node:os'), async () => {
@@ -45,8 +41,13 @@ vi.mock(import('node:os'), async () => {
 
 vi.mock(import('./util'));
 
+let rosettaProvisioner: RosettaProvisioner;
+
 beforeEach(() => {
   vi.resetAllMocks();
+
+  const podmanBinary = {} as PodmanBinary;
+  rosettaProvisioner = new RosettaProvisioner(podmanBinary);
 });
 
 describe('checkRosettaMacArm', async () => {
@@ -55,7 +56,7 @@ describe('checkRosettaMacArm', async () => {
   } as unknown as PodmanConfiguration;
 
   test('check do nothing on non-macOS', async () => {
-    await checkRosettaMacArm(podmanConfiguration);
+    await rosettaProvisioner.checkRosettaMacArm(podmanConfiguration);
     // not called as not on macOS
     expect(vi.mocked(podmanConfiguration.isRosettaEnabled)).not.toBeCalled();
   });
@@ -63,7 +64,7 @@ describe('checkRosettaMacArm', async () => {
   test('check do nothing on macOS with intel', async () => {
     vi.mocked(envAPI).isMac = true;
     vi.mocked(arch).mockReturnValue('x64');
-    await checkRosettaMacArm(podmanConfiguration);
+    await rosettaProvisioner.checkRosettaMacArm(podmanConfiguration);
     // not called as not on arm64
     expect(vi.mocked(podmanConfiguration.isRosettaEnabled)).not.toBeCalled();
   });
@@ -77,7 +78,7 @@ describe('checkRosettaMacArm', async () => {
     // mock rosetta is working when executing commands
     vi.mocked(processAPI.exec).mockResolvedValue({} as RunResult);
 
-    await checkRosettaMacArm(podmanConfiguration);
+    await rosettaProvisioner.checkRosettaMacArm(podmanConfiguration);
     // check showInformationMessage is not called
     expect(processAPI.exec).toBeCalled();
     expect(podmanConfiguration.isRosettaEnabled).toBeCalled();
@@ -90,7 +91,7 @@ describe('checkRosettaMacArm', async () => {
     // rosetta is being enabled per configuration
     vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(false);
 
-    await checkRosettaMacArm(podmanConfiguration);
+    await rosettaProvisioner.checkRosettaMacArm(podmanConfiguration);
     // do not try to execute something as disabled
     expect(processAPI.exec).not.toBeCalled();
     expect(podmanConfiguration.isRosettaEnabled).toBeCalled();
@@ -106,7 +107,7 @@ describe('checkRosettaMacArm', async () => {
     // mock rosetta is not working when executing commands
     vi.mocked(processAPI.exec).mockRejectedValue({ stderr: 'Bad CPU' } as RunError);
 
-    await checkRosettaMacArm(podmanConfiguration);
+    await rosettaProvisioner.checkRosettaMacArm(podmanConfiguration);
     // check showInformationMessage is not called
     expect(processAPI.exec).toBeCalled();
     expect(podmanConfiguration.isRosettaEnabled).toBeCalled();
@@ -141,7 +142,7 @@ describe('needsRosettaEnableFile', () => {
     vi.mocked(release).mockReturnValue(darwinRelease);
     vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(rosettaEnabled);
 
-    expect(await needsRosettaEnableFile(podmanConfiguration, podmanVersion, vmType)).toBe(expected);
+    expect(await rosettaProvisioner.needsRosettaEnableFile(podmanConfiguration, podmanVersion, vmType)).toBe(expected);
   });
 });
 
@@ -157,7 +158,12 @@ describe('enableRosettaInMachine', () => {
 
   test('returns false when conditions are not met (non-macOS)', async () => {
     vi.mocked(envAPI).isMac = false;
-    const result = await enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
+    const result = await rosettaProvisioner.enableRosettaInMachine(
+      machineName,
+      vmType,
+      podmanConfiguration,
+      podmanVersion,
+    );
     expect(result).toBe(false);
     expect(execPodman).not.toBeCalled();
   });
@@ -170,7 +176,12 @@ describe('enableRosettaInMachine', () => {
     // test -f succeeds → file exists
     vi.mocked(execPodman).mockResolvedValue({ stdout: '', stderr: '', command: '' } as RunResult);
 
-    const result = await enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
+    const result = await rosettaProvisioner.enableRosettaInMachine(
+      machineName,
+      vmType,
+      podmanConfiguration,
+      podmanVersion,
+    );
     expect(result).toBe(false);
     expect(execPodman).toHaveBeenCalledWith(
       ['machine', 'ssh', machineName, 'test -f /etc/containers/enable-rosetta'],
@@ -189,7 +200,12 @@ describe('enableRosettaInMachine', () => {
       .mockRejectedValueOnce(new Error('exit code 1'))
       .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult);
 
-    const result = await enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
+    const result = await rosettaProvisioner.enableRosettaInMachine(
+      machineName,
+      vmType,
+      podmanConfiguration,
+      podmanVersion,
+    );
     expect(result).toBe(true);
     expect(execPodman).toHaveBeenNthCalledWith(
       1,
@@ -222,7 +238,12 @@ describe('provisionAndRestartForRosetta', () => {
     // test -f succeeds → file exists
     vi.mocked(execPodman).mockResolvedValue({ stdout: '', stderr: '', command: '' } as RunResult);
 
-    const result = await provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion);
+    const result = await rosettaProvisioner.provisionAndRestartForRosetta(
+      machineName,
+      vmType,
+      podmanConfiguration,
+      podmanVersion,
+    );
     expect(result).toBe(false);
     expect(execPodman).toHaveBeenCalledTimes(1);
   });
@@ -239,7 +260,12 @@ describe('provisionAndRestartForRosetta', () => {
       .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult)
       .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult);
 
-    const result = await provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion);
+    const result = await rosettaProvisioner.provisionAndRestartForRosetta(
+      machineName,
+      vmType,
+      podmanConfiguration,
+      podmanVersion,
+    );
     expect(result).toBe(true);
     // ssh test -f, ssh sudo touch, machine stop, machine start
     expect(execPodman).toHaveBeenCalledTimes(4);
@@ -259,7 +285,13 @@ describe('provisionAndRestartForRosetta', () => {
       .mockResolvedValueOnce({ stdout: '', stderr: '', command: '' } as RunResult);
 
     const options = { logger: { log: vi.fn() } } as unknown as RunOptions;
-    await provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion, options);
+    await rosettaProvisioner.provisionAndRestartForRosetta(
+      machineName,
+      vmType,
+      podmanConfiguration,
+      podmanVersion,
+      options,
+    );
     expect(execPodman).toHaveBeenNthCalledWith(4, ['machine', 'start', machineName], vmType, options);
   });
 
@@ -269,7 +301,12 @@ describe('provisionAndRestartForRosetta', () => {
     vi.mocked(release).mockReturnValue(tahoeRelease);
     vi.mocked(podmanConfiguration.isRosettaEnabled).mockResolvedValue(true);
 
-    const result = await provisionAndRestartForRosetta(machineName, 'libkrun', podmanConfiguration, podmanVersion);
+    const result = await rosettaProvisioner.provisionAndRestartForRosetta(
+      machineName,
+      'libkrun',
+      podmanConfiguration,
+      podmanVersion,
+    );
     expect(result).toBe(false);
     expect(execPodman).not.toBeCalled();
   });
@@ -285,7 +322,12 @@ describe('provisionAndRestartForRosetta', () => {
       .mockRejectedValueOnce(new Error('SSH connection refused'));
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const result = await provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion);
+    const result = await rosettaProvisioner.provisionAndRestartForRosetta(
+      machineName,
+      vmType,
+      podmanConfiguration,
+      podmanVersion,
+    );
     expect(result).toBe(false);
     expect(warnSpy).toHaveBeenCalled();
     // stop/start should not have been attempted
@@ -305,7 +347,7 @@ describe('provisionAndRestartForRosetta', () => {
       .mockRejectedValueOnce(new Error('start failed'));
 
     await expect(
-      provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion),
+      rosettaProvisioner.provisionAndRestartForRosetta(machineName, vmType, podmanConfiguration, podmanVersion),
     ).rejects.toThrow('start failed');
   });
 });

--- a/extensions/podman/packages/extension/src/utils/rosetta.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.ts
@@ -16,12 +16,112 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************/
 
-import { arch } from 'node:os';
+import { arch, release } from 'node:os';
 
-import type { RunError } from '@podman-desktop/api';
+import type { RunError, RunOptions } from '@podman-desktop/api';
 import { env, process as processAPI, window } from '@podman-desktop/api';
+import { compare } from 'semver';
 
 import type { PodmanConfiguration } from './podman-configuration';
+import { execPodman, VMTYPE } from './util';
+
+export const ROSETTA_ENABLE_FILE = '/etc/containers/enable-rosetta';
+
+// Darwin kernel major version for macOS Tahoe (macOS 26)
+const MACOS_TAHOE_DARWIN_MAJOR_VERSION = 25;
+
+// Podman 5.6 introduced the /etc/containers/enable-rosetta opt-in mechanism
+// for machines running with Linux kernel 6.13+ on macOS Tahoe
+const PODMAN_MINIMUM_VERSION_FOR_ROSETTA_ENABLE_FILE = '5.6.0';
+
+/**
+ * Returns true when all conditions for the /etc/containers/enable-rosetta
+ * opt-in are satisfied: AppleHV provider on macOS Tahoe+ ARM64 with Rosetta
+ * enabled and Podman 5.6+.
+ * Does not require the machine to be running — safe to call before starting it.
+ */
+export async function needsRosettaEnableFile(
+  podmanConfiguration: PodmanConfiguration,
+  podmanVersion: string,
+  vmType?: string,
+): Promise<boolean> {
+  if (!env.isMac || arch() !== 'arm64') return false;
+
+  if (vmType !== VMTYPE.APPLEHV) return false;
+
+  // The Apple-side fix only landed in macOS Tahoe (Darwin 25.x / macOS 26)
+  const darwinMajor = Number.parseInt(release().split('.')[0], 10);
+  if (darwinMajor < MACOS_TAHOE_DARWIN_MAJOR_VERSION) return false;
+
+  // The enable-rosetta file mechanism was introduced in Podman 5.6 machine images
+  if (compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_ROSETTA_ENABLE_FILE) < 0) return false;
+
+  return podmanConfiguration.isRosettaEnabled();
+}
+
+/**
+ * Creates /etc/containers/enable-rosetta inside a running Podman VM when needed.
+ * This is required on macOS Tahoe with Podman 5.6+ because the newer machine
+ * image (kernel 6.13+) disabled Rosetta by default; Apple fixed the kernel
+ * incompatibility in Tahoe so the opt-in file re-enables it.
+ *
+ * Returns true if the file was created, meaning the machine must be restarted
+ * for Rosetta to become active. The machine must be running when this is called.
+ * https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
+ */
+export async function enableRosettaInMachine(
+  machineName: string,
+  vmType: string | undefined,
+  podmanConfiguration: PodmanConfiguration,
+  podmanVersion: string,
+): Promise<boolean> {
+  if (!(await needsRosettaEnableFile(podmanConfiguration, podmanVersion, vmType))) return false;
+
+  // Check if the file already exists so we avoid an unnecessary restart
+  try {
+    await execPodman(['machine', 'ssh', machineName, `test -f ${ROSETTA_ENABLE_FILE}`], vmType);
+    return false; // file already present, nothing to do
+  } catch {
+    // non-zero exit means the file is missing — fall through to create it
+  }
+
+  await execPodman(['machine', 'ssh', machineName, `sudo touch ${ROSETTA_ENABLE_FILE}`], vmType);
+  return true;
+}
+
+/**
+ * Provisions /etc/containers/enable-rosetta inside a running Podman VM and
+ * restarts the machine so the binfmt_misc handler registers Rosetta.
+ *
+ * Returns true if a restart was performed, false if nothing was needed.
+ *
+ * Errors during file creation (SSH) are caught and logged as warnings because
+ * the machine is still running. Errors during the stop/start cycle are
+ * propagated because the machine state may have changed.
+ * https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
+ */
+export async function provisionAndRestartForRosetta(
+  machineName: string,
+  vmType: string | undefined,
+  podmanConfiguration: PodmanConfiguration,
+  podmanVersion: string,
+  options?: RunOptions,
+): Promise<boolean> {
+  let fileCreated: boolean;
+  try {
+    fileCreated = await enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
+  } catch (err) {
+    console.warn(`Failed to provision Rosetta enable file: ${err}`);
+    return false;
+  }
+  if (!fileCreated) return false;
+
+  // Stop/start errors propagate — the machine state has changed and the
+  // caller must not report a stale status.
+  await execPodman(['machine', 'stop', machineName], vmType);
+  await execPodman(['machine', 'start', machineName], vmType, options);
+  return true;
+}
 
 export async function checkRosettaMacArm(podmanConfiguration: PodmanConfiguration): Promise<void> {
   // check that rosetta is there for macOS / arm as the machine may fail to start

--- a/extensions/podman/packages/extension/src/utils/rosetta.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.ts
@@ -86,15 +86,16 @@ export class RosettaProvisioner {
   ): Promise<boolean> {
     if (!(await this.needsRosettaEnableFile(podmanConfiguration, podmanVersion, vmType))) return false;
 
+    const args = machineName ? [machineName] : [];
     // Check if the file already exists so we avoid an unnecessary restart
     try {
-      await execPodman(['machine', 'ssh', machineName, `test -f ${ROSETTA_ENABLE_FILE}`], vmType);
+      await execPodman(['machine', 'ssh', ...args, `test -f ${ROSETTA_ENABLE_FILE}`], vmType);
       return false; // file already present, nothing to do
     } catch {
       // non-zero exit means the file is missing — fall through to create it
     }
 
-    await execPodman(['machine', 'ssh', machineName, `sudo touch ${ROSETTA_ENABLE_FILE}`], vmType);
+    await execPodman(['machine', 'ssh', ...args, `sudo touch ${ROSETTA_ENABLE_FILE}`], vmType);
     return true;
   }
 
@@ -125,10 +126,11 @@ export class RosettaProvisioner {
     }
     if (!fileCreated) return false;
 
+    const args = machineName ? [machineName] : [];
     // Stop/start errors propagate — the machine state has changed and the
     // caller must not report a stale status.
-    await execPodman(['machine', 'stop', machineName], vmType);
-    await execPodman(['machine', 'start', machineName], vmType, options);
+    await execPodman(['machine', 'stop', ...args], vmType);
+    await execPodman(['machine', 'start', ...args], vmType, options);
     return true;
   }
 

--- a/extensions/podman/packages/extension/src/utils/rosetta.ts
+++ b/extensions/podman/packages/extension/src/utils/rosetta.ts
@@ -20,8 +20,10 @@ import { arch, release } from 'node:os';
 
 import type { RunError, RunOptions } from '@podman-desktop/api';
 import { env, process as processAPI, window } from '@podman-desktop/api';
+import { inject, injectable } from 'inversify';
 import { compare } from 'semver';
 
+import { PodmanBinary } from './podman-binary';
 import type { PodmanConfiguration } from './podman-configuration';
 import { execPodman, VMTYPE } from './util';
 
@@ -34,121 +36,129 @@ const MACOS_TAHOE_DARWIN_MAJOR_VERSION = 25;
 // for machines running with Linux kernel 6.13+ on macOS Tahoe
 const PODMAN_MINIMUM_VERSION_FOR_ROSETTA_ENABLE_FILE = '5.6.0';
 
-/**
- * Returns true when all conditions for the /etc/containers/enable-rosetta
- * opt-in are satisfied: AppleHV provider on macOS Tahoe+ ARM64 with Rosetta
- * enabled and Podman 5.6+.
- * Does not require the machine to be running — safe to call before starting it.
- */
-export async function needsRosettaEnableFile(
-  podmanConfiguration: PodmanConfiguration,
-  podmanVersion: string,
-  vmType?: string,
-): Promise<boolean> {
-  if (!env.isMac || arch() !== 'arm64') return false;
+@injectable()
+export class RosettaProvisioner {
+  constructor(
+    @inject(PodmanBinary)
+    private readonly podmanBinary: PodmanBinary,
+  ) {}
 
-  if (vmType !== VMTYPE.APPLEHV) return false;
+  /**
+   * Returns true when all conditions for the /etc/containers/enable-rosetta
+   * opt-in are satisfied: AppleHV provider on macOS Tahoe+ ARM64 with Rosetta
+   * enabled and Podman 5.6+.
+   * Does not require the machine to be running — safe to call before starting it.
+   */
+  async needsRosettaEnableFile(
+    podmanConfiguration: PodmanConfiguration,
+    podmanVersion: string,
+    vmType?: string,
+  ): Promise<boolean> {
+    if (!env.isMac || arch() !== 'arm64') return false;
 
-  // The Apple-side fix only landed in macOS Tahoe (Darwin 25.x / macOS 26)
-  const darwinMajor = Number.parseInt(release().split('.')[0], 10);
-  if (darwinMajor < MACOS_TAHOE_DARWIN_MAJOR_VERSION) return false;
+    if (vmType !== VMTYPE.APPLEHV) return false;
 
-  // The enable-rosetta file mechanism was introduced in Podman 5.6 machine images
-  if (compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_ROSETTA_ENABLE_FILE) < 0) return false;
+    // The Apple-side fix only landed in macOS Tahoe (Darwin 25.x / macOS 26)
+    const darwinMajor = Number.parseInt(release().split('.')[0], 10);
+    if (darwinMajor < MACOS_TAHOE_DARWIN_MAJOR_VERSION) return false;
 
-  return podmanConfiguration.isRosettaEnabled();
-}
+    // The enable-rosetta file mechanism was introduced in Podman 5.6 machine images
+    if (compare(podmanVersion, PODMAN_MINIMUM_VERSION_FOR_ROSETTA_ENABLE_FILE) < 0) return false;
 
-/**
- * Creates /etc/containers/enable-rosetta inside a running Podman VM when needed.
- * This is required on macOS Tahoe with Podman 5.6+ because the newer machine
- * image (kernel 6.13+) disabled Rosetta by default; Apple fixed the kernel
- * incompatibility in Tahoe so the opt-in file re-enables it.
- *
- * Returns true if the file was created, meaning the machine must be restarted
- * for Rosetta to become active. The machine must be running when this is called.
- * https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
- */
-export async function enableRosettaInMachine(
-  machineName: string,
-  vmType: string | undefined,
-  podmanConfiguration: PodmanConfiguration,
-  podmanVersion: string,
-): Promise<boolean> {
-  if (!(await needsRosettaEnableFile(podmanConfiguration, podmanVersion, vmType))) return false;
-
-  // Check if the file already exists so we avoid an unnecessary restart
-  try {
-    await execPodman(['machine', 'ssh', machineName, `test -f ${ROSETTA_ENABLE_FILE}`], vmType);
-    return false; // file already present, nothing to do
-  } catch {
-    // non-zero exit means the file is missing — fall through to create it
+    return podmanConfiguration.isRosettaEnabled();
   }
 
-  await execPodman(['machine', 'ssh', machineName, `sudo touch ${ROSETTA_ENABLE_FILE}`], vmType);
-  return true;
-}
+  /**
+   * Creates /etc/containers/enable-rosetta inside a running Podman VM when needed.
+   * This is required on macOS Tahoe with Podman 5.6+ because the newer machine
+   * image (kernel 6.13+) disabled Rosetta by default; Apple fixed the kernel
+   * incompatibility in Tahoe so the opt-in file re-enables it.
+   *
+   * Returns true if the file was created, meaning the machine must be restarted
+   * for Rosetta to become active. The machine must be running when this is called.
+   * https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
+   */
+  async enableRosettaInMachine(
+    machineName: string,
+    vmType: string | undefined,
+    podmanConfiguration: PodmanConfiguration,
+    podmanVersion: string,
+  ): Promise<boolean> {
+    if (!(await this.needsRosettaEnableFile(podmanConfiguration, podmanVersion, vmType))) return false;
 
-/**
- * Provisions /etc/containers/enable-rosetta inside a running Podman VM and
- * restarts the machine so the binfmt_misc handler registers Rosetta.
- *
- * Returns true if a restart was performed, false if nothing was needed.
- *
- * Errors during file creation (SSH) are caught and logged as warnings because
- * the machine is still running. Errors during the stop/start cycle are
- * propagated because the machine state may have changed.
- * https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
- */
-export async function provisionAndRestartForRosetta(
-  machineName: string,
-  vmType: string | undefined,
-  podmanConfiguration: PodmanConfiguration,
-  podmanVersion: string,
-  options?: RunOptions,
-): Promise<boolean> {
-  let fileCreated: boolean;
-  try {
-    fileCreated = await enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
-  } catch (err) {
-    console.warn(`Failed to provision Rosetta enable file: ${err}`);
-    return false;
+    // Check if the file already exists so we avoid an unnecessary restart
+    try {
+      await execPodman(['machine', 'ssh', machineName, `test -f ${ROSETTA_ENABLE_FILE}`], vmType);
+      return false; // file already present, nothing to do
+    } catch {
+      // non-zero exit means the file is missing — fall through to create it
+    }
+
+    await execPodman(['machine', 'ssh', machineName, `sudo touch ${ROSETTA_ENABLE_FILE}`], vmType);
+    return true;
   }
-  if (!fileCreated) return false;
 
-  // Stop/start errors propagate — the machine state has changed and the
-  // caller must not report a stale status.
-  await execPodman(['machine', 'stop', machineName], vmType);
-  await execPodman(['machine', 'start', machineName], vmType, options);
-  return true;
-}
+  /**
+   * Provisions /etc/containers/enable-rosetta inside a running Podman VM and
+   * restarts the machine so the binfmt_misc handler registers Rosetta.
+   *
+   * Returns true if a restart was performed, false if nothing was needed.
+   *
+   * Errors during file creation (SSH) are caught and logged as warnings because
+   * the machine is still running. Errors during the stop/start cycle are
+   * propagated because the machine state may have changed.
+   * https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/
+   */
+  async provisionAndRestartForRosetta(
+    machineName: string,
+    vmType: string | undefined,
+    podmanConfiguration: PodmanConfiguration,
+    podmanVersion: string,
+    options?: RunOptions,
+  ): Promise<boolean> {
+    let fileCreated: boolean;
+    try {
+      fileCreated = await this.enableRosettaInMachine(machineName, vmType, podmanConfiguration, podmanVersion);
+    } catch (err) {
+      console.warn(`Failed to provision Rosetta enable file: ${err}`);
+      return false;
+    }
+    if (!fileCreated) return false;
 
-export async function checkRosettaMacArm(podmanConfiguration: PodmanConfiguration): Promise<void> {
-  // check that rosetta is there for macOS / arm as the machine may fail to start
-  if (env.isMac && arch() === 'arm64') {
-    const isEnabled = await podmanConfiguration.isRosettaEnabled();
-    if (isEnabled) {
-      // call the command `arch -arch x86_64 uname -m` to check if rosetta is enabled
-      // if not installed, it will fail
-      try {
-        await processAPI.exec('arch', ['-arch', 'x86_64', 'uname', '-m']);
-      } catch (error: unknown) {
-        const runError = error as RunError;
-        if (runError.stderr?.includes('Bad CPU')) {
-          // rosetta is enabled but not installed, it will fail, stop from there and prompt the user to install rosetta or disable rosetta support
-          const result = await window.showInformationMessage(
-            'Podman machine is configured to use Rosetta but the support is not installed. The startup of the machine will fail.\nDo you want to install Rosetta? Rosetta is allowing to execute amd64 images on Apple silicon architecture.',
-            'Yes',
-            'No',
-            'Disable rosetta support',
-          );
-          if (result === 'Yes') {
-            // ask the person to perform the installation using cli
-            await window.showInformationMessage(
-              'Please install Rosetta from the command line by running `softwareupdate --install-rosetta`',
+    // Stop/start errors propagate — the machine state has changed and the
+    // caller must not report a stale status.
+    await execPodman(['machine', 'stop', machineName], vmType);
+    await execPodman(['machine', 'start', machineName], vmType, options);
+    return true;
+  }
+
+  async checkRosettaMacArm(podmanConfiguration: PodmanConfiguration): Promise<void> {
+    // check that rosetta is there for macOS / arm as the machine may fail to start
+    if (env.isMac && arch() === 'arm64') {
+      const isEnabled = await podmanConfiguration.isRosettaEnabled();
+      if (isEnabled) {
+        // call the command `arch -arch x86_64 uname -m` to check if rosetta is enabled
+        // if not installed, it will fail
+        try {
+          await processAPI.exec('arch', ['-arch', 'x86_64', 'uname', '-m']);
+        } catch (error: unknown) {
+          const runError = error as RunError;
+          if (runError.stderr?.includes('Bad CPU')) {
+            // rosetta is enabled but not installed, it will fail, stop from there and prompt the user to install rosetta or disable rosetta support
+            const result = await window.showInformationMessage(
+              'Podman machine is configured to use Rosetta but the support is not installed. The startup of the machine will fail.\nDo you want to install Rosetta? Rosetta is allowing to execute amd64 images on Apple silicon architecture.',
+              'Yes',
+              'No',
+              'Disable rosetta support',
             );
-          } else if (result === 'Disable rosetta support') {
-            await podmanConfiguration.updateRosettaSetting(false);
+            if (result === 'Yes') {
+              // ask the person to perform the installation using cli
+              await window.showInformationMessage(
+                'Please install Rosetta from the command line by running `softwareupdate --install-rosetta`',
+              );
+            } else if (result === 'Disable rosetta support') {
+              await podmanConfiguration.updateRosettaSetting(false);
+            }
           }
         }
       }


### PR DESCRIPTION
### What does this PR do?
This PR adds a fix from https://blog.podman.io/2025/08/podman-5-6-released-rosetta-status-update/ to creation/starting of podman machine on macOS Tahoe with podman 5.6+

### Screenshot / video of UI

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/16168

### How to test this PR?
Create podman machine from podman desktop (production version) - applev provider
Start the machine, run `podman machine ssh "cat /proc/sys/fs/binfmt_misc/rosetta"` (for podman-machine-default) - you should see `cat: /proc/sys/fs/binfmt_misc/rosetta: No such file or directory`

Run PD from this PR, try to stop/start the machine 
run `podman machine ssh "cat /proc/sys/fs/binfmt_misc/rosetta"` 
You should see: ±
```
enabled
interpreter /mnt/rosetta
flags: POCF
offset 0
magic 7f454c4602010100000000000000000002003e00
mask fffffffffffefe00fffffffffffffffffeffffff
```

Delete the machine, create new machine (also with appleV)
run the command again, you should see the same output

- [x] Tests are covering the bug fix or the new feature
