### PR TITLE
feat(Preferences): added error tooltip to connections 

### DIFF
--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1632,6 +1632,55 @@ export class ProviderRegistry {
     this.onProviderConnectionApiAttached(`${providerId}.${providerConnectionInfo.name}`, () => sendEvents('started'));
   }
 
+  protected fireConnectionUpdateEvent(
+    providerId: string,
+    providerConnectionInfo: ProviderConnectionInfo,
+    status: ProviderConnectionStatus,
+    error?: string,
+  ): void {
+    if (this.isProviderContainerConnection(providerConnectionInfo)) {
+      const event = {
+        providerId,
+        connection: {
+          displayName: providerConnectionInfo.displayName,
+          name: providerConnectionInfo.name,
+          type: providerConnectionInfo.type,
+          endpoint: providerConnectionInfo.endpoint,
+          status: (): ProviderConnectionStatus => status,
+          error,
+        },
+        status,
+        error,
+      };
+      this._onBeforeDidUpdateContainerConnection.fire(event);
+      this._onDidUpdateContainerConnection.fire(event);
+      this._onAfterDidUpdateContainerConnection.fire(event);
+    } else if (this.isProviderKubernetesConnectionInfo(providerConnectionInfo)) {
+      this._onDidUpdateKubernetesConnection.fire({
+        providerId,
+        connection: {
+          name: providerConnectionInfo.name,
+          endpoint: providerConnectionInfo.endpoint,
+          status: (): ProviderConnectionStatus => status,
+          error,
+        },
+        status,
+        error,
+      });
+    } else {
+      this._onDidUpdateVmConnection.fire({
+        providerId,
+        connection: {
+          name: providerConnectionInfo.name,
+          status: (): ProviderConnectionStatus => status,
+          error,
+        },
+        status,
+        error,
+      });
+    }
+  }
+
   isContainerProviderConnectionRegistered(
     provider: ProviderImpl,
     containerProviderConnection: ContainerProviderConnection,

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -1632,55 +1632,6 @@ export class ProviderRegistry {
     this.onProviderConnectionApiAttached(`${providerId}.${providerConnectionInfo.name}`, () => sendEvents('started'));
   }
 
-  protected fireConnectionUpdateEvent(
-    providerId: string,
-    providerConnectionInfo: ProviderConnectionInfo,
-    status: ProviderConnectionStatus,
-    error?: string,
-  ): void {
-    if (this.isProviderContainerConnection(providerConnectionInfo)) {
-      const event = {
-        providerId,
-        connection: {
-          displayName: providerConnectionInfo.displayName,
-          name: providerConnectionInfo.name,
-          type: providerConnectionInfo.type,
-          endpoint: providerConnectionInfo.endpoint,
-          status: (): ProviderConnectionStatus => status,
-          error,
-        },
-        status,
-        error,
-      };
-      this._onBeforeDidUpdateContainerConnection.fire(event);
-      this._onDidUpdateContainerConnection.fire(event);
-      this._onAfterDidUpdateContainerConnection.fire(event);
-    } else if (this.isProviderKubernetesConnectionInfo(providerConnectionInfo)) {
-      this._onDidUpdateKubernetesConnection.fire({
-        providerId,
-        connection: {
-          name: providerConnectionInfo.name,
-          endpoint: providerConnectionInfo.endpoint,
-          status: (): ProviderConnectionStatus => status,
-          error,
-        },
-        status,
-        error,
-      });
-    } else {
-      this._onDidUpdateVmConnection.fire({
-        providerId,
-        connection: {
-          name: providerConnectionInfo.name,
-          status: (): ProviderConnectionStatus => status,
-          error,
-        },
-        status,
-        error,
-      });
-    }
-  }
-
   isContainerProviderConnectionRegistered(
     provider: ProviderImpl,
     containerProviderConnection: ContainerProviderConnection,

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.spec.ts
@@ -85,6 +85,22 @@ test('Expect that name, socket and type are displayed for Docker', async () => {
   expect(spanType.textContent).toBe('Docker');
 });
 
+test('Expect error is displayed when connection has error', async () => {
+  render(PreferencesContainerConnectionDetailsSummary, {
+    containerConnectionInfo: { ...podmanContainerConnection, error: 'Machine failed to start' },
+  });
+  const errorAlert = screen.getByRole('alert');
+  expect(errorAlert).toBeInTheDocument();
+  expect(errorAlert).toHaveTextContent('Machine failed to start');
+});
+
+test('Expect error is not displayed when connection has no error', async () => {
+  render(PreferencesContainerConnectionDetailsSummary, {
+    containerConnectionInfo: podmanContainerConnection,
+  });
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+});
+
 describe('resource metrics display', () => {
   const resourceProperties: IConfigurationPropertyRecordedSchema[] = [
     {

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionDetailsSummary.svelte
@@ -47,6 +47,12 @@ $effect(() => {
 <div class="h-full text-[var(--pd-details-body-text)]">
   {#if containerConnectionInfo}
     <div class="flex pl-8 py-4 flex-col w-full text-sm">
+      {#if containerConnectionInfo.error}
+        <div class="flex flex-row mt-5 text-[var(--pd-state-error)]" role="alert" aria-label="Connection error">
+          <span class="font-semibold min-w-[150px]">Error</span>
+          <span>{containerConnectionInfo.error}</span>
+        </div>
+      {/if}
       <div class="flex flex-row mt-5">
         <span class="font-semibold min-w-[150px]">Name</span>
         <span aria-label={containerConnectionInfo.name}>{containerConnectionInfo.name}</span>

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -9,6 +9,7 @@ import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
+import ConnectionErrorIndicator from '/@/lib/ui/ConnectionErrorIndicator.svelte';
 import ConnectionErrorInfoButton from '/@/lib/ui/ConnectionErrorInfoButton.svelte';
 import ConnectionStatus from '/@/lib/ui/ConnectionStatus.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
@@ -141,6 +142,7 @@ function setNoLogs(): void {
       {#if connectionInfo}
         <div class="flex flex-row">
           <ConnectionStatus status={connectionInfo.status} />
+          <ConnectionErrorIndicator error={connectionInfo.error} />
           <ConnectionErrorInfoButton status={connectionStatus} />
         </div>
       {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.spec.ts
@@ -53,3 +53,19 @@ test('Expect that name, url and kubernetes are displayed', async () => {
   expect(kubernetes).toBeInTheDocument();
   expect(kubernetes.textContent).toBe('Kubernetes');
 });
+
+test('Expect error is displayed when connection has error', async () => {
+  render(PreferencesKubernetesConnectionDetailsSummary, {
+    kubernetesConnectionInfo: { ...kubernetesConnection, error: 'Failed to start cluster' },
+  });
+  const errorAlert = screen.getByRole('alert');
+  expect(errorAlert).toBeInTheDocument();
+  expect(errorAlert).toHaveTextContent('Failed to start cluster');
+});
+
+test('Expect error is not displayed when connection has no error', async () => {
+  render(PreferencesKubernetesConnectionDetailsSummary, {
+    kubernetesConnectionInfo: kubernetesConnection,
+  });
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
@@ -40,6 +40,12 @@ $: providerConnectionConfiguration = tmpProviderContainerConfiguration.filter(
 <div class="h-full text-[var(--pd-table-body-text)]">
   {#if kubernetesConnectionInfo}
     <div class="flex pl-8 py-4 flex-col w-full text-sm">
+      {#if kubernetesConnectionInfo.error}
+        <div class="flex flex-row mt-5 text-[var(--pd-state-error)]" role="alert" aria-label="Connection error">
+          <span class="font-semibold min-w-[150px]">Error</span>
+          <span>{kubernetesConnectionInfo.error}</span>
+        </div>
+      {/if}
       <div class="flex flex-row mt-5">
         <span class="font-semibold min-w-[150px]">Name</span>
         <span aria-label={kubernetesConnectionInfo.name}>{kubernetesConnectionInfo.name}</span>

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -9,6 +9,7 @@ import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
+import ConnectionErrorIndicator from '/@/lib/ui/ConnectionErrorIndicator.svelte';
 import ConnectionErrorInfoButton from '/@/lib/ui/ConnectionErrorInfoButton.svelte';
 import ConnectionStatus from '/@/lib/ui/ConnectionStatus.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
@@ -137,6 +138,7 @@ function setNoLogs(): void {
       {#if connectionInfo}
         <div class="flex flex-row">
           <ConnectionStatus status={connectionInfo.status} />
+          <ConnectionErrorIndicator error={connectionInfo.error} />
           <ConnectionErrorInfoButton status={connectionStatus} />
         </div>
       {/if}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -19,6 +19,7 @@ import Donut from '/@/lib/donut/Donut.svelte';
 import ActionsMenu from '/@/lib/image/ActionsMenu.svelte';
 import { normalizeOnboardingWhenClause } from '/@/lib/onboarding/onboarding-utils';
 import BooleanEnumDisplay from '/@/lib/ui/BooleanEnumDisplay.svelte';
+import ConnectionErrorIndicator from '/@/lib/ui/ConnectionErrorIndicator.svelte';
 import ConnectionErrorInfoButton from '/@/lib/ui/ConnectionErrorInfoButton.svelte';
 import ConnectionStatus from '/@/lib/ui/ConnectionStatus.svelte';
 import EngineIcon from '/@/lib/ui/EngineIcon.svelte';
@@ -543,6 +544,7 @@ $effect(() => {
               </div>
               <div class="flex" aria-label="Connection Status">
                 <ConnectionStatus status={container.status} />
+                <ConnectionErrorIndicator error={container.error} />
                 {#if containerConnectionStatus.has(getProviderConnectionName(provider, container))}
                   {@const status = containerConnectionStatus.get(getProviderConnectionName(provider, container))}
                   <ConnectionErrorInfoButton status={status} />
@@ -628,6 +630,7 @@ $effect(() => {
               </div>
               <div class="flex mt-1" aria-label="Connection Status">
                 <ConnectionStatus status={kubeConnection.status} />
+                <ConnectionErrorIndicator error={kubeConnection.error} />
               </div>
               <div class="mt-2">
                 <div class="text-[var(--pd-content-text)] text-xs">Kubernetes endpoint</div>
@@ -664,6 +667,7 @@ $effect(() => {
             </div>
             <div class="flex mt-1" aria-label="Connection Status">
               <ConnectionStatus status={vmConnection.status} />
+              <ConnectionErrorIndicator error={vmConnection.error} />
               {#if containerConnectionStatus.has(getProviderConnectionName(provider, vmConnection))}
                 {@const status = containerConnectionStatus.get(getProviderConnectionName(provider, vmConnection))}
                 <ConnectionErrorInfoButton status={status} />

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
@@ -7,6 +7,7 @@ import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
+import ConnectionErrorIndicator from '/@/lib/ui/ConnectionErrorIndicator.svelte';
 import ConnectionErrorInfoButton from '/@/lib/ui/ConnectionErrorInfoButton.svelte';
 import ConnectionStatus from '/@/lib/ui/ConnectionStatus.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
@@ -118,6 +119,7 @@ function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
       {#if connectionInfo}
         <div class="flex flex-row">
           <ConnectionStatus status={connectionInfo.status} />
+          <ConnectionErrorIndicator error={connectionInfo.error} />
           <ConnectionErrorInfoButton status={connectionStatus} />
         </div>
       {/if}

--- a/packages/renderer/src/lib/ui/ConnectionErrorIndicator.spec.ts
+++ b/packages/renderer/src/lib/ui/ConnectionErrorIndicator.spec.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ConnectionErrorIndicator from './ConnectionErrorIndicator.svelte';
+
+test('should render nothing when error is undefined', () => {
+  render(ConnectionErrorIndicator, { error: undefined });
+
+  const button = screen.queryByRole('button');
+  expect(button).not.toBeInTheDocument();
+});
+
+test('should render error icon with tooltip when error is defined', () => {
+  const errorMessage = 'Connection refused';
+  render(ConnectionErrorIndicator, { error: errorMessage });
+
+  const button = screen.getByRole('button', { name: `Connection Error: ${errorMessage}` });
+  expect(button).toBeInTheDocument();
+});
+
+test('should render nothing when error is empty string', () => {
+  render(ConnectionErrorIndicator, { error: '' });
+
+  const button = screen.queryByRole('button');
+  expect(button).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/ui/ConnectionErrorIndicator.spec.ts
+++ b/packages/renderer/src/lib/ui/ConnectionErrorIndicator.spec.ts
@@ -34,7 +34,7 @@ test('should render error icon with tooltip when error is defined', () => {
   const errorMessage = 'Connection refused';
   render(ConnectionErrorIndicator, { error: errorMessage });
 
-  const button = screen.getByRole('button', { name: `Connection Error: ${errorMessage}` });
+  const button = screen.getByRole('button');
   expect(button).toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/ui/ConnectionErrorIndicator.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionErrorIndicator.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+interface Props {
+  error?: string;
+}
+
+let { error }: Props = $props();
+</script>
+
+{#if error}
+  <Tooltip bottom tip={error}>
+    <button aria-label="Connection Error: {error}" class="ml-2 flex items-center">
+      <Icon icon={faTriangleExclamation} class="text-[var(--pd-state-error)]" size="0.875x" />
+    </button>
+  </Tooltip>
+{/if}

--- a/packages/renderer/src/lib/ui/ConnectionErrorIndicator.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionErrorIndicator.svelte
@@ -11,9 +11,11 @@ let { error }: Props = $props();
 </script>
 
 {#if error}
-  <Tooltip bottom tip={error}>
-    <button aria-label="Connection Error: {error}" class="ml-2 flex items-center">
-      <Icon icon={faTriangleExclamation} class="text-[var(--pd-state-error)]" size="0.875x" />
-    </button>
-  </Tooltip>
+  <div class="pl-2 flex items-center">
+    <Tooltip bottom tip={error}>
+      <span role='button' tabindex='0'>
+        <Icon icon={faTriangleExclamation} class="text-[var(--pd-state-error)]" />
+      </span>
+    </Tooltip>
+  </div>
 {/if}


### PR DESCRIPTION
### What does this PR do?
Adds label for error to the connections 

AFAIK the whole Resources will be changing in the future 

### Screenshot / video of UI

<img width="1253" height="911" alt="image" src="https://github.com/user-attachments/assets/fec9821a-0d06-4233-b1d7-63b982bb9233" />

<img width="1173" height="803" alt="image" src="https://github.com/user-attachments/assets/b97c0230-5c46-4be9-a8b9-8b25fba0d224" />

### What issues does this PR fix or reference?
Needs rebase after https://github.com/podman-desktop/podman-desktop/pull/17117

### How to test this PR?
Add to error property of conenction some erorr text in extension.ts e.g. of kind/podman etc.. 
e.g. during starting/stoping the connection

- [x] Tests are covering the bug fix or the new feature
