### PR TITLE
fix(ui): increase spinner segment opacity for better contrast

### DIFF
--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -16,14 +16,14 @@ let { size = '2em', class: className, style, label = 'Loading' }: Props = $props
   style={style}>
   <svg width={size} height={size} viewBox="0 0 64 64" aria-hidden="true">
     <g>
-      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(0, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.4" />
-      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(45, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.08" />
-      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(90, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.16" />
-      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(135, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.24" />
-      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(180, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.32" />
-      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(225, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.36" />
-      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(270, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.4" />
-      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(315, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(0, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.8" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(45, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.16" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(90, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.32" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(135, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.48" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(180, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.64" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(225, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.72" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(270, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.8" />
+      <line x1="32" y1="4" x2="32" y2="16" transform="rotate(315, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.8" />
     </g>
   </svg>
 </i>


### PR DESCRIPTION
### What does this PR do?

Increases the opacity values of all eight tick marks in the Spinner component by two. The previous range (0.08 - 0.4) made the spinner too faint, especially on light backgrounds. The new range (0.16 - 0.8) doubles the opacity at each step, giving the animation better contrast and visibility without changing the stepped rotation behavior.

### What issues does this PR fix or reference?

Resolves #16901

### How to test this PR?

1. Run `pnpm --filter storybook dev§ and open the Spinner story
2. Verify the spinner segments are visibly distinct and the animation reads clearly on both light and dark backgrounds

- [ ] Tests are covering the bug fix or the new feature