### PR TITLE
refactor(ui): use color-registry token in SearchInput search icon

### DIFF
--- a/packages/ui/src/lib/inputs/SearchInput.svelte
+++ b/packages/ui/src/lib/inputs/SearchInput.svelte
@@ -27,7 +27,7 @@ let { title = '', searchTerm = $bindable(''), oninput = bubble('input'), class: 
   {#snippet left()}
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      class="w-4 h-4 mx-1 text-gray-700"
+      class="w-4 h-4 mx-1 text-(--pd-input-field-icon)"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"


### PR DESCRIPTION
### What does this PR do?

Replaces the hard-coded Tailwind palette color `text-gray-700` on the search icon SVG in `SearchInput.svelte` with the semantic color-registry CSS variable `text-(--pd-input-field-icon)`. This ensures the icon color responds correctly to light, dark, and high-contrast themes.

### Screenshot / video of UI

No visible change in dark mode (the default). The icon now correctly uses `charcoal[200]` in light mode and `white`/`black` in HC themes instead of always rendering as `gray[700]`.

### What issues does this PR fix or reference?

Resolves #16778

### How to test this PR?

1. Run the app in dark mode - search icon should look unchanged (gray).
2. Switch to light mode - search icon should render in `charcoal[200]`.
3. Switch to a high-contrast theme - icon should be `white` (HC dark) or `black` (HC light).
4. Run unit tests: `pnpm exec vitest run packages/ui/src/lib/inputs/SearchInput.spec.ts`

- [x] Tests are covering the bug fix or the new feature