### PR TITLE
feat(main): add schema generation script and CI sync for extension JSON schema

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -233,6 +233,9 @@ jobs:
       - name: Run formatter
         run: pnpm format:check
 
+      - name: Generate schemas
+        run: pnpm generate:schemas
+
       # Check we don't have changes in git
       - name: Check no changes in git
         run: |

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -21,7 +21,8 @@
       "!**/website/static/release-notes/**",
       "!**/website-argos/screenshots/**",
       "!**/storybook/.storybook/themes.css",
-      "!**/storybook/storybook-static/**"
+      "!**/storybook/storybook-static/**",
+      "!**/schemas/**"
     ]
   },
   "javascript": {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -21,8 +21,7 @@
       "!**/website/static/release-notes/**",
       "!**/website-argos/screenshots/**",
       "!**/storybook/.storybook/themes.css",
-      "!**/storybook/storybook-static/**",
-      "!**/schemas/**"
+      "!**/storybook/storybook-static/**"
     ]
   },
   "javascript": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
       "biome format --write"
     ],
     "*.md": "prettier --cache --write",
-    "*.{css,json}": "biome format --write"
+    "*.{css,json}": "biome format --write --no-errors-on-unmatched"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "website:prod": "pnpm run website:build && cd website/build && pnpm serve",
     "website:dev": "pnpm run storybook:build && cd website && pnpm run docusaurus start",
     "website:screenshots": "cd website-argos && pnpm run screenshot",
+    "generate:schemas": "pnpm run generate:schemas:extension",
+    "generate:schemas:extension": "pnpm run build:main && node packages/main/dist/generate-extension-schema.cjs",
     "storybook:css": "tsx ./scripts/generate-stylesheet.ts --output storybook/.storybook/themes.css",
     "storybook:dev": "pnpm run storybook:css && cd storybook && pnpm run dev",
     "storybook:build": "pnpm run build:ui && pnpm run storybook:css && cd storybook && pnpm run build",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "website:prod": "pnpm run website:build && cd website/build && pnpm serve",
     "website:dev": "pnpm run storybook:build && cd website && pnpm run docusaurus start",
     "website:screenshots": "cd website-argos && pnpm run screenshot",
-    "generate:schemas": "pnpm run generate:schemas:extension",
+    "generate:schemas": "pnpm run generate:schemas:extension && biome format --write schemas/",
     "generate:schemas:extension": "pnpm run build:main && node packages/main/dist/generate-extension-schema.cjs",
     "storybook:css": "tsx ./scripts/generate-stylesheet.ts --output storybook/.storybook/themes.css",
     "storybook:dev": "pnpm run storybook:css && cd storybook && pnpm run dev",
@@ -134,7 +134,7 @@
       "biome format --write"
     ],
     "*.md": "prettier --cache --write",
