### PR TITLE
feat(renderer): add telemetry tracking to SystemOverviewCard

### DIFF
--- a/packages/renderer/src/lib/dashboard/SystemOverview.spec.ts
+++ b/packages/renderer/src/lib/dashboard/SystemOverview.spec.ts
@@ -55,3 +55,22 @@ test('should call updateConfigurationValue when toggle is triggered', async () =
   await waitFor(() => expect(window.updateConfigurationValue).toHaveBeenCalled());
   await waitFor(() => expect(window.updateConfigurationValue).toHaveBeenCalledWith('systemOverview.expanded', false));
 });
+
+test('should track dashboard.healthCard.collapsed telemetry when collapsing', async () => {
+  render(SystemOverview);
+
+  const expandButton = await waitFor(() => screen.getByRole('button', { name: 'System Overview' }));
+  await fireEvent.click(expandButton);
+
+  await waitFor(() => expect(window.telemetryTrack).toHaveBeenCalledWith('dashboard.healthCard.collapsed'));
+});
+
+test('should track dashboard.healthCard.expanded telemetry when expanding', async () => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+  render(SystemOverview);
+
+  const expandButton = await waitFor(() => screen.getByRole('button', { name: 'System Overview' }));
+  await fireEvent.click(expandButton);
+
+  await waitFor(() => expect(window.telemetryTrack).toHaveBeenCalledWith('dashboard.healthCard.expanded'));
+});

--- a/packages/renderer/src/lib/dashboard/SystemOverviewContent.spec.ts
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewContent.spec.ts
@@ -156,3 +156,44 @@ test('should navigate to Resources on overall status button click', async () => 
 
   await vi.waitFor(() => expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/resources'));
 });
+
+describe('telemetry', () => {
+  test('should track dashboard.healthCard.viewed on mount with no connections', async () => {
+    providerInfos.set([baseProvider]);
+    render(SystemOverviewContent);
+
+    await vi.waitFor(() =>
+      expect(window.telemetryTrack).toHaveBeenCalledWith('dashboard.healthCard.viewed', {
+        itemCount: 0,
+        healthyCount: 0,
+        issueCount: 0,
+      }),
+    );
+  });
+
+  test('should track dashboard.healthCard.viewed with correct counts for mixed connections', async () => {
+    const errorConnection: ProviderContainerConnectionInfo = {
+      ...containerConnection,
+      name: 'error-machine',
+      displayName: 'Error Machine',
+      status: 'stopped',
+      error: 'Connection refused',
+    };
+
+    const provider: ProviderInfo = {
+      ...baseProvider,
+      containerConnections: [containerConnection, errorConnection],
+      kubernetesConnections: [kubernetesConnection],
+    };
+    providerInfos.set([provider]);
+    render(SystemOverviewContent);
+
+    await vi.waitFor(() =>
+      expect(window.telemetryTrack).toHaveBeenCalledWith('dashboard.healthCard.viewed', {
+        itemCount: 3,
+        healthyCount: 2,
+        issueCount: 1,
+      }),
+    );
+  });
+});

--- a/packages/renderer/src/lib/dashboard/SystemOverviewContent.svelte
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewContent.svelte
@@ -7,6 +7,7 @@ import {
   type ProviderInfo,
 } from '@podman-desktop/core-api';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { onMount } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
 import SystemOverviewProviderCardCompact from '/@/lib/dashboard/SystemOverviewProviderCardCompact.svelte';
@@ -44,6 +45,18 @@ let nonContainerConnectionsWithProvider = $derived.by(() => {
     }
   }
   return result;
+});
+
+onMount(async () => {
+  const allConnections = [
+    ...containerConnectionsWithProvider.map(c => c.connection),
+    ...nonContainerConnectionsWithProvider.map(c => c.connection),
+  ];
+  await window.telemetryTrack('dashboard.healthCard.viewed', {
+    itemCount: allConnections.length,
+    healthyCount: allConnections.filter(c => c.status === 'started' && !c.error).length,
+    issueCount: allConnections.filter(c => c.error).length,
+  });
 });
 
 // Go through all containers and find the matching label to a connection name.

--- a/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardDetailed.spec.ts
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardDetailed.spec.ts
@@ -258,3 +258,23 @@ test('should navigate to container connection on View button click', async () =>
     ),
   );
 });
