### PR TITLE
docs(website): update footer to LF Projects Series LLC disclaimer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -535,10 +535,9 @@ const config = {
             </div>
             <div class="text-sm">
               <p class="mb-1">We are a <a href="https://cncf.io/" class="underline">Cloud Native Computing Foundation</a> sandbox project.</p>
-              <p class="mb-1">© Copyright Podman Desktop Contributors ${new Date().getFullYear()}. © ${new Date().getFullYear()} The Linux Foundation. All rights reserved.</p>
-              <p class="mb-1">The Linux Foundation has registered trademarks and uses trademarks.
-              For a list of trademarks of The Linux Foundation, please see our
-              <a href="https://www.linuxfoundation.org/trademark-usage/" class="underline"> Trademark Usage</a> page.</p>
+              <p class="mb-1">© ${new Date().getFullYear()} Podman Desktop, a Series of LF Projects, LLC.</p>
+              <p class="mb-1">For website terms of use, trademark policy and other project policies please see
+              <a href="https://lfprojects.org/policies/" class="underline">lfprojects.org/policies</a>.</p>
             </div>
           </div>
       `,


### PR DESCRIPTION
### What does this PR do?

Updates the website footer copyright and trademark disclaimer to reflect that Podman Desktop is now a Series of LF Projects, LLC, as requested by the CNCF projects team.

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17277

### How to test this PR?

1. Run the website locally: `cd website && pnpm start`
2. Scroll to the footer
3. Verify the new copyright line reads

- [x] Tests are covering the bug fix or the new feature