### PR TITLE
fix(api): support Docker API v1.52+ event format  

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3712,6 +3712,151 @@ test('check handleEvents is not calling the console.log for health_status event'
   expect(consoleLogSpy).not.toBeCalled();
 });
 
+test('check handleEvents with Docker API v1.52+ event shape', async () => {
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      Type: 'container',
+      Action: 'start',
+      Actor: {
+        ID: 'abc123',
+      },
+    }),
+  );
+
+  await vi.waitFor(() => expect(apiSender.send).toBeCalledWith('container-started-event', 'abc123'));
+});
+
+test('check handleEvents normalizes Docker v1.52+ event before emitting to extensions', async () => {
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+  const receivedEvents: unknown[] = [];
+  containerRegistry.onEvent(event => receivedEvents.push(event));
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      Type: 'container',
+      Action: 'stop',
+      Actor: { ID: 'docker29-id' },
+    }),
+  );
+
+  await vi.waitFor(() => expect(receivedEvents.length).toBe(1));
+  expect(receivedEvents[0]).toMatchObject({
+    status: 'stop',
+    id: 'docker29-id',
+    Type: 'container',
+  });
+});
+
+test('check handleEvents does not log Docker compound health_status actions', async () => {
+  const consoleLogSpy = vi.spyOn(console, 'log');
+  consoleLogSpy.mockClear();
+
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      Type: 'container',
+      Action: 'health_status: healthy',
+      Actor: {
+        ID: 'abc123',
+      },
+    }),
+  );
+
+  await vi.waitFor(() => expect(eventsMockCallback).toBeDefined());
+  expect(consoleLogSpy).not.toBeCalled();
+});
+
+test('check handleEvents prefers Podman-style fields over Docker-style fields', async () => {
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  passThrough.emit(
+    'data',
+    JSON.stringify({
+      status: 'stop',
+      id: 'podman-id',
+      Type: 'container',
+      Action: 'start',
+      Actor: { ID: 'docker-id' },
+    }),
+  );
+
+  await vi.waitFor(() => expect(apiSender.send).toBeCalledWith('container-stopped-event', 'podman-id'));
+  expect(apiSender.send).not.toBeCalledWith('container-started-event', 'docker-id');
+});
+
 test('check handleEvents tracks telemetry when stream emits error', async () => {
   telemetryTrackMock.mockClear();
   const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -115,6 +115,8 @@ interface JSONEvent {
   status: string;
   id: string;
   Type?: string;
+  Action?: string;
+  Actor?: { ID: string };
 }
 
 @injectable()
@@ -190,15 +192,17 @@ export class ContainerProviderRegistry {
       // reconnected
       this.notify = true;
 
-      const status = jsonEvent.status;
-      const id = jsonEvent.id;
+      // Podman uses top-level `status`/`id`; Docker API v1.52+ uses `Action`/`Actor.ID` instead.
+      // Docker can emit compound Action values like "health_status: healthy" — keep only the base action.
+      const status = jsonEvent.status ?? jsonEvent.Action?.split(':')[0]?.trim();
+      const id = jsonEvent.id ?? jsonEvent.Actor?.ID;
 
       // do not log healthcheck(health_status) events
       // as it's too verbose/repeating a lot
       if (status !== 'health_status') {
         console.log('event is', jsonEvent);
       }
-      this._onEvent.fire(jsonEvent);
+      this._onEvent.fire({ ...jsonEvent, status: status ?? '', id: id ?? '' });
       if (status === 'stop' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been stopped
         this.apiSender.send('container-stopped-event', id);


### PR DESCRIPTION
### What does this PR do?

Docker Engine 29 (API v1.52+) removed the deprecated top-level `status`, `id` and `from` fields from the `/events` stream, replacing them with `Action` and `Actor.ID`. This broke automatic UI updates — containers, images, volumes and networks stopped refreshing in the dashboard for Docker 29+ users.

This PR adds optional `Action` and `Actor` fields to the internal `JSONEvent` interface, then falls back to these new fields when the old ones are absent. Events are normalized before being emitted to extensions — `status` and `id` are always populated from `Action`/`Actor.ID` when missing — so **no changes are needed to the public `ContainerJSONEvent` extension API**. Docker compound actions like `health_status: healthy` are split to extract the base action.

Both types are kept separate intentionally — [per project convention](https://github.com/podman-desktop/podman-desktop/pull/16403#pullrequestreview-3902774774) the internal type can diverge from the one published to extensions.

Supersedes #16388 (author unresponsive).

### Screenshot / video of UI

<!-- TODO: attach video -->

### What issues does this PR fix or reference?

Fixes #17229
Fixes #17024
Fixes #16405
Fixes #16420
Fixes #16273

### How to test this PR?

1. Install Docker Desktop 4.44+ (Docker Engine 29, API v1.52+)
2. `pnpm watch` from this branch
3. **Test 1 — CLI events reflected in UI:**
   ```bash
   docker run -d --name test-event nginx
   docker stop test-event
   docker start test-event
   docker rm -f test-event
   ```
   Confirm the Containers tab updates in real time for each action.

4. **Test 2 — UI controls work:**
   - `docker run -d --name test-ui nginx`
   - In Podman Desktop, click the stop button on the container
   - Confirm the container shows as stopped
   - Click the start button
   - Confirm the container shows as running again
   - Delete the container from the UI

5. Run unit tests: `pnpm exec vitest run packages/main/src/plugin/container-registry.spec.ts` — 178 tests pass (174 existing + 4 new)

- [x] Tests are covering the bug fix or the new feature

> [!NOTE]
> This PR was authored with AI assistance.