### PR TITLE
chore: add configuration properties override option in product.json

### DIFF
--- a/packages/api/src/configuration/models.ts
+++ b/packages/api/src/configuration/models.ts
@@ -85,6 +85,8 @@ const IConfigurationPropertySchemaSchema = z.object({
   experimental: IExperimentalConfigurationSchema.optional(),
 });
 
+export type IConfigurationPropertySchema = z.output<typeof IConfigurationPropertySchemaSchema>;
+
 const IConfigurationExtensionInfoSchema = z.object({
   id: z.string(),
 });

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -22,12 +22,14 @@ import { access, copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 
 import type { IDisposable } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
-import type { IConfigurationNode } from '@podman-desktop/core-api/configuration';
+import type { IConfigurationNode, IConfigurationPropertySchema } from '@podman-desktop/core-api/configuration';
 import {
   CONFIGURATION_SYSTEM_MANAGED_DEFAULTS_SCOPE,
   CONFIGURATION_SYSTEM_MANAGED_LOCKED_SCOPE,
 } from '@podman-desktop/core-api/configuration';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import product from '/@product.json' with { type: 'json' };
 
 import { ConfigurationRegistry } from './configuration-registry.js';
 import type { DefaultConfiguration } from './default-configuration.js';
@@ -59,6 +61,8 @@ vi.mock(import('./default-configuration.js'), () => ({
 vi.mock(import('./locked-configuration.js'), () => ({
   LockedConfiguration: vi.fn(),
 }));
+
+vi.mock(import('/@product.json'));
 
 let configurationRegistry: ConfigurationRegistry;
 
@@ -843,5 +847,222 @@ describe('Managed Locked', () => {
     // other.setting should NOT be marked as locked
     expect(properties['other.setting']).toBeDefined();
     expect(properties['other.setting']?.locked).toBe(false);
+  });
+});
+
+// Tests for experimentalFeaturesFeedback overrides from product.json
+describe('experimentalFeaturesFeedback from product.json', () => {
+  beforeEach(() => {
+    // Reset product mock before each test
+    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
+  });
+
+  test('should override configuration properties from experimentalFeaturesFeedback', async () => {
+    // Mock product.json with experimentalFeaturesFeedback
+    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+      'test.setting': {
+        description: 'Overridden description from product.json',
+        experimental: {
+          githubDiscussionLink: 'https://github.com/example/discussions/123',
+        },
+      },
+      test2: {
+        default: '1',
+      },
+    };
+
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    const node: IConfigurationNode = {
+      id: 'test',
+      title: 'Test Settings',
+      type: 'object',
+      properties: {
+        'test.setting': {
+          description: 'Original description',
+          type: 'string',
+          default: 'myDefault',
+        },
+      },
+    };
+
+    testRegistry.registerConfigurations([node]);
+
+    const properties = testRegistry.getConfigurationProperties();
+    const property = properties['test.setting'];
+
+    // Description should be overridden
+    expect(property?.description).toBe('Overridden description from product.json');
+    // Experimental property should be added from product.json
+    expect(property?.experimental).toEqual({
+      githubDiscussionLink: 'https://github.com/example/discussions/123',
+    });
+    // Other properties should remain from original configuration
+    expect(property?.type).toBe('string');
+    expect(property?.default).toBe('myDefault');
+  });
+
+  test('should override default value from experimentalFeaturesFeedback', async () => {
+    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+      'feature.enabled': {
+        default: true, // Override default from false to true
+      },
+    };
+
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    const node: IConfigurationNode = {
+      id: 'feature',
+      title: 'Feature Settings',
+      type: 'object',
+      properties: {
+        'feature.enabled': {
+          description: 'Enable feature',
+          type: 'boolean',
+          default: false,
+        },
+      },
+    };
+
+    testRegistry.registerConfigurations([node]);
+
+    const properties = testRegistry.getConfigurationProperties();
+    const property = properties['feature.enabled'];
+
+    // Default should be overridden
+    expect(property?.default).toBe(true);
+    expect(property?.description).toBe('Enable feature');
+  });
+
+  test('should handle multiple properties in experimentalFeaturesFeedback', async () => {
+    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+      'setting.one': {
+        experimental: {
+          githubDiscussionLink: 'https://github.com/example/1',
+        },
+      },
+      'setting.two': {
+        experimental: {
+          githubDiscussionLink: 'https://github.com/example/2',
+        },
+        description: 'Overridden for setting two',
+      },
+    };
+
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    const nodes: IConfigurationNode[] = [
+      {
+        id: 'settings',
+        title: 'Settings',
+        type: 'object',
+        properties: {
+          'setting.one': {
+            description: 'Setting 1',
+            type: 'string',
+            default: 'default1',
+          },
+          'setting.two': {
+            description: 'Setting 2',
+            type: 'string',
+            default: 'default2',
+          },
+          'setting.three': {
+            description: 'Setting 3',
+            type: 'string',
+            default: 'default3',
+          },
+        },
+      },
+    ];
+
+    testRegistry.registerConfigurations(nodes);
+
+    const properties = testRegistry.getConfigurationProperties();
+
+    // setting.one should have experimental property added
+    expect(properties['setting.one']?.experimental).toEqual({
+      githubDiscussionLink: 'https://github.com/example/1',
+    });
+    expect(properties['setting.one']?.description).toBe('Setting 1');
+
+    // setting.two should have both experimental and description overridden
+    expect(properties['setting.two']?.experimental).toEqual({
+      githubDiscussionLink: 'https://github.com/example/2',
+    });
+    expect(properties['setting.two']?.description).toBe('Overridden for setting two');
+
+    // setting.three should remain unchanged
+    expect(properties['setting.three']?.experimental).toBeUndefined();
+    expect(properties['setting.three']?.description).toBe('Setting 3');
+  });
+
+  test('should work when experimentalFeaturesFeedback is empty', async () => {
+    // Empty experimentalFeaturesFeedback
+    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
+
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    const node: IConfigurationNode = {
+      id: 'test',
+      title: 'Test Settings',
+      type: 'object',
+      properties: {
+        'test.setting': {
+          description: 'Original description',
+          type: 'string',
+          default: 'myDefault',
+        },
+      },
+    };
+
+    testRegistry.registerConfigurations([node]);
+
+    const properties = testRegistry.getConfigurationProperties();
+    const property = properties['test.setting'];
+
+    // Everything should remain as original
+    expect(property?.description).toBe('Original description');
+    expect(property?.type).toBe('string');
+    expect(property?.default).toBe('myDefault');
+    expect(property?.experimental).toBeUndefined();
+  });
+
+  test('should work when experimentalFeaturesFeedback is undefined', async () => {
+    // Undefined experimentalFeaturesFeedback (product.json doesn't have it)
+    (vi.mocked(product).experimentalFeaturesFeedback as
+      | { [key: string]: Partial<IConfigurationPropertySchema> }
+      | undefined) = undefined;
+
+    const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
+    await testRegistry.init();
+
+    const node: IConfigurationNode = {
+      id: 'test',
+      title: 'Test Settings',
+      type: 'object',
+      properties: {
+        'test.setting': {
+          description: 'Original description',
+          type: 'string',
+          default: 'myDefault',
+        },
+      },
+    };
+
+    testRegistry.registerConfigurations([node]);
+
+    const properties = testRegistry.getConfigurationProperties();
+    const property = properties['test.setting'];
+
+    // Everything should remain as original
+    expect(property?.description).toBe('Original description');
+    expect(property?.type).toBe('string');
+    expect(property?.default).toBe('myDefault');
+    expect(property?.experimental).toBeUndefined();
   });
 });

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -850,16 +850,16 @@ describe('Managed Locked', () => {
   });
 });
 
