### PR TITLE
fix(main): propagate event stream parser errors to trigger reconnection

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3906,6 +3906,39 @@ test('check handleEvents tracks telemetry when stream emits error', async () => 
   consoleErrorSpy.mockRestore();
 });
 
+test('check handleEvents calls errorCallback and destroys pipeline on parse error', async () => {
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((ignored: unknown, stream: PassThrough) => void) | undefined;
+  getEventsMock.mockImplementation((options: (ignored: unknown, stream: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const passThrough = new PassThrough();
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  if (eventsMockCallback) {
+    eventsMockCallback?.(undefined, passThrough);
+  }
+
+  // send malformed data to trigger a JSON parse error in the pipeline
+  passThrough.write('this is not valid JSON{{{');
+  passThrough.end();
+
+  await vi.waitFor(() => expect(errorCallback).toHaveBeenCalled());
+
+  expect(consoleErrorSpy).toHaveBeenCalledWith('Error while parsing events', expect.any(Error));
+  expect(errorCallback).toHaveBeenCalledWith(expect.objectContaining({ message: 'Error while parsing events' }));
+
+  consoleErrorSpy.mockRestore();
+});
+
 test('check volume mounted is replicated when executing replicatePodmanContainer with named volume', async () => {
   const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -278,6 +278,8 @@ export class ContainerProviderRegistry {
       const pipeline = stream?.pipe(withParserAsStream());
       pipeline?.on('error', error => {
         console.error('Error while parsing events', error);
+        pipeline.destroy();
+        errorCallback(new Error('Error while parsing events', error));
       });
       pipeline?.on('data', data => {
         if (data?.value !== undefined) {


### PR DESCRIPTION
### What does this PR do?

The JSON parser pipeline error handler only logged the error but did not call errorCallback, so a single malformed event permanently broke event processing without triggering reconnection. The UI would show stale data while the podman CLI reflected the real state.

### Screenshot / video of UI

Before: the second container is not displayed after receiving one malformed event in the meantime

https://github.com/user-attachments/assets/52b712f3-9059-44c1-b1ae-8e58cb2b2dfe

After: the second container is properly displayed after receiving one malformed event in the meantime

(Video coming)


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Partial fix of #14877

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?


A script that sets up a transparent proxy on the podman socket and injects a single malformed JSON event. The proxy is fully transparent, all data passes through normally. One bad event is enough to permanently break event processing.

<details>
<summary>repro-desync.sh</summary>

```bash
#!/bin/zsh
# Prerequisites: node, podman machine running, Podman Desktop CLOSED before starting.
set -e
SOCK=$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}')
PROXY_PID=""
cleanup() {
  echo "\n--- Cleanup ---"
  kill $PROXY_PID 2>/dev/null
  mv "${SOCK}.real" "$SOCK" 2>/dev/null
  podman rm -f before-desync after-desync 2>/dev/null
  echo "Done."
}
trap cleanup EXIT

echo "=== Step 1: Set up transparent proxy on podman socket ==="
mv "$SOCK" "${SOCK}.real"
node -e '
const net=require("net"),fs=require("fs"),S=process.argv[1],R=S+".real",D=[];
const srv=net.createServer(c=>{
  const u=net.connect(R);D.push(c);c.pipe(u);u.pipe(c);
  c.on("close",()=>{u.destroy();D.splice(D.indexOf(c),1)});
  u.on("close",()=>c.destroy());
  c.on("error",()=>u.destroy());u.on("error",()=>c.destroy())
});
process.on("SIGUSR1",()=>{
  const b="{bad}\n";
  console.log("Injecting ONE malformed event into "+D.length+" connections");
  D.forEach(c=>c.write(b.length.toString(16)+"\r\n"+b+"\r\n"));
});
try{fs.unlinkSync(S)}catch{};
srv.listen(S,()=>console.log("Transparent proxy ready (PID "+process.pid+")"))
' "$SOCK" &
PROXY_PID=$!
sleep 1

echo "\n=== Step 2: Open Podman Desktop now, then press Enter ==="
read
echo "\n=== Step 3: Create a container ==="
podman run -d --name before-desync alpine sleep 3600
echo ">>> Verify 'before-desync' appears in Podman Desktop, then press Enter"
read
echo "\n=== Step 4: Inject ONE malformed JSON event ==="
kill -USR1 $PROXY_PID
sleep 2
echo "\n=== Step 5: Create another container ==="
podman run -d --name after-desync alpine sleep 3600
echo "\n=== Step 6: Verify desync ==="
podman ps --format "table {{.Names}}\t{{.Status}}"
echo "\n>>> Podman Desktop only shows 'before-desync' (stale data)."
echo "Press Enter to clean up."
read
```

</details>



<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
