### PR TITLE
fix: cleanup watchers on stop

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -187,7 +187,9 @@ const kubernetesClient: KubernetesClient = {
   dispose: vi.fn(),
 } as unknown as KubernetesClient;
 
-const fileSystemMonitoring: FilesystemMonitoring = {} as unknown as FilesystemMonitoring;
+const fileSystemMonitoring: FilesystemMonitoring = {
+  asyncDispose: vi.fn().mockResolvedValue(undefined),
+} as unknown as FilesystemMonitoring;
 
 const proxy: Proxy = {} as unknown as Proxy;
 
@@ -3040,6 +3042,13 @@ test('ExtensionLoader async dispose should stop all extensions', async () => {
   await extensionLoader.asyncDispose();
 
   expect(deactivateMock).toHaveBeenCalledOnce();
+  expect(fileSystemMonitoring.asyncDispose).toHaveBeenCalledOnce();
+});
+
+test('asyncDispose should call fileSystemMonitoring.asyncDispose', async () => {
+  await extensionLoader.asyncDispose();
+
+  expect(fileSystemMonitoring.asyncDispose).toHaveBeenCalledOnce();
 });
 
 describe('env API', () => {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -239,6 +239,7 @@ export class ExtensionLoader implements IAsyncDisposable {
 
     // stop the webview HTTP server
     await this.webviewRegistry.stop();
+    await this.fileSystemMonitoring.asyncDispose();
 
     // clear maps
     this.activatedExtensions.clear();

--- a/packages/main/src/plugin/filesystem-monitoring.spec.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.spec.ts
@@ -21,11 +21,11 @@ import os from 'node:os';
 import path, { join } from 'node:path';
 
 import { watch } from 'chokidar';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { isWindows } from '/@/util.js';
 
-import { FileSystemWatcherImpl } from './filesystem-monitoring.js';
+import { FilesystemMonitoring, FileSystemWatcherImpl } from './filesystem-monitoring.js';
 import { Uri } from './types/uri.js';
 
 let rootdir: string;
@@ -202,4 +202,49 @@ test.runIf(os.platform() === 'darwin')('Watch a directory with a lot of files', 
   });
 
   await vi.waitFor(() => expect(counter).toBeGreaterThan(3));
+});
+
+describe('FilesystemMonitoring', () => {
+  let monitoring: FilesystemMonitoring;
+
+  beforeEach(() => {
+    monitoring = new FilesystemMonitoring();
+  });
+
+  test('createFileSystemWatcher should return a FileSystemWatcher', () => {
+    const fsWatcher = monitoring.createFileSystemWatcher(path.join(rootdir, 'somefile'));
+    expect(fsWatcher).toBeDefined();
+    expect(fsWatcher.dispose).toBeDefined();
+    expect(fsWatcher.onDidCreate).toBeDefined();
+    expect(fsWatcher.onDidChange).toBeDefined();
+    expect(fsWatcher.onDidDelete).toBeDefined();
+    fsWatcher.dispose();
+  });
+
+  test('asyncDispose should dispose all tracked watchers', async () => {
+    const watcher1 = monitoring.createFileSystemWatcher(path.join(rootdir, 'file1'));
+    const watcher2 = monitoring.createFileSystemWatcher(path.join(rootdir, 'file2'));
+    const disposeSpy1 = vi.spyOn(watcher1, 'dispose');
+    const disposeSpy2 = vi.spyOn(watcher2, 'dispose');
+
+    await monitoring.asyncDispose();
+
+    expect(disposeSpy1).toHaveBeenCalledOnce();
+    expect(disposeSpy2).toHaveBeenCalledOnce();
+  });
+
+  test('asyncDispose should clear the watchers so subsequent calls are no-ops', async () => {
+    const fsWatcher = monitoring.createFileSystemWatcher(path.join(rootdir, 'file'));
+    const disposeSpy = vi.spyOn(fsWatcher, 'dispose');
+
+    await monitoring.asyncDispose();
+    expect(disposeSpy).toHaveBeenCalledOnce();
+
+    await monitoring.asyncDispose();
+    expect(disposeSpy).toHaveBeenCalledOnce();
+  });
+
+  test('asyncDispose on empty instance should resolve without error', async () => {
+    await expect(monitoring.asyncDispose()).resolves.toBeUndefined();
+  });
 });

--- a/packages/main/src/plugin/filesystem-monitoring.ts
+++ b/packages/main/src/plugin/filesystem-monitoring.ts
@@ -20,6 +20,7 @@ import * as fs from 'node:fs';
 import * as pathfs from 'node:path';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
+import type { IAsyncDisposable } from '@podman-desktop/core-api';
 import * as chokidar from 'chokidar';
 import { injectable } from 'inversify';
 
@@ -111,8 +112,23 @@ export class FileSystemWatcherImpl implements containerDesktopAPI.FileSystemWatc
 }
 
 @injectable()
-export class FilesystemMonitoring {
+export class FilesystemMonitoring implements IAsyncDisposable {
+  private watchers: FileSystemWatcherImpl[] = [];
+
   createFileSystemWatcher(path: string): containerDesktopAPI.FileSystemWatcher {
-    return new FileSystemWatcherImpl(path);
+    const watcher = new FileSystemWatcherImpl(path);
+    this.watchers.push(watcher);
+    return watcher;
+  }
+
+  async asyncDispose(): Promise<void> {
+    await Promise.all(
+      this.watchers.map(watcher =>
+        Promise.resolve().then(() => {
+          watcher.dispose();
+        }),
+      ),
+    );
+    this.watchers = [];
   }
 }


### PR DESCRIPTION

### What does this PR do?
watchers can still keep filesystem reference on stop and then we see a crash dialog on macOS
now, cleanup references on stop

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/17402

### How to test this PR?

I added unit tests

- [x] Tests are covering the bug fix or the new feature
