### PR TITLE
chore(eslint): enable vitest/prefer-mock-return-shorthand

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -154,6 +154,7 @@ export default [
       'vitest/prefer-import-in-mock': 'error',
       'vitest/hoisted-apis-on-top': 'error',
       'vitest/prefer-mock-promise-shorthand': 'error',
+      'vitest/prefer-mock-return-shorthand': 'error',
       eqeqeq: 'error',
       'prefer-promise-reject-errors': 'error',
       semi: ['error', 'always'],

--- a/extensions/compose/src/cli-run.spec.ts
+++ b/extensions/compose/src/cli-run.spec.ts
@@ -45,22 +45,21 @@ test('error: expect installBinaryToSystem to fail with a non existing binary', a
     value: 'linux',
   });
 
-  vi.mocked(extensionApi.process.exec).mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>((_, reject) => {
-        const error: extensionApi.RunError = {
-          name: '',
-          message: 'Command failed',
-          exitCode: 1603,
-          command: 'command',
-          stdout: 'stdout',
-          stderr: 'stderr',
-          cancelled: false,
-          killed: false,
-        };
+  vi.mocked(extensionApi.process.exec).mockReturnValue(
+    new Promise<extensionApi.RunResult>((_, reject) => {
+      const error: extensionApi.RunError = {
+        name: '',
+        message: 'Command failed',
+        exitCode: 1603,
+        command: 'command',
+        stdout: 'stdout',
+        stderr: 'stderr',
+        cancelled: false,
+        killed: false,
+      };
 
-        reject(error);
-      }),
+      reject(error);
+    }),
   );
 
   // Expect await installBinaryToSystem to throw an error
@@ -74,9 +73,7 @@ test('success: installBinaryToSystem on mac with /usr/local/bin already created'
   });
 
   // Mock existsSync to be true since within the function it's doing: !fs.existsSync(localBinDir)
-  vi.mocked(fs.existsSync).mockImplementation(() => {
-    return true;
-  });
+  vi.mocked(fs.existsSync).mockReturnValue(true);
 
   // Run installBinaryToSystem which will trigger the spyOn mock
   await installBinaryToSystem('test', 'tmpBinary');
@@ -95,9 +92,7 @@ test('success: installBinaryToSystem on linux with /usr/local/bin NOT created ye
   });
 
   // Mock existsSync to be false since within the function it's doing: !fs.existsSync(localBinDir)
-  vi.mocked(fs.existsSync).mockImplementation(() => {
-    return false;
-  });
+  vi.mocked(fs.existsSync).mockReturnValue(false);
 
   // Run installBinaryToSystem which will trigger the spyOn mock
   await installBinaryToSystem('test', 'tmpBinary');
