### PR TITLE
fix(main): correct Allow/Deny button response index in auth dialog

### DIFF
--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -129,9 +129,16 @@ test('Authentication creates new auth request when silent is true and session fo
 });
 
 test('Authentication does not create new auth request when silent is true and session exists', async () => {
+  const mb = {
+    showMessageBox: vi
+      .fn()
+      .mockResolvedValueOnce({ response: 1 }) // "Sign In?" dialog: Allow (index 1)
+      .mockResolvedValueOnce({ response: 0 }), // "Allow Access" dialog: Allow (index 0)
+  } as unknown as MessageBox;
+  const authentication = new AuthenticationImpl(apiSender, mb);
   const authProvidrer1 = new AuthenticationProviderSingleAccount();
-  authModule.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvidrer1);
-  const session1 = await authModule.getSession(
+  authentication.registerAuthenticationProvider('company.auth-provider', 'Provider 1', authProvidrer1);
+  const session1 = await authentication.getSession(
     { id: 'ext1', label: 'Ext 2' },
     'company.auth-provider',
     ['scope1', 'scope2'],
@@ -140,7 +147,7 @@ test('Authentication does not create new auth request when silent is true and se
 
   expect(session1).toBeDefined();
 
-  const session2 = await authModule.getSession(
+  const session2 = await authentication.getSession(
     { id: 'ext2', label: 'Ext 2' },
     'company.auth-provider',
     ['scope1', 'scope2'],
@@ -148,7 +155,7 @@ test('Authentication does not create new auth request when silent is true and se
   );
 
   expect(session2).toBeDefined();
-  expect(authModule.getSessionRequests()).length(0);
+  expect(authentication.getSessionRequests()).length(0);
 });
 
 test('Authentication does not create session if user has not allowed it', async () => {
@@ -331,7 +338,9 @@ test('authentication shows confirmation request when signing out from a session'
   );
 
   vi.mocked(mb.showMessageBox).mockReset();
-  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(mb.showMessageBox)
+    .mockResolvedValueOnce({ response: 0 }) // "Allow Access" dialog: Allow (index 0) for ext2
+    .mockResolvedValueOnce({ response: 1 }); // "Sign Out?" dialog: Sign Out (index 1)
 
   await authentication.getSession({ id: 'ext2', label: 'Ext 2' }, 'company.auth-provider', ['scope1', 'scope2'], {
     createIfNone: true,
@@ -455,7 +464,7 @@ test('getSession returns session when extension access is allowed', async () => 
 
 test('getSession prompts for allowance when accessing session without prior decision', async () => {
   const mb = {
-    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }), // User clicks "Allow"
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }), // "Sign In?" dialog: Allow (index 1)
   } as unknown as MessageBox;
   const authentication = new AuthenticationImpl(apiSender, mb);
   const authProvider = new AuthenticationProviderSingleAccount();
@@ -473,7 +482,7 @@ test('getSession prompts for allowance when accessing session without prior deci
 
   // Reset mock to track only the next call
   vi.mocked(mb.showMessageBox).mockClear();
-  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 1 }); // User clicks "Allow"
+  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 0 }); // "Allow Access" dialog: Allow (index 0)
 
   // ext2 tries to access the session - should prompt for allowance
   const sessionForExt2 = await authentication.getSession(
@@ -501,7 +510,7 @@ test('getSession prompts for allowance when accessing session without prior deci
 
 test('getSession denies access when user clicks Deny on allowance prompt but does not store denial', async () => {
   const mb = {
-    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }), // First call: Allow (for createIfNone)
+    showMessageBox: vi.fn().mockResolvedValue({ response: 1 }), // "Sign In?" dialog: Allow (index 1)
   } as unknown as MessageBox;
   const authentication = new AuthenticationImpl(apiSender, mb);
   const authProvider = new AuthenticationProviderSingleAccount();
@@ -519,7 +528,7 @@ test('getSession denies access when user clicks Deny on allowance prompt but doe
 
   // Reset mock - user will click "Deny" this time
   vi.mocked(mb.showMessageBox).mockClear();
-  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 0 }); // User clicks "Deny"
+  vi.mocked(mb.showMessageBox).mockResolvedValue({ response: 1 }); // User clicks "Deny"
 
   // ext2 tries to access the session - user denies
   const sessionForExt2 = await authentication.getSession(

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -338,7 +338,7 @@ export class AuthenticationImpl {
           type: 'info',
         });
 
-        const isAllowed = allowRsp.response === 1;
+        const isAllowed = allowRsp.response === 0;
 
         // Only store allowance when user allows, not when they deny
         // This way, denying will prompt again next time instead of permanently blocking


### PR DESCRIPTION
### What does this PR do?

Fixes the "Allow Access" authentication dialog so that clicking "Allow" actually allows access, and clicking "Deny" actually denies it.

Commit 5a33ac7c621 (#16961) swapped the button order from `['Deny', 'Allow']` to `['Allow', 'Deny']` but did not update the response index check:

```ts
const isAllowed = allowRsp.response === 1;
```

With the new button order, index 0 is "Allow" and index 1 is "Deny", so `response === 1` incorrectly treated Allow clicks as denials and vice versa:

| Button clicked | `response` | Old behavior (correct) | New behavior (broken) |
|---|---|---|---|
| Allow | `0` | — | Treated as **Deny** |
| Deny | `1` | — | Treated as **Allow** |

This broke any extension that calls `authentication.getSession()` to access an existing session from another provider — the user would click "Allow" but the session was never returned, preventing downstream workflows like registry configuration.

The fix changes the check to `allowRsp.response === 0` and updates all affected test mocks to use the correct button indices for each dialog type:

- **"Sign In?" dialog:** `['Cancel', 'Allow']` → response 1 = Allow
- **"Allow Access" dialog:** `['Allow', 'Deny']` → response 0 = Allow
- **"Sign Out?" dialog:** `['Cancel', 'Sign Out']` → response 1 = Sign Out

### What issue does this PR fix?

Fixes redhat-developer/podman-desktop-redhat-account-ext#1143

### How to test this PR?

1. Install the Red Hat SSO extension (v1.0.7)
2. Sign in via SSO authentication
3. When the "Allow Access" dialog appears, click "Allow"
4. Verify the Red Hat Container Registry entry in the Registry page shows as **logged in** with credentials (not showing "Login now")

### Changelog Description

<!-- The text entered here will be added to the release notes / changelog -->

fix: correct inverted Allow/Deny button response in authentication dialog

### Additional information

AI-assisted: Claude helped identify and fix this bug.

Made with [Cursor](https://cursor.com)