### PR TITLE
chore(ci): update podman-install action digest

### DIFF
--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        uses: redhat-actions/podman-install@92eb12467c2fc271e7781d006c413e17770230ed
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        uses: redhat-actions/podman-install@92eb12467c2fc271e7781d006c413e17770230ed
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -321,7 +321,7 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        uses: redhat-actions/podman-install@92eb12467c2fc271e7781d006c413e17770230ed
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -380,7 +380,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install latest Podman version using external action
-        uses: redhat-actions/podman-install@38597414074271e07efa9fb2292cff7eea8d374d
+        uses: redhat-actions/podman-install@92eb12467c2fc271e7781d006c413e17770230ed
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -479,7 +479,7 @@ jobs:
           echo "KIND_PROVIDER=${{ env.DEFAULT_KIND_PROVIDER }}" >> $GITHUB_ENV
 
       - name: Install Podman v5 using external action
-        uses: redhat-actions/podman-install@15cb93f5a6b78a758fd8f4d1cecbf6651d4bcea3
+        uses: redhat-actions/podman-install@92eb12467c2fc271e7781d006c413e17770230ed
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### What does this PR do?
Update the podman-install action to use the latest available where we are not using kubic repositories anymore. Instead we are using ubuntu questing 25.04 repository to install more recent podman 5.4.2.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/14074
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
All CI is passing and podman used in e2e tests is now 5.4.2 (kubic repos has only 5.2.5).
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
