### PR TITLE
docs: add dialog language guide to CODE-GUIDELINES.md

### DIFF
--- a/CODE-GUIDELINES.md
+++ b/CODE-GUIDELINES.md
@@ -651,3 +651,56 @@ expect(info).toMatchInlineSnapshot(`
 - **Use Inline for Small Data:** If the snapshot is less than 10 lines, prefer `toMatchInlineSnapshot()` for better visibility.
 
 For more details, see the [Vitest snapshot guide](https://vitest.dev/guide/snapshot.html).
+
+## Dialog language guide
+
+All dialogs (`showMessageBox` calls) must follow consistent language patterns for titles, body text, and buttons.
+
+### Titles
+
+Use `[Verb] [Object]` format. Add `?` for confirmations. No articles ("a", "the").
+
+| Dialog type  | Format                   | Examples                                      |
+| ------------ | ------------------------ | --------------------------------------------- |
+| Confirmation | `[Verb] [Object]?`       | `Delete Container?`, `Update Podman Desktop?` |
+| Action       | `[Verb] [Object]`        | `Push Image`, `Apply Kubernetes YAML`         |
+| Error result | `[Verb] [Object] Failed` | `Run Container Failed`, `Pull Image Failed`   |
+| Info         | `[Verb] [Object]`        | `View Version`, `Feedback Submitted`          |
+
+### Confirmation questions
+
+Format: `Are you sure you want to [verb] [object]?`
+
+Include the specific resource name: `Are you sure you want to delete container angry_vaughan?`
+
+### Button text
+
+- Use action verbs that match the title: `Delete`, `Install`, `Update`, `Prune`
+- Never use generic labels: no `Yes`, `No`, `OK`, `Confirm`
+- Use `Dismiss` for single-button info/error dialogs
+- Use `Cancel` for the cancel/escape action
+- Use title case for multi-word buttons: `View Release Notes`, `Copy Link`
+- Destructive actions use `variant: 'delete'` for danger styling
+
+### Using `withConfirmation`
+
+Pass an explicit `title` and `variant` via options. For non-delete actions, use `buttonLabel` to set the confirmation button text:
+
+```typescript
+withConfirmation(deleteContainer, `delete container ${name}`, {
+  title: 'Delete Container?',
+  variant: 'delete',
+});
+
+withConfirmation(cancelTask, `cancel task ${name}`, {
+  title: 'Cancel Task?',
+  buttonLabel: 'Cancel',
+});
+```
+
+### Tone
+
+- Professional but conversational
+- Direct and clear
+- Active voice
+- Specific, not generic


### PR DESCRIPTION
### What does this PR do?

Adds a "Dialog language guide" section to `CODE-GUIDELINES.md` documenting the standard patterns for dialog titles, confirmation questions, button text, and tone. This ensures future dialogs follow the consistent patterns established in the #15961 epic.

Covers:
- Title formats: `[Verb] [Object]` for actions, `[Verb] [Object]?` for confirmations, `[Verb] [Object] Failed` for errors
- Button rules: action verbs, no generic labels (Yes/OK/Confirm), `Dismiss` for info/error, `Cancel` for escape
- `withConfirmation` usage examples with `title`, `buttonLabel`, and `variant` options
- Tone guidelines

### Screenshot / video of UI

N/A - documentation only.

### What issues does this PR fix or reference?

- Part of #15961
- Resolves #17189

### How to test this PR?

N/A - documentation change only.

- [ ] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>