### PR TITLE
fix(podman-docker-context): use unique docker context names on Linux

### DIFF
--- a/extensions/podman-docker-context/src/docker-context-synchronizer.spec.ts
+++ b/extensions/podman-docker-context/src/docker-context-synchronizer.spec.ts
@@ -83,38 +83,42 @@ class TestDockerContextSynchronizer extends DockerContextSynchronizer {
 }
 
 describe('toDockerContextName', () => {
-  test.each(['Windows', 'Linux', 'MacOS'])('should return the name prefixed with podman- (%s)', platform => {
-    vi.mocked(env).isWindows = platform === 'Windows';
-    vi.mocked(env).isLinux = platform === 'Linux';
-    vi.mocked(env).isMac = platform === 'MacOS';
+  test('should return podman on macOS', () => {
+    vi.mocked(env).isMac = true;
     const name = toDockerContextName('foo');
-    expect(name).toBe(env.isWindows ? 'podman-foo' : 'podman');
+    expect(name).toBe('podman');
   });
 
-  test.each(['Windows', 'Linux', 'MacOS'])('should return the name (%s)', platform => {
+  test.each(['Windows', 'Linux'])('should prefix name with podman- on %s', platform => {
+    vi.mocked(env).isMac = false;
     vi.mocked(env).isWindows = platform === 'Windows';
     vi.mocked(env).isLinux = platform === 'Linux';
-    vi.mocked(env).isMac = platform === 'MacOS';
+    const name = toDockerContextName('foo');
+    expect(name).toBe('podman-foo');
+  });
+
+  test.each(['Windows', 'Linux'])('should not double-prefix name that already starts with podman- on %s', platform => {
+    vi.mocked(env).isMac = false;
+    vi.mocked(env).isWindows = platform === 'Windows';
+    vi.mocked(env).isLinux = platform === 'Linux';
     const name = toDockerContextName('podman-foo');
-    expect(name).toBe(env.isWindows ? 'podman-foo' : 'podman');
+    expect(name).toBe('podman-foo');
   });
 });
 
 describe('toDescription', () => {
-  test.each(['Windows', 'Linux', 'MacOS'])('should return the description (%s)', platform => {
-    vi.mocked(env).isWindows = platform === 'Windows';
-    vi.mocked(env).isLinux = platform === 'Linux';
-    vi.mocked(env).isMac = platform === 'MacOS';
-    const name = toDescription('foo');
-    expect(name).toBe(env.isWindows ? 'Podman machine foo' : 'Podman');
+  test('should return Podman on macOS', () => {
+    vi.mocked(env).isMac = true;
+    const desc = toDescription('foo');
+    expect(desc).toBe('Podman');
   });
 
-  test.each(['Windows', 'Linux', 'MacOS'])('should also return the description (%s)', platform => {
+  test.each(['Windows', 'Linux'])('should return Podman machine description on %s', platform => {
+    vi.mocked(env).isMac = false;
     vi.mocked(env).isWindows = platform === 'Windows';
     vi.mocked(env).isLinux = platform === 'Linux';
-    vi.mocked(env).isMac = platform === 'MacOS';
-    const name = toDescription('podman-foo');
-    expect(name).toBe(env.isWindows ? 'Podman machine podman-foo' : 'Podman');
+    const desc = toDescription('foo');
+    expect(desc).toBe('Podman machine foo');
   });
 });
 
@@ -177,6 +181,8 @@ describe('delete context', () => {
     expect(dockerExtensionAPI.createContext).toHaveBeenCalledTimes(2);
     vi.mocked(PODMAN_CONNECTION2.connection.status).mockReturnValue('stopped');
     await dockerContextSynchronizer.processUpdatedConnection(PODMAN_CONNECTION2.connection);
-    expect(dockerExtensionAPI.removeContext).toHaveBeenCalledTimes(1);
+    expect(dockerExtensionAPI.removeContext).toHaveBeenCalledWith(
+      toDockerContextName(PODMAN_CONNECTION2.connection.name),
+    );
   });
 });

--- a/extensions/podman-docker-context/src/docker-context-synchronizer.ts
+++ b/extensions/podman-docker-context/src/docker-context-synchronizer.ts
@@ -20,11 +20,13 @@ import { env, provider } from '@podman-desktop/api';
 import type { DockerExtensionApi } from '@podman-desktop/docker-extension-api';
 
 export function toDockerContextName(name: string): string {
-  return env.isWindows ? (name.startsWith('podman-') ? name : `podman-${name}`) : 'podman';
+  if (env.isMac) return 'podman';
+  return name.startsWith('podman-') ? name : `podman-${name}`;
 }
 
 export function toDescription(name: string): string {
-  return env.isWindows ? `Podman machine ${name}` : 'Podman';
+  if (env.isMac) return 'Podman';
+  return `Podman machine ${name}`;
 }
 
 export function toEndpoint(socketPath: string): string {


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Fixes Docker context naming on Linux to use unique, connection-specific names (e.g. `podman-Podman`, `podman-machine-default`) instead of hardcoding all contexts to a single `"podman"` name. This prevents overwriting user-defined Docker contexts.

Previously, `toDockerContextName()` always returned `"podman"` on non-Windows platforms, while Windows already used the correct `podman-{name}` prefix. This PR extends the unique naming logic to Linux, while keeping the existing `"podman"` behavior on macOS where only one machine is used.

> **Note:** Users upgrading from older versions on Linux may have a stale `"podman"` Docker context left behind. A follow-up PR could add legacy context cleanup in `init()` to automatically remove it.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes #15310 

### How to test this PR?

On Linux start a Podman machine
2. Run `docker context ls`
3. Verify the context is named `podman-{machine-name}` (e.g. `podman-podman-machine-default`) instead of just `podman`
4. Create a custom Docker context named `podman` — confirm it is **not** overwritten after restarting Podman Desktop
5. Stop the Podman machine — confirm the corresponding `podman-{name}` context is removed

- [x] Tests are covering the bug fix or the new feature
