### PR TITLE
fix: allow pre-installed extension resuse auth sessions without user confirmation

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -610,3 +610,133 @@ test('getSession returns undefined in silent mode when no allowance decision exi
   // Session should not be returned in silent mode without prior allowance
   expect(sessionForExt2).toBeUndefined();
 });
+
+test('getSession auto-allows whitelisted extension without prompting', async () => {
+  const mb = {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }),
+  } as unknown as MessageBox;
+  const authentication = new AuthenticationImpl(apiSender, mb);
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authentication.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  // ext1 creates a session
+  const session = await authentication.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  vi.mocked(mb.showMessageBox).mockClear();
+
+  // Whitelisted ext2 accesses the session — should not prompt
+  const sessionForExt2 = await authentication.getSession(
+    { id: 'ext2', label: 'Extension 2', whitelisted: true },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+  );
+
+  expect(mb.showMessageBox).not.toHaveBeenCalled();
+  expect(sessionForExt2).toBeDefined();
+  expect(sessionForExt2?.id).toBe(session!.id);
+  // Whitelisted extensions skip the allowance table entirely
+  expect(authentication.isAccessAllowed('company.auth-provider', session!.account.id, 'ext2')).toBeUndefined();
+});
+
+test('getSession auto-allows whitelisted extension even in silent mode', async () => {
+  const mb = {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }),
+  } as unknown as MessageBox;
+  const authentication = new AuthenticationImpl(apiSender, mb);
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authentication.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  const session = await authentication.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  vi.mocked(mb.showMessageBox).mockClear();
+
+  // Whitelisted ext2 in silent mode — should auto-allow
+  const sessionForExt2 = await authentication.getSession(
+    { id: 'ext2', label: 'Extension 2', whitelisted: true },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { silent: true },
+  );
+
+  expect(mb.showMessageBox).not.toHaveBeenCalled();
+  expect(sessionForExt2).toBeDefined();
+  expect(sessionForExt2?.id).toBe(session!.id);
+});
+
+test('getSession still prompts for non-whitelisted extension', async () => {
+  const mb = {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }),
+  } as unknown as MessageBox;
+  const authentication = new AuthenticationImpl(apiSender, mb);
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authentication.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  const session = await authentication.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  vi.mocked(mb.showMessageBox).mockClear();
+  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 1 });
+
+  // Non-whitelisted ext should still be prompted
+  await authentication.getSession({ id: 'ext2', label: 'Extension 2', whitelisted: false }, 'company.auth-provider', [
+    'scope1',
+    'scope2',
+  ]);
+
+  expect(mb.showMessageBox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      title: 'Allow Access',
+      buttons: ['Deny', 'Allow'],
+    }),
+  );
+});
+
+test('getSession still prompts when whitelisted is undefined', async () => {
+  const mb = {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }),
+  } as unknown as MessageBox;
+  const authentication = new AuthenticationImpl(apiSender, mb);
+  const authProvider = new AuthenticationProviderSingleAccount();
+  authentication.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvider);
+
+  const session = await authentication.getSession(
+    { id: 'ext1', label: 'Ext 1' },
+    'company.auth-provider',
+    ['scope1', 'scope2'],
+    { createIfNone: true },
+  );
+
+  expect(session).toBeDefined();
+
+  vi.mocked(mb.showMessageBox).mockClear();
+  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 1 });
+
+  // Extension without whitelisted field should still be prompted (backward compat)
+  await authentication.getSession({ id: 'ext2', label: 'Extension 2' }, 'company.auth-provider', ['scope1', 'scope2']);
+
+  expect(mb.showMessageBox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      title: 'Allow Access',
+    }),
+  );
+});

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -319,8 +319,9 @@ export class AuthenticationImpl {
       const session = sessions[0];
       const accountId = session.account.id;
       const accountLabel = session.account.label || accountId; // Fallback to accountId if label is empty
-      const accessAllowed =
-        requestingExtension.whitelisted ?? this.isAccessAllowed(providerId, accountId, requestingExtension.id);
+      const accessAllowed = requestingExtension.whitelisted
+        ? true
+        : this.isAccessAllowed(providerId, accountId, requestingExtension.id);
 
       // If explicitly denied, don't return the session
       if (accessAllowed === false) {

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -47,6 +47,8 @@ export interface ExtensionInfo {
   id: string;
   label: string;
   icon?: string | { light: string; dark: string };
+  // true for preinstalled/bundled extensions that can share sessions without user confirmation
+  whitelisted?: boolean;
 }
 
 export interface AllowedExtension {
@@ -317,7 +319,8 @@ export class AuthenticationImpl {
       const session = sessions[0];
       const accountId = session.account.id;
       const accountLabel = session.account.label || accountId; // Fallback to accountId if label is empty
-      const accessAllowed = this.isAccessAllowed(providerId, accountId, requestingExtension.id);
+      const accessAllowed =
+        requestingExtension.whitelisted ?? this.isAccessAllowed(providerId, accountId, requestingExtension.id);
 
       // If explicitly denied, don't return the session
       if (accessAllowed === false) {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -921,6 +921,7 @@ export class ExtensionLoader implements IAsyncDisposable {
       name: extManifest.name,
       extensionPath,
       icon: extManifest.icon ? instance.updateImage(extManifest.icon, extensionPath) : undefined,
+      whitelisted: !analyzedExtension.removable,
     };
 
     const commandRegistry = this.commandRegistry;


### PR DESCRIPTION
### What does this PR do?

packages/main/src/plugin/authentication.ts — Added whitelisted?: boolean to ExtensionInfo. In getSession, when accessAllowed === undefined and the requesting extension has whitelisted: true, it auto-allows it to access authentication sessions created by other extensions without showing the "Allow Access" dialog. This also works in silent mode (whitelisted extensions bypass the silent early-return).

packages/main/src/plugin/extension/extension-loader.ts — Added whitelisted: !analyzedExtension.removable to the extensionInfo object in createApi, so bundled extensions (removable: false) get whitelisted: true and user-installed extensions (removable: true) get whitelisted: false.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

It fix issue https://github.com/redhat-developer/podman-desktop-redhat-account-ext/issues/1087 for downstream, when extension that use authentication module are pre-installed. For upstream when removable extension using authentication module it needs further discussion about how to save list of extensions allowed to reuse authentication sessions created by other extensions.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

Added 4 tests:

Whitelisted extension gets auto-allowed without any prompt
Whitelisted extension gets auto-allowed even in silent mode
Non-whitelisted extension (whitelisted: false) still gets prompted
Extension without whitelisted field (undefined) still gets prompted (backward compatibility)