### PR TITLE
refactor(onboarding): replace bg-black with color-registry variable

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -495,7 +495,7 @@ let globalOnboarding = $derived(global);
 {/if}
 {#if displayCancelSetup}
   <!-- Create overlay-->
-  <div class="fixed top-0 left-0 right-0 bottom-0 bg-black bg-opacity-60 bg-blend-multiply h-full grid z-50">
+  <div class="fixed top-0 left-0 right-0 bottom-0 bg-(--pd-modal-fade) bg-opacity-60 bg-blend-multiply h-full grid z-50">
     <div
       class="flex flex-col place-self-center w-[550px] rounded-xl bg-[var(--pd-modal-bg)] shadow-xl shadow-black"
       role="dialog"


### PR DESCRIPTION
### What does this PR do?

Replaces the hard-coded `bg-black` Tailwind color on the cancel-setup modal overlay in `Onboarding.svelte` with the `--pd-modal-fade` CSS variable from `color-registry.ts`, using the Tailwind v4 parenthesis shorthand `bg-(--pd-modal-fade)`.

### Screenshot / video of UI

No visible change - the color value is identical in the default dark theme. The benefit is correct theming across all registered themes.

### What issues does this PR fix or reference?

Resolves #16782

### How to test this PR?

1. Open Podman Desktop and trigger the onboarding flow for any extension (e.g. Podman).
2. Click "Skip this entire setup" to open the cancel-setup confirmation dialog.
3. Verify the semi-transparent overlay appears behind the dialog.
4. Repeat with a light theme applied and confirm the overlay renders correctly.

- [ ] Tests are covering the bug fix or the new feature