### PR TITLE
fix(renderer): preserve original casing of terms in SearchTermParser  

### DIFF
--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -222,7 +222,9 @@ export class ExtensionsUtils {
     return extensions.filter(extension => {
       return (
         (terms.length === 0 ||
-          terms.every(term => `${extension.displayName} ${extension.shortDescription}`.toLowerCase().includes(term))) &&
+          terms.every(term =>
+            `${extension.displayName} ${extension.shortDescription}`.toLowerCase().includes(term.toLowerCase()),
+          )) &&
         (categories.length === 0 ||
           categories.every(category => extension.categories.map(c => c.toLowerCase()).includes(category))) &&
         (keywords.length === 0 ||

--- a/packages/renderer/src/lib/search/search-term-parser.spec.ts
+++ b/packages/renderer/src/lib/search/search-term-parser.spec.ts
@@ -91,7 +91,7 @@ describe('SearchTermParser', () => {
     },
     {
       input: 'FOO category:Containers keyword:"My Key"',
-      terms: ['foo'],
+      terms: ['FOO'],
       filters: { category: ['containers'], keyword: ['my key'] },
     },
     {

--- a/packages/renderer/src/lib/search/search-term-parser.ts
+++ b/packages/renderer/src/lib/search/search-term-parser.ts
@@ -22,11 +22,12 @@ import SearchString from 'search-string';
  * Parses a search string into plain-text terms and filter values,
  * respecting quoted values (double or single) via the `search-string` library.
  *
- * All terms and filter values are lowercased.
+ * Terms preserve the original casing of the input.
+ * Filter values are lowercased for case-insensitive comparison.
  *
  * @example
  * const parsed = new SearchTermParser('Foo category:"Extension Packs" is:installed', ['category', 'keyword', 'is', 'not']);
- * parsed.terms              // => ['foo']
+ * parsed.terms              // => ['Foo']
  * parsed.getFilter('category') // => ['extension packs']
  * parsed.getFilter('is')      // => ['installed']
  */
@@ -38,13 +39,12 @@ export class SearchTermParser<F extends string> {
     const terms: string[] = [];
     const filters = new Map<F, string[]>();
     const allowedSet = new Set<string>(allowedFilters);
-    const normalized = searchTerm.toLowerCase();
 
     for (const filter of allowedFilters) {
       filters.set(filter, []);
     }
 
-    const parsed = SearchString.parse(normalized);
+    const parsed = SearchString.parse(searchTerm);
 
     for (const segment of parsed.getTextSegments()) {
       if (!segment.negated && segment.text.length > 0) {
@@ -54,10 +54,10 @@ export class SearchTermParser<F extends string> {
 
     for (const condition of parsed.getConditionArray()) {
       if (condition.negated) continue;
-      const key = condition.keyword as F;
+      const key = condition.keyword.toLowerCase() as F;
       const bucket = allowedSet.has(key) ? filters.get(key) : undefined;
       if (bucket) {
-        bucket.push(condition.value);
+        bucket.push(condition.value.toLowerCase());
       } else {
         terms.push(`${condition.keyword}:${condition.value}`);
       }


### PR DESCRIPTION
### What does this PR do?

With the new SearchTermParser, I always lowercased the search term. But in the integration with the extension catalog draft PR (https://github.com/podman-desktop/podman-desktop/pull/16993), I noticed that changing tab from "Installed" to "Catalog" made the search term lowercased which is an unwanted change. So before I continue with this PR, I need to amend the SearchTermParser with this fix.

Parser responsibilities separated: terms now retain their original casing; filter values are still lowercased at parse time since they are only used for case-insensitive comparison.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Follow up of https://github.com/podman-desktop/podman-desktop/pull/17002

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
