### PR TITLE
chore(test): update the k8s dialog and confirm dialog handling error …

### DIFF
--- a/tests/playwright/src/model/pages/kubernetes-resource-details-page.ts
+++ b/tests/playwright/src/model/pages/kubernetes-resource-details-page.ts
@@ -80,7 +80,7 @@ export class KubernetesResourceDetailsPage extends DetailsPage {
       await playExpect(this.revertChagesButton).toBeEnabled();
       await playExpect(this.applyChangesButton).toBeEnabled();
       await this.applyChangesButton.click();
-      await handleConfirmationDialog(this.page, 'Kubernetes', true, 'OK');
+      await handleConfirmationDialog(this.page, 'Apply Kubernetes YAML', true, 'Dismiss');
     });
   }
 }

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -212,8 +212,9 @@ export async function handleConfirmationDialog(
   // Note: Intentionally not wrapped in test.step to allow proper try-catch handling
   // by callers. test.step has special failure semantics that can interfere with
   // exception handling when this function is used in "try and see" patterns.
+  let errMessage = `Timeout (${timeout} ms) reached waiting for ${dialogTitle} dialog to show up`;
   const dialog = page.getByRole('dialog', { name: dialogTitle, exact: true });
-  await waitUntil(async () => await dialog.isVisible(), { timeout: timeout });
+  await waitUntil(async () => await dialog.isVisible(), { timeout: timeout, message: errMessage });
   const button = confirm
     ? dialog.getByRole('button', { name: confirmationButton })
     : dialog.getByRole('button', { name: cancelButton });
@@ -226,7 +227,8 @@ export async function handleConfirmationDialog(
     await doneButton.click();
   }
 
-  await waitUntil(async () => !(await dialog.isVisible()), { timeout: timeout });
+  errMessage = `Timeout (${timeout} ms) reached waiting for ${dialogTitle} dialog to disolve when clicking: ${confirm ? confirmationButton : cancelButton}`;
+  await waitUntil(async () => !(await dialog.isVisible()), { timeout: timeout, message: errMessage });
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?
Fixes update dialog title name and button text in k8s resources and broken e2e tests and also improves handling of the wait error to be more verbose.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/17241
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
K8s sanity e2e tests should be passing now.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