-    "*.{css,json}": "biome format --write --no-errors-on-unmatched"
+    "*.{css,json}": "biome format --write"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/packages/main/scripts/generate-extension-schema.spec.ts
+++ b/packages/main/scripts/generate-extension-schema.spec.ts
@@ -1,0 +1,78 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { generateExtensionManifestJsonSchema } from '/@/plugin/extension/extension-manifest-json-schema.js';
+
+import { main, parseArgs } from './generate-extension-schema.js';
+
+vi.mock(import('node:fs/promises'));
+vi.mock(import('/@/plugin/extension/extension-manifest-json-schema.js'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('parseArgs', () => {
+  test('returns default output path when no --output is provided', () => {
+    const { output } = parseArgs([]);
+    expect(output).toBe(resolve(process.cwd(), 'schemas', 'extension-schema.json'));
+  });
+
+  test('returns provided absolute output path', () => {
+    const { output } = parseArgs(['--output', '/tmp/my-schema.json']);
+    expect(output).toBe('/tmp/my-schema.json');
+  });
+
+  test('throws when output path is relative', () => {
+    expect(() => parseArgs(['--output', 'relative/path.json'])).toThrow('the output path should be absolute');
+  });
+});
+
+describe('main', () => {
+  test('writes generated schema to output path', async () => {
+    const fakeSchema = { $schema: 'http://json-schema.org/draft-07/schema#', title: 'test' };
+    vi.mocked(generateExtensionManifestJsonSchema).mockReturnValue(fakeSchema);
+    vi.mocked(mkdir).mockResolvedValue(undefined);
+    vi.mocked(writeFile).mockResolvedValue();
+
+    await main(['--output', '/tmp/test-schema.json']);
+
+    expect(generateExtensionManifestJsonSchema).toHaveBeenCalled();
+    expect(mkdir).toHaveBeenCalledWith('/tmp', { recursive: true });
+    expect(writeFile).toHaveBeenCalledWith('/tmp/test-schema.json', `${JSON.stringify(fakeSchema, undefined, 2)}\n`, {
+      encoding: 'utf-8',
+    });
+  });
+
+  test('uses default output when no args provided', async () => {
+    const fakeSchema = { test: true };
+    vi.mocked(generateExtensionManifestJsonSchema).mockReturnValue(fakeSchema);
+    vi.mocked(mkdir).mockResolvedValue(undefined);
+    vi.mocked(writeFile).mockResolvedValue();
+
+    await main([]);
+
+    const expectedPath = resolve(process.cwd(), 'schemas', 'extension-schema.json');
+    expect(writeFile).toHaveBeenCalledWith(expectedPath, expect.any(String), { encoding: 'utf-8' });
+  });
+});

--- a/packages/main/scripts/generate-extension-schema.ts
+++ b/packages/main/scripts/generate-extension-schema.ts
@@ -1,0 +1,60 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+
+import minimist from 'minimist';
+
+import { generateExtensionManifestJsonSchema } from '/@/plugin/extension/extension-manifest-json-schema.js';
+
+const DEFAULT_OUTPUT = join('schemas', 'extension-schema.json');
+
+export function parseArgs(args: string[]): { output: string } {
+  const parsed = minimist(args);
+  const output: string | undefined = parsed['output'];
+
+  if (!output) {
+    return { output: resolve(process.cwd(), DEFAULT_OUTPUT) };
+  }
+
+  if (!isAbsolute(output)) {
+    throw new Error('the output path should be absolute');
+  }
+
+  return { output };
+}
+
+export async function main(args: string[]): Promise<void> {
+  const { output } = parseArgs(args);
+
+  const schema = generateExtensionManifestJsonSchema();
+  const content = `${JSON.stringify(schema, undefined, 2)}\n`;
+
+  await mkdir(dirname(output), { recursive: true });
+  await writeFile(output, content, { encoding: 'utf-8' });
+
+  console.log(`Extension schema written to ${output}`);
+}
+
+if (!process.env['VITEST']) {
+  main(process.argv.slice(2)).catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/main/scripts/generate-extension-schema.ts
+++ b/packages/main/scripts/generate-extension-schema.ts
@@ -27,11 +27,17 @@ const DEFAULT_OUTPUT = join('schemas', 'extension-schema.json');
 
 export function parseArgs(args: string[]): { output: string } {
   const parsed = minimist(args);
-  const output: string | undefined = parsed['output'];
+  const rawOutput: unknown = parsed['output'];
 
-  if (!output) {
+  if (rawOutput === undefined || rawOutput === null || rawOutput === false) {
     return { output: resolve(process.cwd(), DEFAULT_OUTPUT) };
   }
+
+  if (typeof rawOutput !== 'string' || rawOutput.trim() === '') {
+    throw new Error('--output must be a non-empty string path');
+  }
+
+  const output = rawOutput;
 
   if (!isAbsolute(output)) {
     throw new Error('the output path should be absolute');

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -43,7 +43,7 @@ const config = {
     assetsDir: '.',
     minify: process.env.MODE === 'production' ? 'esbuild' : false,
     lib: {
-      entry: ['src/index.ts', 'scripts/download-remote-extensions.ts'],
+      entry: ['src/index.ts', 'scripts/download-remote-extensions.ts', 'scripts/generate-extension-schema.ts'],
       formats: ['cjs'],
     },
     rollupOptions: {

--- a/schemas/extension-schema.json
+++ b/schemas/extension-schema.json
@@ -1,0 +1,573 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Podman Desktop Extension Manifest",
+  "description": "Schema for Podman Desktop extension package.json files",
+  "allOf": [
+    {
+      "$ref": "https://json.schemastore.org/package.json"
+    },
+    {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "publisher": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "main": {
+          "type": "string"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "light": {
+                  "type": "string"
+                },
+                "dark": {
+                  "type": "string"
+                }
+              },
+              "required": ["light", "dark"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "extensionDependencies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extensionPack": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "engines": {
+          "type": "object",
+          "properties": {
+            "podman-desktop": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "contributes": {
+          "type": "object",
+          "properties": {
+            "configuration": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "properties": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": ["markdown", "string", "number", "integer", "boolean", "null", "array", "object"]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": ["markdown", "string", "number", "integer", "boolean", "null", "array", "object"]
+                            }
+                          }
+                        ]
+                      },
+                      "default": {},
+                      "group": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "placeholder": {
+                        "type": "string"
+                      },
+                      "markdownDescription": {
+                        "type": "string"
+                      },
+                      "minimum": {
+                        "type": "number"
+                      },
+                      "maximum": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "format": {
+                        "type": "string"
+                      },
+                      "step": {
+                        "type": "number"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "DEFAULT",
+                              "ContainerConnection",
+                              "KubernetesConnection",
+                              "VmConnection",
+                              "ContainerProviderConnectionFactory",
+                              "KubernetesProviderConnectionFactory",
+                              "VmProviderConnectionFactory",
+                              "DockerCompatibility",
+                              "Onboarding"
+                            ]
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "DEFAULT",
+                                "ContainerConnection",
+                                "KubernetesConnection",
+                                "VmConnection",
+                                "ContainerProviderConnectionFactory",
+                                "KubernetesProviderConnectionFactory",
+                                "VmProviderConnectionFactory",
+                                "DockerCompatibility",
+                                "Onboarding"
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "readonly": {
+                        "type": "boolean"
+                      },
+                      "hidden": {
+                        "type": "boolean"
+                      },
+                      "enum": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "when": {
+                        "type": "string"
+                      },
+                      "experimental": {
+                        "type": "object",
+                        "properties": {
+                          "githubDiscussionLink": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "scope": {
+                  "type": "string",
+                  "enum": [
+                    "DEFAULT",
+                    "ContainerConnection",
+                    "KubernetesConnection",
+                    "VmConnection",
+                    "ContainerProviderConnectionFactory",
+                    "KubernetesProviderConnectionFactory",
+                    "VmProviderConnectionFactory",
+                    "DockerCompatibility",
+                    "Onboarding"
+                  ]
+                },
+                "extension": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["id"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["title"],
+              "additionalProperties": false
+            },
+            "commands": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "command": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "category": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "light": {
+                            "type": "string"
+                          },
+                          "dark": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["light", "dark"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "keybinding": {
+                    "type": "string"
+                  },
+                  "enablement": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "menus": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "command": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    },
+                    "when": {
+                      "type": "string"
+                    },
+                    "disabled": {
+                      "type": "string"
+                    },
+                    "icon": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["command", "title"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "icons": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "default": {
+                    "type": "object",
+                    "properties": {
+                      "fontPath": {
+                        "type": "string"
+                      },
+                      "fontCharacter": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["fontCharacter"],
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "themes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "parent": {
+                    "type": "string"
+                  },
+                  "colors": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["id", "name", "parent", "colors"],
+                "additionalProperties": false
+              }
+            },
+            "views": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "when": {
+                          "type": "string"
+                        },
+                        "icon": {
+                          "type": "string"
+                        }
+                      },
+                      "required": ["icon"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "when": {
+                          "type": "string"
+                        },
+                        "badge": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string"
+                            },
+                            "color": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "light": {
+                                      "type": "string"
+                                    },
+                                    "dark": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": ["light", "dark"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            }
+                          },
+                          "required": ["label"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": ["badge"],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              }
+            },
+            "onboarding": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "number"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "media": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "altText": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["path", "altText"],
+                  "additionalProperties": false
+                },
+                "steps": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "description": {
+                        "type": "string"
+                      },
+                      "media": {
+                        "type": "object",
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "altText": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["path", "altText"],
+                        "additionalProperties": false
+                      },
+                      "command": {
+                        "type": "string"
+                      },
+                      "completionEvents": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "content": {
+                        "type": "array",
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "value": {
+                                "type": "string"
+                              },
+                              "highlight": {
+                                "type": "boolean"
+                              },
+                              "when": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["value"],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "component": {
+                        "type": "string",
+                        "enum": ["createContainerProviderConnection", "createKubernetesProviderConnection"]
+                      },
+                      "when": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string",
+                        "enum": ["completed", "failed", "skipped"]
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": ["completed", "failed"]
+                      }
+                    },
+                    "required": ["id", "title"],
+                    "additionalProperties": false
+                  }
+                },
+                "enablement": {
+                  "type": "string"
+                }
+              },
+              "required": ["title", "steps", "enablement"],
+              "additionalProperties": false
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["name", "displayName", "version", "publisher", "description"],
+      "additionalProperties": {}
+    }
+  ]
+}

--- a/schemas/extension-schema.json
+++ b/schemas/extension-schema.json
@@ -43,7 +43,10 @@
                   "type": "string"
                 }
               },
-              "required": ["light", "dark"],
+              "required": [
+                "light",
+                "dark"
+              ],
               "additionalProperties": false
             }
           ]
