### PR TITLE
refactor(renderer): remove icon from TroubleshootingPageStoreDetails dialog

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.svelte
@@ -26,10 +26,6 @@ async function fetch(): Promise<void> {
 </script>
 
 <Dialog title="Details of {eventStoreInfo.name}" onclose={closeCallback}>
-  {#snippet icon()}
-    <eventStoreInfo.iconComponent  size="20" />
-  {/snippet}
-
   {#snippet content()}
     <div  class="inline-block w-full overflow-hidden overflow-y-auto text-left transition-all">
       <div class="flex flex-col rounded-lg">


### PR DESCRIPTION
### What does this PR do?

Remove the icon snippet from `TroubleshootingPageStoreDetails`, the last remaining non-semantic icon in `Dialog` components. Recent PRs (#17181, #17186) already addressed other dialog consistency issues.

Of the nine `Dialog` usages in the codebase, only `MessageBox` and `TroubleshootingPageStoreDetails` used icons.

`MessageBox` semantic icons (error, warning, info, question) are retained as they serve a functional purpose following platform conventions.

### Screenshot / video of UI

No structural UI changes beyond removing the dynamic icon from the store details dialog header.

### What issues does this PR fix or reference?

- Resolves #15955

### How to test this PR?

1. Navigate to Troubleshooting → Stores tab
2. Click on any store to open the details dialog
3. Verify the dialog opens without an icon
4. Verify title is properly aligned
5. Verify dialog functionality unchanged
6. Test in both light and dark themes
7. Run `pnpm exec vitest run packages/renderer/src/lib/troubleshooting/TroubleshootingPageStoreDetails.spec.ts` - four tests pass

- [x] Tests are covering the bug fix or the new feature