### PR TITLE
fix(renderer): show error feedback when volume creation fails

### DIFF
--- a/packages/renderer/src/lib/volume/CreateVolume.spec.ts
+++ b/packages/renderer/src/lib/volume/CreateVolume.spec.ts
@@ -127,6 +127,40 @@ test('Expect Create with a custom name', async () => {
   });
 });
 
+test('Expect error message when volume creation fails', async () => {
+  const errorMessage = 'volume name "bad/name" includes invalid characters';
+  createVolumeMock.mockRejectedValueOnce(new Error(errorMessage));
+
+  providerInfos.set([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  render(CreateVolume, {});
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.type(nameInput, 'bad/name');
+
+  const createButton = screen.getByRole('button', { name: createButtonTitle });
+  await userEvent.click(createButton);
+
+  const errorElement = screen.getByText(errorMessage);
+  expect(errorElement).toBeInTheDocument();
+
+  // should not show the Done button on failure
+  const doneButton = screen.queryByRole('button', { name: 'Done' });
+  expect(doneButton).not.toBeInTheDocument();
+});
+
 test('Expect Create with a custom name and multiple providers', async () => {
   providerInfos.set([
     {

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -4,7 +4,7 @@
 import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 /* eslint-enable import/no-duplicates */
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
-import { Button, Input } from '@podman-desktop/ui-svelte';
+import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount } from 'svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
@@ -30,15 +30,19 @@ onMount(async () => {
 });
 
 let createVolumeInProgress = false;
+let createError: string | undefined = undefined;
 onDestroy(() => {});
 
 async function createVolume(providerConnectionInfo: ProviderContainerConnectionInfo): Promise<void> {
+  createError = undefined;
   createVolumeInProgress = true;
   try {
     await window.createVolume(providerConnectionInfo, { Name: volumeName });
+    createVolumeFinished = true;
+  } catch (error: unknown) {
+    createError = error instanceof Error ? error.message : String(error);
   } finally {
     createVolumeInProgress = false;
-    createVolumeFinished = true;
   }
 }
 
@@ -103,6 +107,10 @@ export let volumeName = '';
         <Button on:click={end} class="w-full">Done</Button>
       {/if}
     </div>
+
+    {#if createError}
+      <ErrorMessage class="text-sm" error={createError} />
+    {/if}
   </div>
   {/snippet}
 </EngineFormPage>


### PR DESCRIPTION
### What does this PR do?

Display an error message in the Create Volume form when volume creation fails (e.g. invalid name characters). Previously the creation would silently fail with no feedback.

### Screenshot / video of UI

<img width="1028" height="712" alt="Image" src="https://github.com/user-attachments/assets/4cdd812b-8997-4ce5-9eaf-31683ee136c4" />

### What issues does this PR fix or reference?

Closes #17273

### How to test this PR?

1. Start Podman Desktop with a running Podman machine
2. Go to Volumes > Create Volume
3. Enter an invalid name (e.g. `bad/name`)
4. Click Create
5. An error message should appear below the Create button
6. The Done button should not appear (creation failed)
7. Fix the name (e.g. `good-name`), click Create again
8. Error disappears, Done button appears

- [x] Tests are covering the bug fix or the new feature