### PR TITLE
fix: resolve CVE-2026-42338 in ip-address

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,7 +236,8 @@
       "smol-toml": "^1.6.1",
       "follow-redirects": "^1.16.0",
       "uuid": "^14.0.0",
-      "postcss": ">=8.5.12"
+      "postcss": ">=8.5.12",
+      "ip-address": ">=10.1.1"
     },
     "patchedDependencies": {
       "docker-modem": "patches/docker-modem.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ overrides:
   follow-redirects: ^1.16.0
   uuid: ^14.0.0
   postcss: '>=8.5.12'
+  ip-address: '>=10.1.1'
 
 patchedDependencies:
   docker-modem:
@@ -7945,8 +7946,8 @@ packages:
   inversify@8.1.0:
     resolution: {integrity: sha512-LeMjL2MKHM0E8UmKo2ilRvdxG3o0pLZPYFjkaHwcjcFIrhzBGetphNkaWJ6YaM78uC1gK9v45i1R7CkCJDvG4Q==}
 
-  ip-address@10.0.1:
-    resolution: {integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -20909,7 +20910,7 @@ snapshots:
     transitivePeerDependencies:
       - reflect-metadata
 
-  ip-address@10.0.1: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -24445,7 +24446,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.0.1
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   sort-css-media-queries@2.2.0: {}


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-42338 in `ip-address`.

**Advisory**: ip-address has XSS in Address6 HTML-emitting methods
**Vulnerable versions**: <=10.1.0
**Patched versions**: >=10.1.1
**Advisory URL**: https://github.com/advisories/GHSA-v2v4-37r5-5v8g

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-42338: _ip-address has XSS in Address6 HTML-emitting methods_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-42338 is no longer reported