### PR TITLE
fix(kind): sync provider version on CLI tool install/uninstall

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -316,6 +316,14 @@ describe('cli#update', () => {
 
     expect(disposeMock).toHaveBeenCalled();
   });
+
+  test('uninstall should clear the provider version', async () => {
+    vi.mocked(KindInstaller.prototype.getLatestVersionAsset).mockResolvedValue(mockV1Release);
+
+    await (await getCliToolInstaller()).doUninstall({} as unknown as extensionApi.Logger);
+
+    expect(PROVIDER_MOCK.updateVersion).toHaveBeenCalledWith('');
+  });
 });
 
 /**
@@ -395,6 +403,7 @@ describe('cli#install', () => {
       path: 'path',
       version: '1.0.2',
     });
+    expect(PROVIDER_MOCK.updateVersion).toHaveBeenCalledWith('1.0.2');
   });
 
   test('if installing system wide fails, it should not throw', async () => {

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -605,6 +605,7 @@ async function registerCliTool(
         installationSource: 'extension',
       });
       kindPath = cliPath;
+      provider.updateVersion(releaseVersionToInstall);
       if (releaseVersionToInstall === latestVersion) {
         delete update.version;
       } else {
@@ -629,6 +630,7 @@ async function registerCliTool(
       // update the version and path to undefined
       kindPath = undefined;
 
+      provider.updateVersion('');
       currentUpdateDisposable?.dispose();
     },
   });


### PR DESCRIPTION
### What does this PR do?

Syncs the Kind provider version (shown on Resources page) with CLI tool install/uninstall actions.

Two fixes:
- `doUninstall`: clears provider version so Resources page no longer shows a stale version after uninstall
- `doInstall`: sets provider version so Resources page shows the version immediately after install (consistent with `doUpdate` which already did this)

### Screenshot / video of UI

https://github.com/user-attachments/assets/9219bfa9-a69d-4a55-90a0-49e66ad15e91

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17063

### How to test this PR?

1. Install Kind from CLI Tools page → Resources page should now show the version
2. Uninstall Kind from CLI Tools page → Resources page should no longer show any version

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)