### PR TITLE
fix: change order of 'Allow' and 'Deny' button in confirmation dialog

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -487,7 +487,7 @@ test('getSession prompts for allowance when accessing session without prior deci
     expect.objectContaining({
       title: 'Allow Access',
       message: expect.stringContaining('Extension 2'),
-      buttons: ['Deny', 'Allow'],
+      buttons: ['Allow', 'Deny'],
     }),
   );
 

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -334,7 +334,7 @@ export class AuthenticationImpl {
         const allowRsp = await this.messageBox.showMessageBox({
           title: 'Allow Access',
           message: `The extension '${requestingExtension.label}' wants to access the ${providerData?.label ?? providerId} account '${accountLabel}'.`,
-          buttons: ['Deny', 'Allow'],
+          buttons: ['Allow', 'Deny'],
           type: 'info',
         });
 


### PR DESCRIPTION
### What does this PR do?

PR updates buttons order in access confirmation dialog from 'Allow' and 'Deny' to 'Deny' and 'Allow' co match other confirmation dialogs

### Screenshot / video of UI

<img width="796" height="326" alt="image" src="https://github.com/user-attachments/assets/e9369c7a-3de5-484b-b6da-12017dddea24" />

### What issues does this PR fix or reference?

Fix https://github.com/redhat-developer/podman-desktop-redhat-account-ext/issues/1098.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
