### PR TITLE
fix(ci): update redhat-actions/podman-install to latest

### DIFF
--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -75,8 +75,9 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        uses: redhat-actions/podman-install@0b0ebeccb256851665136971d7782ba7180773df
         with:
+          ubuntu-version: '24.04'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup testenv using external action

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -111,8 +111,9 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        uses: redhat-actions/podman-install@0b0ebeccb256851665136971d7782ba7180773df
         with:
+          ubuntu-version: '24.04'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup testenv using external action

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -321,8 +321,9 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        uses: redhat-actions/podman-install@0b0ebeccb256851665136971d7782ba7180773df
         with:
+          ubuntu-version: '24.04'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup testenv using external action
@@ -380,7 +381,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install latest Podman version using external action
-        uses: redhat-actions/podman-install@38597414074271e07efa9fb2292cff7eea8d374d
+        uses: redhat-actions/podman-install@0b0ebeccb256851665136971d7782ba7180773df
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -479,8 +480,9 @@ jobs:
           echo "KIND_PROVIDER=${{ env.DEFAULT_KIND_PROVIDER }}" >> $GITHUB_ENV
 
       - name: Install Podman v5 using external action
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        uses: redhat-actions/podman-install@0b0ebeccb256851665136971d7782ba7180773df
         with:
+          ubuntu-version: '24.04'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup testenv using external action


### PR DESCRIPTION
### What does this PR do?

Updates `redhat-actions/podman-install` action SHA from `15cb93f5a6b7` (Nov 2025) to `0b0ebeccb256` (Feb 2026, HEAD of main) across all workflows:
- `.github/workflows/pr-check.yaml` (smoke e2e, windows sanity, k8s sanity)
- `.github/workflows/e2e-main.yaml`
- `.github/workflows/e2e-kubernetes-main.yaml`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A — CI-only change.

### What issues does this PR fix or reference?

The old action version uses the kubic unstable repository which has a broken `crun → criu` dependency chain on `ubuntu-24.04` runners, causing `"Unable to correct problems, you have held broken packages"` during Podman installation.

Same root cause as [containers/podman-desktop-extension-ai-lab#4421](https://github.com/containers/podman-desktop-extension-ai-lab/pull/4421).

Example failure: [Run #25335131919](https://github.com/podman-desktop/podman-desktop/actions/runs/25335131919)

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Observe that smoke e2e and k8s sanity CI jobs pass (the "Install Podman v5 using external action" step should succeed)
- [ ] Tests are covering the bug fix or the new feature