### PR TITLE
fix(podman): skip setup notification when remote connections exist

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -430,12 +430,12 @@
         {
           "id": "welcomeCreatePodmanMachineView",
           "title": "We could not find any Podman machine. Let's create one!",
-          "when": "!onboardingContext:podmanMachineExists && !isLinux"
+          "when": "!onboardingContext:podmanMachineExists && !onboardingContext:podmanRemoteConnectionExists && !isLinux"
         },
         {
           "id": "createPodmanMachineCommand",
           "title": "Create a Podman machine",
-          "when": "!onboardingContext:podmanMachineExists && !isLinux",
+          "when": "!onboardingContext:podmanMachineExists && !onboardingContext:podmanRemoteConnectionExists && !isLinux",
           "completionEvents": [
             "onboardingContext:podmanMachineExists"
           ],
@@ -458,7 +458,7 @@
           ]
         }
       ],
-      "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || (!isLinux && !onboardingContext:podmanMachineExists) || podman.needPodmanMachineCleanup"
+      "enablement": "(isLinux && onboardingContext:podmanIsNotInstalled) || (!isLinux && !onboardingContext:podmanMachineExists && !onboardingContext:podmanRemoteConnectionExists) || podman.needPodmanMachineCleanup"
     },
     "menus": {
       "dashboard/container-connection": [

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -68,6 +68,7 @@ import {
 import { InversifyBinding } from './inject/inversify-binding';
 import type { UpdateCheck } from './installer/podman-install';
 import { PodmanInstall } from './installer/podman-install';
+import type { PodmanRemoteConnections } from './remote/podman-remote-connections';
 import * as podmanCli from './utils/podman-cli';
 import type { PodmanConfiguration } from './utils/podman-configuration';
 import { RosettaProvisioner } from './utils/rosetta';
@@ -262,6 +263,7 @@ beforeEach(async () => {
   extension.initTelemetryLogger();
   extension.initExtensionNotification();
   extension.resetShouldNotifySetup();
+  extension.initPodmanRemoteConnections(undefined as unknown as PodmanRemoteConnections);
 
   // mock PodmanInstall class methods
   vi.mocked(PODMAN_INSTALL_MOCK.checkForUpdate).mockResolvedValue({
@@ -3951,6 +3953,94 @@ describe('Check notify podman setup', () => {
     await extension.doMonitorProvider(provider);
     expect(extensionApi.window.showNotification).toHaveBeenCalledTimes(2);
     expect(extensionApi.window.showNotification).toHaveBeenLastCalledWith(notifySetupPodmanExpectedContent);
+  });
+
+  test('do not show setup podman notification if remote connections exist and machine list is empty', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+
+    vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
+
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({
+      version: '5.0.0',
+    });
+
+    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+      stdout: '[]',
+    } as unknown as extensionApi.RunResult);
+
+    const mockRemoteConnections = {
+      hasConnections: vi.fn().mockReturnValue(true),
+    } as unknown as PodmanRemoteConnections;
+    extension.initPodmanRemoteConnections(mockRemoteConnections);
+
+    await extension.updateMachines(provider, podmanConfiguration);
+
+    expect(extensionApi.window.showNotification).not.toBeCalled();
+  });
+
+  test('show setup podman notification if no remote connections and machine list is empty', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+
+    vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
+
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({
+      version: '5.0.0',
+    });
+
+    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+      stdout: '[]',
+    } as unknown as extensionApi.RunResult);
+
+    const mockRemoteConnections = {
+      hasConnections: vi.fn().mockReturnValue(false),
+    } as unknown as PodmanRemoteConnections;
+    extension.initPodmanRemoteConnections(mockRemoteConnections);
+
+    await extension.updateMachines(provider, podmanConfiguration);
+
+    expect(extensionApi.window.showNotification).toBeCalledWith(notifySetupPodmanExpectedContent);
+  });
+
+  test('set provider status to ready when remote connections exist but no local machines', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+
+    vi.mocked(extensionApi.commands.registerCommand).mockReturnValue({ dispose: vi.fn() });
+
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({
+      version: '5.0.0',
+    });
+
+    vi.mocked(extensionApi.process.exec).mockResolvedValueOnce({
+      stdout: '[]',
+    } as unknown as extensionApi.RunResult);
+
+    const mockRemoteConnections = {
+      hasConnections: vi.fn().mockReturnValue(true),
+    } as unknown as PodmanRemoteConnections;
+    extension.initPodmanRemoteConnections(mockRemoteConnections);
+
+    await extension.updateMachines(provider, podmanConfiguration);
+
+    expect(provider.updateStatus).toBeCalledWith('ready');
+  });
+
+  test('do not show setup notification on error if remote connections exist', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+
+    vi.spyOn(extensionApi.process, 'exec').mockRejectedValue({
+      name: 'name',
+      message: 'description',
+      stderr: 'error',
+    });
+
+    const mockRemoteConnections = {
+      hasConnections: vi.fn().mockReturnValue(true),
+    } as unknown as PodmanRemoteConnections;
+    extension.initPodmanRemoteConnections(mockRemoteConnections);
+
+    await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('description');
+    expect(extensionApi.window.showNotification).not.toBeCalled();
+    expect(extensionApi.context.setValue).toBeCalledWith('podmanRemoteConnectionExists', true, 'onboarding');
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -137,6 +137,7 @@ let wslAndHypervEnabledContextValue = false;
 let wslEnabled = false;
 
 let extensionNotifications: ExtensionNotifications;
+let podmanRemoteConnections: PodmanRemoteConnections | undefined;
 
 export function isIncompatibleMachineOutput(output: string | undefined): boolean {
   // apple HV v4 to v5 machine config error
@@ -164,6 +165,9 @@ async function doUpdateMachines(
   provider: extensionApi.Provider,
   podmanConfiguration: PodmanConfiguration,
 ): Promise<void> {
+  const hasRemoteConnections = podmanRemoteConnections?.hasConnections() ?? false;
+  extensionApi.context.setValue('podmanRemoteConnectionExists', hasRemoteConnections, 'onboarding');
+
   // init machines available
   let machineListOutput: MachineJSONListOutput;
   try {
@@ -177,7 +181,9 @@ async function doUpdateMachines(
     }
     extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
 
-    extensionNotifications.notifySetupPodmanNotLinux();
+    if (!hasRemoteConnections) {
+      extensionNotifications.notifySetupPodmanNotLinux();
+    }
     throw error;
   }
 
@@ -195,17 +201,18 @@ async function doUpdateMachines(
   }
 
   // invalid machines is not making the provider working properly so always notify
-  if (shouldCleanMachine || machines.length === 0) {
+  // but skip if remote connections exist and no cleanup is needed
+  if (shouldCleanMachine || (machines.length === 0 && !hasRemoteConnections)) {
     // push setup notification
     extensionNotifications.notifySetupPodmanNotLinux();
   }
 
   extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
 
-  // if there is at least one machine which does not need to be cleaned and the OS is not Linux
-  // podman is correctly setup so if there is an old notification asking the user to take action
-  // we dispose it as not needed anymore
-  if (!shouldCleanMachine && machines.length > 0 && !extensionApi.env.isLinux) {
+  // if there is at least one machine (or remote connection) which does not need to be cleaned
+  // and the OS is not Linux, podman is correctly setup so if there is an old notification
+  // asking the user to take action we dispose it as not needed anymore
+  if (!shouldCleanMachine && (machines.length > 0 || hasRemoteConnections) && !extensionApi.env.isLinux) {
     extensionNotifications.disposeNotification();
   }
 
@@ -338,10 +345,12 @@ async function doUpdateMachines(
   // if we are on Linux, ignore this as podman machine is OPTIONAL and the provider status in Linux is based upon
   // the native podman installation / not machine.
   if (!extensionApi.env.isLinux) {
-    if (machines.length === 0) {
+    if (machines.length === 0 && !hasRemoteConnections) {
       if (provider.status !== 'configuring') {
         provider.updateStatus('installed');
       }
+    } else if (machines.length === 0 && hasRemoteConnections) {
+      provider.updateStatus('ready');
     } else {
       /*
        * The machine can have 3 states, based on `Starting` and `Running` fields:
@@ -1123,6 +1132,10 @@ export function initExtensionNotification(): void {
   extensionNotifications = new ExtensionNotifications(telemetryLogger);
 }
 
+export function initPodmanRemoteConnections(remoteConnections: PodmanRemoteConnections): void {
+  podmanRemoteConnections = remoteConnections;
+}
+
 const currentUpdatesDisposables: extensionApi.Disposable[] = [];
 export async function initCheckAndRegisterUpdate(
   provider: extensionApi.Provider,
@@ -1639,6 +1652,11 @@ export async function start(
     });
   }
 
+  // Initialize remote connections before machine monitoring so hasConnections()
+  // is populated before the first updateMachines() call
+  podmanRemoteConnections = new PodmanRemoteConnections(extensionContext, provider);
+  await podmanRemoteConnections.start();
+
   // Podman Machine support is on macOS, Windows and Linux
   // Despite Linux having native container support, Podman Machine is still supported on Linux
   // so let's monitor for the machines
@@ -1769,9 +1787,6 @@ export async function start(
   await registrySetup.setup();
 
   await calcPodmanMachineSetting();
-
-  const podmanRemoteConnections = new PodmanRemoteConnections(extensionContext, provider);
-  podmanRemoteConnections.start();
 }
 
 export async function connectionAuditor(items: extensionApi.AuditRequestItems): Promise<extensionApi.AuditResult> {

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
@@ -63,10 +63,7 @@ test('should do nothing if the configuration is disabled', async () => {
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
 
   // start
-  podmanRemoteConnections.start();
-
-  // wait for the getConfiguration being called
-  await vi.waitFor(() => expect(extensionApi.configuration.getConfiguration).toHaveBeenCalled());
+  await podmanRemoteConnections.start();
 
   // no connection should be created
   expect(spyCreateTunnel).not.toHaveBeenCalled();
@@ -91,29 +88,170 @@ test('should check connections if configuration is enabled', async () => {
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
 
   // start
-  podmanRemoteConnections.start();
-
-  // wait for the getConfiguration being called
-  await vi.waitFor(() => expect(extensionApi.configuration.getConfiguration).toHaveBeenCalled());
+  await podmanRemoteConnections.start();
 
   // no connection should be created
   expect(spyCreateTunnel).not.toHaveBeenCalled();
   expect(spyRefreshRemoteConnections).toHaveBeenCalled();
 });
 
+test('hasConnections should return false when no connections exist', () => {
+  const remoteConnections = new TestPodmanRemoteConnections(extensionContext, provider);
+  expect(remoteConnections.hasConnections()).toBe(false);
+});
+
+test('hasConnections should return true after remote connections are registered', async () => {
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: () => true,
+  } as unknown as extensionApi.Configuration);
+
+  const mockProvider = {
+    registerContainerProviderConnection: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  } as unknown as extensionApi.Provider;
+  const mockContext = {
+    subscriptions: [],
+  } as unknown as extensionApi.ExtensionContext;
+
+  const remoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
+
+  vi.spyOn(fs, 'readFileSync').mockReturnValue('fake-key');
+  vi.spyOn(remoteConnections, 'createTunnel').mockReturnValue({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    status: () => 'started',
+  } as unknown as PodmanRemoteSshTunnel);
+
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    stdout: JSON.stringify([
+      {
+        IsMachine: false,
+        URI: 'ssh://dummy@192.168.1.100:22/run/podman/podman.sock',
+        Identity: '/tmp/fakepath',
+        Name: 'RemoteConnection1',
+      },
+    ]),
+  } as unknown as extensionApi.RunResult);
+
+  await remoteConnections.refreshRemoteConnections();
+
+  expect(remoteConnections.hasConnections()).toBe(true);
+});
+
+test('should skip broken connection and still register valid ones', async () => {
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: () => true,
+  } as unknown as extensionApi.Configuration);
+
+  const mockProvider = {
+    registerContainerProviderConnection: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  } as unknown as extensionApi.Provider;
+  const mockContext = {
+    subscriptions: [],
+  } as unknown as extensionApi.ExtensionContext;
+
+  const remoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
+
+  vi.spyOn(fs, 'readFileSync').mockImplementation((path: unknown) => {
+    if (String(path) === '/tmp/broken-key') {
+      throw new Error('ENOENT: no such file');
+    }
+    return 'fake-key';
+  });
+  vi.spyOn(remoteConnections, 'createTunnel').mockReturnValue({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    status: () => 'started',
+  } as unknown as PodmanRemoteSshTunnel);
+
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    stdout: JSON.stringify([
+      {
+        IsMachine: false,
+        URI: 'ssh://user@192.168.1.1:22/run/podman/podman.sock',
+        Identity: '/tmp/broken-key',
+        Name: 'BrokenRemote',
+      },
+      {
+        IsMachine: false,
+        URI: 'ssh://user@192.168.1.2:22/run/podman/podman.sock',
+        Identity: '/tmp/valid-key',
+        Name: 'ValidRemote',
+      },
+    ]),
+  } as unknown as extensionApi.RunResult);
+
+  await remoteConnections.refreshRemoteConnections();
+
+  expect(remoteConnections.hasConnections()).toBe(true);
+});
+
+test('should disconnect tunnel if registration fails after connect', async () => {
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: () => true,
+  } as unknown as extensionApi.Configuration);
+
+  const mockProvider = {
+    registerContainerProviderConnection: vi.fn().mockImplementation(() => {
+      throw new Error('registration failed');
+    }),
+  } as unknown as extensionApi.Provider;
+  const mockContext = {
+    subscriptions: [],
+  } as unknown as extensionApi.ExtensionContext;
+
+  const remoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
+
+  vi.spyOn(fs, 'readFileSync').mockReturnValue('fake-key');
+  const mockDisconnect = vi.fn();
+  vi.spyOn(remoteConnections, 'createTunnel').mockReturnValue({
+    connect: vi.fn(),
+    disconnect: mockDisconnect,
+    status: () => 'started',
+  } as unknown as PodmanRemoteSshTunnel);
+
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    stdout: JSON.stringify([
+      {
+        IsMachine: false,
+        URI: 'ssh://user@192.168.1.1:22/run/podman/podman.sock',
+        Identity: '/tmp/fakepath',
+        Name: 'FailingRemote',
+      },
+    ]),
+  } as unknown as extensionApi.RunResult);
+
+  await remoteConnections.refreshRemoteConnections();
+
+  expect(mockDisconnect).toHaveBeenCalledOnce();
+  expect(remoteConnections.hasConnections()).toBe(false);
+});
+
 test('should check connections if configuration is enabled and a system connection', async () => {
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
     get: () => true,
   } as unknown as extensionApi.Configuration);
-  const podmanRemoteConnections = new TestPodmanRemoteConnections(extensionContext, provider);
+
+  const mockProvider = {
+    registerContainerProviderConnection: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  } as unknown as extensionApi.Provider;
+  const mockContext = {
+    subscriptions: [],
+  } as unknown as extensionApi.ExtensionContext;
+
+  const podmanRemoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
 
   // mock readFileSync
   vi.spyOn(fs, 'readFileSync').mockReturnValue('file');
 
+  // mock createTunnel to return a mock tunnel
+  const spyCreateTunnel = vi.spyOn(podmanRemoteConnections, 'createTunnel').mockReturnValue({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    status: () => 'started',
+  } as unknown as PodmanRemoteSshTunnel);
+
   // mock exec method for listing podman system connections
-
   // one machine and one remote connection
-
   vi.mocked(extensionApi.process.exec).mockResolvedValue({
     stdout: JSON.stringify([
       {
@@ -122,7 +260,6 @@ test('should check connections if configuration is enabled and a system connecti
         Identity: '/tmp/fakepath',
         Name: 'Machine1',
       },
-
       {
         IsMachine: false,
         URI: 'ssh://dummy@127.0.0.1:1234/run/podman/podman.sock',
@@ -132,19 +269,14 @@ test('should check connections if configuration is enabled and a system connecti
     ]),
   } as unknown as extensionApi.RunResult);
 
-  // spy createTunnel method
-  const spyCreateTunnel = vi.spyOn(podmanRemoteConnections, 'createTunnel');
-
   // spy refreshRemoteConnections method
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
 
   // start
-  podmanRemoteConnections.start();
+  await podmanRemoteConnections.start();
 
-  // wait for the getConfiguration being called
-  await vi.waitFor(() => expect(extensionApi.configuration.getConfiguration).toHaveBeenCalled());
-
-  // no connection should be created
-  expect(spyCreateTunnel).not.toHaveBeenCalled();
+  // remote connection should trigger tunnel creation (machine is filtered out)
+  expect(spyCreateTunnel).toHaveBeenCalledOnce();
   expect(spyRefreshRemoteConnections).toHaveBeenCalled();
+  expect(podmanRemoteConnections.hasConnections()).toBe(true);
 });

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
@@ -80,7 +80,7 @@ export class PodmanRemoteConnections {
       .filter(connection => connection.URI.startsWith('ssh:'));
   }
 
-  start(): void {
+  async start(): Promise<void> {
     // need to watch the configuration to enable again the monitoring
     extensionApi.configuration.onDidChangeConfiguration(async e => {
       if (e.affectsConfiguration(PODMAN_CONFIGURATION_REMOTE_ENABLED_KEY)) {
@@ -88,9 +88,7 @@ export class PodmanRemoteConnections {
       }
     });
 
-    this.monitorRemoteConnections().catch((error: unknown) => {
-      console.error('Error starting remote podman system connections', error);
-    });
+    await this.monitorRemoteConnections();
   }
 
   protected async monitorRemoteConnections(): Promise<void> {
@@ -139,58 +137,48 @@ export class PodmanRemoteConnections {
 
     // for each new connection, setup a tunnel and add the provider
     for (const connection of toAdd) {
-      // extract values from the configuration it looks like
-      /*{
-      "Name": "fedora40",
-      "URI": "ssh://username@1.2.3.4:22/run/user/1000/podman/podman.sock",
-      "Identity": "/Users/username/.ssh/id_1234",
-      "Default": false,
-      "ReadWrite": true
-  },*/
+      let sshTunnel: PodmanRemoteSshTunnel | undefined;
+      try {
+        const uri = new URL(connection.URI);
+        const host = uri.hostname;
+        const port = Number.parseInt(uri.port, 10);
+        const username = uri.username;
+        const privateKeyFile = connection.Identity;
 
-      const uri = new URL(connection.URI);
-      const host = uri.hostname;
-      const port = parseInt(uri.port);
-      const username = uri.username;
-      const privateKeyFile = connection.Identity;
+        const privateKey = readFileSync(privateKeyFile, 'utf8');
+        const remotePath = uri.pathname;
 
-      // read the content of the private key
-      const privateKey = readFileSync(privateKeyFile, 'utf8');
-      const remotePath = uri.pathname;
+        let localPath: string;
+        if (extensionApi.env.isWindows) {
+          localPath = `\\\\.\\pipe\\podman-remote-${connection.Name}`;
+        } else {
+          localPath = join(tmpdir(), `podman-remote-${connection.Name}.sock`);
+        }
 
-      let localPath;
-      // on Windows, use npipe
-      if (extensionApi.env.isWindows) {
-        localPath = `\\\\.\\pipe\\podman-remote-${connection.Name}`;
-      } else {
-        // on mac and Linux use socket file
-        localPath = join(tmpdir(), `podman-remote-${connection.Name}.sock`);
+        sshTunnel = this.createTunnel(host, port, username, privateKey, remotePath, localPath);
+        sshTunnel.connect();
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const tunnel = sshTunnel;
+        const connectionDisposable = this.#provider.registerContainerProviderConnection({
+          name: connection.Name,
+          status: () => tunnel.status(),
+          type: 'podman',
+          endpoint: {
+            socketPath: localPath,
+          },
+        });
+        this.#extensionContext.subscriptions.push(connectionDisposable);
+        this.#currentConnections.set(connection.Name, {
+          name: connection.Name,
+          sshTunnel,
+          connectionDisposable,
+        });
+      } catch (error) {
+        sshTunnel?.disconnect();
+        console.warn(`Failed to register remote Podman connection ${connection.Name}`, error);
       }
-
-      const sshTunnel = this.createTunnel(host, port, username, privateKey, remotePath, localPath);
-
-      // connect the tunnel
-      sshTunnel.connect();
-
-      //delay before registering the socket
-      await new Promise(resolve => setTimeout(resolve, 1000));
-
-      // register the socket
-      const connectionDisposable = this.#provider.registerContainerProviderConnection({
-        name: connection.Name,
-        status: () => sshTunnel.status(),
-        type: 'podman',
-        endpoint: {
-          socketPath: localPath,
-        },
-      });
-      this.#extensionContext.subscriptions.push(connectionDisposable);
-      const remoteConnection: RemoteSystemConnection = {
-        name: connection.Name,
-        sshTunnel,
-        connectionDisposable,
-      };
-      this.#currentConnections.set(connection.Name, remoteConnection);
     }
 
     // for each connection to remove, close the tunnel and remove the provider
@@ -218,6 +206,10 @@ export class PodmanRemoteConnections {
     localPath: string,
   ): PodmanRemoteSshTunnel {
     return new PodmanRemoteSshTunnel(host, port, username, privateKey, remotePath, localPath);
+  }
+
+  hasConnections(): boolean {
+    return this.#currentConnections.size > 0;
   }
 
   stop(): void {


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

This PR suppresses the "Podman needs to be set up" notification and onboarding prompt when a remote Podman connection is already configured. Previously, Podman Desktop would always prompt users to install WSL or create a local Podman machine on Windows/macOS, even if they had a working remote Podman connection via SSH.

Changes:
- Added `hasConnections()` method to `PodmanRemoteConnections` to check for active remote connections
- Guarded the setup notification in `doUpdateMachines()` — skipped when remote connections exist
- Updated provider status to `ready` (instead of `installed`) when remote connections exist but no local machines
- Updated onboarding enablement conditions in `package.json` to respect remote connections

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes #13183 

### How to test this PR?

1. Configure a remote Podman connection via SSH (`podman system connection add`)
2. Enable remote connections in Podman Desktop settings (`podman.system.connections.remote`)
3. Ensure no local Podman machine exists
4. Verify the "Podman needs to be set up" notification does **not** appear
5. Verify the onboarding prompt to create a machine does **not** appear
6. Remove the remote connection and verify the notification **does** appear again

- [x] Tests are covering the bug fix or the new feature