### PR TITLE
fix(main): reset corrupt safe storage file after backup

### DIFF
--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.spec.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { existsSync } from 'node:fs';
+import { cpSync, existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 
 import type Electron from 'electron';
@@ -124,6 +124,10 @@ test('should init safe storage if error', async () => {
   const notifications = await safeStorageRegistry.init();
   expect(notifications).toBeDefined();
   expect(notifications.length).toBe(1);
+
+  expect(cpSync).toHaveBeenCalledWith(expect.stringContaining('data.json'), expect.stringContaining('.backup-'));
+
+  expect(writeFile).toHaveBeenCalledWith(expect.stringContaining('data.json'), JSON.stringify({}), 'utf-8');
 });
 
 test('should throw error if not initialized', async () => {

--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
@@ -71,6 +71,8 @@ export class SafeStorageRegistry {
       // keep original file as a backup
       cpSync(safeStoragePath, backupFilename);
 
+      await writeFile(safeStoragePath, JSON.stringify({}), 'utf-8');
+
       // append notification for the user
       notifications.push({
         title: 'Corrupted secure storage',


### PR DESCRIPTION
### What does this PR do?

When the safe storage data.json file is corrupted, it was backed up and in-memory state was reset to empty, but the original file was left unchanged. This caused the "Corrupted secure storage" notification to reappear on every restart.

Write an empty JSON object to data.json after creating the backup so the notification only appears once.


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes #8527


<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?


```bash
echo "not json" > ~/.local/share/containers/podman-desktop/safe-storage/data.json
```
Start Podman Desktop -- notification appears. Quit, restart, notification disappeared. The backup file contains `not json` and `data.json` contains `{}`:
```
$ cat data.json
{}
$ cat data.json.backup-1777971618273
not json
```


<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
