### PR TITLE
chore(deps): fix duplicate entry lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7577,10 +7577,6 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
-  get-east-asian-width@1.6.0:
-    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
-    engines: {node: '>=18'}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -20558,8 +20554,6 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
-
-  get-east-asian-width@1.6.0: {}
 
   get-east-asian-width@1.6.0: {}
 


### PR DESCRIPTION
chore(deps): fix duplicate entry lockfile

### What does this PR do?

When doing:

```
pnpm install --frozen-lockfile
```

on a clean `git clone` of PD, we get this error:

```
pnpm install --frozen-lockfile
Scope: all 25 workspace projects
 ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "/<redacted>/pnpm-lock.yaml" is broken: duplicated mapping key (7580:3)

 7577 |     resolution: {integrity: sha5 ...
 7578 |     engines: {node: '>=18'}
 7579 |
 7580 |   get-east-asian-width@1.6.0:
----------^
 7581 |     resolution: {integrity: sha5 ...
 7582 |     engines: {node: '>=18'}
step-package-artifacts :-
```

There's multiple duplicate entries, and we're unable to do `pnpm
install --frozen-lockfile`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

N/A, discovered downstream.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Git clone fresh PD
2. `pnpm install --frozen-lockfile`
3. No errors.
