### PR TITLE
feat(extensions): add $schema reference to extension package.json files

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../schemas/extension-schema.json",
   "name": "compose",
   "displayName": "Compose",
   "description": "Install Compose binary to work with Podman",

--- a/extensions/docker/packages/extension/package.json
+++ b/extensions/docker/packages/extension/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../../schemas/extension-schema.json",
   "name": "docker",
   "displayName": "Docker",
   "description": "Integration for Docker engine",

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../schemas/extension-schema.json",
   "name": "kind",
   "displayName": "Kind",
   "description": "Integration for Kind: run local Kubernetes clusters using container “nodes”",

--- a/extensions/kube-context/package.json
+++ b/extensions/kube-context/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../schemas/extension-schema.json",
   "name": "kube-context",
   "displayName": "Kube Context",
   "description": "Easily switch between Kubernetes contexts",

--- a/extensions/kubectl-cli/package.json
+++ b/extensions/kubectl-cli/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../schemas/extension-schema.json",
   "name": "kubectl-cli",
   "displayName": "kubectl CLI",
   "description": "Install and update kubectl CLI Tools without leaving Podman Desktop",

--- a/extensions/lima/package.json
+++ b/extensions/lima/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../schemas/extension-schema.json",
   "name": "lima",
   "displayName": "Lima",
   "description": "Integration for Lima: Linux Machines (typically macOS)",

--- a/extensions/podman-docker-context/package.json
+++ b/extensions/podman-docker-context/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../schemas/extension-schema.json",
   "name": "podman-docker-context",
   "displayName": "Podman Docker Context",
   "description": "Synchronize Docker Contexts with Podman",

--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../../../schemas/extension-schema.json",
   "name": "podman",
   "displayName": "Podman",
   "description": "Integration for Podman and Podman Machines",

--- a/extensions/registries/package.json
+++ b/extensions/registries/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../schemas/extension-schema.json",
   "name": "registries",
   "displayName": "Registries",
   "description": "Adds default registries for Quay, DockerHub, GitHub, and Google Container Registry",


### PR DESCRIPTION
### What does this PR do?

Adds a `$schema` reference pointing to the local `schemas/extension-schema.json` in all built-in extension `package.json` files. This enables JSON validation and autocompletion in VS Code / Cursor for Podman Desktop extension-specific fields like `contributes`, `displayName`, `engines.podman-desktop`, etc.

Uses a relative local path (`../../schemas/extension-schema.json`) instead of a remote URL because `raw.githubusercontent.com` is not in VS Code's trusted domains list, which causes an "untrusted location" error and silently blocks the schema. The local path works offline, requires no trust configuration, and is available to anyone who clones the repo.

For external extensions, registering the schema on [SchemaStore](https://www.schemastore.org/) can be explored later to provide universal zero-config support.

### Screenshot / video of UI
<img width="798" height="487" alt="Screenshot 2026-04-21 at 15 31 02" src="https://github.com/user-attachments/assets/c25418f3-f04a-4f22-b5b8-95c390e7a4c9" />

<!-- Will add screenshot showing autocompletion -->

### What issues does this PR fix or reference?

Point 4 of https://github.com/podman-desktop/podman-desktop/issues/16051

Supersedes https://github.com/podman-desktop/podman-desktop/pull/17134

### How to test this PR?

1. Open any extension `package.json` (e.g. `extensions/kind/package.json`)
2. Inside `contributes` > `configuration`, start typing a property name (e.g. `"t..."`) and verify autocompletion suggests `title`
3. Verify that validation works (e.g. add an unknown property inside `configuration` and see a warning)

- [ ] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)