### PR TITLE
feat(main): wire download progress into task during extension installation

### DIFF
--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -154,7 +154,9 @@ export async function downloadExtension(options: DownloadOptions): Promise<void>
     }
   }
 
-  await imageRegistry.downloadAndExtractImage(options.extension.oci, tmpFolderPath, console.log);
+  await imageRegistry.downloadAndExtractImage(options.extension.oci, tmpFolderPath, event =>
+    console.log(event.message),
+  );
 
   if (!existsSync(join(tmpFolderPath, 'extension', 'package.json'))) {
     throw new Error(

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -536,7 +536,7 @@ export class ImageRegistry {
   async downloadAndExtractImage(
     imageName: string,
     destFolder: string,
-    logger: (message: string) => void,
+    logger: (event: { message: string; progress: number }) => void,
   ): Promise<void> {
     const imageData = this.extractImageDataFromImageName(imageName);
 
@@ -608,7 +608,7 @@ export class ImageRegistry {
     token: string,
     currentDownloaded: number,
     totalSize: number,
-    logger: (message: string) => void,
+    logger: (event: { message: string; progress: number }) => void,
   ): Promise<void> {
     const options = this.getOptions();
     options.headers = options.headers ?? {};
@@ -638,9 +638,10 @@ export class ImageRegistry {
 
     readStream.on('downloadProgress', ({ transferred }) => {
       const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
-      logger(
-        `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
-      );
+      logger({
+        message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
+        progress: globalPercentage,
+      });
     });
     await pipeline(readStream, createWriteStream(tmpFileName));
     // in case of zstd, we need to unpack the file first

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -138,6 +138,30 @@ describe('installFromImage task lifecycle', () => {
     expect(task.status).toBe('success');
   });
 
+  test('should update task.progress during image download', async () => {
+    getImageConfigLabelsMock.mockResolvedValueOnce({
+      'org.opencontainers.image.title': 'title',
+      'org.opencontainers.image.description': 'desc',
+      'org.opencontainers.image.vendor': 'vendor',
+      'io.podman-desktop.api.version': '1.0.0',
+    });
+    listExtensionsMock.mockResolvedValueOnce([]);
+    vi.spyOn(extensionInstaller, 'extractExtensionFiles').mockResolvedValueOnce();
+    analyzeExtensionMock.mockResolvedValueOnce({ manifest: {} } as AnalyzedExtension);
+
+    downloadAndExtractImageMock.mockImplementation(
+      async (_image: string, _dest: string, logger: (event: { message: string; progress: number }) => void) => {
+        logger({ message: 'Downloading layer 1/2', progress: 50 });
+        logger({ message: 'Downloading layer 2/2', progress: 100 });
+      },
+    );
+
+    await extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageToPull);
+
+    const task = createTaskMock.mock.results[0]?.value;
+    expect(task.progress).toBe(100);
+  });
+
   test('should mark task as failed when installation errors', async () => {
     getImageConfigLabelsMock.mockRejectedValueOnce(new Error('network failure'));
 

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -115,6 +115,7 @@ export class ExtensionInstaller {
     sendError: (message: string) => void,
     imageName: string,
     catatlogExtensionId?: string,
+    onProgress?: (progress: number) => void,
   ): Promise<AnalyzedExtension | DockerDesktopContribution | undefined> {
     imageName = imageName.trim();
     sendLog(`Analyzing image ${imageName}...`);
@@ -190,7 +191,10 @@ export class ExtensionInstaller {
     }
 
     sendLog('Downloading and extract layers...');
-    await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, sendLog);
+    await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, event => {
+      sendLog(event.message);
+      onProgress?.(event.progress);
+    });
 
     sendLog('Filtering image content...');
     if (isPDExtension) {
@@ -329,6 +333,9 @@ export class ExtensionInstaller {
         imageName,
         extensionAnalyzed,
         catalogExtensionId,
+        (progress: number) => {
+          task.progress = progress;
+        },
       );
     } catch (error: unknown) {
       task.error = String(error);
@@ -347,11 +354,18 @@ export class ExtensionInstaller {
     imageName: string,
     extensionAnalyzed?: (extension: AnalyzedExtension) => void,
     catalogExtensionId?: string,
+    onProgress?: (progress: number) => void,
   ): Promise<void> {
     // now collect all transitive dependencies
     const analyzedExtensions: AnalyzedExtension[] = [];
     const errors: string[] = [];
-    const analyzedExtension = await this.analyzeFromImage(sendLog, sendError, imageName, catalogExtensionId);
+    const analyzedExtension = await this.analyzeFromImage(
+      sendLog,
+      sendError,
+      imageName,
+      catalogExtensionId,
+      onProgress,
+    );
     if (analyzedExtension instanceof DockerDesktopContribution) {
       sendEnd('Docker Desktop Extension Successfully installed.');
       return;


### PR DESCRIPTION
### What does this PR do?

- Changes the `downloadAndExtractImage` logger to a structured callback `(event: { message: string; progress: number }) => void`
- Wires `event.progress` into `task.progress` so the Task Manager shows a live download percentage during extension installation

### Screenshot / video of UI

<img width="1817" height="1263" alt="Screenshot 2026-05-04 at 15 49 21" src="https://github.com/user-attachments/assets/9b6b2049-e678-4c56-b22d-52a6e3bf976d" />

### What issues does this PR fix or reference?

Closes #17294
Part of #17054

Depends on #17292.

### How to test this PR?

1. Install an extension from the catalog or manually via OCI image
2. Open the Task Manager — verify the progress bar fills during download
3. On completion, verify the task shows success/failure

- [x] Unit test: `should update task.progress during image download`
- [ ] Manual: verify the Task Manager shows a progress bar filling during download