-// Tests for ConfigurationOverride overrides from product.json
-describe('ConfigurationOverride from product.json', () => {
+// Tests for configuration.override overrides from product.json
+describe('configuration.override from product.json', () => {
   beforeEach(() => {
     // Reset product mock before each test
-    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
+    (vi.mocked(product).configuration.override as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
   });
 
-  test('should override configuration properties from ConfigurationOverride', async () => {
-    // Mock product.json with ConfigurationOverride
-    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+  test('should override configuration properties from configuration.override', async () => {
+    // Mock product.json with configuration.override
+    (vi.mocked(product).configuration.override as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
       'test.setting': {
         description: 'Overridden description from product.json',
         experimental: {
@@ -903,8 +903,8 @@ describe('ConfigurationOverride from product.json', () => {
     expect(property?.default).toBe('myDefault');
   });
 
-  test('should override default value from ConfigurationOverride', async () => {
-    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+  test('should override default value from configuration.override', async () => {
+    (vi.mocked(product).configuration.override as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
       'feature.enabled': {
         default: true, // Override default from false to true
       },
@@ -936,8 +936,8 @@ describe('ConfigurationOverride from product.json', () => {
     expect(property?.description).toBe('Enable feature');
   });
 
-  test('should handle multiple properties in ConfigurationOverride', async () => {
-    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+  test('should handle multiple properties in configuration.override', async () => {
+    (vi.mocked(product).configuration.override as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
       'setting.one': {
         experimental: {
           githubDiscussionLink: 'https://github.com/example/1',
@@ -1000,9 +1000,9 @@ describe('ConfigurationOverride from product.json', () => {
     expect(properties['setting.three']?.description).toBe('Setting 3');
   });
 
-  test('should work when ConfigurationOverride is empty', async () => {
-    // Empty ConfigurationOverride
-    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
+  test('should work when configuration.override is empty', async () => {
+    // Empty configuration.override
+    (vi.mocked(product).configuration.override as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
 
     const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
     await testRegistry.init();
@@ -1032,10 +1032,11 @@ describe('ConfigurationOverride from product.json', () => {
     expect(property?.experimental).toBeUndefined();
   });
 
-  test('should work when ConfigurationOverride is undefined', async () => {
-    // Undefined ConfigurationOverride (product.json doesn't have it)
-    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> } | undefined) =
-      undefined;
+  test('should work when configuration.override is undefined', async () => {
+    // Undefined configuration.override (product.json doesn't have it)
+    (vi.mocked(product).configuration.override as
+      | { [key: string]: Partial<IConfigurationPropertySchema> }
+      | undefined) = undefined;
 
     const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
     await testRegistry.init();

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -850,16 +850,16 @@ describe('Managed Locked', () => {
   });
 });
 
-// Tests for experimentalFeaturesFeedback overrides from product.json
-describe('experimentalFeaturesFeedback from product.json', () => {
+// Tests for ConfigurationOverride overrides from product.json
+describe('ConfigurationOverride from product.json', () => {
   beforeEach(() => {
     // Reset product mock before each test
-    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
+    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
   });
 
-  test('should override configuration properties from experimentalFeaturesFeedback', async () => {
-    // Mock product.json with experimentalFeaturesFeedback
-    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+  test('should override configuration properties from ConfigurationOverride', async () => {
+    // Mock product.json with ConfigurationOverride
+    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
       'test.setting': {
         description: 'Overridden description from product.json',
         experimental: {
@@ -903,8 +903,8 @@ describe('experimentalFeaturesFeedback from product.json', () => {
     expect(property?.default).toBe('myDefault');
   });
 
-  test('should override default value from experimentalFeaturesFeedback', async () => {
-    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+  test('should override default value from ConfigurationOverride', async () => {
+    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
       'feature.enabled': {
         default: true, // Override default from false to true
       },
@@ -936,8 +936,8 @@ describe('experimentalFeaturesFeedback from product.json', () => {
     expect(property?.description).toBe('Enable feature');
   });
 
-  test('should handle multiple properties in experimentalFeaturesFeedback', async () => {
-    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
+  test('should handle multiple properties in ConfigurationOverride', async () => {
+    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {
       'setting.one': {
         experimental: {
           githubDiscussionLink: 'https://github.com/example/1',
@@ -1000,9 +1000,9 @@ describe('experimentalFeaturesFeedback from product.json', () => {
     expect(properties['setting.three']?.description).toBe('Setting 3');
   });
 
-  test('should work when experimentalFeaturesFeedback is empty', async () => {
-    // Empty experimentalFeaturesFeedback
-    (vi.mocked(product).experimentalFeaturesFeedback as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
+  test('should work when ConfigurationOverride is empty', async () => {
+    // Empty ConfigurationOverride
+    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> }) = {};
 
     const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
     await testRegistry.init();
@@ -1032,11 +1032,10 @@ describe('experimentalFeaturesFeedback from product.json', () => {
     expect(property?.experimental).toBeUndefined();
   });
 
-  test('should work when experimentalFeaturesFeedback is undefined', async () => {
-    // Undefined experimentalFeaturesFeedback (product.json doesn't have it)
-    (vi.mocked(product).experimentalFeaturesFeedback as
-      | { [key: string]: Partial<IConfigurationPropertySchema> }
-      | undefined) = undefined;
+  test('should work when ConfigurationOverride is undefined', async () => {
+    // Undefined ConfigurationOverride (product.json doesn't have it)
+    (vi.mocked(product).ConfigurationOverride as { [key: string]: Partial<IConfigurationPropertySchema> } | undefined) =
+      undefined;
 
     const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
     await testRegistry.init();

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -205,7 +205,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     // Get all the locked keys at the start to avoid multiple lookups
     const lockedSet = this.lockedKeys.getAllKeys();
 
-    const productConfigurationsProperties = (product.experimentalFeaturesFeedback ?? {}) as {
+    const productConfigurationsProperties = (product.ConfigurationOverride ?? {}) as {
       [key: string]: Partial<IConfigurationPropertySchema>;
     };
 

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -38,6 +38,8 @@ import {
 } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
 
+import product from '/@product.json' with { type: 'json' };
+
 import { ConfigurationImpl } from './configuration-impl.js';
 import { DefaultConfiguration } from './default-configuration.js';
 import { Directories } from './directories.js';
@@ -202,12 +204,18 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     // Get all the locked keys at the start to avoid multiple lookups
     const lockedSet = this.lockedKeys.getAllKeys();
 
+    const productConfigurationsProperties = (product.experimentalFeaturesFeedback ?? {}) as {
+      [key: string]: Partial<IConfigurationNode['properties']>;
+    };
+
     // biome-ignore lint/complexity/noForEach: <explanation>
     configurations.forEach(configuration => {
       for (const key in configuration.properties) {
         properties.push(key);
+        const productConfigProperties = productConfigurationsProperties[key];
         const configProperty: IConfigurationPropertyRecordedSchema = {
           ...configuration.properties[key],
+          ...productConfigProperties,
           title: configuration.title,
           id: key,
           parentId: configuration.id,

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -29,6 +29,7 @@ import type {
   IConfigurationChangeEvent,
   IConfigurationNode,
   IConfigurationPropertyRecordedSchema,
+  IConfigurationPropertySchema,
   IConfigurationRegistry,
 } from '@podman-desktop/core-api/configuration';
 import {
@@ -205,7 +206,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     const lockedSet = this.lockedKeys.getAllKeys();
 
     const productConfigurationsProperties = (product.experimentalFeaturesFeedback ?? {}) as {
-      [key: string]: Partial<IConfigurationNode['properties']>;
+      [key: string]: Partial<IConfigurationPropertySchema>;
     };
 
     // biome-ignore lint/complexity/noForEach: <explanation>

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -205,7 +205,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
     // Get all the locked keys at the start to avoid multiple lookups
     const lockedSet = this.lockedKeys.getAllKeys();
 
-    const productConfigurationsProperties = (product.ConfigurationOverride ?? {}) as {
+    const productConfigurationsProperties = (product.configuration.override ?? {}) as {
       [key: string]: Partial<IConfigurationPropertySchema>;
     };
 

--- a/product.json
+++ b/product.json
@@ -163,5 +163,17 @@
     "feature": "https://github.com/podman-desktop/podman-desktop/issues?q=is%3Aissue%20state%3Aopen%20type%3AFeature",
     "issues": "https://github.com/podman-desktop/podman-desktop/issues"
   },
-  "feedbackLinks": {}
+  "feedbackLinks": {},
+  "experimentalFeaturesFeedback": {
+    "dashboard.enhancedDashboard": {
+      "experimental": {
+        "githubDiscussionLink": "https://github.com/podman-desktop/podman-desktop/discussions/16055"
+      }
+    },
+    "statusbarProviders.showProviders": {
+      "experimental": {
+        "githubDiscussionLink": "https://github.com/podman-desktop/podman-desktop/discussions/10802"
+      }
+    }
+  }
 }

--- a/product.json
+++ b/product.json
@@ -165,14 +165,6 @@
   },
   "feedbackLinks": {},
   "configuration": {
-    "override": {
-      "statusbarProviders.showProviders": {
-        "description": "Some new description ",
-        "experimental": {
-          "githubDiscussionLink": "",
-          "image": ""
-        }
-      }
-    }
+    "override": {}
   }
 }

--- a/product.json
+++ b/product.json
@@ -164,5 +164,15 @@
     "issues": "https://github.com/podman-desktop/podman-desktop/issues"
   },
   "feedbackLinks": {},
-  "ConfigurationOverride": {}
+  "configuration": {
+    "override": {
+      "statusbarProviders.showProviders": {
+        "description": "Some new description ",
+        "experimental": {
+          "githubDiscussionLink": "",
+          "image": ""
+        }
+      }
+    }
+  }
 }

--- a/product.json
+++ b/product.json
@@ -164,16 +164,5 @@
     "issues": "https://github.com/podman-desktop/podman-desktop/issues"
   },
   "feedbackLinks": {},
-  "experimentalFeaturesFeedback": {
-    "dashboard.enhancedDashboard": {
-      "experimental": {
-        "githubDiscussionLink": "https://github.com/podman-desktop/podman-desktop/discussions/16055"
-      }
-    },
-    "statusbarProviders.showProviders": {
-      "experimental": {
-        "githubDiscussionLink": "https://github.com/podman-desktop/podman-desktop/discussions/10802"
-      }
-    }
-  }
+  "ConfigurationOverride": {}
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds the support to override certain properties of configuration items from `product.json`.
Properties that can be overridden are in the type `IConfigurationPropertySchema`

In `product.json`, in the `configuration.override` field, add the id of the configuration property you want to modify (as the key), and add the sub properties that are modified (as the value). For example: 
```
"configuration": {
    "override": {
      "statusbarProviders.showProviders": {
        "description": "Some new description ",
        "experimental": {
          "githubDiscussionLink": "",
          "image": ""
        }
      }
    }
}
```

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/17306

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
