### PR TITLE
fix(watch): wait for build completion in getWatcher

### DIFF
--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -56,10 +56,24 @@ const stderrFilterPatterns = [
  * @param {{name: string; configFile: string; writeBundle: import('rollup').OutputPlugin['writeBundle'] }} param0
  */
 const getWatcher = ({ name, configFile, writeBundle }) => {
-  return build({
-    ...sharedConfig,
-    configFile,
-    plugins: [{ name, writeBundle }],
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+    build({
+      ...sharedConfig,
+      configFile,
+      plugins: [
+        {
+          name,
+          writeBundle(...args) {
+            writeBundle?.(...args);
+            if (!resolved) {
+              resolved = true;
+              resolve();
+            }
+          },
+        },
+      ],
+    }).catch(reject);
   });
 };
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes `getWatcher` in the watch script to wait for the first build to actually complete before resolving, instead of resolving as soon as the Vite watcher is set up. This ensures that `@podman-desktop/core-api` output files exist on disk before dependent watchers (preload, main, etc.) start their builds

### What issues does this PR fix or reference?

Fixes #16935 

### How to test this PR?

1. Remove core-api build artifacts: `rm -rf packages/api/dist`
2. Run `pnpm watch`
3. Verify the `Failed to resolve entry for package "@podman-desktop/core-api"` error no longer appears in the console
4. Verify hot reload still works: edit a file in `packages/api/` and confirm the renderer reloads

- [x] Tests are covering the bug fix or the new feature