### PR TITLE
fix(podman): clear provider version when podman is uninstalled

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -3672,6 +3672,20 @@ describe('Check notify podman setup', () => {
     expect(extensionApi.window.showNotification).not.toHaveBeenCalled();
   });
 
+  test('clear provider version when podman is uninstalled', async () => {
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValueOnce({
+      version: '5.0.0',
+    });
+
+    await extension.doMonitorProvider(provider);
+    expect(provider.updateVersion).toHaveBeenCalledWith('5.0.0');
+
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValueOnce(undefined);
+
+    await extension.doMonitorProvider(provider);
+    expect(provider.updateVersion).toHaveBeenCalledWith();
+  });
+
   test('reset the notification flag so if podman is uninstalled in future we can show the notification again', async () => {
     vi.mocked(extensionApi.env).isLinux = true;
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -695,6 +695,7 @@ export async function doMonitorProvider(provider: extensionApi.Provider): Promis
 
     // update version
     if (!installedPodman) {
+      provider.updateVersion();
       provider.updateStatus('not-installed');
       extensionApi.context.setValue('podmanIsNotInstalled', true, 'onboarding');
       // if podman is not installed and the OS is linux we show the podman onboarding notification (if it has not been shown earlier)


### PR DESCRIPTION
### What does this PR do?

When doMonitorProvider detects podman is no longer installed, clear the cached version so the dashboard no longer shows a stale version string.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Relates to #14972 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?


*Case 1 — Without custom binary path preference (simple uninstall):*

1. Start Podman Desktop in dev mode with the fix applied
2. Verify the dashboard shows "Podman v5.8.2" with a running machine
3. Hide the podman binary (`sudo mv /opt/podman/bin/podman /opt/podman/bin/podman.bak`)
4. After a few seconds, the dashboard no longer shows the version and displays the "Podman needs to be set up" notification
5. Restore the binary (`sudo mv /opt/podman/bin/podman.bak /opt/podman/bin/podman`)
6. Version reappeared on the dashboard

*Case 2 — With custom binary path preference (matching the issue's reproduction steps):*

1. Set the custom binary path preference (Settings > Preferences > Podman) to `/opt/podman/bin/podman`
2. Hide the podman binary (`sudo mv /opt/podman/bin/podman /opt/podman/bin/podman.bak`)
3. At this point the dashboard still shows the version — this is expected because `PodmanBinary` caches the lookup result and the preference hasn't changed yet
4. Clear the custom binary path preference (reset to blank) — this invalidates the cache via `onDidChangeConfiguration`
5. After a few seconds, the dashboard no longer shows the version and displays the "Podman needs to be set up" notification
6. Restore the binary and version reappeared

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
