### PR TITLE
chore(extension-api): add Arch property to ImageInfo

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2534,6 +2534,11 @@ declare module '@podman-desktop/api' {
 
     // isManifest will be returned and set to true if the image is identified to be a manifest list
     isManifest?: boolean;
+
+    /**
+     * CPU architecture of the image. Podman-specific, available since Podman v5.1.0.
+     */
+    Arch?: string;
   }
 
   export interface ImageInspectInfo {


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

This PR adds an optional `Arch` property to the `ImageInfo` interface in the extension API, allowing extensions to access the architecture (e.g. `amd64`, `arm64`) of a container image.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes #16967 

### How to test this PR?

1. Build the project with `pnpm build`
2. Confirm the `Arch` field is available on `ImageInfo` objects in the extension API
3. Extensions can now read `image.Arch` to determine the image architecture

- [x] Tests are covering the bug fix or the new feature
