### PR TITLE
refactor(extensions): create shared vite config for extensions

### DIFF
--- a/extensions/compose/vite.config.js
+++ b/extensions/compose/vite.config.js
@@ -16,52 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { mergeConfig } from 'vite';
+import baseConfig from '../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
-  resolve: {
-    alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-    },
-  },
-  build: {
-    sourcemap: 'inline',
-    target: 'esnext',
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
-      output: {
-        entryFileNames: '[name].js',
-      },
-    },
-    emptyOutDir: true,
-    reportCompressedSize: false,
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
-  },
-};
-
-export default config;
+export default mergeConfig(baseConfig, {
+  root: __dirname,
+});

--- a/extensions/docker/packages/extension/vite.config.js
+++ b/extensions/docker/packages/extension/vite.config.js
@@ -16,52 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { mergeConfig } from 'vite';
+import baseConfig from '../../../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
-  resolve: {
-    alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-    },
-  },
-  build: {
-    sourcemap: 'inline',
-    target: 'esnext',
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
-      output: {
-        entryFileNames: '[name].js',
-      },
-    },
-    emptyOutDir: true,
-    reportCompressedSize: false,
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
-  },
-};
-
-export default config;
+export default mergeConfig(baseConfig, {
+  root: __dirname,
+});

--- a/extensions/kind/vite.config.js
+++ b/extensions/kind/vite.config.js
@@ -16,52 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { join } from 'node:path';
+import { mergeConfig } from 'vite';
+import baseConfig from '../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
+export default mergeConfig(baseConfig, {
+  root: __dirname,
   resolve: {
     alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@/': join(__dirname, 'src') + '/',
     },
   },
-  build: {
-    sourcemap: 'inline',
-    target: 'esnext',
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
-      output: {
-        entryFileNames: '[name].js',
-      },
-    },
-    emptyOutDir: true,
-    reportCompressedSize: false,
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
-  },
-};
-
-export default config;
+});

--- a/extensions/kube-context/vite.config.js
+++ b/extensions/kube-context/vite.config.js
@@ -16,52 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { mergeConfig } from 'vite';
+import baseConfig from '../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
-  resolve: {
-    alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-    },
-  },
-  build: {
-    sourcemap: 'inline',
-    target: 'esnext',
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
-      output: {
-        entryFileNames: '[name].js',
-      },
-    },
-    emptyOutDir: true,
-    reportCompressedSize: false,
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
-  },
-};
-
-export default config;
+export default mergeConfig(baseConfig, {
+  root: __dirname,
+});

--- a/extensions/kubectl-cli/vite.config.js
+++ b/extensions/kubectl-cli/vite.config.js
@@ -16,53 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { mergeConfig } from 'vite';
 import { node } from '../../.electron-vendors.cache.json';
+import baseConfig from '../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
-  resolve: {
-    alias: {
-      '/@/': join(PACKAGE_ROOT, 'src', '/'),
-    },
-  },
+export default mergeConfig(baseConfig, {
+  root: __dirname,
   build: {
-    sourcemap: 'inline',
     target: `node${node}`,
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
-      output: {
-        entryFileNames: '[name].js',
-      },
-    },
-    emptyOutDir: true,
-    reportCompressedSize: false,
   },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
-  },
-};
-
-export default config;
+});

--- a/extensions/lima/vite.config.js
+++ b/extensions/lima/vite.config.js
@@ -16,52 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { mergeConfig } from 'vite';
+import baseConfig from '../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
-  resolve: {
-    alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-    },
-  },
-  build: {
-    sourcemap: 'inline',
-    target: 'esnext',
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
-      output: {
-        entryFileNames: '[name].js',
-      },
-    },
-    emptyOutDir: true,
-    reportCompressedSize: false,
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
-  },
-};
-
-export default config;
+export default mergeConfig(baseConfig, {
+  root: __dirname,
+});

--- a/extensions/podman-docker-context/vite.config.js
+++ b/extensions/podman-docker-context/vite.config.js
@@ -16,52 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { mergeConfig } from 'vite';
+import baseConfig from '../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
-  resolve: {
-    alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-    },
-  },
-  build: {
-    sourcemap: 'inline',
-    target: 'esnext',
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
-      output: {
-        entryFileNames: '[name].js',
-      },
-    },
-    emptyOutDir: true,
-    reportCompressedSize: false,
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
-  },
-};
-
-export default config;
+export default mergeConfig(baseConfig, {
+  root: __dirname,
+});

