### PR TITLE
refactor: update main package tests to use mocked product.json values

### DIFF
--- a/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.spec.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { TelemetryLogger } from '@podman-desktop/api';
+import { env, type TelemetryLogger } from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { PowerShellClient } from '/@/utils/powershell';
@@ -40,6 +40,7 @@ const POWERSHELL_CLIENT: PowerShellClient = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(env).appName = 'Test app';
   vi.mocked(getPowerShellClient).mockResolvedValue(POWERSHELL_CLIENT);
 });
 
@@ -49,9 +50,7 @@ test('expect PodmanDesktopElevatedCheck preflight check return failure result if
   const podmanDesktopElevatedCheck = new PodmanDesktopElevatedCheck(mockTelemetryLogger);
   const result = await podmanDesktopElevatedCheck.execute();
   expect(result.successful).toBeFalsy();
-  expect(result.description).equal(
-    'You must run Podman Desktop with administrative rights to run Hyper-V Podman machines.',
-  );
+  expect(result.description).equal('You must run Test app with administrative rights to run Hyper-V Podman machines.');
   expect(result.docLinks).toBeUndefined();
 });
 

--- a/packages/main/src/main.spec.ts
+++ b/packages/main/src/main.spec.ts
@@ -23,6 +23,7 @@ import { DefaultProtocolClient } from '/@/plugin/app-ready/default-protocol-clie
 import { WindowPlugin } from '/@/plugin/app-ready/window-plugin.js';
 import { SecurityRestrictions } from '/@/security-restrictions.js';
 import { isLinux, isMac, isWindows } from '/@/util.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { Main } from './main.js';
 
