### PR TITLE
refactor(main): use consistent titles and buttons for auth and navigation dialogs

### DIFF
--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -164,7 +164,7 @@ export class AuthenticationImpl {
         }, []);
         const message = `${accountMessage}\n\n\t${extensionNames.join('\n\t')}\n\nSign out from ${multiple ? 'these' : 'this'} extension${multiple ? 's' : ''}?`;
         const choice = await this.messageBox.showMessageBox({
-          title: 'Sign Out Request',
+          title: 'Sign Out?',
           message,
           buttons: ['Cancel', 'Sign Out'],
         });
@@ -358,7 +358,7 @@ export class AuthenticationImpl {
     if (options.createIfNone) {
       if (providerData) {
         const allowRsp = await this.messageBox.showMessageBox({
-          title: 'Sign In Request',
+          title: 'Sign In?',
           message: `The extension '${requestingExtension.label}' wants to sign in using ${providerData.label}.`,
           buttons: ['Cancel', 'Allow'],
           type: 'info',

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -203,7 +203,7 @@ export class ExperimentalFeatureFeedbackHandler {
 
       this.messageBox
         .showMessageBox({
-          title: `Share Your Feedback`,
+          title: `Share Feedback`,
           message: `We are testing something new!\n\nHow's your experience so far with [${featureName}](${featureGitHubLink})? Let us know on GitHub!`,
           type: `info`,
           buttons: [

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -203,9 +203,9 @@ export class ExperimentalFeatureFeedbackHandler {
 
       this.messageBox
         .showMessageBox({
-          title: `Share Feedback`,
+          title: 'Share Feedback',
           message: `We are testing something new!\n\nHow's your experience so far with [${featureName}](${featureGitHubLink})? Let us know on GitHub!`,
-          type: `info`,
+          type: 'info',
           buttons: [
             {
               heading: 'Remind me later',

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -186,11 +186,11 @@ test('Check SecurityRestrictions on Links and user accept', async () => {
   const value = await securityRestrictionCurrentHandler.handler?.('https://www.my-custom-domain.io');
 
   expect(showMessageBoxMock).toBeCalledWith({
-    buttons: ['Yes', 'Copy link', 'Cancel'],
+    buttons: ['Open', 'Copy Link', 'Cancel'],
     message: 'Are you sure you want to open the external website?',
     detail: 'https://www.my-custom-domain.io',
     cancelId: 2,
-    title: 'Open External Website',
+    title: 'Open External Link?',
     type: 'question',
   });
   expect(value).toBeTruthy();
@@ -213,10 +213,10 @@ test('Check SecurityRestrictions on Links and user copy link', async () => {
   const value = await securityRestrictionCurrentHandler.handler?.('https://www.my-custom-domain.io');
 
   expect(showMessageBoxMock).toBeCalledWith({
-    buttons: ['Yes', 'Copy link', 'Cancel'],
+    buttons: ['Open', 'Copy Link', 'Cancel'],
     message: 'Are you sure you want to open the external website?',
     detail: 'https://www.my-custom-domain.io',
-    title: 'Open External Website',
+    title: 'Open External Link?',
     cancelId: 2,
     type: 'question',
   });
@@ -243,10 +243,10 @@ test('Check SecurityRestrictions on Links and user refuses', async () => {
 
   expect(showMessageBoxMock).toBeCalledWith({
     cancelId: 2,
-    buttons: ['Yes', 'Copy link', 'Cancel'],
+    buttons: ['Open', 'Copy Link', 'Cancel'],
     message: 'Are you sure you want to open the external website?',
     detail: 'https://www.my-custom-domain.io',
-    title: 'Open External Website',
+    title: 'Open External Link?',
     type: 'question',
   });
   expect(value).toBeFalsy();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -461,11 +461,11 @@ export class PluginSystem {
       }
 
       const result = await messageBox.showMessageBox({
-        title: 'Open External Website',
+        title: 'Open External Link?',
         message: 'Are you sure you want to open the external website?',
         detail: url,
         type: 'question',
-        buttons: ['Yes', 'Copy link', 'Cancel'],
+        buttons: ['Open', 'Copy Link', 'Cancel'],
         cancelId: 2,
       });
 


### PR DESCRIPTION
### What does this PR do?

Standardizes dialog titles and buttons for authentication and navigation dialogs:

- "Sign Out Request" → "Sign Out?"
- "Sign In Request" → "Sign In?"
- "Open External Website" → "Open External Link?" with "Open" button instead of "Yes"
- "Copy link" → "Copy Link" (title case)
- "Share Your Feedback" → "Share Feedback" (remove unnecessary word)

4 files updated (3 source + 1 test file).

### Screenshot / video of UI

N/A - string-only changes.

### What issues does this PR fix or reference?

- Part of #15961
- Resolves #17187

### How to test this PR?

1. Run `pnpm exec vitest run packages/main/src/plugin/index.spec.ts` - all tests should pass
2. Run `pnpm exec vitest run packages/main/src/plugin/authentication.spec.ts` - all tests should pass

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>