### PR TITLE
fix(main): remove `Manage Docker` feature card when docker-compat disabled

### DIFF
--- a/packages/main/src/plugin/explore-features/explore-features.json
+++ b/packages/main/src/plugin/explore-features/explore-features.json
@@ -42,7 +42,7 @@
       "buttonLink": "/preferences/docker-compatibility",
       "tutorialLink": "",
       "learnMore": "https://podman-desktop.io/docs/migrating-from-docker/managing-docker-compatibility",
-      "when": "!isDockerCompatibilityEnabled"
+      "when": "isDockerCompatibilityEnabled"
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the "Manage Docker" explore feature card on the Dashboard so it only appears when Docker Compatibility is enabled. Previously, the card was shown when Docker Compatibility was disabled (`!isDockerCompatibilityEnabled`), which linked users to the `/preferences/docker-compatibility` page that is hidden from the navigation when the setting is off.

The fix changes the `when` condition from `!isDockerCompatibilityEnabled` to `isDockerCompatibilityEnabled`.

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #15585 

### How to test this PR?

1. Reset or ensure `dockerCompatibility.enabled` is `false` in settings
2. Open the Dashboard — the "Manage Docker" card should not appear
3. Enable Docker Compatibility in config file (`$HOME/.config/containers/podman-desktop/settings.json`)
4. Return to the Dashboard — the "Manage Docker" card should now appear, and clicking "Manage compatibility" should navigate to `/preferences/docker-compatibility` with the page properly selected in the nav

- [x] Tests are covering the bug fix or the new feature
