### PR TITLE
fix(renderer): use disconnect() for ResizeObserver cleanup in onDestroy 

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfiguring.svelte
@@ -85,7 +85,7 @@ onMount(async () => {
 
 onDestroy(() => {
   // Cleanup the observer on destroy
-  resizeObserver?.unobserve(logsXtermDiv);
+  resizeObserver?.disconnect();
 });
 </script>
 

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -122,7 +122,7 @@ onMount(async () => {
 
 onDestroy(() => {
   // Cleanup the observer on destroy
-  resizeObserver?.unobserve(logsXtermDiv);
+  resizeObserver?.disconnect();
 });
 
 function updateOptionsMenu(visible: boolean): void {

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -96,7 +96,7 @@ onMount(async () => {
 
 onDestroy(() => {
   // Cleanup the observer on destroy
-  resizeObserver?.unobserve(logsXtermDiv);
+  resizeObserver?.disconnect();
 });
 </script>
 


### PR DESCRIPTION
### What does this PR do?

Fixes `TypeError` crash in `onDestroy` when cleaning up `ResizeObserver` instances.

Svelte 5.55.3 ([sveltejs/svelte#17921](https://github.com/sveltejs/svelte/pull/17921)) changed the lifecycle ordering so that DOM elements bound via `bind:this` are already `undefined` when `onDestroy` runs. This causes `resizeObserver.unobserve(element)` to throw a `TypeError`.

**Fix:** Replace `unobserve(element)` with `disconnect()` which stops observing all targets without requiring an element reference.

**Affected components:**
- `ProviderInstalled.svelte`
- `ProviderConfiguring.svelte`
- `PreferencesConnectionDetailsLogs.svelte`

### Screenshot / video of UI

N/A — no visual changes, crash fix only.

### What issues does this PR fix or reference?

Fixes #16897

### How to test this PR?

1. Run `pnpm watch`
2. Navigate to the Containers tab (triggers dashboard providers)
3. Open browser console — no `TypeError: Failed to execute 'unobserve' on 'ResizeObserver'` errors should appear
4. Navigate between dashboard views and provider settings — no console errors

- [x] Tests are covering the bug fix


🤖 Generated with [Claude Code](https://claude.com/claude-code)