### PR TITLE
chore(kind): remove tmp-promise dependency and replace with Node.js b…

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -119,7 +119,6 @@
   "devDependencies": {
     "adm-zip": "^0.5.17",
     "mkdirp": "^3.0.1",
-    "tmp-promise": "^3.0.3",
     "tsx": "^4.21.0",
     "vite": "^7.3.2",
     "vitest": "^4.1.5"

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -22,7 +22,6 @@ import * as path from 'node:path';
 
 import type { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
-import { tmpName } from 'tmp-promise';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { KindGithubReleaseArtifactMetadata } from './kind-installer';
@@ -71,8 +70,8 @@ beforeEach(() => {
 test.skip('expect installBinaryToSystem to succesfully pass with a binary', async () => {
   (extensionApi.env.isLinux as unknown as boolean) = true;
 
-  // Create a tmp file using tmp-promise
-  const filename = await tmpName();
+  // Create a tmp file using Node.js built-ins
+  const filename = path.join(os.tmpdir(), 'kind-tmp-binary');
 
   // "Install" the binary, this should pass sucessfully
   await expect(() => util.installBinaryToSystem(filename, 'tmpBinary')).rejects.toThrowError();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,9 +305,6 @@ importers:
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
-      tmp-promise:
-        specifier: ^3.0.3
-        version: 3.0.3
       tsx:
         specifier: ^4.21.0
         version: 4.21.0


### PR DESCRIPTION
### What does this PR do?

Removes the `tmp-promise` third-party library from the kind extension and replaces it with Node.js built-ins (`node:os`, `node:path`, `node:crypto`). The library was only used in test files and one production file (`image-handler.ts`) to generate temporary file paths — functionality that's natively available without an extra dependency.

### What issues does this PR fix or reference?

Closes #16970
Fixes #16986 

### How to test this PR?

Run the kind extension unit tests — everything should pass as before:

```bash
pnpm --filter kind test