@@ -109,13 +112,31 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": ["markdown", "string", "number", "integer", "boolean", "null", "array", "object"]
+                            "enum": [
+                              "markdown",
+                              "string",
+                              "number",
+                              "integer",
+                              "boolean",
+                              "null",
+                              "array",
+                              "object"
+                            ]
                           },
                           {
                             "type": "array",
                             "items": {
                               "type": "string",
-                              "enum": ["markdown", "string", "number", "integer", "boolean", "null", "array", "object"]
+                              "enum": [
+                                "markdown",
+                                "string",
+                                "number",
+                                "integer",
+                                "boolean",
+                                "null",
+                                "array",
+                                "object"
+                              ]
                             }
                           }
                         ]
@@ -239,11 +260,15 @@
                       "type": "string"
                     }
                   },
-                  "required": ["id"],
+                  "required": [
+                    "id"
+                  ],
                   "additionalProperties": false
                 }
               },
-              "required": ["title"],
+              "required": [
+                "title"
+              ],
               "additionalProperties": false
             },
             "commands": {
@@ -278,7 +303,10 @@
                             "type": "string"
                           }
                         },
-                        "required": ["light", "dark"],
+                        "required": [
+                          "light",
+                          "dark"
+                        ],
                         "additionalProperties": false
                       }
                     ]
