### PR TITLE
fix(ci): align podman-install Kubic repo with ubuntu-24.04

### DIFF
--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -78,6 +78,7 @@ jobs:
         uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          ubuntu-version: '24.04'
 
       - name: Setup testenv using external action
         uses: podman-desktop/e2e/.github/actions/pde2e-testenv-prepare@13e2c57c759137bfc1f437f221967461e8a98e2a

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -110,6 +110,7 @@ jobs:
         uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          ubuntu-version: '24.04'
 
       - name: Setup testenv using external action
         uses: podman-desktop/e2e/.github/actions/pde2e-testenv-prepare@13e2c57c759137bfc1f437f221967461e8a98e2a

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -322,6 +322,7 @@ jobs:
         uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          ubuntu-version: '24.04'
 
       - name: Setup testenv using external action
         uses: podman-desktop/e2e/.github/actions/pde2e-testenv-prepare@13e2c57c759137bfc1f437f221967461e8a98e2a
@@ -480,6 +481,7 @@ jobs:
         uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          ubuntu-version: '24.04'
 
       - name: Setup testenv using external action
         uses: podman-desktop/e2e/.github/actions/pde2e-testenv-prepare@13e2c57c759137bfc1f437f221967461e8a98e2a


### PR DESCRIPTION
### What does this PR do?
Pass ubuntu-version 24.04 to redhat-actions/podman-install on Linux jobs so APT can resolve crun/criu dependencies on Noble runners.

Functionally, it solves the 'Install Podman v5 using external action' step from 'smoke e2e tests (development)' job failing during the pr-check workflow.

Made-with: Cursor

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
