### PR TITLE
test(e2e): add network smoke tests for container network integration

### DIFF
--- a/tests/playwright/src/model/pages/container-details-page.ts
+++ b/tests/playwright/src/model/pages/container-details-page.ts
@@ -156,4 +156,8 @@ export class ContainerDetailsPage extends DetailsPage {
       await this.clearLogsButton.click();
     });
   }
+
+  async searchInInspectEditor(text: string): Promise<boolean> {
+    return this.searchInEditor(ContainerDetailsPage.INSPECT_TAB, text);
+  }
 }

--- a/tests/playwright/src/model/pages/details-page.ts
+++ b/tests/playwright/src/model/pages/details-page.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import test, { type Locator, type Page } from '@playwright/test';
+import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
+import { isMac } from '/@/utility/platform';
 import { waitUntil } from '/@/utility/wait';
 
 import { BasePage } from './base-page';
@@ -33,6 +34,8 @@ export abstract class DetailsPage extends BasePage {
   readonly resourceName: string;
   readonly heading: Locator;
   readonly breadcrumb: Locator;
+  readonly editorWidget: Locator;
+  readonly findTextArea: Locator;
 
   constructor(page: Page, resourceName: string) {
     super(page);
@@ -47,6 +50,8 @@ export abstract class DetailsPage extends BasePage {
     this.closeButton = this.breadcrumb.getByRole('button', { name: 'Close' });
     this.backLink = this.breadcrumb.getByRole('link', { name: 'Back' });
     this.pageName = this.breadcrumb.getByRole('region', { name: 'Page Name' });
+    this.editorWidget = page.getByRole('dialog', { name: 'Find / Replace' });
+    this.findTextArea = this.editorWidget.getByPlaceholder('Find');
   }
 
   async activateTab(tabName: string): Promise<this> {
@@ -57,6 +62,26 @@ export abstract class DetailsPage extends BasePage {
       });
       await tabItem.click();
       return this;
+    });
+  }
+
+  async searchInEditor(tabName: string, text: string): Promise<boolean> {
+    return test.step(`Search '${text}' in ${tabName} editor`, async () => {
+      await this.activateTab(tabName);
+      const presentation = this.tabContent.getByRole('presentation');
+      await playExpect(presentation).toBeVisible();
+      await presentation.click();
+      if (isMac) {
+        await this.page.keyboard.press('Meta+F');
+      } else {
+        await this.page.keyboard.press('Control+F');
+      }
+      await playExpect(this.editorWidget).toBeVisible();
+      await playExpect(this.findTextArea).toBeVisible();
+      await this.findTextArea.fill(text);
+      const noResults = this.editorWidget.getByText('No results');
+      const hasNoResults = await noResults.isVisible();
+      return !hasNoResults;
     });
   }
 }

--- a/tests/playwright/src/model/pages/run-image-page.ts
+++ b/tests/playwright/src/model/pages/run-image-page.ts
@@ -188,4 +188,22 @@ export class RunImagePage extends BasePage {
       await containerPort.fill(customPortMapping.split(':')[1]);
     });
   }
+
+  async selectUserDefinedNetwork(networkName: string): Promise<void> {
+    return test.step(`Select user-defined network: ${networkName}`, async () => {
+      await this.activateTab('Networking');
+      // Open the Mode dropdown (shows current selection as button text) and pick User-defined network
+      const modeButton = this.page.getByRole('button', { name: /Creates a network stack/ });
+      await playExpect(modeButton).toBeVisible();
+      await modeButton.click();
+      await this.page.getByRole('button', { name: 'User-defined network' }).click();
+      // Open the Network dropdown and select the specific network
+      const networkDropdown = this.page.getByRole('button', { name: /\(used by \d+ containers\)/ }).first();
+      await playExpect(networkDropdown).toBeVisible();
+      await networkDropdown.click();
+      await this.page
+        .getByRole('button', { name: new RegExp(`^${networkName} \\(used by \\d+ containers\\)$`) })
+        .click();
+    });
+  }
 }

--- a/tests/playwright/src/specs/network-smoke.spec.ts
+++ b/tests/playwright/src/specs/network-smoke.spec.ts
@@ -16,21 +16,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ContainerState } from '/@/model/core/states';
 import { expect as playExpect, test } from '/@/utility/fixtures';
-import { deleteNetwork, isPodmanCliVersionAtLeast } from '/@/utility/operations';
+import { deleteContainer, deleteImage, deleteNetwork, isPodmanCliVersionAtLeast } from '/@/utility/operations';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const defaultNetworkName = 'bridge';
 const testNetworkName = 'e2e-test-network';
 const testNetworkSubnet = '192.168.1.0/24';
