### PR TITLE
chore(eslint): enable vitest/prefer-mock-promise-shorthand

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -152,6 +152,7 @@ export default [
       'vitest/no-identical-title': 'error',
       'vitest/prefer-import-in-mock': 'error',
       'vitest/hoisted-apis-on-top': 'error',
+      'vitest/prefer-mock-promise-shorthand': 'error',
       eqeqeq: 'error',
       'prefer-promise-reject-errors': 'error',
       semi: ['error', 'always'],

--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -65,7 +65,7 @@ describe('Check for Docker Compose', async () => {
   });
 
   test('installed', async () => {
-    vi.mocked(extensionApi.process.exec).mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
     const result = await detect.checkForDockerCompose();
     expect(result).toBeTruthy();
   });
@@ -125,9 +125,10 @@ describe('Check storage path', async () => {
 
 describe('Check getDockerComposePath uses proper tooling by platform', () => {
   beforeEach(() => {
-    vi.mocked(extensionApi.process.exec).mockImplementation(() =>
-      Promise.resolve({ exitCode: 0, stdout: 'hello-world' } as extensionApi.RunError),
-    );
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({
+      exitCode: 0,
+      stdout: 'hello-world',
+    } as extensionApi.RunError);
   });
 
   test('linux should use which', async () => {

--- a/extensions/compose/src/utils.spec.ts
+++ b/extensions/compose/src/utils.spec.ts
@@ -33,7 +33,7 @@ describe('makeExecutable', async () => {
 
     // fake chmod
     const chmodMock = vi.spyOn(promises, 'chmod');
-    chmodMock.mockImplementation(() => Promise.resolve());
+    chmodMock.mockResolvedValue(undefined);
     await makeExecutable(fakePath);
     // check it has been called
     expect(chmodMock).toHaveBeenCalledWith(fakePath, 0o755);
@@ -44,7 +44,7 @@ describe('makeExecutable', async () => {
 
     // fake chmod
     const chmodMock = vi.spyOn(promises, 'chmod');
-    chmodMock.mockImplementation(() => Promise.resolve());
+    chmodMock.mockResolvedValue(undefined);
     await makeExecutable(fakePath);
     // check it has been called
     expect(chmodMock).toHaveBeenCalledWith(fakePath, 0o755);
@@ -55,7 +55,7 @@ describe('makeExecutable', async () => {
 
     // fake chmod
     const chmodMock = vi.spyOn(promises, 'chmod');
-    chmodMock.mockImplementation(() => Promise.resolve());
+    chmodMock.mockResolvedValue(undefined);
     await makeExecutable(fakePath);
     // check it has not been called on Windows
     expect(chmodMock).not.toHaveBeenCalled();

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -243,9 +243,7 @@ describe('install', () => {
 
     vi.mocked(fs.existsSync).mockReturnValue(true);
     const chmodMock = vi.spyOn(fs.promises, 'chmod');
-    const downloadReleaseAssetMock = vi
-      .spyOn(installer, 'downloadReleaseAsset')
-      .mockImplementation(() => Promise.resolve());
+    const downloadReleaseAssetMock = vi.spyOn(installer, 'downloadReleaseAsset').mockResolvedValue(undefined);
     const output = await installer.download(resultREST[0]);
     expect(output).toStrictEqual(path.join(installer.getKindCliStoragePath()));
     expect(downloadReleaseAssetMock).toBeCalledWith(186178238, expect.any(String));
@@ -267,9 +265,7 @@ describe('install', () => {
     vi.mocked(os.arch).mockReturnValue('x64');
     vi.mocked(fs.existsSync).mockReturnValue(true);
     const chmodMock = vi.spyOn(fs.promises, 'chmod').mockResolvedValue();
-    const downloadReleaseAssetMock = vi
-      .spyOn(installer, 'downloadReleaseAsset')
-      .mockImplementation(() => Promise.resolve());
+    const downloadReleaseAssetMock = vi.spyOn(installer, 'downloadReleaseAsset').mockResolvedValue(undefined);
     await installer.download(resultREST[0]);
     expect(downloadReleaseAssetMock).toBeCalledWith(186178216, expect.any(String));
     expect(chmodMock).toBeCalledWith(expect.any(String), 0o755);

--- a/extensions/kubectl-cli/src/detect.spec.ts
+++ b/extensions/kubectl-cli/src/detect.spec.ts
@@ -65,7 +65,7 @@ describe('Check for kubectl', async () => {
   });
 
   test('installed', async () => {
-    vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
     const result = await detect.checkForKubectl();
     expect(result).toBeTruthy();
   });

--- a/extensions/kubectl-cli/src/handler.spec.ts
+++ b/extensions/kubectl-cli/src/handler.spec.ts
@@ -37,9 +37,9 @@ beforeEach(() => {
 });
 
 test('updateConfigAndContextKubectlBinary: make sure configuration gets updated if checkSystemWideKubectl had returned true', async () => {
-  vi.mocked(Detect.prototype.checkSystemWideKubectl).mockReturnValue(Promise.resolve(true));
-  vi.mocked(Detect.prototype.checkForKubectl).mockReturnValue(Promise.resolve(true));
-  vi.mocked(Detect.prototype.getStoragePath).mockReturnValue(Promise.resolve('mockPath'));
+  vi.mocked(Detect.prototype.checkSystemWideKubectl).mockResolvedValue(true);
+  vi.mocked(Detect.prototype.checkForKubectl).mockResolvedValue(true);
+  vi.mocked(Detect.prototype.getStoragePath).mockResolvedValue('mockPath');
 
   // Spy on setValue and configuration updates
   const contextUpdateSpy = vi.spyOn(extensionApi.context, 'setValue');

--- a/extensions/kubectl-cli/src/utils.spec.ts
+++ b/extensions/kubectl-cli/src/utils.spec.ts
@@ -33,7 +33,7 @@ describe('makeExecutable', async () => {
 
     // fake chmod
     const chmodMock = vi.spyOn(promises, 'chmod');
-    chmodMock.mockImplementation(() => Promise.resolve());
+    chmodMock.mockResolvedValue(undefined);
     await makeExecutable(fakePath);
     // check it has been called
     expect(chmodMock).toHaveBeenCalledWith(fakePath, 0o755);
@@ -44,7 +44,7 @@ describe('makeExecutable', async () => {
 
     // fake chmod
     const chmodMock = vi.spyOn(promises, 'chmod');
-    chmodMock.mockImplementation(() => Promise.resolve());
+    chmodMock.mockResolvedValue(undefined);
     await makeExecutable(fakePath);
     // check it has been called
     expect(chmodMock).toHaveBeenCalledWith(fakePath, 0o755);
@@ -55,7 +55,7 @@ describe('makeExecutable', async () => {
 
     // fake chmod
     const chmodMock = vi.spyOn(promises, 'chmod');
-    chmodMock.mockImplementation(() => Promise.resolve());
+    chmodMock.mockResolvedValue(undefined);
     await makeExecutable(fakePath);
     // check it has not been called on Windows
     expect(chmodMock).not.toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/checks/macos-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/macos-check.spec.ts
@@ -65,9 +65,10 @@ test('expect success on a recent macOS version', async () => {
 
 describe('Krunkit', () => {
   test('Krunkit is installed by brew', async () => {
-    vi.mocked(extensionApi.process.exec).mockImplementation(() =>
-      Promise.resolve({ exitCode: 0, stdout: 'hello-world' } as extensionApi.RunError),
-    );
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({
+      exitCode: 0,
+      stdout: 'hello-world',
+    } as extensionApi.RunError);
 
     const krunkitCheck = new MacKrunkitPodmanMachineCreationCheck();
     const result = await krunkitCheck.execute();
@@ -76,7 +77,7 @@ describe('Krunkit', () => {
   });
 
   test('Krunkit is installed by Podman installer', async () => {
-    vi.mocked(extensionApi.process.exec).mockImplementation(() => Promise.reject(new Error('Brew is not installed')));
+    vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('Brew is not installed'));
 
     const krunkitCheck = new MacKrunkitPodmanMachineCreationCheck();
     const result = await krunkitCheck.execute();
@@ -85,13 +86,15 @@ describe('Krunkit', () => {
   });
 
   test('Krunkit is not installed', async () => {
-    vi.mocked(extensionApi.process.exec).mockImplementation(() =>
-      Promise.resolve({ exitCode: 1, stderr: 'error-world' } as extensionApi.RunError),
-    );
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({
+      exitCode: 1,
+      stderr: 'error-world',
+    } as extensionApi.RunError);
 
-    vi.mocked(extensionApi.process.exec).mockImplementationOnce(() =>
-      Promise.resolve({ exitCode: 0, stdout: 'hello-world' } as extensionApi.RunError),
-    );
+    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: 'hello-world',
+    } as extensionApi.RunError);
     const krunkitCheck = new MacKrunkitPodmanMachineCreationCheck();
     const result = await krunkitCheck.execute();
     expect(result).toBeDefined();

--- a/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.spec.ts
+++ b/extensions/podman/packages/extension/src/compatibility-mode/darwin-socket-compatibility.spec.ts
@@ -78,9 +78,7 @@ test('darwin: DarwinSocketCompatibility class, test runMacHelperCommandWithAdmin
 
   // Mock that admin command ran successfully (since we cannot test interactive mode priv in vitest / has to be integration tests)
   const spyMacHelperCommand = vi.spyOn(socketCompatClass, 'runMacHelperCommandWithAdminPriv');
-  spyMacHelperCommand.mockImplementation(() => {
-    return Promise.resolve();
-  });
+  spyMacHelperCommand.mockResolvedValue(undefined);
 
   // Run the command
   await socketCompatClass.runCommand('enable', 'enabled');
@@ -92,18 +90,14 @@ test('darwin: DarwinSocketCompatibility class, test runMacHelperCommandWithAdmin
 test('darwin: DarwinSocketCompatibility class, test promptRestart ran within runCommand', async () => {
   const socketCompatClass = new DarwinSocketCompatibility();
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
 
   const spyFindRunningMachine = vi.spyOn(extension, 'findRunningMachine');
-  spyFindRunningMachine.mockImplementation(() => {
-    return Promise.resolve('default');
-  });
+  spyFindRunningMachine.mockResolvedValue('default');
 
   // Mock that enable ran successfully
   const spyEnable = vi.spyOn(socketCompatClass, 'runCommand');
-  spyEnable.mockImplementation(() => {
-    return Promise.resolve();
-  });
+  spyEnable.mockResolvedValue(undefined);
 
   const spyPromptRestart = vi.spyOn(socketCompatClass, 'promptRestart');
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -358,9 +358,7 @@ beforeEach(() => {
     },
   });
 
-  vi.mocked(PodmanInfoHelper.prototype.updateWithPodmanInfoRecords).mockImplementation(() => {
-    return Promise.resolve();
-  });
+  vi.mocked(PodmanInfoHelper.prototype.updateWithPodmanInfoRecords).mockResolvedValue(undefined);
 });
 
 afterEach(async () => {
@@ -876,9 +874,9 @@ test('checkDefaultMachine: do not prompt if the running machine is already the d
     },
   ];
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() =>
-    Promise.resolve({ stdout: JSON.stringify(fakeConnectionJSON) } as extensionApi.RunResult),
-  );
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({
+    stdout: JSON.stringify(fakeConnectionJSON),
+  } as extensionApi.RunResult);
 
   await extension.checkDefaultMachine(fakeJSON);
   expect(extensionApi.window.showInformationMessage).not.toHaveBeenCalled();
@@ -890,9 +888,7 @@ test('if a machine is successfully started it changes its state to started', asy
     return;
   });
 
-  const spyExecPromise = vi
-    .spyOn(extensionApi.process, 'exec')
-    .mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
   await extension.startMachine(provider, podmanConfiguration, machineInfo);
 
   expect(spyExecPromise).toBeCalledWith(podmanCli.getPodmanCli(), ['machine', 'start', 'name'], {
@@ -911,9 +907,7 @@ test('if autoStart is true, machine start uses detached mode', async () => {
     return;
   });
 
-  const spyExecPromise = vi
-    .spyOn(extensionApi.process, 'exec')
-    .mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
 
   await extension.startMachine(provider, podmanConfiguration, machineInfo, undefined, undefined, undefined, true);
 
@@ -929,9 +923,7 @@ test('if autoStart is true, machine start uses detached mode', async () => {
 });
 
 test('if a machine is successfully reporting telemetry', async () => {
-  const spyExecPromise = vi
-    .spyOn(extensionApi.process, 'exec')
-    .mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
   await extension.startMachine(provider, podmanConfiguration, machineInfo);
 
   await waitTelemetryLoggerUsage();
@@ -989,9 +981,7 @@ test('if a machine failed to start with a wsl distro not found error, the user i
 
 test('if a machine failed to start with a wsl distro not found error but the skipHandleError is false, the error is thrown', async () => {
   const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
-  spyExecPromise.mockImplementation(() => {
-    return Promise.reject(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
-  });
+  spyExecPromise.mockRejectedValue(new Error('wsl bootstrap script failed: exit status 0xffffffff'));
   await expect(
     extension.startMachine(provider, podmanConfiguration, machineInfo, undefined, undefined, true),
   ).rejects.toThrow('wsl bootstrap script failed: exit status 0xffffffff');
@@ -1155,9 +1145,9 @@ test('test checkDefaultMachine - if there is no machine marked as default, take 
     },
   ];
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() =>
-    Promise.resolve({ stdout: JSON.stringify(fakeConnectionJSON) } as extensionApi.RunResult),
-  );
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({
+    stdout: JSON.stringify(fakeConnectionJSON),
+  } as extensionApi.RunResult);
 
   await extension.checkDefaultMachine(fakeJSON);
 
@@ -1205,9 +1195,9 @@ test('test checkDefaultMachine - if there is no machine marked as default, take 
     },
   ];
 
-  vi.spyOn(extensionApi.process, 'exec').mockImplementation(() =>
-    Promise.resolve({ stdout: JSON.stringify(fakeConnectionJSON) } as extensionApi.RunResult),
-  );
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({
+    stdout: JSON.stringify(fakeConnectionJSON),
+  } as extensionApi.RunResult);
 
   await extension.checkDefaultMachine(fakeJSON);
   expect(extensionApi.window.showInformationMessage).not.toHaveBeenCalled();
@@ -3005,9 +2995,7 @@ describe('sendTelemetryRecords', () => {
 test('if a machine stopped is successfully reporting telemetry', async () => {
   vi.mocked(extensionApi.env).isMac = true;
 
-  const spyExecPromise = vi
-    .spyOn(extensionApi.process, 'exec')
-    .mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+  const spyExecPromise = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
   vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({
     version: '5.1.2',
   });

--- a/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/win-installer.spec.ts
@@ -66,7 +66,7 @@ beforeEach(() => {
 });
 
 test('expect update on windows to show notification in case of 0 exit code', async () => {
-  vi.mocked(extensionApi.process.exec).mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
 
   vi.mocked(existsSync).mockReturnValue(true);
   vi.mocked(readdirSync).mockReturnValue([]);

--- a/extensions/podman/packages/extension/src/utils/util.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/util.spec.ts
@@ -72,9 +72,7 @@ function strEncodeUTF16(str: string): Uint16Array {
 }
 
 test('expect exec called with CONTAINERS_MACHINE_PROVIDER if a provider is defined', async () => {
-  const execMock = vi
-    .spyOn(extensionApi.process, 'exec')
-    .mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+  const execMock = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
 
   await execPodman(['machine', 'inspect'], 'libkrun', {
     env: {
@@ -91,9 +89,7 @@ test('expect exec called with CONTAINERS_MACHINE_PROVIDER if a provider is defin
 });
 
 test('expect exec called without CONTAINERS_MACHINE_PROVIDER if a provider is NOT defined', async () => {
-  const execMock = vi
-    .spyOn(extensionApi.process, 'exec')
-    .mockImplementation(() => Promise.resolve({} as extensionApi.RunResult));
+  const execMock = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
 
   await execPodman(['machine', 'inspect'], undefined, {
     env: {

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
@@ -67,7 +67,7 @@ const configurationRegistry: ConfigurationRegistry = {
 } as unknown as ConfigurationRegistry;
 
 const configurationGetMock = vi.fn();
-const updateMock = vi.fn().mockImplementation(() => Promise.resolve());
+const updateMock = vi.fn().mockResolvedValue(undefined);
 
 const telemetryTrackMock = vi.fn().mockResolvedValue({});
 const telemetry: Telemetry = { track: telemetryTrackMock } as unknown as Telemetry;
@@ -119,9 +119,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   feedbackForm = new TestExperimentalFeatureFeedbackHandler(configurationRegistry, messageBox, telemetry);
 
-  vi.spyOn(feedbackForm, 'save').mockImplementation(() => {
-    return Promise.resolve();
-  });
+  vi.spyOn(feedbackForm, 'save').mockResolvedValue(undefined);
 });
 
 describe('init', () => {
@@ -174,9 +172,7 @@ describe('init', () => {
     configurationGetMock.mockReturnValue(conf);
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
-    const showFeedbackDialogSpy = vi.spyOn(feedbackForm, 'showFeedbackDialog').mockImplementation(() => {
-      return Promise.resolve();
-    });
+    const showFeedbackDialogSpy = vi.spyOn(feedbackForm, 'showFeedbackDialog').mockResolvedValue(undefined);
     await feedbackForm.init();
 
     expect(setReminderSpy).not.toHaveBeenCalled();
@@ -305,9 +301,7 @@ describe('showFeedbackDialog', () => {
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
     vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 1 });
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
-    const openExternalSpy = vi.spyOn(shell, 'openExternal').mockImplementation(() => {
-      return Promise.resolve();
-    });
+    const openExternalSpy = vi.spyOn(shell, 'openExternal').mockResolvedValue(undefined);
 
     feedbackForm.experimentalFeatures = new Map([['feat.feature1', existingTimestamps]]);
     await feedbackForm.showFeedbackDialog();
@@ -324,9 +318,7 @@ describe('showFeedbackDialog', () => {
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
     vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 0, dropdownIndex: 0 });
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
-    const openExternalSpy = vi.spyOn(shell, 'openExternal').mockImplementation(() => {
-      return Promise.resolve();
-    });
+    const openExternalSpy = vi.spyOn(shell, 'openExternal').mockResolvedValue(undefined);
 
     feedbackForm.experimentalFeatures = new Map([['feat.feature1', existingTimestamps]]);
     await feedbackForm.showFeedbackDialog();
@@ -342,9 +334,7 @@ describe('showFeedbackDialog', () => {
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
     vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 0, dropdownIndex: 1 });
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
-    const openExternalSpy = vi.spyOn(shell, 'openExternal').mockImplementation(() => {
-      return Promise.resolve();
-    });
+    const openExternalSpy = vi.spyOn(shell, 'openExternal').mockResolvedValue(undefined);
 
     feedbackForm.experimentalFeatures = new Map([['feat.feature1', existingTimestamps]]);
     await feedbackForm.showFeedbackDialog();
@@ -360,9 +350,7 @@ describe('showFeedbackDialog', () => {
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
     vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 0, dropdownIndex: 2 });
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
-    const openExternalSpy = vi.spyOn(shell, 'openExternal').mockImplementation(() => {
-      return Promise.resolve();
-    });
+    const openExternalSpy = vi.spyOn(shell, 'openExternal').mockResolvedValue(undefined);
 
     feedbackForm.experimentalFeatures = new Map([['feat.feature1', existingTimestamps]]);
     await feedbackForm.showFeedbackDialog();

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -397,7 +397,7 @@ beforeEach(() => {
 vi.mock(import('node:fs'));
 
 beforeEach(() => {
-  telemetryTrackMock.mockImplementation(() => Promise.resolve());
+  telemetryTrackMock.mockResolvedValue(undefined);
   vi.clearAllMocks();
 
   vi.mocked(extensionDevelopmentFolder).getDevelopmentFolders.mockReturnValue([]);
@@ -1517,7 +1517,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const containerExistSpy = vi.spyOn(containerProviderRegistry, 'containerExist');
-    containerExistSpy.mockImplementation(() => Promise.resolve(true));
+    containerExistSpy.mockResolvedValue(true);
 
     // Spy send method
     const sendMock = vi.spyOn(apiSender, 'send');
@@ -1557,7 +1557,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const containerExistSpy = vi.spyOn(containerProviderRegistry, 'containerExist');
-    containerExistSpy.mockImplementation(() => Promise.resolve(false));
+    containerExistSpy.mockResolvedValue(false);
 
     // Call the method provided
     let error = undefined;
@@ -1586,7 +1586,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const imageExistSpy = vi.spyOn(containerProviderRegistry, 'imageExist');
-    imageExistSpy.mockImplementation(() => Promise.resolve(true));
+    imageExistSpy.mockResolvedValue(true);
     // Spy send method
     const sendMock = vi.spyOn(apiSender, 'send');
 
@@ -1611,7 +1611,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const imageExistSpy = vi.spyOn(containerProviderRegistry, 'imageExist');
-    imageExistSpy.mockImplementation(() => Promise.resolve(false));
+    imageExistSpy.mockResolvedValue(false);
 
     // Spy send method
     const sendMock = vi.spyOn(apiSender, 'send');
@@ -1645,7 +1645,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const volumeExistSpy = vi.spyOn(containerProviderRegistry, 'volumeExist');
-    volumeExistSpy.mockImplementation(() => Promise.resolve(true));
+    volumeExistSpy.mockResolvedValue(true);
     // Spy send method
     const sendMock = vi.spyOn(apiSender, 'send');
 
@@ -1669,7 +1669,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const volumeExistSpy = vi.spyOn(containerProviderRegistry, 'volumeExist');
-    volumeExistSpy.mockImplementation(() => Promise.resolve(false));
+    volumeExistSpy.mockResolvedValue(false);
 
     // Spy send method
     const sendMock = vi.spyOn(apiSender, 'send');
@@ -1703,7 +1703,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const podExistSpy = vi.spyOn(containerProviderRegistry, 'podExist');
-    podExistSpy.mockImplementation(() => Promise.resolve(true));
+    podExistSpy.mockResolvedValue(true);
 
     // Spy send method
     const sendMock = vi.spyOn(apiSender, 'send');
@@ -1728,7 +1728,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const podExistSpy = vi.spyOn(containerProviderRegistry, 'podExist');
-    podExistSpy.mockImplementation(() => Promise.resolve(false));
+    podExistSpy.mockResolvedValue(false);
 
     // Spy send method
     const sendMock = vi.spyOn(apiSender, 'send');
@@ -1901,20 +1901,18 @@ test('check listWebviews', async () => {
 
   // Mock listSimpleWebviews implementation
   const listSimpleWebviewsSpy = vi.spyOn(webviewRegistry, 'listSimpleWebviews');
-  listSimpleWebviewsSpy.mockImplementation(() =>
-    Promise.resolve([
-      {
-        id: '123',
-        viewType: 'customView',
-        title: 'customTitle1',
-      },
-      {
-        id: '456',
-        viewType: 'anotherView',
-        title: 'customTitle2',
-      },
-    ]),
-  );
+  listSimpleWebviewsSpy.mockResolvedValue([
+    {
+      id: '123',
+      viewType: 'customView',
+      title: 'customTitle1',
+    },
+    {
+      id: '456',
+      viewType: 'anotherView',
+      title: 'customTitle2',
+    },
+  ]);
   // Call the method provided
   const result = await api.window.listWebviews();
 

--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -530,9 +530,7 @@ test('Check update with empty kubeconfig file', async () => {
 
 test('test that blank kubeconfig path will be set to default one', async () => {
   const client = createTestClient('fooNS');
-  vi.spyOn(client, 'refresh').mockImplementation(() => {
-    return Promise.resolve();
-  });
+  vi.spyOn(client, 'refresh').mockResolvedValue(undefined);
   const setKubeconfigSpy = vi.spyOn(client, 'setKubeconfig');
 
   await client.init();

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -819,9 +819,7 @@ test('open release notes from GitHub', async () => {
 
 test('get release notes', async () => {
   const fetchJSONMock = vi.fn().mockResolvedValue({ data: 'some data' });
-  vi.spyOn(global, 'fetch').mockImplementation(() =>
-    Promise.resolve({ ok: true, json: fetchJSONMock } as unknown as Response),
-  );
+  vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true, json: fetchJSONMock } as unknown as Response);
   vi.mocked(app.getVersion).mockReturnValue('1.1.0');
 
   const updater = new Updater(
@@ -907,9 +905,7 @@ test('get release notes with product override', async () => {
 
 test('get release notes in dev mode', async () => {
   const fetchJSONMock = vi.fn().mockResolvedValue({ data: 'some data' });
-  vi.spyOn(global, 'fetch').mockImplementation(() =>
-    Promise.resolve({ ok: true, json: fetchJSONMock } as unknown as Response),
-  );
+  vi.spyOn(global, 'fetch').mockResolvedValue({ ok: true, json: fetchJSONMock } as unknown as Response);
   vi.mocked(app.getVersion).mockReturnValue('1.1.0-next');
 
   // use dev mode

--- a/packages/preload-webview/src/webview-preload.spec.ts
+++ b/packages/preload-webview/src/webview-preload.spec.ts
@@ -144,7 +144,7 @@ describe('ipcInvoke', () => {
 
     const fakeResult = 'foo';
     // fake remote implementation sending no error and foo as result
-    spyIpcRendererInvoke.mockImplementation(() => Promise.resolve({ result: fakeResult, error: undefined }));
+    spyIpcRendererInvoke.mockResolvedValue({ result: fakeResult, error: undefined });
 
     const result = await webviewPreload.ipcInvoke('test', 'arg1');
 
@@ -158,7 +158,7 @@ describe('ipcInvoke', () => {
 
     const fakeError = new Error('dummy error');
     // fake remote implementation sending no error and foo as result
-    spyIpcRendererInvoke.mockImplementation(() => Promise.resolve({ result: undefined, error: fakeError }));
+    spyIpcRendererInvoke.mockResolvedValue({ result: undefined, error: fakeError });
 
     await expect(webviewPreload.ipcInvoke('test', 'arg1')).rejects.toThrow('dummy error');
 
@@ -287,7 +287,7 @@ test('check buildApi', async () => {
 
   // spy ipcInvoke
   const spyIpcInvoke = vi.spyOn(webviewPreload, 'ipcInvoke');
-  spyIpcInvoke.mockImplementation(() => Promise.resolve({ result: undefined, error: undefined }));
+  spyIpcInvoke.mockResolvedValue({ result: undefined, error: undefined });
 
   // remove spy on buildApi
   spyBuildApi.mockRestore();

--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -90,7 +90,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -63,7 +63,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -32,7 +32,7 @@ const getContributedMenusMock = vi.fn();
 vi.mock(import('./image-utils'), () => {
   return {
     ImageUtils: vi.fn().mockImplementation(() => ({
-      deleteImage: vi.fn().mockImplementation(() => Promise.reject(new Error('Cannot delete image in test'))),
+      deleteImage: vi.fn().mockRejectedValue(new Error('Cannot delete image in test')),
     })),
   };
 });
@@ -51,7 +51,7 @@ beforeAll(() => {
 
   Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
   Object.defineProperty(window, 'hasAuthconfigForImage', {
-    value: vi.fn().mockImplementation(() => Promise.resolve(false)),
+    value: vi.fn().mockResolvedValue(false),
   });
 });
 
@@ -84,7 +84,7 @@ beforeEach(() => {
 
 test('Expect showMessageBox to be called when error occurs', async () => {
   vi.mocked(withConfirmation).mockImplementation(f => f());
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 
   const image: ImageInfoUI = new Image('dummy', 'UNUSED') as unknown as ImageInfoUI;
 
@@ -194,7 +194,7 @@ test('Expect no dropdown when several contributions and dropdownMenu mode on', a
 });
 
 test('Expect Push image to be there', async () => {
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 
   const image: ImageInfoUI = {
     name: 'dummy',
@@ -212,7 +212,7 @@ test('Expect Push image to be there', async () => {
 });
 
 test('Expect Save image to be there', async () => {
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
   const goToMock = vi.spyOn(router, 'goto');
 
   const image: ImageInfoUI = {
@@ -235,7 +235,7 @@ test('Expect Save image to be there', async () => {
 });
 
 test('Expect withConfirmation to indicate image name and tag', async () => {
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 
   const image: ImageInfoUI = {
     name: 'image-name',

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -81,7 +81,7 @@ beforeAll(() => {
 beforeEach(() => {
   imagesInfos.set([]);
   viewsContributions.set([]);
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/image/ManifestActions.spec.ts
+++ b/packages/renderer/src/lib/image/ManifestActions.spec.ts
@@ -41,7 +41,7 @@ beforeAll(() => {
 
   Object.defineProperty(window, 'getContributedMenus', { value: getContributedMenusMock });
   Object.defineProperty(window, 'hasAuthconfigForImage', {
-    value: vi.fn().mockImplementation(() => Promise.resolve(false)),
+    value: vi.fn().mockResolvedValue(false),
   });
 });
 
@@ -61,7 +61,7 @@ test('Expect Delete Manifest to be there', async () => {
 test('Expect Push Manifest to be there', async () => {
   // Mock the showMessageBox to return 0 (yes)
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 
   render(ManifestActions, { manifest: fakedManifest, onPushManifest: vi.fn() });
 

--- a/packages/renderer/src/lib/image/ManifestActions.spec.ts
+++ b/packages/renderer/src/lib/image/ManifestActions.spec.ts
@@ -70,7 +70,7 @@ test('Expect Push Manifest to be there', async () => {
 });
 
 test('Expect withConfirmation to be called with delete variant when clicking Delete Manifest', async () => {
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 
   const manifest: ImageInfoUI = {
     ...fakedManifest,

--- a/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
@@ -38,7 +38,7 @@ beforeEach(() => {
     { Id: 'pod', Ports: [{ PublicPort: 8080 } as Port] as Port[] } as ContainerInfo,
   ]);
 
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -257,7 +257,7 @@ beforeAll(() => {
   };
 
   (window as any).getContributedMenus = getContributedMenusMock;
-  getContributedMenusMock.mockImplementation(() => Promise.resolve([]));
+  getContributedMenusMock.mockResolvedValue([]);
 });
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -249,7 +249,7 @@ describe('CLI Tool item', () => {
   });
 
   test('check version is sent to updateCliTool', async () => {
-    const selectCliToolVersionToUpdateMock = vi.fn().mockImplementation(() => Promise.resolve('1.1.1'));
+    const selectCliToolVersionToUpdateMock = vi.fn().mockResolvedValue('1.1.1');
     (window as any).selectCliToolVersionToUpdate = selectCliToolVersionToUpdateMock;
     render(PreferencesCliTool, {
       cliTool: cliToolInfoItem4,

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -47,7 +47,7 @@ beforeEach(async () => {
   vi.resetAllMocks();
   volumeListInfos.set([]);
 
-  vi.mocked(window.onDidUpdateProviderStatus).mockImplementation(() => Promise.resolve());
+  vi.mocked(window.onDidUpdateProviderStatus).mockResolvedValue(undefined);
   vi.mocked(window.getProviderInfos).mockResolvedValue([]);
   vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
   vi.mocked(window.listVolumes).mockResolvedValue([]);


### PR DESCRIPTION
### What does this PR do?

Enable the `vitest/prefer-mock-promise-shorthand` rule. All the changes are auto fixes from the `pnpm run linter:fix`.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17210

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle: 
