### PR TITLE
refactor(ci): use official download artifact action 

### DIFF
--- a/.github/workflows/publish-website-pr-cloudflare.yaml
+++ b/.github/workflows/publish-website-pr-cloudflare.yaml
@@ -27,6 +27,7 @@ on:
       - completed
 
 permissions:
+  actions: read
   contents: read
   deployments: write
 
@@ -36,12 +37,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download website content artifact
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
+          run-id: ${{ github.event.workflow_run.id }}
           name: website-content
           path: content
-          allow_forks: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Cloudflare Pages
         uses: AdrianGonz97/refined-cf-pages-action@45ea15c1c69a7bce8ffbb79ba114daa2b52f0cff # v1.3.0


### PR DESCRIPTION
### What does this PR do?

Replaces `dawidd6/action-download-artifact` with the official `actions/download-artifact` action in the `publish-website-pr-cloudflare.yaml` workflow.

The workflow still downloads the `website-content` artifact from the completed `pr-check` workflow run, but now uses the official GitHub action with the workflow run id and `GITHUB_TOKEN`. It also adds the narrow `actions: read` permission needed to read artifacts from that workflow run.

### Screenshot / video of UI
N/A

### What issues does this PR fix or reference?

Fixes #17310

### How to test this PR?

This was checked locally with:

- `pnpm exec prettier --check .github/workflows/publish-website-pr-cloudflare.yaml`
- `git diff --check`
- YAML parse validation
- `pnpm lint:check`

The workflow behavior can be verified by opening a PR and confirming that the website preview publish workflow downloads the `website-content` artifact from the related `pr-check` workflow run.

- [x] Tests are covering the bug fix or the new feature
