### PR TITLE
chore(test): update network-smoke container state expectation for Pod…

### DIFF
--- a/tests/playwright/src/specs/network-smoke.spec.ts
+++ b/tests/playwright/src/specs/network-smoke.spec.ts
@@ -142,9 +142,8 @@ test.describe
       await playExpect(containerDetails.heading).toContainText(testContainerName);
 
       await containerDetails.stopContainer();
-      await playExpect
-        .poll(async () => await containerDetails.getState(), { timeout: 30_000 })
-        .toBe(ContainerState.Exited);
+      const regexp = new RegExp(`${ContainerState.Stopped}|${ContainerState.Exited}`);
+      await playExpect.poll(async () => await containerDetails.getState(), { timeout: 30_000 }).toMatch(regexp);
 
       const updatedContainersPage = await containerDetails.deleteContainer();
       await playExpect(updatedContainersPage.heading).toBeVisible();


### PR DESCRIPTION
…man nightly

### What does this PR do?
It makes networking e2e test more robust. Containers might end up in exited/stopped state depending on the platform and some other circumstances (not investigated). Since it is not part of the test, we should make test more robust by adding a regexp for a possible container stop/exit states. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/17259
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