@@ -319,7 +347,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["command", "title"],
+                  "required": [
+                    "command",
+                    "title"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -345,7 +376,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["fontCharacter"],
+                    "required": [
+                      "fontCharacter"
+                    ],
                     "additionalProperties": false
                   }
                 },
@@ -376,7 +409,12 @@
                     }
                   }
                 },
-                "required": ["id", "name", "parent", "colors"],
+                "required": [
+                  "id",
+                  "name",
+                  "parent",
+                  "colors"
+                ],
                 "additionalProperties": false
               }
             },
@@ -399,7 +437,9 @@
                           "type": "string"
                         }
                       },
-                      "required": ["icon"],
+                      "required": [
+                        "icon"
+                      ],
                       "additionalProperties": false
                     },
                     {
@@ -429,17 +469,24 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": ["light", "dark"],
+                                  "required": [
+                                    "light",
+                                    "dark"
+                                  ],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": ["label"],
+                          "required": [
+                            "label"
+                          ],
                           "additionalProperties": false
                         }
                       },
-                      "required": ["badge"],
+                      "required": [
+                        "badge"
+                      ],
                       "additionalProperties": false
                     }
                   ]
@@ -468,7 +515,10 @@
                       "type": "string"
                     }
                   },
-                  "required": ["path", "altText"],
+                  "required": [
+                    "path",
+                    "altText"
+                  ],
                   "additionalProperties": false
                 },
                 "steps": {
@@ -495,7 +545,10 @@
                             "type": "string"
                           }
                         },
