### PR TITLE
fix: load protocol name from product.json urlProtocol attribute

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -168,6 +168,7 @@ import { Welcome } from '/@/plugin/welcome.js';
 import { securityRestrictionCurrentHandler } from '/@/security-restrictions-handler.js';
 import { TrayMenu } from '/@/tray-menu.js';
 import { createHash, isMac } from '/@/util.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { MainWindowDeferred } from './api.js';
 import { AppearanceInit } from './appearance-init.js';
@@ -3183,6 +3184,10 @@ export class PluginSystem {
 
     this.ipcHandle('welcome:getWelcomeMessages', async (): Promise<WelcomeMessages> => {
       return welcome.getWelcomeMessages();
+    });
+
+    this.ipcHandle('product:getUrlProtocol', async (): Promise<string> => {
+      return product.urlProtocol;
     });
 
     this.ipcHandle(

--- a/packages/main/src/protocol-launcher.spec.ts
+++ b/packages/main/src/protocol-launcher.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import type { BrowserWindow } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { isWindows } from '/@/util.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { ProtocolLauncher } from './protocol-launcher.js';
 
@@ -45,9 +46,11 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+const PROTOCOL = product.urlProtocol;
+
 test('should send the URL to open when mainWindow is created', async () => {
   const protocol = getProtocolLauncher();
-  protocol.handleOpenUrl('podman-desktop:extension/my.extension');
+  protocol.handleOpenUrl(`${PROTOCOL}:extension/my.extension`);
 
   // wait sendMock being called
   await vi.waitFor(() => expect(BROWSER_WINDOW_MOCK.webContents.send).toHaveBeenCalled());
@@ -60,7 +63,7 @@ test('should send the URL to open when mainWindow is created', async () => {
 
 test('should send the URL to open when mainWindow is created with :// format', async () => {
   const protocol = getProtocolLauncher();
-  protocol.handleOpenUrl('podman-desktop://extension/my.extension');
+  protocol.handleOpenUrl(`${PROTOCOL}://extension/my.extension`);
 
   // wait sendMock being called
   await vi.waitFor(() =>
@@ -73,7 +76,7 @@ test('should send the URL to open when mainWindow is created with :// format', a
 
 test('should not send the URL for invalid URLs', async () => {
   const protocol = getProtocolLauncher();
-  protocol.handleOpenUrl('podman-desktop:foobar');
+  protocol.handleOpenUrl(`${PROTOCOL}:foobar`);
 
   // expect an error
   expect(vi.mocked(BROWSER_WINDOW_MOCK.webContents.send)).not.toHaveBeenCalled();
@@ -81,10 +84,10 @@ test('should not send the URL for invalid URLs', async () => {
 
 test.each([
   {
-    url: 'podman-desktop:extension/my.extension',
+    url: `${PROTOCOL}:extension/my.extension`,
     webContentsSend: ['podman-desktop-protocol:install-extension', 'my.extension'],
   },
-  { url: 'podman-desktop:experimental', webContentsSend: ['podman-desktop-protocol:open-experimental-features'] },
+  { url: `${PROTOCOL}:experimental`, webContentsSend: ['podman-desktop-protocol:open-experimental-features'] },
 ])('should handle valid URL on Windows', async ({ url, webContentsSend }) => {
   vi.mocked(isWindows).mockReturnValue(true);
 
@@ -96,8 +99,8 @@ test.each([
 });
 
 test.each([
-  'podman-desktop:extension/my.extension',
-  'podman-desktop:experimental',
+  `${PROTOCOL}:extension/my.extension`,
+  `${PROTOCOL}:experimental`,
 ])('should not do anything with valid URL on OS different than Windows', async url => {
   vi.mocked(isWindows).mockReturnValue(false);
 
@@ -113,15 +116,15 @@ describe('sanitizeProtocolForExtension', () => {
   test('handle sanitizeProtocolForExtension', () => {
     const protocol = getProtocolLauncher();
 
-    const fakeLink = 'podman-desktop://extension/my.extension';
-    const sanitizedLink = 'podman-desktop:extension/my.extension';
+    const fakeLink = `${PROTOCOL}://extension/my.extension`;
+    const sanitizedLink = `${PROTOCOL}:extension/my.extension`;
     expect(protocol.sanitizeProtocolForExtension(fakeLink)).toEqual(sanitizedLink);
   });
 
   test('handle sanitizeProtocolForExtension noop', () => {
     const protocol = getProtocolLauncher();
 
-    const sanitizedLink = 'podman-desktop:extension/my.extension';
+    const sanitizedLink = `${PROTOCOL}:extension/my.extension`;
     expect(protocol.sanitizeProtocolForExtension(sanitizedLink)).toEqual(sanitizedLink);
   });
 });

--- a/packages/main/src/protocol-launcher.ts
+++ b/packages/main/src/protocol-launcher.ts
@@ -34,9 +34,9 @@ export class ProtocolLauncher {
     const singleColonPrefix = `${this.protocol}:`;
 
     if (url.startsWith(`${doubleSlashPrefix}extension/`)) {
-      url = url.replace(`${doubleSlashPrefix}extension/`, `${singleColonPrefix}extension/`);
+      return url.replace(`${doubleSlashPrefix}extension/`, `${singleColonPrefix}extension/`);
     } else if (url.startsWith(`${doubleSlashPrefix}preferences/experimental`)) {
-      url = url.replace(`${doubleSlashPrefix}preferences/experimental`, `${singleColonPrefix}experimental`);
+      return url.replace(`${doubleSlashPrefix}preferences/experimental`, `${singleColonPrefix}experimental`);
     }
 
     return url;
@@ -62,14 +62,14 @@ export class ProtocolLauncher {
     // if the url starts with ${this.protocol}:extension/<id>
     // we need to install the extension
 
-    // if url starts with '${this.protocol}://extension', replace it with 'podman-desktop:extension'
-    url = this.sanitizeProtocolForExtension(url);
+    // if url starts with '${this.protocol}://extension', replace it with '${this.protocol}:extension'
+    const normalizedUrl = this.sanitizeProtocolForExtension(url);
 
     const extensionPrefix = `${this.protocol}:extension/`;
     const experimentalPrefix = `${this.protocol}:experimental`;
 
-    if (url.startsWith(extensionPrefix)) {
-      const extensionId = url.substring(extensionPrefix.length);
+    if (normalizedUrl.startsWith(extensionPrefix)) {
+      const extensionId = normalizedUrl.substring(extensionPrefix.length);
 
       this.browserWindow.promise
         .then(w => {
@@ -78,7 +78,7 @@ export class ProtocolLauncher {
         .catch((error: unknown) => {
           console.error('Error sending open-url event to webcontents', error);
         });
-    } else if (url.startsWith(experimentalPrefix)) {
+    } else if (normalizedUrl.startsWith(experimentalPrefix)) {
       this.browserWindow.promise
         .then(w => {
           w.webContents.send('podman-desktop-protocol:open-experimental-features');
@@ -87,7 +87,7 @@ export class ProtocolLauncher {
           console.error('Error sending open-url event to webcontents', error);
         });
     } else {
-      console.log(`url ${url} does not start with ${extensionPrefix} or ${experimentalPrefix}, skipping.`);
+      console.log(`url ${normalizedUrl} does not start with ${extensionPrefix} or ${experimentalPrefix}, skipping.`);
       return;
     }
   }

--- a/packages/main/src/protocol-launcher.ts
+++ b/packages/main/src/protocol-launcher.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,25 @@
 import type { BrowserWindow } from 'electron';
 
 import { isWindows } from '/@/util.js';
+import product from '/@product.json' with { type: 'json' };
 
 export class ProtocolLauncher {
+  private readonly protocol = product.urlProtocol;
+
   constructor(private browserWindow: PromiseWithResolvers<BrowserWindow>) {}
 
   /**
-   * if arg starts with 'podman-desktop://extension', replace it with 'podman-desktop:extension'
+   * if arg starts with '<protocol>://extension', replace it with '<protocol>:extension'
    * @param url
    */
   sanitizeProtocolForExtension(url: string): string {
-    if (url.startsWith('podman-desktop://extension/')) {
-      url = url.replace('podman-desktop://extension/', 'podman-desktop:extension/');
-    } else if (url.startsWith('podman-desktop://preferences/experimental')) {
-      url = url.replace('podman-desktop://preferences/experimental', 'podman-desktop:experimental');
+    const doubleSlashPrefix = `${this.protocol}://`;
+    const singleColonPrefix = `${this.protocol}:`;
+
+    if (url.startsWith(`${doubleSlashPrefix}extension/`)) {
+      url = url.replace(`${doubleSlashPrefix}extension/`, `${singleColonPrefix}extension/`);
+    } else if (url.startsWith(`${doubleSlashPrefix}preferences/experimental`)) {
+      url = url.replace(`${doubleSlashPrefix}preferences/experimental`, `${singleColonPrefix}experimental`);
     }
 
     return url;
@@ -40,13 +46,12 @@ export class ProtocolLauncher {
     // On Windows protocol handler will call the app with '<url>' args
     // on macOS it's done with 'open-url' event
     if (isWindows()) {
-      // now search if we have 'open-url' in the list of args and give it to the handler
+      const extensionPrefix = `${this.protocol}:extension/`;
+      const experimentalPrefix = `${this.protocol}:experimental`;
+
       for (const arg of args) {
         const analyzedArg = this.sanitizeProtocolForExtension(arg);
-        if (
-          analyzedArg.startsWith('podman-desktop:extension/') ||
-          analyzedArg.startsWith('podman-desktop:experimental')
-        ) {
+        if (analyzedArg.startsWith(extensionPrefix) || analyzedArg.startsWith(experimentalPrefix)) {
           this.handleOpenUrl(analyzedArg);
         }
       }
@@ -54,17 +59,18 @@ export class ProtocolLauncher {
   }
 
   handleOpenUrl(url: string): void {
-    // if the url starts with podman-desktop:extension/<id>
+    // if the url starts with ${this.protocol}:extension/<id>
     // we need to install the extension
 
-    // if url starts with 'podman-desktop://extension', replace it with 'podman-desktop:extension'
+    // if url starts with '${this.protocol}://extension', replace it with 'podman-desktop:extension'
     url = this.sanitizeProtocolForExtension(url);
 
-    if (url.startsWith('podman-desktop:extension/')) {
-      // grab the extension id
-      const extensionId = url.substring('podman-desktop:extension/'.length);
+    const extensionPrefix = `${this.protocol}:extension/`;
+    const experimentalPrefix = `${this.protocol}:experimental`;
 
-      // wait that the window is ready
+    if (url.startsWith(extensionPrefix)) {
+      const extensionId = url.substring(extensionPrefix.length);
+
       this.browserWindow.promise
         .then(w => {
           w.webContents.send('podman-desktop-protocol:install-extension', extensionId);
@@ -72,7 +78,7 @@ export class ProtocolLauncher {
         .catch((error: unknown) => {
           console.error('Error sending open-url event to webcontents', error);
         });
-    } else if (url.startsWith('podman-desktop:experimental')) {
+    } else if (url.startsWith(experimentalPrefix)) {
       this.browserWindow.promise
         .then(w => {
           w.webContents.send('podman-desktop-protocol:open-experimental-features');
@@ -81,7 +87,7 @@ export class ProtocolLauncher {
           console.error('Error sending open-url event to webcontents', error);
         });
     } else {
-      console.log(`url ${url} does not start with podman-desktop:extension/ or podman-desktop:experimental, skipping.`);
+      console.log(`url ${url} does not start with ${extensionPrefix} or ${experimentalPrefix}, skipping.`);
       return;
     }
   }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1694,6 +1694,10 @@ export function initExposure(): void {
     return ipcInvoke('welcome:getWelcomeMessages');
   });
 
+  contextBridge.exposeInMainWorld('getUrlProtocol', async (): Promise<string> => {
+    return ipcInvoke('product:getUrlProtocol');
+  });
+
   contextBridge.exposeInMainWorld('stopExtension', async (extensionId: string): Promise<void> => {
     return ipcInvoke('extension-loader:stopExtension', extensionId);
   });

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -36,7 +36,6 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mocked(window.getUrlProtocol).mockResolvedValue('podman-desktop');
 });
 
 test('Expect to have bold', async () => {

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -31,11 +31,11 @@ async function waitRender(customProperties: object): Promise<void> {
 
 beforeAll(() => {
   Object.defineProperty(window, 'executeCommand', { value: vi.fn() });
-  Object.defineProperty(window, 'getUrlProtocol', { value: vi.fn().mockResolvedValue('podman-desktop') });
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.getUrlProtocol).mockResolvedValue('podman-desktop');
 });
 
 test('Expect to have bold', async () => {

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ async function waitRender(customProperties: object): Promise<void> {
 
 beforeAll(() => {
   Object.defineProperty(window, 'executeCommand', { value: vi.fn() });
+  Object.defineProperty(window, 'getUrlProtocol', { value: vi.fn().mockResolvedValue('podman-desktop') });
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -36,6 +36,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.getUrlProtocol).mockResolvedValue('podman-desktop');
 });
 
 test('Expect to have bold', async () => {

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -88,7 +88,7 @@ function decode(htmlString: string): string {
   return textArea.value;
 }
 
-onMount(() => {
+onMount(async () => {
   if (markdown) {
     text = markdown;
   }
@@ -98,6 +98,9 @@ onMount(() => {
     extensions: [directive()],
     htmlExtensions: [directiveHtml({ button, image, link, warnings })],
   });
+
+  const urlProtocol: string = await window.getUrlProtocol();
+  const protocolPrefix = `${urlProtocol}://`;
 
   // remove href values in each anchor using # for links
   // and set the attribute data-pd-jump-in-page
@@ -119,8 +122,8 @@ onMount(() => {
 
       // add a class for cursor
       link.classList.add('cursor-pointer');
-    } else if (link.getAttribute('href')?.startsWith('podman-desktop://')) {
-      let internalLink = link.getAttribute('href')?.replace('podman-desktop://', '/') ?? '';
+    } else if (link.getAttribute('href')?.startsWith(protocolPrefix)) {
+      let internalLink = link.getAttribute('href')?.replace(protocolPrefix, '/') ?? '';
       link.setAttribute('href', internalLink);
     }
   });

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -140,6 +140,7 @@ beforeAll(() => {
     value: {
       updateCliTool: vi.fn(),
       executeCommand: vi.fn(),
+      getUrlProtocol: vi.fn().mockResolvedValue('podman-desktop'),
       navigator: {
         clipboard: {
           writeText: vi.fn(),
@@ -152,6 +153,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.getUrlProtocol).mockResolvedValue('podman-desktop');
 });
 
 describe('CLI Tool item', () => {


### PR DESCRIPTION
### What does this PR do?

PR removes hardcoded 'podman-desktop' protocol and use urlProtocol from product.json

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Related to https://github.com/redhat-developer/podman-desktop-redhat-account-ext/issues/1070

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
