### PR TITLE
fix(renderer): detect untagged images as in-use via ImageID

### DIFF
--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -182,6 +182,17 @@ describe('inUse', () => {
     // image should be used
     expect(isUsed).toBe(expected);
   });
+
+  test('should expect inUse for untagged image when container references it by original tag name', async () => {
+    const containerWithTag = {
+      Id: 'container1',
+      Image: 'quay.io/podman/hello:latest',
+      ImageID: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
+    } as unknown as ContainerInfo;
+
+    const isUsed = imageUtils.getInUse(untaggedImageInfo, undefined, [containerWithTag]);
+    expect(isUsed).toBeTruthy();
+  });
 });
 
 describe('getImagesFromManifest and construct ImageInfoUI', () => {

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -99,13 +99,14 @@ export class ImageUtils {
       return false;
     }
 
-    // if there is a container with the same image id and the same repository tag, it's in use
-    // else check if we have an untagged ilmage and in that case we check that container is matching the image id
     return containersInfo.some(container => {
-      return (
-        (container.ImageID === imageInfo.Id && container.Image === repositoryTag) ||
-        (!!repositoryTag === false && imageInfo.Id.includes(container.Image) && (imageInfo.RepoTags ?? []).length === 0)
-      );
+      if (container.ImageID !== imageInfo.Id) {
+        return false;
+      }
+      if (repositoryTag) {
+        return container.Image === repositoryTag;
+      }
+      return (imageInfo.RepoTags ?? []).length === 0;
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

This PR fixes the `getInUse()` check for images that have lost their tags. When a newer version of a tagged image is pulled (e.g. `alpine:latest`), the old image becomes `<none>:<none>`. Previously, the delete button was incorrectly enabled for these untagged images even though a container was still using them. The fix matches images to containers using `container.ImageID` instead of comparing the image ID against the container's `Image` field (which holds the original tag name and never matches a SHA).

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #17113 

### How to test this PR?

1. `podman pull docker.io/library/alpine:latest`
2. `podman run --name test-bug-17113 -d alpine:latest sleep 3600`
3. `podman untag alpine:latest`
4. Open Podman Desktop → Images page
5. Verify the `<none>` image shows status **USED**(Green image icon) and the delete button is **disabled**
6. Cleanup: `podman stop test-bug-17113 && podman rm test-bug-17113`

- [x] Tests are covering the bug fix or the new feature
