### PR TITLE
fix: add fallback implementation to detect when window should be showed up on linux

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -234,7 +234,6 @@ const config = {
       '--talk-name=org.freedesktop.Flatpak',
       // required to fix cursor scaling on wayland https://github.com/electron/electron/issues/19810 when the user uses --socket=wayland in their flatpak run
       '--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons',
-      '--env=XDG_SESSION_TYPE=x11',
     ],
     useWaylandFlags: 'false',
     artifactName: `${product.artifactName}-\${version}.\${ext}`,

--- a/packages/main/src/mainWindow.spec.ts
+++ b/packages/main/src/mainWindow.spec.ts
@@ -107,7 +107,7 @@ beforeEach(() => {
   BrowserWindow.prototype.destroy = vi.fn();
   BrowserWindow.prototype.hide = vi.fn();
   Object.defineProperty(BrowserWindow.prototype, 'webContents', {
-    value: { send: vi.fn(), on: vi.fn() },
+    value: { send: vi.fn(), on: vi.fn(), once: vi.fn() },
     configurable: true,
   });
 
@@ -293,6 +293,10 @@ describe('createNewWindow', () => {
       vi.mocked(util.isLinux).mockReturnValue(true);
     });
 
+    afterEach(() => {
+      delete process.env['WAYLAND_DISPLAY'];
+    });
+
     test('should show window via did-finish-load on Linux X11', async () => {
       const { createNewWindow } = await import('./mainWindow.js');
 
@@ -301,7 +305,7 @@ describe('createNewWindow', () => {
       const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
       assert(bwInstance);
 
-      const didFinishLoad = getHandler(bwInstance.webContents.on, 'did-finish-load');
+      const didFinishLoad = getHandler(bwInstance.webContents.once, 'did-finish-load');
       didFinishLoad();
 
       expect(bwInstance.show).toHaveBeenCalled();
@@ -317,12 +321,10 @@ describe('createNewWindow', () => {
       const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
       assert(bwInstance);
 
-      const didFinishLoad = getHandler(bwInstance.webContents.on, 'did-finish-load');
+      const didFinishLoad = getHandler(bwInstance.webContents.once, 'did-finish-load');
       didFinishLoad();
 
       expect(bwInstance.show).toHaveBeenCalled();
-
-      delete process.env['WAYLAND_DISPLAY'];
     });
 
     test('should not register ready-to-show on Linux (avoids Wayland show() feedback loop)', async () => {
@@ -347,7 +349,7 @@ describe('createNewWindow', () => {
       const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
       assert(bwInstance);
 
-      expect(bwInstance.webContents.on).not.toHaveBeenCalledWith('did-finish-load', expect.any(Function));
+      expect(bwInstance.webContents.once).not.toHaveBeenCalledWith('did-finish-load', expect.any(Function));
     });
 
     test('should not show window via did-finish-load when --minimize flag is set', async () => {
@@ -360,7 +362,7 @@ describe('createNewWindow', () => {
       const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
       assert(bwInstance);
 
-      const didFinishLoad = getHandler(bwInstance.webContents.on, 'did-finish-load');
+      const didFinishLoad = getHandler(bwInstance.webContents.once, 'did-finish-load');
       didFinishLoad();
 
       expect(bwInstance.show).not.toHaveBeenCalled();

--- a/packages/main/src/mainWindow.spec.ts
+++ b/packages/main/src/mainWindow.spec.ts
@@ -107,7 +107,7 @@ beforeEach(() => {
   BrowserWindow.prototype.destroy = vi.fn();
   BrowserWindow.prototype.hide = vi.fn();
   Object.defineProperty(BrowserWindow.prototype, 'webContents', {
-    value: { send: vi.fn() },
+    value: { send: vi.fn(), on: vi.fn() },
     configurable: true,
   });
 
@@ -286,5 +286,84 @@ describe('createNewWindow', () => {
     // Should quit (destroy + app.quit) even though ExitOnClose is false, because tray is hidden
     expect(bwInstance.destroy).toHaveBeenCalled();
     expect(app.quit).toHaveBeenCalled();
+  });
+
+  describe('Linux did-finish-load (replaces ready-to-show)', () => {
+    beforeEach(() => {
+      vi.mocked(util.isLinux).mockReturnValue(true);
+    });
+
+    test('should show window via did-finish-load on Linux X11', async () => {
+      const { createNewWindow } = await import('./mainWindow.js');
+
+      await createNewWindow();
+
+      const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+      assert(bwInstance);
+
+      const didFinishLoad = getHandler(bwInstance.webContents.on, 'did-finish-load');
+      didFinishLoad();
+
+      expect(bwInstance.show).toHaveBeenCalled();
+    });
+
+    test('should show window via did-finish-load on Linux Wayland', async () => {
+      process.env['WAYLAND_DISPLAY'] = 'wayland-0';
+
+      const { createNewWindow } = await import('./mainWindow.js');
+
+      await createNewWindow();
+
+      const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+      assert(bwInstance);
+
+      const didFinishLoad = getHandler(bwInstance.webContents.on, 'did-finish-load');
+      didFinishLoad();
+
+      expect(bwInstance.show).toHaveBeenCalled();
+
+      delete process.env['WAYLAND_DISPLAY'];
+    });
+
+    test('should not register ready-to-show on Linux (avoids Wayland show() feedback loop)', async () => {
+      const { createNewWindow } = await import('./mainWindow.js');
+
+      await createNewWindow();
+
+      const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+      assert(bwInstance);
+
+      const registeredEvents = vi.mocked(bwInstance.on).mock.calls.map((c: unknown[]) => c[0]);
+      expect(registeredEvents).not.toContain('ready-to-show');
+    });
+
+    test('should not register did-finish-load handler when not on Linux', async () => {
+      vi.mocked(util.isLinux).mockReturnValue(false);
+
+      const { createNewWindow } = await import('./mainWindow.js');
+
+      await createNewWindow();
+
+      const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+      assert(bwInstance);
+
+      expect(bwInstance.webContents.on).not.toHaveBeenCalledWith('did-finish-load', expect.any(Function));
+    });
+
+    test('should not show window via did-finish-load when --minimize flag is set', async () => {
+      process.argv = ['electron', '--minimize'];
+
+      const { createNewWindow } = await import('./mainWindow.js');
+
+      await createNewWindow();
+
+      const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+      assert(bwInstance);
+
+      const didFinishLoad = getHandler(bwInstance.webContents.on, 'did-finish-load');
+      didFinishLoad();
+
+      expect(bwInstance.show).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -64,8 +64,12 @@ async function createWindow(): Promise<BrowserWindow> {
     },
   };
 
-  // frameless window
-  if (isLinux()) {
+  // On Wayland, frame: false strips all native decorations and the compositor has no
+  // server-side decoration protocol to fall back on, so the window appears borderless.
+  // Use titleBarStyle: 'hidden' instead to keep the native compositor frame (border,
+  // resize handles, shadow) while still letting the app render its own title bar chrome.
+  // On X11 Linux, frame: false is fine because the window manager draws decorations.
+  if (isLinux() && !isWayland()) {
     browserWindowConstructorOptions.frame = false;
   } else {
     browserWindowConstructorOptions.titleBarStyle = 'hidden';
@@ -104,7 +108,8 @@ async function createWindow(): Promise<BrowserWindow> {
   // to check the preferences.login.minimize setting.
   let deferredShow = false;
 
-  browserWindow.on('ready-to-show', () => {
+  // Shared show logic used by both ready-to-show and the Wayland did-finish-load fallback.
+  const handleWindowShow = (): void => {
     // If started with --minimize flag (Windows login item or manual CLI), hide the window
     if (isStartedMinimize()) {
       if (isMac()) {
@@ -116,7 +121,16 @@ async function createWindow(): Promise<BrowserWindow> {
     } else {
       browserWindow.show();
     }
-  });
+  };
+
+  // On Linux, ready-to-show is not reliably fired by Electron (affects both X11 and Wayland).
+  // On Wayland specifically, calling show() from within ready-to-show also re-triggers the
+  // event causing a feedback loop. Use did-finish-load for all Linux sessions to avoid both.
+  if (isLinux()) {
+    browserWindow.webContents.on('did-finish-load', handleWindowShow);
+  } else {
+    browserWindow.on('ready-to-show', handleWindowShow);
+  }
 
   let configurationRegistry: ConfigurationRegistry;
   ipcMain.on('configuration-registry', (_, data) => {
@@ -280,4 +294,11 @@ function isStartedMinimize(): boolean {
   // environment, so instead of checking each element, simply convert to string and see if --minimize was included.
   const argv = process.argv.toString();
   return argv.includes('--minimize');
+}
+
+// Detects whether the current session is running under Wayland.
+// XDG_SESSION_TYPE is checked first as it can be overridden by the user;
+// WAYLAND_DISPLAY is used as a fallback (set by the Wayland compositor).
+function isWayland(): boolean {
+  return process.env['XDG_SESSION_TYPE'] === 'wayland' || !!process.env['WAYLAND_DISPLAY'];
 }

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -127,7 +127,7 @@ async function createWindow(): Promise<BrowserWindow> {
   // On Wayland specifically, calling show() from within ready-to-show also re-triggers the
   // event causing a feedback loop. Use did-finish-load for all Linux sessions to avoid both.
   if (isLinux()) {
-    browserWindow.webContents.on('did-finish-load', handleWindowShow);
+    browserWindow.webContents.once('did-finish-load', handleWindowShow);
   } else {
     browserWindow.on('ready-to-show', handleWindowShow);
   }


### PR DESCRIPTION
### What does this PR do?

PR introduce workaround for 'ready-to-show' not firing on linux when starting on desktop using wayland.
It uses did-finish-load instead event for linux distributions.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fix #14388.

### How to test this PR?

1. Pull PR branch on linux
2. Build the next release using `pnpm build:next`
3. After successful build install built version using `flatpak install ./dist/podman-desktop-1.28.0-next.flatpack` 
4. Run `flatpak run io.podman_desktop.PodmanDesktop` and main window shows up
5. exit podman desktop
6. Run `WAYLAND_DISPLAY= XDG_SESSION_TYPE=x11 flatpak run io.podman_desktop.PodmanDesktop` main window still pops up
- [x] Tests are covering the bug fix or the new feature
