### PR TITLE
fix(extension/podman): use detached mode for machine autoStart

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -886,6 +886,29 @@ test('if a machine is successfully started it changes its state to started', asy
   expect(spyUpdateStatus).toBeCalledWith('started');
 });
 
+test('if autoStart is true, machine start uses detached mode', async () => {
+  const spyUpdateStatus = vi.spyOn(provider, 'updateStatus');
+  spyUpdateStatus.mockImplementation(() => {
+    return;
+  });
+
+  const spyExecPromise = vi
+    .spyOn(extensionApi.process, 'exec')
+    .mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+
+  await extension.startMachine(provider, podmanConfiguration, machineInfo, undefined, undefined, undefined, true);
+
+  expect(spyExecPromise).toHaveBeenCalledWith(podmanCli.getPodmanCli(), ['machine', 'start', 'name'], {
+    env: {
+      CONTAINERS_MACHINE_PROVIDER: VMTYPE.LIBKRUN,
+    },
+    logger: new LoggerDelegator(),
+    detached: true,
+  });
+
+  expect(spyUpdateStatus).toHaveBeenCalledWith('started');
+});
+
 test('if a machine is successfully reporting telemetry', async () => {
   const spyExecPromise = vi
     .spyOn(extensionApi.process, 'exec')

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -874,9 +874,15 @@ export async function startMachine(
 
   try {
     // start the machine
-    await execPodman(['machine', 'start', machineInfo.name], machineInfo.vmType, {
+    const runOptions: extensionApi.RunOptions = {
       logger: new LoggerDelegator(context, logger),
-    });
+    };
+
+    if (autoStart) {
+      runOptions.detached = true;
+    }
+
+    await execPodman(['machine', 'start', machineInfo.name], machineInfo.vmType, runOptions);
     provider.updateStatus('started');
   } catch (err) {
     telemetryRecords.error = err;


### PR DESCRIPTION
### What does this PR do?

When autoStart is true, the machine start command now runs in detached mode, allowing the process to continue independently even if Podman Desktop exits.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Relates to https://github.com/podman-desktop/podman-desktop/issues/9670

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

- Enable Autostart in Podman Extension settings.
- While the Machine is displaying "Starting" in the interface, force close Podman Desktop (Ctrlc-C of terminal, or Cmd+Q on Mac on the window).
- Check with the command line that `podman machine list` displays the running machine (and not stuck starting).

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
