### PR TITLE
fix(installer): hyperv failure logs werent showing for onboarding

### DIFF
--- a/extensions/podman/packages/extension/src/checks/base-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/base-check.spec.ts
@@ -59,7 +59,7 @@ describe('OrCheck', () => {
     expect(orCheck.title).toBe('orcheck');
     const result = await orCheck.execute();
     expect(result.successful).toBeFalsy();
-    expect(result.description).toBe('check has failed');
+    expect(result.description).toBe('failed check: check has failed\nfailed check: check has failed');
   });
 });
 

--- a/extensions/podman/packages/extension/src/checks/base-check.ts
+++ b/extensions/podman/packages/extension/src/checks/base-check.ts
@@ -90,6 +90,12 @@ export class OrCheck extends BaseCheck {
       return leftResult;
     }
     const rightResult = await this.right.execute();
-    return rightResult.successful ? rightResult : leftResult;
+    if (rightResult.successful) {
+      return rightResult;
+    }
+    return {
+      successful: false,
+      description: `${this.left.title}: ${leftResult.description}\n${this.right.title}: ${rightResult.description}`,
+    };
   }
 }


### PR DESCRIPTION
if both wsl and hyperv logs fail show both. Wsl will always be tried first so for those who only use hyperv now proper logs can be shown

### What does this PR do?

### Screenshot / video of UI

<img width="627" height="363" alt="image" src="https://github.com/user-attachments/assets/178ba27e-7fb6-4d59-b5f2-1a984c004c8c" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes: https://github.com/podman-desktop/podman-desktop/issues/16148

and other hyperv related issues where the logs werent accurate on the ui

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
