### PR TITLE
fix(tests): use vi.mocked for getUrlProtocol in PreferencesRenderingItem.spec

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ const EXPERIMENTAL_RECORD: IConfigurationPropertyRecordedSchema = {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.openExternal).mockResolvedValue(undefined);
-  (window as unknown as Record<string, unknown>).getUrlProtocol = vi.fn().mockResolvedValue('podman-desktop');
+  vi.mocked(window.getUrlProtocol).mockResolvedValue('podman-desktop');
 });
 
 test('experimental record should have clickable GitHub link', async () => {


### PR DESCRIPTION
## Description

Fixes #17446

Replaces the incorrect direct window cast assignment of `getUrlProtocol` with the proper `vi.mocked()` pattern, consistent with how other window methods like `openExternal` are handled in the same test file.

### Why this works

The global test setup in `vite.tests.setup.js` automatically reads all methods from the `Window` interface in `exposedInMainWorld.d.ts` and creates `vi.fn()` mocks for all of them — including `getUrlProtocol`. So `vi.mocked(window.getUrlProtocol)` already has a mock in place and just needs its return value configured in `beforeEach`.

### Changes

- `packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts`: Replace unsafe cast with `vi.mocked(window.getUrlProtocol).mockResolvedValue('podman-desktop')`

## Tests

All 8 tests in the file pass after the fix.

Assisted-by: Claude Sonnet 4.6

Made with [Cursor](https://cursor.com)