### PR TITLE
fix(compose): sync provider version on CLI tool install/uninstall

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -357,6 +357,9 @@ describe('registerCLITool', () => {
       installationSource: 'extension',
       version: '1.0.0',
     });
+
+    const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
+    expect(providerMock.updateVersion).toHaveBeenCalledWith('1.0.0');
   });
 
   test('by uninstalling it should delete all executables', async () => {
@@ -390,6 +393,9 @@ describe('registerCLITool', () => {
     await installer?.doUninstall({} as unknown as Logger);
     expect(fs.promises.unlink).toHaveBeenNthCalledWith(1, 'storage-path');
     expect(extensionApi.process.exec).toHaveBeenCalledWith('rm', ['system-wide-path'], { isAdmin: true });
+
+    const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
+    expect(providerMock.updateVersion).toHaveBeenCalledWith('');
   });
 
   test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -416,6 +416,7 @@ async function registerCLITool(
         installationSource: 'extension',
       });
       binaryVersion = releaseVersionToInstall;
+      provider.updateVersion(releaseVersionToInstall);
       releaseVersionToInstall = undefined;
       releaseToInstall = undefined;
       extensionApi.context.setValue('compose.isComposeInstalledSystemWide', true);
@@ -436,6 +437,7 @@ async function registerCLITool(
       // update the version to undefined
       binaryVersion = undefined;
       binaryPath = undefined;
+      provider.updateVersion('');
       extensionApi.context.setValue('compose.isComposeInstalledSystemWide', false);
       composeProviderUpdateDisposable?.dispose();
     },


### PR DESCRIPTION
### What does this PR do?

Syncs the Compose provider version (shown on Resources page) with CLI tool install/uninstall actions.

Two fixes:
- `doUninstall`: clears provider version so Resources page no longer shows a stale version after uninstall
- `doInstall`: sets provider version so Resources page shows the version immediately after install (consistent with `doUpdate` which already did this)

### Screenshot / video of UI

https://github.com/user-attachments/assets/b239d275-b96b-4c44-af3e-18abb5cb4c33


<!-- TODO: add video/screenshot -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17092

### How to test this PR?

1. Install Compose from CLI Tools page → Resources page should now show the version
2. Uninstall Compose from CLI Tools page → Resources page should no longer show any version

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)