### PR TITLE
refactor(extensions): omit version argument to clear provider version

### DIFF
--- a/extensions/compose/src/extension.spec.ts
+++ b/extensions/compose/src/extension.spec.ts
@@ -428,7 +428,7 @@ describe('registerCLITool', () => {
     expect(extensionApi.process.exec).toHaveBeenCalledWith('rm', ['system-wide-path'], { isAdmin: true });
 
     const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
-    expect(providerMock.updateVersion).toHaveBeenCalledWith('');
+    expect(providerMock.updateVersion).toHaveBeenCalledWith();
   });
 
   test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -445,7 +445,7 @@ async function registerCLITool(
       // update the version to undefined
       binaryVersion = undefined;
       binaryPath = undefined;
-      provider.updateVersion('');
+      provider.updateVersion();
       extensionApi.context.setValue('compose.isComposeInstalledSystemWide', false);
       composeProviderUpdateDisposable?.dispose();
     },

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -340,7 +340,7 @@ describe('cli#update', () => {
 
     await (await getCliToolInstaller()).doUninstall({} as unknown as extensionApi.Logger);
 
-    expect(PROVIDER_MOCK.updateVersion).toHaveBeenCalledWith('');
+    expect(PROVIDER_MOCK.updateVersion).toHaveBeenCalledWith();
   });
 });
 

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -634,7 +634,7 @@ async function registerCliTool(
       // update the version and path to undefined
       kindPath = undefined;
 
-      provider.updateVersion('');
+      provider.updateVersion();
       currentUpdateDisposable?.dispose();
     },
   });

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -713,7 +713,7 @@ describe('postActivate', () => {
     expect(extensionApi.process.exec).toHaveBeenCalledWith('rm', ['system-path'], { isAdmin: true });
 
     const providerMock = vi.mocked(extensionApi.provider.createProvider).mock.results[0].value as Provider;
-    expect(providerMock.updateVersion).toHaveBeenCalledWith('');
+    expect(providerMock.updateVersion).toHaveBeenCalledWith();
   });
 
   test('if unlink fails because of a permission issue, it should delete all binaries as admin', async () => {

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -453,7 +453,7 @@ async function postActivate(
 
       // update the version to undefined
       vpState.version = undefined;
-      provider.updateVersion('');
+      provider.updateVersion();
       kubectlProviderUpdateDisposable?.dispose();
     },
   });


### PR DESCRIPTION
### What does this PR do?

Migrate compose, kubectl-cli and kind extensions to call `provider.updateVersion()` with no argument instead of `provider.updateVersion('')` when a tool is uninstalled, now that the API accepts an optional version parameter (see #17371).

As [requested by @benoitf](https://github.com/podman-desktop/podman-desktop/pull/17360#issuecomment-4369430664).

### Screenshot / video of UI

N/A — no UI change.

### What issues does this PR fix or reference?

Depends on #17371
Follow-up for #14972

### How to test this PR?

1. Install a tool (e.g. compose, kubectl, kind) and verify the version shows on the Resources page
2. Uninstall the tool and verify the version is cleared from the Resources page

- [x] Tests are covering the bug fix or the new feature