### PR TITLE
chore(pr-check): use default types for pull-request trigger

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -20,7 +20,6 @@ name: pr-check
 on:
   merge_group:
   pull_request:
-    types: [labeled, synchronize, opened, ready_for_review, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
### What does this PR do?
Today, labeler is added but as the GitHub app is adding labels
 to approve/review domains, there is like a loop effect
where when user is approving, bot is adding the label then it starts again the PR checks...

only drawback is that if you add the `area/ci` label it means you need to push a change to the branch to trigger it

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

cascade run checks on PR review

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
