### PR TITLE
fix(ui): replace raw tailwind color with design token in ListOrganizer

### DIFF
--- a/packages/ui/src/lib/layouts/ListOrganizer.svelte
+++ b/packages/ui/src/lib/layouts/ListOrganizer.svelte
@@ -320,7 +320,7 @@ function handleReset(): void {
             disabled={isResetDisabled}
             tabindex={isResetDisabled ? -1 : 0}
           >
-            <div class="flex items-center justify-start gap-3 flex-1 border-t border-gray-600 pt-2">
+            <div class="flex items-center justify-start gap-3 flex-1 border-t border-(--pd-dropdown-divider) pt-2">
               <div class="w-4 h-4 flex items-center justify-center flex-shrink-0">
                 <Icon icon={faUndo} size='0.8x'/>
               </div>


### PR DESCRIPTION
### What does this PR do?

Replaces the raw Tailwind palette color `border-gray-600` with the design token `border-(--pd-dropdown-divider)` in `ListOrganizer.svelte`. This ensures the reset button divider uses the color registry instead of a hard-coded Tailwind color, consistent with the rest of the component.

### Screenshot / video of UI

No visible change - the divider color is identical in default dark mode (`charcoal[600]` maps to the same value as `gray-600`).

### What issues does this PR fix or reference?

Resolves #16779

### How to test this PR?

1. Open any view that renders `ListOrganizer` (e.g. a table with column organizer enabled).
2. Click the organizer button to open the dropdown.
3. Confirm the divider above "Reset to default" renders correctly in all themes (dark, light, high-contrast dark, high-contrast light).

- [ ] Tests are covering the bug fix or the new feature