### PR TITLE
feat(container): make mapped ports clickable in summary to open browser

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
@@ -19,10 +19,16 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import ContainerDetailsSummary from './ContainerDetailsSummary.svelte';
 import { ContainerGroupInfoTypeUI, type ContainerInfoUI } from './ContainerInfoUI';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.openExternal).mockResolvedValue(undefined);
+});
 
 const fakePodContainer: ContainerInfoUI = {
   id: 'fakeId1',
@@ -115,4 +121,39 @@ test('ContainerDetailsSummary renders with standalone ContainerInfoUI object', a
   expect(screen.getByText('standalone')).toBeInTheDocument();
   expect(screen.getByText('running')).toBeInTheDocument();
   expect(screen.getByText('group2')).toBeInTheDocument();
+});
+
+test('clicking a port opens the browser via openExternal', async () => {
+  const containerWithPorts: ContainerInfoUI = {
+    ...fakeStandaloneContainer,
+    ports: [{ IP: '0.0.0.0', PrivatePort: 80, PublicPort: 8080, Type: 'tcp' }],
+    portsAsString: '8080',
+    hasPublicPort: true,
+  };
+
+  render(ContainerDetailsSummary, { container: containerWithPorts });
+
+  const portLink = screen.getByText('8080');
+  expect(portLink).toBeInTheDocument();
+
+  await userEvent.click(portLink);
+
+  expect(window.openExternal).toHaveBeenCalledWith('http://localhost:8080');
+});
+
+test('port link shows tooltip with full URL and external link icon', async () => {
+  const containerWithPorts: ContainerInfoUI = {
+    ...fakeStandaloneContainer,
+    ports: [{ IP: '0.0.0.0', PrivatePort: 80, PublicPort: 3000, Type: 'tcp' }],
+    portsAsString: '3000',
+    hasPublicPort: true,
+  };
+
+  render(ContainerDetailsSummary, { container: containerWithPorts });
+
+  const portLink = screen.getByText('3000');
+  expect(portLink).toBeInTheDocument();
+
+  const tooltipTrigger = portLink.closest('[data-testid="tooltip-trigger"]');
+  expect(tooltipTrigger).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { ChevronExpander, Link } from '@podman-desktop/ui-svelte';
+import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
+import { ChevronExpander, Link, Tooltip } from '@podman-desktop/ui-svelte';
+import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
 import DetailsCell from '/@/lib/details/DetailsCell.svelte';
@@ -14,6 +16,14 @@ let startedTime: Date = new Date(container.startedAt);
 let createdTime: Date | undefined;
 if (container.groupInfo.created) {
   createdTime = new Date(container.groupInfo.created);
+}
+
+function portUrl(port: number): string {
+  return `http://localhost:${port}`;
+}
+
+function openPort(port: number): void {
+  window.openExternal(portUrl(port)).catch((err: unknown) => console.error(`Error opening port ${port}`, err));
 }
 </script>
 
@@ -52,7 +62,16 @@ if (container.groupInfo.created) {
   <tr>
     <DetailsCell>Ports</DetailsCell>
     {#if container.hasPublicPort}
-      <DetailsCell>{container.portsAsString}</DetailsCell>
+      <DetailsCell>
+        {#each container.ports as port, i (port.PublicPort)}
+          {#if i > 0},&nbsp;{/if}
+          <Tooltip tip={portUrl(port.PublicPort)} bottom>
+            <Link on:click={(): void => openPort(port.PublicPort)}>
+              <span class="inline-flex items-center">{port.PublicPort}<Fa icon={faExternalLink} class="ml-1" size="0.7x" /></span>
+            </Link>
+          </Tooltip>
+        {/each}
+      </DetailsCell>
     {:else}
       <DetailsCell>N/A</DetailsCell>
     {/if}


### PR DESCRIPTION
### What does this PR do?

Each mapped port in the container details Summary pane is now rendered as a clickable link that opens `http://localhost:<port>` in the default browser. Includes a Tooltip showing the full URL and an external link icon next to each port number.

### Screenshot / video of UI

<img width="1162" height="812" alt="Image" src="https://github.com/user-attachments/assets/26eab7b3-1f71-4ab6-a96f-a9f748379bd3" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes #13459

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
