### PR TITLE
feat(extensions): expose repository and homepage metadata end to end

### DIFF
--- a/packages/api/src/extension-info.ts
+++ b/packages/api/src/extension-info.ts
@@ -45,4 +45,6 @@ export interface ExtensionInfo {
     version: string;
     ociUri: string;
   };
+  repository?: string | { type: string; url: string; directory?: string };
+  homepage?: string;
 }

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -280,6 +280,8 @@ export class ExtensionLoader implements IAsyncDisposable {
       update: extension.update,
       readme: extension.readme,
       icon: extension.manifest.icon ? this.updateImage(extension.manifest.icon, extension.path) : undefined,
+      repository: extension.manifest.repository,
+      homepage: extension.manifest.homepage,
     }));
   }
 

--- a/packages/main/src/plugin/extension/extension-manifest-schema.spec.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-schema.spec.ts
@@ -87,6 +87,34 @@ describe('ExtensionManifestSchema', () => {
     expect(result.data.extensionPack).toEqual(['publisher.pack1']);
   });
 
+  test('accepts repository as a string', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      repository: 'https://github.com/example/repository',
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.repository).toBe('https://github.com/example/repository');
+  });
+
+  test('accepts repository as an object', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      repository: {
+        type: 'git',
+        url: 'git+https://github.com/example/repository.git',
+        directory: 'extensions/example',
+      },
+    });
+    expect(result.success).toBe(true);
+    assert(result.data);
+    expect(result.data.repository).toEqual({
+      type: 'git',
+      url: 'git+https://github.com/example/repository.git',
+      directory: 'extensions/example',
+    });
+  });
+
   test('accepts contributes with features', () => {
     const result = ExtensionManifestSchema.safeParse({
       ...minimalValidManifest,
@@ -165,5 +193,27 @@ describe('ExtensionManifestSchema', () => {
     expect(result.success).toBe(false);
     assert(result.error);
     expect(z.prettifyError(result.error)).toBe('✖ Invalid input\n  → at icon');
+  });
+
+  test('rejects manifest with invalid repository type', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      repository: 42,
+    });
+    expect(result.success).toBe(false);
+    assert(result.error);
+    expect(z.prettifyError(result.error)).toBe('✖ Invalid input\n  → at repository');
+  });
+
+  test('rejects repository object missing required type', () => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      repository: {
+        url: 'git+https://github.com/example/repository.git',
+      },
+    });
+    expect(result.success).toBe(false);
+    assert(result.error);
+    expect(z.prettifyError(result.error)).toBe('✖ Invalid input\n  → at repository');
   });
 });

--- a/packages/main/src/plugin/extension/extension-manifest-schema.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-schema.ts
@@ -28,6 +28,15 @@ import { z } from 'zod';
 
 import { RawCommandSchema } from '/@/plugin/command-registry.js';
 
