### PR TITLE
fix(renderer): nest provider routes under /resources to fix unresponsive navigation

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.spec.ts
@@ -108,14 +108,14 @@ test('expect to have links for each Kubernetes provider', async () => {
 
   const link1 = screen.getByLabelText('Go create');
   await fireEvent.click(link1);
-  expect(router.goto).toHaveBeenCalledWith('/preferences/provider/101');
+  expect(router.goto).toHaveBeenCalledWith('/preferences/resources/provider/101');
   expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('kubernetes.nocontext.createNew', {
     provider: 'provider1',
   });
 
   const link2 = screen.getByLabelText('Create new');
   await fireEvent.click(link2);
-  expect(router.goto).toHaveBeenCalledWith('/preferences/provider/102');
+  expect(router.goto).toHaveBeenCalledWith('/preferences/resources/provider/102');
   expect(vi.mocked(window.telemetryTrack)).toHaveBeenCalledWith('kubernetes.nocontext.createNew', {
     provider: 'provider2',
   });

--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -17,7 +17,7 @@ async function createNew(provider: ProviderInfo): Promise<void> {
   await window.telemetryTrack('kubernetes.nocontext.createNew', {
     provider: provider.id,
   });
-  router.goto(`/preferences/provider/${provider.internalId}`);
+  router.goto(`/preferences/resources/provider/${provider.internalId}`);
 }
 
 async function oninstall(extensionId: string): Promise<void> {

--- a/packages/renderer/src/lib/preferences/PreferencesPage.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesPage.svelte
@@ -55,17 +55,17 @@ onMount(async () => {
   <Route path="/default/:key/*" breadcrumb="Preferences" let:meta>
     <PreferencesRendering key={meta.params.key} properties={properties} />
   </Route>
-  <Route path="/provider/:providerInternalId/*" breadcrumb="Resources" let:meta navigationHint="root">
+  <Route path="/resources" breadcrumb="Resources" navigationHint="root" let:meta>
+    <PreferencesResourcesRendering focus={meta.query.focus}/>
+  </Route>
+  <Route path="/resources/provider/:providerInternalId/*" breadcrumb="Resources" let:meta navigationHint="details">
     <PreferencesProviderRendering providerInternalId={meta.params.providerInternalId} properties={properties} />
   </Route>
-  <Route path="/provider-task/:providerInternalId/:taskId/*" breadcrumb="Resources" let:meta>
+  <Route path="/resources/provider-task/:providerInternalId/:taskId/*" breadcrumb="Resources" let:meta navigationHint="details">
     <PreferencesProviderRendering
       providerInternalId={meta.params.providerInternalId}
       properties={properties}
       taskId={+meta.params.taskId} />
-  </Route>
-  <Route path="/resources" breadcrumb="Resources" navigationHint="root" let:meta>
-    <PreferencesResourcesRendering focus={meta.query.focus}/>
   </Route>
   <Route path="/docker-compatibility" breadcrumb="Docker Compatibility">
     <PreferencesDockerCompatibilityRendering />

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -516,7 +516,7 @@ describe.each<{
       name: customProviderInfo.name,
     });
     // redirect to create new page
-    expect(router.goto).toHaveBeenCalledWith(`/preferences/provider/${customProviderInfo.internalId}`);
+    expect(router.goto).toHaveBeenCalledWith(`/preferences/resources/provider/${customProviderInfo.internalId}`);
   });
 
   test('Expect to display the dialog if missing requirements for installation', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -267,14 +267,14 @@ async function doCreateNew(provider: ProviderInfo, displayName: string): Promise
   if (provider.status === 'not-installed') {
     providerInstallationInProgress.set(provider.name, true);
     providerToBeInstalled = { provider, displayName };
-    doExecuteAfterInstallation = (): void => router.goto(`/preferences/provider/${provider.internalId}`);
+    doExecuteAfterInstallation = (): void => router.goto(`/preferences/resources/provider/${provider.internalId}`);
     await performInstallation(provider);
   } else {
     await window.telemetryTrack('createNewProviderConnectionPageRequested', {
       providerId: provider.id,
       name: provider.name,
     });
-    router.goto(`/preferences/provider/${provider.internalId}`);
+    router.goto(`/preferences/resources/provider/${provider.internalId}`);
   }
 }
 

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -222,7 +222,7 @@ test(`Test navigationHandle for ${NavigationPage.PROVIDER_TASK}`, () => {
     },
   });
 
-  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/provider-task/dummyProviderId/55');
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/resources/provider-task/dummyProviderId/55');
 });
 
 test(`Test navigationHandle for ${NavigationPage.WEBVIEW}`, () => {
@@ -276,7 +276,7 @@ test(`Test navigationHandle for ${NavigationPage.CREATE_PROVIDER_CONNECTION}`, (
     },
   });
 
-  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/provider/dummyProviderId');
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/preferences/resources/provider/dummyProviderId');
 });
 
 test(`Test navigationHandle for ${NavigationPage.NETWORK}`, () => {

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -121,7 +121,7 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       router.goto(`/preferences/cli-tools`);
       break;
     case NavigationPage.PROVIDER_TASK:
-      router.goto(`/preferences/provider-task/${request.parameters.internalId}/${request.parameters.taskId}`);
+      router.goto(`/preferences/resources/provider-task/${request.parameters.internalId}/${request.parameters.taskId}`);
       break;
     case NavigationPage.WEBVIEW:
       router.goto(`/webviews/${request.parameters.id}`);
@@ -139,7 +139,7 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
       router.goto('/preferences/experimental');
       break;
     case NavigationPage.CREATE_PROVIDER_CONNECTION:
-      router.goto(`/preferences/provider/${request.parameters.provider}`);
+      router.goto(`/preferences/resources/provider/${request.parameters.provider}`);
       break;
     case NavigationPage.NETWORKS:
       router.goto('/networks');


### PR DESCRIPTION
### What does this PR do?

Fixes unresponsive close button and breadcrumb navigation on resource setup pages (Podman, Kind, etc.).

The `/provider/:providerInternalId/*` and `/provider-task/:providerInternalId/:taskId/*` routes were using `navigationHint="root"`, which reset breadcrumb history to the current page. Clicking X or breadcrumbs navigated to the same URL, appearing unresponsive.

Fix: nest these routes under `/resources/` and change their `navigationHint` to `"details"`, so the breadcrumb correctly points back to the Resources page.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes #17242

### How to test this PR?

1. Go to Settings > Resources
2. Click "Create new" on any provider (e.g. Podman)
3. Verify the X button and breadcrumb links navigate back to the Resources page
4. Verify creating a provider connection still works end-to-end

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)