@@ -37,6 +38,7 @@ vi.mock(import('electron-context-menu'), () => ({
 // App Plugin
 vi.mock(import('/@/plugin/app-ready/default-protocol-client.js'));
 vi.mock(import('/@/plugin/app-ready/window-plugin.js'));
+vi.mock(import('/@product.json'));
 
 const ELECTRON_APP_MOCK: ElectronApp = {
   name: 'dummy-electron-mock',
@@ -57,6 +59,7 @@ let PROCESS_EXIT_ORIGINAL: typeof process.exit;
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(product).appId = 'io.test_app.TestApp';
 
   // mock process.exit
   PROCESS_EXIT_ORIGINAL = process.exit;
@@ -102,7 +105,7 @@ test('on windows setAppUserModelId should be called', async () => {
   const code = new Main(ELECTRON_APP_MOCK);
   code.main([]);
 
-  expect(ELECTRON_APP_MOCK.setAppUserModelId).toHaveBeenCalledWith('io.podman_desktop.PodmanDesktop');
+  expect(ELECTRON_APP_MOCK.setAppUserModelId).toHaveBeenCalledWith('io.test_app.TestApp');
 });
 
 describe('gtk-version', () => {

--- a/packages/main/src/plugin/app-ready/default-protocol-client.spec.ts
+++ b/packages/main/src/plugin/app-ready/default-protocol-client.spec.ts
@@ -21,10 +21,12 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { AppPlugin } from '/@/plugin/app-ready/app-plugin.js';
 import { isWindows } from '/@/util.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { DefaultProtocolClient } from './default-protocol-client.js';
 
 vi.mock(import('/@/util.js'));
+vi.mock(import('/@product.json'));
 
 const ELECTRON_APP_MOCK: ElectronApp = {
   setAsDefaultProtocolClient: vi.fn(),
@@ -36,6 +38,7 @@ let originalProcessArgv: string[];
 let plugin: AppPlugin;
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(product).urlProtocol = 'test-protocol';
 
   originalExecPath = process.execPath;
   originalProcessArgv = process.argv;
@@ -63,7 +66,7 @@ test('ElectronApp#setAsDefaultProtocolClient should be called when application i
   await plugin.onReady();
 
   expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledOnce();
-  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledWith('podman-desktop');
+  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledWith('test-protocol');
 });
 
 test('on windows ElectronApp#setAsDefaultProtocolClient should be called with process args', async () => {
@@ -72,7 +75,7 @@ test('on windows ElectronApp#setAsDefaultProtocolClient should be called with pr
   await plugin.onReady();
 
   expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledOnce();
-  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledWith('podman-desktop', '/foo/bar', [
+  expect(ELECTRON_APP_MOCK.setAsDefaultProtocolClient).toHaveBeenCalledWith('test-protocol', '/foo/bar', [
     'foo',
     'bar',
   ]);

--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -22,6 +22,8 @@ import type { IConfigurationNode } from '@podman-desktop/core-api/configuration'
 import { CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE } from '@podman-desktop/core-api/configuration';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import product from '/@product.json' with { type: 'json' };
+
 import { AutostartEngine } from './autostart-engine.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import type { DefaultConfiguration } from './default-configuration.js';
@@ -39,8 +41,11 @@ const extensionDisplayName = 'name';
 const mockRegisterConfiguration = vi.fn();
 const mockRunAutostart = vi.fn().mockResolvedValue('');
 
+vi.mock(import('/@product.json'));
+
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(product).name = 'Test app';
 });
 
 /* eslint-disable @typescript-eslint/no-empty-function */
@@ -74,7 +79,7 @@ test('Check that default value is true if provider autostart setting is not set'
     },
     properties: {
       [`preferences.${extensionId}.engine.autostart`]: {
-        description: `Autostart ${extensionDisplayName} engine when launching Podman Desktop`,
+        description: `Autostart ${extensionDisplayName} engine when launching Test app`,
         type: 'boolean',
         default: true,
         scope: [CONFIGURATION_DEFAULT_SCOPE, CONFIGURATION_ONBOARDING_SCOPE],

--- a/packages/main/src/plugin/directories-legacy.spec.ts
+++ b/packages/main/src/plugin/directories-legacy.spec.ts
@@ -33,10 +33,22 @@ const originalProcessEnv = process.env;
 // Mock file system
 vi.mock(import('node:fs'));
 vi.mock(import('/@/util.js'));
+vi.mock(import('/@product.json'));
 
 beforeEach(() => {
   // Reset environment variables to clean state
   process.env = { ...originalProcessEnv };
+
+  vi.mocked(product).appId = 'io.test_app.TestApp';
+  vi.mocked(product).paths = {
+    config: 'containers/test-app',
+    managed: {
+      macOS: '/Library/Application Support/io.test_app.TestApp',
+      windows: '%PROGRAMDATA%\\Test App',
+      linux: '/usr/share/test-app',
+      flatpak: '/run/host/usr/share/test-app',
+    },
+  };
 
   vi.spyOn(fs, 'existsSync').mockReturnValue(true);
   vi.spyOn(fs, 'mkdirSync').mockImplementation(() => '');
@@ -52,11 +64,17 @@ describe('LegacyDirectories', () => {
 
   describe('Default Directory Structure', () => {
     beforeEach(() => {
+      // Mock the static property that was evaluated at module load time
+      Object.defineProperty(LegacyDirectories, 'XDG_DATA_DIRECTORY', {
+        value: `.local${path.sep}share${path.sep}containers${path.sep}test-app`,
+        writable: true,
+        configurable: true,
+      });
       provider = new LegacyDirectories();
     });
 
     test('should use default legacy base directory', () => {
-      const expectedBaseDir = path.resolve(os.homedir(), '.local', 'share', 'containers', 'podman-desktop');
+      const expectedBaseDir = path.resolve(os.homedir(), '.local', 'share', 'containers', 'test-app');
       expect(provider.getDataDirectory()).toBe(expectedBaseDir);
     });
 
@@ -137,7 +155,7 @@ describe('LegacyDirectories', () => {
 
       // The macOS managed path folder should be the appId (macOS format is different vs Windows / Linux)
       // so make sure we still have the correct format
-      expect(provider.getManagedDefaultsDirectory()).toBe(`/Library/Application Support/${product.appId}`);
+      expect(provider.getManagedDefaultsDirectory()).toBe('/Library/Application Support/io.test_app.TestApp');
     });
 
     test('should map PROGRAMDATA into windows managed folder path', () => {

--- a/packages/main/src/plugin/directories-linux-xdg.spec.ts
+++ b/packages/main/src/plugin/directories-linux-xdg.spec.ts
@@ -28,9 +28,21 @@ import { LinuxXDGDirectories } from './directories-linux-xdg.js';
 
 const originalProcessEnv = process.env;
 
+vi.mock(import('/@product.json'));
+
 beforeEach(() => {
   // Reset environment variables to clean state
   process.env = { ...originalProcessEnv };
+
+  vi.mocked(product).paths = {
+    config: 'containers/test-app',
+    managed: {
+      macOS: '/Library/Application Support/io.test_app.TestApp',
+      windows: '%PROGRAMDATA%\\Test App',
+      linux: '/usr/share/test-app',
+      flatpak: '/run/host/usr/share/test-app',
+    },
+  };
 
   // Clear XDG environment variables for clean tests
   // biome-ignore lint/complexity/useLiteralKeys: XDG_CONFIG_HOME comes from an index signature
@@ -55,13 +67,13 @@ describe('LinuxXDGDirectories', () => {
     });
 
     test('should use default XDG configuration directory', () => {
-      const expectedConfigDir = path.resolve(os.homedir(), '.config', 'containers', 'podman-desktop');
+      const expectedConfigDir = path.resolve(os.homedir(), '.config', 'containers', 'test-app');
 
       expect(provider.getConfigurationDirectory()).toBe(expectedConfigDir);
     });
 
     test('should use default XDG data directory', () => {
-      const expectedDataDir = path.resolve(os.homedir(), '.local', 'share', 'containers', 'podman-desktop');
+      const expectedDataDir = path.resolve(os.homedir(), '.local', 'share', 'containers', 'test-app');
 
       expect(provider.getDataDirectory()).toBe(expectedDataDir);
     });
@@ -102,8 +114,8 @@ describe('LinuxXDGDirectories', () => {
       const configDir = provider.getConfigurationDirectory();
       const dataDir = provider.getDataDirectory();
 
-      expect(configDir).toBe(path.resolve(customConfigHome, 'containers', 'podman-desktop'));
-      expect(dataDir).toBe(path.resolve(customDataHome, 'containers', 'podman-desktop'));
+      expect(configDir).toBe(path.resolve(customConfigHome, 'containers', 'test-app'));
+      expect(dataDir).toBe(path.resolve(customDataHome, 'containers', 'test-app'));
     });
 
     test('should use custom paths for data subdirectories', () => {
@@ -113,7 +125,7 @@ describe('LinuxXDGDirectories', () => {
 
       provider = new LinuxXDGDirectories();
 
-      const expectedDataDir = path.resolve(customDataHome, 'containers', 'podman-desktop');
+      const expectedDataDir = path.resolve(customDataHome, 'containers', 'test-app');
 
       expect(provider.getPluginsDirectory()).toBe(path.resolve(expectedDataDir, 'plugins'));
       expect(provider.getExtensionsStorageDirectory()).toBe(path.resolve(expectedDataDir, 'extensions-storage'));

--- a/packages/main/src/plugin/feedback-handler.spec.ts
+++ b/packages/main/src/plugin/feedback-handler.spec.ts
@@ -93,17 +93,6 @@ function containSearchParams(url: string | undefined, params: Record<string, str
 }
 
 describe('getFeedbackMessages', () => {
-  test('should return feedback messages with default product name', () => {
-    const feedbackHandler = new FeedbackHandler(extensionLoaderMock);
-    const messages = feedbackHandler.getFeedbackMessages();
-
-    expect(messages.experienceLabel).toBe('How was your experience with Podman Desktop');
-    expect(messages.thankYouMessage).toBe(
-      'Your input is valuable in helping us better understand and tailor Podman Desktop.',
-    );
-    expect(messages.gitHubStarsMessage).toBe('Like Podman Desktop? Give us a star on GitHub');
-  });
-
   test('should return feedback messages with custom product name', () => {
     vi.mocked(productJSONFile).name = 'Custom Product';
 

--- a/packages/main/src/plugin/onboarding-registry.spec.ts
+++ b/packages/main/src/plugin/onboarding-registry.spec.ts
@@ -23,12 +23,15 @@ import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
+import product from '/@product.json' with { type: 'json' };
 
 import { Context } from './context/context.js';
 import { OnboardingRegistry } from './onboarding-registry.js';
 import type { Disposable } from './types/disposable.js';
 
 vi.mock(import('node:fs'));
+
+vi.mock(import('/@product.json'));
 
 let onboardingRegistry: OnboardingRegistry;
 const extensionId = 'myextension.id';
@@ -46,6 +49,11 @@ const context = new Context(apiSender);
 
 let registerOnboardingDisposable: Disposable;
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(product).name = 'Test app';
+});
+
 describe('an OnboardingRegistry instance exists', () => {
   /* eslint-disable @typescript-eslint/no-empty-function */
   beforeEach(() => {
@@ -54,7 +62,7 @@ describe('an OnboardingRegistry instance exists', () => {
     const manifest = {
       contributes: {
         onboarding: {
-          title: 'Get started with Podman Desktop',
+          title: 'Get started with Test app',
           priority: 1,
           removable: false,
           steps: [
@@ -95,8 +103,8 @@ describe('an OnboardingRegistry instance exists', () => {
   test('Should onboarding for known extension', async () => {
     const onboarding = onboardingRegistry.getOnboarding(extensionId);
     expect(onboarding).toBeDefined();
-    expect(onboarding?.title).toBe('Get started with Podman Desktop');
-    expect(onboarding?.welcomeMessage).toBe('Get started with Podman Desktop');
+    expect(onboarding?.title).toBe('Get started with Test app');
+    expect(onboarding?.welcomeMessage).toBe('Get started with Test app');
   });
 
   test('Should not find onboarding after dispose', async () => {
@@ -116,7 +124,7 @@ describe('an OnboardingRegistry instance exists', () => {
     expect(onboarding).toBeDefined();
     expectTypeOf(onboarding).toBeArray();
     expect(onboarding.length).toBe(1);
-    expect(onboarding[0]?.title).toBe('Get started with Podman Desktop');
+    expect(onboarding[0]?.title).toBe('Get started with Test app');
   });
 
   test('Should update state of step', async () => {
@@ -199,7 +207,7 @@ describe('checkIdsReadability tests', () => {
       id: extensionId,
     } as AnalyzedExtension;
     const onboarding = {
-      title: 'Get started with Podman Desktop',
+      title: 'Get started with Test app',
       priority: 50,
       steps: [
         {
@@ -280,7 +288,7 @@ describe('checkIdsReadability tests', () => {
           removable,
         } as AnalyzedExtension,
         {
-          title: `Get started with Podman Desktop ${id}`,
+          title: `Get started with Test app ${id}`,
           priority,
           enablement: '',
           steps: [

--- a/packages/main/src/plugin/open-devtools-init.spec.ts
+++ b/packages/main/src/plugin/open-devtools-init.spec.ts
@@ -18,8 +18,12 @@
 
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import product from '/@product.json' with { type: 'json' };
+
 import type { ConfigurationRegistry } from './configuration-registry.js';
 import { OpenDevToolsInit } from './open-devtools-init.js';
+
+vi.mock(import('/@product.json'));
 
 let openDevToolsInit: OpenDevToolsInit;
 
@@ -31,6 +35,7 @@ const configurationRegistryMock = {
 
 beforeEach(() => {
   openDevToolsInit = new OpenDevToolsInit(configurationRegistryMock);
+  vi.mocked(product).name = 'Test app';
 });
 test('should register a configuration', async () => {
   // register configuration
@@ -47,7 +52,7 @@ test('should register a configuration', async () => {
   expect(configurationNode?.properties).toBeDefined();
   expect(configurationNode?.properties?.['preferences.OpenDevTools']).toBeDefined();
   expect(configurationNode?.properties?.['preferences.OpenDevTools']?.description).toBe(
-    'Open DevTools when launching Podman Desktop in development mode.',
+    'Open DevTools when launching Test app in development mode.',
   );
   expect(configurationNode?.properties?.['preferences.OpenDevTools']?.type).toBe('string');
   expect(configurationNode?.properties?.['preferences.OpenDevTools']?.enum).toEqual([

--- a/packages/main/src/plugin/telemetry/telemetry.spec.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.spec.ts
@@ -399,17 +399,6 @@ describe('aggregateTrack', () => {
     expect(pending?.properties).toEqual([{ foo: 1 }, { bar: 2 }]);
   });
 
-  test('should return telemetry messages with default product name', async () => {
-    const messages = telemetry.getTelemetryMessages();
-    expect(messages.acceptMessage).toBe(
-      'Help improve Podman Desktop by allowing Red Hat to collect anonymous usage data.',
-    );
-    expect(messages.info?.link).toBe('For more information read our statement');
-    expect(messages.info?.url).toBe('https://developers.redhat.com/article/tool-data-collection');
-    expect(messages.privacy?.link).toBe('Read our privacy statement');
-    expect(messages.privacy?.url).toBe('https://www.redhat.com/en/about/privacy-policy');
-  });
-
   test('should register telemetry preference correctly', async () => {
     await telemetry.init();
 

--- a/packages/main/src/plugin/welcome.spec.ts
+++ b/packages/main/src/plugin/welcome.spec.ts
@@ -16,19 +16,24 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { Welcome } from '/@/plugin/welcome.js';
 import productJSONFile from '/@product.json' with { type: 'json' };
 
 vi.mock(import('/@product.json'));
 
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(productJSONFile).name = 'Test app';
+});
+
 test('should return welcome messages with default product name', () => {
   const welcome = new Welcome();
   const messages = welcome.getWelcomeMessages();
 
-  expect(messages.getStartedMessage).toBe('Get started with Podman Desktop');
-  expect(messages.welcomeMessage).toBe('Welcome to Podman Desktop');
+  expect(messages.getStartedMessage).toBe('Get started with Test app');
+  expect(messages.welcomeMessage).toBe('Welcome to Test app');
 });
 
 test('should return welcome messages with custom product name', () => {


### PR DESCRIPTION
### What does this PR do?
Updates tests in main and extensions packages to use mocked values from `product.json` instead of hardcoded values that will fail if `product.json` changes

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/16455

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
