### PR TITLE
fix: resolve CVE-2026-34043 in serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
       "picomatch@^2": "^2.3.2",
       "picomatch@^3": "^3.0.2",
       "picomatch@^4": "^4.0.4",
-      "serialize-javascript": "^7.0.4",
+      "serialize-javascript": "^7.0.5",
       "ajv@^6": "^6.14.0",
       "ajv@^8": "^8.18.0",
       "electron-builder-squirrel-windows": "^26.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ overrides:
   picomatch@^2: ^2.3.2
   picomatch@^3: ^3.0.2
   picomatch@^4: ^4.0.4
-  serialize-javascript: ^7.0.4
+  serialize-javascript: ^7.0.5
   ajv@^6: ^6.14.0
   ajv@^8: ^8.18.0
   electron-builder-squirrel-windows: ^26.8.2
@@ -10673,8 +10673,8 @@ packages:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
-  serialize-javascript@7.0.4:
-    resolution: {integrity: sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
 
   serve-handler@6.1.6:
@@ -18385,7 +18385,7 @@ snapshots:
       globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.2.0
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       webpack: 5.105.0
 
   copyfiles@2.4.1:
@@ -18509,7 +18509,7 @@ snapshots:
       jest-worker: 29.7.0
       postcss: 8.5.10
       schema-utils: 4.2.0
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       webpack: 5.105.0
     optionalDependencies:
       clean-css: 5.3.3
@@ -24150,7 +24150,7 @@ snapshots:
       type-fest: 0.13.1
     optional: true
 
-  serialize-javascript@7.0.4: {}
+  serialize-javascript@7.0.5: {}
 
   serve-handler@6.1.6:
     dependencies:
@@ -24865,7 +24865,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 3.3.0
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       terser: 5.36.0
       webpack: 5.105.0
 
@@ -24874,7 +24874,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       terser: 5.36.0
       webpack: 5.105.0(esbuild@0.25.12)
     optionalDependencies:
@@ -24886,7 +24886,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 7.0.4
+      serialize-javascript: 7.0.5
       terser: 5.36.0
       webpack: 5.105.0
 


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-34043 in `serialize-javascript`.

- **Advisory**: Serialize JavaScript has CPU Exhaustion Denial of Service via crafted array-like objects
- **Vulnerable versions**: <7.0.5
- **Patched versions**: >=7.0.5
- **Advisory URL**: https://github.com/advisories/GHSA-qj8w-gfj5-8c6v

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-34043 — Serialize JavaScript has CPU Exhaustion Denial of Service via crafted array-like objects

### How to test this PR?

* Run `pnpm audit` and verify CVE-2026-34043 is no longer reported
* Run `pnpm install && pnpm test` to confirm no regressions