-                        "required": ["path", "altText"],
+                        "required": [
+                          "path",
+                          "altText"
+                        ],
                         "additionalProperties": false
                       },
                       "command": {
@@ -524,28 +577,43 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["value"],
+                            "required": [
+                              "value"
+                            ],
                             "additionalProperties": false
                           }
                         }
                       },
                       "component": {
                         "type": "string",
-                        "enum": ["createContainerProviderConnection", "createKubernetesProviderConnection"]
+                        "enum": [
+                          "createContainerProviderConnection",
+                          "createKubernetesProviderConnection"
+                        ]
                       },
                       "when": {
                         "type": "string"
                       },
                       "status": {
                         "type": "string",
-                        "enum": ["completed", "failed", "skipped"]
+                        "enum": [
+                          "completed",
+                          "failed",
+                          "skipped"
+                        ]
                       },
                       "state": {
                         "type": "string",
-                        "enum": ["completed", "failed"]
+                        "enum": [
+                          "completed",
+                          "failed"
+                        ]
                       }
                     },
-                    "required": ["id", "title"],
+                    "required": [
+                      "id",
+                      "title"
+                    ],
                     "additionalProperties": false
                   }
                 },
@@ -553,7 +621,11 @@
                   "type": "string"
                 }
               },
-              "required": ["title", "steps", "enablement"],
+              "required": [
+                "title",
+                "steps",
+                "enablement"
+              ],
               "additionalProperties": false
             },
             "features": {
@@ -566,7 +638,13 @@
           "additionalProperties": false
         }
       },
-      "required": ["name", "displayName", "version", "publisher", "description"],
+      "required": [
+        "name",
+        "displayName",
+        "version",
+        "publisher",
+        "description"
+      ],
       "additionalProperties": {}
     }
   ]

--- a/schemas/extension-schema.json
+++ b/schemas/extension-schema.json
@@ -43,10 +43,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "light",
-                "dark"
-              ],
+              "required": ["light", "dark"],
               "additionalProperties": false
             }
           ]
@@ -112,31 +109,13 @@
                         "anyOf": [
                           {
                             "type": "string",
-                            "enum": [
-                              "markdown",
-                              "string",
-                              "number",
-                              "integer",
-                              "boolean",
-                              "null",
-                              "array",
-                              "object"
-                            ]
+                            "enum": ["markdown", "string", "number", "integer", "boolean", "null", "array", "object"]
                           },
                           {
                             "type": "array",
                             "items": {
                               "type": "string",
-                              "enum": [
-                                "markdown",
-                                "string",
-                                "number",
-                                "integer",
-                                "boolean",
-                                "null",
-                                "array",
-                                "object"
-                              ]
+                              "enum": ["markdown", "string", "number", "integer", "boolean", "null", "array", "object"]
                             }
                           }
                         ]
@@ -260,15 +239,11 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "id"
-                  ],
+                  "required": ["id"],
                   "additionalProperties": false
                 }
               },
-              "required": [
-                "title"
-              ],
+              "required": ["title"],
               "additionalProperties": false
             },
             "commands": {
@@ -303,10 +278,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "light",
-                          "dark"
-                        ],
+                        "required": ["light", "dark"],
                         "additionalProperties": false
                       }
                     ]
@@ -347,10 +319,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "command",
-                    "title"
-                  ],
+                  "required": ["command", "title"],
                   "additionalProperties": false
                 }
               }
@@ -376,9 +345,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "fontCharacter"
-                    ],
+                    "required": ["fontCharacter"],
                     "additionalProperties": false
                   }
                 },
@@ -409,12 +376,7 @@
                     }
                   }
                 },
-                "required": [
-                  "id",
-                  "name",
-                  "parent",
-                  "colors"
-                ],
+                "required": ["id", "name", "parent", "colors"],
                 "additionalProperties": false
               }
             },
