### PR TITLE
refactor(renderer): require action-oriented titles for bulk confirmation dialogs

### DIFF
--- a/packages/renderer/src/lib/actions/BulkActions.ts
+++ b/packages/renderer/src/lib/actions/BulkActions.ts
@@ -18,7 +18,7 @@
 
 import { type ConfirmationOptions, withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 
-export function withBulkConfirmation(callback: () => unknown, text: string, options?: ConfirmationOptions): void {
+export function withBulkConfirmation(callback: () => unknown, text: string, options: ConfirmationOptions): void {
   window
     .getConfigurationValue('userConfirmation.bulk')
     .then(confirm => (confirm ? withConfirmation(callback, text, options) : callback()))

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -416,7 +416,7 @@ function label(item: ContainerGroupInfoUI | ContainerInfoUI): string {
               withBulkConfirmation(
                 deleteSelectedContainers,
                 `delete ${selectedItemsNumber} container${selectedItemsNumber > 1 ? 's' : ''}`,
-                { variant:'delete' }
+                { title: 'Delete Containers?', variant:'delete' }
               );
             }
           }}

--- a/packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts
@@ -28,7 +28,7 @@ test('expect withConfirmation call callback if result OK', async () => {
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   const callback = vi.fn();
-  withConfirmation(callback, 'Destroy world');
+  withConfirmation(callback, 'Destroy world', { title: 'Destroy World?' });
 
   await vi.waitFor(() => {
     expect(window.showMessageBox).toHaveBeenCalledOnce();
@@ -40,7 +40,7 @@ test('expect withConfirmation not to call callback if result not OK', async () =
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
 
   const callback = vi.fn();
-  withConfirmation(callback, 'Destroy world');
+  withConfirmation(callback, 'Destroy world', { title: 'Destroy World?' });
 
   await vi.waitFor(() => {
     expect(window.showMessageBox).toHaveBeenCalledOnce();
@@ -53,7 +53,7 @@ test('expect withConfirmation to propagate error', async () => {
   vi.mocked(window.showMessageBox).mockRejectedValue(error);
 
   const callback = vi.fn();
-  withConfirmation(callback, 'Destroy world');
+  withConfirmation(callback, 'Destroy world', { title: 'Destroy World?' });
 
   await vi.waitFor(() => {
     expect(window.showMessageBox).toHaveBeenCalledOnce();
@@ -61,15 +61,15 @@ test('expect withConfirmation to propagate error', async () => {
   });
 });
 
-test('expect withConfirmation to use default variant when no options provided', async () => {
+test('expect withConfirmation to use default variant', async () => {
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   const callback = vi.fn();
-  withConfirmation(callback, 'Destroy world');
+  withConfirmation(callback, 'Destroy world', { title: 'Destroy World?' });
 
   await vi.waitFor(() => {
     expect(window.showMessageBox).toHaveBeenCalledWith({
-      title: 'Confirmation',
+      title: 'Destroy World?',
       message: 'Are you sure you want to Destroy world?',
       buttons: ['Yes', 'Cancel'],
       type: 'question',
@@ -98,11 +98,11 @@ test('expect withConfirmation to use delete variant with Delete button and dange
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   const callback = vi.fn();
-  withConfirmation(callback, 'delete this resource', { variant: 'delete' });
+  withConfirmation(callback, 'delete this resource', { title: 'Delete Resource?', variant: 'delete' });
 
   await vi.waitFor(() => {
     expect(window.showMessageBox).toHaveBeenCalledWith({
-      title: 'Confirmation',
+      title: 'Delete Resource?',
       message: 'Are you sure you want to delete this resource?',
       buttons: ['Delete', 'Cancel'],
       type: 'danger',
@@ -115,11 +115,11 @@ test('expect withConfirmation to use default variant explicitly', async () => {
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
 
   const callback = vi.fn();
-  withConfirmation(callback, 'continue', { variant: 'default', buttonLabel: 'Continue' });
+  withConfirmation(callback, 'continue', { title: 'Continue?', variant: 'default', buttonLabel: 'Continue' });
 
   await vi.waitFor(() => {
     expect(window.showMessageBox).toHaveBeenCalledWith({
-      title: 'Confirmation',
+      title: 'Continue?',
       message: 'Are you sure you want to continue?',
       buttons: ['Continue', 'Cancel'],
       type: 'question',

--- a/packages/renderer/src/lib/dialogs/messagebox-utils.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-utils.ts
@@ -19,7 +19,7 @@ type ConfirmationVariant = 'default' | 'delete';
 
 export interface ConfirmationOptions {
   variant?: ConfirmationVariant;
-  title?: string;
+  title: string;
   buttonLabel?: string;
 }
 
@@ -32,14 +32,10 @@ export interface ConfirmationOptions {
  * @param action the action label to use
  * @param options the options to use for the confirmation dialog
  */
-export function withConfirmation(
-  func: (err?: unknown) => unknown,
-  action: string,
-  options?: ConfirmationOptions,
-): void {
-  const isDelete = options?.variant === 'delete';
-  const activationButton = isDelete ? 'Delete' : (options?.buttonLabel ?? 'Yes');
-  const title = options?.title ?? 'Confirmation';
+export function withConfirmation(func: (err?: unknown) => unknown, action: string, options: ConfirmationOptions): void {
+  const isDelete = options.variant === 'delete';
+  const activationButton = isDelete ? 'Delete' : (options.buttonLabel ?? 'Yes');
+  const title = options.title;
   window
     .showMessageBox({
       title,

--- a/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ListTable.svelte
@@ -75,7 +75,7 @@ function label(extensionFolder: SelectableExtensionDevelopmentFolderInfoUI): str
         withBulkConfirmation(
           deleteSelectedFolders,
           `Untrack loading extension from ${selectedItemsNumber} folder${selectedItemsNumber > 1 ? 's' : ''}`,
-          { variant: 'delete' },
+          { title: 'Untrack Extensions?', variant: 'delete' },
         )}
       title="Untrack {selectedItemsNumber} selected items"
       inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -337,7 +337,7 @@ function label(item: ImageInfoUI): string {
           if (selectedItemsNumber) {withBulkConfirmation(
             deleteSelectedImages,
             `delete ${selectedItemsNumber} image${selectedItemsNumber > 1 ? 's' : ''}`,
-            { variant:'delete' }
+            { title: 'Delete Images?', variant:'delete' }
           );}}}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -141,7 +141,7 @@ function key(network: NetworkInfoUI): string {
           withBulkConfirmation(
             deleteSelectedNetworks,
             `delete ${selectedItemsNumber} network${selectedItemsNumber > 1 ? 's' : ''}`,
-            { variant:'delete' }
+            { title: 'Delete Networks?', variant:'delete' }
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -137,7 +137,7 @@ let selectedItemsNumber = $state<number>(0);
           withBulkConfirmation(
             deleteSelectedObjects,
             `delete ${selectedItemsNumber} ${selectedItemsNumber > 1 ? plural : singular}`,
-            { variant:'delete' }
+            { title: `Delete ${plural.charAt(0).toUpperCase() + plural.slice(1)}?`, variant:'delete' }
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -198,7 +198,7 @@ function label(pod: PodInfoUI): string {
           withBulkConfirmation(
             deleteSelectedPods,
             `delete ${selectedItemsNumber} pod${selectedItemsNumber > 1 ? 's' : ''}`,
-            { variant:'delete' }
+            { title: 'Delete Pods?', variant:'delete' }
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -221,7 +221,7 @@ function label(obj: VolumeInfoUI): string {
           withBulkConfirmation(
             deleteSelectedVolumes,
             `delete ${selectedItemsNumber} volume${selectedItemsNumber > 1 ? 's' : ''}`,
-            { variant: 'delete' }
+            { title: 'Delete Volumes?', variant: 'delete' }
           )}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}

--- a/tests/playwright/src/model/pages/images-page.ts
+++ b/tests/playwright/src/model/pages/images-page.ts
@@ -217,7 +217,7 @@ export class ImagesPage extends MainPage {
 
       await playExpect(this.deleteAllSelectedButton).toBeEnabled();
       await this.deleteAllSelectedButton.click();
-      await handleConfirmationDialog(this.page, 'Confirmation', true, 'Delete');
+      await handleConfirmationDialog(this.page, 'Delete Images?', true, 'Delete');
     });
   }
 

--- a/tests/playwright/src/model/pages/networks-page.ts
+++ b/tests/playwright/src/model/pages/networks-page.ts
@@ -81,7 +81,7 @@ export class NetworksPage extends MainPage {
     return test.step('Delete selected networks', async () => {
       await playExpect(this.deleteSelectedButton).toBeEnabled();
       await this.deleteSelectedButton.click();
-      await handleConfirmationDialog(this.page);
+      await handleConfirmationDialog(this.page, 'Delete Networks?', true, 'Delete');
       return this;
     });
   }

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -202,7 +202,7 @@ export async function deleteNetwork(page: Page, name: string): Promise<void> {
 // Handles dialog that has accessible name `dialogTitle` and either confirms or rejects it.
 export async function handleConfirmationDialog(
   page: Page,
-  dialogTitle = 'Confirmation',
+  dialogTitle: string,
   confirm = true,
   confirmationButton = 'Yes',
   cancelButton = 'Cancel',


### PR DESCRIPTION
### What does this PR do?

Adds explicit action-oriented titles to all seven bulk-delete confirmation dialogs that previously fell through to the generic "Confirmation" default. Makes `title` a required field in `ConfirmationOptions` to prevent future regressions at compile time.

Changes:
- Bulk delete dialogs now show "Delete Containers?", "Delete Images?", "Delete Networks?", "Delete Pods?", "Delete Volumes?", "Delete [Resources]?", and "Untrack Extensions?" instead of "Confirmation"
- `ConfirmationOptions.title` is now required (no longer optional)
- `withConfirmation` and `withBulkConfirmation` require `options` parameter
- Playwright `handleConfirmationDialog` no longer defaults to "Confirmation" - callers must pass explicit dialog titles

### Screenshot / video of UI

No visual changes beyond the dialog title text updating from generic "Confirmation" to action-specific titles like "Delete Containers?".

### What issues does this PR fix or reference?

- Resolves #15958

### How to test this PR?

1. Select multiple containers and click the bulk delete button - verify the dialog title says "Delete Containers?"
2. Repeat for images, pods, volumes, networks - verify each shows the correct "Delete [Resource]?" title
3. Select multiple Kubernetes resources and bulk delete - verify the title uses the correct resource type name
4. Run `pnpm typecheck` - verify no compilation errors
5. Run `pnpm exec vitest run packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts` - verify all 7 tests pass

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>