### PR TITLE
fix(renderer): show error dialog when network deletion fails

### DIFF
--- a/packages/renderer/src/lib/network/NetworkActions.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkActions.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -71,6 +71,27 @@ test('Expect non-podman unused network to have delete option and disabled edit',
   const deleteButton = screen.getByTitle('Delete Network');
   await fireEvent.click(deleteButton);
   expect(window.removeNetwork).toHaveBeenCalledWith(network1.engineId, network1.id);
+});
+
+test('Expect error dialog when network deletion fails', async () => {
+  const errorMessage = 'default network podman cannot be removed';
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.removeNetwork).mockRejectedValueOnce(new Error(errorMessage));
+
+  const network: NetworkInfoUI = { ...network1, status: 'UNUSED' };
+  render(NetworkActions, { object: network });
+
+  const deleteButton = screen.getByTitle('Delete Network');
+  await fireEvent.click(deleteButton);
+
+  await waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Delete Network Failed',
+        type: 'error',
+      }),
+    );
+  });
 });
 
 test('Expect podman used network to have edit option and disabled delete', async () => {

--- a/packages/renderer/src/lib/network/NetworkActions.svelte
+++ b/packages/renderer/src/lib/network/NetworkActions.svelte
@@ -23,8 +23,13 @@ async function removeNetwork(): Promise<void> {
   try {
     await window.removeNetwork(object.engineId, object.id);
   } catch (error) {
-    console.error(`error while removing network ${object.name}`, error);
     object.status = oldStatus;
+    await window.showMessageBox({
+      title: 'Delete Network Failed',
+      message: `Error while deleting network ${object.name}: ${String(error)}`,
+      type: 'error',
+      buttons: ['Dismiss'],
+    });
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

When deleting a network fails (e.g. trying to remove the default bridge network), show an error dialog instead of silently swallowing the error. Follows the same pattern as image and manifest deletion.

### Screenshot / video of UI

<img width="1795" height="1147" alt="Image" src="https://github.com/user-attachments/assets/7ce2b7f4-f3be-46cf-9688-017adec11f05" />
<img width="1795" height="1147" alt="Image" src="https://github.com/user-attachments/assets/744681a4-be59-45b8-9c5d-6334e475db52" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes #17313

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
