### PR TITLE
chore(test): ensure app process is terminated after closing

### DIFF
--- a/tests/playwright/src/runner/electron-runner.ts
+++ b/tests/playwright/src/runner/electron-runner.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 
 import type { ElectronApplication, JSHandle, Page } from '@playwright/test';
@@ -46,6 +47,8 @@ export class ElectronRunner extends Runner {
       console.log('Podman Desktop is already running');
       return this.getPage();
     }
+
+    this.killStaleElectronInstances();
 
     try {
       // start the app with given properties
@@ -178,12 +181,7 @@ export class ElectronRunner extends Runner {
     } catch (err: unknown) {
       console.log(`Caught exception in closing: ${err}`);
       if (pid) {
-        console.log(`Killing the electron app process with PID: ${pid}`);
-        try {
-          process.kill(pid);
-        } catch (error: unknown) {
-          console.log(`Exception thrown when killing the process: ${error}`);
-        }
+        this.forceKillProcess(pid);
       }
     }
 
@@ -201,6 +199,47 @@ export class ElectronRunner extends Runner {
       }
     }
     await this.removeTracesOnFinished();
+  }
+
+  /**
+   * Force-kill a process by PID. On Windows, uses `taskkill /F /T` to ensure
+   * the entire process tree is terminated and OS-level resources (such as
+   * Electron's single-instance lock) are released.
+   */
+  protected forceKillProcess(pid: number): void {
+    console.log(`Force-killing the electron app process with PID: ${pid}`);
+    try {
+      if (process.platform === 'win32') {
+        // eslint-disable-next-line sonarjs/os-command, n/no-sync
+        execSync(`taskkill /F /T /PID ${pid}`, { timeout: 30_000 });
+      } else {
+        process.kill(pid, 'SIGKILL');
+      }
+    } catch (error: unknown) {
+      console.log(`Exception thrown when force-killing process ${pid}: ${error}`);
+    }
+  }
+
+  /**
+   * Kill any stale Electron or Podman Desktop processes left over from a
+   * previous test run whose close sequence failed. On Windows, a dangling
+   * process keeps the Electron single-instance lock, blocking all subsequent
+   * launches with "An instance of Podman Desktop is already running".
+   */
+  protected killStaleElectronInstances(): void {
+    if (process.platform !== 'win32') {
+      return;
+    }
+
+    for (const processName of ['electron.exe', 'pd.exe', 'podman-desktop.exe', 'Podman Desktop.exe']) {
+      try {
+        // eslint-disable-next-line sonarjs/os-command, n/no-sync
+        execSync(`taskkill /F /IM "${processName}" /T`, { timeout: 30_000 });
+        console.log(`Killed stale process: ${processName}`);
+      } catch {
+        // Expected when no matching process is running
+      }
+    }
   }
 
   protected override defaultOptions(): object {

--- a/tests/playwright/src/runner/electron-runner.ts
+++ b/tests/playwright/src/runner/electron-runner.ts
@@ -235,6 +235,7 @@ export class ElectronRunner extends Runner {
       return;
     }
 
+    // eslint-disable-next-line quotes
     const wmicFilter = "CommandLine like '%podman-desktop%' OR CommandLine like '%podman desktop%'";
     try {
       // eslint-disable-next-line sonarjs/no-os-command-from-path, n/no-sync

--- a/tests/playwright/src/runner/electron-runner.ts
+++ b/tests/playwright/src/runner/electron-runner.ts
@@ -226,9 +226,11 @@ export class ElectronRunner extends Runner {
    * Electron single-instance lock, blocking all subsequent launches with
    * "An instance of Podman Desktop is already running".
    *
-   * Only targets processes whose executable path contains "podman-desktop"
-   * (covers electron.exe launched from the PD workspace, pd.exe, and
-   * podman-desktop.exe) so unrelated Electron apps are never affected.
+   * Uses WMIC to find processes whose command line contains "podman-desktop"
+   * or "podman desktop", then force-kills them by PID. This matches the
+   * Electron binary launched from the PD workspace as well as compiled
+   * binaries (pd.exe, podman-desktop.exe) without affecting unrelated
+   * Electron apps.
    */
   protected killStaleElectronInstances(): void {
     if (process.platform !== 'win32') {

--- a/tests/playwright/src/runner/electron-runner.ts
+++ b/tests/playwright/src/runner/electron-runner.ts
@@ -48,8 +48,6 @@ export class ElectronRunner extends Runner {
       return this.getPage();
     }
 
-    this.killStaleElectronInstances();
-
     try {
       // start the app with given properties
       console.log('Starting Podman Desktop');
@@ -217,50 +215,6 @@ export class ElectronRunner extends Runner {
       }
     } catch (error: unknown) {
       console.log(`Exception thrown when force-killing process ${pid}: ${error}`);
-    }
-  }
-
-  /**
-   * Kill stale Podman Desktop processes left over from a previous test run
-   * whose close sequence failed. On Windows, a dangling process keeps the
-   * Electron single-instance lock, blocking all subsequent launches with
-   * "An instance of Podman Desktop is already running".
-   *
-   * Uses WMIC to find processes whose command line contains "podman-desktop"
-   * or "podman desktop", then force-kills them by PID. This matches the
-   * Electron binary launched from the PD workspace as well as compiled
-   * binaries (pd.exe, podman-desktop.exe) without affecting unrelated
-   * Electron apps.
-   */
-  protected killStaleElectronInstances(): void {
-    if (process.platform !== 'win32') {
-      return;
-    }
-
-    // eslint-disable-next-line quotes
-    const wmicFilter = "CommandLine like '%podman-desktop%' OR CommandLine like '%podman desktop%'";
-    try {
-      // eslint-disable-next-line sonarjs/no-os-command-from-path, n/no-sync
-      const output = execFileSync('wmic', ['process', 'where', wmicFilter, 'get', 'ProcessId', '/FORMAT:CSV'], {
-        timeout: 10_000,
-        encoding: 'utf-8',
-      });
-      const pids = output
-        .split(/\r?\n/)
-        .map(line => line.split(',').pop()?.trim())
-        .filter((pid): pid is string => !!pid && /^\d+$/.test(pid));
-
-      for (const pid of pids) {
-        try {
-          // eslint-disable-next-line sonarjs/no-os-command-from-path, n/no-sync
-          execFileSync('taskkill', ['/F', '/T', '/PID', pid], { timeout: 10_000 });
-          console.log(`Killed stale Podman Desktop process with PID: ${pid}`);
-        } catch {
-          // Process may have exited between query and kill
-        }
-      }
-    } catch {
-      // wmic query returned no results or failed — nothing to clean up
     }
   }
 

--- a/tests/playwright/src/runner/electron-runner.ts
+++ b/tests/playwright/src/runner/electron-runner.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 
 import type { ElectronApplication, JSHandle, Page } from '@playwright/test';
@@ -210,8 +210,8 @@ export class ElectronRunner extends Runner {
     console.log(`Force-killing the electron app process with PID: ${pid}`);
     try {
       if (process.platform === 'win32') {
-        // eslint-disable-next-line sonarjs/os-command, n/no-sync
-        execSync(`taskkill /F /T /PID ${pid}`, { timeout: 30_000 });
+        // eslint-disable-next-line sonarjs/no-os-command-from-path, n/no-sync
+        execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], { timeout: 30_000 });
       } else {
         process.kill(pid, 'SIGKILL');
       }
@@ -221,24 +221,43 @@ export class ElectronRunner extends Runner {
   }
 
   /**
-   * Kill any stale Electron or Podman Desktop processes left over from a
-   * previous test run whose close sequence failed. On Windows, a dangling
-   * process keeps the Electron single-instance lock, blocking all subsequent
-   * launches with "An instance of Podman Desktop is already running".
+   * Kill stale Podman Desktop processes left over from a previous test run
+   * whose close sequence failed. On Windows, a dangling process keeps the
+   * Electron single-instance lock, blocking all subsequent launches with
+   * "An instance of Podman Desktop is already running".
+   *
+   * Only targets processes whose executable path contains "podman-desktop"
+   * (covers electron.exe launched from the PD workspace, pd.exe, and
+   * podman-desktop.exe) so unrelated Electron apps are never affected.
    */
   protected killStaleElectronInstances(): void {
     if (process.platform !== 'win32') {
       return;
     }
 
-    for (const processName of ['electron.exe', 'pd.exe', 'podman-desktop.exe', 'Podman Desktop.exe']) {
-      try {
-        // eslint-disable-next-line sonarjs/os-command, n/no-sync
-        execSync(`taskkill /F /IM "${processName}" /T`, { timeout: 30_000 });
-        console.log(`Killed stale process: ${processName}`);
-      } catch {
-        // Expected when no matching process is running
+    const wmicFilter = "CommandLine like '%podman-desktop%' OR CommandLine like '%podman desktop%'";
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path, n/no-sync
+      const output = execFileSync('wmic', ['process', 'where', wmicFilter, 'get', 'ProcessId', '/FORMAT:CSV'], {
+        timeout: 10_000,
+        encoding: 'utf-8',
+      });
+      const pids = output
+        .split(/\r?\n/)
+        .map(line => line.split(',').pop()?.trim())
+        .filter((pid): pid is string => !!pid && /^\d+$/.test(pid));
+
+      for (const pid of pids) {
+        try {
+          // eslint-disable-next-line sonarjs/no-os-command-from-path, n/no-sync
+          execFileSync('taskkill', ['/F', '/T', '/PID', pid], { timeout: 10_000 });
+          console.log(`Killed stale Podman Desktop process with PID: ${pid}`);
+        } catch {
+          // Process may have exited between query and kill
+        }
       }
+    } catch {
+      // wmic query returned no results or failed — nothing to clean up
     }
   }
 

--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -98,6 +98,7 @@ export abstract class Runner {
     // create parent folder if missing
     const parentDir = dirname(settingsFile);
     if (!existsSync(parentDir)) {
+      // eslint-disable-next-line n/no-sync
       mkdirSync(parentDir, { recursive: true });
     }
 
@@ -105,6 +106,7 @@ export abstract class Runner {
 
     // write the file
     console.log(`disabling OpenDevTools in configuration file ${settingsFile}`);
+    // eslint-disable-next-line n/no-sync
     writeFileSync(settingsFile, settingsContent);
 
     return env;
@@ -149,6 +151,7 @@ export abstract class Runner {
 
     if (existsSync(rawTracesPath)) {
       console.log(`Removing raw traces folder: ${rawTracesPath}`);
+      // eslint-disable-next-line n/no-sync
       rmSync(rawTracesPath, { recursive: true, force: true, maxRetries: 5 });
     }
 
@@ -165,6 +168,7 @@ export abstract class Runner {
       const tracesPath = join(this._testOutput, 'traces', `${this._videoAndTraceName}_trace.zip`);
       if (existsSync(tracesPath)) {
         console.log(`Removing traces folder: ${tracesPath}`);
+        // eslint-disable-next-line n/no-sync
         rmSync(tracesPath, { recursive: true, force: true, maxRetries: 5 });
       }
     }
@@ -173,6 +177,7 @@ export abstract class Runner {
       const videoPath = join(this._testOutput, 'videos', `${this._videoAndTraceName}.webm`);
       if (existsSync(videoPath)) {
         console.log(`Removing video folder: ${videoPath}`);
+        // eslint-disable-next-line n/no-sync
         rmSync(videoPath, { recursive: true, force: true, maxRetries: 5 });
       }
     }


### PR DESCRIPTION
### What does this PR do?
Seems that with some recent changes on windows the pd/electron process can hang upon closing and preventing any further PD instance from being created. This PR ensures relevant processes do not hang upon termination.

### What issues does this PR fix or reference?