### PR TITLE
fix(main): use product appId for Windows AppUserModelId

### DIFF
--- a/packages/main/src/main.spec.ts
+++ b/packages/main/src/main.spec.ts
@@ -102,7 +102,7 @@ test('on windows setAppUserModelId should be called', async () => {
   const code = new Main(ELECTRON_APP_MOCK);
   code.main([]);
 
-  expect(ELECTRON_APP_MOCK.setAppUserModelId).toHaveBeenCalledWith(ELECTRON_APP_MOCK.name);
+  expect(ELECTRON_APP_MOCK.setAppUserModelId).toHaveBeenCalledWith('io.podman_desktop.PodmanDesktop');
 });
 
 describe('gtk-version', () => {

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -101,7 +101,7 @@ export class Main implements IDisposable {
      *  @see https://www.electronjs.org/docs/latest/api/app#appsetappusermodelidid-windows
      */
     if (isWindows()) {
-      this.app.setAppUserModelId(this.app.name);
+      this.app.setAppUserModelId(product.appId);
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

Fixes the Windows notification title showing "Electron" and the wrong taskbar icon by aligning the runtime `AppUserModelId` with the one registered by the NSIS installer.

The installer registers `io.podman_desktop.PodmanDesktop` (from `product.json` `appId`), but `setAppUserModelId` was called with `app.name` (`podman-desktop`). This mismatch causes Windows to fall back to the Electron executable identity for notifications and taskbar grouping.

### Screenshot / video of UI

<img width="2628" height="1389" alt="Screenshot 2026-04-27 at 18 24 29" src="https://github.com/user-attachments/assets/c597df6e-daac-4060-a258-b65182a38e58" />

### What issues does this PR fix or reference?

Fixes #16658

### How to test this PR?

1. Build for Windows (`pnpm compile:current` on Windows, or download the artifact from CI)
2. Install the built `.exe`
3. Trigger a notification (e.g. uninstall Podman, open PD)
4. Notification should show "Podman Desktop" instead of "Electron"
5. Taskbar icon should display the correct Podman Desktop icon

### Conformance

- [x] The PR has a clear and descriptive title
- [x] The PR has a description that explains the changes
- [x] The PR has tests (unit / e2e) that cover the changes

Made with [Cursor](https://cursor.com)