### PR TITLE
fix(renderer): prevent duplicate markdown rendering for type: markdwn preferences

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -138,6 +138,28 @@ test('locked record should not show reset to default button', async () => {
   expect(resetButton).not.toBeInTheDocument();
 });
 
+test('type markdown record with markdownDescription renders markdown content only once via format component', async () => {
+  (window as unknown as Record<string, unknown>).getUrlProtocol = vi.fn().mockResolvedValue('podman-desktop');
+
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'ext.markdown.info',
+    title: 'Info',
+    parentId: 'ext',
+    description: 'plain description text',
+    markdownDescription: 'Some **markdown** content',
+    type: 'markdown',
+  };
+
+  const { getAllByLabelText, getByText } = render(PreferencesRenderingItem, { record });
+
+  await vi.waitFor(() => {
+    const markdownSections = getAllByLabelText('markdown-content');
+    expect(markdownSections).toHaveLength(1);
+  });
+
+  expect(getByText('plain description text')).toBeInTheDocument();
+});
+
 test('Expect reset enum value to update dropdown value', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -139,7 +139,7 @@ test('locked record should not show reset to default button', async () => {
   expect(resetButton).not.toBeInTheDocument();
 });
 
-test('type markdown record with markdownDescription renders markdown content only once via format component', async () => {
+test('type markdown record with markdownDescription should render markdown content only once', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'ext.markdown.info',
     title: 'Info',

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -41,6 +41,7 @@ const EXPERIMENTAL_RECORD: IConfigurationPropertyRecordedSchema = {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.openExternal).mockResolvedValue(undefined);
+  (window as unknown as Record<string, unknown>).getUrlProtocol = vi.fn().mockResolvedValue('podman-desktop');
 });
 
 test('experimental record should have clickable GitHub link', async () => {
@@ -139,8 +140,6 @@ test('locked record should not show reset to default button', async () => {
 });
 
 test('type markdown record with markdownDescription renders markdown content only once via format component', async () => {
-  (window as unknown as Record<string, unknown>).getUrlProtocol = vi.fn().mockResolvedValue('podman-desktop');
-
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'ext.markdown.info',
     title: 'Info',

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -113,7 +113,7 @@ async function openGitHubDiscussion(): Promise<void> {
           </div>
         {/if}
       </div>
-      {#if recordUI.markdownDescription}
+      {#if recordUI.markdownDescription && recordUI.original.type !== 'markdown'}
         <div class="pt-1 text-[color:var(--pd-invert-content-card-text)] text-sm pr-2">
           <Markdown markdown={recordUI.markdownDescription} />
         </div>


### PR DESCRIPTION
When a configuration property has type: 'markdown' and a markdownDescription, the content was rendered twice: once in the description area and again via PreferencesRenderingItemFormat. 

### What does this PR do?

Adds a guard to skip the description-area render for markdown-type records, matching the existing pattern in
PreferencesConnectionCreationOrEditRendering.svelte.

### Screenshot / video of UI

### What issues does this PR fix or reference?

Closes #17443


### How to test this PR?
## How to reproduce

Add a test configuration property with `type: 'markdown'` and `markdownDescription` to any extension's `package.json`, for example in `extensions/podman/packages/extension/package.json`:

```json
"podman.test.markdown.duplicate": {
  "type": "markdown",
  "description": "Test markdown property",
  "markdownDescription": "Click here to do something: :button[Do it]{command=podman.onboarding.checkPodmanInstalled}",
  "scope": "DEFAULT"
}
```

**Before the fix:** Go to Settings > Preferences and find the property. The button "Do it" appears **twice** — once in the description area and once in the value/control area.

**After the fix:** The button renders only **once** (via the format component), and "Test markdown property" is shown as the plain-text label.

- [ ] Tests are covering the bug fix or the new feature
