### PR TITLE
refactor(api): unify DialogType definition in @podman-desktop/core-api 

### DIFF
--- a/packages/api/src/dialog.ts
+++ b/packages/api/src/dialog.ts
@@ -32,6 +32,8 @@ export interface DropdownType extends BaseButtonType {
   type: 'dropdownButton';
 }
 
+export type DialogType = 'none' | 'info' | 'error' | 'question' | 'warning' | 'danger';
+
 export type ButtonsType = string | DropdownType | IconButtonType;
 
 /**
@@ -57,7 +59,7 @@ export interface MessageBoxOptions {
   /**
    * The (optional) type, one of 'none' | 'info' | 'error' | 'question' | 'warning' | 'danger'.
    */
-  type?: string;
+  type?: DialogType;
   /**
    * The (optional) index of the default button.
    */

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -15,11 +15,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { ButtonsType, DropdownType, MessageBoxOptions, MessageBoxReturnValue } from '@podman-desktop/core-api';
+import type {
+  ButtonsType,
+  DialogType,
+  DropdownType,
+  MessageBoxOptions,
+  MessageBoxReturnValue,
+} from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
-
-type DialogType = 'none' | 'info' | 'error' | 'question' | 'warning';
 
 @injectable()
 export class MessageBox {

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { faCircle, faCircleQuestion } from '@fortawesome/free-regular-svg-icons';
 import { faCircleExclamation, faInfo, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
-import { type ButtonsType, type DropdownType, type IconButtonType } from '@podman-desktop/core-api';
+import { type ButtonsType, type DialogType, type DropdownType, type IconButtonType } from '@podman-desktop/core-api';
 import { Button, type ButtonType, Dropdown } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onDestroy, onMount } from 'svelte';
@@ -16,15 +16,13 @@ let title: string = $state('');
 let message: string = $state('');
 let detail: string | undefined = $state();
 let buttonsType: ButtonsType[] = $state([]);
-let type: string | undefined = $state();
+let type: DialogType | undefined = $state();
 let cancelId = $state(-1);
 let defaultId: number | undefined = $state();
 let buttonOrder: number[] = $state([]);
 let footerMarkdownDescription: string | undefined = $state();
 
 let display = $state(false);
-
-const DANGER_TYPE = 'danger';
 
 const showMessageBoxCallback = (messageBoxParameter: unknown): void => {
   const options: MessageBoxOptions | undefined = messageBoxParameter as MessageBoxOptions;
@@ -109,7 +107,7 @@ async function onClose(): Promise<void> {
 
 function getButtonType(b: boolean): ButtonType {
   // eslint-disable-next-line sonarjs/no-selector-parameter
-  if (b && type === DANGER_TYPE) {
+  if (b && type === 'danger') {
     return 'danger';
   } else if (b) {
     return 'primary';
@@ -123,7 +121,7 @@ function getButtonType(b: boolean): ButtonType {
   <Dialog title={title} onclose={onClose}>
     {#snippet icon()}
       
-        {#if type === 'error' || type === DANGER_TYPE}
+        {#if type === 'error' || type === 'danger'}
           <Icon class="h-4 w-4 text-[var(--pd-state-error)]" icon={faCircleExclamation} />
         {:else if type === 'warning'}
           <Icon class="h-4 w-4 text-[var(--pd-state-warning)]" icon={faTriangleExclamation} />

--- a/packages/renderer/src/lib/dialogs/messagebox-input.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-input.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ButtonsType } from '@podman-desktop/core-api';
+import type { ButtonsType, DialogType } from '@podman-desktop/core-api';
 
 export interface MessageBoxOptions {
   id: number;
@@ -24,7 +24,7 @@ export interface MessageBoxOptions {
   message: string;
   detail?: string;
   buttons?: ButtonsType[];
-  type?: string;
+  type?: DialogType;
   defaultId?: number;
   cancelId?: number;
   footerMarkdownDescription?: string;

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faPen } from '@fortawesome/free-solid-svg-icons';
-import { PROXY_CONFIG_KEYS, ProxyState } from '@podman-desktop/core-api';
+import { type DialogType, PROXY_CONFIG_KEYS, ProxyState } from '@podman-desktop/core-api';
 import { Button, Dropdown, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 
@@ -98,7 +98,7 @@ async function updateProxySettings(): Promise<void> {
   // show a simple message to confirm that the settings are applied,
   // or a longer warning if the user may need to take action
   let message = 'Proxy settings have been applied.';
-  let type = 'info';
+  let type: DialogType = 'info';
   if (runningProviders) {
     message += ' You might need to restart running container engines for the changes to take effect.';
     type = 'warning';


### PR DESCRIPTION
### What does this PR do?

This PR unifies the `DialogType` definition across the codebase by moving it to `@podman-desktop/core-api` (`packages/api/src/dialog.ts`).

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #17043 

### How to test this PR?

1. Run `pnpm typecheck` --> confirms all type references resolve correctly
2. Run `pnpm lint:check` --> no lint issues
3. Try to trigger a message box dialog in the app (e.g., prune containers) and confirm it displays with the correct icon and button styling

- [x] Tests are covering the bug fix or the new feature
