### PR TITLE
refactor(main): use structured progress callback in downloadAndExtractImage

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -536,7 +536,7 @@ export class ImageRegistry {
   async downloadAndExtractImage(
     imageName: string,
     destFolder: string,
-    logger: (message: string) => void,
+    logger: (event: { message: string; progress: number }) => void,
   ): Promise<void> {
     const imageData = this.extractImageDataFromImageName(imageName);
 
@@ -608,7 +608,7 @@ export class ImageRegistry {
     token: string,
     currentDownloaded: number,
     totalSize: number,
-    logger: (message: string) => void,
+    logger: (event: { message: string; progress: number }) => void,
   ): Promise<void> {
     const options = this.getOptions();
     options.headers = options.headers ?? {};
@@ -638,9 +638,10 @@ export class ImageRegistry {
 
     readStream.on('downloadProgress', ({ transferred }) => {
       const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
-      logger(
-        `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
-      );
+      logger({
+        message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
+        progress: globalPercentage,
+      });
     });
     await pipeline(readStream, createWriteStream(tmpFileName));
     // in case of zstd, we need to unpack the file first

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -110,6 +110,7 @@ export class ExtensionInstaller {
   async analyzeFromImage(
     sendLog: (message: string) => void,
     sendError: (message: string) => void,
+    onProgress: (progress: number) => void,
     imageName: string,
     catatlogExtensionId?: string,
   ): Promise<AnalyzedExtension | DockerDesktopContribution | undefined> {
@@ -187,7 +188,10 @@ export class ExtensionInstaller {
     }
 
     sendLog('Downloading and extract layers...');
-    await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, sendLog);
+    await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, event => {
+      sendLog(event.message);
+      onProgress(event.progress);
+    });
 
     sendLog('Filtering image content...');
     if (isPDExtension) {
@@ -235,6 +239,7 @@ export class ExtensionInstaller {
     errors: string[],
     sendLog: (message: string) => void,
     sendError: (message: string) => void,
+    onProgress: (progress: number) => void,
   ): Promise<boolean> {
     if (!analyzedExtension) {
       return false;
@@ -287,12 +292,19 @@ export class ExtensionInstaller {
       // now analyze all these dependencies
       for (const imageNameToAnalyze of imagesOfExtensionsToAnalyze) {
         try {
-          const imageToAnalyze = await this.analyzeFromImage(sendLog, sendError, imageNameToAnalyze);
+          const imageToAnalyze = await this.analyzeFromImage(sendLog, sendError, onProgress, imageNameToAnalyze);
 
           if (!imageToAnalyze || imageToAnalyze instanceof DockerDesktopContribution) {
             return false;
           }
-          await this.analyzeTransitiveDependencies(imageToAnalyze, analyzedExtensions, errors, sendLog, sendError);
+          await this.analyzeTransitiveDependencies(
+            imageToAnalyze,
+            analyzedExtensions,
+            errors,
+            sendLog,
+            sendError,
+            onProgress,
+          );
         } catch (error) {
           errors.push(`Error while analyzing extension ${imageNameToAnalyze}: ${error}`);
         }
@@ -305,6 +317,7 @@ export class ExtensionInstaller {
     sendLog: (message: string) => void,
     sendError: (message: string) => void,
     sendEnd: (message: string) => void,
+    onProgress: (progress: number) => void,
     imageName: string,
     extensionAnalyzed?: (extension: AnalyzedExtension) => void,
     catalogExtensionId?: string,
@@ -312,7 +325,13 @@ export class ExtensionInstaller {
     // now collect all transitive dependencies
     const analyzedExtensions: AnalyzedExtension[] = [];
     const errors: string[] = [];
-    const analyzedExtension = await this.analyzeFromImage(sendLog, sendError, imageName, catalogExtensionId);
+    const analyzedExtension = await this.analyzeFromImage(
+      sendLog,
+      sendError,
+      onProgress,
+      imageName,
+      catalogExtensionId,
+    );
     if (analyzedExtension instanceof DockerDesktopContribution) {
       sendEnd('Docker Desktop Extension Successfully installed.');
       return;
@@ -326,6 +345,7 @@ export class ExtensionInstaller {
       errors,
       sendLog,
       sendError,
+      onProgress,
     );
 
     // if we have some undefined objects, it is an error, cleanup extensions
@@ -376,13 +396,17 @@ export class ExtensionInstaller {
           event.reply('extension-installer:install-from-image-end', logCallbackId, message);
         };
 
+        const sendProgress = (progress: number): void => {
+          event.reply('extension-installer:install-from-image-progress', logCallbackId, progress);
+        };
+
         const extAnalyzed = (extension: AnalyzedExtension): void => {
           if (extension) {
             telemetryData.extensionId = extension.id;
           }
         };
 
-        this.installFromImage(sendLog, sendError, sendEnd, imageName, extAnalyzed, catalogExtensionId)
+        this.installFromImage(sendLog, sendError, sendEnd, sendProgress, imageName, extAnalyzed, catalogExtensionId)
           .catch((error: unknown) => {
             sendError('' + error);
             telemetryData.error = `${error}`;


### PR DESCRIPTION
### What does this PR do?

- Changes the `downloadAndExtractImage` / `fetchAndExtractLayer` logger callback from `(message: string) => void` to `(event: { message: string; progress: number }) => void`
- Threads an `onProgress` callback through `installFromImage` and `analyzeFromImage` so download progress is available to upstream callers

### What issues does this PR fix or reference?

Closes #17293
Part of #17054

### How to test this PR?

1. Install an extension from the catalog or manually via OCI image
2. Verify installation completes successfully
3. Verify existing unit tests pass

- [x] Tests are covering the bug fix or the new feature