### PR TITLE
refactor(main): use consistent titles and messages for updater dialogs

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -158,6 +158,7 @@ beforeEach(() => {
   // eslint-disable-next-line no-null/no-null
   vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue(null);
 
+  vi.mocked(product).name = 'Podman Desktop';
   vi.mocked(product).releaseNotes = {
     url: '',
     blog: '',

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -600,7 +600,7 @@ describe('expect update command to depends on context', async () => {
       buttons: ['Update now', `What's new`, 'Remind me later', `Don't show again`],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
-      title: 'Update Available now',
+      title: 'Update Podman Desktop?',
       type: 'info',
     });
   });
@@ -616,7 +616,7 @@ describe('expect update command to depends on context', async () => {
       buttons: ['Update now', `What's new`, 'Cancel'],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
-      title: 'Update Available now',
+      title: 'Update Podman Desktop?',
       type: 'info',
     });
   });

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -226,7 +226,7 @@ export class Updater {
       if (this.#updateAlreadyDownloaded) {
         const result = await this.messageBox.showMessageBox({
           type: 'info',
-          title: 'Restart Podman Desktop?',
+          title: `Restart ${product.name}?`,
           message: 'An update has been downloaded. Restart now to apply it?',
           cancelId: 1,
           buttons: ['Restart', 'Cancel'],
@@ -240,7 +240,7 @@ export class Updater {
       if (this.#updateInProgress) {
         await this.messageBox.showMessageBox({
           type: 'info',
-          title: 'Update Podman Desktop',
+          title: `Update ${product.name}`,
           message: 'An update is being downloaded. Please wait for it to complete.',
           buttons: ['Dismiss'],
         });
@@ -259,8 +259,8 @@ export class Updater {
 
       const result = await this.messageBox.showMessageBox({
         type: 'info',
-        title: 'Update Podman Desktop?',
-        message: `A new version ${updateVersion} of Podman Desktop is available. Do you want to update your current version ${this.#currentVersion}?`,
+        title: `Update ${product.name}?`,
+        message: `A new version ${updateVersion} of ${product.name} is available. Do you want to update your current version ${this.#currentVersion}?`,
         buttons: buttons,
         cancelId: 2,
       });
@@ -402,8 +402,8 @@ export class Updater {
 
     this.messageBox
       .showMessageBox({
-        title: 'Restart Podman Desktop?',
-        message: `Podman Desktop ${updatedDownloadedEvent.version} has been downloaded. Restart now to apply the update?`,
+        title: `Restart ${product.name}?`,
+        message: `${product.name} ${updatedDownloadedEvent.version} has been downloaded. Restart now to apply the update?`,
         cancelId: 1,
         type: 'info',
         buttons: ['Restart', 'Cancel'],

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -206,10 +206,10 @@ export class Updater {
     this.commandRegistry.registerCommand('version', async () => {
       const result = await this.messageBox.showMessageBox({
         type: 'info',
-        title: 'Version',
+        title: 'View Version',
         message: `Using version ${this.#currentVersion}`,
         detail: detailMessage,
-        buttons: ['View release notes banner'],
+        buttons: ['View Release Notes'],
       });
       if (result.response === 0) {
         await this.configurationRegistry.updateConfigurationValue(`releaseNotesBanner.show`, 'show');
@@ -226,8 +226,8 @@ export class Updater {
       if (this.#updateAlreadyDownloaded) {
         const result = await this.messageBox.showMessageBox({
           type: 'info',
-          title: 'Update',
-          message: 'There is already an update downloaded. Please Restart Podman Desktop.',
+          title: 'Restart Podman Desktop?',
+          message: 'An update has been downloaded. Restart now to apply it?',
           cancelId: 1,
           buttons: ['Restart', 'Cancel'],
         });
@@ -240,9 +240,9 @@ export class Updater {
       if (this.#updateInProgress) {
         await this.messageBox.showMessageBox({
           type: 'info',
-          title: 'Update',
-          message: 'There is already an update in progress. Please wait until it is downloaded',
-          buttons: ['OK'],
+          title: 'Update Podman Desktop',
+          message: 'An update is being downloaded. Please wait for it to complete.',
+          buttons: ['Dismiss'],
         });
         return;
       }
@@ -259,7 +259,7 @@ export class Updater {
 
       const result = await this.messageBox.showMessageBox({
         type: 'info',
-        title: 'Update Available now',
+        title: 'Update Podman Desktop?',
         message: `A new version ${updateVersion} of Podman Desktop is available. Do you want to update your current version ${this.#currentVersion}?`,
         buttons: buttons,
         cancelId: 2,
@@ -287,7 +287,7 @@ export class Updater {
             type: 'error',
             title: 'Update Failed',
             message: `An error occurred while trying to update to version ${updateVersion}. See the developer console for more information.`,
-            buttons: ['OK'],
+            buttons: ['Dismiss'],
           });
         }
       }
@@ -402,8 +402,8 @@ export class Updater {
 
     this.messageBox
       .showMessageBox({
-        title: 'Update Downloaded',
-        message: `v${updatedDownloadedEvent.version} update downloaded, Do you want to restart Podman Desktop ?`,
+        title: 'Restart Podman Desktop?',
+        message: `Podman Desktop ${updatedDownloadedEvent.version} has been downloaded. Restart now to apply the update?`,
         cancelId: 1,
         type: 'info',
         buttons: ['Restart', 'Cancel'],

--- a/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
+++ b/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
@@ -28,7 +28,7 @@ test.skip(isLinux, 'Podman installation is not supported on Linux');
 
 test.beforeAll(async ({ page, runner, welcomePage }) => {
   runner.setVideoAndTraceName('podman-install-e2e');
-  const updateAvailableDialog = page.getByRole('dialog', { name: 'Update Available now' });
+  const updateAvailableDialog = page.getByRole('dialog', { name: 'Update Podman Desktop?' });
   try {
     await playExpect(updateAvailableDialog).toBeVisible({ timeout: 20_000 });
     const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });

--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -43,9 +43,9 @@ test.beforeAll(async ({ runner, page, statusBar }) => {
   runner.setVideoAndTraceName('update-e2e');
 
   sBar = statusBar;
-  updateAvailableDialog = page.getByRole('dialog', { name: 'Update Available now' });
-  updateDialog = page.getByRole('dialog', { name: 'Update', exact: true });
-  updateDownloadedDialog = page.getByRole('dialog', { name: 'Update Downloaded', exact: true });
+  updateAvailableDialog = page.getByRole('dialog', { name: 'Update Podman Desktop?' });
+  updateDialog = page.getByRole('dialog', { name: 'Update Podman Desktop', exact: true });
+  updateDownloadedDialog = page.getByRole('dialog', { name: 'Restart Podman Desktop?', exact: true });
 });
 
 test.afterAll(async ({ runner }) => {
@@ -125,7 +125,7 @@ test.describe
     test('User initiated update option is available', async ({ page }) => {
       await playExpect(sBar.updateButtonTitle).toHaveText(await sBar.versionButton.innerText());
       await sBar.updateButtonTitle.click();
-      await handleConfirmationDialog(page, 'Update Available now', false, '', 'Cancel');
+      await handleConfirmationDialog(page, 'Update Podman Desktop?', false, '', 'Cancel');
     });
 
     test('Update can be initiated', async () => {
@@ -145,7 +145,7 @@ test.describe
       // now it takes some time to perform, in case of failure, PD gets closed
       await playExpect(updateDownloadedDialog).toBeVisible({ timeout: 120000 });
       // some buttons
-      await handleConfirmationDialog(page, 'Update Downloaded', false, 'Restart', 'Cancel');
+      await handleConfirmationDialog(page, 'Restart Podman Desktop?', false, 'Restart', 'Cancel');
       await playExpect(updateDownloadedDialog).not.toBeVisible();
     });
 


### PR DESCRIPTION
### What does this PR do?

Standardizes all dialog titles and messages in the updater:

- "Version" → "View Version" with "View Release Notes" button
- "Update" (ambiguous, used for 2 different dialogs) → "Restart Podman Desktop?" / "Update Podman Desktop"
- "Update Available now" → "Update Podman Desktop?"
- "Update Downloaded" → "Restart Podman Desktop?"
- Message text cleaned up for clarity and consistency
- "OK" buttons replaced with "Dismiss"

2 files updated (1 source + 1 test file).

### Screenshot / video of UI

N/A - string-only changes.

### What issues does this PR fix or reference?

- Part of #15961
- Resolves #17185

### How to test this PR?

1. Run `pnpm exec vitest run packages/main/src/plugin/updater.spec.ts` - all tests should pass

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>