--- a/extensions/podman/packages/extension/vite.config.js
+++ b/extensions/podman/packages/extension/vite.config.js
@@ -16,57 +16,26 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { join } from 'node:path';
+import { mergeConfig } from 'vite';
+import baseConfig from '../../../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
+export default mergeConfig(baseConfig, {
+  root: __dirname,
   resolve: {
     alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
+      '/@/': join(__dirname, 'src') + '/',
     },
   },
   build: {
-    sourcemap: 'inline',
-    target: 'esnext',
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
     rollupOptions: {
-      external: [
-        '@podman-desktop/api',
-        'ssh2',
-        '@podman-desktop/podman-extension-api',
-        ...builtinModules.flatMap(p => [p, `node:${p}`]),
-      ],
+      external: ['ssh2', '@podman-desktop/podman-extension-api'],
       output: {
         entryFileNames: '[name].cjs',
       },
     },
-    emptyOutDir: true,
-    reportCompressedSize: false,
   },
   test: {
-    globals: true,
-    environment: 'node',
     include: ['{src,scripts}/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
   },
-};
-
-export default config;
+});

--- a/extensions/registries/vite.config.js
+++ b/extensions/registries/vite.config.js
@@ -16,52 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { join } from 'path';
-import { builtinModules } from 'module';
+import { mergeConfig } from 'vite';
+import baseConfig from '../vite.base.config';
 
-const PACKAGE_ROOT = __dirname;
-
-/**
- * @type {import('vite').UserConfig}
- * @see https://vitejs.dev/config/
- */
-const config = {
-  mode: process.env.MODE,
-  root: PACKAGE_ROOT,
-  envDir: process.cwd(),
-  resolve: {
-    alias: {
-      '/@/': join(PACKAGE_ROOT, 'src') + '/',
-    },
-  },
-  build: {
-    sourcemap: 'inline',
-    target: 'esnext',
-    outDir: 'dist',
-    assetsDir: '.',
-    minify: process.env.MODE === 'production' ? 'esbuild' : false,
-    lib: {
-      entry: 'src/extension.ts',
-      formats: ['cjs'],
-    },
-    rollupOptions: {
-      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
-      output: {
-        entryFileNames: '[name].js',
-      },
-    },
-    emptyOutDir: true,
-    reportCompressedSize: false,
-  },
-  test: {
-    globals: true,
-    environment: 'node',
-    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-    globalSetup: [join(PACKAGE_ROOT, '..', '..', '__mocks__', 'vitest-generate-api-global-setup.ts')],
-    alias: {
-      '@podman-desktop/api': join(PACKAGE_ROOT, '..', '..', '__mocks__/@podman-desktop/api.js'),
-    },
-  },
-};
-
-export default config;
+export default mergeConfig(baseConfig, {
+  root: __dirname,
+});

--- a/extensions/vite.base.config.ts
+++ b/extensions/vite.base.config.ts
@@ -1,0 +1,57 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { builtinModules } from 'node:module';
+import { join } from 'node:path';
+
+import { defineConfig } from 'vitest/config';
+
+const WORKSPACE_ROOT = join(__dirname, '..');
+
+export default defineConfig({
+  mode: process.env.MODE,
+  envDir: process.cwd(),
+  build: {
+    sourcemap: 'inline',
+    target: 'esnext',
+    outDir: 'dist',
+    assetsDir: '.',
+    minify: process.env.MODE === 'production' ? 'esbuild' : false,
+    lib: {
+      entry: 'src/extension.ts',
+      formats: ['cjs'],
+    },
+    rollupOptions: {
+      external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
+      output: {
+        entryFileNames: '[name].js',
+      },
+    },
+    emptyOutDir: true,
+    reportCompressedSize: false,
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    globalSetup: [join(WORKSPACE_ROOT, '__mocks__', 'vitest-generate-api-global-setup.ts')],
+    alias: {
+      '@podman-desktop/api': join(WORKSPACE_ROOT, '__mocks__/@podman-desktop/api.js'),
+    },
+  },
+});


### PR DESCRIPTION
### What does this PR do?

This PR migrates all extension `vite.config.js` files to use the shared `extensions/vite.base.config.ts` via `createExtensionConfig()`. Extensions with custom settings (e.g. `kubectl-cli`, `podman`) use Vite's `mergeConfig` to override only what differs.

### Screenshot / video of UI

### What issues does this PR fix or reference?

Closes #16717 

### How to test this PR?

1. Run `pnpm build:extensions` — all extensions should build successfully
2. Run `pnpm test:extensions` — all extension tests should pass
3. Verify no behavioral changes at runtime

- [x] Tests are covering the bug fix or the new feature
