### PR TITLE
feat(renderer): add timestamps to troubleshooting logs page

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -834,6 +834,7 @@ export class PluginSystem {
     const cancellationTokenRegistry = container.get<CancellationTokenRegistry>(CancellationTokenRegistry);
     const cliToolRegistry = container.get<CliToolRegistry>(CliToolRegistry);
     const troubleshooting = container.get<Troubleshooting>(Troubleshooting);
+    troubleshooting.init();
     const menuRegistry = container.get<MenuRegistry>(MenuRegistry);
     const contributionManager = container.get<ContributionManager>(ContributionManager);
     const iconRegistry = container.get<IconRegistry>(IconRegistry);

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs';
 
 import type { LogType } from '@podman-desktop/core-api';
+import type { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import type AdmZip from 'adm-zip';
 import type { IpcMain } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -33,6 +34,10 @@ import { Troubleshooting } from './troubleshooting.js';
 const DIALOG_REGISTRY_MOCK: DialogRegistry = {
   saveDialog: vi.fn(),
 } as unknown as DialogRegistry;
+
+const CONFIGURATION_REGISTRY_MOCK: IConfigurationRegistry = {
+  registerConfigurations: vi.fn(),
+} as unknown as IConfigurationRegistry;
 
 const writeZipMock = vi.fn();
 const addFileMock = vi.fn();
@@ -64,12 +69,29 @@ beforeEach(() => {
   vi.mocked(product).artifactName = 'test-id';
 });
 
+test('init should register the logsTimestamps configuration', () => {
+  const troubleshooting = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
+  troubleshooting.init();
+
+  expect(CONFIGURATION_REGISTRY_MOCK.registerConfigurations).toHaveBeenCalledWith([
+    expect.objectContaining({
+      id: 'troubleshooting.logs',
+      properties: expect.objectContaining({
+        'troubleshooting.logsTimestamps': expect.objectContaining({
+          type: 'boolean',
+          default: false,
+        }),
+      }),
+    }),
+  ]);
+});
+
 describe('saveLogs', () => {
   test('should use DialogRegistry#saveDialog', async () => {
     const output = Uri.file('foo.zip');
     vi.mocked(DIALOG_REGISTRY_MOCK.saveDialog).mockResolvedValue(output);
 
-    const troubleshooting = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+    const troubleshooting = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
 
     await troubleshooting.saveLogs([]);
 
@@ -82,7 +104,7 @@ describe('saveLogs', () => {
   test('should return empty array if user cancelled save dialog', async () => {
     vi.mocked(DIALOG_REGISTRY_MOCK.saveDialog).mockResolvedValue(undefined);
 
-    const troubleshooting = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+    const troubleshooting = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
 
     const result = await troubleshooting.saveLogs([]);
     expect(result).toHaveLength(0);
@@ -91,7 +113,7 @@ describe('saveLogs', () => {
 
 // Test the saveLogsToZip function
 test('Should save a zip file with the correct content', async () => {
-  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
   const fileMaps = [
     {
       filename: 'file1',
@@ -113,7 +135,7 @@ test('Should save a zip file with the correct content', async () => {
 
 // Do not expect writeZipMock to have been called if fileMaps is empty
 test('Should not save a zip file if fileMaps is empty', async () => {
-  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
   const fileMaps: TroubleshootingFileMap[] = [];
 
   const zipSpy = vi.spyOn(zipFile, 'saveLogsToZip');
@@ -126,7 +148,7 @@ test('Should not save a zip file if fileMaps is empty', async () => {
 
 // Expect the file name to have a .txt extension
 test('Should have a .txt extension in the file name', async () => {
-  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
   const fileMaps = [
     {
       filename: 'file1',
@@ -149,7 +171,7 @@ test('Should have a .txt extension in the file name', async () => {
 
 // Expect getConsoleLogs to correctly format the console logs passed in
 test('Should correctly format console logs', async () => {
-  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
   const consoleLogs = [
     {
       logType: 'log' as LogType,
@@ -187,7 +209,7 @@ test('Should return getMacSystemLogs if the platform is darwin', async () => {
     return true;
   });
 
-  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
   const getSystemLogsSpy = vi.spyOn(zipFile, 'getSystemLogs');
 
   await zipFile.getSystemLogs();
@@ -215,7 +237,7 @@ test('Should return getWindowsSystemLogs if the platform is win32', async () => 
   const readFileMock = vi.spyOn(fs.promises, 'readFile');
   readFileMock.mockResolvedValue('content');
 
-  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+  const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
   const getSystemLogsSpy = vi.spyOn(zipFile, 'getSystemLogs');
 
   await zipFile.getSystemLogs();
@@ -235,7 +257,7 @@ test.each([
   { file: 'test.log', extension: undefined, expected: /test-\d{14}\.log/ }, // use extension from filename
   { file: 'test.log', extension: 'customExtension', expected: /test-\d{14}\.customExtension/ }, //use provided extension
 ])('test generateLogFileName, file: $file, extension: $extension', async ({ file, extension, expected }) => {
-  const ts = new Troubleshooting(DIALOG_REGISTRY_MOCK);
+  const ts = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
   const filename = ts.generateLogFileName(file, extension);
   // Check the format of "name"-"date(14digits)"-"extension"
   expect(filename).toMatch(new RegExp(expected));

--- a/packages/main/src/plugin/troubleshooting.ts
+++ b/packages/main/src/plugin/troubleshooting.ts
@@ -20,6 +20,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 
 import { LogType } from '@podman-desktop/core-api';
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import AdmZip from 'adm-zip';
 import { inject, injectable } from 'inversify';
 import moment from 'moment';
@@ -40,7 +41,26 @@ export class Troubleshooting {
   constructor(
     @inject(DialogRegistry)
     private dialogRegistry: DialogRegistry,
+    @inject(IConfigurationRegistry)
+    private configurationRegistry: IConfigurationRegistry,
   ) {}
+
+  init(): void {
+    const node: IConfigurationNode = {
+      id: 'troubleshooting.logs',
+      title: 'Troubleshooting',
+      type: 'object',
+      properties: {
+        ['troubleshooting.logsTimestamps']: {
+          description: 'Show timestamps in the troubleshooting console logs.',
+          type: 'boolean',
+          default: false,
+          hidden: true,
+        },
+      },
+    };
+    this.configurationRegistry.registerConfigurations([node]);
+  }
 
   // The "main" function that is exposes that is used to gather
   // all the logs and save them to a zip file.

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
@@ -41,16 +41,17 @@ async function waitRender(customProperties: object): Promise<void> {
 }
 
 test('Check logs are displayed with clipboard button', async () => {
+  const fixedDate = new Date('2026-04-29T14:30:45');
   getDevtoolsConsoleLogsMock.mockReturnValue([
     {
       logType: 'log',
       message: 'test1',
-      date: new Date(),
+      date: fixedDate,
     },
     {
       logType: 'error',
       message: 'test2',
-      date: new Date(),
+      date: fixedDate,
     },
   ]);
 
@@ -72,5 +73,5 @@ test('Check logs are displayed with clipboard button', async () => {
   await fireEvent.click(clipboardButton);
 
   // check the content of the clipboard button
-  expect(clipboardWriteTextMock).toBeCalledWith('log : test1\nerror : test2');
+  expect(clipboardWriteTextMock).toHaveBeenCalledWith('14:30:45 [log] test1\n14:30:45 [error] test2');
 });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
@@ -28,11 +28,17 @@ import TroubleshootingDevToolsConsoleLogs from './TroubleshootingDevToolsConsole
 
 const getDevtoolsConsoleLogsMock = vi.fn();
 const clipboardWriteTextMock = vi.fn();
+const getConfigurationValueMock = vi.fn();
+const updateConfigurationValueMock = vi.fn();
 
 // fake the window.events object
 beforeAll(() => {
   (window as any).getDevtoolsConsoleLogs = getDevtoolsConsoleLogsMock;
   (window as any).clipboardWriteText = clipboardWriteTextMock;
+  (window as any).getConfigurationValue = getConfigurationValueMock;
+  (window as any).updateConfigurationValue = updateConfigurationValueMock;
+  getConfigurationValueMock.mockResolvedValue(false);
+  updateConfigurationValueMock.mockResolvedValue(undefined);
 });
 
 async function waitRender(customProperties: object): Promise<void> {
@@ -99,6 +105,21 @@ test('Timestamps are hidden by default and shown after toggle', async () => {
   // click again to hide
   await fireEvent.click(toggleButton);
   expect(logsList.textContent).not.toContain('14:30:45');
+});
+
+test('Toggle persists the setting via updateConfigurationValue', async () => {
+  getDevtoolsConsoleLogsMock.mockReturnValue([{ logType: 'log', message: 'hello', date: new Date() }]);
+
+  await waitRender({});
+
+  const toggleButton = screen.getByRole('button', { name: 'Toggle Timestamps' });
+  await fireEvent.click(toggleButton);
+
+  expect(updateConfigurationValueMock).toHaveBeenCalledWith('troubleshooting.logsTimestamps', true);
+
+  await fireEvent.click(toggleButton);
+
+  expect(updateConfigurationValueMock).toHaveBeenCalledWith('troubleshooting.logsTimestamps', false);
 });
 
 test('Clipboard includes timestamps when toggle is enabled', async () => {

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
@@ -73,5 +73,5 @@ test('Check logs are displayed with clipboard button', async () => {
   await fireEvent.click(clipboardButton);
 
   // check the content of the clipboard button
-  expect(clipboardWriteTextMock).toHaveBeenCalledWith('14:30:45 [log] test1\n14:30:45 [error] test2');
+  expect(clipboardWriteTextMock).toHaveBeenCalledWith('14:30:45 log : test1\n14:30:45 error : test2');
 });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
@@ -72,6 +72,51 @@ test('Check logs are displayed with clipboard button', async () => {
   expect(clipboardButton).toBeEnabled();
   await fireEvent.click(clipboardButton);
 
-  // check the content of the clipboard button
+  // timestamps are hidden by default, so clipboard should not include them
+  expect(clipboardWriteTextMock).toHaveBeenCalledWith('log : test1\nerror : test2');
+});
+
+test('Timestamps are hidden by default and shown after toggle', async () => {
+  const fixedDate = new Date('2026-04-29T14:30:45');
+  getDevtoolsConsoleLogsMock.mockReturnValue([{ logType: 'log', message: 'hello', date: fixedDate }]);
+
+  await waitRender({});
+
+  const logsList = screen.getByRole('list', { name: 'logs' });
+
+  // timestamps should be hidden by default
+  expect(logsList.textContent).not.toContain('14:30:45');
+  expect(logsList.textContent).toContain('hello');
+
+  // click the toggle timestamps button
+  const toggleButton = screen.getByRole('button', { name: 'Toggle Timestamps' });
+  expect(toggleButton).toBeInTheDocument();
+  await fireEvent.click(toggleButton);
+
+  // timestamps should now be visible
+  expect(logsList.textContent).toContain('14:30:45');
+
+  // click again to hide
+  await fireEvent.click(toggleButton);
+  expect(logsList.textContent).not.toContain('14:30:45');
+});
+
+test('Clipboard includes timestamps when toggle is enabled', async () => {
+  const fixedDate = new Date('2026-04-29T14:30:45');
+  getDevtoolsConsoleLogsMock.mockReturnValue([
+    { logType: 'log', message: 'test1', date: fixedDate },
+    { logType: 'error', message: 'test2', date: fixedDate },
+  ]);
+
+  await waitRender({});
+
+  // enable timestamps
+  const toggleButton = screen.getByRole('button', { name: 'Toggle Timestamps' });
+  await fireEvent.click(toggleButton);
+
+  // copy to clipboard
+  const clipboardButton = screen.getByRole('button', { name: 'Copy To Clipboard' });
+  await fireEvent.click(clipboardButton);
+
   expect(clipboardWriteTextMock).toHaveBeenCalledWith('14:30:45 log : test1\n14:30:45 error : test2');
 });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -8,6 +8,8 @@ import { onDestroy, onMount } from 'svelte';
 
 import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 
+const TIMESTAMPS_CONFIG_KEY = 'troubleshooting.logsTimestamps';
+
 let logs: {
   logType: LogType;
   date: Date;
@@ -18,6 +20,7 @@ let showTimestamps = $state(false);
 
 onMount(async () => {
   logs = await window.getDevtoolsConsoleLogs();
+  showTimestamps = (await window.getConfigurationValue<boolean>(TIMESTAMPS_CONFIG_KEY)) ?? false;
 });
 
 onDestroy(() => {});
@@ -43,7 +46,7 @@ async function copyLogsToClipboard(): Promise<void> {
     <Icon size="1.875x" class="pr-3" icon={faFileLines} />
     <div class="text-xl">Logs</div>
     <div class="flex flex-1 justify-end items-center gap-1">
-      <Button title="Toggle Timestamps" on:click={(): boolean => (showTimestamps = !showTimestamps)} type="link"
+      <Button title="Toggle Timestamps" on:click={async (): Promise<void> => { showTimestamps = !showTimestamps; await window.updateConfigurationValue(TIMESTAMPS_CONFIG_KEY, showTimestamps); }} type="link"
         ><Icon class="h-5 w-5 cursor-pointer text-xl {showTimestamps ? 'text-[var(--pd-button-primary-bg)]' : 'text-[var(--pd-content-text)]'}" icon={faClock} /></Button>
       <Button title="Copy To Clipboard" on:click={async (): Promise<void> => await copyLogsToClipboard()} type="link"
         ><Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faPaste} /></Button>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -42,7 +42,7 @@ async function copyLogsToClipboard(): Promise<void> {
     <div class="h-full overflow-auto p-2 bg-[var(--pd-invert-content-card-bg)]">
       <ul aria-label="logs">
         {#each logs as log, index (index)}
-          <li class="py-[3px]">
+          <li class="py-[3px] px-1 rounded-sm {index % 2 === 0 ? 'bg-black/4 dark:bg-white/4' : ''}">
             <div class="flex flex-row items-start gap-2">
               <span
                 class="font-mono text-[10px] font-thin shrink-0 {log.logType === 'error'

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -19,8 +19,12 @@ onMount(async () => {
 
 onDestroy(() => {});
 
+function formatTimestamp(date: Date): string {
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
+}
+
 async function copyLogsToClipboard(): Promise<void> {
-  const logsText = logs.map(log => `${log.logType} : ${log.message}`).join('\n');
+  const logsText = logs.map(log => `${formatTimestamp(log.date)} [${log.logType}] ${log.message}`).join('\n');
   await window.clipboardWriteText(logsText);
 }
 </script>
@@ -39,7 +43,10 @@ async function copyLogsToClipboard(): Promise<void> {
       <ul aria-label="logs">
         {#each logs as log, index (index)}
           <li>
-            <div class="flex flex-row align-middle items-center">
+            <div class="flex flex-row align-middle items-center gap-2">
+              <span class="font-mono text-[10px] font-thin text-[var(--pd-content-text-secondary)] shrink-0">
+                {formatTimestamp(log.date)}
+              </span>
               <div
                 class="font-mono text-[10px] font-thin {log.logType === 'error'
                   ? 'text-[var(--pd-state-error)]'

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faFileLines, faPaste } from '@fortawesome/free-regular-svg-icons';
+import { faClock } from '@fortawesome/free-solid-svg-icons';
 import type { LogType } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
@@ -13,6 +14,8 @@ let logs: {
   message: string;
 }[] = $state([]);
 
+let showTimestamps = $state(false);
+
 onMount(async () => {
   logs = await window.getDevtoolsConsoleLogs();
 });
@@ -24,7 +27,13 @@ function formatTimestamp(date: Date): string {
 }
 
 async function copyLogsToClipboard(): Promise<void> {
-  const logsText = logs.map(log => `${formatTimestamp(log.date)} ${log.logType} : ${log.message}`).join('\n');
+  const logsText = logs
+    .map(log =>
+      showTimestamps
+        ? `${formatTimestamp(log.date)} ${log.logType} : ${log.message}`
+        : `${log.logType} : ${log.message}`,
+    )
+    .join('\n');
   await window.clipboardWriteText(logsText);
 }
 </script>
@@ -33,8 +42,10 @@ async function copyLogsToClipboard(): Promise<void> {
   <div class="flex flex-row align-middle items-center w-full mb-4">
     <Icon size="1.875x" class="pr-3" icon={faFileLines} />
     <div class="text-xl">Logs</div>
-    <div class="flex flex-1 justify-end">
-      <Button title="Copy To Clipboard" class="ml-5" on:click={async (): Promise<void> => await copyLogsToClipboard()} type="link"
+    <div class="flex flex-1 justify-end items-center gap-1">
+      <Button title="Toggle Timestamps" on:click={(): boolean => (showTimestamps = !showTimestamps)} type="link"
+        ><Icon class="h-5 w-5 cursor-pointer text-xl {showTimestamps ? 'text-[var(--pd-button-primary-bg)]' : 'text-[var(--pd-content-text)]'}" icon={faClock} /></Button>
+      <Button title="Copy To Clipboard" on:click={async (): Promise<void> => await copyLogsToClipboard()} type="link"
         ><Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faPaste} /></Button>
     </div>
   </div>
@@ -44,12 +55,14 @@ async function copyLogsToClipboard(): Promise<void> {
         {#each logs as log, index (index)}
           <li class="py-[3px] px-1 rounded-sm {index % 2 === 0 ? 'bg-black/4 dark:bg-white/4' : ''}">
             <div class="flex flex-row items-start gap-2">
-              <span
-                class="font-mono text-[10px] font-thin shrink-0 {log.logType === 'error'
-                  ? 'text-[var(--pd-state-error)]'
-                  : ''} {log.logType === 'warn' ? 'text-[var(--pd-state-warning)]' : 'text-[var(--pd-content-text)]'}">
-                {formatTimestamp(log.date)}
-              </span>
+              {#if showTimestamps}
+                <span
+                  class="font-mono text-[10px] font-thin shrink-0 {log.logType === 'error'
+                    ? 'text-[var(--pd-state-error)]'
+                    : ''} {log.logType === 'warn' ? 'text-[var(--pd-state-warning)]' : 'text-[var(--pd-content-text)]'}">
+                  {formatTimestamp(log.date)}
+                </span>
+              {/if}
               <div
                 class="font-mono text-[10px] font-thin {log.logType === 'error'
                   ? 'text-[var(--pd-state-error)]'

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -24,7 +24,7 @@ function formatTimestamp(date: Date): string {
 }
 
 async function copyLogsToClipboard(): Promise<void> {
-  const logsText = logs.map(log => `${formatTimestamp(log.date)} [${log.logType}] ${log.message}`).join('\n');
+  const logsText = logs.map(log => `${formatTimestamp(log.date)} ${log.logType} : ${log.message}`).join('\n');
   await window.clipboardWriteText(logsText);
 }
 </script>
@@ -42,9 +42,12 @@ async function copyLogsToClipboard(): Promise<void> {
     <div class="h-full overflow-auto p-2 bg-[var(--pd-invert-content-card-bg)]">
       <ul aria-label="logs">
         {#each logs as log, index (index)}
-          <li>
-            <div class="flex flex-row align-middle items-center gap-2">
-              <span class="font-mono text-[10px] font-thin text-[var(--pd-content-text-secondary)] shrink-0">
+          <li class="py-[3px]">
+            <div class="flex flex-row items-start gap-2">
+              <span
+                class="font-mono text-[10px] font-thin shrink-0 {log.logType === 'error'
+                  ? 'text-[var(--pd-state-error)]'
+                  : ''} {log.logType === 'warn' ? 'text-[var(--pd-state-warning)]' : 'text-[var(--pd-content-text)]'}">
                 {formatTimestamp(log.date)}
               </span>
               <div


### PR DESCRIPTION
### What does this PR do?

Adds timestamps to each log entry on the Troubleshooting / Logs page, matching the format shown in the developer console. Timestamps are opt-in via a clock icon toggle button, hidden by default.

The toggle state is persisted to the configuration registry (`troubleshooting.logsTimestamps`), so it survives page navigation and app restarts.

The clipboard copy format includes the timestamp when the toggle is enabled: `HH:MM:SS [logType] message`.

### Screenshot / video of UI
<img width="1023" height="803" alt="Screenshot 2026-04-29 at 17 11 53" src="https://github.com/user-attachments/assets/d987043e-8abc-4c76-9de1-19349cc0a8d6" />

### What issues does this PR fix or reference?

Closes #17274

### How to test this PR?

1. Run `pnpm watch` and open Podman Desktop
2. Navigate to **Troubleshooting** > **Logs** tab
3. Verify timestamps are hidden by default
4. Click the clock icon to toggle timestamps on
5. Verify each log entry now shows a timestamp prefix (e.g. `14:30:45`)
6. Navigate to another page and come back — verify the toggle is still enabled
7. Restart `pnpm watch` and reopen the Logs tab — verify the toggle is still enabled (persisted across restarts)
8. Click **Copy To Clipboard** and paste — verify the copied text includes timestamps when the toggle is on, and excludes them when off

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)