### PR TITLE
fix(compose): show error step when CLI version fetch fails during onboarding

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -56,10 +56,23 @@
           ]
         },
         {
+          "id": "versionCheckFailedView",
+          "title": "Unable to retrieve Compose version",
+          "when": "onboardingContext:composeVersionCheckFailed",
+          "state": "failed",
+          "content": [
+            [
+              {
+                "value": "Podman Desktop was unable to retrieve the latest Compose version. This may be caused by a GitHub API rate limit or a network issue.\n\nPlease try again later or check your network connection."
+              }
+            ]
+          ]
+        },
+        {
           "id": "welcomeDownloadView",
           "label": "Compose Download",
           "title": "Compose download",
-          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded && !onboardingContext:composeVersionCheckFailed",
           "content": [
             [
               {
@@ -84,7 +97,7 @@
           "id": "downloadCommand",
           "title": "Downloading Compose ${onboardingContext:composeDownloadVersion}",
           "description": "Downloading the binary.\n\nOnce downloaded, the next step will install Compose system-wide.",
-          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded && !onboardingContext:composeVersionCheckFailed",
           "command": "compose.onboarding.downloadCommand",
           "completionEvents": [
             "onCommand:compose.onboarding.downloadCommand"

--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -63,7 +63,7 @@
           "content": [
             [
               {
-                "value": "Podman Desktop was unable to retrieve the latest Compose version. This may be caused by a GitHub API rate limit or a network issue.\n\nPlease try again later or check your network connection."
+                "value": "Unable to retrieve the latest Compose version. This may be caused by a GitHub API rate limit or a network issue.\n\nPlease try again later or check your network connection."
               }
             ]
           ]
@@ -97,7 +97,7 @@
           "id": "downloadCommand",
           "title": "Downloading Compose ${onboardingContext:composeDownloadVersion}",
           "description": "Downloading the binary.\n\nOnce downloaded, the next step will install Compose system-wide.",
-          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded && !onboardingContext:composeVersionCheckFailed",
+          "when": "!compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide && onboardingContext:composeIsNotDownloaded && !onboardingContext:composeVersionCheckFailed",
           "command": "compose.onboarding.downloadCommand",
           "completionEvents": [
             "onCommand:compose.onboarding.downloadCommand"

--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -471,6 +471,40 @@ describe('registerCLITool', () => {
     });
   });
 
+  test('checkDownloadedCommand sets composeVersionCheckFailed when version fetch fails', async () => {
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('');
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
+    vi.mocked(ComposeDownload.prototype.getLatestVersionAsset).mockRejectedValue(new Error('API rate limit exceeded'));
+
+    await activate(extensionContextMock);
+
+    const checkDownloadedHandler = vi.mocked(extensionApi.commands.registerCommand).mock.calls[1][1];
+    await checkDownloadedHandler();
+
+    expect(extensionApi.context.setValue).toHaveBeenCalledWith('composeVersionCheckFailed', true, 'onboarding');
+    expect(extensionApi.context.setValue).not.toHaveBeenCalledWith(
+      'composeDownloadVersion',
+      expect.anything(),
+      'onboarding',
+    );
+  });
+
+  test('checkDownloadedCommand sets composeDownloadVersion on success', async () => {
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('');
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
+    vi.mocked(ComposeDownload.prototype.getLatestVersionAsset).mockResolvedValue({
+      tag: 'v2.30.0',
+    } as unknown as ComposeGithubReleaseArtifactMetadata);
+
+    await activate(extensionContextMock);
+
+    const checkDownloadedHandler = vi.mocked(extensionApi.commands.registerCommand).mock.calls[1][1];
+    await checkDownloadedHandler();
+
+    expect(extensionApi.context.setValue).toHaveBeenCalledWith('composeDownloadVersion', 'v2.30.0', 'onboarding');
+    expect(extensionApi.context.setValue).toHaveBeenCalledWith('composeVersionCheckFailed', false, 'onboarding');
+  });
+
   test('onboarding download command shows error message if version list cannot be obtained', async () => {
     await activate(extensionContextMock);
     const downloadCommandHandler = vi.mocked(extensionApi.commands.registerCommand).mock.calls[2][1];

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -115,12 +115,16 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
       // we will run getLatestVersionAsset so we can show the user the latest
       // latest version of compose that is available.
       if (!isDownloaded) {
-        // Get the latest version and store the metadata in a local variable
-        const composeLatestVersion = await composeDownload.getLatestVersionAsset();
-        // Set the value in the context to the version we're downloading so it appears in the onboarding sequence
-        if (composeLatestVersion) {
-          composeVersionMetadata = composeLatestVersion;
-          extensionApi.context.setValue('composeDownloadVersion', composeVersionMetadata.tag, 'onboarding');
+        try {
+          const composeLatestVersion = await composeDownload.getLatestVersionAsset();
+          if (composeLatestVersion) {
+            composeVersionMetadata = composeLatestVersion;
+            extensionApi.context.setValue('composeDownloadVersion', composeVersionMetadata.tag, 'onboarding');
+            extensionApi.context.setValue('composeVersionCheckFailed', false, 'onboarding');
+          }
+        } catch (error: unknown) {
+          console.error('Failed to retrieve latest Compose version:', error);
+          extensionApi.context.setValue('composeVersionCheckFailed', true, 'onboarding');
         }
       }
 


### PR DESCRIPTION
### What does this PR do?

When the GitHub API rate limit is hit (or any network error occurs) during the Compose onboarding, `checkDownloadedCommand` now catches the failure, sets a `composeVersionCheckFailed` context value, and the onboarding flow displays a dedicated error step instead of proceeding with broken `${onboardingContext:...}` placeholder text.

Changes:
- Wrap `getLatestVersionAsset()` in a try/catch in `checkDownloadedCommand`, set `composeVersionCheckFailed` on failure
- Add a new `versionCheckFailedView` onboarding step gated on `composeVersionCheckFailed`
- Gate `welcomeDownloadView` and `downloadCommand` so they don't show when the version check failed

### Screenshot / video of UI

https://github.com/user-attachments/assets/ae9eaa68-8bf9-4f31-8ae6-1ca1e080ccc7


<!-- TODO: attach recorded video -->

### What issues does this PR fix or reference?

Partial fix of https://github.com/podman-desktop/podman-desktop/issues/13868

### How to test this PR?

1. Block the GitHub API: `sudo sh -c 'echo "127.0.0.1 api.github.com" >> /etc/hosts'`
2. Reset onboarding state: `mv ~/.local/share/containers/podman-desktop ~/.local/share/containers/podman-desktop.bak`
3. Start the app, go through the Compose onboarding
4. Verify you see the "Unable to retrieve Compose version" error step instead of broken placeholder text
5. Clean up: `sudo sed -i '' '/127.0.0.1 api.github.com/d' /etc/hosts` and restore backup if needed

- [x] Tests are covering the bug fix or the new feature

Co-authored-by: Claude <claude@anthropic.com>

Made with [Cursor](https://cursor.com)