### PR TITLE
chore(argos): fix CSS formatting for biome 2.4.15 compat

### DIFF
--- a/website-argos/screenshot.css
+++ b/website-argos/screenshot.css
@@ -1,22 +1,22 @@
 /* Iframes can load lazily */
 iframe,
 /* Avatars can be flaky due to using external sources: GitHub/Unavatar */
-  .avatar__photo,
+.avatar__photo,
 /* Gifs load lazily and are animated */
-  img[src$='.gif'],
+img[src$='.gif'],
 /* Algolia keyboard shortcuts appear with a little delay */
 .DocSearch-Button-Keys > kbd,
 /* The live playground preview can often display dates/counters */
-  [class*='playgroundPreview'] {
+[class*='playgroundPreview'] {
   visibility: hidden;
 }
 
 /* Different docs last-update dates can alter layout */
 .theme-last-updated,
 /* Mermaid diagrams are rendered client-side and produce layout shifts */
-  .docusaurus-mermaid-container,
+.docusaurus-mermaid-container,
 /* Mermaid.ink external images can change between renders */
-  img[src*='mermaid.ink'] {
+img[src*='mermaid.ink'] {
   display: none;
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes CSS formatting in `website-argos/screenshot.css` to satisfy biome 2.4.15.

Biome 2.4.15 tightened CSS formatter rules — it no longer allows extra indentation before selectors in comma-separated lists. Since `package.json` specifies `"@biomejs/biome": "^2.4.13"`, CI installs the latest `2.4.x` and the formatter check fails.

This is currently blocking **all PRs** targeting `main`.

### Screenshot / video of UI

N/A — no visual changes, CI fix only.

### What issues does this PR fix or reference?

N/A — unblocks CI for all open PRs.

### How to test this PR?

1. Verify CI `linter, formatters` check passes
2. Run locally: `npx @biomejs/biome@2.4.15 format website-argos/screenshot.css` — should report no changes needed


🤖 Generated with [Claude Code](https://claude.com/claude-code)