### PR TITLE
chore(test): adjust tests for cdp runner and downstream variation

### DIFF
--- a/tests/playwright/src/model/pages/welcome-page.ts
+++ b/tests/playwright/src/model/pages/welcome-page.ts
@@ -42,7 +42,7 @@ export class WelcomePage extends BasePage {
 
   constructor(page: Page) {
     super(page);
-    this.welcomeMessage = page.getByText('Welcome to Podman Desktop');
+    this.welcomeMessage = page.getByText(/Welcome to.*Podman Desktop/);
     this.telemetryConsent = page.getByLabel('Enable telemetry');
     this.skipOnBoarding = page.getByRole('button', {
       name: 'Skip',

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -45,9 +45,9 @@ let resourceLabel: string | undefined;
 let ociImageUrl: string | undefined;
 
 let navigationBar: NavigationBar;
-const skipExtesnionsTest = process.env.SKIP_EXTENSIONS_TEST ?? false;
+const skipExtensionsTest = process.env.SKIP_EXTENSIONS_TEST === 'true';
 
-test.skip(!!skipExtesnionsTest, 'Skip test suite based on env. variable');
+test.skip(skipExtensionsTest, 'Skip test suite based on env. variable');
 
 // Set PODMAN_DESKTOP_EXTENSIONS env var to a comma-separated list of extension names to run only specific extensions.
 // Available extension names:

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -45,6 +45,9 @@ let resourceLabel: string | undefined;
 let ociImageUrl: string | undefined;
 
 let navigationBar: NavigationBar;
+const skipExtesnionsTest = process.env.SKIP_EXTENSIONS_TEST ?? false;
+
+test.skip(!!skipExtesnionsTest, 'Skip test suite based on env. variable');
 
 // Set PODMAN_DESKTOP_EXTENSIONS env var to a comma-separated list of extension names to run only specific extensions.
 // Available extension names:

--- a/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
@@ -25,6 +25,9 @@ import { isMac } from '/@/utility/platform';
 let rateLimitReachedFlag = false;
 let composeOnboardingStatusText: string | undefined;
 let kubectlOnboardingStatusText: string | undefined;
+const skipExtesnionsOnboardingTest = process.env.SKIP_EXTENSIONS_ONBOARDING_TEST ?? false;
+
+test.skip(!!skipExtesnionsOnboardingTest, 'Skip test suite based on env. variable');
 
 test.use({ runnerOptions: new RunnerOptions({ customFolder: 'compose-onboarding' }) });
 test.beforeAll(async ({ runner, page }) => {

--- a/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
@@ -25,9 +25,10 @@ import { isMac } from '/@/utility/platform';
 let rateLimitReachedFlag = false;
 let composeOnboardingStatusText: string | undefined;
 let kubectlOnboardingStatusText: string | undefined;
-const skipExtesnionsOnboardingTest = process.env.SKIP_EXTENSIONS_ONBOARDING_TEST ?? false;
+const skipExtensionsOnboardingTest = process.env.SKIP_EXTENSIONS_ONBOARDING_TEST === 'true';
 
-test.skip(!!skipExtesnionsOnboardingTest, 'Skip test suite based on env. variable');
+test.skip(skipExtensionsOnboardingTest, 'Skip test suite based on env. variable');
+test.skip(!!isMac, 'This test is not supported on Mac due to requiring admin permissions to install tools');
 
 test.use({ runnerOptions: new RunnerOptions({ customFolder: 'compose-onboarding' }) });
 test.beforeAll(async ({ runner, page }) => {
@@ -42,8 +43,6 @@ test.beforeAll(async ({ runner, page }) => {
     }
   });
 });
-
-test.skip(!!isMac, 'This test is not supported on Mac due to requiring admin permissions to install tools');
 
 test.afterAll(async ({ runner }) => {
   await runner.close();

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -304,6 +304,10 @@ test.describe
     });
 
     test('Save image as tar, delete, load from tar', async ({ navigationBar }) => {
+      test.skip(
+        process.env.DEBUGGING_PORT !== undefined && process.env.PODMAN_DESKTOP_BINARY !== undefined,
+        'Test is not runnig with CDP runner',
+      );
       test.setTimeout(180_000);
 
       const tarFilePath = path.join(tmpdir(), 'podman-desktop-e2e-hello.tar');

--- a/tests/playwright/src/specs/podman-kube-play-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-kube-play-smoke.spec.ts
@@ -46,6 +46,11 @@ const POD_BUILD_YAML_PATH: string = path.resolve(
   'podman-kube-play-build-test.yaml',
 );
 
+test.skip(
+  process.env.DEBUGGING_PORT !== undefined && process.env.PODMAN_DESKTOP_BINARY !== undefined,
+  'Test is not supported with CDP runner',
+);
+
 test.describe
   .serial('Podman Kube Play Yaml - Create Pod from Scratch', { tag: '@smoke' }, () => {
     test.beforeAll(async ({ runner, page, welcomePage }) => {

--- a/tests/playwright/src/specs/search-bar-smoke.spec.ts
+++ b/tests/playwright/src/specs/search-bar-smoke.spec.ts
@@ -80,7 +80,7 @@ test.describe
       await commandPalette.allTab.click();
       await playExpect(commandPalette.commandPaletteInputField).toHaveAttribute(
         'placeholder',
-        'Search Podman Desktop, or type > for commands',
+        /Search.*Podman Desktop, or type > for commands/,
       );
 
       await commandPalette.close();

--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -50,6 +50,11 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
+test.skip(
+  process.env.DEBUGGING_PORT !== undefined && process.env.PODMAN_DESKTOP_BINARY !== undefined,
+  'Test is not supported with CDP runner',
+);
+
 test.describe
   .serial(`Play yaml file to pull images and create pod for app ${podAppName}`, {
     tag: ['@smoke', '@windows_sanity'],


### PR DESCRIPTION
### What does this PR do?
Skips some tests that requires ElectronRunner (when using CDPrunner). Add options to skip some of the tests in environment where they are not supported.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#17330 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
All e2e tests should be passing.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
