### PR TITLE
chore(preload*): prefer-import-in-mock

### DIFF
--- a/packages/preload-webview/src/webview-preload.spec.ts
+++ b/packages/preload-webview/src/webview-preload.spec.ts
@@ -18,7 +18,7 @@
 
 import type { ColorInfo, WebviewInfo } from '@podman-desktop/core-api';
 import type { WebviewApi } from '@podman-desktop/webview-api';
-import type { IpcRendererEvent } from 'electron';
+import type { ContextBridge, IpcMain, IpcRenderer, IpcRendererEvent } from 'electron';
 import { contextBridge, ipcRenderer } from 'electron';
 import type { MockInstance } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -68,22 +68,22 @@ const webviewInfo: WebviewInfo = {
   state: { foo: 'bar' },
 };
 
-vi.mock('electron', async () => {
+vi.mock(import('electron'), async () => {
   return {
     contextBridge: {
       exposeInMainWorld: vi.fn(),
-    },
+    } as unknown as ContextBridge,
     ipcRenderer: {
       on: vi.fn(),
       emit: vi.fn(),
       handle: vi.fn(),
       invoke: vi.fn(),
-    },
+    } as unknown as IpcRenderer,
     ipcMain: {
       on: vi.fn(),
       emit: vi.fn(),
       handle: vi.fn(),
-    },
+    } as unknown as IpcMain,
   };
 });
 

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -21,29 +21,29 @@
 import type { OpenDialogOptions, SaveDialogOptions } from '@podman-desktop/api';
 import type { ForwardConfig } from '@podman-desktop/core-api';
 import { WorkloadKind } from '@podman-desktop/core-api';
-import type { IpcRenderer, IpcRendererEvent } from 'electron';
+import type { ContextBridge, IpcMain, IpcRenderer, IpcRendererEvent } from 'electron';
 import { contextBridge, ipcRenderer } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { buildApiSender, initExposure } from './index.js';
 
-vi.mock('electron', async () => {
+vi.mock(import('electron'), async () => {
   return {
     contextBridge: {
       exposeInMainWorld: vi.fn(),
-    },
+    } as unknown as ContextBridge,
     ipcRenderer: {
       on: vi.fn(),
       emit: vi.fn(),
       handle: vi.fn(),
       send: vi.fn(),
       invoke: vi.fn(),
-    },
+    } as unknown as IpcRenderer,
     ipcMain: {
       on: vi.fn(),
       emit: vi.fn(),
       handle: vi.fn(),
-    },
+    } as unknown as IpcMain,
   };
 });
 


### PR DESCRIPTION
### What does this PR do?

Enabling `vitest/prefer-import-in-mock` rule in `packages/preload` and  `packages/preload-webview`

```ts
// BAD
vi.mock('./path/to/module')

// GOOD
vi.mock(import('./path/to/module'))
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16503

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