@@ -437,9 +399,7 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "icon"
-                      ],
+                      "required": ["icon"],
                       "additionalProperties": false
                     },
                     {
@@ -469,24 +429,17 @@
                                       "type": "string"
                                     }
                                   },
-                                  "required": [
-                                    "light",
-                                    "dark"
-                                  ],
+                                  "required": ["light", "dark"],
                                   "additionalProperties": false
                                 }
                               ]
                             }
                           },
-                          "required": [
-                            "label"
-                          ],
+                          "required": ["label"],
                           "additionalProperties": false
                         }
                       },
-                      "required": [
-                        "badge"
-                      ],
+                      "required": ["badge"],
                       "additionalProperties": false
                     }
                   ]
@@ -515,10 +468,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "path",
-                    "altText"
-                  ],
+                  "required": ["path", "altText"],
                   "additionalProperties": false
                 },
                 "steps": {
@@ -545,10 +495,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "path",
-                          "altText"
-                        ],
+                        "required": ["path", "altText"],
                         "additionalProperties": false
                       },
                       "command": {
@@ -577,43 +524,28 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "value"
-                            ],
+                            "required": ["value"],
                             "additionalProperties": false
                           }
                         }
                       },
                       "component": {
                         "type": "string",
-                        "enum": [
-                          "createContainerProviderConnection",
-                          "createKubernetesProviderConnection"
-                        ]
+                        "enum": ["createContainerProviderConnection", "createKubernetesProviderConnection"]
                       },
                       "when": {
                         "type": "string"
                       },
                       "status": {
                         "type": "string",
-                        "enum": [
-                          "completed",
-                          "failed",
-                          "skipped"
-                        ]
+                        "enum": ["completed", "failed", "skipped"]
                       },
                       "state": {
                         "type": "string",
-                        "enum": [
-                          "completed",
-                          "failed"
-                        ]
+                        "enum": ["completed", "failed"]
                       }
                     },
-                    "required": [
-                      "id",
-                      "title"
-                    ],
+                    "required": ["id", "title"],
                     "additionalProperties": false
                   }
                 },
@@ -621,11 +553,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "title",
-                "steps",
-                "enablement"
-              ],
+              "required": ["title", "steps", "enablement"],
               "additionalProperties": false
             },
             "features": {
@@ -638,13 +566,7 @@
           "additionalProperties": false
         }
       },
-      "required": [
-        "name",
-        "displayName",
-        "version",
-        "publisher",
-        "description"
-      ],
+      "required": ["name", "displayName", "version", "publisher", "description"],
       "additionalProperties": {}
     }
   ]


### PR DESCRIPTION
### What does this PR do?

Addresses points 1–3 from @benoitf's [comment on #16051](https://github.com/podman-desktop/podman-desktop/issues/16051#issuecomment-2804846523):

1. **Schema file checked into source code** — the generated JSON schema is committed at `schemas/extension-schema.json` (named `extension-schema`).
2. **Root pnpm scripts** — adds `generate:schemas` (top-level, extensible for future schemas) calling `generate:schemas:extension`.
3. **PR check sync** — adds a `Generate schemas` step in `pr-check.yaml` before the existing git-diff gate, so any Zod schema change without a regenerated JSON file fails CI.

The generation script (`packages/main/scripts/generate-extension-schema.ts`) follows the same Vite entry-point pattern as `download-remote-extensions.ts` — compiled during `build:main` then executed with Node.

### Screenshot / video of UI

_No UI changes._

### What issues does this PR fix or reference?

Partial fix for https://github.com/podman-desktop/podman-desktop/issues/16051

Remaining items (release workflow `$schema` URL rewriting, `podman-desktop.io/schemas` redirects) will follow in separate PRs.

### How to test this PR?

1. Run `pnpm generate:schemas` — verify `schemas/extension-schema.json` is written with the expected JSON Schema content.
2. Modify any field in `ExtensionManifestSchema` (e.g. add a new required property), run `pnpm generate:schemas` again, and confirm the JSON file updates accordingly.
3. Without regenerating, run `git diff` — the diff should be non-empty, which is what the CI check gates on.

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)