### PR TITLE
test(e2e): add managed-configuration tests for extensions catalog and local extensions

### DIFF
--- a/tests/playwright/resources/managed-configuration/default-settings.json
+++ b/tests/playwright/resources/managed-configuration/default-settings.json
@@ -19,5 +19,7 @@
   ],
   "proxy.http": "http://managed-proxy.example.com:8080",
   "proxy.https": "https://managed-proxy.example.com:8443",
-  "proxy.no": "localhost,127.0.0.1,.example.com"
+  "proxy.no": "localhost,127.0.0.1,.example.com",
+  "extensions.catalog.enabled": false,
+  "extensions.localExtensions.enabled": false
 }

--- a/tests/playwright/resources/managed-configuration/locked.json
+++ b/tests/playwright/resources/managed-configuration/locked.json
@@ -5,6 +5,8 @@
     "preferences.ExitOnClose",
     "registries.preferred",
     "proxy.http",
-    "proxy.https"
+    "proxy.https",
+    "extensions.catalog.enabled",
+    "extensions.localExtensions.enabled"
   ]
 }

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -30,6 +30,7 @@ export class ExtensionsPage {
   readonly additionalActions: Locator;
   readonly installedTab: Locator;
   readonly catalogTab: Locator;
+  readonly localExtensionsTab: Locator;
   readonly installExtensionFromOCIImageButton: Locator;
 
   constructor(page: Page) {
@@ -42,6 +43,7 @@ export class ExtensionsPage {
     });
     this.installedTab = this.page.getByRole('button', { name: 'Installed' });
     this.catalogTab = this.page.getByRole('button', { name: 'Catalog', exact: true });
+    this.localExtensionsTab = this.page.getByRole('button', { name: 'Local Extensions' });
     this.installExtensionFromOCIImageButton = this.additionalActions.getByLabel('Install custom');
   }
 

--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-extensions.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-extensions.spec.ts
@@ -1,0 +1,68 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { expect as playExpect } from '@playwright/test';
+
+import type { ExtensionsPage } from '/@/model/pages/extensions-page';
+import { RunnerOptions } from '/@/runner/runner-options';
+import { test } from '/@/utility/fixtures';
+
+let extensionsPage: ExtensionsPage;
+
+test.use({
+  runnerOptions: new RunnerOptions({
+    customFolder: 'managed-configuration',
+  }),
+});
+
+test.beforeAll(async ({ runner, welcomePage, navigationBar }) => {
+  test.setTimeout(60_000);
+  runner.setVideoAndTraceName('managed-configuration-extensions-e2e');
+  await welcomePage.handleWelcomePage(true);
+  extensionsPage = await navigationBar.openExtensions();
+});
+
+test.afterAll(async ({ runner }) => {
+  await runner.close();
+});
+
+test.describe
+  .serial('Managed Configuration - extensions', { tag: '@managed-configuration' }, () => {
+    test.describe
+      .serial('Defaults + Locked setting: Extensions Catalog disabled', () => {
+        test('Installed tab is still visible', async () => {
+          await playExpect(extensionsPage.heading).toBeVisible();
+          await playExpect(extensionsPage.installedTab).toBeVisible();
+        });
+
+        test('Catalog tab is not rendered when extensions.catalog.enabled is false', async () => {
+          // ExtensionList.svelte conditionally renders the Catalog tab
+          // with {#if enableCatalog}, so the button should not exist in the DOM
+          await playExpect(extensionsPage.catalogTab).not.toBeAttached();
+        });
+      });
+
+    test.describe
+      .serial('Defaults + Locked setting: Local Extensions disabled', () => {
+        test('Local Extensions tab is not rendered when extensions.localExtensions.enabled is false', async () => {
+          // ExtensionList.svelte conditionally renders the Local Extensions tab
+          // with {#if enableLocalExtensions}, so the button should not exist in the DOM
+          await playExpect(extensionsPage.localExtensionsTab).not.toBeAttached();
+        });
+      });
+  });


### PR DESCRIPTION
### What does this PR do?
* Verifies managed configuration for extensions catalog and local extensions tabs on Extensions page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #16671 
Closes #16674 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
