### PR TITLE
chore: update electron app name to be from product.json and use correct logs files paths

### DIFF
--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -55,6 +55,7 @@ export class Main implements IDisposable {
 
   constructor(app: ElectronApp) {
     this.app = app;
+    this.app.name = product.name;
     this.mainWindowDeferred = Promise.withResolvers<BrowserWindow>();
     this.protocolLauncher = new ProtocolLauncher(this.mainWindowDeferred);
     this.#plugins = [new DefaultProtocolClient(this.app), new WindowPlugin(this.app, this.mainWindowDeferred.resolve)];

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -23,6 +23,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { DialogRegistry } from '/@/plugin/dialog-registry.js';
 import { Uri } from '/@/plugin/types/uri.js';
+import product from '/@product.json' with { type: 'json' };
 
 import type { TroubleshootingFileMap } from './troubleshooting.js';
 import { Troubleshooting } from './troubleshooting.js';
@@ -52,8 +53,12 @@ vi.mock('adm-zip', () => {
   };
 });
 
+vi.mock(import('/@product.json'));
+
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(product).name = 'Test Id';
+  vi.mocked(product).artifactName = 'test-id';
 });
 
 describe('saveLogs', () => {
@@ -190,14 +195,8 @@ test('Should return getMacSystemLogs if the platform is darwin', async () => {
   expect(readFileMock).toHaveBeenCalledTimes(2);
 
   // Expect readFileMock to have been called with /Library/Logs/Podman Desktop/launchd-stdout.log but CONTAINED in the path
-  expect(readFileMock).toHaveBeenCalledWith(
-    expect.stringContaining('/Library/Logs/Podman Desktop/launchd-stdout'),
-    'utf-8',
-  );
-  expect(readFileMock).toHaveBeenCalledWith(
-    expect.stringContaining('/Library/Logs/Podman Desktop/launchd-stderr'),
-    'utf-8',
-  );
+  expect(readFileMock).toHaveBeenCalledWith(expect.stringContaining('/Library/Logs/Test Id/launchd-stdout'), 'utf-8');
+  expect(readFileMock).toHaveBeenCalledWith(expect.stringContaining('/Library/Logs/Test Id/launchd-stderr'), 'utf-8');
 });
 
 // Should return getWindowsSystemLogs if the platform is win32
@@ -225,10 +224,7 @@ test('Should return getWindowsSystemLogs if the platform is win32', async () => 
   expect(readFileMock).toHaveBeenCalledTimes(1);
 
   // Expect readFileMock to have been called with ~/AppData/Roaming/Podman Desktop/logs/podman-desktop.log but CONTAINED in the path
-  expect(readFileMock).toHaveBeenCalledWith(
-    expect.stringContaining('/AppData/Roaming/Podman Desktop/logs/podman-desktop'),
-    'utf-8',
-  );
+  expect(readFileMock).toHaveBeenCalledWith(expect.stringContaining('/AppData/Roaming/Test Id/logs/test-id'), 'utf-8');
 });
 
 // test generateLogFileName for different cases

--- a/packages/main/src/plugin/troubleshooting.ts
+++ b/packages/main/src/plugin/troubleshooting.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/main/src/plugin/troubleshooting.ts
+++ b/packages/main/src/plugin/troubleshooting.ts
@@ -26,6 +26,7 @@ import moment from 'moment';
 
 import { DialogRegistry } from '/@/plugin/dialog-registry.js';
 import { Uri } from '/@/plugin/types/uri.js';
+import product from '/@product.json' with { type: 'json' };
 
 const SYSTEM_FILENAME = 'system';
 
@@ -45,7 +46,7 @@ export class Troubleshooting {
   // all the logs and save them to a zip file.
   // this also takes in the console logs and adds them to the zip file (see preload/src/index.ts) regarding memoryLogs
   async saveLogs(console: { logType: LogType; message: string }[]): Promise<string[]> {
-    const defaultUri = this.generateLogFileName('podman-desktop', 'zip');
+    const defaultUri = this.generateLogFileName(product.artifactName, 'zip');
     const uri = await this.dialogRegistry.saveDialog({ title: 'Save Logs as .zip', defaultUri: Uri.file(defaultUri) });
 
     if (!uri) {
@@ -81,10 +82,10 @@ export class Troubleshooting {
       case 'darwin':
         return this.getLogsFromFiles(
           ['launchd-stdout.log', 'launchd-stderr.log'],
-          `${os.homedir()}/Library/Logs/Podman Desktop`,
+          `${os.homedir()}/Library/Logs/${product.name}`,
         );
       case 'win32':
-        return this.getLogsFromFiles(['podman-desktop'], `${os.homedir()}/AppData/Roaming/Podman Desktop/logs`);
+        return this.getLogsFromFiles([product.artifactName], `${os.homedir()}/AppData/Roaming/${product.name}/logs`);
       default:
         // Unsupported platform, so do not return anything
         return [];


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Updates the electron app name to use the name from product.json, and update the log files paths to use the correct artifact and product names

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Jira issue RHDESK-369

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Change the name and artifact name in `product.json`
`app.getPath('userData')` should return a path with the correct app name
When saving logs file, the file name should have the correct artifact name

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