+const ExtensionRepositorySchema = z.union([
+  z.string(),
+  z.object({
+    type: z.string(),
+    url: z.string(),
+    directory: z.string().optional(),
+  }),
+]);
+
 export const ExtensionManifestSchema = z
   .object({
     name: z.string(),
@@ -37,6 +46,8 @@ export const ExtensionManifestSchema = z
     description: z.string(),
     main: z.string().optional(),
     icon: z.union([z.string(), z.object({ light: z.string(), dark: z.string() })]).optional(),
+    repository: ExtensionRepositorySchema.optional(),
+    homepage: z.string().optional(),
     extensionDependencies: z.array(z.string()).optional(),
     extensionPack: z.array(z.string()).optional(),
     engines: z

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { ExtensionDetailsUI } from './extension-details-ui';
@@ -26,6 +26,7 @@ import ExtensionDetailsSummaryCard from './ExtensionDetailsSummaryCard.svelte';
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.openExternal).mockResolvedValue(undefined);
 });
 
 test('Expect to have text of the card including version, release date, publisher and categories', async () => {
@@ -66,4 +67,166 @@ test('Expect to have text of the card including version, release date, publisher
   // categories
   const categories = screen.getByText('cat1, cat2');
   expect(categories).toBeInTheDocument();
+});
+
+test('Expect repository link to open external URL', async () => {
+  const extensionDetails: ExtensionDetailsUI = {
+    displayName: 'my display name',
+    description: 'my description',
+    type: 'pd',
+    removable: false,
+    devMode: false,
+    state: 'started',
+    name: 'foo',
+    icon: 'fooIcon',
+    readme: { content: '' },
+    releaseDate: '2024-01-01',
+    categories: [],
+    publisherDisplayName: 'my publisher',
+    version: 'v1.2.3',
+    id: 'myId',
+    fetchable: true,
+    fetchLink: 'myLink',
+    fetchVersion: 'v3.4.5',
+    repository: 'https://github.com/example/repo',
+  };
+
+  render(ExtensionDetailsSummaryCard, { extensionDetails });
+
+  expect(screen.getByText('resources')).toBeInTheDocument();
+  const repoLink = screen.getByText('Repository');
+  expect(repoLink).toBeInTheDocument();
+
+  await fireEvent.click(repoLink);
+  expect(window.openExternal).toHaveBeenCalledWith('https://github.com/example/repo');
+});
+
+test('Expect repository object link to open external URL', async () => {
+  const extensionDetails: ExtensionDetailsUI = {
+    displayName: 'my display name',
+    description: 'my description',
+    type: 'pd',
+    removable: false,
+    devMode: false,
+    state: 'started',
+    name: 'foo',
+    icon: 'fooIcon',
+    readme: { content: '' },
+    releaseDate: '2024-01-01',
+    categories: [],
+    publisherDisplayName: 'my publisher',
+    version: 'v1.2.3',
+    id: 'myId',
+    fetchable: true,
+    fetchLink: 'myLink',
+    fetchVersion: 'v3.4.5',
+    repository: {
+      type: 'git',
+      url: 'https://github.com/example/repo-object',
+      directory: 'extensions/example',
+    },
+  };
+
+  render(ExtensionDetailsSummaryCard, { extensionDetails });
+
+  const repoLink = screen.getByText('Repository');
+  expect(repoLink).toBeInTheDocument();
+
+  await fireEvent.click(repoLink);
+  expect(window.openExternal).toHaveBeenCalledWith('https://github.com/example/repo-object');
+});
+
+test('Expect repository link to strip git+ prefix before opening', async () => {
+  const extensionDetails: ExtensionDetailsUI = {
+    displayName: 'my display name',
+    description: 'my description',
+    type: 'pd',
+    removable: false,
+    devMode: false,
+    state: 'started',
+    name: 'foo',
+    icon: 'fooIcon',
+    readme: { content: '' },
+    releaseDate: '2024-01-01',
+    categories: [],
+    publisherDisplayName: 'my publisher',
+    version: 'v1.2.3',
+    id: 'myId',
+    fetchable: true,
+    fetchLink: 'myLink',
+    fetchVersion: 'v3.4.5',
+    repository: {
+      type: 'git',
+      url: 'git+https://github.com/example/repo-with-git-plus.git',
+      directory: 'extensions/example',
+    },
+  };
+
+  render(ExtensionDetailsSummaryCard, { extensionDetails });
+
+  const repoLink = screen.getByText('Repository');
+  expect(repoLink).toBeInTheDocument();
+
+  await fireEvent.click(repoLink);
+  expect(window.openExternal).toHaveBeenCalledWith('https://github.com/example/repo-with-git-plus.git');
+});
+
+test('Expect homepage link to open external URL', async () => {
+  const extensionDetails: ExtensionDetailsUI = {
+    displayName: 'my display name',
+    description: 'my description',
+    type: 'pd',
+    removable: false,
+    devMode: false,
+    state: 'started',
+    name: 'foo',
+    icon: 'fooIcon',
+    readme: { content: '' },
+    releaseDate: '2024-01-01',
+    categories: [],
+    publisherDisplayName: 'my publisher',
+    version: 'v1.2.3',
+    id: 'myId',
+    fetchable: true,
+    fetchLink: 'myLink',
+    fetchVersion: 'v3.4.5',
+    homepage: 'https://example.com',
+  };
+
+  render(ExtensionDetailsSummaryCard, { extensionDetails });
+
+  expect(screen.getByText('resources')).toBeInTheDocument();
+  const homepageLink = screen.getByText('Homepage');
+  expect(homepageLink).toBeInTheDocument();
+
+  await fireEvent.click(homepageLink);
+  expect(window.openExternal).toHaveBeenCalledWith('https://example.com');
+});
+
+test('Expect no repository or homepage when not provided', async () => {
+  const extensionDetails: ExtensionDetailsUI = {
+    displayName: 'my display name',
+    description: 'my description',
+    type: 'pd',
+    removable: false,
+    devMode: false,
+    state: 'started',
+    name: 'foo',
+    icon: 'fooIcon',
+    readme: { content: '' },
+    releaseDate: '2024-01-01',
+    categories: [],
+    publisherDisplayName: 'my publisher',
+    version: 'v1.2.3',
+    id: 'myId',
+    fetchable: true,
+    fetchLink: 'myLink',
+    fetchVersion: 'v3.4.5',
+  };
+
+  render(ExtensionDetailsSummaryCard, { extensionDetails });
+
+  expect(screen.queryByText('resources')).not.toBeInTheDocument();
+  expect(screen.queryByText('Repository')).not.toBeInTheDocument();
+  expect(screen.queryByText('Homepage')).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+import { faCodeBranch, faExternalLink } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
 import type { ExtensionDetailsUI } from './extension-details-ui';
 import ExtensionDetailsSummaryCardEntry from './InstalledExtensionDetailsSummaryCardEntry.svelte';
 
@@ -7,6 +11,21 @@ interface Props {
 }
 
 let { extensionDetails }: Props = $props();
+
+function normalizeExternalUrl(url: string): string {
+  // npm package.json repository URLs can be prefixed with "git+".
+  return url.startsWith('git+') ? url.slice(4) : url;
+}
+
+const repositoryUrl = $derived(
+  typeof extensionDetails.repository === 'string'
+    ? normalizeExternalUrl(extensionDetails.repository)
+    : extensionDetails.repository?.url
+      ? normalizeExternalUrl(extensionDetails.repository.url)
+      : undefined,
+);
+
+const hasResources = $derived(Boolean(repositoryUrl) || Boolean(extensionDetails.homepage));
 </script>
 
 <div class="order-first lg:order-last w-full lg:w-48 flex flex-row grow justify-end pb-4 lg:pb-0">
@@ -20,6 +39,41 @@ let { extensionDetails }: Props = $props();
 
     {#if extensionDetails.categories.length > 0}
       <ExtensionDetailsSummaryCardEntry label="categories" value={extensionDetails.categories.join(', ')} />
+    {/if}
+
+    {#if hasResources}
+      <div class="flex flex-col items-start gap-1">
+        <div class="uppercase text-sm text-[var(--pd-details-card-header)]">resources</div>
+        {#if repositoryUrl}
+          <Tooltip top tip={repositoryUrl}>
+            <!-- Native anchor keeps browser/electron context-menu options (e.g. copy link). -->
+            <a
+              href={repositoryUrl}
+              class="text-[var(--pd-link)] hover:bg-[var(--pd-link-hover-bg)] transition-all rounded-[4px] p-0.5 no-underline cursor-pointer flex flex-row items-center gap-1 text-sm"
+              onclick={async (): Promise<void> => window.openExternal(repositoryUrl)}>
+              <span aria-hidden="true">
+                <Icon icon={faCodeBranch} size="sm" />
+              </span>
+              Repository
+            </a>
+          </Tooltip>
+        {/if}
+        {#if extensionDetails.homepage}
+          {@const homepageUrl = extensionDetails.homepage}
+          <Tooltip top tip={homepageUrl}>
+            <!-- Native anchor keeps browser/electron context-menu options (e.g. copy link). -->
+            <a
+              href={homepageUrl}
+              class="text-[var(--pd-link)] hover:bg-[var(--pd-link-hover-bg)] transition-all rounded-[4px] p-0.5 no-underline cursor-pointer flex flex-row items-center gap-1 text-sm"
+              onclick={async (): Promise<void> => window.openExternal(homepageUrl)}>
+              <span aria-hidden="true">
+                <Icon icon={faExternalLink} size="sm" />
+              </span>
+              Homepage
+            </a>
+          </Tooltip>
+        {/if}
+      </div>
     {/if}
   </div>
 </div>

--- a/packages/renderer/src/lib/extensions/extension-details-ui.ts
+++ b/packages/renderer/src/lib/extensions/extension-details-ui.ts
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ExtensionError } from '@podman-desktop/core-api';
+import type { ExtensionError, ExtensionInfo } from '@podman-desktop/core-api';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 
-export interface ExtensionDetailsUI {
+export interface ExtensionDetailsUI extends Pick<ExtensionInfo, 'repository' | 'homepage'> {
   displayName: string;
   description: string;
   type: 'dd' | 'pd';

--- a/packages/renderer/src/lib/extensions/extensions-utils.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.ts
@@ -126,6 +126,9 @@ export class ExtensionsUtils {
 
     const fetchable = fetchLink.length > 0;
 
+    const repository = matchingInstalledExtension?.repository;
+    const homepage = matchingInstalledExtension?.homepage;
+
     const matchingExtension: ExtensionDetailsUI = {
       id: extensionId,
       displayName,
@@ -147,6 +150,8 @@ export class ExtensionsUtils {
       fetchLink,
       fetchVersion,
       error,
+      repository,
+      homepage,
     };
     return matchingExtension;
   }

--- a/schemas/extension-schema.json
+++ b/schemas/extension-schema.json
@@ -48,6 +48,32 @@
             }
           ]
         },
+        "repository": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "directory": {
+                  "type": "string"
+                }
+              },
+              "required": ["type", "url"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "homepage": {
+          "type": "string"
+        },
         "extensionDependencies": {
           "type": "array",
           "items": {


### PR DESCRIPTION
### What does this PR do?

Exposes `repository` and `homepage` metadata end to end, from extension schema validation to renderer display in the extension details summary card.

When an extension `package.json` includes these fields, Podman Desktop now validates and carries them through the extension metadata pipeline so they can be shown as clickable external links in the UI.

Changes included:
- Add optional `repository` and `homepage` fields in the extension Zod schema
- Propagate these fields through main and API models (`ExtensionInfo` to renderer UI contracts)
- Render them in `ExtensionDetailsSummaryCard` as clickable links (with external link icon)

### Screenshot / video of UI

<img width="1263" height="896" alt="Screenshot 2026-07-20 at 08 52 28" src="https://github.com/user-attachments/assets/37bfbbe7-e840-4c5e-8c27-2dbc70306273" />
<img width="1263" height="896" alt="Screenshot 2026-07-20 at 08 52 43" src="https://github.com/user-attachments/assets/1c5d48cd-027d-485f-a4b1-28ea84911427" />
<img width="928" height="712" alt="Screenshot 2026-07-20 at 08 53 05" src="https://github.com/user-attachments/assets/0cfce229-b289-4f6d-b5fc-c1e3c56716bb" />

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/15639

### How to test this PR?

1. Open Podman Desktop, navigate to Extensions then Docker then Details
2. Verify `repository` and `homepage` links appear in the summary card with URL text
3. Click both links and verify they open in the external browser
4. Verify extension metadata without these fields still renders correctly

- [x] Tests are covering the bug fix or the new feature

🤖 Generated with AI

Made with [Cursor](https://cursor.com)