### PR TITLE
fix(renderer): decouple details page redirect from DOM lifecycle 

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -10,6 +10,7 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
 import { containersInfos } from '/@/stores/containers';
 
 import { ContainerUtils } from './container-utils';
@@ -31,8 +32,8 @@ let { containerID }: Props = $props();
 
 const containerUtils = new ContainerUtils();
 
-let detailsPage = $state<DetailsPage | undefined>();
 let displayTty: boolean = $state(false);
+let hadContainer = false;
 
 let container: ContainerInfoUI | undefined = $derived(
   getContainerInfoUI($containersInfos.find(c => c.Id === containerID)),
@@ -40,6 +41,7 @@ let container: ContainerInfoUI | undefined = $derived(
 
 $effect(() => {
   if (container) {
+    hadContainer = true;
     window
       .getContainerInspect(container.engineId, container.id)
       .then(inspect => {
@@ -55,8 +57,8 @@ $effect(() => {
         }
       })
       .catch((err: unknown) => console.error(`Error getting container inspect ${container?.id}: ${err}`));
-  } else {
-    detailsPage?.close();
+  } else if (hadContainer) {
+    router.goto($lastPage.path);
   }
 });
 
@@ -66,7 +68,7 @@ function getContainerInfoUI(cont: ContainerInfo | undefined): ContainerInfoUI | 
 </script>
 
 {#if container}
-  <DetailsPage title={container.name} bind:this={detailsPage}>
+  <DetailsPage title={container.name}>
     {#snippet iconSnippet()}
       <StatusIcon icon={ContainerIcon} size={24} status={container.state} />
     {/snippet}

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -14,6 +14,7 @@ import {
   IMAGE_VIEW_ICONS,
 } from '/@/lib/view/views';
 import Route from '/@/Route.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
 import { containersInfos } from '/@/stores/containers';
 import { context } from '/@/stores/context';
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
@@ -73,21 +74,22 @@ let image: ImageInfoUI | undefined = $derived(
     ? imageUtils.getImageInfoUI(imageInfo, base64RepoTag, $containersInfos, $context, viewContributions)
     : undefined,
 );
-let detailsPage: DetailsPage | undefined = $state();
-
 let showCheckTab: boolean = $derived($imageCheckerProviders.length > 0);
 let showFilesTab: boolean = $derived($imageFilesProviders.length > 0);
+let hadImage = false;
 
 $effect(() => {
-  if (!image) {
+  if (image) {
+    hadImage = true;
+  } else if (hadImage) {
     // the image has been deleted
-    detailsPage?.close();
+    router.goto($lastPage.path);
   }
 });
 </script>
 
 {#if image}
-  <DetailsPage title={image.name} titleDetail={image.shortId} subtitle={image.tag} bind:this={detailsPage}>
+  <DetailsPage title={image.name} titleDetail={image.shortId} subtitle={image.tag}>
     {#snippet iconSnippet()}
       {#if image}<StatusIcon icon={image.icon} size={24} status={image.status} />{/if}
     {/snippet}

--- a/packages/renderer/src/lib/network/NetworkDetails.svelte
+++ b/packages/renderer/src/lib/network/NetworkDetails.svelte
@@ -6,6 +6,7 @@ import NetworkIcon from '/@/lib/images/NetworkIcon.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
 import { networksListInfo } from '/@/stores/networks';
 
 import { NetworkUtils } from './network-utils';
@@ -30,17 +31,19 @@ let matchingNetwork = $derived(
 let network: NetworkInfoUI | undefined = $derived(
   matchingNetwork ? networkUtils.toNetworkInfoUI(matchingNetwork) : undefined,
 );
-let detailsPage: DetailsPage | undefined = $state();
+let hadNetwork = false;
 
 $effect(() => {
-  if (!network && detailsPage) {
-    detailsPage.close();
+  if (network) {
+    hadNetwork = true;
+  } else if (hadNetwork) {
+    router.goto($lastPage.path);
   }
 });
 </script>
 
 {#if network}
-  <DetailsPage title={network.name} subtitle={network.shortId} bind:this={detailsPage}>
+  <DetailsPage title={network.name} subtitle={network.shortId}>
     {#snippet iconSnippet()}
       <StatusIcon icon={NetworkIcon} size={24} status={network?.status} />
     {/snippet}

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -6,6 +6,7 @@ import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
 import { volumeListInfos } from '/@/stores/volumes';
 
 import VolumeDetailsSummary from '././VolumeDetailsSummary.svelte';
@@ -21,7 +22,7 @@ interface Props {
 let { volumeName, engineId }: Props = $props();
 
 const volumeUtils = new VolumeUtils();
-let detailsPage = $state<DetailsPage>();
+let hadVolume = false;
 
 let volume: VolumeInfoUI | undefined = $derived.by(() => {
   const allVolumes = $volumeListInfos.map(volumeListInfo => volumeListInfo.Volumes).flat();
@@ -37,12 +38,16 @@ let volume: VolumeInfoUI | undefined = $derived.by(() => {
 });
 
 $effect(() => {
-  if (!volume) detailsPage?.close();
+  if (volume) {
+    hadVolume = true;
+  } else if (hadVolume) {
+    router.goto($lastPage.path);
+  }
 });
 </script>
 
 {#if volume}
-  <DetailsPage title={volume.shortName} subtitle={volume.humanSize} bind:this={detailsPage}>
+  <DetailsPage title={volume.shortName} subtitle={volume.humanSize}>
     {#snippet iconSnippet()}
       <StatusIcon icon={VolumeIcon} size={24} status={volume.status} />
     {/snippet}  


### PR DESCRIPTION
### What does this PR do?

Fixes details page redirect on resource deletion for upcoming Svelte 5.55.5 upgrade.

Svelte 5.55.3 ([sveltejs/svelte#17921](https://github.com/sveltejs/svelte/pull/17921)) changed the lifecycle ordering: DOM updates now happen **before** `$effect` execution. This breaks the `detailsPage?.close()` pattern used in details components.

When a resource is deleted from the store, the `{#if resource}` block destroys the `<DetailsPage>` component (resetting `detailsPage` to `undefined` via `bind:this`) **before** the `$effect` runs. As a result, `detailsPage?.close()` becomes a no-op and the user is never redirected to the previous page.

**Fix:** Replace indirect `detailsPage?.close()` with a direct `router.goto($lastPage.path)` call, guarded by a `hadResource` flag to distinguish "not yet loaded" from "was deleted". This decouples the redirect from DOM lifecycle entirely.

> **Note:** `$effect.pre` was considered but rejected — while it passes unit tests, it breaks incoming navigation in the real app (async logic inside `.then()` callbacks in ContainerDetails doesn't execute correctly from `$effect.pre`).

**Affected components:**
- `ContainerDetails.svelte` — direct `router.goto` with `hadContainer` guard
- `ImageDetails.svelte` — direct `router.goto` with `hadImage` guard
- `NetworkDetails.svelte` — direct `router.goto` with `hadNetwork` guard
- `VolumeDetails.svelte` — direct `router.goto` with `hadVolume` guard

### Screenshot / video of UI

N/A — no visual changes, behavior fix only.

### What issues does this PR fix or reference?

Fixes #16897

### How to test this PR?

1. Run the previously failing unit tests:
   ```bash
   pnpm exec vitest run packages/renderer/src/lib/container/ContainerDetails.spec.ts packages/renderer/src/lib/image/ImageDetails.spec.ts packages/renderer/src/lib/network/NetworkDetails.spec.ts packages/renderer/src/lib/volume/VolumeDetails.spec.ts
   ```
2. All 19 tests should pass, including the 4 that were previously failing:
   - "Expect redirect to previous page if container is deleted"
   - "Expect redirect to previous page if image is deleted"
   - "Expect redirect to previous page if current network is deleted"
   - "Expect redirect to previous page if volume is deleted"
3. Manual verification: run `pnpm watch`, navigate to any resource details page, delete the resource — should redirect back to the list page

- [x] Tests are covering the bug fix


🤖 Generated with [Claude Code](https://claude.com/claude-code)