### PR TITLE
fix(deps): use caret range for TypeScript in root package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "minimist": "^1.2.8",
     "msw": "^2.13.6",
     "prettier": "^3.8.3",
-    "typescript": "5.9.3",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.1",
     "vite": "^7.3.2",
     "mustache": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,7 +207,7 @@ importers:
         specifier: ^3.8.3
         version: 3.8.3
       typescript:
-        specifier: 5.9.3
+        specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.59.1


### PR DESCRIPTION
### What does this PR do?

Changes the root `package.json` TypeScript dependency from an exact pin (`"5.9.3"`) to a caret range (`"^5.9.3"`), matching all other workspace packages.

### Screenshot / video of UI

N/A — no UI changes.

### What issues does this PR fix or reference?

Required for #17248

### How to test this PR?

After merging, monitor Dependabot for TypeScript update PRs.

- [ ] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)