### PR TITLE
chore: add and update registries from the UI in registries.conf file

### DIFF
--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.ts
@@ -65,6 +65,8 @@ export interface RegistryConfigurationFile {
 export interface RegistryConfiguration {
   init(): Promise<Disposable[]>;
   getPlaybookScriptPath(): Promise<string>;
+  readRegistriesConfContent(): Promise<RegistryConfigurationFile>;
+  saveRegistriesConfContent(content: RegistryConfigurationFile): Promise<void>;
 }
 
 /**

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1693,7 +1693,7 @@ export async function start(
   extensionContext.subscriptions.push(syncCertsCommand);
 
   // register the registries
-  const registrySetup = new RegistrySetup();
+  const registrySetup = new RegistrySetup(podmanConfiguration.registryConfiguration);
   await registrySetup.setup();
 
   await calcPodmanMachineSetting();

--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -22,6 +22,8 @@ import { chmod, readFile, writeFile } from 'node:fs/promises';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import type { RegistryConfiguration, RegistryConfigurationFile } from '/@/configuration/registry-configuration';
+
 import type { ContainersAuthConfigFile } from './registry-setup';
 import { RegistrySetup } from './registry-setup';
 
@@ -42,6 +44,14 @@ export class TestRegistrySetup extends RegistrySetup {
   publicWriteAuthFile(data: string): Promise<void> {
     return super.writeAuthFile(data);
   }
+
+  publicUpdateRegistriesConf(registry: extensionApi.Registry): Promise<void> {
+    return super.updateRegistriesConf(registry);
+  }
+
+  publicRemoveFromRegistriesConf(registry: extensionApi.Registry): Promise<void> {
+    return super.removeFromRegistriesConf(registry);
+  }
 }
 
 let registrySetup: TestRegistrySetup;
@@ -55,8 +65,15 @@ const originalConsoleWarn = console.warn;
 const consoleErroMock = vi.fn();
 const consoleWarnMock = vi.fn();
 
+const mockRegistryConfiguration: RegistryConfiguration = {
+  init: vi.fn(),
+  getPlaybookScriptPath: vi.fn(),
+  readRegistriesConfContent: vi.fn(),
+  saveRegistriesConfContent: vi.fn(),
+};
+
 beforeAll(() => {
-  registrySetup = new TestRegistrySetup();
+  registrySetup = new TestRegistrySetup(mockRegistryConfiguration);
 });
 
 beforeEach(() => {
@@ -257,4 +274,141 @@ test('writeAuthFile should call writeFile and chmod with 0o600', async () => {
     mode: 0o600,
   });
   expect(chmod).toHaveBeenCalledWith(authJsonLocation, 0o600);
+});
+
+test('updateRegistriesConf should add a new insecure registry', async () => {
+  const emptyConfig: RegistryConfigurationFile = { registry: [] };
+  vi.mocked(mockRegistryConfiguration.readRegistriesConfContent).mockResolvedValue(emptyConfig);
+
+  const registry: extensionApi.Registry = {
+    source: 'podman',
+    serverUrl: 'https://myregistry.io',
+    username: 'user',
+    secret: 'pass',
+    insecure: true,
+  };
+
+  await registrySetup.publicUpdateRegistriesConf(registry);
+
+  expect(mockRegistryConfiguration.readRegistriesConfContent).toHaveBeenCalled();
+  expect(mockRegistryConfiguration.saveRegistriesConfContent).toHaveBeenCalledWith({
+    registry: [
+      {
+        location: 'myregistry.io',
+        insecure: true,
+      },
+    ],
+  });
+});
+
+test('updateRegistriesConf should update an existing registry', async () => {
+  const existingConfig: RegistryConfigurationFile = {
+    registry: [
+      {
+        location: 'myregistry.io',
+        insecure: false,
+      },
+    ],
+  };
+  vi.mocked(mockRegistryConfiguration.readRegistriesConfContent).mockResolvedValue(existingConfig);
+
+  const registry: extensionApi.Registry = {
+    source: 'podman',
+    serverUrl: 'https://myregistry.io',
+    username: 'user',
+    secret: 'pass',
+    insecure: true,
+  };
+
+  await registrySetup.publicUpdateRegistriesConf(registry);
+
+  expect(mockRegistryConfiguration.saveRegistriesConfContent).toHaveBeenCalledWith({
+    registry: [
+      {
+        location: 'myregistry.io',
+        insecure: true,
+      },
+    ],
+  });
+});
+
+test('updateRegistriesConf should handle serverUrl without protocol', async () => {
+  const emptyConfig: RegistryConfigurationFile = { registry: [] };
+  vi.mocked(mockRegistryConfiguration.readRegistriesConfContent).mockResolvedValue(emptyConfig);
+
+  const registry: extensionApi.Registry = {
+    source: 'podman',
+    serverUrl: 'myregistry.io',
+    username: 'user',
+    secret: 'pass',
+    insecure: false,
+  };
+
+  await registrySetup.publicUpdateRegistriesConf(registry);
+
+  expect(mockRegistryConfiguration.saveRegistriesConfContent).toHaveBeenCalledWith({
+    registry: [
+      {
+        location: 'myregistry.io',
+        insecure: false,
+      },
+    ],
+  });
+});
+
+test('removeFromRegistriesConf should remove a registry', async () => {
+  const existingConfig: RegistryConfigurationFile = {
+    registry: [
+      {
+        location: 'myregistry.io',
+        insecure: true,
+      },
+      {
+        location: 'otherregistry.io',
+        insecure: false,
+      },
+    ],
+  };
+  vi.mocked(mockRegistryConfiguration.readRegistriesConfContent).mockResolvedValue(existingConfig);
+
+  const registry: extensionApi.Registry = {
+    source: 'podman',
+    serverUrl: 'https://myregistry.io',
+    username: 'user',
+    secret: 'pass',
+  };
+
+  await registrySetup.publicRemoveFromRegistriesConf(registry);
+
+  expect(mockRegistryConfiguration.saveRegistriesConfContent).toHaveBeenCalledWith({
+    registry: [
+      {
+        location: 'otherregistry.io',
+        insecure: false,
+      },
+    ],
+  });
+});
+
+test('updateRegistriesConf should handle errors gracefully', async () => {
+  vi.mocked(mockRegistryConfiguration.readRegistriesConfContent).mockRejectedValue(
+    new Error('Failed to read registries.conf'),
+  );
+
+  const registry: extensionApi.Registry = {
+    source: 'podman',
+    serverUrl: 'https://myregistry.io',
+    username: 'user',
+    secret: 'pass',
+  };
+
+  // Should not throw, but log error
+  await registrySetup.publicUpdateRegistriesConf(registry);
+
+  expect(consoleErroMock).toHaveBeenCalledWith(
+    'Error updating registries.conf for registry',
+    'https://myregistry.io',
+    expect.any(Error),
+  );
+  expect(mockRegistryConfiguration.saveRegistriesConfContent).not.toHaveBeenCalled();
 });

--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -282,7 +282,7 @@ test('updateRegistriesConf should add a new insecure registry', async () => {
 
   const registry: extensionApi.Registry = {
     source: 'podman',
-    serverUrl: 'https://myregistry.io',
+    serverUrl: 'myregistry.io',
     username: 'user',
     secret: 'pass',
     insecure: true,
@@ -314,7 +314,7 @@ test('updateRegistriesConf should update an existing registry', async () => {
 
   const registry: extensionApi.Registry = {
     source: 'podman',
-    serverUrl: 'https://myregistry.io',
+    serverUrl: 'myregistry.io',
     username: 'user',
     secret: 'pass',
     insecure: true,
@@ -373,7 +373,7 @@ test('removeFromRegistriesConf should remove a registry', async () => {
 
   const registry: extensionApi.Registry = {
     source: 'podman',
-    serverUrl: 'https://myregistry.io',
+    serverUrl: 'myregistry.io',
     username: 'user',
     secret: 'pass',
   };
@@ -397,7 +397,7 @@ test('updateRegistriesConf should handle errors gracefully', async () => {
 
   const registry: extensionApi.Registry = {
     source: 'podman',
-    serverUrl: 'https://myregistry.io',
+    serverUrl: 'myregistry.io',
     username: 'user',
     secret: 'pass',
   };
@@ -407,7 +407,7 @@ test('updateRegistriesConf should handle errors gracefully', async () => {
 
   expect(consoleErroMock).toHaveBeenCalledWith(
     'Error updating registries.conf for registry',
-    'https://myregistry.io',
+    'myregistry.io',
     expect.any(Error),
   );
   expect(mockRegistryConfiguration.saveRegistriesConfContent).not.toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -45,8 +45,8 @@ export class TestRegistrySetup extends RegistrySetup {
     return super.writeAuthFile(data);
   }
 
-  publicUpdateRegistriesConf(registry: extensionApi.Registry): Promise<void> {
-    return super.updateRegistriesConf(registry);
+  publicUpdateRegistriesConf(registry: extensionApi.Registry, isNew = false): Promise<void> {
+    return super.updateRegistriesConf(registry, isNew);
   }
 
   publicRemoveFromRegistriesConf(registry: extensionApi.Registry): Promise<void> {
@@ -276,19 +276,19 @@ test('writeAuthFile should call writeFile and chmod with 0o600', async () => {
   expect(chmod).toHaveBeenCalledWith(authJsonLocation, 0o600);
 });
 
-test('updateRegistriesConf should add a new insecure registry', async () => {
+test('updateRegistriesConf should add a new insecure registry when it does not exist', async () => {
   const emptyConfig: RegistryConfigurationFile = { registry: [] };
   vi.mocked(mockRegistryConfiguration.readRegistriesConfContent).mockResolvedValue(emptyConfig);
 
   const registry: extensionApi.Registry = {
     source: 'podman',
-    serverUrl: 'myregistry.io',
+    serverUrl: 'https://myregistry.io',
     username: 'user',
     secret: 'pass',
     insecure: true,
   };
 
-  await registrySetup.publicUpdateRegistriesConf(registry);
+  await registrySetup.publicUpdateRegistriesConf(registry, true); // isNew=true
 
   expect(mockRegistryConfiguration.readRegistriesConfContent).toHaveBeenCalled();
   expect(mockRegistryConfiguration.saveRegistriesConfContent).toHaveBeenCalledWith({
@@ -301,7 +301,7 @@ test('updateRegistriesConf should add a new insecure registry', async () => {
   });
 });
 
-test('updateRegistriesConf should update an existing registry', async () => {
+test('updateRegistriesConf should update an existing registry when isNew=false', async () => {
   const existingConfig: RegistryConfigurationFile = {
     registry: [
       {
@@ -314,13 +314,13 @@ test('updateRegistriesConf should update an existing registry', async () => {
 
   const registry: extensionApi.Registry = {
     source: 'podman',
-    serverUrl: 'myregistry.io',
+    serverUrl: 'https://myregistry.io',
     username: 'user',
     secret: 'pass',
     insecure: true,
   };
 
-  await registrySetup.publicUpdateRegistriesConf(registry);
+  await registrySetup.publicUpdateRegistriesConf(registry, false); // isNew=false
 
   expect(mockRegistryConfiguration.saveRegistriesConfContent).toHaveBeenCalledWith({
     registry: [
@@ -330,6 +330,37 @@ test('updateRegistriesConf should update an existing registry', async () => {
       },
     ],
   });
+});
+
+test('updateRegistriesConf should warn and skip when new registry already exists in file', async () => {
+  const existingConfig: RegistryConfigurationFile = {
+    registry: [
+      {
+        location: 'myregistry.io',
+        insecure: false,
+        blocked: true,
+      },
+    ],
+  };
+  vi.mocked(mockRegistryConfiguration.readRegistriesConfContent).mockResolvedValue(existingConfig);
+
+  const registry: extensionApi.Registry = {
+    source: 'podman',
+    serverUrl: 'https://myregistry.io',
+    username: 'user',
+    secret: 'pass',
+    insecure: true,
+  };
+
+  await registrySetup.publicUpdateRegistriesConf(registry, true); // isNew=true
+
+  // Should warn
+  expect(consoleWarnMock).toHaveBeenCalledWith(
+    expect.stringContaining('Registry myregistry.io already exists in registries.conf'),
+  );
+
+  // Should NOT save (existing config should remain unchanged)
+  expect(mockRegistryConfiguration.saveRegistriesConfContent).not.toHaveBeenCalled();
 });
 
 test('updateRegistriesConf should handle serverUrl without protocol', async () => {
@@ -344,7 +375,7 @@ test('updateRegistriesConf should handle serverUrl without protocol', async () =
     insecure: false,
   };
 
-  await registrySetup.publicUpdateRegistriesConf(registry);
+  await registrySetup.publicUpdateRegistriesConf(registry, true); // isNew=true
 
   expect(mockRegistryConfiguration.saveRegistriesConfContent).toHaveBeenCalledWith({
     registry: [
@@ -356,7 +387,7 @@ test('updateRegistriesConf should handle serverUrl without protocol', async () =
   });
 });
 
-test('removeFromRegistriesConf should remove a registry', async () => {
+test('removeFromRegistriesConf should remove a registry and strip protocol', async () => {
   const existingConfig: RegistryConfigurationFile = {
     registry: [
       {
@@ -373,7 +404,7 @@ test('removeFromRegistriesConf should remove a registry', async () => {
 
   const registry: extensionApi.Registry = {
     source: 'podman',
-    serverUrl: 'myregistry.io',
+    serverUrl: 'https://myregistry.io',
     username: 'user',
     secret: 'pass',
   };
@@ -397,17 +428,17 @@ test('updateRegistriesConf should handle errors gracefully', async () => {
 
   const registry: extensionApi.Registry = {
     source: 'podman',
-    serverUrl: 'myregistry.io',
+    serverUrl: 'https://myregistry.io',
     username: 'user',
     secret: 'pass',
   };
 
   // Should not throw, but log error
-  await registrySetup.publicUpdateRegistriesConf(registry);
+  await registrySetup.publicUpdateRegistriesConf(registry, true);
 
   expect(consoleErroMock).toHaveBeenCalledWith(
     'Error updating registries.conf for registry',
-    'myregistry.io',
+    'https://myregistry.io',
     expect.any(Error),
   );
   expect(mockRegistryConfiguration.saveRegistriesConfContent).not.toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -240,16 +240,13 @@ export class RegistrySetup {
       // Read current registries.conf content
       const configFileContent = await this.registryConfiguration.readRegistriesConfContent();
 
-      // Extract the location from serverUrl (remove protocol if present)
-      const location = registry.serverUrl.replace(/^https?:\/\//, '');
-
       // Check if registry already exists in the configuration
       const existingIndex = configFileContent.registry.findIndex(
-        (entry: RegistryConfigurationEntry) => entry.location === location,
+        (entry: RegistryConfigurationEntry) => entry.location === registry.serverUrl,
       );
 
       const registryEntry: RegistryConfigurationEntry = {
-        location,
+        location: registry.serverUrl,
         insecure: registry.insecure ?? false,
       };
 
@@ -279,12 +276,9 @@ export class RegistrySetup {
       // Read current registries.conf content
       const configFileContent = await this.registryConfiguration.readRegistriesConfContent();
 
-      // Extract the location from serverUrl
-      const location = registry.serverUrl.replace(/^https?:\/\//, '');
-
       // Filter out the registry to remove
       configFileContent.registry = configFileContent.registry.filter(
-        (entry: RegistryConfigurationEntry) => entry.location !== location,
+        (entry: RegistryConfigurationEntry) => entry.location !== registry.serverUrl,
       );
 
       // Save updated configuration

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -148,7 +148,7 @@ export class RegistrySetup {
         }
 
         // Update registries.conf with the registry configuration
-        await this.updateRegistriesConf(registry);
+        await this.updateRegistriesConf(registry, true);
       }
     });
 
@@ -185,7 +185,7 @@ export class RegistrySetup {
         await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
 
         // Update registries.conf with the updated registry configuration
-        await this.updateRegistriesConf(registry);
+        await this.updateRegistriesConf(registry, false);
       }
     });
 
@@ -233,31 +233,48 @@ export class RegistrySetup {
 
   /**
    * Updates the registries.conf file to add or update a registry entry.
-   * This ensures the registry is configured for insecure access if needed.
+   *
+   * For new registries (isNew=true):
+   *   - If registry already exists in registries.conf, warns about conflict and does NOT modify the file
+   *   - If registry doesn't exist, adds it to registries.conf
+   *
+   * For existing registries (isNew=false):
+   *   - Updates the registry entry in registries.conf
+   *
    */
-  protected async updateRegistriesConf(registry: extensionApi.Registry): Promise<void> {
+  protected async updateRegistriesConf(registry: extensionApi.Registry, isNew = false): Promise<void> {
     try {
       // Read current registries.conf content
       const configFileContent = await this.registryConfiguration.readRegistriesConfContent();
 
+      // Extract the location from serverUrl (remove protocol if present)
+      const location = registry.serverUrl.replace(/^https?:\/\//, '');
+
       // Check if registry already exists in the configuration
       const existingIndex = configFileContent.registry.findIndex(
-        (entry: RegistryConfigurationEntry) => entry.location === registry.serverUrl,
+        (entry: RegistryConfigurationEntry) => entry.location === location,
       );
 
       const registryEntry: RegistryConfigurationEntry = {
-        location: registry.serverUrl,
+        location,
         insecure: registry.insecure ?? false,
       };
 
       if (existingIndex >= 0) {
-        // Update existing entry
+        // If this is a new registry and it already exists in the file, warn and don't modify
+        if (isNew) {
+          console.warn(
+            `Registry ${location} already exists in registries.conf.\nSkipping to avoid conflicts. Please resolve manually by editing registries.conf.`,
+          );
+          return;
+        }
+
         configFileContent.registry[existingIndex] = {
           ...configFileContent.registry[existingIndex],
           ...registryEntry,
         };
       } else {
-        // Add new entry
+        // Registry doesn't exist, add new entry
         configFileContent.registry.push(registryEntry);
       }
 
@@ -276,9 +293,12 @@ export class RegistrySetup {
       // Read current registries.conf content
       const configFileContent = await this.registryConfiguration.readRegistriesConfContent();
 
+      // Extract the location from serverUrl (remove protocol if present)
+      const location = registry.serverUrl.replace(/^https?:\/\//, '');
+
       // Filter out the registry to remove
       configFileContent.registry = configFileContent.registry.filter(
-        (entry: RegistryConfigurationEntry) => entry.location !== registry.serverUrl,
+        (entry: RegistryConfigurationEntry) => entry.location !== location,
       );
 
       // Save updated configuration

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -23,6 +23,8 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
+import type { RegistryConfiguration, RegistryConfigurationEntry } from '/@/configuration/registry-configuration';
+
 export type ContainerAuthConfigEntry = {
   [key: string]: {
     auth: string;
@@ -36,6 +38,11 @@ export type ContainersAuthConfigFile = {
 
 export class RegistrySetup {
   private localRegistries: Map<string, extensionApi.Registry> = new Map();
+  private registryConfiguration: RegistryConfiguration;
+
+  constructor(registryConfiguration: RegistryConfiguration) {
+    this.registryConfiguration = registryConfiguration;
+  }
 
   protected getAuthFileLocation(): string {
     let podmanConfigContainersPath = '';
@@ -139,6 +146,9 @@ export class RegistrySetup {
 
           await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
         }
+
+        // Update registries.conf with the registry configuration
+        await this.updateRegistriesConf(registry);
       }
     });
 
@@ -153,6 +163,9 @@ export class RegistrySetup {
           delete authFile.auths[registry.serverUrl];
         }
         await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
+
+        // Remove from registries.conf
+        await this.removeFromRegistriesConf(registry);
       }
     });
 
@@ -170,6 +183,9 @@ export class RegistrySetup {
         };
 
         await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
+
+        // Update registries.conf with the updated registry configuration
+        await this.updateRegistriesConf(registry);
       }
     });
 
@@ -213,5 +229,68 @@ export class RegistrySetup {
     });
     // writeFile is not updating the mode if the file already exist
     await chmod(path, 0o600);
+  }
+
+  /**
+   * Updates the registries.conf file to add or update a registry entry.
+   * This ensures the registry is configured for insecure access if needed.
+   */
+  protected async updateRegistriesConf(registry: extensionApi.Registry): Promise<void> {
+    try {
+      // Read current registries.conf content
+      const configFileContent = await this.registryConfiguration.readRegistriesConfContent();
+
+      // Extract the location from serverUrl (remove protocol if present)
+      const location = registry.serverUrl.replace(/^https?:\/\//, '');
+
+      // Check if registry already exists in the configuration
+      const existingIndex = configFileContent.registry.findIndex(
+        (entry: RegistryConfigurationEntry) => entry.location === location,
+      );
+
+      const registryEntry: RegistryConfigurationEntry = {
+        location,
+        insecure: registry.insecure ?? false,
+      };
+
+      if (existingIndex >= 0) {
+        // Update existing entry
+        configFileContent.registry[existingIndex] = {
+          ...configFileContent.registry[existingIndex],
+          ...registryEntry,
+        };
+      } else {
+        // Add new entry
+        configFileContent.registry.push(registryEntry);
+      }
+
+      // Save updated configuration
+      await this.registryConfiguration.saveRegistriesConfContent(configFileContent);
+    } catch (error: unknown) {
+      console.error('Error updating registries.conf for registry', registry.serverUrl, error);
+    }
+  }
+
+  /**
+   * Removes a registry entry from the registries.conf file.
+   */
+  protected async removeFromRegistriesConf(registry: extensionApi.Registry): Promise<void> {
+    try {
+      // Read current registries.conf content
+      const configFileContent = await this.registryConfiguration.readRegistriesConfContent();
+
+      // Extract the location from serverUrl
+      const location = registry.serverUrl.replace(/^https?:\/\//, '');
+
+      // Filter out the registry to remove
+      configFileContent.registry = configFileContent.registry.filter(
+        (entry: RegistryConfigurationEntry) => entry.location !== location,
+      );
+
+      // Save updated configuration
+      await this.registryConfiguration.saveRegistriesConfContent(configFileContent);
+    } catch (error: unknown) {
+      console.error('Error removing registry from registries.conf', registry.serverUrl, error);
+    }
   }
 }

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -22,13 +22,17 @@ import type { Registry } from '@podman-desktop/api';
 import { waitFor } from '@testing-library/dom';
 import { render, screen } from '@testing-library/svelte';
 import { default as userEvent } from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { registriesInfos } from '/@/stores/registries';
 
 import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
 
 describe('PreferencesRegistriesEditing', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
   test('Expect that add registry button is visible and enabled', async () => {
     render(PreferencesRegistriesEditing, {});
 
@@ -102,7 +106,7 @@ describe('PreferencesRegistriesEditing', () => {
     expect(window.createImageRegistry).toHaveBeenCalledOnce();
     expect(window.createImageRegistry).toHaveBeenLastCalledWith(undefined, {
       source: undefined,
-      serverUrl: 'https://registry.host',
+      serverUrl: 'registry.host',
       username: 'username',
       secret: 'password',
       insecure: true,

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -181,10 +181,12 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry): Promise<
   registry.source = defaultProviderSourceName;
 
   const newRegistry = registry === newRegistryRequest;
+  console.log(newRegistry);
   if (newRegistry) {
     registry.serverUrl = registry.serverUrl.trim();
     registry.username = registry.username.trim();
     registry.secret = registry.secret.trim();
+    registry.serverUrl = registry.serverUrl.replace(/^https?:\/\//, '');
   }
 
   // Always check credentials before creating image / updating to see if they pass.

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -181,7 +181,6 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry): Promise<
   registry.source = defaultProviderSourceName;
 
   const newRegistry = registry === newRegistryRequest;
-  console.log(newRegistry);
   if (newRegistry) {
     registry.serverUrl = registry.serverUrl.trim();
     registry.username = registry.username.trim();

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -182,10 +182,9 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry): Promise<
 
   const newRegistry = registry === newRegistryRequest;
   if (newRegistry) {
-    registry.serverUrl = registry.serverUrl.trim();
+    registry.serverUrl = registry.serverUrl.trim().replace(/^https?:\/\//, '');
     registry.username = registry.username.trim();
     registry.secret = registry.secret.trim();
-    registry.serverUrl = registry.serverUrl.replace(/^https?:\/\//, '');
   }
 
   // Always check credentials before creating image / updating to see if they pass.


### PR DESCRIPTION
### What does this PR do?
When adding a registry in the UI, this will update the `registries.conf` file. This way, insecure registries will be added to the Podman machine configuration, allowing pushing and pulling from Podman Desktop.

~**Note:** In order for the registry changes to be applied, the Podman needs to be restarted~

The sync happening in this PR is one-way, from Podman Desktop to `registries.conf` file to ensure that all the registries that are added in Podman Desktop show, are also configured in the file. If a registry already exists in the file, adding it from Podman Desktop won't work.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/14687

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
