### PR TITLE
chore(test,ci): create script for insecure signed registry setup and teardown, add tests

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -127,6 +127,16 @@ jobs:
           echo "Docker images after cleanup:"
           docker image ls
 
+      - name: Setup insecure test registry
+        run: |
+          chmod +x tests/playwright/scripts/setup-insecure-registry.sh
+          tests/playwright/scripts/setup-insecure-registry.sh start
+          echo "Insecure registry started on localhost:5443"
+          # Install self-signed cert into Ubuntu system trust store
+          sudo cp /tmp/pd-test-registry/registry.crt /usr/local/share/ca-certificates/pd-test-registry.crt
+          sudo update-ca-certificates
+          echo "Self-signed cert installed into system trust store"
+
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         with:
@@ -156,6 +166,9 @@ jobs:
           SKIP_KIND_INSTALL: 'true'
           KIND_PROVIDER_GHA: ${{ env.KIND_PROVIDER }}
           ELECTRON_ENABLE_INSPECT: true
+          INSECURE_REGISTRY_URL: 'localhost:5443'
+          INSECURE_REGISTRY_USERNAME: 'testuser'
+          INSECURE_REGISTRY_PASSWORD: 'testpassword123'
         run: |
           echo "Compiling the Podman Desktop in production mode"
           pnpm compile:current --linux dir
@@ -173,6 +186,9 @@ jobs:
           SKIP_KIND_INSTALL: 'true'
           KIND_PROVIDER_GHA: ${{ env.KIND_PROVIDER }}
           ELECTRON_ENABLE_INSPECT: true
+          INSECURE_REGISTRY_URL: 'localhost:5443'
+          INSECURE_REGISTRY_USERNAME: 'testuser'
+          INSECURE_REGISTRY_PASSWORD: 'testpassword123'
         run: |
           echo "Building Podman Desktop flatpak bundle"
           pnpm compile:current --linux flatpak
@@ -201,6 +217,13 @@ jobs:
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw
+
+      - name: Cleanup insecure test registry
+        if: always()
+        run: |
+          tests/playwright/scripts/setup-insecure-registry.sh cleanup || true
+          sudo rm -f /usr/local/share/ca-certificates/pd-test-registry.crt
+          sudo update-ca-certificates || true
 
   win-update-e2e-test:
     name: ${{ matrix.os }} update e2e tests - ${{ matrix.installation }}

