### PR TITLE
fix(renderer): restore explore features section after page refresh

### DIFF
--- a/packages/renderer/src/stores/explore-features.ts
+++ b/packages/renderer/src/stores/explore-features.ts
@@ -23,12 +23,12 @@ import { writable } from 'svelte/store';
 import { EventStore } from './event-store';
 
 const windowEvents = ['explore-features-loaded', 'provider-change', 'provider-container-connection-update-status'];
-const windowListeners = ['update-explore-features'];
+const windowListeners = ['update-explore-features', 'extensions-already-started'];
 
 let readyToUpdate = false;
 
 async function checkForUpdate(eventName: string): Promise<boolean> {
-  if ('explore-features-loaded' === eventName) {
+  if ('explore-features-loaded' === eventName || 'extensions-already-started' === eventName) {
     readyToUpdate = true;
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the "Explore Features" section on the dashboard disappearing after a page refresh (Ctrl+R).

**Root cause:** The `explore-features` EventStore relies on a `readyToUpdate` flag that is only set to `true` when the `explore-features-loaded` IPC event fires from the main process. This event fires once during initial startup but does not re-fire when the renderer reloads (Ctrl+R). Other similar stores (e.g., `featured-extensions`) handle this by also listening to the `extensions-already-started` DOM event dispatched by `Loader.svelte`, which fires on every renderer load.

**Fix:** Add `extensions-already-started` to the store's `windowListeners` and accept it as a trigger to set `readyToUpdate = true`, aligning with the pattern used by other stores.

### Screenshot / video of UI


Uploading Screen Recording 2026-04-30 at 13.46.28.mov…



<!-- @simonrey1 please add a before/after video here -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17289

### How to test this PR?

1. Start Podman Desktop in dev mode (`pnpm watch`)
2. Navigate to the Dashboard — verify the "Explore Features" section is visible
3. Press Ctrl+R (or Cmd+R on macOS) to reload the renderer
4. Verify the "Explore Features" section is still visible after reload

- [ ] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)