### PR TITLE
fix(kind): use shared temp directory for image push in Flatpak

### DIFF
--- a/extensions/kind/src/image-handler.spec.ts
+++ b/extensions/kind/src/image-handler.spec.ts
@@ -17,24 +17,27 @@
  ***********************************************************************/
 
 import { writeFileSync } from 'node:fs';
+import * as os from 'node:os';
 
 import * as extensionApi from '@podman-desktop/api';
 import type { Mock } from 'vitest';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ImageHandler } from './image-handler';
-import { getKindPath } from './util';
+import { getKindPath, getTempDir } from './util';
 
 let imageHandler: ImageHandler;
 
 vi.mock(import('./util'), async () => {
   return {
     getKindPath: vi.fn(),
+    getTempDir: vi.fn(),
   };
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(getTempDir).mockResolvedValue(os.tmpdir());
   imageHandler = new ImageHandler();
 });
 

--- a/extensions/kind/src/image-handler.ts
+++ b/extensions/kind/src/image-handler.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import * as fs from 'node:fs';
+import { join } from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
-import { tmpName } from 'tmp-promise';
 
 import type { KindCluster } from './extension';
-import { getKindPath } from './util';
+import { getKindPath, getTempDir } from './util';
 
 export type ImageInfo = { engineId: string; name?: string; tag?: string };
 
@@ -56,6 +56,7 @@ export class ImageHandler {
     // Only proceed if a cluster was selected
     if (selectedCluster) {
       let name = image.name;
+      let tmpDirectory: string | undefined;
       let filename: string | undefined;
       const env: { [key: string]: string } = {};
 
@@ -73,8 +74,12 @@ export class ImageHandler {
 
       env.PATH = getKindPath() ?? '';
       try {
-        // Create a temporary file to store the image
-        filename = await tmpName();
+        // Create a temporary directory to store the image archive.
+        // In Flatpak, /tmp is sandbox-private; getTempDir() returns a shared directory
+        // so the host-side `kind` process can access the file via flatpak-spawn.
+        const baseDir = await getTempDir();
+        tmpDirectory = await fs.promises.mkdtemp(join(baseDir, 'kind-image-'));
+        filename = join(tmpDirectory, 'image.tar');
 
         // Save the image to the temporary file
         await extensionApi.containerEngine.saveImage(image.engineId, name, filename);
@@ -98,9 +103,9 @@ export class ImageHandler {
         // Throw the errors to the console aswell
         throw new Error(`Unable to push image to Kind cluster: ${err}`);
       } finally {
-        // Remove the temporary file if one was created
-        if (filename !== undefined) {
-          await fs.promises.rm(filename);
+        // Remove the temporary directory and its contents
+        if (tmpDirectory !== undefined) {
+          await fs.promises.rm(tmpDirectory, { recursive: true });
         }
       }
     }

--- a/extensions/kind/src/util.spec.ts
+++ b/extensions/kind/src/util.spec.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getTempDir } from './util';
+
+vi.mock(import('node:fs'));
+
+describe('getTempDir', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env['FLATPAK_ID'];
+    delete process.env['XDG_CACHE_HOME'];
+    vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('returns os.tmpdir() when not running in Flatpak', async () => {
+    const result = await getTempDir();
+    expect(result).toBe(os.tmpdir());
+    expect(fs.promises.mkdir).not.toHaveBeenCalled();
+  });
+
+  test('returns XDG_CACHE_HOME/kind-tmp when running in Flatpak with XDG_CACHE_HOME set', async () => {
+    process.env['FLATPAK_ID'] = 'io.podman_desktop.PodmanDesktop';
+    process.env['XDG_CACHE_HOME'] = '/custom/cache';
+
+    const result = await getTempDir();
+    const expected = join('/custom/cache', 'kind-tmp');
+    expect(result).toBe(expected);
+    expect(fs.promises.mkdir).toHaveBeenCalledWith(expected, { recursive: true });
+  });
+
+  test('falls back to ~/.cache/kind-tmp when running in Flatpak without XDG_CACHE_HOME', async () => {
+    process.env['FLATPAK_ID'] = 'io.podman_desktop.PodmanDesktop';
+
+    const result = await getTempDir();
+    const expected = join(os.homedir(), '.cache', 'kind-tmp');
+    expect(result).toBe(expected);
+    expect(fs.promises.mkdir).toHaveBeenCalledWith(expected, { recursive: true });
+  });
+});

--- a/extensions/kind/src/util.ts
+++ b/extensions/kind/src/util.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as os from 'node:os';
 import { isAbsolute, join } from 'node:path';
@@ -196,4 +197,19 @@ export async function getMemTotalInfo(socketPath: string): Promise<number> {
 
 export function removeVersionPrefix(version: string): string {
   return version.replace('v', '').trim();
+}
+
+/**
+ * Returns a temp directory accessible from both the Flatpak sandbox and the host.
+ * In Flatpak, /tmp is a private tmpfs, so we use ~/.cache/kind-tmp/ which is
+ * shared via --filesystem=home.
+ */
+export async function getTempDir(): Promise<string> {
+  if (process.env['FLATPAK_ID']) {
+    const cacheHome = process.env['XDG_CACHE_HOME'] ?? join(os.homedir(), '.cache');
+    const tmpDir = join(cacheHome, 'kind-tmp');
+    await fs.promises.mkdir(tmpDir, { recursive: true });
+    return tmpDir;
+  }
+  return os.tmpdir();
 }


### PR DESCRIPTION
### What does this PR do?

Fixes image push to Kind cluster failing in Flatpak builds. In Flatpak, `/tmp` is a sandbox-private tmpfs. The image archive was saved inside the sandbox's `/tmp`, but `kind load image-archive` runs on the host via `flatpak-spawn --host` and cannot access it. This PR uses `~/.cache/kind-tmp/` instead, which is shared between the sandbox and host via Flatpak's --`filesystem=home permission`.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

fixes #15812 

### How to test this PR?

1. Build and install Podman Desktop as a Flatpak on Linux
2. Create a Kind cluster: `KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster --name test-cluster`
3. Pull an image in Podman Desktop (e.g. docker.io/library/alpine:latest)
4. Context menu on the image → "Push image to Kind cluster"
5. Verify the push succeeds (previously failed with "Command execution failed with exit code 1")

- [x] Tests are covering the bug fix or the new feature