--- a/tests/playwright/scripts/setup-insecure-registry.sh
+++ b/tests/playwright/scripts/setup-insecure-registry.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# /**********************************************************************
+#  Copyright (C) 2026 Red Hat, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#  **********************************************************************/
+set -euo pipefail
+
+# Requires Bash 3.2+ (macOS GitHub runners ship Bash 3.2).
+#
+# Deploy a local Docker registry with self-signed TLS and basic auth.
+# The registry listens on localhost:5443 and is intended for E2E testing
+# of insecure/self-signed registry workflows in Podman Desktop.
+#
+# All artifacts (certs, htpasswd) live under /tmp - nothing is written
+# outside of it, so the script is safe to run on any dev machine.
+#
+# Usage:
+#   ./setup-insecure-registry.sh          # start the registry
+#   ./setup-insecure-registry.sh cleanup  # stop and remove everything
+#
+# Authentication:
+#   Username / Password: override via INSECURE_REGISTRY_USERNAME / INSECURE_REGISTRY_PASSWORD
+#   Defaults: testuser / testpassword123
+
+DEFAULT_USERNAME="testuser"
+DEFAULT_PASSWORD="testpassword123"
+# Dollar signs are literal (bcrypt hash), not variables
+# shellcheck disable=SC2016
+DEFAULT_HTPASSWD='testuser:$2y$05$vsNY0rsRh7vNP360CqaAD.PtXGF0e1hRCPkpztRkMFZ422aPyA6Qe'
+
+REGISTRY_NAME="${INSECURE_REGISTRY_CONTAINER_NAME:-pd-test-registry}"
+REGISTRY_PORT="${INSECURE_REGISTRY_PORT:-5443}"
+REGISTRY_USERNAME="${INSECURE_REGISTRY_USERNAME:-${DEFAULT_USERNAME}}"
+REGISTRY_PASSWORD="${INSECURE_REGISTRY_PASSWORD:-${DEFAULT_PASSWORD}}"
+WORK_DIR="/tmp/${REGISTRY_NAME}"
+
+cleanup() {
+  echo "Stopping registry container..."
+  podman stop "${REGISTRY_NAME}" 2>/dev/null || true
+  podman rm -f "${REGISTRY_NAME}" 2>/dev/null || true
+
+  if [ -d "${WORK_DIR}" ]; then
+    echo "Removing artifacts from ${WORK_DIR}..."
+    rm -rf "${WORK_DIR}"
+  fi
+
+  echo "Cleanup complete."
+}
+
+generate_certs() {
+  mkdir -p "${WORK_DIR}"
+
+  # Use a config file for SANs instead of -addext, which is not
+  # supported by LibreSSL (the default openssl on macOS / GH runners).
+  cat > "${WORK_DIR}/openssl.cnf" <<EOF
+[req]
+distinguished_name = req_dn
+x509_extensions    = v3_ca
+prompt             = no
+
+[req_dn]
+CN = localhost
+
+[v3_ca]
+subjectAltName = DNS:localhost,IP:127.0.0.1
+keyUsage = digitalSignature,keyCertSign
+extendedKeyUsage = serverAuth
+basicConstraints = critical,CA:true
+EOF
+
+  openssl req -newkey rsa:2048 -nodes -sha256 \
+    -keyout "${WORK_DIR}/registry.key" \
+    -x509 -days 1 \
+    -out "${WORK_DIR}/registry.crt" \
+    -config "${WORK_DIR}/openssl.cnf" \
+    2>/dev/null
+  echo "Self-signed certificate generated in ${WORK_DIR}"
+}
+
+generate_htpasswd() {
+  if [ "${REGISTRY_USERNAME}" = "${DEFAULT_USERNAME}" ] && [ "${REGISTRY_PASSWORD}" = "${DEFAULT_PASSWORD}" ]; then
+    echo "${DEFAULT_HTPASSWD}" > "${WORK_DIR}/htpasswd"
+  else
+    local hash
+    hash=$(openssl passwd -apr1 "${REGISTRY_PASSWORD}")
+    echo "${REGISTRY_USERNAME}:${hash}" > "${WORK_DIR}/htpasswd"
+  fi
+  echo "htpasswd file created in ${WORK_DIR} (user: ${REGISTRY_USERNAME})"
+}
+
+start_registry() {
+  podman run -d \
+    --name "${REGISTRY_NAME}" \
+    -p "${REGISTRY_PORT}:5000" \
+    -v "${WORK_DIR}:/certs:Z" \
+    -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/registry.crt \
+    -e REGISTRY_HTTP_TLS_KEY=/certs/registry.key \
+    -e REGISTRY_AUTH=htpasswd \
+    -e REGISTRY_AUTH_HTPASSWD_REALM="Podman Desktop Test Registry" \
+    -e REGISTRY_AUTH_HTPASSWD_PATH=/certs/htpasswd \
+    docker.io/library/registry:2
+
+  echo "Registry started at localhost:${REGISTRY_PORT}"
+}
+
+registry_exists() {
+  podman container exists "${REGISTRY_NAME}" 2>/dev/null
+}
+
+case "${1:-start}" in
+  start)
+    if registry_exists; then
+      if [ "${CI:-}" = "true" ]; then
+        echo "CI detected - tearing down existing registry."
+        cleanup
+      else
+        echo "Registry container '${REGISTRY_NAME}' already exists."
+        echo ""
+        read -rp "  [t]eardown and recreate / [R]estart existing? (t/R): " choice
+        case "${choice}" in
+          t|T)
+            cleanup
+            ;;
+          *)
+            echo "Restarting existing container..."
+            podman restart "${REGISTRY_NAME}"
+            echo "Registry restarted at localhost:${REGISTRY_PORT}"
+            exit 0
+            ;;
+        esac
+      fi
+    fi
+    generate_certs
+    generate_htpasswd
+    start_registry
+    ;;
+  cleanup)
+    cleanup
+    ;;
+  *)
+    echo "Usage: $0 {start|cleanup}" >&2
+    exit 1
+    ;;
+esac