@@ -122,9 +117,7 @@ test('success: installBinaryToSystem to show warning if binary path not in PATH'
   process.env.PATH = '';
 
   // Mock existsSync to be false since within the function it's doing: !fs.existsSync(localBinDir)
-  vi.mocked(fs.existsSync).mockImplementation(() => {
-    return false;
-  });
+  vi.mocked(fs.existsSync).mockReturnValue(false);
 
   // Run installBinaryToSystem which will trigger the spyOn mock
   await installBinaryToSystem('test', 'tmpBinary');

--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -57,9 +57,7 @@ test('expect grab 5 releases', async () => {
   const resultREST = JSON.parse(
     fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/compose-github-release-all.json'), 'utf8'),
   );
-  listReleasesMock.mockImplementation(() => {
-    return { data: resultREST };
-  });
+  listReleasesMock.mockReturnValue({ data: resultREST });
 
   const result = await composeGitHubReleases.grabLatestsReleasesMetadata();
   expect(result).toBeDefined();
@@ -107,9 +105,7 @@ describe.each([
     // mock the result of listReleaseAssetsMock REST API
     const resultREST = JSON.parse(fsActual.readFileSync(path.resolve(__dirname, resource), 'utf8'));
 
-    vi.mocked(octokitMock.paginate).mockImplementation(() => {
-      return resultREST;
-    });
+    vi.mocked(octokitMock.paginate).mockReturnValue(resultREST);
   });
 
   test('macOS x86_64', async () => {
@@ -156,14 +152,10 @@ describe.each([
 });
 
 test('should download the file if parent folder does exist', async () => {
-  getReleaseAssetMock.mockImplementation(() => {
-    return { data: 'foo' };
-  });
+  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 
   // mock fs
-  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   const writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
 
@@ -178,9 +170,7 @@ test('should download the file if parent folder does exist', async () => {
 });
 
 test('should download the file if parent folder does not exist', async () => {
-  getReleaseAssetMock.mockImplementation(() => {
-    return { data: 'foo' };
-  });
+  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 
   // mock fs
   const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/extensions/compose/src/detect.spec.ts
+++ b/extensions/compose/src/detect.spec.ts
@@ -116,7 +116,7 @@ describe('Check storage path', async () => {
 
   test('found', async () => {
     const existSyncSpy = vi.mocked(fs.existsSync);
-    existSyncSpy.mockImplementation(() => true);
+    existSyncSpy.mockReturnValue(true);
 
     const result = await detect.getStoragePath();
     expect(result).toBe(path.resolve('/', 'storage-path', 'bin', 'docker-compose'));

--- a/extensions/compose/src/download.spec.ts
+++ b/extensions/compose/src/download.spec.ts
@@ -77,9 +77,7 @@ afterEach(() => {
 });
 
 test('expect getLatestVersionAsset to return the first release from a list of releases', async () => {
-  grabLatestsReleasesMetadataMock.mockImplementation(() => {
-    return releases;
-  });
+  grabLatestsReleasesMetadataMock.mockReturnValue(releases);
 
   // Expect the test to return the first release from the list (as the function simply returns the first one)
   const composeDownload = new ComposeDownload(extensionContext, composeGitHubReleasesMock, os);
@@ -89,9 +87,7 @@ test('expect getLatestVersionAsset to return the first release from a list of re
 });
 
 test('pick the 4th option option in the quickpickmenu and expect it to return the github release information', async () => {
-  grabLatestsReleasesMetadataMock.mockImplementation(() => {
-    return releases;
-  });
+  grabLatestsReleasesMetadataMock.mockReturnValue(releases);
   const showQuickPickMock = vi.spyOn(extensionApi.window, 'showQuickPick');
 
   showQuickPickMock.mockResolvedValue({
@@ -114,9 +110,7 @@ test('test download of compose passes and that mkdir and executable mocks are ca
   const downloadReleaseAssetMock = vi.spyOn(composeGitHubReleasesMock, 'downloadReleaseAsset');
 
   // Mock that the storage path does not exist
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
   // Mock the mkdir to return "success"
   mkdirMock.mockResolvedValue(undefined);

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -227,12 +227,12 @@ test('Ensuring a progress task is created when calling kind.image.move command',
 
   const createProviderMock = vi.fn();
   podmanDesktopApi.provider.createProvider = createProviderMock;
-  createProviderMock.mockImplementation(() => ({
+  createProviderMock.mockReturnValue({
     setKubernetesProviderConnectionFactory: vi.fn(),
     onDidUpdateVersion: vi.fn(),
     updateVersion: vi.fn(),
     updateWarnings: vi.fn(),
-  }));
+  });
 
   const listContainersMock = vi.fn();
   podmanDesktopApi.containerEngine.listContainers = listContainersMock;
@@ -240,9 +240,7 @@ test('Ensuring a progress task is created when calling kind.image.move command',
 
   const withProgressMock = vi
     .fn()
-    .mockImplementation(() =>
-      extension.moveImage({ report: vi.fn() }, { id: 'id', image: 'hello:world', engineId: '1' }),
-    );
+    .mockReturnValue(extension.moveImage({ report: vi.fn() }, { id: 'id', image: 'hello:world', engineId: '1' }));
   podmanDesktopApi.window.withProgress = withProgressMock;
 
   const contextSetValueMock = vi.fn();

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -238,13 +238,12 @@ test('Ensuring a progress task is created when calling kind.image.move command',
   podmanDesktopApi.containerEngine.listContainers = listContainersMock;
   listContainersMock.mockResolvedValue([]);
 
-  const withProgressMock = vi
-    .fn()
-    .mockReturnValue(extension.moveImage({ report: vi.fn() }, { id: 'id', image: 'hello:world', engineId: '1' }));
-  podmanDesktopApi.window.withProgress = withProgressMock;
-
-  const contextSetValueMock = vi.fn();
-  podmanDesktopApi.context.setValue = contextSetValueMock;
+  vi.mocked(podmanDesktopApi.window.withProgress).mockImplementation((_, fn) =>
+    fn({ report: vi.fn() }, {
+      isCancellationRequested: false,
+      onCancellationRequested: vi.fn(),
+    } as podmanDesktopApi.CancellationToken),
+  );
 
   vi.mocked(util.getKindBinaryInfo).mockResolvedValue({
     path: 'kind',
@@ -259,10 +258,10 @@ test('Ensuring a progress task is created when calling kind.image.move command',
   // simulate a call to the command
   await commandRegistry['kind.image.move']({ id: 'id', image: 'hello:world', engineId: '1' });
 
-  expect(withProgressMock).toHaveBeenCalled();
-  expect(contextSetValueMock).toBeCalledTimes(2);
-  expect(contextSetValueMock).toHaveBeenNthCalledWith(1, 'imagesPushInProgressToKind', ['id']);
-  expect(contextSetValueMock).toHaveBeenNthCalledWith(2, 'imagesPushInProgressToKind', []);
+  expect(podmanDesktopApi.window.withProgress).toHaveBeenCalled();
+  expect(podmanDesktopApi.context.setValue).toBeCalledTimes(2);
+  expect(podmanDesktopApi.context.setValue).toHaveBeenNthCalledWith(1, 'imagesPushInProgressToKind', ['id']);
+  expect(podmanDesktopApi.context.setValue).toHaveBeenNthCalledWith(2, 'imagesPushInProgressToKind', []);
 });
 
 const mockV1Release = {

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -94,9 +94,7 @@ describe('grabLatestsReleasesMetadata', () => {
     const resultREST = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockImplementation(() => {
-      return { data: resultREST };
-    });
+    listReleasesMock.mockReturnValue({ data: resultREST });
     const releases = await installer.grabLatestsReleasesMetadata();
     expect(releases).toBeDefined();
     expect(releases.length).toBe(5);
@@ -112,9 +110,7 @@ describe('promptUserForVersion', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockImplementation(() => {
-      return { data: resultREST };
-    });
+    listReleasesMock.mockReturnValue({ data: resultREST });
     const showQuickPickMock = vi.spyOn(extensionApi.window, 'showQuickPick').mockResolvedValue(resultREST[0]);
     const release = await installer.promptUserForVersion();
 
@@ -132,9 +128,7 @@ describe('promptUserForVersion', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockImplementation(() => {
-      return { data: resultREST };
-    });
+    listReleasesMock.mockReturnValue({ data: resultREST });
     vi.spyOn(extensionApi.window, 'showQuickPick').mockResolvedValue(undefined);
     await expect(() => installer.promptUserForVersion()).rejects.toThrowError('No version selected');
   });
@@ -150,9 +144,7 @@ describe('getReleaseAssetId', () => {
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-assets.json'), 'utf8'),
     );
 
-    listReleaseAssetsMock.mockImplementation(() => {
-      return { data: resultREST };
-    });
+    listReleaseAssetsMock.mockReturnValue({ data: resultREST });
   });
 
   test('macOS x86_64', async () => {
@@ -222,9 +214,7 @@ describe('install', () => {
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-assets.json'), 'utf8'),
     );
 
-    listReleaseAssetsMock.mockImplementation(() => {
-      return { data: resultREST };
-    });
+    listReleaseAssetsMock.mockReturnValue({ data: resultREST });
   });
   test('should download file on win system', async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -234,9 +224,7 @@ describe('install', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockImplementation(() => {
-      return { data: resultREST };
-    });
+    listReleasesMock.mockReturnValue({ data: resultREST });
     vi.mocked(os.platform).mockReturnValue('win32');
     vi.mocked(os.arch).mockReturnValue('x64');
 
@@ -257,9 +245,7 @@ describe('install', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockImplementation(() => {
-      return { data: resultREST };
-    });
+    listReleasesMock.mockReturnValue({ data: resultREST });
     vi.mocked(os.platform).mockReturnValue('darwin');
     vi.mocked(os.arch).mockReturnValue('x64');
     vi.mocked(fs.existsSync).mockReturnValue(true);
@@ -273,14 +259,10 @@ describe('install', () => {
 
 describe('downloadReleaseAsset', () => {
   test('should download the file if parent folder does exist', async () => {
-    getReleaseAssetMock.mockImplementation(() => {
-      return { data: 'foo' };
-    });
+    getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 
     // mock fs
-    const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-      return true;
-    });
+    const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
     const writeFileSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
 
@@ -295,9 +277,7 @@ describe('downloadReleaseAsset', () => {
   });
 
   test('should download the file if parent folder does not exist', async () => {
-    getReleaseAssetMock.mockImplementation(() => {
-      return { data: 'foo' };
-    });
+    getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 
     // mock fs
     const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/extensions/kubectl-cli/src/cli-run.spec.ts
+++ b/extensions/kubectl-cli/src/cli-run.spec.ts
@@ -42,22 +42,21 @@ test('error: expect installBinaryToSystem to fail with a non existing binary', a
     value: 'linux',
   });
 
-  vi.mocked(extensionApi.process.exec).mockImplementation(
-    () =>
-      new Promise<extensionApi.RunResult>((_, reject) => {
-        const error: extensionApi.RunError = {
-          name: '',
-          message: 'Command failed',
-          exitCode: 1603,
-          command: 'command',
-          stdout: 'stdout',
-          stderr: 'stderr',
-          cancelled: false,
-          killed: false,
-        };
+  vi.mocked(extensionApi.process.exec).mockReturnValue(
+    new Promise<extensionApi.RunResult>((_, reject) => {
+      const error: extensionApi.RunError = {
+        name: '',
+        message: 'Command failed',
+        exitCode: 1603,
+        command: 'command',
+        stdout: 'stdout',
+        stderr: 'stderr',
+        cancelled: false,
+        killed: false,
+      };
 
-        reject(error);
-      }),
+      reject(error);
+    }),
   );
 
   // Expect await installBinaryToSystem to throw an error
@@ -71,9 +70,7 @@ test('success: installBinaryToSystem on mac with /usr/local/bin already created'
   });
 
   // Mock existsSync to be true since within the function it's doing: !fs.existsSync(localBinDir)
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Run installBinaryToSystem which will trigger the spyOn mock
   await installBinaryToSystem('test', 'tmpBinary');
@@ -93,9 +90,7 @@ test('success: installBinaryToSystem on linux with /usr/local/bin NOT created ye
   });
 
   // Mock existsSync to be false since within the function it's doing: !fs.existsSync(localBinDir)
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
   // Run installBinaryToSystem which will trigger the spyOn mock
   await installBinaryToSystem('test', 'tmpBinary');

--- a/extensions/kubectl-cli/src/detect.spec.ts
+++ b/extensions/kubectl-cli/src/detect.spec.ts
@@ -103,7 +103,7 @@ describe('Check storage path', async () => {
 
   test('found', async () => {
     const existSyncSpy = vi.spyOn(fs, 'existsSync');
-    existSyncSpy.mockImplementation(() => true);
+    existSyncSpy.mockReturnValue(true);
 
     const result = await detect.getStoragePath();
     expect(result).toBe(path.resolve('/', 'storage-path', 'bin', 'kubectl'));

--- a/extensions/kubectl-cli/src/download.spec.ts
+++ b/extensions/kubectl-cli/src/download.spec.ts
@@ -102,9 +102,7 @@ test('expect getLatestVersionAsset to return the latest release from a list of r
 });
 
 test('pick the 6th option option in the quickpickmenu and expect it to return the github release information', async () => {
-  grabLatestsReleasesMetadataMock.mockImplementation(() => {
-    return releases;
-  });
+  grabLatestsReleasesMetadataMock.mockReturnValue(releases);
   const showQuickPickMock = vi.spyOn(extensionApi.window, 'showQuickPick');
 
   showQuickPickMock.mockResolvedValue({
@@ -126,9 +124,7 @@ test('test download of kubectl passes and that mkdir and executable mocks are ca
   const downloadReleaseAssetMock = vi.spyOn(kubectlGitHubReleasesMock, 'downloadReleaseAsset');
 
   // Mock that the storage path does not exist
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
   // Mock the mkdir to return "success"
   mkdirMock.mockResolvedValue(undefined);

--- a/extensions/kubectl-cli/src/extension.spec.ts
+++ b/extensions/kubectl-cli/src/extension.spec.ts
@@ -320,18 +320,16 @@ describe('postActivate', () => {
         }),
     );
     const deferredCliUpdate: Promise<CliToolSelectUpdate> = new Promise<CliToolSelectUpdate>(resolve => {
-      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
-        return {
-          registerUpdate: (listener: CliToolSelectUpdate) => {
-            resolve(listener);
-            return {
-              dispose: vi.fn(),
-            };
-          },
-          registerInstaller: vi.fn(),
-          updateVersion: vi.fn(),
-        } as unknown as extensionApi.CliTool;
-      });
+      vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({
+        registerUpdate: (listener: CliToolSelectUpdate) => {
+          resolve(listener);
+          return {
+            dispose: vi.fn(),
+          };
+        },
+        registerInstaller: vi.fn(),
+        updateVersion: vi.fn(),
+      } as unknown as extensionApi.CliTool);
     });
 
     await KubectlExtension.activate(extensionContext);
@@ -433,18 +431,16 @@ describe('postActivate', () => {
       },
     ]);
     const deferredCliUpdate: Promise<CliToolSelectUpdate> = new Promise<CliToolSelectUpdate>(resolve => {
-      vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
-        return {
-          registerUpdate: (listener: CliToolSelectUpdate) => {
-            resolve(listener);
-            return {
-              dispose: vi.fn(),
-            };
-          },
-          registerInstaller: vi.fn(),
-          updateVersion: vi.fn(),
-        } as unknown as extensionApi.CliTool;
-      });
+      vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({
+        registerUpdate: (listener: CliToolSelectUpdate) => {
+          resolve(listener);
+          return {
+            dispose: vi.fn(),
+          };
+        },
+        registerInstaller: vi.fn(),
+        updateVersion: vi.fn(),
+      } as unknown as extensionApi.CliTool);
     });
 
     await KubectlExtension.activate(extensionContext);
@@ -496,9 +492,7 @@ describe('postActivate', () => {
       registerUpdate: vi.fn(),
     } as unknown as extensionApi.CliTool;
 
-    vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
-      return cliToolMock;
-    });
+    vi.mocked(extensionApi.cli.createCliTool).mockReturnValue(cliToolMock);
 
     await KubectlExtension.activate(extensionContext);
 
@@ -545,18 +539,16 @@ describe('postActivate', () => {
     ]);
     const deferredCliUpdate: Promise<extensionApi.CliToolInstaller> = new Promise<extensionApi.CliToolInstaller>(
       resolve => {
-        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
-          return {
-            registerUpdate: vi.fn(),
-            registerInstaller: (listener: extensionApi.CliToolInstaller) => {
-              resolve(listener);
-              return {
-                dispose: vi.fn(),
-              };
-            },
-            updateVersion: vi.fn(),
-          } as unknown as extensionApi.CliTool;
-        });
+        vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({
+          registerUpdate: vi.fn(),
+          registerInstaller: (listener: extensionApi.CliToolInstaller) => {
+            resolve(listener);
+            return {
+              dispose: vi.fn(),
+            };
+          },
+          updateVersion: vi.fn(),
+        } as unknown as extensionApi.CliTool);
       },
     );
 
@@ -620,18 +612,16 @@ describe('postActivate', () => {
     vi.mocked(KubectlGitHubReleases.prototype.grabLatestsReleasesMetadata).mockResolvedValue(releasesMetadata);
     const deferredCliUpdate: Promise<extensionApi.CliToolInstaller> = new Promise<extensionApi.CliToolInstaller>(
       resolve => {
-        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
-          return {
-            registerUpdate: vi.fn(),
-            registerInstaller: (listener: extensionApi.CliToolInstaller) => {
-              resolve(listener);
-              return {
-                dispose: vi.fn(),
-              };
-            },
-            updateVersion: vi.fn(),
-          } as unknown as extensionApi.CliTool;
-        });
+        vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({
+          registerUpdate: vi.fn(),
+          registerInstaller: (listener: extensionApi.CliToolInstaller) => {
+            resolve(listener);
+            return {
+              dispose: vi.fn(),
+            };
+          },
+          updateVersion: vi.fn(),
+        } as unknown as extensionApi.CliTool);
       },
     );
     vi.spyOn(KubectlDownload.prototype, 'promptUserForVersion').mockResolvedValue(releasesMetadata[0]);
@@ -686,18 +676,16 @@ describe('postActivate', () => {
     ]);
     const deferredCliInstall: Promise<extensionApi.CliToolInstaller> = new Promise<extensionApi.CliToolInstaller>(
       resolve => {
-        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
-          return {
-            registerUpdate: vi.fn(),
-            registerInstaller: (listener: extensionApi.CliToolInstaller) => {
-              resolve(listener);
-              return {
-                dispose: vi.fn(),
-              };
-            },
-            updateVersion: vi.fn(),
-          } as unknown as extensionApi.CliTool;
-        });
+        vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({
+          registerUpdate: vi.fn(),
+          registerInstaller: (listener: extensionApi.CliToolInstaller) => {
+            resolve(listener);
+            return {
+              dispose: vi.fn(),
+            };
+          },
+          updateVersion: vi.fn(),
+        } as unknown as extensionApi.CliTool);
       },
     );
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -746,18 +734,16 @@ describe('postActivate', () => {
     ]);
     const deferredCliInstall: Promise<extensionApi.CliToolInstaller> = new Promise<extensionApi.CliToolInstaller>(
       resolve => {
-        vi.mocked(extensionApi.cli.createCliTool).mockImplementation(() => {
-          return {
-            registerUpdate: vi.fn(),
-            registerInstaller: (listener: extensionApi.CliToolInstaller) => {
-              resolve(listener);
-              return {
-                dispose: vi.fn(),
-              };
-            },
-            updateVersion: vi.fn(),
-          } as unknown as extensionApi.CliTool;
-        });
+        vi.mocked(extensionApi.cli.createCliTool).mockReturnValue({
+          registerUpdate: vi.fn(),
+          registerInstaller: (listener: extensionApi.CliToolInstaller) => {
+            resolve(listener);
+            return {
+              dispose: vi.fn(),
+            };
+          },
+          updateVersion: vi.fn(),
+        } as unknown as extensionApi.CliTool);
       },
     );
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -56,9 +56,7 @@ test('expect grab 5 releases', async () => {
   const resultREST = JSON.parse(
     fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kubectl-github-release-all.json'), 'utf8'),
   );
-  listReleasesMock.mockImplementation(() => {
-    return { data: resultREST };
-  });
+  listReleasesMock.mockReturnValue({ data: resultREST });
 
   const result = await kubectlGitHubReleases.grabLatestsReleasesMetadata();
   expect(result).toBeDefined();
@@ -75,9 +73,7 @@ describe('Grab asset id for a given release id', async () => {
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kubectl-github-release-all.json'), 'utf8'),
     );
 
-    listReleaseAssetsMock.mockImplementation(() => {
-      return { data: resultREST };
-    });
+    listReleaseAssetsMock.mockReturnValue({ data: resultREST });
   });
 
   test('macOS x86_64', async () => {
@@ -118,14 +114,10 @@ describe('Grab asset id for a given release id', async () => {
 });
 
 test('should download the file if parent folder does exist', async () => {
-  getReleaseAssetMock.mockImplementation(() => {
-    return { data: 'foo' };
-  });
+  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 
   // mock fs
-  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   const writeFileSpy = vi.spyOn(fs.promises, 'writeFile');
 

--- a/extensions/podman/packages/extension/src/certificate-detection/certificate-detection-service.spec.ts
+++ b/extensions/podman/packages/extension/src/certificate-detection/certificate-detection-service.spec.ts
@@ -222,7 +222,7 @@ describe('CertificateDetectionService', () => {
       const serviceWithTimeout = new CertificateDetectionService(mockTelemetryLogger, shortTimeoutConfig);
 
       vi.mocked(fs.access).mockResolvedValue();
-      vi.mocked(fs.readdir).mockImplementation(() => new Promise(resolve => setTimeout(() => resolve([]), 100)));
+      vi.mocked(fs.readdir).mockReturnValue(new Promise(resolve => setTimeout(() => resolve([]), 100)));
 
       const result = await serviceWithTimeout.detectCustomCertificates();
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1312,9 +1312,7 @@ test('test checkDefaultMachine - if user wants to change machine, check that it 
   const spyPrompt = vi.mocked(extensionApi.window.showInformationMessage);
   spyPrompt.mockResolvedValue('Yes');
 
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
   await extension.checkDefaultMachine(fakeMachineJSON);
 

--- a/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
@@ -74,9 +74,7 @@ rosetta = false
     `;
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(configFileContent);
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   await podmanConfiguration.updateRosettaSetting(true);
 
@@ -95,9 +93,7 @@ rosetta = true
     `;
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(configFileContent);
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   await podmanConfiguration.updateRosettaSetting(false);
 
@@ -110,9 +106,7 @@ rosetta = true
 test('if rosetta is set to true and the file does NOT exist, do not try and create the file.', async () => {
   vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
   vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue('');
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
   await podmanConfiguration.updateRosettaSetting(true);
 

--- a/packages/main/src/plugin/authentication.spec.ts
+++ b/packages/main/src/plugin/authentication.spec.ts
@@ -290,10 +290,8 @@ test('authentication provider send event to update settings page', async () => {
   const authentication = new AuthenticationImpl(apiSender, messageBox);
 
   const providerMock = {
-    onDidChangeSessions: vi.fn().mockImplementation(() => {
-      return {
-        dispose: vi.fn(),
-      };
+    onDidChangeSessions: vi.fn().mockReturnValue({
+      dispose: vi.fn(),
     }),
     getSessions: vi.fn().mockResolvedValue([]),
     createSession: vi.fn(),

--- a/packages/main/src/plugin/autostart-engine.spec.ts
+++ b/packages/main/src/plugin/autostart-engine.spec.ts
@@ -64,11 +64,9 @@ beforeAll(() => {
 });
 
 test('Check that default value is true if provider autostart setting is not set', async () => {
-  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
-    return {
-      get: (_section: string, defaultValue: boolean) => defaultValue,
-    } as Configuration;
-  });
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockReturnValue({
+    get: (_section: string, defaultValue: boolean) => defaultValue,
+  } as Configuration);
 
   const autoStartConfigurationNode: IConfigurationNode = {
     id: `preferences.${extensionId}.engine.autostart`,
@@ -94,11 +92,9 @@ test('Check that default value is true if provider autostart setting is not set'
 });
 
 test('Disposing the provider should not delete the configuration', async () => {
-  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
-    return {
-      get: (_section: string, defaultValue: boolean) => defaultValue,
-    } as Configuration;
-  });
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockReturnValue({
+    get: (_section: string, defaultValue: boolean) => defaultValue,
+  } as Configuration);
 
   const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
   disposable.dispose();
@@ -107,11 +103,9 @@ test('Disposing the provider should not delete the configuration', async () => {
 });
 
 test('Check that runAutostart is called once if only one provider has registered autostart process', async () => {
-  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
-    return {
-      get: (_section: string, _defaultValue: boolean) => true,
-    } as Configuration;
-  });
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockReturnValue({
+    get: (_section: string, _defaultValue: boolean) => true,
+  } as Configuration);
 
   const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
   await autostartEngine.start();
@@ -122,11 +116,9 @@ test('Check that runAutostart is called once if only one provider has registered
 });
 
 test('Check that runAutostart is never called if only one provider has registered autostart process but its setting is false', async () => {
-  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
-    return {
-      get: (_section: string, _defaultValue: boolean) => false,
-    } as Configuration;
-  });
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockReturnValue({
+    get: (_section: string, _defaultValue: boolean) => false,
+  } as Configuration);
 
   const disposable = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId');
 
@@ -137,11 +129,9 @@ test('Check that runAutostart is never called if only one provider has registere
 });
 
 test('Check that runAutostart is called twice if only two providers has registered autostart process', async () => {
-  vi.spyOn(configurationRegistry, 'getConfiguration').mockImplementation(() => {
-    return {
-      get: (_section: string, _defaultValue: boolean) => true,
-    } as Configuration;
-  });
+  vi.spyOn(configurationRegistry, 'getConfiguration').mockReturnValue({
+    get: (_section: string, _defaultValue: boolean) => true,
+  } as Configuration);
 
   const disposable1 = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId1');
   const disposable2 = autostartEngine.registerProvider(extensionId, extensionDisplayName, 'internalId2');

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -54,13 +54,13 @@ test('should register a configuration', async () => {
 });
 
 test('should set default value of configuraton registry on Linux and FreeBSD to true', async () => {
-  vi.spyOn(util, 'isUnixLike').mockImplementation(() => true);
+  vi.spyOn(util, 'isUnixLike').mockReturnValue(true);
   await closeBehavior.init();
   expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose']?.default).toBeTruthy();
 });
 
 test('should set default value of configuraton registry if not Linux or FreeBSD', async () => {
-  vi.spyOn(util, 'isUnixLike').mockImplementation(() => false);
+  vi.spyOn(util, 'isUnixLike').mockReturnValue(false);
   await closeBehavior.init();
   expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose']?.default).toBeFalsy();
 });

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1468,7 +1468,7 @@ describe('buildImage', () => {
       canDelete: false,
     };
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
     vi.spyOn(tar, 'pack').mockReturnValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI, 'buildImage').mockRejectedValue('human error message');
 
@@ -1510,7 +1510,7 @@ describe('buildImage', () => {
       status: () => 'started',
     };
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
     vi.spyOn(tar, 'pack').mockReturnValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI, 'buildImage').mockRejectedValue('human error message');
 
@@ -1558,7 +1558,7 @@ describe('buildImage', () => {
       canDelete: false,
     };
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(true);
     vi.spyOn(tar, 'pack').mockReturnValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI, 'buildImage').mockResolvedValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI.modem, 'followProgress').mockImplementation((_s, f, _p) => {
@@ -1609,7 +1609,7 @@ describe('buildImage', () => {
       status: () => 'started',
     };
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(true);
     vi.spyOn(tar, 'pack').mockReturnValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI, 'buildImage').mockResolvedValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI.modem, 'followProgress').mockImplementation((_s, f, _p) => {
@@ -1665,7 +1665,7 @@ describe('buildImage', () => {
       canDelete: false,
     };
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
     vi.spyOn(dockerAPI, 'buildImage').mockResolvedValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI.modem, 'followProgress').mockImplementation((_s, f, _p) => {
       return f(null, []);
@@ -1774,7 +1774,7 @@ describe('buildImage', () => {
       canDelete: false,
     };
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
     vi.spyOn(dockerAPI, 'buildImage').mockResolvedValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI.modem, 'followProgress').mockImplementation((_s, f, _p) => {
       return f(null, []);
@@ -1859,7 +1859,7 @@ describe('buildImage', () => {
       canDelete: false,
     };
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
     vi.spyOn(tar, 'pack').mockReturnValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI, 'buildImage').mockResolvedValue({} as NodeJS.ReadableStream);
     vi.spyOn(dockerAPI.modem, 'followProgress').mockImplementation((_e, f, _d) => {
@@ -5956,13 +5956,13 @@ describe('using fake timers', () => {
     const tokenSource = cancellationTokenRegistry.getCancellationTokenSource(cancellableTokenId);
     const token = tokenSource?.token;
     const dockerode = new Dockerode({ protocol: 'http', host: 'localhost' });
-    const imageObjectGetMock = vi.fn().mockImplementation(() => {
-      return new Promise(resolve => {
+    const imageObjectGetMock = vi.fn().mockReturnValue(
+      new Promise(resolve => {
         setTimeout(() => {
           resolve(undefined);
         }, 1000);
-      });
-    });
+      }),
+    );
     const stream: Dockerode.Image = {
       get: imageObjectGetMock,
     } as unknown as Dockerode.Image;

--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -317,7 +317,7 @@ test('waitForAContainerConnection delayed twice', async () => {
 
 describe('findComposeBinary', () => {
   test('Check findComposeBinary on Windows', async () => {
-    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(true);
 
     // mock exec
     vi.spyOn(exec, 'exec').mockResolvedValue({} as RunResult);
@@ -328,7 +328,7 @@ describe('findComposeBinary', () => {
   });
 
   test('Check findComposeBinary not exists on Windows', async () => {
-    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(true);
 
     // mock exec
     vi.spyOn(exec, 'exec').mockRejectedValue(new Error('not found'));
@@ -340,8 +340,8 @@ describe('findComposeBinary', () => {
   });
 
   test('Check findComposeBinary on macOS', async () => {
-    vi.spyOn(util, 'isMac').mockImplementation(() => true);
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isMac').mockReturnValue(true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
 
     // mock existsSync as returning false first time and true second time
     vi.spyOn(fs, 'existsSync').mockReturnValueOnce(false).mockReturnValueOnce(true);
@@ -356,9 +356,9 @@ describe('findComposeBinary', () => {
   });
 
   test('Check findComposeBinary on Linux', async () => {
-    vi.spyOn(util, 'isUnixLike').mockImplementation(() => true);
-    vi.spyOn(util, 'isMac').mockImplementation(() => false);
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isUnixLike').mockReturnValue(true);
+    vi.spyOn(util, 'isMac').mockReturnValue(false);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
 
     // mock existsSync as returning true
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -609,7 +609,7 @@ test('execComposeCommand on a non-Windows OS', async () => {
   // mock exec
   vi.spyOn(exec, 'exec').mockResolvedValue({} as RunResult);
 
-  vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+  vi.spyOn(util, 'isWindows').mockReturnValue(false);
 
   // call
   await contributionManager.execComposeCommand('/fake/directory', ['arg1', 'arg2']);
@@ -640,7 +640,7 @@ test('execComposeCommand on a Windows OS', async () => {
   // mock exec
   vi.spyOn(exec, 'exec').mockResolvedValue({} as RunResult);
 
-  vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+  vi.spyOn(util, 'isWindows').mockReturnValue(true);
 
   // call
   await contributionManager.execComposeCommand('/fake/directory', ['arg1', 'arg2']);

--- a/packages/main/src/plugin/directories-legacy.spec.ts
+++ b/packages/main/src/plugin/directories-legacy.spec.ts
@@ -51,7 +51,7 @@ beforeEach(() => {
   };
 
   vi.spyOn(fs, 'existsSync').mockReturnValue(true);
-  vi.spyOn(fs, 'mkdirSync').mockImplementation(() => '');
+  vi.spyOn(fs, 'mkdirSync').mockReturnValue('');
 });
 
 afterEach(() => {

--- a/packages/main/src/plugin/docker/docker-compatibility.spec.ts
+++ b/packages/main/src/plugin/docker/docker-compatibility.spec.ts
@@ -148,13 +148,13 @@ describe('resolveLinkIfAny', async () => {
   test('on Windows return same path', async () => {
     const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(true);
     const path = '/var/run/docker.sock';
     expect(await dockerCompatibility.resolveLinkIfAny(path)).toBe(path);
   });
 
   test('on macOS or Linux without symlink return same path', async () => {
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
     const isSymbolicLink = vi.fn();
     vi.spyOn(promises, 'lstat').mockResolvedValue({
       isSymbolicLink,
@@ -170,7 +170,7 @@ describe('resolveLinkIfAny', async () => {
     const path = '/var/run/docker.sock';
     const newPath = '/var/run/docker.sock2';
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
     const isSymbolicLink = vi.fn();
     vi.spyOn(promises, 'lstat').mockResolvedValue({
       isSymbolicLink,
@@ -194,7 +194,7 @@ describe('getSystemDockerSocketMappingStatus', async () => {
     const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
 
     vi.spyOn(dockerCompatibility, 'getTypeFromServerInfo').mockReturnValue('docker');
-    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(true);
 
     dockerodePodmanInfoMock.mockResolvedValue({
       ServerVersion: '1.0.0',
@@ -222,7 +222,7 @@ describe('getSystemDockerSocketMappingStatus', async () => {
   test('error on dockerode call', async () => {
     const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
 
-    vi.spyOn(util, 'isWindows').mockImplementation(() => true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(true);
 
     dockerodeInfoMock.mockRejectedValue(new Error('test error'));
 
@@ -235,8 +235,8 @@ describe('getSystemDockerSocketMappingStatus', async () => {
     const dockerCompatibility = new TestDockerCompatibility(configurationRegistry, providerRegistry);
 
     vi.spyOn(dockerCompatibility, 'getTypeFromServerInfo').mockReturnValue('docker');
-    vi.spyOn(util, 'isWindows').mockImplementation(() => false);
-    vi.spyOn(util, 'isMac').mockImplementation(() => true);
+    vi.spyOn(util, 'isWindows').mockReturnValue(false);
+    vi.spyOn(util, 'isMac').mockReturnValue(true);
 
     // mock resolveLinkIfAny
     vi.spyOn(dockerCompatibility, 'resolveLinkIfAny').mockResolvedValue(DockerCompatibility.UNIX_SOCKET_PATH);

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -1868,7 +1868,7 @@ describe('Navigation', async () => {
 
     // Mock listSimpleContainer implementation
     const listContributionsSpy = vi.spyOn(contributionManager, 'listContributions');
-    listContributionsSpy.mockImplementation(() => [
+    listContributionsSpy.mockReturnValue([
       {
         name: 'valid-name',
       } as unknown as ContributionInfo,
@@ -1895,7 +1895,7 @@ describe('Navigation', async () => {
 
     // Mock listContributions implementation
     const listContributionsSpy = vi.spyOn(contributionManager, 'listContributions');
-    listContributionsSpy.mockImplementation(() => []);
+    listContributionsSpy.mockReturnValue([]);
     // Spy send method
     const sendMock = vi.spyOn(apiSender, 'send');
 

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -124,14 +124,12 @@ beforeAll(async () => {
   vi.mocked(ipcMain.handle).mockImplementation((channel: string, listener: any) => {
     handlers.set(channel, listener);
   });
-  vi.mocked(BrowserWindow.getAllWindows).mockImplementation(() => {
-    return [
-      {
-        isDestroyed: () => false,
-        webContents,
-      } as unknown as BrowserWindow,
-    ];
-  });
+  vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+    {
+      isDestroyed: () => false,
+      webContents,
+    } as unknown as BrowserWindow,
+  ]);
   vi.mocked(app.getVersion).mockReturnValue('100.0.0');
   vi.spyOn(Updater.prototype, 'init').mockReturnValue(new Disposable(vi.fn()));
   vi.spyOn(ExtensionLoader.prototype, 'readDevelopmentFolders').mockResolvedValue([]);

--- a/packages/main/src/plugin/tasks/notification-registry.spec.ts
+++ b/packages/main/src/plugin/tasks/notification-registry.spec.ts
@@ -78,9 +78,7 @@ test('expect notification added to the queue', async () => {
 });
 
 test('expect notification is disposed correctly', async () => {
-  vi.spyOn(notificationRegistry, 'showNotification').mockImplementation(() => {
-    return Disposable.create(() => {});
-  });
+  vi.spyOn(notificationRegistry, 'showNotification').mockReturnValue(Disposable.create(() => {}));
   const notificationDisposeMock = vi.fn();
   const notificationTask = {
     id: `main-1`,
@@ -89,7 +87,7 @@ test('expect notification is disposed correctly', async () => {
     description: 'description',
     dispose: notificationDisposeMock,
   };
-  createNotificationtaskMock.mockImplementation(() => notificationTask);
+  createNotificationtaskMock.mockReturnValue(notificationTask);
   let queue = notificationRegistry.getNotifications();
 
   expect(queue.length).toEqual(0);
@@ -282,7 +280,7 @@ test('expect correct notification is disposed when multiple are added', async ()
     description: 'description',
     dispose: notificationDisposeMock,
   };
-  createNotificationtaskMock.mockImplementation(() => notificationTask);
+  createNotificationtaskMock.mockReturnValue(notificationTask);
   const disposable1 = notificationRegistry.addNotification({
     extensionId,
     title: 'notification 1',

--- a/packages/main/src/plugin/troubleshooting.spec.ts
+++ b/packages/main/src/plugin/troubleshooting.spec.ts
@@ -205,9 +205,7 @@ test('Should return getMacSystemLogs if the platform is darwin', async () => {
   readFileMock.mockResolvedValue('content');
 
   // Mock exists to be true
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   const zipFile = new Troubleshooting(DIALOG_REGISTRY_MOCK, CONFIGURATION_REGISTRY_MOCK);
   const getSystemLogsSpy = vi.spyOn(zipFile, 'getSystemLogs');
@@ -227,9 +225,7 @@ test('Should return getMacSystemLogs if the platform is darwin', async () => {
 // ~/AppData/Roaming/Podman Desktop/logs/podman-desktop.log
 test('Should return getWindowsSystemLogs if the platform is win32', async () => {
   // Mock exists to be true
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // Mock platform to be win32
   vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');

--- a/packages/main/src/plugin/util/directory-strategy.spec.ts
+++ b/packages/main/src/plugin/util/directory-strategy.spec.ts
@@ -61,7 +61,7 @@ describe('shouldUseXDGDirectories', () => {
       vi.mocked(isLinux).mockReturnValue(true);
 
       const existSyncSpy = vi.mocked(existsSync);
-      existSyncSpy.mockImplementation(() => false);
+      existSyncSpy.mockReturnValue(false);
 
       // biome-ignore lint/complexity/useLiteralKeys: <PODMAN_DESKTOP_HOME_DIR comes from an index signature>
       process.env['PODMAN_DESKTOP_HOME_DIR'] = '/custom/path';
@@ -73,7 +73,7 @@ describe('shouldUseXDGDirectories', () => {
       vi.mocked(isLinux).mockReturnValue(true);
 
       const existSyncSpy = vi.mocked(existsSync);
-      existSyncSpy.mockImplementation(() => true);
+      existSyncSpy.mockReturnValue(true);
 
       expect(strategy.shouldUseXDGDirectories()).toBe(false);
     });

--- a/packages/main/src/plugin/webview/webview-registry.spec.ts
+++ b/packages/main/src/plugin/webview/webview-registry.spec.ts
@@ -144,10 +144,8 @@ test('check configureRouter with missing referrer', async () => {
   };
   const sendMock = vi.fn();
   const res = {
-    status: vi.fn().mockImplementation(() => {
-      return {
-        send: sendMock,
-      };
+    status: vi.fn().mockReturnValue({
+      send: sendMock,
     }),
   };
   func(req, res);
@@ -193,10 +191,8 @@ test('check configureRouter with invalid uuid', async () => {
   };
   const sendMock = vi.fn();
   const res = {
-    status: vi.fn().mockImplementation(() => {
-      return {
-        send: sendMock,
-      };
+    status: vi.fn().mockReturnValue({
+      send: sendMock,
     }),
   };
   func(req, res);
@@ -221,10 +217,8 @@ test('check configureRouter with valid uuid but no matching webview', async () =
   const sendMock = vi.fn();
   const res = {
     sendFile: vi.fn(),
-    status: vi.fn().mockImplementation(() => {
-      return {
-        send: sendMock,
-      };
+    status: vi.fn().mockReturnValue({
+      send: sendMock,
     }),
   };
 
@@ -242,9 +236,7 @@ test('check configureRouter with valid uuid but no matching webview', async () =
 
 test('check configureRouter with valid uuid and file exists', async () => {
   // spy fs.existsSync
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return true;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 
   // register the webview first
   const panel = webviewRegistry.createWebviewPanel(
@@ -267,10 +259,8 @@ test('check configureRouter with valid uuid and file exists', async () => {
   const sendMock = vi.fn();
   const res = {
     sendFile: vi.fn(),
-    status: vi.fn().mockImplementation(() => {
-      return {
-        send: sendMock,
-      };
+    status: vi.fn().mockReturnValue({
+      send: sendMock,
     }),
   };
 
@@ -285,9 +275,7 @@ test('check configureRouter with valid uuid and file exists', async () => {
 
 test('check configureRouter with valid uuid and file does not exist', async () => {
   // spy fs.existsSync
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
   // register the webview first
   const panel = webviewRegistry.createWebviewPanel(
@@ -310,10 +298,8 @@ test('check configureRouter with valid uuid and file does not exist', async () =
   const sendMock = vi.fn();
   const res = {
     sendFile: vi.fn(),
-    status: vi.fn().mockImplementation(() => {
-      return {
-        send: sendMock,
-      };
+    status: vi.fn().mockReturnValue({
+      send: sendMock,
     }),
   };
 
@@ -331,9 +317,7 @@ test('check configureRouter with valid uuid and file does not exist', async () =
 
 test('check configureRouter with valid uuid and file from another directory', async () => {
   // spy fs.existsSync
-  vi.spyOn(fs, 'existsSync').mockImplementation(() => {
-    return false;
-  });
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
 
   // register the webview first
   const panel = webviewRegistry.createWebviewPanel(
@@ -356,10 +340,8 @@ test('check configureRouter with valid uuid and file from another directory', as
   const sendMock = vi.fn();
   const res = {
     sendFile: vi.fn(),
-    status: vi.fn().mockImplementation(() => {
-      return {
-        send: sendMock,
-      };
+    status: vi.fn().mockReturnValue({
+      send: sendMock,
     }),
   };
 

--- a/packages/renderer/src/Route.spec.ts
+++ b/packages/renderer/src/Route.spec.ts
@@ -32,10 +32,8 @@ beforeEach(() => {
 });
 
 test('renders the route with request parser', async () => {
-  vi.mocked(createRouteObject).mockImplementation(() => {
-    return {
-      update: vi.fn(),
-    };
+  vi.mocked(createRouteObject).mockReturnValue({
+    update: vi.fn(),
   });
   const myParser = (request: {
     query: Record<string, string>;
@@ -68,10 +66,8 @@ test('renders the route with request parser', async () => {
 });
 
 test('renders the route without request parser', async () => {
-  vi.mocked(createRouteObject).mockImplementation(() => {
-    return {
-      update: vi.fn(),
-    };
+  vi.mocked(createRouteObject).mockReturnValue({
+    update: vi.fn(),
   });
   render(RouteSpec, {});
 

--- a/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsTerminal.spec.ts
@@ -548,11 +548,10 @@ test('concurrent receiveEndCallback calls do not create duplicate connections', 
   await vi.waitFor(() => expect(shellInContainerMock).toHaveBeenCalledTimes(1));
 
   // Make the next shellInContainer call hang so we can test the guard
-  shellInContainerMock.mockImplementation(
-    () =>
-      new Promise<number>(resolve => {
-        resolveShell = resolve;
-      }),
+  shellInContainerMock.mockReturnValue(
+    new Promise<number>(resolve => {
+      resolveShell = resolve;
+    }),
   );
 
   // First exec dies — receiveEndCallback starts a reconnect (now in flight)
@@ -624,11 +623,10 @@ test('receiveEndCallback during reconnect schedules safety-net retry to prevent 
   await vi.waitFor(() => expect(shellInContainerMock).toHaveBeenCalledTimes(1));
 
   // Make reconnect hang so we can simulate the race
-  shellInContainerMock.mockImplementation(
-    () =>
-      new Promise<number>(resolve => {
-        resolveShell = resolve;
-      }),
+  shellInContainerMock.mockReturnValue(
+    new Promise<number>(resolve => {
+      resolveShell = resolve;
+    }),
   );
 
   // Exec dies → receiveEndCallback → restartTerminal starts (reconnecting = true)

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -86,17 +86,14 @@ function mockExtensionInstallFromImage(): {
   logCallback: (data: string) => void;
   errorCallback: (data: string) => void;
 } {
-  const resolve = vi.fn();
-  const reject = vi.fn();
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+
   const logCallback = vi.fn<(data: string) => void>();
   const errorCallback = vi.fn<(data: string) => void>();
   vi.mocked(window.extensionInstallFromImage).mockImplementation((_image, mLogCallback, mErrorCallback) => {
     logCallback.mockImplementation((content: string) => mLogCallback(content));
     errorCallback.mockImplementation((content: string) => mErrorCallback(content));
-    return new Promise((mResolve, mReject) => {
-      resolve.mockReturnValue(mResolve());
-      reject.mockImplementation((err: unknown) => mReject(err));
-    });
+    return promise;
   });
   return { resolve, reject, logCallback, errorCallback };
 }

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -94,7 +94,7 @@ function mockExtensionInstallFromImage(): {
     logCallback.mockImplementation((content: string) => mLogCallback(content));
     errorCallback.mockImplementation((content: string) => mErrorCallback(content));
     return new Promise((mResolve, mReject) => {
-      resolve.mockImplementation(() => mResolve());
+      resolve.mockReturnValue(mResolve());
       reject.mockImplementation((err: unknown) => mReject(err));
     });
   });

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -104,9 +104,7 @@ test('Expect redirect to previous page if image is deleted', async () => {
   deleteImageMock.mockImplementation(() => {
     imagesInfos.update(images => images.filter(image => image.Id !== myImage.Id));
   });
-  hasAuthMock.mockImplementation(() => {
-    return new Promise(() => false);
-  });
+  hasAuthMock.mockReturnValue(new Promise(() => false));
 
   // defines a fake lastPage so we can check where we will be redirected
   lastPage.set({ name: 'Fake Previous', path: '/last' });
@@ -145,9 +143,7 @@ test('expect delete image called with image id when image name is <none>', async
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
-  hasAuthMock.mockImplementation(() => {
-    return new Promise(() => false);
-  });
+  hasAuthMock.mockReturnValue(new Promise(() => false));
 
   // render the component
   render(ImageDetails, {
@@ -183,9 +179,7 @@ describe('expect display usage of an image', () => {
     } as unknown as ImageInfo;
     imagesInfos.set([myImage]);
 
-    hasAuthMock.mockImplementation(() => {
-      return new Promise(() => false);
-    });
+    hasAuthMock.mockReturnValue(new Promise(() => false));
 
     // render the component
     render(ImageDetails, {
@@ -215,9 +209,7 @@ describe('expect display usage of an image', () => {
     } as unknown as ImageInfo;
     imagesInfos.set([myImage]);
 
-    hasAuthMock.mockImplementation(() => {
-      return new Promise(() => false);
-    });
+    hasAuthMock.mockReturnValue(new Promise(() => false));
 
     // render the component
     render(ImageDetails, {
@@ -242,9 +234,7 @@ test('expect Check tab is not displayed by default', () => {
   } as unknown as ImageInfo;
   imagesInfos.set([myImage]);
 
-  hasAuthMock.mockImplementation(() => {
-    return new Promise(() => false);
-  });
+  hasAuthMock.mockReturnValue(new Promise(() => false));
 
   render(ImageDetails, {
     imageID,
@@ -267,9 +257,7 @@ test('expect Check tab is displayed when an image checker provider exists', () =
   } as unknown as ImageInfo;
   imagesInfos.set([myImage]);
 
-  hasAuthMock.mockImplementation(() => {
-    return new Promise(() => false);
-  });
+  hasAuthMock.mockReturnValue(new Promise(() => false));
 
   imageCheckerProviders.set([
     {
@@ -306,9 +294,7 @@ test.each([
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
-  hasAuthMock.mockImplementation(() => {
-    return new Promise(() => false);
-  });
+  hasAuthMock.mockReturnValue(new Promise(() => false));
 
   const contribs = [
     {
@@ -363,9 +349,7 @@ test.each([
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
-  hasAuthMock.mockImplementation(() => {
-    return new Promise(() => false);
-  });
+  hasAuthMock.mockReturnValue(new Promise(() => false));
 
   const contribs = [
     {

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -34,7 +34,7 @@ const cancelTokenSpy = vi.fn();
 const tokenID = 70735;
 beforeAll(() => {
   Object.defineProperty(window, 'getCancellableTokenSource', { value: getCancellableTokenSourceMock });
-  getCancellableTokenSourceMock.mockImplementation(() => tokenID);
+  getCancellableTokenSourceMock.mockReturnValue(tokenID);
   Object.defineProperty(window, 'imageCheck', { value: imageCheckMock });
   Object.defineProperty(window, 'cancelToken', { value: cancelTokenSpy.mockResolvedValue(undefined) });
   Object.defineProperty(window, 'telemetryTrack', { value: vi.fn().mockResolvedValue(undefined) });

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -350,25 +350,25 @@ describe.each([
     const callback = vi.fn();
     let auditSpy = vi.spyOn(window as any, 'auditConnectionParameters');
     if (!connectionInfo) {
-      auditSpy = vi.spyOn(window as any, 'auditConnectionParameters').mockImplementationOnce(() => ({ records: [] }));
+      auditSpy = vi.spyOn(window as any, 'auditConnectionParameters').mockReturnValueOnce({ records: [] });
     }
     auditSpy
-      .mockImplementationOnce(() => ({
+      .mockReturnValueOnce({
         records: [
           {
             type: 'error',
             record: 'error message',
           },
         ],
-      }))
-      .mockImplementationOnce(() => ({
+      })
+      .mockReturnValueOnce({
         records: [
           {
             type: 'info',
             record: 'info message',
           },
         ],
-      }));
+      });
     // eslint-disable-next-line @typescript-eslint/await-thenable
     render(PreferencesConnectionCreationOrEditRendering, {
       properties: [

--- a/packages/ui/src/lib/utils/dialog-utils.spec.ts
+++ b/packages/ui/src/lib/utils/dialog-utils.spec.ts
@@ -55,9 +55,9 @@ test('check tabbing order', async () => {
   event.preventDefault = vi.fn();
 
   const container = {} as HTMLDivElement;
-  container.querySelectorAll = vi.fn().mockImplementation(() => {
-    return [{ name: 'a component' }, button1, button2, { name: 'another component' }, button3];
-  });
+  container.querySelectorAll = vi
+    .fn()
+    .mockReturnValue([{ name: 'a component' }, button1, button2, { name: 'another component' }, button3]);
 
   // expect tabbing order to be 1 -> 2 -> 3 -> 1
   vi.spyOn(document, 'activeElement', 'get').mockReturnValue(button1);


### PR DESCRIPTION
### What does this PR do?

Enable `vitest/prefer-mock-return-shorthand` eslint rule, I did nothing manually only run `pnpm lint:fix`

**Edit**

I had to fix `packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts` (321ad75265f63473c5cb04a80879507eb143cbc3) as the test was so strange that the autofix was not understanding it. 

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17213

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle:  
