### PR TITLE
chore(storybook): add renderer lib components to Tailwind content scanning

### DIFF
--- a/storybook/tailwind.config.js
+++ b/storybook/tailwind.config.js
@@ -3,5 +3,9 @@ import config from '../tailwind.config.cjs';
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   ...config,
-  content: ['./src/**/*.{svelte,ts,css}', '../packages/ui/**/*.{svelte,ts,css}'],
+  content: [
+    './src/**/*.{svelte,ts,css}',
+    '../packages/ui/**/*.{svelte,ts,css}',
+    '../packages/renderer/src/lib/**/*.svelte',
+  ],
 };


### PR DESCRIPTION
### What does this PR do?

Adds `../packages/renderer/src/lib/**/*.svelte` to the Storybook Tailwind content scanning paths. Previously only `./src/**` and `../packages/ui/**` were scanned, so arbitrary-value Tailwind classes used by renderer components (e.g. `bg-[var(--pd-progressBar-bg)]`) were not generated in Storybook builds.

### Screenshot / video of UI

N/A - no visual change. This is an infrastructure prerequisite for upcoming renderer component stories.

### What issues does this PR fix or reference?

- Resolves #17414
- Related: #16244

### How to test this PR?

1. Run `pnpm --filter storybook build` and verify it completes successfully
2. Run `pnpm --filter storybook dev` and verify existing stories still render correctly across all themes

- Tests are covering the bug fix or the new feature

No test needed - this is a build config change verified by a successful Storybook build.