### PR TITLE
fix(extensions): sync CLI tool version to provider on startup

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -187,6 +187,39 @@ describe('registerCLITool', () => {
     expect(cliToolMock.registerUpdate).toHaveBeenCalled();
   });
 
+  test('syncs detected version to provider on startup', async () => {
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
+    vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({
+      version: 'v2.0.0',
+      path: 'system-wide-path',
+      updatable: false,
+    });
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-wide-path');
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(extensionApi.cli.createCliTool).toHaveBeenCalled();
+    });
+
+    const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
+    expect(providerMock.updateVersion).toHaveBeenCalledWith('2.0.0');
+  });
+
+  test('does not sync version to provider when no binary is detected', async () => {
+    vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(false);
+    vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('');
+
+    await activate(extensionContextMock);
+
+    await vi.waitFor(() => {
+      expect(extensionApi.cli.createCliTool).toHaveBeenCalled();
+    });
+
+    const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
+    expect(providerMock.updateVersion).not.toHaveBeenCalled();
+  });
+
   test('createCliTool already installed system wide by user', async () => {
     vi.mocked(Detect.prototype.checkSystemWideDockerCompose).mockResolvedValue(true);
     vi.mocked(Detect.prototype.getDockerComposeBinaryInfo).mockResolvedValue({

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -304,6 +304,10 @@ async function registerCLITool(
     });
   }
 
+  if (binaryVersion) {
+    provider.updateVersion(binaryVersion);
+  }
+
   // register the updater to allow users to upgrade/downgrade their cli
   let releaseToUpdateTo: ComposeGithubReleaseArtifactMetadata | undefined;
   let releaseVersionToUpdateTo: string | undefined;

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -139,6 +139,24 @@ describe('cli tool', () => {
     });
   });
 
+  test('syncs detected version to provider on startup', async () => {
+    await activate();
+
+    expect(PROVIDER_MOCK.updateVersion).toHaveBeenCalledWith('0.0.1');
+  });
+
+  test('does not sync version to provider when no binary is detected', async () => {
+    vi.mocked(util.getKindBinaryInfo).mockRejectedValue(new Error('does not exist'));
+    vi.mocked(podmanDesktopApi.cli.createCliTool).mockReturnValue({
+      ...CLI_TOOL_MOCK,
+      version: undefined,
+    } as unknown as extensionApi.CliTool);
+
+    await activate();
+
+    expect(PROVIDER_MOCK.updateVersion).not.toHaveBeenCalled();
+  });
+
   test('activation should register cli tool when available, installed by user', async () => {
     vi.mocked(util.getSystemBinaryPath).mockReturnValue('user-kind');
 

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -357,6 +357,10 @@ export async function createProvider(
 
   provider = extensionApi.provider.createProvider(providerOptions);
 
+  if (kindCli?.version) {
+    provider.updateVersion(kindCli.version);
+  }
+
   extensionContext.subscriptions.push(provider);
   await registerProvider(provider, telemetryLogger);
   extensionContext.subscriptions.push(

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -339,6 +339,66 @@ describe('postActivate', () => {
     return deferredCliUpdate;
   });
 
+  test('syncs detected version to provider on startup', async () => {
+    vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-path');
+    vi.mocked(extensionApi.process.exec).mockImplementation(
+      (_command: string, _args?: string[], _options?: extensionApi.RunOptions) =>
+        new Promise<extensionApi.RunResult>(resolve => {
+          if (_args?.[0] === 'version') {
+            resolve({
+              stderr: '',
+              stdout: JSON.stringify(jsonStdout),
+              command: 'kubectl version --client=true -o=json',
+            });
+            return;
+          }
+          resolve({
+            stderr: '',
+            stdout: 'system-path',
+            command: 'which kubectl',
+          });
+        }),
+    );
+    const deferredCliTool: Promise<void> = new Promise<void>(resolve => {
+      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
+        resolve();
+        return {
+          registerUpdate: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+          registerInstaller: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+          updateVersion: vi.fn(),
+        } as unknown as extensionApi.CliTool;
+      });
+    });
+
+    await KubectlExtension.activate(extensionContext);
+    await deferredCliTool;
+
+    await vi.waitFor(() => {
+      const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
+      expect(providerMock.updateVersion).toHaveBeenCalledWith('1.28.3');
+    });
+  });
+
+  test('does not sync version to provider when no binary is detected', async () => {
+    vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('Error running version command'));
+
+    const deferred = new Promise<void>(resolve => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {
+        resolve();
+      });
+    });
+
+    await KubectlExtension.activate(extensionContext);
+    await deferred;
+
+    await vi.waitFor(() => {
+      expect(extensionApi.cli.createCliTool).toHaveBeenCalled();
+    });
+
+    const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
+    expect(providerMock.updateVersion).not.toHaveBeenCalled();
+  });
+
   test('onUpdate should download and install binary', async () => {
     vi.spyOn(cliRun, 'getSystemBinaryPath').mockReturnValue('system-path');
     vi.mocked(extensionApi.process.exec).mockImplementation(

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -340,6 +340,10 @@ async function postActivate(
 
   extensionContext.subscriptions.push(kubectlCliTool);
 
+  if (vpState.version) {
+    provider.updateVersion(vpState.version);
+  }
+
   // create and register the installer
   let releaseToInstall: KubectlGithubReleaseArtifactMetadata | undefined;
   let releaseVersionToInstall: string | undefined;


### PR DESCRIPTION
### What does this PR do?

The Resources page displays `provider.version` for each extension, but the Compose, kubectl, and Kind extensions only called `provider.updateVersion()` during user-triggered update/install/uninstall operations. On startup, the CLI tool binary was correctly detected with its version, but the provider was never informed — leaving the version blank on the Resources page until a manual action forced a sync.

This PR adds `provider.updateVersion()` calls after initial CLI tool binary detection in all three extensions so the Resources page shows the correct version immediately on startup:

- **Compose** — calls `provider.updateVersion(binaryVersion)` after creating/updating the CLI tool in `registerCLITool()`
- **kubectl** — calls `provider.updateVersion(vpState.version)` after registering the CLI tool in `postActivate()`
- **Kind** — calls `provider.updateVersion(kindCli.version)` in `createProvider()` (which runs after `registerCliTool()`)

All calls are guarded to only fire when a version was actually detected.

### Screenshot / video of UI

<img width="1162" height="812" alt="Screenshot 2026-04-22 at 09 52 48" src="https://github.com/user-attachments/assets/33f128fd-edb3-489a-9557-0f31f7602f7f" />


### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/17172

### How to test this PR?

1. Ensure a CLI tool (e.g. `docker-compose`, `kubectl`, or `kind`) is installed on the system.
2. Start Podman Desktop.
3. Navigate to the **Resources** page.
4. Verify the version is displayed immediately — no need to visit CLI Tools or perform an update first.
5. Restart the app and confirm the version still appears on first load.

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)