### PR TITLE
fix: resolve GHSA-39q2-94rc-95cp in dompurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
       "serve-handler>path-to-regexp": "^3.3.0",
       "express>cookie": "^0.7.0",
       "qs": "^6.15.0",
-      "dompurify@^3": "^3.3.3",
+      "dompurify@^3": "^3.4.0",
       "webpack-dev-server>http-proxy-middleware": "^2.0.9",
       "esbuild-register>esbuild": "^0.25.0",
       "tsx>esbuild": "^0.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   serve-handler>path-to-regexp: ^3.3.0
   express>cookie: ^0.7.0
   qs: ^6.15.0
-  dompurify@^3: ^3.3.3
+  dompurify@^3: ^3.4.0
   webpack-dev-server>http-proxy-middleware: ^2.0.9
   esbuild-register>esbuild: ^0.25.0
   tsx>esbuild: ^0.25.0
@@ -6573,8 +6573,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -19084,7 +19084,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -21852,7 +21852,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.11
       dayjs: 1.11.13
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       katex: 0.16.25
       khroma: 2.1.0
       lodash-es: 4.18.1
@@ -22303,7 +22303,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.3.3
+      dompurify: 3.4.0
       marked: 14.0.0
 
   moo-color@1.0.3:


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability GHSA-39q2-94rc-95cp in `dompurify`.

**Advisory**: DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation
**Vulnerable versions**: <=3.3.3
**Patched versions**: >=3.4.0
**Advisory URL**: https://github.com/advisories/GHSA-39q2-94rc-95cp

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-39q2-94rc-95cp: _DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation_

### How to test this PR?

Run `pnpm audit` and verify GHSA-39q2-94rc-95cp is no longer reported