### PR TITLE
test(e2e): add managed configuration test for custom extensions toggle

### DIFF
--- a/tests/playwright/resources/managed-configuration/default-settings.json
+++ b/tests/playwright/resources/managed-configuration/default-settings.json
@@ -21,5 +21,6 @@
   "proxy.https": "https://managed-proxy.example.com:8443",
   "proxy.no": "localhost,127.0.0.1,.example.com",
   "extensions.catalog.enabled": false,
-  "extensions.localExtensions.enabled": false
+  "extensions.localExtensions.enabled": false,
+  "extensions.customExtensions.enabled": false
 }

--- a/tests/playwright/resources/managed-configuration/locked.json
+++ b/tests/playwright/resources/managed-configuration/locked.json
@@ -7,6 +7,7 @@
     "proxy.http",
     "proxy.https",
     "extensions.catalog.enabled",
-    "extensions.localExtensions.enabled"
+    "extensions.localExtensions.enabled",
+    "extensions.customExtensions.enabled"
   ]
 }

--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-extensions.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-extensions.spec.ts
@@ -65,4 +65,11 @@ test.describe
           await playExpect(extensionsPage.localExtensionsTab).not.toBeAttached();
         });
       });
+
+    test.describe
+      .serial('Defaults + Locked setting: Custom Extensions disabled', () => {
+        test('Install custom button is not rendered when extensions.customExtensions.enabled is false', async () => {
+          await playExpect(extensionsPage.installExtensionFromOCIImageButton).not.toBeAttached();
+        });
+      });
   });


### PR DESCRIPTION
### What does this PR do?
* Adds managed configuration test for disabling `Install Custom Extension` button
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #17312
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
