### PR TITLE
feat(extension-api): added optional error property

### DIFF
--- a/packages/api/src/provider-info.ts
+++ b/packages/api/src/provider-info.ts
@@ -34,6 +34,7 @@ export interface ProviderContainerConnectionInfo {
   name: string;
   displayName: string;
   status: ProviderConnectionStatus;
+  error?: string;
   endpoint: {
     socketPath: string;
   };
@@ -59,6 +60,7 @@ export interface ProviderKubernetesConnectionInfo {
   connectionType: 'kubernetes';
   name: string;
   status: ProviderConnectionStatus;
+  error?: string;
   endpoint: {
     apiURL: string;
   };
@@ -77,6 +79,7 @@ export interface ProviderVmConnectionInfo {
   connectionType: 'vm';
   name: string;
   status: ProviderConnectionStatus;
+  error?: string;
   lifecycleMethods?: LifecycleMethod[];
   // can start the connection
   canStart: boolean;

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -401,6 +401,13 @@ declare module '@podman-desktop/api' {
     shellAccess?: ProviderConnectionShellAccess;
     lifecycle?: ProviderConnectionLifecycle;
     status(): ProviderConnectionStatus;
+    /**
+     * Optional error message describing why this connection is in a failed state.
+     * The connection retains its lifecycle status (e.g. 'starting', 'stopped') while
+     * this field provides the error details. Cleared automatically on successful
+     * lifecycle transitions.
+     */
+    error?: string;
     vmType?: string;
     /**
      * the vmTypeDisplayName property cannot be set if vmType is undefined
@@ -528,6 +535,11 @@ declare module '@podman-desktop/api' {
     endpoint: KubernetesProviderConnectionEndpoint;
     lifecycle?: ProviderConnectionLifecycle;
     status(): ProviderConnectionStatus;
+    /**
+     * Optional error message describing why this connection is in a failed state.
+     * @see {@link ContainerProviderConnection.error}
+     */
+    error?: string;
   }
 
   export interface VmProviderConnection {
@@ -535,6 +547,11 @@ declare module '@podman-desktop/api' {
     shellAccess?: ProviderConnectionShellAccess;
     lifecycle?: ProviderConnectionLifecycle;
     status(): ProviderConnectionStatus;
+    /**
+     * Optional error message describing why this connection is in a failed state.
+     * @see {@link ContainerProviderConnection.error}
+     */
+    error?: string;
   }
 
   export type ProviderConnection = ContainerProviderConnection | KubernetesProviderConnection | VmProviderConnection;
@@ -807,18 +824,21 @@ declare module '@podman-desktop/api' {
     providerId: string;
     connection: ContainerProviderConnection;
     status: ProviderConnectionStatus;
+    error?: string;
   }
 
   export interface UpdateKubernetesConnectionEvent {
     providerId: string;
     connection: KubernetesProviderConnection;
     status: ProviderConnectionStatus;
+    error?: string;
   }
 
   export interface UpdateVmConnectionEvent {
     providerId: string;
     connection: VmProviderConnection;
     status: ProviderConnectionStatus;
+    error?: string;
   }
 
   export interface UnregisterContainerConnectionEvent {

--- a/website/docs/extensions/developing/index.md
+++ b/website/docs/extensions/developing/index.md
@@ -139,6 +139,34 @@ Upon a successful start up via the `activate` function within your extension, `P
 - `extension-loader.ts`: Attempts to load the extension and sets the status accordingly (either `started`, `stopped`, `starting` or `stopping`). If an unknown error has occurred, the status is set to `unknown`. `extension-loader.ts` also sends an API call to Podman Desktop to update the UI of the extension.
 - `tray-menu.ts`: If `extensionApi.tray.registerMenuItem(item);` API call has been used, a tray menu of the extension will be created. When created, Podman Desktop will use the `ProviderConnectionStatus` to indicate the status within the tray menu.
 
+### Using the `error` property on connections
+
+Each connection interface (`ContainerProviderConnection`, `KubernetesProviderConnection`, `VmProviderConnection`) supports an optional `error?: string` property. This field provides a human-readable error message when the connection is in a failed state, while the `status()` retains the lifecycle state (e.g. `'starting'`, `'stopped'`).
+
+**How it works:**
+
+- When a lifecycle operation (start, stop) fails, Podman Desktop automatically sets the `error` on the connection info and fires update events that include the error.
+- When a lifecycle operation succeeds, the error is automatically cleared.
+- Extensions can also set the `error` property directly on their connection objects to report extension-specific errors (e.g. a container that exited unexpectedly).
+
+**UI behavior when `error` is set:**
+
+- The connection shows a critical/error indicator in both the dashboard and resources pages.
+- Action buttons remain enabled so users can retry the failed operation.
+- The error message is displayed to the user.
+
+**Example:**
+
+```ts
+const connection: extensionApi.KubernetesProviderConnection = {
+  name: 'my-cluster',
+  status: () => clusterStatus,
+  error: clusterError, // set to a string when an error occurs, undefined otherwise
+  endpoint: { apiURL: 'https://localhost:6443' },
+  lifecycle,
+};
+```
+
 ### Adding commands
 
 ## Commands


### PR DESCRIPTION
### What does this PR do?
Adds a new optional error property to connections, this way we can propagate an error message e.g. to SystemOverview or Resources 

### Screenshot / video of UI
Na

### What issues does this PR fix or reference?
Relate to https://github.com/podman-desktop/podman-desktop/pull/16111 https://github.com/podman-desktop/podman-desktop/pull/16282 and https://github.com/podman-desktop/podman-desktop/pull/17057

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
