### PR TITLE
chore(dependencies): updates node-forge to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
       "esbuild-register>esbuild": "^0.25.0",
       "tsx>esbuild": "^0.25.0",
       "vite>esbuild": "^0.25.0",
-      "node-forge": "^1.3.3",
+      "node-forge": "^1.4.0",
       "config-file-ts>glob": "^10.5.0",
       "compression>on-headers": "^1.1.0",
       "electron-builder-notarize>js-yaml": "^3.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   esbuild-register>esbuild: ^0.25.0
   tsx>esbuild: ^0.25.0
   vite>esbuild: ^0.25.0
-  node-forge: ^1.3.3
+  node-forge: ^1.4.0
   config-file-ts>glob: ^10.5.0
   compression>on-headers: ^1.1.0
   electron-builder-notarize>js-yaml: ^3.14.2
@@ -9173,8 +9173,8 @@ packages:
       encoding:
         optional: true
 
-  node-forge@1.3.3:
-    resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
 
   node-gyp@11.5.0:
@@ -22360,7 +22360,7 @@ snapshots:
     optionalDependencies:
       encoding: 0.1.13
 
-  node-forge@1.3.3: {}
+  node-forge@1.4.0: {}
 
   node-gyp@11.5.0:
     dependencies:
@@ -23957,7 +23957,7 @@ snapshots:
   selfsigned@2.4.1:
     dependencies:
       '@types/node-forge': 1.3.11
-      node-forge: 1.3.3
+      node-forge: 1.4.0
 
   semver-compare@1.0.0:
     optional: true
@@ -25790,7 +25790,7 @@ snapshots:
     dependencies:
       is-electron: 2.2.2
       make-dir: 1.3.0
-      node-forge: 1.3.3
+      node-forge: 1.4.0
       split: 1.0.1
 
   winreg@1.2.5: {}


### PR DESCRIPTION
chore(dependencies): updates node-forge to 1.4.0

### What does this PR do?

Updates the node-forge package overide to 1.4.0 (new release:
https://www.npmjs.com/package/node-forge)

Affected function: retrieveWindowsCertificates()

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

CVE fixes / security alerts.

### How to test this PR?

* Verify that certificate handling with Windows machines works as normal when pulling / pushing an image behind CA on your host.
* Verify "refreshing catalog" works fine / can download extensions
* Verify PD on Windows starts up / no errors in console regarding certificate issues.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
