### PR TITLE
fix(spinner): all icons rotating on the docker compatibility page

### DIFF
--- a/packages/ui/src/lib/progress/Spinner.svelte
+++ b/packages/ui/src/lib/progress/Spinner.svelte
@@ -15,7 +15,7 @@ let { size = '2em', class: className, style, label = 'Loading' }: Props = $props
   class="flex justify-center items-center {className}"
   style={style}>
   <svg width={size} height={size} viewBox="0 0 64 64" aria-hidden="true">
-    <g>
+    <g class="spinner-group">
       <line x1="32" y1="4" x2="32" y2="16" transform="rotate(0, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.8" />
       <line x1="32" y1="4" x2="32" y2="16" transform="rotate(45, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.16" />
       <line x1="32" y1="4" x2="32" y2="16" transform="rotate(90, 32, 32)" stroke="currentColor" stroke-width="8" stroke-linecap="round" opacity="0.32" />
@@ -29,7 +29,7 @@ let { size = '2em', class: className, style, label = 'Loading' }: Props = $props
 </i>
 
 <style>
-  g {
+  .spinner-group {
     animation: spinner-rotate 720ms steps(8) infinite;
     transform-origin: 32px 32px;
   }
@@ -41,7 +41,7 @@ let { size = '2em', class: className, style, label = 'Loading' }: Props = $props
   }
 
   @media (prefers-reduced-motion: reduce) {
-    g {
+    .spinner-group {
       animation: none;
     }
   }


### PR DESCRIPTION
Fixes: #16991 

Wraps the spinner into a class, so the CSS leak is prevented (no global g selector). 

This was visible only on the Docker Compatibility page as it's the only place that uses micromark to render a button with spinner (the <style> is not stripped and inserted to DOM directly, exposing the global 'g' CSS selector).