### PR TITLE
chore(fix): prevent horizontal scrollbar in preferences with long navigation labels 

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -186,7 +186,7 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
       {/each}
 
       <div
-        class="flex flex-col w-full h-full overflow-hidden"
+        class="flex flex-col w-full min-w-0 h-full overflow-hidden"
         class:bg-[var(--pd-content-bg)]={!meta.url.startsWith('/preferences')}
         class:bg-[var(--pd-invert-content-bg)]={meta.url.startsWith('/preferences')}>
         <TaskManager />

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -148,7 +148,7 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
       {/each}
 
       <div
-        class="flex flex-col w-full h-full overflow-hidden"
+        class="flex flex-col w-full min-w-0 h-full overflow-hidden"
         class:bg-[var(--pd-content-bg)]={!meta.url.startsWith('/preferences')}
         class:bg-[var(--pd-invert-content-bg)]={meta.url.startsWith('/preferences')}>
         <TaskManager />

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -28,16 +28,116 @@ import PreferencesNavigation from './PreferencesNavigation.svelte';
 import { configurationProperties } from './stores/configurationProperties';
 import { onDidChangeRegisteredFeatures, registeredFeatures } from './stores/registered-features';
 
+const DEFAULT_META = {
+  url: '/',
+} as unknown as TinroRouteMeta;
+
+const LONG_CONFIG: IConfigurationPropertyRecordedSchema = {
+  id: 'dummy-config',
+  title: 'A Very Long Preference Entry',
+  default: false,
+  parentId: 'preferences.long-entry',
+  type: 'boolean',
+  scope: 'DEFAULT',
+};
+
+function renderPreferencesNavigation(): void {
+  render(PreferencesNavigation, {
+    meta: DEFAULT_META,
+  });
+}
+
+async function waitForNavigationWidth(width: string): Promise<void> {
+  await vi.waitFor(() => {
+    expect(screen.getByRole('navigation', { name: 'PreferencesNavigation' })).toHaveStyle({ width });
+  });
+}
+
+function mockNavigationMeasurements(options: {
+  minWidth?: string;
+  rowNonTitleWidth?: number;
+  titleWidths?: Record<string, number>;
+  innerWidth?: number;
+  withRequestAnimationFrame?: boolean;
+}): void {
+  const { minWidth = '170px', rowNonTitleWidth = 24, titleWidths = {}, innerWidth = 1024 } = options;
+
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: innerWidth,
+  });
+
+  Object.defineProperty(window, 'getComputedStyle', {
+    configurable: true,
+    value: vi.fn((element: Element) => {
+      const htmlElement = element as HTMLElement;
+      return {
+        minWidth: htmlElement.getAttribute('aria-label') === 'PreferencesNavigation' ? minWidth : '',
+        whiteSpace: htmlElement.dataset.settingsNavTitle !== undefined ? 'nowrap' : 'normal',
+        font: '',
+        fontSize: '',
+        fontWeight: '',
+        fontFamily: '',
+        letterSpacing: '',
+        textTransform: '',
+      };
+    }),
+  });
+
+  if (options.withRequestAnimationFrame) {
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: vi.fn((callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      }),
+    });
+  }
+
+  vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockImplementation(function (this: HTMLElement) {
+    return titleWidths[this.textContent ?? ''] ?? 0;
+  });
+
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(function (this: HTMLElement) {
+    if (this.getAttribute('aria-label') === 'PreferencesNavigation') {
+      return Number.parseFloat(minWidth);
+    }
+    return titleWidths[this.textContent ?? ''] ?? 0;
+  });
+
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    const width =
+      this.dataset.settingsNavRow !== undefined ? rowNonTitleWidth : (titleWidths[this.textContent ?? ''] ?? 0);
+
+    return {
+      x: 0,
+      y: 0,
+      width,
+      height: 0,
+      top: 0,
+      right: width,
+      bottom: 0,
+      left: 0,
+      toJSON: (): object => ({}),
+    };
+  });
+}
+
 // fake the window.events object
 beforeEach(() => {
+  vi.restoreAllMocks();
   vi.resetAllMocks();
   registeredFeatures.set([]);
+  configurationProperties.set([]);
+  Object.defineProperty(global, 'ResizeObserver', {
+    configurable: true,
+    value: undefined,
+  });
   Object.defineProperty(global, 'window', {
     value: {
       getConfigurationValue: vi.fn(),
       events: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        receive: (_channel: string, func: any) => {
+        receive: (_channel: string, func: () => void): void => {
           func();
         },
       },
@@ -285,5 +385,226 @@ describe('Kubernetes menu visibility based on kubernetes-contexts-manager featur
     await vi.waitFor(() => {
       expect(screen.getByRole('link', { name: 'Kubernetes' })).toBeVisible();
     });
+  });
+});
+
+describe('Navigation width measurement and calculation', () => {
+  test('should render navigation container with correct structure', async () => {
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await tick();
+    const navigationBar = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
+    expect(navigationBar).toBeVisible();
+    expect(navigationBar).toHaveClass('flex-col');
+    expect(navigationBar).toHaveClass('justify-between');
+  });
+
+  test('should calculate navigation width based on label lengths', async () => {
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await tick();
+    const navigationBar = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
+    expect(navigationBar).toBeInTheDocument();
+
+    // Verify links are present and properly measured
+    const resourcesLink = screen.getByRole('link', { name: 'Resources' });
+    expect(resourcesLink).toBeInTheDocument();
+  });
+
+  test('should update width styling when navigation items change', async () => {
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await tick();
+
+    const navigationBar = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
+    expect(navigationBar).toBeVisible();
+
+    // Re-render with updated configuration
+    configurationProperties.set([EXPERIMENTAL_CONFIG]);
+    await tick();
+
+    const updatedNav = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
+    expect(updatedNav).toBeVisible();
+  });
+
+  test('should apply width-related CSS classes to navigation', async () => {
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await tick();
+
+    const navigationBar = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
+    // Verify it has the expected size-related classes from the squashed commit
+    expect(navigationBar.className).toContain('min-w-leftsidebar');
+    expect(navigationBar.className).toContain('w-leftsidebar');
+    expect(navigationBar.className).toContain('max-w-none');
+  });
+
+  test('should handle section expansion with navigation width stability', async () => {
+    configurationProperties.set([EXPERIMENTAL_CONFIG]);
+    render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await tick();
+
+    // Navigate to trigger section rendering
+    const experimentalLink = await screen.findByRole('link', { name: 'Experimental' });
+    expect(experimentalLink).toBeVisible();
+
+    // Verify navigation dimensions remain stable
+    const navigationBar = screen.getByRole('navigation', { name: 'PreferencesNavigation' });
+    expect(navigationBar).toBeVisible();
+    expect(navigationBar.className).toContain('flex');
+  });
+
+  test('should expand navigation width to fit a visible child preference label', async () => {
+    mockNavigationMeasurements({
+      titleWidths: {
+        'A Very Long Preference Entry': 260,
+      },
+    });
+    configurationProperties.set([LONG_CONFIG]);
+
+    renderPreferencesNavigation();
+
+    await fireEvent.click(await screen.findByRole('link', { name: 'preferences' }));
+
+    expect(await screen.findByRole('link', { name: 'A Very Long Preference Entry' })).toBeVisible();
+    await waitForNavigationWidth('292px');
+  });
+
+  test('should clamp navigation width to keep content visible', async () => {
+    mockNavigationMeasurements({
+      innerWidth: 260,
+      minWidth: '100px',
+      titleWidths: {
+        'A Very Long Preference Entry': 500,
+      },
+    });
+    configurationProperties.set([LONG_CONFIG]);
+
+    renderPreferencesNavigation();
+
+    await fireEvent.click(await screen.findByRole('link', { name: 'preferences' }));
+
+    await waitForNavigationWidth('180px');
+  });
+
+  test('should clear widened navigation width when the expanded section disappears', async () => {
+    mockNavigationMeasurements({
+      titleWidths: {
+        'A Very Long Preference Entry': 260,
+      },
+    });
+    configurationProperties.set([LONG_CONFIG]);
+
+    renderPreferencesNavigation();
+
+    await fireEvent.click(await screen.findByRole('link', { name: 'preferences' }));
+    await waitForNavigationWidth('292px');
+
+    configurationProperties.set([]);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole('link', { name: 'preferences' })).toBeNull();
+      expect(
+        screen.getByRole('navigation', { name: 'PreferencesNavigation' }).getAttribute('style') ?? '',
+      ).not.toContain('width');
+    });
+  });
+
+  test('should measure after requestAnimationFrame when it is available', async () => {
+    mockNavigationMeasurements({
+      withRequestAnimationFrame: true,
+      titleWidths: {
+        'A Very Long Preference Entry': 260,
+      },
+    });
+    configurationProperties.set([LONG_CONFIG]);
+
+    renderPreferencesNavigation();
+
+    await fireEvent.click(await screen.findByRole('link', { name: 'preferences' }));
+
+    await waitForNavigationWidth('292px');
+    expect(window.requestAnimationFrame).toHaveBeenCalled();
+  });
+
+  test('should update navigation width when the window is resized', async () => {
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    Object.assign(window, {
+      addEventListener,
+      removeEventListener,
+    });
+    const titleWidths: Record<string, number> = {};
+    mockNavigationMeasurements({
+      titleWidths,
+    });
+
+    const { unmount } = render(PreferencesNavigation, {
+      meta: {
+        url: '/preferences/docker',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await vi.waitFor(() => expect(addEventListener).toHaveBeenCalledWith('resize', expect.any(Function)));
+
+    const resizeListener = addEventListener.mock.calls.find(([eventName]) => eventName === 'resize')?.[1] as
+      | (() => void)
+      | undefined;
+    expect(resizeListener).toBeDefined();
+
+    titleWidths.Resources = 260;
+    resizeListener?.();
+
+    await waitForNavigationWidth('292px');
+
+    unmount();
+    expect(removeEventListener).toHaveBeenCalledWith('resize', resizeListener);
+  });
+
+  test('should observe parent resize and disconnect observer on unmount', async () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    class MockResizeObserver {
+      observe = observe;
+      disconnect = disconnect;
+    }
+
+    Object.defineProperty(global, 'ResizeObserver', {
+      configurable: true,
+      value: MockResizeObserver,
+    });
+    mockNavigationMeasurements({});
+
+    const { unmount } = render(PreferencesNavigation, {
+      meta: {
+        url: '/',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await vi.waitFor(() => expect(observe).toHaveBeenCalled());
+
+    unmount();
+    expect(disconnect).toHaveBeenCalled();
   });
 });

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -2,7 +2,7 @@
 import { DockerCompatibilitySettings } from '@podman-desktop/core-api';
 import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
-import { onMount } from 'svelte';
+import { onMount, tick } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 
 import PreferencesIcon from '/@/lib/images/PreferencesIcon.svelte';
@@ -25,6 +25,129 @@ let experimentalSection: boolean = $state(false);
 
 let settingsNavigationItems: SettingsNavItemConfig[] = $state(settingsNavigationEntries);
 
+let navigationElement: HTMLElement | undefined = $state();
+let navigationWidthPx: number | undefined = $state();
+const MIN_CONTENT_WIDTH_PX = 80;
+
+function measureTitleTextWidth(titleElement: HTMLElement): number {
+  const titleText = titleElement.textContent ?? '';
+  if (!titleText.trim() || !document.body) {
+    return Math.ceil(titleElement.scrollWidth);
+  }
+
+  const titleStyle = typeof window.getComputedStyle === 'function' ? window.getComputedStyle(titleElement) : undefined;
+
+  const measurementElement = document.createElement('span');
+  measurementElement.textContent = titleText;
+  measurementElement.style.position = 'absolute';
+  measurementElement.style.visibility = 'hidden';
+  measurementElement.style.pointerEvents = 'none';
+  measurementElement.style.whiteSpace = 'nowrap';
+  measurementElement.style.font = titleStyle?.font ?? '';
+  measurementElement.style.fontSize = titleStyle?.fontSize ?? '';
+  measurementElement.style.fontWeight = titleStyle?.fontWeight ?? '';
+  measurementElement.style.fontFamily = titleStyle?.fontFamily ?? '';
+  measurementElement.style.letterSpacing = titleStyle?.letterSpacing ?? '';
+  measurementElement.style.textTransform = titleStyle?.textTransform ?? '';
+
+  document.body.appendChild(measurementElement);
+  const textWidth = Math.ceil(measurementElement.getBoundingClientRect().width);
+  measurementElement.remove();
+
+  return textWidth;
+}
+
+function measureRowNonTitleWidth(rowElement: HTMLElement): number {
+  if (!document.body) {
+    return 0;
+  }
+
+  const measurementRow = rowElement.cloneNode(true) as HTMLElement;
+  const measurementTitle = measurementRow.querySelector<HTMLElement>('[data-settings-nav-title]');
+  if (measurementTitle) {
+    measurementTitle.textContent = '';
+    measurementTitle.style.width = '0';
+    measurementTitle.style.minWidth = '0';
+    measurementTitle.style.maxWidth = '0';
+    measurementTitle.style.padding = '0';
+    measurementTitle.style.margin = '0';
+    measurementTitle.style.border = '0';
+  }
+
+  measurementRow.style.position = 'absolute';
+  measurementRow.style.visibility = 'hidden';
+  measurementRow.style.pointerEvents = 'none';
+  measurementRow.style.left = '-9999px';
+  measurementRow.style.top = '0';
+  measurementRow.style.width = 'max-content';
+  measurementRow.style.minWidth = '0';
+  measurementRow.style.maxWidth = 'none';
+
+  document.body.appendChild(measurementRow);
+  const nonTitleWidth = Math.ceil(measurementRow.getBoundingClientRect().width);
+  measurementRow.remove();
+
+  return nonTitleWidth;
+}
+
+function updateNavigationWidth(): void {
+  if (!navigationElement) {
+    return;
+  }
+
+  const computedStyle =
+    typeof window.getComputedStyle === 'function' ? window.getComputedStyle(navigationElement) : undefined;
+  const minWidth = Number.parseFloat(computedStyle?.minWidth ?? '') || navigationElement.clientWidth;
+  let requiredWidth = minWidth;
+
+  const titleElements = navigationElement.querySelectorAll<HTMLElement>('[data-settings-nav-title]');
+  for (const titleElement of titleElements) {
+    const rowElement = titleElement.closest<HTMLElement>('[data-settings-nav-row]');
+    if (!rowElement) {
+      continue;
+    }
+
+    const titleWhiteSpace =
+      typeof window.getComputedStyle === 'function' ? window.getComputedStyle(titleElement).whiteSpace : 'nowrap';
+    const fullTitleWidth =
+      titleWhiteSpace === 'nowrap'
+        ? Math.ceil(titleElement.scrollWidth)
+        : Math.ceil(measureTitleTextWidth(titleElement));
+    const otherContentWidth = measureRowNonTitleWidth(rowElement);
+    const rowRequiredWidth = Math.ceil(otherContentWidth + fullTitleWidth + 8);
+    if (rowRequiredWidth > requiredWidth) {
+      requiredWidth = rowRequiredWidth;
+    }
+  }
+
+  const viewportWidth = typeof window.innerWidth === 'number' ? window.innerWidth : 1024;
+  // Allow very long labels while keeping a small visible content pane.
+  const maxNavigationWidthPx = Math.max(minWidth, viewportWidth - MIN_CONTENT_WIDTH_PX);
+
+  const nextWidth = Math.min(Math.max(requiredWidth, minWidth), maxNavigationWidthPx);
+  const nextWidthState = nextWidth > minWidth ? nextWidth : undefined;
+  if (navigationWidthPx !== nextWidthState) {
+    navigationWidthPx = nextWidthState;
+  }
+}
+
+function scheduleNavigationWidthUpdate(): void {
+  void tick()
+    .then(() => {
+      // Measure after next paint so newly-shown items have final layout metrics.
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(() => {
+          updateNavigationWidth();
+        });
+      } else {
+        updateNavigationWidth();
+      }
+    })
+    .catch(() => {
+      updateNavigationWidth();
+    });
+}
+
 function updateDockerCompatibility(): void {
   window
     .getConfigurationValue<boolean>(`${DockerCompatibilitySettings.SectionName}.${DockerCompatibilitySettings.Enabled}`)
@@ -33,6 +156,7 @@ function updateDockerCompatibility(): void {
         const index = settingsNavigationEntries.findIndex(entry => entry.title === 'Docker Compatibility');
         if (index !== -1) {
           settingsNavigationItems[index].visible = result;
+          scheduleNavigationWidthUpdate();
         }
       }
     })
@@ -54,6 +178,7 @@ function updateKubernetesVisibility(enabled: boolean): void {
   const kubernetesIndex = settingsNavigationItems.findIndex(entry => entry.title === 'Kubernetes');
   if (kubernetesIndex !== -1) {
     settingsNavigationItems[kubernetesIndex].visible = !enabled;
+    scheduleNavigationWidthUpdate();
   }
 }
 
@@ -62,6 +187,23 @@ const featureListener = (event: Event): void => {
 };
 
 onMount(() => {
+  const resizeListener = (): void => {
+    scheduleNavigationWidthUpdate();
+  };
+
+  let resizeObserver: ResizeObserver | undefined;
+  if (navigationElement && typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => {
+      scheduleNavigationWidthUpdate();
+    });
+    const resizeTarget = navigationElement.parentElement ?? navigationElement;
+    resizeObserver.observe(resizeTarget);
+  }
+
+  if (typeof window.addEventListener === 'function') {
+    window.addEventListener('resize', resizeListener);
+  }
+
   onDidChangeRegisteredFeatures.addEventListener(kubernetesContextsManagerFeature, featureListener);
 
   const unsubFeatures = registeredFeatures.subscribe(features => {
@@ -81,7 +223,7 @@ onMount(() => {
     }
 
     // update config properties
-    configProperties = value.reduce((map, current) => {
+    const nextConfigProperties = value.reduce((map, current) => {
       // filter on default scope
       if (current.scope !== CONFIGURATION_DEFAULT_SCOPE) return map;
 
@@ -97,9 +239,24 @@ onMount(() => {
       }
       return map;
     }, new Map<string, NavItem[]>());
+
+    configProperties = nextConfigProperties;
+
+    // Drop expansion flags for sections no longer present to avoid stale widened width.
+    sectionExpanded = Object.fromEntries(
+      Object.entries(sectionExpanded).filter(([sectionId]) => nextConfigProperties.has(sectionId)),
+    );
+
+    scheduleNavigationWidthUpdate();
   });
 
+  scheduleNavigationWidthUpdate();
+
   return (): void => {
+    if (typeof window.removeEventListener === 'function') {
+      window.removeEventListener('resize', resizeListener);
+    }
+    resizeObserver?.disconnect();
     unsubConfig();
     unsubFeatures();
     onDidChangeRegisteredFeatures.removeEventListener(kubernetesContextsManagerFeature, featureListener);
@@ -108,7 +265,9 @@ onMount(() => {
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  bind:this={navigationElement}
+  style:width={navigationWidthPx ? `${navigationWidthPx}px` : undefined}
+  class="z-1 w-leftsidebar min-w-leftsidebar max-w-none shrink-0 flex-col justify-between flex bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 px-3 mb-5">
@@ -125,6 +284,7 @@ onMount(() => {
           title={navItem.title} 
           href={navItem.href} 
           icon={navItem.icon}
+          onClick={scheduleNavigationWidthUpdate}
           selected={meta.url === navItem.href} 
         />
       {/if}
@@ -138,6 +298,7 @@ onMount(() => {
         icon={PreferencesIcon}
         section={configItems.length > 0}
         selected={meta.url === `/preferences/default/${configSection}`}
+        onClick={scheduleNavigationWidthUpdate}
         bind:expanded={sectionExpanded[configSection]} />
       {#if sectionExpanded[configSection]}
         {#each sortItems(configItems) as configItem (configItem.id)}
@@ -145,6 +306,7 @@ onMount(() => {
             title={configItem.title}
             href="/preferences/default/{configItem.id}"
             child={true}
+            onClick={scheduleNavigationWidthUpdate}
             selected={meta.url === `/preferences/default/${configItem.id}`} />
         {/each}
       {/if}
@@ -157,6 +319,7 @@ onMount(() => {
       iconRightAlign="end"
       title="Troubleshooting"
       href="/troubleshooting/repair-connections"
+      onClick={scheduleNavigationWidthUpdate}
       selected={meta.url === '/troubleshooting/repair-connections'}
     />
   </div>

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -2,7 +2,7 @@
 import { DockerCompatibilitySettings } from '@podman-desktop/core-api';
 import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import { SettingsNavItem } from '@podman-desktop/ui-svelte';
-import { onMount } from 'svelte';
+import { onMount, tick } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
 
 import PreferencesIcon from '/@/lib/images/PreferencesIcon.svelte';
@@ -25,6 +25,84 @@ let experimentalSection: boolean = $state(false);
 
 let settingsNavigationItems: SettingsNavItemConfig[] = $state(settingsNavigationEntries);
 
+let navigationElement: HTMLElement | undefined = $state();
+let navigationWidthPx: number | undefined = $state();
+const MIN_CONTENT_WIDTH_PX = 80;
+
+function measureTitleTextWidth(titleElement: HTMLElement): number {
+  const titleText = titleElement.textContent ?? '';
+  if (!titleText.trim()) {
+    return titleElement.scrollWidth;
+  }
+
+  if (typeof window.getComputedStyle !== 'function') {
+    return titleElement.scrollWidth;
+  }
+
+  const titleStyle = window.getComputedStyle(titleElement);
+  const measurementElement = document.createElement('span');
+  measurementElement.textContent = titleText;
+  measurementElement.style.position = 'absolute';
+  measurementElement.style.visibility = 'hidden';
+  measurementElement.style.pointerEvents = 'none';
+  measurementElement.style.whiteSpace = 'nowrap';
+  measurementElement.style.font = titleStyle.font;
+  measurementElement.style.fontSize = titleStyle.fontSize;
+  measurementElement.style.fontWeight = titleStyle.fontWeight;
+  measurementElement.style.fontFamily = titleStyle.fontFamily;
+  measurementElement.style.letterSpacing = titleStyle.letterSpacing;
+  measurementElement.style.textTransform = titleStyle.textTransform;
+
+  document.body.appendChild(measurementElement);
+  const textWidth = Math.ceil(measurementElement.getBoundingClientRect().width);
+  measurementElement.remove();
+  return textWidth;
+}
+
+function updateNavigationWidth(): void {
+  if (!navigationElement) {
+    return;
+  }
+
+  const hasExpandedSections = Object.values(sectionExpanded).some(Boolean);
+  if (!hasExpandedSections) {
+    navigationWidthPx = undefined;
+    return;
+  }
+
+  const computedStyle =
+    typeof window.getComputedStyle === 'function' ? window.getComputedStyle(navigationElement) : undefined;
+  const minWidth = Number.parseFloat(computedStyle?.minWidth ?? '') || navigationElement.clientWidth;
+  let requiredWidth = minWidth;
+
+  const titleElements = navigationElement.querySelectorAll<HTMLElement>('[data-settings-nav-title]');
+  for (const titleElement of titleElements) {
+    const rowElement = titleElement.closest<HTMLElement>('[data-settings-nav-row]');
+    if (!rowElement) {
+      continue;
+    }
+
+    const fullTitleWidth = Math.max(titleElement.scrollWidth, measureTitleTextWidth(titleElement));
+    const hiddenTitleWidth = Math.max(0, fullTitleWidth - titleElement.clientWidth);
+    const rowRequiredWidth = Math.ceil(rowElement.clientWidth + hiddenTitleWidth + 8);
+    if (rowRequiredWidth > requiredWidth) {
+      requiredWidth = rowRequiredWidth;
+    }
+  }
+
+  const viewportWidth = typeof window.innerWidth === 'number' ? window.innerWidth : 1024;
+  // Allow very long labels while keeping a small visible content pane.
+  const maxNavigationWidthPx = Math.max(minWidth, viewportWidth - MIN_CONTENT_WIDTH_PX);
+
+  navigationWidthPx = Math.min(Math.max(requiredWidth, minWidth), maxNavigationWidthPx);
+}
+
+function scheduleNavigationWidthUpdate(): void {
+  void tick().then(() => {
+    updateNavigationWidth();
+  });
+}
+
 function updateDockerCompatibility(): void {
   window
     .getConfigurationValue<boolean>(`${DockerCompatibilitySettings.SectionName}.${DockerCompatibilitySettings.Enabled}`)
@@ -33,6 +111,7 @@ function updateDockerCompatibility(): void {
         const index = settingsNavigationEntries.findIndex(entry => entry.title === 'Docker Compatibility');
         if (index !== -1) {
           settingsNavigationItems[index].visible = result;
+          scheduleNavigationWidthUpdate();
         }
       }
     })
@@ -54,6 +133,7 @@ function updateKubernetesVisibility(enabled: boolean): void {
   const kubernetesIndex = settingsNavigationItems.findIndex(entry => entry.title === 'Kubernetes');
   if (kubernetesIndex !== -1) {
     settingsNavigationItems[kubernetesIndex].visible = !enabled;
+    scheduleNavigationWidthUpdate();
   }
 }
 
@@ -62,6 +142,22 @@ const featureListener = (event: Event): void => {
 };
 
 onMount(() => {
+  const resizeListener = (): void => {
+    scheduleNavigationWidthUpdate();
+  };
+
+  let resizeObserver: ResizeObserver | undefined;
+  if (navigationElement && typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => {
+      updateNavigationWidth();
+    });
+    resizeObserver.observe(navigationElement);
+  }
+
+  if (typeof window.addEventListener === 'function') {
+    window.addEventListener('resize', resizeListener);
+  }
+
   onDidChangeRegisteredFeatures.addEventListener(kubernetesContextsManagerFeature, featureListener);
 
   const unsubFeatures = registeredFeatures.subscribe(features => {
@@ -97,9 +193,17 @@ onMount(() => {
       }
       return map;
     }, new Map<string, NavItem[]>());
+
+    scheduleNavigationWidthUpdate();
   });
 
+  scheduleNavigationWidthUpdate();
+
   return (): void => {
+    if (typeof window.removeEventListener === 'function') {
+      window.removeEventListener('resize', resizeListener);
+    }
+    resizeObserver?.disconnect();
     unsubConfig();
     unsubFeatures();
     onDidChangeRegisteredFeatures.removeEventListener(kubernetesContextsManagerFeature, featureListener);
@@ -108,7 +212,9 @@ onMount(() => {
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px] overflow-x-hidden"
+  bind:this={navigationElement}
+  style:width={navigationWidthPx ? `${navigationWidthPx}px` : undefined}
+  class="z-1 w-leftsidebar min-w-leftsidebar max-w-none shrink-0 flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 px-3 mb-5">
@@ -118,13 +224,14 @@ onMount(() => {
       </p>
     </div>
   </div>
-  <div class="h-full overflow-y-auto overflow-x-hidden" style="margin-bottom:auto">
+  <div class="h-full overflow-y-auto" style="margin-bottom:auto">
     {#each settingsNavigationItems as navItem, index (index)}
       {#if navItem.visible}
         <SettingsNavItem 
           title={navItem.title} 
           href={navItem.href} 
           icon={navItem.icon}
+          onClick={scheduleNavigationWidthUpdate}
           selected={meta.url === navItem.href} 
         />
       {/if}
@@ -138,6 +245,7 @@ onMount(() => {
         icon={PreferencesIcon}
         section={configItems.length > 0}
         selected={meta.url === `/preferences/default/${configSection}`}
+        onClick={scheduleNavigationWidthUpdate}
         bind:expanded={sectionExpanded[configSection]} />
       {#if sectionExpanded[configSection]}
         {#each sortItems(configItems) as configItem (configItem.id)}
@@ -145,6 +253,7 @@ onMount(() => {
             title={configItem.title}
             href="/preferences/default/{configItem.id}"
             child={true}
+            onClick={scheduleNavigationWidthUpdate}
             selected={meta.url === `/preferences/default/${configItem.id}`} />
         {/each}
       {/if}
@@ -157,6 +266,7 @@ onMount(() => {
       iconRightAlign="end"
       title="Troubleshooting"
       href="/troubleshooting/repair-connections"
+      onClick={scheduleNavigationWidthUpdate}
       selected={meta.url === '/troubleshooting/repair-connections'}
     />
   </div>

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -108,7 +108,7 @@ onMount(() => {
 </script>
 
 <nav
-  class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  class="z-1 w-leftsidebar min-w-leftsidebar flex-col justify-between flex transition-all duration-500 ease-in-out bg-[var(--pd-secondary-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px] overflow-x-hidden"
   aria-label="PreferencesNavigation">
   <div class="flex items-center">
     <div class="pt-4 px-3 mb-5">
@@ -118,7 +118,7 @@ onMount(() => {
       </p>
     </div>
   </div>
-  <div class="h-full overflow-y-auto" style="margin-bottom:auto">
+  <div class="h-full overflow-y-auto overflow-x-hidden" style="margin-bottom:auto">
     {#each settingsNavigationItems as navItem, index (index)}
       {#if navItem.visible}
         <SettingsNavItem 

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -59,6 +59,39 @@ function measureTitleTextWidth(titleElement: HTMLElement): number {
   return textWidth;
 }
 
+function measureRowNonTitleWidth(rowElement: HTMLElement): number {
+  if (!document.body) {
+    return 0;
+  }
+
+  const measurementRow = rowElement.cloneNode(true) as HTMLElement;
+  const measurementTitle = measurementRow.querySelector<HTMLElement>('[data-settings-nav-title]');
+  if (measurementTitle) {
+    measurementTitle.textContent = '';
+    measurementTitle.style.width = '0';
+    measurementTitle.style.minWidth = '0';
+    measurementTitle.style.maxWidth = '0';
+    measurementTitle.style.padding = '0';
+    measurementTitle.style.margin = '0';
+    measurementTitle.style.border = '0';
+  }
+
+  measurementRow.style.position = 'absolute';
+  measurementRow.style.visibility = 'hidden';
+  measurementRow.style.pointerEvents = 'none';
+  measurementRow.style.left = '-9999px';
+  measurementRow.style.top = '0';
+  measurementRow.style.width = 'max-content';
+  measurementRow.style.minWidth = '0';
+  measurementRow.style.maxWidth = 'none';
+
+  document.body.appendChild(measurementRow);
+  const nonTitleWidth = Math.ceil(measurementRow.getBoundingClientRect().width);
+  measurementRow.remove();
+
+  return nonTitleWidth;
+}
+
 function updateNavigationWidth(): void {
   if (!navigationElement) {
     return;
@@ -83,8 +116,8 @@ function updateNavigationWidth(): void {
     }
 
     const fullTitleWidth = Math.max(titleElement.scrollWidth, measureTitleTextWidth(titleElement));
-    const hiddenTitleWidth = Math.max(0, fullTitleWidth - titleElement.clientWidth);
-    const rowRequiredWidth = Math.ceil(rowElement.clientWidth + hiddenTitleWidth + 8);
+    const otherContentWidth = measureRowNonTitleWidth(rowElement);
+    const rowRequiredWidth = Math.ceil(otherContentWidth + fullTitleWidth + 8);
     if (rowRequiredWidth > requiredWidth) {
       requiredWidth = rowRequiredWidth;
     }

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -29,36 +29,6 @@ let navigationElement: HTMLElement | undefined = $state();
 let navigationWidthPx: number | undefined = $state();
 const MIN_CONTENT_WIDTH_PX = 80;
 
-function measureTitleTextWidth(titleElement: HTMLElement): number {
-  const titleText = titleElement.textContent ?? '';
-  if (!titleText.trim()) {
-    return titleElement.scrollWidth;
-  }
-
-  if (typeof window.getComputedStyle !== 'function') {
-    return titleElement.scrollWidth;
-  }
-
-  const titleStyle = window.getComputedStyle(titleElement);
-  const measurementElement = document.createElement('span');
-  measurementElement.textContent = titleText;
-  measurementElement.style.position = 'absolute';
-  measurementElement.style.visibility = 'hidden';
-  measurementElement.style.pointerEvents = 'none';
-  measurementElement.style.whiteSpace = 'nowrap';
-  measurementElement.style.font = titleStyle.font;
-  measurementElement.style.fontSize = titleStyle.fontSize;
-  measurementElement.style.fontWeight = titleStyle.fontWeight;
-  measurementElement.style.fontFamily = titleStyle.fontFamily;
-  measurementElement.style.letterSpacing = titleStyle.letterSpacing;
-  measurementElement.style.textTransform = titleStyle.textTransform;
-
-  document.body.appendChild(measurementElement);
-  const textWidth = Math.ceil(measurementElement.getBoundingClientRect().width);
-  measurementElement.remove();
-  return textWidth;
-}
-
 function measureRowNonTitleWidth(rowElement: HTMLElement): number {
   if (!document.body) {
     return 0;
@@ -97,7 +67,10 @@ function updateNavigationWidth(): void {
     return;
   }
 
-  const hasExpandedSections = Object.values(sectionExpanded).some(Boolean);
+  const visibleSectionIds = new Set(configProperties.keys());
+  const hasExpandedSections = Object.entries(sectionExpanded).some(
+    ([sectionId, expanded]) => visibleSectionIds.has(sectionId) && expanded,
+  );
   if (!hasExpandedSections) {
     navigationWidthPx = undefined;
     return;
@@ -115,7 +88,7 @@ function updateNavigationWidth(): void {
       continue;
     }
 
-    const fullTitleWidth = Math.max(titleElement.scrollWidth, measureTitleTextWidth(titleElement));
+    const fullTitleWidth = Math.ceil(titleElement.getBoundingClientRect().width);
     const otherContentWidth = measureRowNonTitleWidth(rowElement);
     const rowRequiredWidth = Math.ceil(otherContentWidth + fullTitleWidth + 8);
     if (rowRequiredWidth > requiredWidth) {
@@ -210,7 +183,7 @@ onMount(() => {
     }
 
     // update config properties
-    configProperties = value.reduce((map, current) => {
+    const nextConfigProperties = value.reduce((map, current) => {
       // filter on default scope
       if (current.scope !== CONFIGURATION_DEFAULT_SCOPE) return map;
 
@@ -226,6 +199,13 @@ onMount(() => {
       }
       return map;
     }, new Map<string, NavItem[]>());
+
+    configProperties = nextConfigProperties;
+
+    // Drop expansion flags for sections no longer present to avoid stale widened width.
+    sectionExpanded = Object.fromEntries(
+      Object.entries(sectionExpanded).filter(([sectionId]) => nextConfigProperties.has(sectionId)),
+    );
 
     scheduleNavigationWidthUpdate();
   });

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -12,8 +12,8 @@ interface Props {
 let { title, subtitle, actions, header, children }: Props = $props();
 </script>
 
-<div class="flex flex-col min-w-full h-full" role="region" aria-label={title}>
-  <div class="min-w-full px-5 py-4" role="region" aria-label="Header">
+<div class="flex flex-col w-full h-full" role="region" aria-label={title}>
+  <div class="w-full px-5 py-4" role="region" aria-label="Header">
     <div class="flex flex-row">
       <div class="grow">
         <div
@@ -36,7 +36,7 @@ let { title, subtitle, actions, header, children }: Props = $props();
 
     {@render header?.()}
   </div>
-  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="Content">
+  <div class="flex flex-row w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="Content">
     <div class="flex flex-col grow max-w-[905px] mx-auto">
       {@render children?.()}
     </div>

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -12,8 +12,8 @@ interface Props {
 let { title, subtitle, actions, header, children }: Props = $props();
 </script>
 
-<div class="flex flex-col min-w-full h-full" role="region" aria-label={title}>
-  <div class="min-w-full px-5 py-4" role="region" aria-label="Header">
+<div class="flex flex-col w-full h-full overflow-x-hidden" role="region" aria-label={title}>
+  <div class="w-full px-5 py-4" role="region" aria-label="Header">
     <div class="flex flex-row">
       <div class="grow">
         <div
@@ -36,7 +36,7 @@ let { title, subtitle, actions, header, children }: Props = $props();
 
     {@render header?.()}
   </div>
-  <div class="flex flex-row min-w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="Content">
+  <div class="flex flex-row w-full h-full px-5 py-4 overflow-y-auto overflow-x-hidden" role="region" aria-label="Content">
     <div class="flex flex-col grow max-w-[905px] mx-auto">
       {@render children?.()}
     </div>

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -12,7 +12,7 @@ interface Props {
 let { title, subtitle, actions, header, children }: Props = $props();
 </script>
 
-<div class="flex flex-col w-full h-full overflow-x-hidden" role="region" aria-label={title}>
+<div class="flex flex-col w-full h-full" role="region" aria-label={title}>
   <div class="w-full px-5 py-4" role="region" aria-label="Header">
     <div class="flex flex-row">
       <div class="grow">
@@ -36,7 +36,7 @@ let { title, subtitle, actions, header, children }: Props = $props();
 
     {@render header?.()}
   </div>
-  <div class="flex flex-row w-full h-full px-5 py-4 overflow-y-auto overflow-x-hidden" role="region" aria-label="Content">
+  <div class="flex flex-row w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="Content">
     <div class="flex flex-col grow max-w-[905px] mx-auto">
       {@render children?.()}
     </div>

--- a/packages/ui/src/lib/dropdownMenu/index.ts
+++ b/packages/ui/src/lib/dropdownMenu/index.ts
@@ -19,7 +19,14 @@ import DropdownMenu from './DropdownMenu.svelte';
 import DropDownMenuItem from './DropDownMenuItem.svelte';
 import DropDownMenuItems from './DropDownMenuItems.svelte';
 
-export default Object.assign(DropdownMenu, {
+type DropdownMenuCompound = typeof DropdownMenu & {
+  Item: typeof DropDownMenuItem;
+  Items: typeof DropDownMenuItems;
+};
+
+const dropdownMenu = Object.assign(DropdownMenu, {
   Item: DropDownMenuItem,
   Items: DropDownMenuItems,
-});
+}) as DropdownMenuCompound;
+
+export default dropdownMenu;

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
@@ -49,6 +49,15 @@ test('Expect correct role and href', async () => {
   expect(element).toHaveAttribute('href', href);
 });
 
+test('Expect tooltip title attribute on truncated labels', async () => {
+  const title = 'Very long settings section label';
+  renderIt(title, '/test');
+
+  const element = screen.getByLabelText(title);
+  expect(element).toHaveAttribute('title', title);
+  expect(screen.getByText(title)).not.toHaveAttribute('title');
+});
+
 test('Expect selection styling', async () => {
   const title = 'Resources';
   const href = '/test';
@@ -147,7 +156,7 @@ describe('icon', () => {
     });
     const svg = getByRole('img', { hidden: true });
     expect(svg).toBeInTheDocument();
-    expect(svg.parentElement).toHaveClass('flex-row');
+    expect(svg.parentElement).toHaveClass('w-4');
   });
 });
 
@@ -163,10 +172,10 @@ describe('iconRight', () => {
     });
     const svgs = getAllByRole('img', { hidden: true });
     expect(svgs).toHaveLength(2);
-    // First icon (left) should be in the title span
-    expect(svgs[0].parentElement).toHaveClass('flex-row');
-    // Second icon (right) should be in the end container with px-2
-    expect(svgs[1].parentElement).toHaveClass('px-2');
+    // First icon (left) should be in the fixed-width left icon gutter.
+    expect(svgs[0].parentElement).toHaveClass('w-4');
+    // Second icon (right) should be in the fixed-width end gutter container.
+    expect(svgs[1].parentElement).toHaveClass('w-3');
   });
 
   test('iconRight with align inline should be next to title', () => {
@@ -180,8 +189,9 @@ describe('iconRight', () => {
     });
     const svgs = getAllByRole('img', { hidden: true });
     expect(svgs).toHaveLength(2);
-    // Both icons should be in the same flex-row container
-    expect(svgs[0].parentElement).toHaveClass('flex-row');
+    // Left icon should be in the fixed-width icon gutter.
+    expect(svgs[0].parentElement).toHaveClass('w-4');
+    // Inline right icon should stay in the title row container.
     expect(svgs[1].parentElement).toHaveClass('flex-row');
   });
 
@@ -194,7 +204,7 @@ describe('iconRight', () => {
     });
     const svgs = getAllByRole('img', { hidden: true });
     expect(svgs).toHaveLength(1);
-    // Icon should be in the end container with px-2
-    expect(svgs[0].parentElement).toHaveClass('px-2');
+    // Icon should be in the fixed-width end gutter container.
+    expect(svgs[0].parentElement).toHaveClass('w-3');
   });
 });

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts
@@ -49,6 +49,15 @@ test('Expect correct role and href', async () => {
   expect(element).toHaveAttribute('href', href);
 });
 
+test('Expect tooltip title attribute on truncated labels', async () => {
+  const title = 'Very long settings section label';
+  renderIt(title, '/test');
+
+  const element = screen.getByLabelText(title);
+  expect(element).toHaveAttribute('title', title);
+  expect(screen.getByText(title)).toHaveAttribute('title', title);
+});
+
 test('Expect selection styling', async () => {
   const title = 'Resources';
   const href = '/test';

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -37,11 +37,14 @@ function click(): void {
 }
 </script>
 
-<a class="no-underline" href={href} aria-label={title} onclick={click}>
+<a class="no-underline block w-full" href={href} aria-label={title} title={title} onclick={click}>
   <div
-    class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px]"
+    data-settings-nav-row
+    class="flex box-border w-full py-2 items-center cursor-pointer border-l-[4px]"
     class:pl-3={!child}
     class:pl-[34px]={child}
+    class:pr-3={!child}
+    class:pr-2={child}
     class:leading-none={child}
     class:text-md={!child}
     class:font-medium={!child}
@@ -53,25 +56,30 @@ function click(): void {
     class:hover:text-[color:var(--pd-secondary-nav-text-hover)]={!selected}
     class:hover:bg-[var(--pd-secondary-nav-text-hover-bg)]={!selected}
     class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]={!selected}>
-    <span
-      class="group-hover:block flex flex-row gap-x-2 items-center"
-      class:capitalize={!child}>
+    <span class="flex flex-row gap-x-2 items-center min-w-0 grow" class:capitalize={!child} class:items-start={child}>
       {#if icon}
+        <span class="w-4 shrink-0 flex justify-center">
           <Icon icon={icon}/>
+        </span>
       {/if}
-      <span>{title}</span>
+      <span
+        data-settings-nav-title
+        class="block"
+        class:truncate={!child}
+        class:whitespace-normal={child}
+        class:break-words={child}>{title}</span>
       {#if iconRight && iconRightAlign === 'inline'}
         <Icon icon={iconRight}/>
       {/if}
     </span>
-    {#if section}
-      <div class="px-2 text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
-        <ChevronExpander expanded={expanded} />
-      </div>
-    {:else if iconRight && iconRightAlign === 'end'}
-      <div class="px-2 flex items-center">
+    <div class="w-3 shrink-0 flex items-center justify-end">
+      {#if section}
+        <span class="text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
+          <ChevronExpander expanded={expanded} />
+        </span>
+      {:else if iconRight && iconRightAlign === 'end'}
         <Icon icon={iconRight}/>
-      </div>
-    {/if}
+      {/if}
+    </div>
   </div>
 </a>

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -37,9 +37,9 @@ function click(): void {
 }
 </script>
 
-<a class="no-underline" href={href} aria-label={title} onclick={click}>
+<a class="no-underline block w-full" href={href} aria-label={title} onclick={click}>
   <div
-    class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px]"
+    class="flex box-border w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px]"
     class:pl-3={!child}
     class:pl-[34px]={child}
     class:leading-none={child}
@@ -54,12 +54,12 @@ function click(): void {
     class:hover:bg-[var(--pd-secondary-nav-text-hover-bg)]={!selected}
     class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]={!selected}>
     <span
-      class="group-hover:block flex flex-row gap-x-2 items-center"
+      class="group-hover:block flex flex-row gap-x-2 items-center min-w-0"
       class:capitalize={!child}>
       {#if icon}
           <Icon icon={icon}/>
       {/if}
-      <span>{title}</span>
+      <span class="truncate">{title}</span>
       {#if iconRight && iconRightAlign === 'inline'}
         <Icon icon={iconRight}/>
       {/if}

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -37,8 +37,9 @@ function click(): void {
 }
 </script>
 
-<a class="no-underline block w-full" href={href} aria-label={title} onclick={click}>
+<a class="no-underline block w-full" href={href} aria-label={title} title={title} onclick={click}>
   <div
+    data-settings-nav-row
     class="flex box-border w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px]"
     class:pl-3={!child}
     class:pl-[34px]={child}
@@ -53,13 +54,17 @@ function click(): void {
     class:hover:text-[color:var(--pd-secondary-nav-text-hover)]={!selected}
     class:hover:bg-[var(--pd-secondary-nav-text-hover-bg)]={!selected}
     class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]={!selected}>
-    <span
-      class="group-hover:block flex flex-row gap-x-2 items-center min-w-0"
-      class:capitalize={!child}>
+    <span class="flex flex-row gap-x-2 items-center min-w-0" class:capitalize={!child} class:items-start={child}>
       {#if icon}
           <Icon icon={icon}/>
       {/if}
-      <span class="truncate">{title}</span>
+      <span
+        data-settings-nav-title
+        class="block"
+        class:truncate={!child}
+        class:whitespace-normal={child}
+        class:break-words={child}
+        title={title}>{title}</span>
       {#if iconRight && iconRightAlign === 'inline'}
         <Icon icon={iconRight}/>
       {/if}


### PR DESCRIPTION
### What does this PR do?

Fixes a horizontal scrollbar that appears in **Settings -> Preferences** when navigation entries are long (for example extension preference entries).

Root cause:
- Settings navigation rows used `w-full` with padding/border in a way that could exceed sidebar width.
- Long labels could force horizontal overflow in the preferences navigation/content wrappers.

Changes included:
- `packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte`
  - Make anchor full-width block (`block w-full`)
  - Use `box-border` on row container so width includes padding/border
  - Add `min-w-0` + `truncate` for long labels
- `packages/renderer/src/PreferencesNavigation.svelte`
  - Clamp horizontal overflow in nav and scroll container (`overflow-x-hidden`)
- `packages/renderer/src/lib/preferences/SettingsPage.svelte`
  - Replace `min-w-full` with `w-full` in wrappers
  - Clamp content horizontal overflow (`overflow-x-hidden`)

This removes the unwanted x-scrollbar while preserving existing layout behavior.

### Screenshot / video of UI

UI change: include before/after screenshots in review.
- Before: horizontal scrollbar visible in Settings -> Preferences with long entries
- After: no horizontal scrollbar; long labels truncate instead of overflowing

### What issues does this PR fix or reference?

Closes #16774

### How to test this PR?

1. Start in dev mode: `pnpm watch`
2. Open **Settings -> Preferences**
3. Ensure long preference entries are visible (for example extension-related or experimental entries)
4. Verify there is no horizontal scrollbar at the bottom
5. Expand/collapse sections and confirm there is still no x-overflow

Unit tests run for changed components:
- `pnpm exec vitest run packages/ui/src/lib/settingsNavItem/SettingsNavItem.spec.ts packages/renderer/src/PreferencesNavigation.spec.ts`
- Result: 2 files passed, 23 tests passed

- [x] Tests are covering the bug fix or the new feature
