### PR TITLE
feat(ci): rewrite `$schema` URLs to tagged version during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,10 @@ jobs:
           sed -i  "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.desktopVersion }}\",#g" package.json
           find packages/* -maxdepth 1 -name "package.json" | xargs -I {} sed -i "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.desktopVersion }}\",#g" {}
           find extensions/* -maxdepth 5 -name "package.json" | xargs -I {} sed -i "s#version\":\ \"\(.*\)\",#version\":\ \"${{ steps.TAG_UTIL.outputs.desktopVersion }}\",#g" {}
+
+          # Update $schema URLs in extension package.json files to point to the tagged version
+          find extensions/* -maxdepth 5 -name "package.json" | xargs -I {} sed -i "s#/podman-desktop/main/schemas/#/podman-desktop/${{ steps.TAG_UTIL.outputs.githubTag }}/schemas/#g" {}
+
           git add package.json extensions/*/package.json extensions/*/packages/extension/package.json packages/*/package.json
 
           # Update the issue template with the new version and move old version below


### PR DESCRIPTION
### What does this PR do?

In the release workflow tag step, rewrite the `$schema` raw GitHub URLs in extension package.json files from `/main/` to `/v<version>/` so each tag carries the correct versioned schema reference.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Point 4 of https://github.com/podman-desktop/podman-desktop/issues/16051

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
