### PR TITLE
fix(extension/podman): wrap machine start with sh on macOS for SIGTERM propagation

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -882,7 +882,20 @@ export async function startMachine(
       runOptions.detached = true;
     }
 
-    await execPodman(['machine', 'start', machineInfo.name], machineInfo.vmType, runOptions);
+    // On macOS, wrap with `sh -c` so that SIGTERM propagates to all child
+    // processes (krunkit, gvproxy, …) instead of only hitting the podman process.
+    // See https://github.com/containers/podman/issues/28318
+    if (extensionApi.env.isMac) {
+      const podmanBin = getPodmanCli();
+      const cmd = [podmanBin, 'machine', 'start', machineInfo.name].join(' ');
+      const env: Record<string, string> = { ...(runOptions.env ?? {}) };
+      if (machineInfo.vmType) {
+        env.CONTAINERS_MACHINE_PROVIDER = getProviderByLabel(machineInfo.vmType);
+      }
+      await extensionApi.process.exec('sh', ['-c', cmd], { ...runOptions, env });
+    } else {
+      await execPodman(['machine', 'start', machineInfo.name], machineInfo.vmType, runOptions);
+    }
     provider.updateStatus('started');
   } catch (err) {
     telemetryRecords.error = err;


### PR DESCRIPTION
### What does this PR do?

To delete, I wanted to open this on my fork

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