--- a/tests/playwright/src/model/pages/registries-page.ts
+++ b/tests/playwright/src/model/pages/registries-page.ts
@@ -20,6 +20,7 @@ import test, { expect as playExpect } from '@playwright/test';
 import type { Locator, Page } from 'playwright';
 
 import { Registries } from '/@/model/core/settings/registries';
+import { handleConfirmationDialog } from '/@/utility/operations';
 import { waitUntil } from '/@/utility/wait';
 
 import { SettingsPage } from './settings-page';
@@ -71,9 +72,20 @@ export class RegistriesPage extends SettingsPage {
     });
   }
 
-  async createRegistry(url: string, username: string, pswd: string): Promise<void> {
+  async createRegistry(url: string, username: string, pswd: string, handleUntrustedCert?: boolean): Promise<void> {
     return test.step('Create a new registry', async () => {
       await this.submitRegistryForm(url, username, pswd);
+
+      if (handleUntrustedCert) {
+        try {
+          await handleConfirmationDialog(this.page, 'Add Untrusted Registry?', true, 'Add', 'Cancel', 5_000);
+        } catch (err) {
+          if ((err as Error).name !== 'TimeoutError' && !(err as Error).message?.includes('Timeout')) {
+            throw err;
+          }
+        }
+      }
+
       await playExpect(this.addRegistryDialog).toBeHidden({ timeout: 30_000 });
     });
   }

--- a/tests/playwright/src/setupFiles/setup-registry.ts
+++ b/tests/playwright/src/setupFiles/setup-registry.ts
@@ -31,3 +31,15 @@ export function canTestRegistry(): boolean {
   const [registry, username, passwd] = setupRegistry();
   return !!registry && !!username && !!passwd;
 }
+
+export function setupInsecureRegistry(): string[] {
+  const registryUrl = process.env.INSECURE_REGISTRY_URL ?? '';
+  const registryUsername = process.env.INSECURE_REGISTRY_USERNAME ?? '';
+  const registryPswdSecret = process.env.INSECURE_REGISTRY_PASSWORD ?? '';
+  return [registryUrl, registryUsername, registryPswdSecret];
+}
+
+export function canTestInsecureRegistry(): boolean {
+  const [registry, username, passwd] = setupInsecureRegistry();
+  return !!registry && !!username && !!passwd;
+}

--- a/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
@@ -17,11 +17,15 @@
  ***********************************************************************/
 
 import { ImagesPage } from '/@/model/pages/images-page';
-import { RegistriesPage } from '/@/model/pages/registries-page';
-import { SettingsBar } from '/@/model/pages/settings-bar';
 import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
 import { expect as playExpect, test } from '/@/utility/fixtures';
-import { deleteImage, deleteRegistry, ensureNoImagesPresentCLI } from '/@/utility/operations';
+import {
+  createRegistryAndVerify,
+  deleteImage,
+  deleteRegistry,
+  ensureNoImagesPresentCLI,
+  removeRegistryAndVerify,
+} from '/@/utility/operations';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const helloContainer = 'ghcr.io/podmandesktop-ci/hello';
@@ -61,17 +65,8 @@ test.skip(!canTestRegistry(), 'Registry tests are disabled');
 
 test.describe
   .serial('Push image to container registry', { tag: '@smoke' }, () => {
-    test('Add registry', async ({ navigationBar, page }) => {
-      await navigationBar.openSettings();
-      const settingsBar = new SettingsBar(page);
-      const registryPage = await settingsBar.openTabPage(RegistriesPage);
-      await playExpect(registryPage.heading).toBeVisible();
-
-      await registryPage.createRegistry(registryUrl, registryUsername, registryPswdSecret);
-
-      const registryBox = registryPage.registriesTable.getByLabel('GitHub');
-      const username = registryBox.getByText(registryUsername);
-      await playExpect(username).toBeVisible({ timeout: 10_000 });
+    test('Add registry', async ({ page }) => {
+      await createRegistryAndVerify(page, registryUrl, registryUsername, registryPswdSecret, 'GitHub');
     });
 
     test('Pull image', async ({ navigationBar }) => {
@@ -147,15 +142,7 @@ test.describe
         .toBeTruthy();
     });
 
-    test('Registry removal verification', async ({ page, navigationBar }) => {
-      await navigationBar.openSettings();
-      const settingsBar = new SettingsBar(page);
-      const registryPage = await settingsBar.openTabPage(RegistriesPage);
-      await playExpect(registryPage.heading).toBeVisible();
-
-      await registryPage.removeRegistry(registryName);
-      const registryBox = registryPage.registriesTable.getByLabel(registryName);
-      const username = registryBox.getByText(registryUsername);
-      await playExpect(username).toBeHidden({ timeout: 10_000 });
+    test('Registry removal verification', async ({ page }) => {
+      await removeRegistryAndVerify(page, registryName, registryUsername);
     });
   });

--- a/tests/playwright/src/specs/insecure-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/insecure-registry-smoke.spec.ts
@@ -1,0 +1,149 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { CommandPalette } from '/@/model/pages/command-palette';
+import { ImagesPage } from '/@/model/pages/images-page';
+import { canTestInsecureRegistry, setupInsecureRegistry } from '/@/setupFiles/setup-registry';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import {
+  createRegistryAndVerify,
+  deleteImage,
+  deleteRegistry,
+  ensureNoImagesPresentCLI,
+  pushImageExpectFailure,
+} from '/@/utility/operations';
+import { isLinux } from '/@/utility/platform';
+import { waitForPodmanMachineStartup } from '/@/utility/wait';
+
+const sourceImage = 'ghcr.io/podmandesktop-ci/hello';
+let registryUrl: string;
+let registryUsername: string;
+let registryPassword: string;
+let fullImageName: string;
+
+test.beforeAll(async ({ runner, welcomePage, page }) => {
+  runner.setVideoAndTraceName('insecure-registry-e2e');
+
+  await welcomePage.handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
+  await ensureNoImagesPresentCLI(page);
+
+  [registryUrl, registryUsername, registryPassword] = setupInsecureRegistry();
+});
+
+test.afterAll(async ({ runner, page }) => {
+  try {
+    await deleteImage(page, sourceImage).catch((error: unknown) => {
+      console.log('Failed to delete source image:', error);
+    });
+    if (fullImageName) {
+      await deleteImage(page, fullImageName).catch((error: unknown) => {
+        console.log('Failed to delete tagged image:', error);
+      });
+    }
+    await deleteRegistry(page, registryUrl).catch((error: unknown) => {
+      console.log('Failed to delete insecure registry:', error);
+    });
+  } finally {
+    await runner.close();
+  }
+});
+
+test.skip(!canTestInsecureRegistry(), 'Insecure registry tests are disabled (env vars not set)');
+
+test.describe
+  .serial('Push image to insecure registry with self-signed certificate', { tag: '@smoke' }, () => {
+    test('Add insecure registry', async ({ page }) => {
+      await createRegistryAndVerify(page, registryUrl, registryUsername, registryPassword, registryUrl, true);
+    });
+
+    test('Pull source image', async ({ navigationBar }) => {
+      let imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      const pullImagePage = await imagesPage.openPullImage();
+      imagesPage = await pullImagePage.pullImage(sourceImage);
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      await imagesPage.waitForRowToExists(sourceImage, 30_000);
+    });
+
+    test('Tag image for insecure registry', async ({ page }) => {
+      let imagesPage = new ImagesPage(page);
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      fullImageName = `${registryUrl}/${registryUsername}/test-image`;
+
+      imagesPage = await imagesPage.renameImage(sourceImage, fullImageName, 'latest');
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      await imagesPage.waitForRowToExists(fullImageName, 30_000);
+    });
+
+    test('Push image to insecure registry', async ({ navigationBar, page }) => {
+      const imagesPage = new ImagesPage(page);
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      const imageDetailsPage = await imagesPage.openImageDetails(fullImageName);
+      await playExpect(imageDetailsPage.heading).toBeVisible();
+
+      if (isLinux) {
+        await imageDetailsPage.pushImage();
+      } else {
+        const errorText = (await pushImageExpectFailure(page, imageDetailsPage.pushButton)).toLowerCase();
+        playExpect(
+          errorText.includes('x509') || errorText.includes('certificate') || errorText.includes('tls'),
+          `Expected TLS/certificate error in push output, got: ${errorText.substring(0, 200)}`,
+        ).toBeTruthy();
+
+        const commandPalette = new CommandPalette(page);
+        await commandPalette.executeCommand('Podman: Synchronize certificates to all VMs');
+
+        // TODO: replace with readiness polling (e.g. podman info) once basic flow is validated.
+        await page.waitForTimeout(15_000);
+
+        const imagesPageAfterSync = await navigationBar.openImages();
+        const imageDetailsAfterSync = await imagesPageAfterSync.openImageDetails(fullImageName);
+        await playExpect(imageDetailsAfterSync.heading).toBeVisible();
+        await imageDetailsAfterSync.pushImage();
+      }
+    });
+
+    test('Verify push by re-pulling from insecure registry', async ({ navigationBar }) => {
+      let imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      const imageDetailPage = await imagesPage.openImageDetails(fullImageName);
+      await playExpect(imageDetailPage.heading).toBeVisible();
+
+      imagesPage = await imageDetailPage.deleteImage();
+      await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
+
+      await imagesPage.waitForRowToBeDelete(fullImageName, 60_000);
+
+      const pullImagePage = await imagesPage.openPullImage();
+      imagesPage = await pullImagePage.pullImage(fullImageName, 'latest');
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      await imagesPage.waitForRowToExists(fullImageName, 30_000);
+    });
+
+    test('Remove insecure registry', async ({ page }) => {
+      await deleteRegistry(page, registryUrl);
+    });
+  });

--- a/tests/playwright/src/specs/insecure-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/insecure-registry-smoke.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { TaskState } from '/@/model/core/states';
 import { CommandPalette } from '/@/model/pages/command-palette';
 import { ImagesPage } from '/@/model/pages/images-page';
 import { canTestInsecureRegistry, setupInsecureRegistry } from '/@/setupFiles/setup-registry';
@@ -29,6 +30,9 @@ import {
 } from '/@/utility/operations';
 import { isLinux } from '/@/utility/platform';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
+
+const SYNC_TIMEOUT = 180_000;
+const POLL_INTERVAL = 2_000;
 
 const sourceImage = 'ghcr.io/podmandesktop-ci/hello';
 let registryUrl: string;
@@ -95,7 +99,9 @@ test.describe
       await imagesPage.waitForRowToExists(fullImageName, 30_000);
     });
 
-    test('Push image to insecure registry', async ({ navigationBar, page }) => {
+    test('Push image to insecure registry', async ({ navigationBar, page, statusBar }) => {
+      test.setTimeout(SYNC_TIMEOUT + 60_000);
+
       const imagesPage = new ImagesPage(page);
       await playExpect(imagesPage.heading).toBeVisible();
 
@@ -111,11 +117,29 @@ test.describe
           `Expected TLS/certificate error in push output, got: ${errorText.substring(0, 200)}`,
         ).toBeTruthy();
 
+        const tasksPage = await statusBar.openTasksPage();
+        await playExpect(tasksPage.heading).toBeVisible();
+
         const commandPalette = new CommandPalette(page);
         await commandPalette.executeCommand('Podman: Synchronize certificates to all VMs');
 
-        // TODO: replace with readiness polling (e.g. podman info) once basic flow is validated.
-        await page.waitForTimeout(15_000);
+        await playExpect
+          .poll(
+            async () => {
+              try {
+                const status = await tasksPage.getStatusForLatestTask();
+                if (status && !status.includes(TaskState.Success)) {
+                  console.log(`Poll: certificate sync task status = "${status}"`);
+                }
+                return status;
+              } catch (error: unknown) {
+                console.log('Poll: task status not yet available —', error instanceof Error ? error.message : error);
+                return '';
+              }
+            },
+            { timeout: SYNC_TIMEOUT, intervals: [POLL_INTERVAL] },
+          )
+          .toContain(TaskState.Success);
 
         const imagesPageAfterSync = await navigationBar.openImages();
         const imageDetailsAfterSync = await imagesPageAfterSync.openImageDetails(fullImageName);
@@ -124,17 +148,11 @@ test.describe
       }
     });
 
-    test('Verify push by re-pulling from insecure registry', async ({ navigationBar }) => {
+    test('Verify push by re-pulling from insecure registry', async ({ navigationBar, page }) => {
+      await deleteImage(page, fullImageName);
+
       let imagesPage = await navigationBar.openImages();
       await playExpect(imagesPage.heading).toBeVisible();
-
-      const imageDetailPage = await imagesPage.openImageDetails(fullImageName);
-      await playExpect(imageDetailPage.heading).toBeVisible();
-
-      imagesPage = await imageDetailPage.deleteImage();
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
-
-      await imagesPage.waitForRowToBeDelete(fullImageName, 60_000);
 
       const pullImagePage = await imagesPage.openPullImage();
       imagesPage = await pullImagePage.pullImage(fullImageName, 'latest');

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -171,7 +171,7 @@ export async function pushImageExpectFailure(page: Page, pushButton: Locator): P
     await playExpect(pushButton).toBeEnabled();
     await pushButton.click();
 
-    await waitUntil(async () => await dialog.isVisible(), { timeout: 10_000 });
+    await playExpect(dialog).toBeVisible({ timeout: 10_000 });
 
     const pushConfirmButton = dialog.getByRole('button', { name: 'Push image' });
     await playExpect(pushConfirmButton).toBeEnabled();
@@ -183,7 +183,7 @@ export async function pushImageExpectFailure(page: Page, pushButton: Locator): P
     const dialogContent = (await dialog.textContent()) ?? '';
 
     await doneButton.click();
-    await waitUntil(async () => !(await dialog.isVisible()), { timeout: 10_000 });
+    await playExpect(dialog).toBeHidden({ timeout: 10_000 });
 
     return dialogContent;
   });

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -135,6 +135,60 @@ export async function deleteRegistry(page: Page, name: string, failIfNotExist = 
   });
 }
 
+export async function createRegistryAndVerify(
+  page: Page,
+  url: string,
+  username: string,
+  pswd: string,
+  registryLabel: string,
+  handleUntrustedCert?: boolean,
+): Promise<void> {
+  return test.step('Create registry and verify', async () => {
+    const navigationBar = new NavigationBar(page);
+    const settingsBar = await navigationBar.openSettings();
+    const registryPage = await settingsBar.openTabPage(RegistriesPage);
+    await registryPage.createRegistry(url, username, pswd, handleUntrustedCert);
+    const registryRow = await registryPage.getRegistryRowByName(registryLabel);
+    await playExpect(registryRow.getByText(username)).toBeVisible({ timeout: 50_000 });
+  });
+}
+
+export async function removeRegistryAndVerify(page: Page, registryLabel: string, username: string): Promise<void> {
+  return test.step('Remove registry and verify', async () => {
+    const navigationBar = new NavigationBar(page);
+    const settingsBar = await navigationBar.openSettings();
+    const registryPage = await settingsBar.openTabPage(RegistriesPage);
+    await registryPage.removeRegistry(registryLabel);
+    const registryRow = await registryPage.getRegistryRowByName(registryLabel);
+    await playExpect(registryRow.getByText(username)).toBeHidden();
+  });
+}
+
+export async function pushImageExpectFailure(page: Page, pushButton: Locator): Promise<string> {
+  return test.step('Push image and expect failure', async () => {
+    const dialog = page.getByRole('dialog', { name: 'Push image', exact: true });
+
+    await playExpect(pushButton).toBeEnabled();
+    await pushButton.click();
+
+    await waitUntil(async () => await dialog.isVisible(), { timeout: 10_000 });
+
+    const pushConfirmButton = dialog.getByRole('button', { name: 'Push image' });
+    await playExpect(pushConfirmButton).toBeEnabled();
+    await pushConfirmButton.click();
+
+    const doneButton = dialog.getByRole('button', { name: 'Done' });
+    await playExpect(doneButton).toBeEnabled({ timeout: 60_000 });
+
+    const dialogContent = (await dialog.textContent()) ?? '';
+
+    await doneButton.click();
+    await waitUntil(async () => !(await dialog.isVisible()), { timeout: 10_000 });
+
+    return dialogContent;
+  });
+}
+
 export async function deletePod(page: Page, name: string, timeout = 50_000): Promise<void> {
   return test.step(`Delete pod ${name}`, async () => {
     const navigationBar = new NavigationBar(page);


### PR DESCRIPTION
### What does this PR do?

Adds E2E smoke tests for insecure (self-signed certificate) registry workflows, along with supporting infrastructure and CI integration.

**Tests added:**

`insecure-registry-smoke.spec.ts` (`@smoke`) — serial test suite for push/pull against a local registry with self-signed TLS:
1. Add insecure registry (with untrusted cert dialog handling)
2. Pull a source image (`ghcr.io/podmandesktop-ci/hello`)
3. Tag image for the insecure registry (`localhost:5443/testuser/test-image`)
4. Push image to insecure registry — on Linux pushes directly; on macOS/Windows expects a TLS certificate error, runs `Podman: Synchronize certificates to all VMs` via command palette, polls task status until success, then retries the push
5. Verify push by deleting local copy and re-pulling from the insecure registry
6. Remove insecure registry

`image-push-to-registry-smoke.spec.ts` — existing ghcr.io push/pull smoke test, refactored to use the new `createRegistryAndVerify` / `removeRegistryAndVerify` helpers (no new test scenarios, reduced code duplication)

**Infrastructure:**

- `tests/playwright/scripts/setup-insecure-registry.sh` — deploys a local Docker registry with self-signed TLS and basic auth on `localhost:5443`, supports `start` and `cleanup` subcommands
- `tests/playwright/src/model/pages/registries-page.ts` — extends `createRegistry()` with an optional `handleUntrustedCert` parameter that dismisses the "Add Untrusted Registry?" confirmation dialog
- `tests/playwright/src/utility/operations.ts` — adds reusable helpers: `createRegistryAndVerify` (navigate → create → assert row visible), `removeRegistryAndVerify` (navigate → remove → assert row hidden), `pushImageExpectFailure` (push via dialog, wait for Done, return dialog text)
- `tests/playwright/src/setupFiles/setup-registry.ts` — adds `setupInsecureRegistry()` and `canTestInsecureRegistry()` reading `INSECURE_REGISTRY_*` env vars
- `.github/workflows/e2e-main.yaml` — adds registry setup/teardown steps and passes `INSECURE_REGISTRY_URL`, `INSECURE_REGISTRY_USERNAME`, `INSECURE_REGISTRY_PASSWORD` env vars to E2E runs

### Screenshot / video of UI

N/A — no UI changes, test infrastructure only.

### What issues does this PR fix or reference?

Closes #16747
Closes #16665

### How to test this PR?

**Automated (CI):**
The `e2e-main` workflow handles everything — registry setup, cert install, env vars, and cleanup.

**Manual (local):**

1. Start the insecure registry:
   ```bash
   tests/playwright/scripts/setup-insecure-registry.sh start
   ```

2. Install the self-signed cert into the system trust store:

   Fedora / RHEL:
   ```bash
   sudo cp /tmp/pd-test-registry/registry.crt /etc/pki/ca-trust/source/anchors/pd-test-registry.crt
   sudo update-ca-trust
   ```

   Ubuntu / Debian:
   ```bash
   sudo cp /tmp/pd-test-registry/registry.crt /usr/local/share/ca-certificates/pd-test-registry.crt
   sudo update-ca-certificates
   ```

3. Verify the registry is working:
   ```bash
   curl --cacert /tmp/pd-test-registry/registry.crt -u testuser:testpassword123 https://localhost:5443/v2/
   # Should return 200
   ```

4. Run smoke tests with insecure registry env vars:
   ```bash
   INSECURE_REGISTRY_URL='localhost:5443' \
   INSECURE_REGISTRY_USERNAME='testuser' \
   INSECURE_REGISTRY_PASSWORD='testpassword123' \
   pnpm test:e2e:smoke
   ```

5. Cleanup:
   ```bash
   tests/playwright/scripts/setup-insecure-registry.sh cleanup
   sudo rm -f /etc/pki/ca-trust/source/anchors/pd-test-registry.crt
   sudo update-ca-trust
   ```

> **Note:** Flatpak installs do not read host CA certificates — use native install (tarball/RPM) for local cert testing. See [QE docs](https://github.com/odockal/podman-desktop-qe/blob/main/docs/howtos/registries-and-images/local-insecure-registry.md) for details.

- [x] Tests are covering the new feature