### PR TITLE
feat(renderer): use delete variant for destructive actions

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -155,7 +155,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Delete Compose"
-  onClick={(): void => withConfirmation(deleteCompose, `delete compose ${compose.name}`)}
+  onClick={(): void => withConfirmation(deleteCompose, `delete compose ${compose.name}`, { variant:'delete' } )}
   icon={faTrash}
   detailed={detailed}
   inProgress={compose.actionInProgress && compose.status === 'DELETING'} />

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.svelte
@@ -29,6 +29,7 @@ async function deleteConfigMapSecret(): Promise<void> {
     withConfirmation(
       deleteConfigMapSecret,
       `delete ${configmapSecretUtils.isSecret(configMapSecret) ? 'secret' : 'configmap'} ${configMapSecret.name}`,
+      { variant:'delete' }
     )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -202,7 +202,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Delete Container"
-  onClick={(): void => withConfirmation(deleteContainer, `delete container ${container.name}`)}
+  onClick={(): void => withConfirmation(deleteContainer, `delete container ${container.name}`, { variant:'delete' } )}
   icon={faTrash}
   detailed={detailed}
   inProgress={container.actionInProgress && container.state === 'DELETING'} />

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -416,6 +416,7 @@ function label(item: ContainerGroupInfoUI | ContainerInfoUI): string {
               withBulkConfirmation(
                 deleteSelectedContainers,
                 `delete ${selectedItemsNumber} container${selectedItemsNumber > 1 ? 's' : ''}`,
+                { variant:'delete' }
               );
             }
           }}

