### PR TITLE
fix(kubectl-cli): sync provider version on CLI tool install/uninstall

### DIFF
--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -519,6 +519,9 @@ describe('postActivate', () => {
     expect(vi.mocked(cliRun.installBinaryToSystem).mock.calls[0][0]).toContain(
       path.resolve(extensionContext.storagePath, 'bin', 'kubectl'),
     );
+
+    const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
+    expect(providerMock.updateVersion).toHaveBeenCalledWith('1.2.0');
   });
 
   test('doInstall should download and install selected binary', async () => {
@@ -648,6 +651,9 @@ describe('postActivate', () => {
 
     expect(fs.promises.unlink).toHaveBeenCalledWith(path.join(extensionContext.storagePath, 'bin', 'kubectl'));
     expect(extensionApi.process.exec).toHaveBeenCalledWith('rm', ['system-path'], { isAdmin: true });
+
+    const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
+    expect(providerMock.updateVersion).toHaveBeenCalledWith('');
   });
 
   test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -425,6 +425,7 @@ async function postActivate(
         installationSource: 'extension',
       });
       vpState.version = releaseVersionToInstall;
+      provider.updateVersion(releaseVersionToInstall);
       if (releaseToInstall === latestAsset) {
         delete update.version;
       } else {
@@ -448,6 +449,7 @@ async function postActivate(
 
       // update the version to undefined
       vpState.version = undefined;
+      provider.updateVersion('');
       kubectlProviderUpdateDisposable?.dispose();
     },
   });


### PR DESCRIPTION
### What does this PR do?

Syncs the kubectl provider version (shown on Resources page) with CLI tool install/uninstall actions.

Two fixes:
- `doUninstall`: clears provider version so Resources page no longer shows a stale version after uninstall
- `doInstall`: sets provider version so Resources page shows the version immediately after install (consistent with `doUpdate` which already did this)

### Screenshot / video of UI

https://github.com/user-attachments/assets/8ba158e1-2728-480d-bbd6-04780419ed11


<!-- TODO: add video/screenshot -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17091

### How to test this PR?

1. Install kubectl from CLI Tools page → Resources page should now show the version
2. Uninstall kubectl from CLI Tools page → Resources page should no longer show any version

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)