### PR TITLE
chore(registry-setup): writing `auth.json` file should have proper permissions

### DIFF
--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
@@ -37,6 +37,10 @@ export class TestRegistrySetup extends RegistrySetup {
 
   updateRegistries(): Promise<void> {
     return super.updateRegistries();
+  }
+
+  publicWriteAuthFile(data: string): Promise<void> {
+    return super.writeAuthFile(data);
   }
 }
 
@@ -238,4 +242,19 @@ test.each([
   onRegisterRegistry?.(registeredRegistry);
 
   await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(timesCalled));
+});
+
+test('writeAuthFile should call writeFile and chmod with 0o600', async () => {
+  const data = JSON.stringify({ auth: {} });
+  const authJsonLocation = '/tmp/containers/auth.json';
+  const mockGetAuthFileLocation = vi.spyOn(registrySetup, 'getAuthFileLocation');
+  mockGetAuthFileLocation.mockReturnValue(authJsonLocation);
+
+  await registrySetup.publicWriteAuthFile(data);
+
+  expect(writeFile).toHaveBeenCalledWith(authJsonLocation, data, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  expect(chmod).toHaveBeenCalledWith(authJsonLocation, 0o600);
 });

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as fs from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -205,7 +205,13 @@ export class RegistrySetup {
     }
   }
 
-  protected writeAuthFile(data: string): Promise<void> {
-    return writeFile(this.getAuthFileLocation(), data, 'utf8');
+  protected async writeAuthFile(data: string): Promise<void> {
+    const path = this.getAuthFileLocation();
+    await writeFile(path, data, {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    // writeFile is not updating the mode if the file already exist
+    await chmod(path, 0o600);
   }
 }


### PR DESCRIPTION
### What does this PR do?

By default node will set 0644 permission when writing file, but podman / docker use 0600 which is more secure, we should follow they standards.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16577

Require rebase after
- https://github.com/podman-desktop/podman-desktop/pull/17101

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing**

On linux

1. Rename the `auth.json`
```bash
$: mv ${XDG_RUNTIME_DIR}/containers/auth.json ${XDG_RUNTIME_DIR}/containers/auth.json.bak
```
2. Go to Podman Desktop
3. Go to `Settings > Registries`
4. Login to any registries
5. Check auth.json permissions
```
$: stat ${XDG_RUNTIME_DIR}/containers/auth.json
  File: /run/user/1000/containers/auth.json
  Size: 250             Blocks: 8          IO Block: 4096   regular file
Device: 0,91    Inode: 5733        Links: 1
Access: (0600/-rw-------)  Uid: ( 1000/axel7083)   Gid: ( 1000/axel7083)
Context: unconfined_u:object_r:user_tmp_t:s0
Access: 2026-04-16 16:05:54.396245732 +0200
Modify: 2026-04-16 16:05:54.396284889 +0200
Change: 2026-04-16 16:05:54.396284889 +0200
 Birth: 2026-04-16 16:05:54.395284876 +0200
```
6. Assert it is **0600**