### PR TITLE
fix: resolve GHSA-r4q5-vmmm-2653 in follow-redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,8 @@
       "electron-builder-squirrel-windows": "^26.8.2",
       "svelte>devalue": "^5.6.4",
       "protobufjs": "^7.5.5",
-      "smol-toml": "^1.6.1"
+      "smol-toml": "^1.6.1",
+      "follow-redirects": "^1.16.0"
     },
     "patchedDependencies": {
       "docker-modem": "patches/docker-modem.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,7 @@ overrides:
   svelte>devalue: ^5.6.4
   protobufjs: ^7.5.5
   smol-toml: ^1.6.1
+  follow-redirects: ^1.16.0
 
 patchedDependencies:
   docker-modem:
@@ -7275,8 +7276,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -20082,7 +20083,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -20705,7 +20706,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.9
+      follow-redirects: 1.16.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability GHSA-r4q5-vmmm-2653 in `follow-redirects`.

- **Advisory**: follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets
- **Vulnerable versions**: <=1.15.11
- **Patched versions**: >=1.16.0
- **Advisory URL**: https://github.com/advisories/GHSA-r4q5-vmmm-2653

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-r4q5-vmmm-2653 _follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets_

### How to test this PR?

Run `pnpm audit` and verify GHSA-r4q5-vmmm-2653 is no longer reported