--- a/packages/renderer/src/lib/cronjob/CronJobActions.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.svelte
@@ -21,6 +21,6 @@ async function deleteCronJob(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete CronJob"
-  onClick={(): void => withConfirmation(deleteCronJob, `delete cronjob ${cronjob.name}`)}
+  onClick={(): void => withConfirmation(deleteCronJob, `delete cronjob ${cronjob.name}`, { variant:'delete' } )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/deployments/DeploymentActions.svelte
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.svelte
@@ -22,6 +22,6 @@ async function deleteDeployment(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Deployment"
-  onClick={(): void => withConfirmation(deleteDeployment, `delete deployment ${deployment.name}`)}
+  onClick={(): void => withConfirmation(deleteDeployment, `delete deployment ${deployment.name}`, { variant:'delete' } )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/engine/Prune.spec.ts
+++ b/packages/renderer/src/lib/engine/Prune.spec.ts
@@ -63,8 +63,9 @@ describe('containers', () => {
 
     // check if the showMessageBox method was called with all the right parameters
     expect(window.showMessageBox).toHaveBeenCalledWith({
-      buttons: ['Cancel', 'Yes'],
+      buttons: ['Cancel', 'Delete'],
       title: 'Prune',
+      type: 'danger',
       message: 'This action will prune all unused containers from the Podman engine.',
     });
 
@@ -109,6 +110,7 @@ describe('images', () => {
     expect(window.showMessageBox).toHaveBeenCalledWith({
       buttons: IMAGE_BUTTONS,
       title: 'Prune',
+      type: 'danger',
       message: 'This action will prune images from the Podman engine.',
     });
 
@@ -133,6 +135,7 @@ describe('images', () => {
     expect(window.showMessageBox).toHaveBeenCalledWith({
       buttons: IMAGE_BUTTONS,
       title: 'Prune',
+      type: 'danger',
       message: 'This action will prune images from the Podman engine.',
     });
 
@@ -156,6 +159,7 @@ describe('images', () => {
     // check if the showMessageBox method was called with all the right parameters
     expect(window.showMessageBox).toHaveBeenCalledWith({
       buttons: IMAGE_BUTTONS,
+      type: 'danger',
       title: 'Prune',
       message: 'This action will prune images from the Podman engine.',
     });

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -34,11 +34,12 @@ async function openPruneDialog(): Promise<void> {
     buttons.push(LABEL_IMAGE_UNUSED);
     buttons.push(LABEL_IMAGE_UNTAGGED);
   } else {
-    buttons.push('Yes');
+    buttons.push('Delete');
   }
 
   const result = await window.showMessageBox({
     title: 'Prune',
+    type: 'danger',
     message: message,
     buttons,
   });

--- a/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
@@ -75,6 +75,7 @@ function label(extensionFolder: SelectableExtensionDevelopmentFolderInfoUI): str
         withBulkConfirmation(
           deleteSelectedFolders,
           `Untrack loading extension from ${selectedItemsNumber} folder${selectedItemsNumber > 1 ? 's' : ''}`,
+          { variant: 'delete' },
         )}
       title="Untrack {selectedItemsNumber} selected items"
       inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -253,6 +253,8 @@ test('Expect withConfirmation to indicate image name and tag', async () => {
   await fireEvent.click(button);
 
   await waitFor(() => {
-    expect(withConfirmation).toHaveBeenNthCalledWith(1, expect.anything(), 'delete image image-name:1.0');
+    expect(withConfirmation).toHaveBeenNthCalledWith(1, expect.anything(), 'delete image image-name:1.0', {
+      variant: 'delete',
+    });
   });
 });

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -104,7 +104,7 @@ function saveImage(): void {
 
 <ListItemButtonIcon
   title="Delete Image"
-  onClick={(): void => withConfirmation(deleteImage, `delete image ${image.name}:${image.tag}`)}
+  onClick={(): void => withConfirmation(deleteImage, `delete image ${image.name}:${image.tag}`, { variant:'delete' } )}
   detailed={detailed}
   icon={faTrash}
   enabled={image.status === 'UNUSED'} />

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -337,6 +337,7 @@ function label(item: ImageInfoUI): string {
           if (selectedItemsNumber) {withBulkConfirmation(
             deleteSelectedImages,
             `delete ${selectedItemsNumber} image${selectedItemsNumber > 1 ? 's' : ''}`,
+            { variant:'delete' }
           );}}}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/image/ManifestActions.spec.ts
+++ b/packages/renderer/src/lib/image/ManifestActions.spec.ts
@@ -18,11 +18,16 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
+import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 import ManifestActions from '/@/lib/image/ManifestActions.svelte';
+
+vi.mock(import('/@/lib/dialogs/messagebox-utils'), () => ({
+  withConfirmation: vi.fn(),
+}));
 
 const getContributedMenusMock = vi.fn();
 
@@ -62,4 +67,25 @@ test('Expect Push Manifest to be there', async () => {
 
   const button = screen.getByRole('button', { name: 'Push Manifest' });
   expect(button).toBeDefined();
+});
+
+test('Expect withConfirmation to be called with delete variant when clicking Delete Manifest', async () => {
+  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+
+  const manifest: ImageInfoUI = {
+    ...fakedManifest,
+    name: 'my-manifest',
+    status: 'UNUSED',
+  } as unknown as ImageInfoUI;
+
+  render(ManifestActions, { manifest, onPushManifest: vi.fn() });
+
+  const button = screen.getByRole('button', { name: 'Delete Manifest' });
+  await fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(withConfirmation).toHaveBeenCalledWith(expect.anything(), 'delete manifest my-manifest', {
+      variant: 'delete',
+    });
+  });
 });

--- a/packages/renderer/src/lib/image/ManifestActions.svelte
+++ b/packages/renderer/src/lib/image/ManifestActions.svelte
@@ -44,7 +44,7 @@ async function onError(error: string): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Manifest"
-  onClick={(): void => withConfirmation(deleteManifest, `delete manifest ${manifest.name}`)}
+  onClick={(): void => withConfirmation(deleteManifest, `delete manifest ${manifest.name}`, { variant:'delete' } )}
   detailed={detailed}
   icon={faTrash}
   enabled={manifest.status === 'UNUSED'} />

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
@@ -30,6 +30,7 @@ async function deleteIngressRoute(): Promise<void> {
     withConfirmation(
       deleteIngressRoute,
       `delete ${ingressRouteUtils.isIngress(ingressRoute) ? 'ingress' : 'route'} ${ingressRoute.name}`,
+      { variant:'delete' }
     )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/job/JobActions.svelte
+++ b/packages/renderer/src/lib/job/JobActions.svelte
@@ -21,6 +21,6 @@ async function deleteJob(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Job"
-  onClick={(): void => withConfirmation(deleteJob, `delete job ${job.name}`)}
+  onClick={(): void => withConfirmation(deleteJob, `delete job ${job.name}`, { variant:'delete' } )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/kube/pods/PodActions.svelte
+++ b/packages/renderer/src/lib/kube/pods/PodActions.svelte
@@ -58,7 +58,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Delete Pod"
-  onClick={():void => withConfirmation(deletePod, `delete pod ${pod.name}`)}
+  onClick={():void => withConfirmation(deletePod, `delete pod ${pod.name}`, { variant:'delete' } )}
   icon={faTrash}
   detailed={detailed}/>
 

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.svelte
@@ -39,5 +39,5 @@ async function openExternal(): Promise<void> {
   icon={faSquareUpRight} />
 <ListItemButtonIcon
   title="Delete forwarded port"
-  onClick={(): void => withConfirmation(deletePortForward, `Delete port forward`)}
+  onClick={(): void => withConfirmation(deletePortForward, `Delete port forward`, { variant:'delete' } )}
   icon={faTrash} />

--- a/packages/renderer/src/lib/network/NetworkActions.svelte
+++ b/packages/renderer/src/lib/network/NetworkActions.svelte
@@ -42,7 +42,7 @@ function closeUpdateDialog(): void {
 
 <ListItemButtonIcon
   title="Delete Network"
-  onClick={(): void => withConfirmation(removeNetwork, `delete network ${object.name}`)}
+  onClick={(): void => withConfirmation(removeNetwork, `delete network ${object.name}`, { variant:'delete' } )}
   icon={faTrash}
   detailed={detailed}
   enabled={object.status === 'UNUSED'} />

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -141,6 +141,7 @@ function key(network: NetworkInfoUI): string {
           withBulkConfirmation(
             deleteSelectedNetworks,
             `delete ${selectedItemsNumber} network${selectedItemsNumber > 1 ? 's' : ''}`,
+            { variant:'delete' }
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -137,6 +137,7 @@ let selectedItemsNumber = $state<number>(0);
           withBulkConfirmation(
             deleteSelectedObjects,
             `delete ${selectedItemsNumber} ${selectedItemsNumber > 1 ? plural : singular}`,
+            { variant:'delete' }
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -159,7 +159,7 @@ const MenuComponent = $derived(dropdownMenu ? DropdownMenu : FlatMenu);
   icon={faStop} />
 <ListItemButtonIcon
   title="Delete Pod"
-  onClick={(): void => withConfirmation(deletePod, `delete pod ${pod.name}`)}
+  onClick={(): void => withConfirmation(deletePod, `delete pod ${pod.name}`, { variant:'delete' } )}
   icon={faTrash}
   detailed={detailed}
   inProgress={pod.actionInProgress && pod.status === 'DELETING'} />

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -198,6 +198,7 @@ function label(pod: PodInfoUI): string {
           withBulkConfirmation(
             deleteSelectedPods,
             `delete ${selectedItemsNumber} pod${selectedItemsNumber > 1 ? 's' : ''}`,
+            { variant:'delete' }
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -172,8 +172,8 @@ describe('delete', () => {
       expect(window.showMessageBox).toHaveBeenCalledExactlyOnceWith({
         title: 'Confirmation',
         message: `Are you sure you want to delete ${containerConnection.name}?`,
-        buttons: ['Yes', 'Cancel'],
-        type: 'question',
+        buttons: ['Delete', 'Cancel'],
+        type: 'danger',
       });
     });
   });

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -191,7 +191,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
         {/if}
         {#if connection.lifecycleMethods.includes('delete')}
           <LoadingIconButton
-            clickAction={withConfirmation.bind(undefined, deleteConnectionProvider.bind(undefined, provider, connection), `delete ${connection.name}`)}
+            clickAction={withConfirmation.bind(undefined, deleteConnectionProvider.bind(undefined, provider, connection), `delete ${connection.name}`, { variant: 'delete'})}
             action="delete"
             icon={faTrash}
             state={connectionStatus}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -96,7 +96,7 @@ async function handleDeleteContext(contextName: string): Promise<void> {
       title: 'Delete Context',
       message:
         'You will delete the current context. If you delete it, you will need to switch to another context. Continue?',
-      buttons: ['Yes', 'Cancel'],
+      buttons: ['Delete', 'Cancel'],
     });
     if (result.response !== 0) {
       return;

--- a/packages/renderer/src/lib/pvc/PVCActions.svelte
+++ b/packages/renderer/src/lib/pvc/PVCActions.svelte
@@ -18,6 +18,6 @@ async function deletePVC(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete PersistentVolumeClaim"
-  onClick={(): void => withConfirmation(deletePVC, `delete pvc ${pvc.name}`)}
+  onClick={(): void => withConfirmation(deletePVC, `delete pvc ${pvc.name}`, { variant:'delete' } )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/service/ServiceActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceActions.svelte
@@ -18,6 +18,6 @@ async function deleteService(): Promise<void> {
 
 <ListItemButtonIcon
   title="Delete Service"
-  onClick={(): void => withConfirmation(deleteService, `delete service ${service.name}`)}
+  onClick={(): void => withConfirmation(deleteService, `delete service ${service.name}`, { variant:'delete' } )}
   detailed={detailed}
   icon={faTrash} />

--- a/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.spec.ts
+++ b/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.spec.ts
@@ -80,10 +80,10 @@ test('Expect bulk button is bringing confirmation but not deleting anything', as
   await fireEvent.click(bulkButton);
 
   expect(window.showMessageBox).toHaveBeenCalledWith({
-    buttons: ['Yes', 'Cancel'],
+    buttons: ['Delete', 'Cancel'],
     message: 'Are you sure you want to bulk delete operation?',
     title: 'Confirmation',
-    type: 'question',
+    type: 'danger',
   });
 
   // expect we did not call the clearTask method

--- a/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.svelte
+++ b/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.svelte
@@ -29,7 +29,7 @@ async function deleteSelectedTasks(): Promise<void> {
 }
 
 function onClick(): void {
-  withBulkConfirmation(deleteSelectedTasks, bulkOperationTitle);
+  withBulkConfirmation(deleteSelectedTasks, bulkOperationTitle, { variant: 'delete' });
 }
 </script>
 

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -23,7 +23,7 @@ async function removeVolume(): Promise<void> {
 {#if volume.status === 'UNUSED'}
   <ListItemButtonIcon
     title="Delete Volume"
-    onClick={(): void => withConfirmation(removeVolume, `delete volume ${volume.name}`)}
+    onClick={(): void => withConfirmation(removeVolume, `delete volume ${volume.name}`, { variant:'delete' } )}
     detailed={detailed}
     icon={faTrash} />
 {/if}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -221,6 +221,7 @@ function label(obj: VolumeInfoUI): string {
           withBulkConfirmation(
             deleteSelectedVolumes,
             `delete ${selectedItemsNumber} volume${selectedItemsNumber > 1 ? 's' : ''}`,
+            { variant: 'delete' }
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/tests/playwright/src/model/pages/container-details-page.ts
+++ b/tests/playwright/src/model/pages/container-details-page.ts
@@ -87,7 +87,7 @@ export class ContainerDetailsPage extends DetailsPage {
     return test.step('Delete container', async () => {
       await playExpect(this.deleteButton).toBeEnabled();
       await this.deleteButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       return new ContainersPage(this.page);
     });
   }

--- a/tests/playwright/src/model/pages/containers-page.ts
+++ b/tests/playwright/src/model/pages/containers-page.ts
@@ -117,7 +117,7 @@ export class ContainersPage extends MainPage {
       await playExpect(containerRowDeleteButton).toBeVisible();
       await playExpect(containerRowDeleteButton).toBeEnabled();
       await containerRowDeleteButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       return new ContainersPage(this.page);
     });
   }
@@ -158,7 +158,7 @@ export class ContainersPage extends MainPage {
   async pruneContainers(): Promise<ContainersPage> {
     return test.step('Prune Containers', async () => {
       await this.pruneContainersButton.click();
-      await handleConfirmationDialog(this.page, 'Prune');
+      await handleConfirmationDialog(this.page, 'Prune', true, 'Delete');
       return this;
     });
   }

--- a/tests/playwright/src/model/pages/image-details-page.ts
+++ b/tests/playwright/src/model/pages/image-details-page.ts
@@ -91,7 +91,7 @@ export class ImageDetailsPage extends DetailsPage {
     return test.step('Delete image', async () => {
       await playExpect(this.deleteButton).toBeEnabled({ timeout: 30_000 });
       await this.deleteButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       return new ImagesPage(this.page);
     });
   }

--- a/tests/playwright/src/model/pages/images-page.ts
+++ b/tests/playwright/src/model/pages/images-page.ts
@@ -217,7 +217,7 @@ export class ImagesPage extends MainPage {
 
       await playExpect(this.deleteAllSelectedButton).toBeEnabled();
       await this.deleteAllSelectedButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
     });
   }
 
@@ -256,7 +256,7 @@ export class ImagesPage extends MainPage {
     const deleteManifestButton = manifest.getByRole('button', { name: 'Delete Manifest' });
     await playExpect(deleteManifestButton).toBeEnabled();
     await deleteManifestButton.click();
-    await handleConfirmationDialog(this.page);
+    await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
   }
 
   async pushManifest(manifestName: string): Promise<void> {

--- a/tests/playwright/src/model/pages/kubernetes-context-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-context-page.ts
@@ -85,7 +85,7 @@ export class KubeContextPage extends SettingsPage {
     await playExpect(deleteButton).toBeEnabled();
     await deleteButton.click();
     if (handleConfirmation) {
-      await handleConfirmationDialog(this.page, 'Delete Context');
+      await handleConfirmationDialog(this.page, 'Delete Context', true, 'Delete');
     }
   }
 

--- a/tests/playwright/src/model/pages/network-details-page.ts
+++ b/tests/playwright/src/model/pages/network-details-page.ts
@@ -58,7 +58,7 @@ export class NetworkDetailsPage extends DetailsPage {
     return test.step('Delete network from details page', async () => {
       await playExpect(this.deleteButton).toBeEnabled();
       await this.deleteButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       return new NetworksPage(this.page);
     });
   }

--- a/tests/playwright/src/model/pages/networks-page.ts
+++ b/tests/playwright/src/model/pages/networks-page.ts
@@ -55,7 +55,7 @@ export class NetworksPage extends MainPage {
       const networkDeleteButton = await this.getDeleteNetworkRowButton(networkName);
       await playExpect(networkDeleteButton).toBeEnabled();
       await networkDeleteButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       return this;
     });
   }

--- a/tests/playwright/src/model/pages/pods-details-page.ts
+++ b/tests/playwright/src/model/pages/pods-details-page.ts
@@ -88,7 +88,7 @@ export class PodDetailsPage extends DetailsPage {
     return test.step('Delete Pod', async () => {
       await playExpect(this.deleteButton).toBeEnabled({ timeout: 10_000 });
       await this.deleteButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       return new PodsPage(this.page);
     });
   }

--- a/tests/playwright/src/model/pages/pods-page.ts
+++ b/tests/playwright/src/model/pages/pods-page.ts
@@ -73,7 +73,7 @@ export class PodsPage extends MainPage {
   async prunePods(): Promise<PodsPage> {
     return test.step('Prune Pods', async () => {
       await this.prunePodsButton.click();
-      await handleConfirmationDialog(this.page, 'Prune');
+      await handleConfirmationDialog(this.page, 'Prune', true, 'Delete');
       return this;
     });
   }

--- a/tests/playwright/src/model/pages/resource-connection-card-page.ts
+++ b/tests/playwright/src/model/pages/resource-connection-card-page.ts
@@ -64,7 +64,7 @@ export class ResourceConnectionCardPage extends ResourceCardPage {
 
       // A confirmation dialog is displayed for deletion
       if (String(operation) === ResourceElementActions.Delete) {
-        await handleConfirmationDialog(this.page);
+        await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       }
     });
   }

--- a/tests/playwright/src/model/pages/resource-details-page.ts
+++ b/tests/playwright/src/model/pages/resource-details-page.ts
@@ -41,7 +41,7 @@ export class ResourceDetailsPage extends DetailsPage {
 
       // A confirmation dialog is displayed for deletion
       if (String(operation) === ResourceElementActions.Delete) {
-        await handleConfirmationDialog(this.page);
+        await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       }
     });
   }

--- a/tests/playwright/src/model/pages/volume-details-page.ts
+++ b/tests/playwright/src/model/pages/volume-details-page.ts
@@ -45,7 +45,7 @@ export class VolumeDetailsPage extends DetailsPage {
     return test.step('Delete Volume', async () => {
       await playExpect(this.deleteButton).toBeEnabled();
       await this.deleteButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
       return new VolumesPage(this.page);
     });
   }

--- a/tests/playwright/src/model/pages/volumes-page.ts
+++ b/tests/playwright/src/model/pages/volumes-page.ts
@@ -74,7 +74,7 @@ export class VolumesPage extends MainPage {
       const containerRowDeleteButton = volumeRow.getByRole('button', { name: 'Delete Volume' });
       await playExpect(containerRowDeleteButton).toBeEnabled();
       await containerRowDeleteButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
 
       return this;
     });
@@ -123,7 +123,7 @@ export class VolumesPage extends MainPage {
     return test.step('Prune Volumes', async () => {
       await playExpect(this.pruneVolumesButton).toBeEnabled();
       await this.pruneVolumesButton.click();
-      await handleConfirmationDialog(this.page, 'Prune');
+      await handleConfirmationDialog(this.page, 'Prune', true, 'Delete');
       return this;
     });
   }

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -93,7 +93,7 @@ export async function deleteKubernetesResource(
     const kubernetesBar = await navigationBar.openKubernetes();
     const kubernetesResourcePage = await kubernetesBar.openTabPage(resourceType);
     await kubernetesResourcePage.deleteKubernetesResource(resourceName);
-    await handleConfirmationDialog(page);
+    await handleConfirmationDialog(page, 'Confirmation', true, 'Delete');
     await playExpect
       .poll(async () => await kubernetesResourcePage.getRowByName(resourceName), { timeout: timeout })
       .not.toBeTruthy();

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -60,7 +60,7 @@ export async function deleteContainer(page: Page, name: string): Promise<void> {
       // delete the container
       const deleteButton = container.getByRole('button').and(container.getByLabel('Delete Container'));
       await deleteButton.click();
-      await handleConfirmationDialog(page);
+      await handleConfirmationDialog(page, 'Confirmation', true, 'Delete');
       // wait for container to disappear
       try {
         console.log('Waiting for container to get deleted ...');
@@ -93,7 +93,7 @@ export async function deleteImage(page: Page, name: string): Promise<void> {
       const deleteButton = row.getByRole('button', { name: 'Delete Image' });
       if (await deleteButton.isEnabled()) {
         await deleteButton.click();
-        await handleConfirmationDialog(page);
+        await handleConfirmationDialog(page, 'Confirmation', true, 'Delete');
       } else {
         throw Error(`Cannot delete image ${name}, because it is in use`);
       }
@@ -149,7 +149,7 @@ export async function deletePod(page: Page, name: string, timeout = 50_000): Pro
       const deleteButton = pod.getByRole('button').and(pod.getByLabel('Delete Pod'));
       await deleteButton.click();
       // config delete dialog
-      await handleConfirmationDialog(page);
+      await handleConfirmationDialog(page, 'Confirmation', true, 'Delete');
       // wait for pod to disappear
       try {
         console.log('Waiting for pod to get deleted ...');


### PR DESCRIPTION
### What does this PR do?

This PR passes `{ variant: 'delete' }` to all `withConfirmation` and `withBulkConfirmation` calls for destructive (delete) actions across the renderer.

Also the message box type and button label was changed in `Prune.svelte`

### Screenshot / video of UI

UI changes was in #16423 

### What issues does this PR fix or reference?

Closes #15956 

### How to test this PR?

1. Start Podman Desktop
2. Click the delete button on any resource (container, image, volume, pod, network, etc.)
3. Verify the confirmation dialog shows with:
   - A red/danger icon instead of the default question icon
   - A "Delete" button instead of "Yes"
4. Click "Delete" and confirm the action proceeds correctly
5. Click "Cancel" and confirm the action is cancelled
6. Test bulk delete actions (select multiple containers/images/volumes, click delete) -> same danger styling should appear

- [x] Tests are covering the bug fix or the new feature
