### PR TITLE
chore(renderer): prefer-import-in-mock

### DIFF
--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -38,48 +38,40 @@ const mocks = vi.hoisted(() => ({
   KubernetesDashboard: vi.fn(),
 }));
 
-vi.mock('./lib/dashboard/DashboardPage.svelte', () => ({
+vi.mock(import('./lib/dashboard/DashboardPage.svelte'), () => ({
   default: mocks.DashboardPage,
 }));
-vi.mock('./lib/image/RunImage.svelte', () => ({
+vi.mock(import('./lib/image/RunImage.svelte'), () => ({
   default: mocks.RunImage,
 }));
-vi.mock('./lib/image/ImagesList.svelte', () => ({
+vi.mock(import('./lib/image/ImagesList.svelte'), () => ({
   default: mocks.ImagesList,
 }));
 
-vi.mock('./lib/ui/TitleBar.svelte', () => ({
-  default: vi.fn(),
-}));
-vi.mock('./lib/welcome/WelcomePage.svelte', () => ({
-  default: vi.fn(),
-}));
+vi.mock(import('./lib/ui/TitleBar.svelte'));
+vi.mock(import('./lib/welcome/WelcomePage.svelte'));
 
-vi.mock('./lib/context/ContextKey.svelte', () => ({
-  default: vi.fn(),
-}));
+vi.mock(import('./lib/context/ContextKey.svelte'));
 
-vi.mock('./lib/appearance/Appearance.svelte', () => ({
-  default: vi.fn(),
-}));
+vi.mock(import('./lib/appearance/Appearance.svelte'));
 
-vi.mock('./SubmenuNavigation.svelte', () => ({
+vi.mock(import('./SubmenuNavigation.svelte'), () => ({
   default: mocks.SubmenuNavigation,
 }));
 
-vi.mock('./lib/kube/KubernetesDashboard.svelte', () => ({
+vi.mock(import('./lib/kube/KubernetesDashboard.svelte'), () => ({
   default: mocks.KubernetesDashboard,
 }));
 
-vi.mock('./lib/deployments/DeploymentsList.svelte', () => ({
+vi.mock(import('./lib/deployments/DeploymentsList.svelte'), () => ({
   default: mocks.DeploymentsList,
 }));
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => {
   return {};
 });
 
-vi.mock('/@/stores/kubernetes-no-current-context');
+vi.mock(import('/@/stores/kubernetes-no-current-context'));
 
 const dispatchEventMock = vi.fn();
 const messages = new Map<string, (args: unknown) => void>();

--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -38,7 +38,7 @@ const eventsMock = vi.fn();
 
 const callbacks = new Map<string, (arg: unknown) => void>();
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => {
   return {};
 });
 

--- a/packages/renderer/src/SubmenuNavigation.spec.ts
+++ b/packages/renderer/src/SubmenuNavigation.spec.ts
@@ -27,9 +27,7 @@ import { lastSubmenuPages } from './stores/breadcrumb';
 import type { NavigationRegistryEntry } from './stores/navigation/navigation-registry';
 import SubmenuNavigation from './SubmenuNavigation.svelte';
 
-vi.mock('@podman-desktop/ui-svelte', () => ({
-  SettingsNavItem: vi.fn(),
-}));
+vi.mock(import('@podman-desktop/ui-svelte'));
 
 test('SubmenuNavigation displays a title and builds SettingsNavItem components', async () => {
   const SettingsNavItemMock = vi.mocked(SettingsNavItem);

--- a/packages/renderer/src/kubernetesNavigation.spec.ts
+++ b/packages/renderer/src/kubernetesNavigation.spec.ts
@@ -22,13 +22,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { navigateTo } from './kubernetesNavigation';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/appearance/IconImage.spec.ts
+++ b/packages/renderer/src/lib/appearance/IconImage.spec.ts
@@ -24,16 +24,17 @@ import { render, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import type { AppearanceUtil } from './appearance-util';
 import IconImage from './IconImage.svelte';
 
 const getConfigurationValueMock = vi.fn();
 const getImageMock = vi.fn();
 
-vi.mock('./appearance-util', () => {
+vi.mock(import('./appearance-util'), () => {
   return {
     AppearanceUtil: class {
       getImage = getImageMock;
-    },
+    } as unknown as typeof AppearanceUtil,
   };
 });
 

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetails.spec.ts
@@ -53,7 +53,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretList.spec.ts
@@ -27,7 +27,7 @@ import * as states from '/@/stores/kubernetes-contexts-state';
 
 import ConfigMapSecretList from './ConfigMapSecretList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/configmaps-secrets/SecretDetails.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/SecretDetails.spec.ts
@@ -53,7 +53,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -51,7 +51,7 @@ const container: ContainerInfoUI = new ContainerInfoUIImpl(
 const getContributedMenusMock = vi.fn();
 const updateMock = vi.fn();
 
-vi.mock('/@/lib/actions/ContributionActions.svelte');
+vi.mock(import('/@/lib/actions/ContributionActions.svelte'));
 
 beforeAll(() => {
   Object.defineProperty(window, 'startContainer', { value: vi.fn() });

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -79,13 +79,7 @@ const localImageList = [
   } as unknown as ImageInfo,
 ];
 
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 const pStatus: ProviderStatus = 'started';
 const pInfo: ProviderContainerConnectionInfo = {

--- a/packages/renderer/src/lib/cronjob/CronJobDetails.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobDetails.spec.ts
@@ -52,7 +52,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobList.spec.ts
@@ -29,8 +29,8 @@ import * as states from '/@/stores/kubernetes-contexts-state';
 
 import CronJobList from './CronJobList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
-vi.mock('/@/lib/kube/resources-listen');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
+vi.mock(import('/@/lib/kube/resources-listen'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -59,7 +59,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/explore-features/ExploreFeatureCard.spec.ts
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatureCard.spec.ts
@@ -25,13 +25,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import ExploreFeatureCard from './ExploreFeatureCard.svelte';
 
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 const featureMock: ExploreFeature = {
   id: 'feature1',

--- a/packages/renderer/src/lib/explore-features/ExploreFeatures.spec.ts
+++ b/packages/renderer/src/lib/explore-features/ExploreFeatures.spec.ts
@@ -27,7 +27,7 @@ import { exploreFeaturesInfo } from '/@/stores/explore-features';
 
 import ExploreFeatures from './ExploreFeatures.svelte';
 
-vi.mock('svelte/transition', () => ({
+vi.mock(import('svelte/transition'), () => ({
   slide: (): { delay: number; duration: number } => ({
     delay: 0,
     duration: 0,

--- a/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.spec.ts
@@ -26,13 +26,7 @@ import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 import CatalogExtension from './CatalogExtension.svelte';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeAll(() => {
   Object.defineProperty(window, 'extensionInstallFromImage', { value: vi.fn() });

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.spec.ts
@@ -27,13 +27,7 @@ import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions
 import ExtensionDetailsLink from './ExtensionDetailsLink.svelte';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftOnboardingAndProperties.spec.ts
@@ -31,13 +31,7 @@ import { onboardingList } from '/@/stores/onboarding';
 import InstalledExtensionCardLeftOnboardingAndProperties from './InstalledExtensionCardLeftOnboardingAndProperties.svelte';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -26,13 +26,9 @@ import DirectFeedback from './feedbackForms/DirectFeedback.svelte';
 import GitHubIssueFeedback from './feedbackForms/GitHubIssueFeedback.svelte';
 import SendFeedback from './SendFeedback.svelte';
 
-vi.mock('./feedbackForms/GitHubIssueFeedback.svelte', () => ({
-  default: vi.fn(),
-}));
+vi.mock(import('./feedbackForms/GitHubIssueFeedback.svelte'));
 
-vi.mock('./feedbackForms/DirectFeedback.svelte', () => ({
-  default: vi.fn(),
-}));
+vi.mock(import('./feedbackForms/DirectFeedback.svelte'));
 
 beforeAll(() => {
   (window.events as unknown) = {

--- a/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
+++ b/packages/renderer/src/lib/forms/ContainerConnectionDropdown.spec.ts
@@ -27,7 +27,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
 import ContainerConnectionDropdownTest from '/@/lib/forms/ContainerConnectionDropdownTest.svelte';
 
-vi.mock('@podman-desktop/ui-svelte');
+vi.mock(import('@podman-desktop/ui-svelte'));
 
 const CONTAINER_CONNECTION_INFO: ProviderContainerConnectionInfo = {
   connectionType: 'container',

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -29,7 +29,7 @@ import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 
 const getContributedMenusMock = vi.fn();
 
-vi.mock('./image-utils', () => {
+vi.mock(import('./image-utils'), () => {
   return {
     ImageUtils: vi.fn().mockImplementation(() => ({
       deleteImage: vi.fn().mockImplementation(() => Promise.reject(new Error('Cannot delete image in test'))),
@@ -37,7 +37,7 @@ vi.mock('./image-utils', () => {
   };
 });
 
-vi.mock('/@/lib/dialogs/messagebox-utils', () => ({
+vi.mock(import('/@/lib/dialogs/messagebox-utils'), () => ({
   withConfirmation: vi.fn(),
 }));
 

--- a/packages/renderer/src/lib/image/ImageColumnName.spec.ts
+++ b/packages/renderer/src/lib/image/ImageColumnName.spec.ts
@@ -23,6 +23,7 @@ import { render, screen } from '@testing-library/svelte';
 import { router } from 'tinro';
 import { expect, test, vi } from 'vitest';
 
+import type { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
 
 import ImageColumnName from './ImageColumnName.svelte';
@@ -49,11 +50,11 @@ const image: ImageInfoUI = {
 };
 const getImageMock = vi.fn();
 
-vi.mock('/@/lib/appearance/appearance-util', () => {
+vi.mock(import('/@/lib/appearance/appearance-util'), () => {
   return {
     AppearanceUtil: class {
       getImage = getImageMock;
-    },
+    } as unknown as typeof AppearanceUtil,
   };
 });
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
@@ -54,7 +54,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -28,7 +28,7 @@ import * as states from '/@/stores/kubernetes-contexts-state';
 
 import IngressesRoutesList from './IngressesRoutesList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
@@ -69,7 +69,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/job/JobDetails.spec.ts
+++ b/packages/renderer/src/lib/job/JobDetails.spec.ts
@@ -52,7 +52,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/job/JobList.spec.ts
+++ b/packages/renderer/src/lib/job/JobList.spec.ts
@@ -29,8 +29,8 @@ import * as states from '/@/stores/kubernetes-contexts-state';
 
 import JobList from './JobList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
-vi.mock('/@/lib/kube/resources-listen');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
+vi.mock(import('/@/lib/kube/resources-listen'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/kube/KubeActions.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeActions.spec.ts
@@ -25,13 +25,7 @@ import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 import KubeActions from '/@/lib/kube/KubeActions.svelte';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeAll(() => {
   Object.defineProperty(global, 'window', {

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -70,13 +70,7 @@ const mockedErroredPlayKubeInfo: PlayKubeInfo = {
 };
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeAll(() => {
   (window.events as unknown) = {

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -36,26 +36,20 @@ import * as kubernetesReourcesCount from '/@/stores/kubernetes-resources-count';
 import KubernetesDashboard from './KubernetesDashboard.svelte';
 import KubernetesDashboardResourceCard from './KubernetesDashboardResourceCard.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
-  return {};
-});
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
-vi.mock('/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte', () => ({
-  default: vi.fn(),
-}));
+vi.mock(import('/@/lib/ui/KubernetesCurrentContextConnectionBadge.svelte'));
 
-vi.mock('./KubernetesDashboardResourceCard.svelte', () => ({
-  default: vi.fn(),
-}));
+vi.mock(import('./KubernetesDashboardResourceCard.svelte'));
 
-vi.mock('/@/stores/kubernetes-experimental');
+vi.mock(import('/@/stores/kubernetes-experimental'));
 
-vi.mock('/@/stores/kubernetes-resources-count');
+vi.mock(import('/@/stores/kubernetes-resources-count'));
 
-vi.mock('/@/lib/kube/active-resources-count-listen');
+vi.mock(import('/@/lib/kube/active-resources-count-listen'));
 
-vi.mock('/@/stores/kubernetes-context-permission');
-vi.mock('/@/stores/kubernetes-no-current-context');
+vi.mock(import('/@/stores/kubernetes-context-permission'));
+vi.mock(import('/@/stores/kubernetes-no-current-context'));
 
 const openExternalMock = vi.fn();
 

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -35,13 +35,7 @@ vi.mock(import('/@/lib/extensions/EmbeddableCatalogExtensionList.svelte'), () =>
 }));
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 Object.defineProperty(window, 'telemetryTrack', { value: vi.fn() });
 

--- a/packages/renderer/src/lib/kube/KubernetesEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyScreen.spec.ts
@@ -26,7 +26,7 @@ import * as kubernetesCheckConnection from '/@/lib/ui/KubernetesCheckConnection.
 import KubernetesEmptyScreen from './KubernetesEmptyScreen.svelte';
 import { listenResourcePermitted } from './resource-permission';
 
-vi.mock('./resource-permission');
+vi.mock(import('./resource-permission'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
+++ b/packages/renderer/src/lib/kube/NamespaceDropdown.spec.ts
@@ -31,7 +31,7 @@ import NamespaceDropdown from './NamespaceDropdown.svelte';
 const firstNS = 'ns1';
 const secondNS = 'ns2';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeAll(() => {
   vi.mocked(window.kubernetesListNamespaces).mockResolvedValue({

--- a/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
+++ b/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
@@ -25,11 +25,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import PodmanKubePlay from './PodmanKubePlay.svelte';
 
 // Mock the router
-vi.mock('tinro', () => ({
-  router: {
-    goto: vi.fn(),
-  },
-}));
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/renderer/src/lib/kube/details/KubeContainerArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeContainerArtifact.spec.ts
@@ -28,7 +28,7 @@ import * as kubeContextStore from '/@/stores/kubernetes-contexts-state'; // Adju
 
 import KubeContainerArtifact from './KubeContainerArtifact.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => ({}));
 
 const fakeContainer: V1Container = {
   name: 'fakeContainerName',

--- a/packages/renderer/src/lib/kube/details/KubePortsList.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePortsList.spec.ts
@@ -27,7 +27,7 @@ import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 
 import KubePortsList from './KubePortsList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => ({}));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/kube/details/KubeServiceArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeServiceArtifact.spec.ts
@@ -26,7 +26,7 @@ import * as kubeContextStore from '/@/stores/kubernetes-contexts-state'; // Adju
 
 import KubeServiceSpecArtifact from './KubeServiceArtifact.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => ({}));
 
 const fakeServiceSpec = {
   type: 'ClusterIP',

--- a/packages/renderer/src/lib/kube/pods/PodDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodDetailsSummary.spec.ts
@@ -36,7 +36,7 @@ import * as eventsTable from '/@/lib/kube/details/EventsTable.svelte';
 
 import PodDetailsSummary from './PodDetailsSummary.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 const fakePod: V1Pod = {
   apiVersion: 'v1',

--- a/packages/renderer/src/lib/kube/resources-listen.spec.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.spec.ts
@@ -27,7 +27,7 @@ import { listenResources } from './resources-listen';
 
 const callbacks = new Map<string, () => void>();
 
-vi.mock('/@/stores/kubernetes-contexts');
+vi.mock(import('/@/stores/kubernetes-contexts'));
 
 const eventEmitter = {
   receive: (message: string, callback: () => void): void => {

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -26,7 +26,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import PortForwardActions from '/@/lib/kubernetes-port-forward/PortForwardActions.svelte';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => ({}));
 
 const MOCKED_USER_FORWARD_CONFIG: ForwardConfig = {
   id: 'fake-id',

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
@@ -33,7 +33,7 @@ const DUMMY_MAPPING: PortMapping = {
   remotePort: 80,
 };
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => ({}));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.spec.ts
@@ -27,7 +27,7 @@ import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 
 import PortForwardList from './PortForwardingList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => ({}));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
+++ b/packages/renderer/src/lib/learning-center/LearningCenter.spec.ts
@@ -35,7 +35,7 @@ const guides: Guide[] = [
   },
 ];
 
-vi.mock('svelte/transition', () => ({
+vi.mock(import('svelte/transition'), () => ({
   slide: (): { delay: number; duration: number } => ({
     delay: 0,
     duration: 0,

--- a/packages/renderer/src/lib/network/NetworkDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkDetailsSummary.spec.ts
@@ -43,7 +43,7 @@ const network: NetworkInfoUI = {
   ],
 };
 
-vi.mock('tinro');
+vi.mock(import('tinro'));
 
 test('Expect all details to show up', () => {
   render(NetworkDetailsSummary, { network: network });

--- a/packages/renderer/src/lib/node/NodeDetails.spec.ts
+++ b/packages/renderer/src/lib/node/NodeDetails.spec.ts
@@ -53,7 +53,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/node/NodesList.spec.ts
+++ b/packages/renderer/src/lib/node/NodesList.spec.ts
@@ -27,7 +27,7 @@ import * as states from '/@/stores/kubernetes-contexts-state';
 
 import NodesList from './NodesList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -34,13 +34,7 @@ import DeployPodToKube from './DeployPodToKube.svelte';
 vi.mock(import('/@/lib/editor/MonacoEditor.svelte'));
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
@@ -26,7 +26,7 @@ import { providerInfos } from '/@/stores/providers';
 
 import PodEmptyScreen from './PodEmptyScreen.svelte';
 
-vi.mock('/@/stores/providers', async () => {
+vi.mock(import('/@/stores/providers'), async () => {
   const store = await import('svelte/store');
   return {
     providerInfos: store.writable<ProviderInfo[]>([]),

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -31,11 +31,7 @@ import { kubernetesResourcesCount } from '/@/stores/kubernetes-resources-count';
 
 import PreferencesKubernetesContextsRendering from './PreferencesKubernetesContextsRendering.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => {
-  return {
-    kubernetesContextsState: vi.fn(),
-  };
-});
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 // Create a fake KubeContextUI
 const mockContext1: KubeContext = {

--- a/packages/renderer/src/lib/preferences/PreferencesProviderRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProviderRendering.spec.ts
@@ -43,7 +43,7 @@ const defaultProviderInfo = {
   installationSupport: undefined,
 } as unknown as ProviderInfo;
 
-vi.mock('./PreferencesConnectionCreationOrEditRendering.svelte');
+vi.mock(import('./PreferencesConnectionCreationOrEditRendering.svelte'));
 
 describe.each<{
   name: string;

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -109,13 +109,7 @@ const providerInfo: ProviderInfo = {
 };
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 // getOsPlatformMock is needed when using PreferencesResourcesRenderingCopyButton
 const getOsPlatformMock = vi.fn().mockResolvedValue('linux');

--- a/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.spec.ts
+++ b/packages/renderer/src/lib/preferences/docker-compat/PreferencesDockerCompatibilitySocketMappingStatus.spec.ts
@@ -52,13 +52,7 @@ const podmanConnectionInfo = {
 };
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 const getOsPlatformMock: Mock<() => Promise<string>> = vi.fn();
 const getSystemDockerSocketMappingStatusMock: Mock<() => Promise<DockerSocketMappingStatusInfo>> = vi.fn();

--- a/packages/renderer/src/lib/pvc/PVCDetails.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCDetails.spec.ts
@@ -52,7 +52,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/pvc/PVCList.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCList.spec.ts
@@ -27,7 +27,7 @@ import * as states from '/@/stores/kubernetes-contexts-state';
 
 import PVCList from './PVCList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -55,7 +55,7 @@ vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {
   };
 });
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetailsSummary.spec.ts
@@ -27,7 +27,7 @@ import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 
 import ServiceDetailsSummary from './ServiceDetailsSummary.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state', async () => ({}));
+vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => ({}));
 
 const service: V1Service = {
   metadata: {

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -27,7 +27,7 @@ import * as states from '/@/stores/kubernetes-contexts-state';
 
 import ServicesList from './ServicesList.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
+++ b/packages/renderer/src/lib/statusbar/ProviderWidget.spec.ts
@@ -32,13 +32,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import ProviderWidget from './ProviderWidget.svelte';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 const providerMock = {
   name: 'provider1',

--- a/packages/renderer/src/lib/task-manager/button/TaskManagerClearAllButton.spec.ts
+++ b/packages/renderer/src/lib/task-manager/button/TaskManagerClearAllButton.spec.ts
@@ -25,7 +25,7 @@ import * as taskStores from '/@/stores/tasks';
 
 import TaskManagerClearAllButton from './TaskManagerClearAllButton.svelte';
 
-vi.mock('/@/stores/tasks');
+vi.mock(import('/@/stores/tasks'));
 
 test('Expect clear tasks is being called', async () => {
   const clearNotificationsSpy = vi.spyOn(taskStores, 'clearNotifications');

--- a/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
+++ b/packages/renderer/src/lib/toast/ToastTaskNotifications.spec.ts
@@ -33,15 +33,7 @@ beforeAll(() => {
   });
 });
 
-vi.mock('@zerodevx/svelte-toast', async () => {
-  return {
-    toast: {
-      push: vi.fn(),
-      pop: vi.fn(),
-      set: vi.fn(),
-    },
-  };
-});
+vi.mock(import('@zerodevx/svelte-toast'));
 
 const started = new Date().getTime();
 

--- a/packages/renderer/src/lib/ui/Badge.spec.ts
+++ b/packages/renderer/src/lib/ui/Badge.spec.ts
@@ -21,17 +21,19 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { AppearanceUtil } from '/@/lib/appearance/appearance-util';
+
 import Badge from './Badge.svelte';
 
 // mock window.getConfigurationValue
 const getConfigurationValueMock = vi.fn();
 const getImageMock = vi.fn();
 
-vi.mock('/@/lib/appearance/appearance-util', () => {
+vi.mock(import('/@/lib/appearance/appearance-util'), () => {
   return {
     AppearanceUtil: class {
       getImage = getImageMock;
-    },
+    } as unknown as typeof AppearanceUtil,
   };
 });
 

--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -30,13 +30,7 @@ import DetailsPage from './DetailsPage.svelte';
 import DetailsPageTest from './DetailsPageTest.svelte';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/renderer/src/lib/ui/EngineFormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/EngineFormPage.spec.ts
@@ -29,13 +29,7 @@ import { currentPage, lastPage } from '/@/stores/breadcrumb';
 import EngineFormPage from './EngineFormPage.svelte';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/renderer/src/lib/ui/FormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/FormPage.spec.ts
@@ -29,13 +29,7 @@ import { currentPage, lastPage } from '/@/stores/breadcrumb';
 import FormPage from './FormPage.svelte';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/packages/renderer/src/lib/ui/KubernetesCheckConnection.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCheckConnection.spec.ts
@@ -28,8 +28,8 @@ import * as kubernetesContextsStateStore from '/@/stores/kubernetes-contexts-sta
 
 import KubernetesCheckConnection from './KubernetesCheckConnection.svelte';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
-vi.mock('/@/stores/kubernetes-contexts');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
+vi.mock(import('/@/stores/kubernetes-contexts'));
 
 test('button is displayed and active if current context is defined and is not reachable', async () => {
   vi.mocked(kubernetesContextsStore).kubernetesContexts = writable<KubeContext[]>([

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -32,10 +32,10 @@ import * as health from '/@/stores/kubernetes-context-health';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts';
 import * as states from '/@/stores/kubernetes-contexts-state';
 
-vi.mock('/@/stores/kubernetes-contexts-state');
-vi.mock('/@/stores/kubernetes-contexts');
-vi.mock('/@/lib/kube/resources-listen');
-vi.mock('/@/stores/kubernetes-context-health');
+vi.mock(import('/@/stores/kubernetes-contexts-state'));
+vi.mock(import('/@/stores/kubernetes-contexts'));
+vi.mock(import('/@/lib/kube/resources-listen'));
+vi.mock(import('/@/stores/kubernetes-context-health'));
 
 let delayed: Writable<Map<string, boolean>>;
 let contexts: Writable<KubeContext[]>;

--- a/packages/renderer/src/lib/ui/TerminalSearchControls.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalSearchControls.spec.ts
@@ -26,7 +26,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import TerminalSearchControls from './TerminalSearchControls.svelte';
 
-vi.mock('@xterm/addon-search');
+vi.mock(import('@xterm/addon-search'));
 
 const TerminalMock: Terminal = {
   onWriteParsed: vi.fn(),

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -23,13 +23,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { handleNavigation } from './navigation';
 
 // mock the router
-vi.mock('tinro', () => {
-  return {
-    router: {
-      goto: vi.fn(),
-    },
-  };
-});
+vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/packages/renderer/src/stores/images.spec.ts
+++ b/packages/renderer/src/stores/images.spec.ts
@@ -48,7 +48,7 @@ Object.defineProperty(global, 'window', {
 
 // We always mock findMatchInLeaves to return true so we can test image.ts without having to render
 // the component, as we are not testing the $searchPattern store / functionality.
-vi.mock('./search-util', () => ({
+vi.mock(import('./search-util'), () => ({
   findMatchInLeaves: vi.fn(() => true), // Assume it always finds a match unless specified otherwise
 }));
 

--- a/packages/renderer/src/stores/navigation-history.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.spec.ts
@@ -18,7 +18,7 @@
 
 import { writable } from 'svelte/store';
 import { router, type TinroRoute } from 'tinro';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
@@ -35,15 +35,7 @@ let routerSubscribeCallback = vi.hoisted(() => {
   return vi.fn() as unknown as (navigation: TinroRoute) => void;
 });
 
-vi.mock('tinro', () => ({
-  router: {
-    goto: vi.fn(),
-    subscribe: vi.fn((callback: (navigation: TinroRoute) => void) => {
-      routerSubscribeCallback = callback;
-      return vi.fn();
-    }),
-  },
-}));
+vi.mock(import('tinro'));
 
 vi.mock(import('/@/stores/kubernetes-no-current-context'));
 vi.mock(import('/@/stores/navigation/navigation-registry'));
@@ -99,6 +91,11 @@ vi.mock(import('/@/stores/navigation/navigation-registry'), async () => {
       unsubscribe: vi.fn(),
     },
   };
+});
+
+beforeAll(() => {
+  expect(router.subscribe).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
+  routerSubscribeCallback = vi.mocked(router.subscribe).mock.calls[0][0];
 });
 
 beforeEach(() => {

--- a/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-kubernetes.svelte.spec.ts
@@ -30,7 +30,7 @@ import { createNavigationKubernetesGroup } from './navigation-registry-kubernete
 vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => {
   return {};
 });
-vi.mock('/@/stores/kubernetes-no-current-context');
+vi.mock(import('/@/stores/kubernetes-no-current-context'));
 
 beforeEach(() => {
   vi.resetAllMocks();


### PR DESCRIPTION
### What does this PR do?

Enabling `vitest/prefer-import-in-mock` rule in `packages/renderer`

```ts
// BAD
vi.mock('./path/to/module')

// GOOD
vi.mock(import('./path/to/module'))
```

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16503

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be 🟢 
