### PR TITLE
feat(main): create a task when installing an extension

### DIFF
--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -23,7 +23,7 @@ import type { ExtensionInfo } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { CatalogFetchableExtension } from '@podman-desktop/core-api/extension-catalog';
 import type { IpcMain, IpcMainEvent } from 'electron';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
 import type { Directories } from '/@/plugin/directories.js';
@@ -31,6 +31,7 @@ import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-c
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import type { ImageRegistry } from '/@/plugin/image-registry.js';
+import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
 import { ExtensionInstaller } from './extension-installer.js';
@@ -83,11 +84,22 @@ const directories = {
 const contributionManager = {} as unknown as ContributionManager;
 const ipcMainOnMock = vi.fn();
 
+const createTaskMock = vi.fn();
+const taskManager = {
+  createTask: createTaskMock,
+} as unknown as TaskManager;
+
 vi.mock(import('node:fs'));
 vi.mock(import('/@/plugin/docker-extension/docker-desktop-installer.js'));
 
 beforeEach(() => {
   vi.resetAllMocks();
+
+  createTaskMock.mockReturnValue({
+    status: 'in-progress',
+    progress: undefined,
+    error: undefined,
+  });
 
   vi.mocked(rmSync).mockReturnValue(undefined);
   vi.mocked(directories.getPluginsDirectory).mockReturnValue('/fake/plugins/directory');
@@ -101,7 +113,40 @@ beforeEach(() => {
     directories,
     contributionManager,
     ipcMainOnMock,
+    taskManager,
   );
+});
+
+describe('installFromImage task lifecycle', () => {
+  const imageToPull = 'fake.io/fake-image:fake-tag';
+
+  test('should create a task with the image name on success', async () => {
+    getImageConfigLabelsMock.mockResolvedValueOnce({
+      'org.opencontainers.image.title': 'title',
+      'org.opencontainers.image.description': 'desc',
+      'org.opencontainers.image.vendor': 'vendor',
+      'io.podman-desktop.api.version': '1.0.0',
+    });
+    listExtensionsMock.mockResolvedValueOnce([]);
+    vi.spyOn(extensionInstaller, 'extractExtensionFiles').mockResolvedValueOnce();
+    analyzeExtensionMock.mockResolvedValueOnce({ manifest: {} } as AnalyzedExtension);
+
+    await extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageToPull);
+
+    expect(createTaskMock).toHaveBeenCalledWith({ title: `Installing extension ${imageToPull}` });
+    const task = createTaskMock.mock.results[0]?.value;
+    expect(task.status).toBe('success');
+  });
+
+  test('should mark task as failed when installation errors', async () => {
+    getImageConfigLabelsMock.mockRejectedValueOnce(new Error('network failure'));
+
+    await extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageToPull);
+
+    expect(createTaskMock).toHaveBeenCalledWith({ title: `Installing extension ${imageToPull}` });
+    const task = createTaskMock.mock.results[0]?.value;
+    expect(task.error).toBe('Error while analyzing image: Error: network failure');
+  });
 });
 
 test('should install an image if labels are correct', async () => {

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -37,6 +37,7 @@ import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalo
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ImageRegistry } from '/@/plugin/image-registry.js';
+import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
 @injectable()
@@ -60,6 +61,8 @@ export class ExtensionInstaller {
     contributionManager: ContributionManager,
     @inject(IPCMainOn)
     private readonly ipcMainOn: IPCMainOn,
+    @inject(TaskManager)
+    private taskManager: TaskManager,
   ) {
     this.#dockerDesktopInstaller = new DockerDesktopInstaller(contributionManager);
   }
@@ -302,6 +305,42 @@ export class ExtensionInstaller {
   }
 
   async installFromImage(
+    sendLog: (message: string) => void,
+    sendError: (message: string) => void,
+    sendEnd: (message: string) => void,
+    imageName: string,
+    extensionAnalyzed?: (extension: AnalyzedExtension) => void,
+    catalogExtensionId?: string,
+  ): Promise<void> {
+    const task = this.taskManager.createTask({
+      title: `Installing extension ${imageName}`,
+    });
+
+    const wrappedSendError = (message: string): void => {
+      sendError(message);
+      task.error = message;
+    };
+
+    try {
+      await this.doInstallFromImage(
+        sendLog,
+        wrappedSendError,
+        sendEnd,
+        imageName,
+        extensionAnalyzed,
+        catalogExtensionId,
+      );
+    } catch (error: unknown) {
+      task.error = String(error);
+      throw error;
+    } finally {
+      if (!task.error) {
+        task.status = 'success';
+      }
+    }
+  }
+
+  protected async doInstallFromImage(
     sendLog: (message: string) => void,
     sendError: (message: string) => void,
     sendEnd: (message: string) => void,


### PR DESCRIPTION
### What does this PR do?

Creates a dedicated task in the Task Manager when installing an extension from the catalog or manually via OCI image. This lets users track the installation status even after navigating away from the catalog page.

- A task titled "Installing extension \<image\>" is created at the start of `installFromImage`
- On success the task is marked as `success`
- On error the task captures the error message and is marked as `failure`

### Screenshot / video of UI

https://github.com/user-attachments/assets/a4a23e97-5683-463a-a7f4-a5179f111088

### What issues does this PR fix or reference?

Closes #17296
Part of #17054

### How to test this PR?

1. Open Podman Desktop and go to the Extensions catalog
2. Install any extension (e.g. from the featured list or manually via OCI image)
3. Open the Task Manager — verify a task appears for the installation
4. On success, the task should show a green checkmark
5. To test the error path, try installing a non-existent image and verify the task shows the error

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)