### PR TITLE
refactor(api): allow updateVersion to accept undefined

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -735,7 +735,7 @@ declare module '@podman-desktop/api' {
 
     // version may not be defined
     readonly version: string | undefined;
-    updateVersion(version: string): void;
+    updateVersion(version?: string): void;
     onDidUpdateVersion: Event<string>;
 
     readonly images: ProviderImages;

--- a/packages/main/src/plugin/provider-impl.ts
+++ b/packages/main/src/plugin/provider-impl.ts
@@ -161,9 +161,9 @@ export class ProviderImpl implements Provider, IDisposable {
     this._status = status;
   }
 
-  updateVersion(version: string): void {
+  updateVersion(version?: string): void {
     if (version !== this._version) {
-      this._onDidUpdateVersion.fire(version);
+      this._onDidUpdateVersion.fire(version ?? '');
     }
     this._version = version;
   }


### PR DESCRIPTION
### What does this PR do?

Widen the `Provider.updateVersion` signature from `string` to `string | undefined` so callers can explicitly clear the version instead of relying on the empty-string convention.

This is a preparatory change as [requested by @benoitf](https://github.com/podman-desktop/podman-desktop/pull/17360#issuecomment-4369430664) — follow-up PRs will migrate existing callers (compose, kubectl-cli, kind, podman) from `provider.updateVersion('')` to `provider.updateVersion(undefined)`.

### Screenshot / video of UI

N/A — no UI change.

### What issues does this PR fix or reference?

Preparatory refactor for #14972

### How to test this PR?

1. Verify that existing callers using `provider.updateVersion('some-version')` still work unchanged
2. Verify that `provider.updateVersion(undefined)` is now accepted by the type system

- [x] Tests are covering the bug fix or the new feature