+
+test('should track dashboard.healthCard.provider.started telemetry when starting a connection', async () => {
+  vi.mocked(window.startProviderConnectionLifecycle).mockResolvedValue(undefined);
+  const stoppedConnection = { ...containerConnection, status: 'stopped' as const };
+  const provider = { ...baseProvider, canStart: true, containerConnections: [stoppedConnection] };
+  render(SystemOverviewProviderCardDetailed, {
+    connection: stoppedConnection,
+    provider,
+    childConnections: [],
+  });
+
+  const button = await vi.waitFor(() => screen.getByRole('button', { name: 'Start Podman' }));
+  await fireEvent.click(button);
+
+  await vi.waitFor(() =>
+    expect(window.telemetryTrack).toHaveBeenCalledWith('dashboard.healthCard.provider.started', {
+      providerName: 'Podman',
+    }),
+  );
+});

--- a/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardDetailed.svelte
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardDetailed.svelte
@@ -80,6 +80,7 @@ async function handleActionButtonClick(): Promise<void> {
     const canStart = (connection.status === 'stopped' || !!connection.error) && hasStartLifecycle(provider);
     if (canStart) {
       await startConnection(provider.internalId, $state.snapshot(connection));
+      await window.telemetryTrack('dashboard.healthCard.provider.started', { providerName: provider.name });
     } else {
       navigateToConnection();
     }

--- a/packages/renderer/src/lib/dashboard/SystemOverviewProviderSetup.spec.ts
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewProviderSetup.spec.ts
@@ -137,6 +137,19 @@ describe('configured provider', () => {
     await vi.waitFor(() => expect(window.startProvider).toHaveBeenCalledWith('podman-internal'));
   });
 
+  test('should track dashboard.healthCard.provider.started telemetry when starting a provider', async () => {
+    render(SystemOverviewProviderSetup, { provider: configuredProvider });
+
+    const button = screen.getByRole('button', { name: 'Start Podman' });
+    await fireEvent.click(button);
+
+    await vi.waitFor(() =>
+      expect(window.telemetryTrack).toHaveBeenCalledWith('dashboard.healthCard.provider.started', {
+        providerName: 'Podman',
+      }),
+    );
+  });
+
   test('should render View button instead of Start for remote machine without lifecycle methods', async () => {
     const remoteProvider: ProviderInfo = {
       ...baseProvider,

--- a/packages/renderer/src/lib/dashboard/SystemOverviewProviderSetup.svelte
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewProviderSetup.svelte
@@ -31,6 +31,7 @@ function handleClick(): void {
     startInProgress = true;
     window
       .startProvider(provider.internalId)
+      .then(() => window.telemetryTrack('dashboard.healthCard.provider.started', { providerName: provider.name }))
       .catch((err: unknown) => console.error('Provider failed to start:', err))
       .finally(() => (startInProgress = false));
   } else {

--- a/packages/renderer/src/lib/ui/expandable-state.svelte.ts
+++ b/packages/renderer/src/lib/ui/expandable-state.svelte.ts
@@ -61,5 +61,6 @@ export class ExpandableState {
 
   async toggle(value: boolean): Promise<void> {
     await window.updateConfigurationValue(this.#configurationKey, value);
+    await window.telemetryTrack(`dashboard.healthCard.${value ? 'expanded' : 'collapsed'}`);
   }
 }


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Adds telemetry tracking to the dashboard System Overview components:

- `dashboard.healthCard.viewed` — fired on mount with `{ itemCount, healthyCount, issueCount }`
- `dashboard.healthCard.expanded` / `dashboard.healthCard.collapsed` — fired when the user toggles the card
- `dashboard.healthCard.provider.started` — fired when the user starts a container engine provider

**Not implemented** (no corresponding UI actions exist in the dashboard):
- `dashboard.healthCard.provider.{stopped/…}` — the health card only exposes a Start action for providers
- `dashboard.healthCard.cluster.{started/stopped/…}` — Kubernetes clusters only have a View/navigate button, no lifecycle actions

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes #16061 

### How to test this PR?

1. Open the Dashboard and verify `dashboard.healthCard.viewed` fires with correct counts
2. Collapse/expand the System Overview card and verify `dashboard.healthCard.collapsed` / `dashboard.healthCard.expanded` events fire
3. Start a stopped provider from the health card and verify `dashboard.healthCard.provider.started` fires with `{ providerName }`

- [x] Tests are covering the bug fix or the new feature
