### PR TITLE
fix: resolve CVE-2026-6321 in fast-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,8 @@
       "follow-redirects": "^1.16.0",
       "uuid": "^14.0.0",
       "postcss": ">=8.5.12",
-      "ip-address": ">=10.1.1"
+      "ip-address": ">=10.1.1",
+      "fast-uri": ">=3.1.1"
     },
     "patchedDependencies": {
       "docker-modem": "patches/docker-modem.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,7 @@ overrides:
   uuid: ^14.0.0
   postcss: '>=8.5.12'
   ip-address: '>=10.1.1'
+  fast-uri: '>=3.1.1'
 
 patchedDependencies:
   docker-modem:
@@ -7236,8 +7237,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -17478,7 +17479,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20063,7 +20064,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-6321 in `fast-uri`.

**Advisory**: fast-uri vulnerable to path traversal via percent-encoded dot segments
**Vulnerable versions**: <=3.1.0
**Patched versions**: >=3.1.1
**Advisory URL**: https://github.com/advisories/GHSA-q3j6-qgpj-74h6

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-6321: _fast-uri vulnerable to path traversal via percent-encoded dot segments_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-6321 is no longer reported