### PR TITLE
refactor(color-registry): replace hover:text-white with color-registry token in WindowsControlButton

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -500,6 +500,13 @@ export class ColorRegistry {
       light: '#c42b1c',
     });
 
+    this.registerColor(`${titlebar}windows-hover-exit-text`, {
+      dark: white,
+      light: white,
+      hcDark: white,
+      hcLight: white,
+    });
+
     this.registerColor(`${titlebar}windows-hover-bg`, {
       dark: '#2d2d2d',
       light: '#dfdfdf',

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
@@ -58,8 +58,8 @@ test('Check Windows Maximize control button colors', async () => {
   const customButton = screen.getByRole('button', { name: 'Maximize' });
   expect(customButton).toBeInTheDocument();
 
-  expect(customButton).toHaveClass('text-[var(--pd-titlebar-icon)]');
-  expect(customButton).toHaveClass('hover:bg-[var(--pd-titlebar-windows-hover-bg)]');
+  expect(customButton).toHaveClass('text-(--pd-titlebar-icon)');
+  expect(customButton).toHaveClass('hover:bg-(--pd-titlebar-windows-hover-bg)');
 });
 
 test('Check Windows Minimize control button colors', async () => {
@@ -68,8 +68,8 @@ test('Check Windows Minimize control button colors', async () => {
   const customButton = screen.getByRole('button', { name: 'Minimize' });
   expect(customButton).toBeInTheDocument();
 
-  expect(customButton).toHaveClass('text-[var(--pd-titlebar-icon)]');
-  expect(customButton).toHaveClass('hover:bg-[var(--pd-titlebar-windows-hover-bg)]');
+  expect(customButton).toHaveClass('text-(--pd-titlebar-icon)');
+  expect(customButton).toHaveClass('hover:bg-(--pd-titlebar-windows-hover-bg)');
 });
 
 test('Check Windows Close control button colors', async () => {
@@ -78,7 +78,7 @@ test('Check Windows Close control button colors', async () => {
   const customButton = screen.getByRole('button', { name: 'Close' });
   expect(customButton).toBeInTheDocument();
 
-  expect(customButton).toHaveClass('text-[var(--pd-titlebar-icon)]');
-  expect(customButton).toHaveClass('hover:bg-[var(--pd-titlebar-windows-hover-exit-bg)]');
-  expect(customButton).toHaveClass('hover:text-[var(--pd-titlebar-windows-hover-exit-text)]');
+  expect(customButton).toHaveClass('text-(--pd-titlebar-icon)');
+  expect(customButton).toHaveClass('hover:bg-(--pd-titlebar-windows-hover-exit-bg)');
+  expect(customButton).toHaveClass('hover:text-(--pd-titlebar-windows-hover-exit-text)');
 });

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
@@ -80,5 +80,5 @@ test('Check Windows Close control button colors', async () => {
 
   expect(customButton).toHaveClass('text-[var(--pd-titlebar-icon)]');
   expect(customButton).toHaveClass('hover:bg-[var(--pd-titlebar-windows-hover-exit-bg)]');
-  expect(customButton).toHaveClass('hover:text-white');
+  expect(customButton).toHaveClass('hover:text-[var(--pd-titlebar-windows-hover-exit-text)]');
 });

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
@@ -59,7 +59,7 @@ function executeAction(): void {
   aria-label={name}
   title={titleName}
   class="h-[32px] w-[45px] cursor-pointer {name === 'Close'
-    ? 'hover:bg-[var(--pd-titlebar-windows-hover-exit-bg)] hover:text-white'
+    ? 'hover:bg-[var(--pd-titlebar-windows-hover-exit-bg)] hover:text-[var(--pd-titlebar-windows-hover-exit-text)]'
     : 'hover:bg-[var(--pd-titlebar-windows-hover-bg)]'} text-[var(--pd-titlebar-icon)] flex place-items-center justify-center">
   {#if icon}
     <svelte:component this={icon} size={iconSize} />

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
@@ -59,8 +59,8 @@ function executeAction(): void {
   aria-label={name}
   title={titleName}
   class="h-[32px] w-[45px] cursor-pointer {name === 'Close'
-    ? 'hover:bg-[var(--pd-titlebar-windows-hover-exit-bg)] hover:text-[var(--pd-titlebar-windows-hover-exit-text)]'
-    : 'hover:bg-[var(--pd-titlebar-windows-hover-bg)]'} text-[var(--pd-titlebar-icon)] flex place-items-center justify-center">
+    ? 'hover:bg-(--pd-titlebar-windows-hover-exit-bg) hover:text-(--pd-titlebar-windows-hover-exit-text)'
+    : 'hover:bg-(--pd-titlebar-windows-hover-bg)'} text-(--pd-titlebar-icon) flex place-items-center justify-center">
   {#if icon}
     <svelte:component this={icon} size={iconSize} />
   {/if}


### PR DESCRIPTION
### What does this PR do?

Replaces the hardcoded `hover:text-white` Tailwind color in `WindowsControlButton.svelte` with a new `color-registry.ts` token `--pd-titlebar-windows-hover-exit-text`. This ensures the Close button hover text color is theme-aware and consistent with the rest of the titlebar color system.

### Screenshot / video of UI

No visible change - the Close button hover text remains white in all themes, but is now driven by the color registry instead of a raw Tailwind value.

### What issues does this PR fix or reference?

Resolves #16786

### How to test this PR?

1. Run the app on Windows (or enable Windows titlebar in settings).
2. Hover over the Close (X) window control button - text should be white against the red background.
3. Verify no visual regression on the Minimize and Maximize buttons.

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>