+const testContainerName = 'e2e-network-test-container';
+const testImageName = 'ghcr.io/linuxcontainers/alpine';
+
+test.skip(
+  !isPodmanCliVersionAtLeast('5.7.0'),
+  'Skipping network smoke tests since Podman CLI version is less than 5.7.0 or not available',
+);
 
 test.describe
   .serial('Network smoke tests', { tag: ['@smoke'] }, () => {
-    test.skip(
-      !isPodmanCliVersionAtLeast('5.7.0'),
-      'Skipping network smoke tests since Podman CLI version is less than 5.7.0 or not available',
-    );
-
     test.beforeAll(async ({ runner, welcomePage, page }) => {
       runner.setVideoAndTraceName('network-smoke');
       await welcomePage.handleWelcomePage(true);
@@ -39,7 +42,9 @@ test.describe
 
     test.afterAll(async ({ runner, page }) => {
       try {
+        await deleteContainer(page, testContainerName);
         await deleteNetwork(page, testNetworkName);
+        await deleteImage(page, testImageName);
       } finally {
         await runner.close();
       }
@@ -69,6 +74,84 @@ test.describe
           timeout: 30_000,
         })
         .toBeTruthy();
+    });
+
+    test('Pull image for network container test', async ({ navigationBar }) => {
+      test.setTimeout(90_000);
+
+      const imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      await imagesPage.pullImage(testImageName);
+
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(testImageName, 60_000), { timeout: 0 })
+        .toBeTruthy();
+    });
+
+    test('Start container using the network', async ({ navigationBar }) => {
+      test.setTimeout(90_000);
+
+      // Open the image and run it on the test network (network already exists from previous test)
+      const imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      const imageDetails = await imagesPage.openImageDetails(testImageName);
+      await playExpect(imageDetails.heading).toBeVisible();
+
+      const runImagePage = await imageDetails.openRunImage();
+      await playExpect(runImagePage.heading).toBeVisible();
+
+      await runImagePage.selectUserDefinedNetwork(testNetworkName);
+      await runImagePage.startContainer(testContainerName);
+
+      // After startContainer(), alpine's /bin/sh causes the app to navigate to
+      // Container Details → Tty tab (interactive shell scenario). Explicitly navigate
+      // to the Containers page to verify the container was created.
+      const containersPage = await navigationBar.openContainers();
+      await playExpect(containersPage.heading).toBeVisible();
+
+      // Wait for container row to appear, then open details and verify it is running
+      await playExpect
+        .poll(async () => await containersPage.getContainerRowByName(testContainerName), { timeout: 30_000 })
+        .toBeTruthy();
+      const containerDetails = await containersPage.openContainersDetails(testContainerName);
+      await playExpect(containerDetails.heading).toContainText(testContainerName);
+      await playExpect
+        .poll(async () => await containerDetails.getState(), { timeout: 30_000 })
+        .toBe(ContainerState.Running);
+    });
+
+    test('Verify container inspect shows correct network', async ({ navigationBar }) => {
+      const containersPage = await navigationBar.openContainers();
+      await playExpect(containersPage.heading).toBeVisible();
+
+      const containerDetails = await containersPage.openContainersDetails(testContainerName);
+      await playExpect(containerDetails.heading).toContainText(testContainerName);
+
+      await playExpect
+        .poll(async () => await containerDetails.searchInInspectEditor(testNetworkName), { timeout: 10_000 })
+        .toBeTruthy();
+    });
+
+    test('Stop and delete the network container', async ({ navigationBar }) => {
+      const containersPage = await navigationBar.openContainers();
+      await playExpect(containersPage.heading).toBeVisible();
+
+      const containerDetails = await containersPage.openContainersDetails(testContainerName);
+      await playExpect(containerDetails.heading).toContainText(testContainerName);
+
+      await containerDetails.stopContainer();
+      await playExpect
+        .poll(async () => await containerDetails.getState(), { timeout: 30_000 })
+        .toBe(ContainerState.Exited);
+
+      const updatedContainersPage = await containerDetails.deleteContainer();
+      await playExpect(updatedContainersPage.heading).toBeVisible();
+
+      await playExpect
+        .poll(async () => await updatedContainersPage.getContainerRowByName(testContainerName), { timeout: 30_000 })
+        .toBeFalsy();
     });
 
     test('Delete network from networks page and verify it was removed', async ({ navigationBar }) => {


### PR DESCRIPTION
### What does this PR do?

- Add network smoke tests covering full container lifecycle:
  - Check default network exists
  - Create network and verify it exists
  - Pull image for container test
  - Start container using user-defined network (fix navigation: after startContainer() with alpine /bin/sh the app lands on Container Details → Tty tab, not Containers list; use navigationBar.openContainers() explicitly)
  - Verify container inspect shows correct network (use Monaco Find widget via Ctrl+F instead of tabContent.toContainText() which only checks the visible viewport of the virtualized editor)
  - Stop and delete the network container
  - Delete network from networks page
  - Delete network from details page

- Add searchInEditor(tabName, text) to DetailsPage base class for reusable Monaco editor search across all detail pages
- Add searchInInspectEditor(text) convenience wrapper in ContainerDetailsPage
- Add selectUserDefinedNetwork(networkName) to RunImagePage


### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/16679
### How to test this PR?

https://github.com/podman-desktop/e2e/actions/runs/24077035436

- [ ] Tests are covering the bug fix or the new feature
