### PR TITLE
feat: added support for error property in connections

### DIFF
--- a/packages/main/src/plugin/provider-registry.spec.ts
+++ b/packages/main/src/plugin/provider-registry.spec.ts
@@ -1071,6 +1071,108 @@ test('should send events when starting a VM connection', async () => {
   expect(event?.connection.status()).toEqual('started');
 });
 
+test('should persist error in connectionErrors map when start fails', async () => {
+  const startMock = vi.fn().mockRejectedValue(new Error('Connection refused'));
+  const stopMock = vi.fn();
+
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'internal',
+    name: 'internal',
+    status: 'installed',
+  });
+  const connection: ProviderContainerConnectionInfo = {
+    connectionType: 'container',
+    name: 'connection',
+    displayName: 'connection',
+    endpoint: { socketPath: '/endpoint1.sock' },
+    canStart: false,
+    canStop: false,
+    canEdit: false,
+    canDelete: false,
+    status: 'stopped',
+    type: 'podman',
+  };
+
+  provider.registerContainerProviderConnection({
+    name: 'connection',
+    lifecycle: {
+      start: startMock,
+      stop: stopMock,
+    },
+    type: 'podman',
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    status() {
+      return 'stopped';
+    },
+  });
+
+  const onDidUpdateMock = vi.fn();
+  providerRegistry.onDidUpdateContainerConnection(onDidUpdateMock);
+
+  await expect(providerRegistry.startProviderConnection('0', connection)).rejects.toThrow('Connection refused');
+
+  expect(onDidUpdateMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      status: 'starting',
+      error: 'Connection refused',
+    }),
+  );
+});
+
+test('should clear error from connectionErrors map when start succeeds', async () => {
+  const startMock = vi.fn();
+  const stopMock = vi.fn();
+
+  const provider = providerRegistry.createProvider('id', 'name', {
+    id: 'internal',
+    name: 'internal',
+    status: 'installed',
+  });
+
+  provider.registerKubernetesProviderConnection({
+    name: 'connection',
+    lifecycle: {
+      start: startMock,
+      stop: stopMock,
+    },
+    endpoint: {
+      apiURL: 'endpoint',
+    },
+    status() {
+      return 'started';
+    },
+  });
+
+  const connection: ProviderKubernetesConnectionInfo = {
+    connectionType: 'kubernetes',
+    name: 'connection',
+    endpoint: { apiURL: 'endpoint' },
+    canStart: false,
+    canStop: false,
+    canEdit: false,
+    canDelete: false,
+    status: 'stopped',
+  };
+
+  const onDidUpdateMock = vi.fn();
+  providerRegistry.onDidUpdateKubernetesConnection(onDidUpdateMock);
+
+  await providerRegistry.startProviderConnection('0', connection);
+
+  expect(onDidUpdateMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      status: 'started',
+    }),
+  );
+  expect(onDidUpdateMock).not.toHaveBeenCalledWith(
+    expect.objectContaining({
+      error: expect.any(String),
+    }),
+  );
+});
+
 describe('when auto-starting a container connection', async () => {
   let connection: ProviderContainerConnectionInfo;
   let provider: Provider;

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -110,6 +110,7 @@ export class ProviderRegistry {
   private autostartEngine: AutostartEngine | undefined = undefined;
 
   private connectionLifecycleContexts: Map<ProviderConnection, LifecycleContextImpl> = new Map();
+  private connectionErrors: Map<ProviderConnection, string> = new Map();
   private listeners: ProviderEventListener[];
   private lifecycleListeners: ProviderLifecycleListener[];
   private containerConnectionLifecycleListeners: ContainerConnectionProviderLifecycleListener[];
@@ -697,12 +698,16 @@ export class ProviderRegistry {
 
   private getProviderConnectionInfo(connection: ProviderConnection): ProviderConnectionInfo {
     let providerConnection: ProviderConnectionInfo;
+    const lifecycleError = this.connectionErrors.get(connection);
+    const error = connection.error ?? lifecycleError;
+
     if (this.isContainerConnection(connection)) {
       providerConnection = {
         connectionType: 'container',
         name: connection.name,
         displayName: connection.displayName ?? connection.name,
         status: connection.status(),
+        error,
         type: connection.type,
         endpoint: {
           socketPath: connection.endpoint.socketPath,
@@ -724,6 +729,7 @@ export class ProviderRegistry {
         connectionType: 'kubernetes',
         name: connection.name,
         status: connection.status(),
+        error,
         endpoint: {
           apiURL: connection.endpoint.apiURL,
         },
@@ -737,6 +743,7 @@ export class ProviderRegistry {
         connectionType: 'vm',
         name: connection.name,
         status: connection.status(),
+        error,
         canStart: false,
         canStop: false,
         canEdit: false,
@@ -1149,12 +1156,17 @@ export class ProviderRegistry {
 
     try {
       await lifecycle.start(context, logHandler);
-    } finally {
+      this.connectionErrors.delete(connection);
       if (this.isProviderContainerConnection(providerConnectionInfo)) {
         this.fireUpdateContainerConnectionEvents(provider.id, providerConnectionInfo);
       } else {
         this.fireConnectionUpdateEvent(provider.id, providerConnectionInfo, 'started');
       }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      this.connectionErrors.set(connection, errorMessage);
+      this.fireConnectionUpdateEvent(provider.id, providerConnectionInfo, 'starting', errorMessage);
+      throw err;
     }
   }
 
@@ -1231,8 +1243,11 @@ export class ProviderRegistry {
     try {
       this.fireConnectionUpdateEvent(provider.id, providerConnectionInfo, 'stopped');
       await lifecycle.stop(context, logHandler);
+      this.connectionErrors.delete(connection);
     } catch (err) {
       console.warn(`Can't stop connection ${provider.id}.${providerConnectionInfo.name}`, err);
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      this.connectionErrors.set(connection, errorMessage);
     }
   }
 
@@ -1546,6 +1561,7 @@ export class ProviderRegistry {
     providerId: string,
     providerConnectionInfo: ProviderConnectionInfo,
     status: ProviderConnectionStatus,
+    error?: string,
   ): void {
     if (this.isProviderContainerConnection(providerConnectionInfo)) {
       const event = {
@@ -1556,8 +1572,10 @@ export class ProviderRegistry {
           type: providerConnectionInfo.type,
           endpoint: providerConnectionInfo.endpoint,
           status: (): ProviderConnectionStatus => status,
+          error,
         },
         status,
+        error,
       };
       this._onBeforeDidUpdateContainerConnection.fire(event);
       this._onDidUpdateContainerConnection.fire(event);
@@ -1569,8 +1587,10 @@ export class ProviderRegistry {
           name: providerConnectionInfo.name,
           endpoint: providerConnectionInfo.endpoint,
           status: (): ProviderConnectionStatus => status,
+          error,
         },
         status,
+        error,
       });
     } else {
       this._onDidUpdateVmConnection.fire({
@@ -1578,8 +1598,10 @@ export class ProviderRegistry {
         connection: {
           name: providerConnectionInfo.name,
           status: (): ProviderConnectionStatus => status,
+          error,
         },
         status,
+        error,
       });
     }
   }


### PR DESCRIPTION
### What does this PR do?
Adds support for `error` property added in https://github.com/podman-desktop/podman-desktop/pull/17115

### Screenshot / video of UI
Not yet any

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/16111

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
