### PR TITLE
chore(eslint): enable vitest/hoisted-apis-on-top

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -151,6 +151,7 @@ export default [
       'vitest/no-import-node-test': 'error',
       'vitest/no-identical-title': 'error',
       'vitest/prefer-import-in-mock': 'error',
+      'vitest/hoisted-apis-on-top': 'error',
       eqeqeq: 'error',
       'prefer-promise-reject-errors': 'error',
       semi: ['error', 'always'],

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -38,6 +38,7 @@ vi.mock(import('node:os'), async () => {
     homedir: vi.fn(),
   };
 });
+vi.mock(import('node:fs'));
 
 const listReleasesMock = vi.fn();
 const listReleaseAssetsMock = vi.fn();
@@ -239,7 +240,7 @@ describe('install', () => {
     });
     vi.mocked(os.platform).mockReturnValue('win32');
     vi.mocked(os.arch).mockReturnValue('x64');
-    vi.mock(import('node:fs'));
+
     vi.mocked(fs.existsSync).mockReturnValue(true);
     const chmodMock = vi.spyOn(fs.promises, 'chmod');
     const downloadReleaseAssetMock = vi
@@ -264,7 +265,6 @@ describe('install', () => {
     });
     vi.mocked(os.platform).mockReturnValue('darwin');
     vi.mocked(os.arch).mockReturnValue('x64');
-    vi.mock(import('node:fs'));
     vi.mocked(fs.existsSync).mockReturnValue(true);
     const chmodMock = vi.spyOn(fs.promises, 'chmod').mockResolvedValue();
     const downloadReleaseAssetMock = vi
