### PR TITLE
fix: resolve CVE-2026-33750 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
       "tar": "^7.5.3",
       "cheerio>undici": "^7.18.2",
       "minimatch>@isaacs/brace-expansion": "^5.0.1",
+      "brace-expansion@^1": "^1.1.14",
       "lodash-es": "^4.18.1",
       "lodash": "^4.18.1",
       "@docusaurus/types>webpack": "^5.105.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ overrides:
   tar: ^7.5.3
   cheerio>undici: ^7.18.2
   minimatch>@isaacs/brace-expansion: ^5.0.1
+  brace-expansion@^1: ^1.1.14
   lodash-es: ^4.18.1
   lodash: ^4.18.1
   '@docusaurus/types>webpack': ^5.105.0
@@ -5459,8 +5460,8 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
@@ -17935,7 +17936,7 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -22324,7 +22325,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@5.1.9:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-33750 in `brace-expansion`.

**Advisory**: brace-expansion: Zero-step sequence causes process hang and memory exhaustion
**Vulnerable versions**: <1.1.13
**Patched versions**: >=1.1.13
**Advisory URL**: https://github.com/advisories/GHSA-f886-m6hf-6m8v

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33750: _brace-expansion: Zero-step sequence causes process hang and memory exhaustion_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33750 is no longer reported