@@ -278,8 +278,6 @@ describe('install', () => {
 
 describe('downloadReleaseAsset', () => {
   test('should download the file if parent folder does exist', async () => {
-    vi.mock(import('node:fs'));
-
     getReleaseAssetMock.mockImplementation(() => {
       return { data: 'foo' };
     });
@@ -302,8 +300,6 @@ describe('downloadReleaseAsset', () => {
   });
 
   test('should download the file if parent folder does not exist', async () => {
-    vi.mock(import('node:fs'));
-
     getReleaseAssetMock.mockImplementation(() => {
       return { data: 'foo' };
     });

--- a/extensions/kubectl-cli/src/detect.spec.ts
+++ b/extensions/kubectl-cli/src/detect.spec.ts
@@ -34,6 +34,7 @@ const osMock: OS = {
 
 let detect: Detect;
 
+vi.mock(import('node:fs'));
 vi.mock(import('shell-path'), () => {
   return {
     shellPath: vi.fn(),
@@ -101,7 +102,6 @@ describe('Check storage path', async () => {
   });
 
   test('found', async () => {
-    vi.mock(import('node:fs'));
     const existSyncSpy = vi.spyOn(fs, 'existsSync');
     existSyncSpy.mockImplementation(() => true);
 

--- a/extensions/kubectl-cli/src/download.spec.ts
+++ b/extensions/kubectl-cli/src/download.spec.ts
@@ -27,6 +27,8 @@ import type { KubectlGithubReleaseArtifactMetadata, KubectlGitHubReleases } from
 import { OS } from './os';
 import * as utils from './utils';
 
+vi.mock(import('node:fs'));
+
 // Create the OS class as well as fake extensionContext
 const os = new OS();
 const extensionContext: extensionApi.ExtensionContext = {
@@ -124,7 +126,6 @@ test('test download of kubectl passes and that mkdir and executable mocks are ca
   const downloadReleaseAssetMock = vi.spyOn(kubectlGitHubReleasesMock, 'downloadReleaseAsset');
 
   // Mock that the storage path does not exist
-  vi.mock(import('node:fs'));
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
     return false;
   });

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -24,6 +24,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { KubectlGitHubReleases } from './kubectl-github-releases';
 
+vi.mock(import('node:fs'));
+
 let kubectlGitHubReleases: KubectlGitHubReleases;
 
 const listReleaseAssetsMock = vi.fn();
@@ -116,8 +118,6 @@ describe('Grab asset id for a given release id', async () => {
 });
 
 test('should download the file if parent folder does exist', async () => {
-  vi.mock(import('node:fs'));
-
   getReleaseAssetMock.mockImplementation(() => {
     return { data: 'foo' };
   });
@@ -140,8 +140,6 @@ test('should download the file if parent folder does exist', async () => {
 });
 
 test('should download the file if parent folder does not exist', async () => {
-  vi.mock(import('node:fs'));
-
   getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 
   // mock fs

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -160,6 +160,7 @@ const fsPromisesReaddirMock = vi.mocked(
 );
 
 vi.mock(import('./inject/inversify-binding'));
+vi.mock(import('./utils/warnings'));
 
 // mock ps-list
 vi.mock(import('ps-list'), async () => {
@@ -295,6 +296,7 @@ const consoleWarnMock = vi.fn();
 const originalConsoleTrace = console.trace;
 const consoleTraceMock = vi.fn();
 
+vi.mock(import('node:fs'));
 vi.mock(import('node:child_process'), async importOriginal => {
   const childProcessActual = await importOriginal();
   return {
@@ -1319,8 +1321,6 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
 
   const spyPrompt = vi.mocked(extensionApi.window.showInformationMessage);
   spyPrompt.mockResolvedValue('Yes');
-
-  vi.mock(import('node:fs'));
 
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
     return false;
@@ -3573,8 +3573,6 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
         return '';
       },
     });
-
-    vi.mock(import('./utils/warnings'));
   });
 
   test('do not show any notifications / messages if the provider is stopped', async () => {

--- a/extensions/podman/packages/extension/src/utils/notifications.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.spec.ts
@@ -33,6 +33,7 @@ const config: Configuration = {
 };
 
 vi.mock(import('node:fs'));
+vi.mock(import('./warnings'));
 
 const mockTelemetryLogger: extensionApi.TelemetryLogger = {
   logUsage: vi.fn(),
@@ -75,8 +76,6 @@ describe('macOS: tests for notifying if disguised podman socket fails / passes',
         return '';
       },
     });
-
-    vi.mock(import('./warnings'));
   });
 
   test('when isDisguisedPodman is true, error message should NOT be shown', async () => {

--- a/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
@@ -24,6 +24,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { PodmanConfiguration } from './podman-configuration';
 import { VMTYPE } from './util';
 
+vi.mock(import('node:fs'));
+
 const extensionContext: ExtensionContext = {} as unknown as ExtensionContext;
 
 // allows to call protected methods
@@ -65,7 +67,6 @@ memory = 4096
 });
 
 test('when enable rosetta is set to true and there is already a file with rosetta = false, remove it.', async () => {
-  vi.mock(import('node:fs'));
   const configFileContent = `
 [machine]
 memory = 4096
@@ -87,7 +88,6 @@ rosetta = false
 });
 
 test('should disable Rosetta when useRosetta is false', async () => {
-  vi.mock(import('node:fs'));
   const configFileContent = `
 [machine]
 memory = 4096
@@ -108,7 +108,6 @@ rosetta = true
 });
 
 test('if rosetta is set to true and the file does NOT exist, do not try and create the file.', async () => {
-  vi.mock(import('node:fs'));
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
@@ -122,7 +121,6 @@ test('if rosetta is set to true and the file does NOT exist, do not try and crea
 
 describe('isRosettaEnabled', () => {
   test('check rosetta is enabled', async () => {
-    vi.mock(import('node:fs'));
     vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
     vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nrosetta=true');
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -133,7 +131,6 @@ describe('isRosettaEnabled', () => {
   });
 
   test('check rosetta is enabled if file is not containing rosetta setting (default value is true)', async () => {
-    vi.mock(import('node:fs'));
     vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
     vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -144,7 +141,6 @@ describe('isRosettaEnabled', () => {
   });
 
   test('check rosetta is disabled', async () => {
-    vi.mock(import('node:fs'));
     vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
     vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nrosetta=false');
 
@@ -157,7 +153,6 @@ describe('isRosettaEnabled', () => {
 });
 
 test('when provider is set to applehv provider and there is already a file with provider = libkrun, remove it.', async () => {
-  vi.mock(import('node:fs'));
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nprovider = "libkrun"');
@@ -174,7 +169,6 @@ test('when provider is set to applehv provider and there is already a file with 
 });
 
 test('should update provider', async () => {
-  vi.mock(import('node:fs'));
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('[machine]\nprovider = "applehv"');
@@ -191,7 +185,6 @@ test('should update provider', async () => {
 });
 
 test('if provider is set default one (on CLI) and the file does NOT exist, do not try and create the file.', async () => {
-  vi.mock(import('node:fs'));
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');

--- a/packages/main/src/plugin/dialog-registry.spec.ts
+++ b/packages/main/src/plugin/dialog-registry.spec.ts
@@ -35,6 +35,11 @@ const fakeBrowserWindow: BrowserWindow = {
   },
 } as unknown as BrowserWindow;
 
+vi.mock(import('/@/util.js'), () => {
+  return {
+    isMac: vi.fn().mockReturnValue(false),
+  };
+});
 vi.mock(import('electron'), async () => {
   return {
     dialog: {
@@ -86,12 +91,6 @@ describe('showOpenDialog', () => {
       filePaths: [tmpMyPath],
       canceled: false,
     });
-  });
-
-  vi.mock(import('/@/util.js'), () => {
-    return {
-      isMac: vi.fn().mockReturnValue(false),
-    };
   });
 
   // check opendialog is failing without browserwindow

--- a/packages/main/src/plugin/directories-legacy.spec.ts
+++ b/packages/main/src/plugin/directories-legacy.spec.ts
@@ -30,14 +30,14 @@ import { LegacyDirectories } from './directories-legacy.js';
 
 const originalProcessEnv = process.env;
 
+// Mock file system
+vi.mock(import('node:fs'));
 vi.mock(import('/@/util.js'));
 
 beforeEach(() => {
   // Reset environment variables to clean state
   process.env = { ...originalProcessEnv };
 
-  // Mock file system
-  vi.mock(import('node:fs'));
   vi.spyOn(fs, 'existsSync').mockReturnValue(true);
   vi.spyOn(fs, 'mkdirSync').mockImplementation(() => '');
 });

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -34,6 +34,8 @@ import type { Directories } from '/@/plugin/directories.js';
 
 import { DockerDesktopInstallation } from './docker-desktop-installation.js';
 
+vi.mock(import('node:fs'));
+
 let dockerDesktopInstallation: TestDockerDesktopInstallation;
 
 const contributionManagerLoadMetadataMock = vi.fn();
@@ -282,8 +284,6 @@ describe('handleExtensionVMServiceRequest', () => {
 });
 
 test('Check handlePluginInstall', async () => {
-  vi.mock(import('node:fs'));
-
   const allReplies: string[] = [];
 
   const ipcMainEventReplyMock = vi.fn().mockImplementation((channel: string, ...args: unknown[]) => {

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
@@ -24,6 +24,8 @@ import type { ContributionManager, DockerExtensionMetadata } from '/@/plugin/con
 
 import { DockerDesktopInstaller } from './docker-desktop-installer.js';
 
+vi.mock(import('node:fs/promises'));
+
 let dockerDesktopInstaller: TestDockerDesktopInstaller;
 
 const contributionManager = {
@@ -46,8 +48,6 @@ beforeEach(() => {
 });
 
 test('Check extractExtensionFiles', async () => {
-  vi.mock(import('node:fs/promises'));
-
   const metadataJson = {
     name: 'My Extension',
     icon: 'icon.png',

--- a/packages/main/src/plugin/extension/extension-analyzer.spec.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.spec.ts
@@ -72,9 +72,6 @@ describe('analyze extension and main', () => {
   });
 
   test('check for extension with linked folder', async () => {
-    vi.mock(import('node:fs'));
-    vi.mock(import('node:fs/promises'));
-
     // mock fs.existsSync
     const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');
     fsExistsSyncMock.mockReturnValue(true);
@@ -108,8 +105,6 @@ describe('analyze extension and main', () => {
   });
 
   test('check for extension without main entry', async () => {
-    vi.mock(import('node:fs'));
-
     // mock fs.existsSync
     const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');
     fsExistsSyncMock.mockReturnValue(true);
@@ -140,8 +135,6 @@ describe('analyze extension and main', () => {
   });
 
   test('check for extension with devMode', async () => {
-    vi.mock(import('node:fs'));
-
     // mock fs.existsSync
     const fsExistsSyncMock = vi.spyOn(fs, 'existsSync');
     fsExistsSyncMock.mockReturnValue(true);

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -84,6 +84,8 @@ import { ExtensionLoader } from './extension-loader.js';
 import type { ExtensionManifest } from './extension-manifest-schema.js';
 import type { ExtensionWatcher } from './extension-watcher.js';
 
+vi.mock(import('node:fs'));
+
 class TestExtensionLoader extends ExtensionLoader {
   public override async setupScanningDirectory(): Promise<void> {
     return super.setupScanningDirectory();
@@ -548,7 +550,6 @@ test('Should load file from watching scanning folder', async () => {
   // reduce timeout delay for tests
   extensionLoader.setWatchTimeout(50);
 
-  vi.mock(import('node:fs'));
   // mock fs.watch
   const fsWatchMock = vi.spyOn(fs, 'watch');
   fsWatchMock.mockImplementation((filename: fs.PathLike, listener?: fs.WatchListener<string>): fs.FSWatcher => {
@@ -1340,8 +1341,6 @@ describe('Removing extension by user', async () => {
 });
 
 test('check dispose when deactivating', async () => {
-  vi.mock(import('node:fs'));
-
   const extensionId = 'fooPublisher.fooName';
   extensionLoader.setActivatedExtension(extensionId, {
     id: extensionId,
@@ -2437,8 +2436,6 @@ describe('containerEngine', async () => {
 
 describe('extensionContext', async () => {
   test('secrets', async () => {
-    vi.mock(import('node:fs'));
-
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
     const extension: AnalyzedExtension = {

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -55,6 +55,29 @@ import { Disposable } from './types/disposable.js';
 import { HttpServer } from './webview/webview-registry.js';
 
 vi.mock(import('./extension/extension-api-version.js'));
+vi.mock(import('electron'), () => {
+  return {
+    shell: {
+      openExternal: vi.fn(),
+    },
+    app: {
+      on: vi.fn(),
+      getVersion: vi.fn(),
+      getAppPath: vi.fn().mockReturnValue('a-custom-appPath'),
+    },
+    clipboard: {
+      writeText: vi.fn(),
+    },
+    ipcMain: {
+      handle: vi.fn(),
+      emit: vi.fn().mockReturnValue(true),
+      on: vi.fn(),
+    },
+    BrowserWindow: {
+      getAllWindows: vi.fn(),
+    },
+  } as unknown as typeof Electron;
+});
 
 let pluginSystem: TestPluginSystem;
 
@@ -95,29 +118,6 @@ const mainWindowDeferred = Promise.withResolvers<BrowserWindow>();
 const handlers = new Map<string, any>();
 
 beforeAll(async () => {
-  vi.mock(import('electron'), () => {
-    return {
-      shell: {
-        openExternal: vi.fn(),
-      },
-      app: {
-        on: vi.fn(),
-        getVersion: vi.fn(),
-        getAppPath: vi.fn().mockReturnValue('a-custom-appPath'),
-      },
-      clipboard: {
-        writeText: vi.fn(),
-      },
-      ipcMain: {
-        handle: vi.fn(),
-        emit: vi.fn().mockReturnValue(true),
-        on: vi.fn(),
-      },
-      BrowserWindow: {
-        getAllWindows: vi.fn(),
-      },
-    } as unknown as typeof Electron;
-  });
   const trayMenuMock = {} as unknown as TrayMenu;
   pluginSystem = new TestPluginSystem(trayMenuMock, mainWindowDeferred);
 

--- a/packages/main/src/plugin/onboarding-registry.spec.ts
+++ b/packages/main/src/plugin/onboarding-registry.spec.ts
@@ -28,6 +28,8 @@ import { Context } from './context/context.js';
 import { OnboardingRegistry } from './onboarding-registry.js';
 import type { Disposable } from './types/disposable.js';
 
+vi.mock(import('node:fs'));
+
 let onboardingRegistry: OnboardingRegistry;
 const extensionId = 'myextension.id';
 const stepId = 'checkInstalledCommand';
@@ -77,7 +79,6 @@ describe('an OnboardingRegistry instance exists', () => {
     registerOnboardingDisposable = onboardingRegistry.registerOnboarding(extension, manifest.contributes.onboarding);
     getConfigMock.mockReturnValue(true);
 
-    vi.mock(import('node:fs'));
     readFileSync.mockReturnValue(JSON.stringify({}));
   });
 

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -37,6 +37,7 @@ const DIALOG_REGISTRY_MOCK: DialogRegistry = {
 const writeZipMock = vi.fn();
 const addFileMock = vi.fn();
 
+vi.mock(import('node:fs'));
 vi.mock(import('electron'), () => {
   return {
     ipcMain: {
@@ -182,7 +183,6 @@ test('Should return getMacSystemLogs if the platform is darwin', async () => {
   readFileMock.mockResolvedValue('content');
 
   // Mock exists to be true
-  vi.mock(import('node:fs'));
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
     return true;
   });
@@ -205,7 +205,6 @@ test('Should return getMacSystemLogs if the platform is darwin', async () => {
 // ~/AppData/Roaming/Podman Desktop/logs/podman-desktop.log
 test('Should return getWindowsSystemLogs if the platform is win32', async () => {
   // Mock exists to be true
-  vi.mock(import('node:fs'));
   vi.spyOn(fs, 'existsSync').mockImplementation(() => {
     return true;
   });

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -35,11 +35,6 @@ import { Exec, getInstallationPath, macosExtraPath } from './exec.js';
 vi.mock(import('@expo/sudo-prompt'));
 vi.mock(import('/@/util.js'));
 vi.mock(import('node:child_process'));
-vi.mock(import('node:child_process'), () => {
-  return {
-    spawn: vi.fn(),
-  };
-});
 
 const setEncodingMock = vi.fn();
 

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -35,6 +35,11 @@ import { Exec, getInstallationPath, macosExtraPath } from './exec.js';
 vi.mock(import('@expo/sudo-prompt'));
 vi.mock(import('/@/util.js'));
 vi.mock(import('node:child_process'));
+vi.mock(import('node:child_process'), () => {
+  return {
+    spawn: vi.fn(),
+  };
+});
 
 const setEncodingMock = vi.fn();
 
@@ -130,12 +135,6 @@ describe('exec', () => {
 
   test('should reject with an error when the process error event received', async () => {
     const command = 'nonexistent-command';
-
-    vi.mock(import('node:child_process'), () => {
-      return {
-        spawn: vi.fn(),
-      };
-    });
 
     const on = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
       if (event === 'data') {

--- a/packages/main/src/util.spec.ts
+++ b/packages/main/src/util.spec.ts
@@ -21,9 +21,10 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { createHash, formatName, getBase64Image, requireNonUndefined } from './util.js';
 
+vi.mock(import('node:fs'));
+
 beforeEach(() => {
   vi.resetAllMocks();
-  vi.mock(import('node:fs'));
 });
 
 test('getBase64Image - return undefined if path do not exists', () => {


### PR DESCRIPTION
### What does this PR do?

Enabling `vitest/hoisted-apis-on-top` rule which is very important, it ensure that `vi.mock` call are at the top level of the file => vitest already put warnings if you are using vi.mock in nested placed (E.g. `beforeEach`, `beforeAll`, `test` etc.)

Moving the vi.mock on the top of the file to fix the errors.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17193

### How to test this PR?

- CI should be :green_circle: 
