### PR TITLE
feat(tray): add option to hide system tray icon

### DIFF
--- a/packages/main/src/index.spec.ts
+++ b/packages/main/src/index.spec.ts
@@ -154,6 +154,7 @@ vi.mock(import('electron'), async () => {
         setImage = vi.fn();
         setToolTip = vi.fn();
         setContextMenu = vi.fn();
+        isDestroyed = vi.fn().mockReturnValue(false);
       },
     ),
   } as unknown as typeof Electron;

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import { type AdditionalData, Main } from './main.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
 import { Emitter } from './plugin/events/emitter.js';
 import { PluginSystem } from './plugin/index.js';
+import { readShowTrayIconSetting } from './plugin/util/read-tray-setting.js';
 import { ZoomLevelHandler } from './plugin/zoom-level-handler.js';
 import { StartupInstall } from './system/startup-install.js';
 import { WindowHandler } from './system/window/window-handler.js';
@@ -80,7 +81,7 @@ app.once('before-quit', event => {
     });
 });
 
-let tray: Tray;
+let tray: Tray | undefined;
 
 // Handle the open-url event (macOS/Linux). For Windows, it needs to be handle in the second-instance event
 app.on('will-finish-launching', () => {
@@ -93,10 +94,13 @@ app.on('will-finish-launching', () => {
 
 app.whenReady().then(
   async () => {
-    // Setup the default tray icon + menu items
-    animatedTray = new AnimatedTray();
-    tray = new Tray(animatedTray.getDefaultImage());
-    animatedTray.setTray(tray);
+    // Setup the default tray icon + menu items (skip if user disabled tray)
+    const showTrayIcon = readShowTrayIconSetting();
+    if (showTrayIcon) {
+      animatedTray = new AnimatedTray();
+      tray = new Tray(animatedTray.getDefaultImage());
+      animatedTray.setTray(tray);
+    }
     const trayMenu = new TrayMenu(tray, animatedTray);
 
     const _onDidCreatedConfigurationRegistry = new Emitter<ConfigurationRegistry>();

--- a/packages/main/src/mainWindow.spec.ts
+++ b/packages/main/src/mainWindow.spec.ts
@@ -251,4 +251,40 @@ describe('createNewWindow', () => {
     // Window should be shown immediately (no deferral on non-macOS)
     expect(bwInstance.show).toHaveBeenCalled();
   });
+
+  test('should force quit on close when tray is disabled', async () => {
+    vi.mocked(util.isLinux).mockReturnValue(true);
+
+    const { createNewWindow } = await import('./mainWindow.js');
+
+    await createNewWindow();
+
+    const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+    assert(bwInstance);
+
+    // Simulate configuration-registry IPC with ExitOnClose=false but ShowTrayIcon=false
+    const configHandler = getHandler(vi.mocked(ipcMain.on), 'configuration-registry');
+
+    const mockConfigRegistry = {
+      getConfiguration: vi.fn().mockReturnValue({
+        get: vi.fn((key: string) => {
+          if (key === 'ExitOnClose') return false;
+          if (key === 'ShowTrayIcon') return false;
+          return undefined;
+        }),
+      } as unknown as Configuration),
+    } as unknown as ConfigurationRegistry;
+
+    configHandler({}, mockConfigRegistry);
+
+    // Now trigger the close event
+    const closeHandler = getHandler(bwInstance.on, 'close');
+    const mockEvent = { preventDefault: vi.fn() };
+
+    closeHandler(mockEvent);
+
+    // Should quit (destroy + app.quit) even though ExitOnClose is false, because tray is hidden
+    expect(bwInstance.destroy).toHaveBeenCalled();
+    expect(app.quit).toHaveBeenCalled();
+  });
 });

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -185,6 +185,9 @@ async function createWindow(): Promise<BrowserWindow> {
     let exitonclose = isLinux(); // default value, which we will use unless the user preference is available.
     if (closeBehaviorConfiguration) {
       exitonclose = closeBehaviorConfiguration.get<boolean>('ExitOnClose') === true;
+      if (closeBehaviorConfiguration.get<boolean>('ShowTrayIcon') === false) {
+        exitonclose = true;
+      }
     }
 
     e.preventDefault();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -243,6 +243,7 @@ import { TempFileService } from './temp-file-service.js';
 import { TerminalInit } from './terminal-init.js';
 import { TrayIconColor } from './tray-icon-color.js';
 import { TrayMenuRegistry } from './tray-menu-registry.js';
+import { TrayVisibility } from './tray-visibility.js';
 import { Troubleshooting } from './troubleshooting.js';
 import { DirectoryStrategy } from './util/directory-strategy.js';
 import { Exec } from './util/exec.js';
@@ -596,6 +597,10 @@ export class PluginSystem {
     container.bind<CloseBehavior>(CloseBehavior).toSelf().inSingletonScope();
     const closeBehaviorConfiguration = container.get<CloseBehavior>(CloseBehavior);
     await closeBehaviorConfiguration.init();
+
+    container.bind<TrayVisibility>(TrayVisibility).toSelf().inSingletonScope();
+    const trayVisibilityConfiguration = container.get<TrayVisibility>(TrayVisibility);
+    await trayVisibilityConfiguration.init();
 
     container.bind<DockerCompatibility>(DockerCompatibility).toSelf().inSingletonScope();
     const dockerCompatibility = container.get<DockerCompatibility>(DockerCompatibility);

--- a/packages/main/src/plugin/tray-visibility.spec.ts
+++ b/packages/main/src/plugin/tray-visibility.spec.ts
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { beforeEach, expect, test } from 'vitest';
+
+import { ConfigurationRegistry } from './configuration-registry.js';
+import type { DefaultConfiguration } from './default-configuration.js';
+import type { Directories } from './directories.js';
+import type { LockedConfiguration } from './locked-configuration.js';
+import { TrayVisibility } from './tray-visibility.js';
+
+let trayVisibility: TrayVisibility;
+let configurationRegistry: ConfigurationRegistry;
+
+beforeEach(() => {
+  configurationRegistry = new ConfigurationRegistry(
+    {} as ApiSenderType,
+    {} as Directories,
+    {} as DefaultConfiguration,
+    {} as LockedConfiguration,
+  );
+  trayVisibility = new TrayVisibility(configurationRegistry);
+});
+
+test('should register a configuration', async () => {
+  const before = configurationRegistry.getConfigurationProperties()['preferences.ShowTrayIcon'];
+  expect(before).toBeUndefined();
+  await trayVisibility.init();
+  const after = configurationRegistry.getConfigurationProperties()['preferences.ShowTrayIcon'];
+  expect(after).toBeDefined();
+});
+
+test('should set default value to true', async () => {
+  await trayVisibility.init();
+  expect(configurationRegistry.getConfigurationProperties()['preferences.ShowTrayIcon']?.default).toBe(true);
+});

--- a/packages/main/src/plugin/tray-visibility.ts
+++ b/packages/main/src/plugin/tray-visibility.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import { inject, injectable } from 'inversify';
+
+@injectable()
+export class TrayVisibility {
+  constructor(@inject(IConfigurationRegistry) private configurationRegistry: IConfigurationRegistry) {}
+
+  async init(): Promise<void> {
+    const trayVisibilityConfigurationNode: IConfigurationNode = {
+      id: 'preferences.ShowTrayIcon',
+      title: 'Show Tray Icon',
+      type: 'object',
+      properties: {
+        ['preferences.ShowTrayIcon']: {
+          description:
+            'Show Podman Desktop icon in the system tray. When disabled, closing the window will always quit the application. (Requires restart)',
+          type: 'boolean',
+          default: true,
+        },
+      },
+    };
+
+    this.configurationRegistry.registerConfigurations([trayVisibilityConfigurationNode]);
+  }
+}

--- a/packages/main/src/plugin/util/read-tray-setting.spec.ts
+++ b/packages/main/src/plugin/util/read-tray-setting.spec.ts
@@ -1,0 +1,102 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { isLinux } from '/@/util.js';
+
+import { readShowTrayIconSetting } from './read-tray-setting.js';
+
+vi.mock(import('node:fs'), () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock(import('node:os'), () => ({
+  homedir: vi.fn(),
+}));
+
+vi.mock(import('/@/util.js'), () => ({
+  isLinux: vi.fn(),
+}));
+
+const originalProcessEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalProcessEnv };
+  vi.clearAllMocks();
+  vi.mocked(homedir).mockReturnValue('/home/user');
+  vi.mocked(isLinux).mockReturnValue(true);
+});
+
+test('should return true when settings file does not exist', () => {
+  vi.mocked(existsSync).mockReturnValue(false);
+
+  const result = readShowTrayIconSetting();
+
+  expect(result).toBe(true);
+});
+
+test('should return true when ShowTrayIcon is not set', () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue(JSON.stringify({}));
+
+  const result = readShowTrayIconSetting();
+
+  expect(result).toBe(true);
+});
+
+test('should return true when ShowTrayIcon is true', () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ 'preferences.ShowTrayIcon': true }));
+
+  const result = readShowTrayIconSetting();
+
+  expect(result).toBe(true);
+});
+
+test('should return false when ShowTrayIcon is false', () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ 'preferences.ShowTrayIcon': false }));
+
+  const result = readShowTrayIconSetting();
+
+  expect(result).toBe(false);
+});
+
+test('should return true on JSON parse error', () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue('invalid json');
+
+  const result = readShowTrayIconSetting();
+
+  expect(result).toBe(true);
+});
+
+test('should return true on filesystem error', () => {
+  vi.mocked(existsSync).mockImplementation(() => {
+    throw new Error('Filesystem error');
+  });
+
+  const result = readShowTrayIconSetting();
+
+  expect(result).toBe(true);
+});

--- a/packages/main/src/plugin/util/read-tray-setting.ts
+++ b/packages/main/src/plugin/util/read-tray-setting.ts
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { LegacyDirectories } from '/@/plugin/directories-legacy.js';
+import { LinuxXDGDirectories } from '/@/plugin/directories-linux-xdg.js';
+import { DirectoryStrategy } from '/@/plugin/util/directory-strategy.js';
+
+export function readShowTrayIconSetting(): boolean {
+  try {
+    const strategy = new DirectoryStrategy();
+    const directories = strategy.shouldUseXDGDirectories() ? new LinuxXDGDirectories() : new LegacyDirectories();
+    const settingsFile = resolve(directories.getConfigurationDirectory(), 'settings.json');
+    if (!existsSync(settingsFile)) return true;
+    const settings = JSON.parse(readFileSync(settingsFile, 'utf-8'));
+    return settings['preferences.ShowTrayIcon'] !== false;
+  } catch {
+    return true;
+  }
+}

--- a/packages/main/src/tray-menu.spec.ts
+++ b/packages/main/src/tray-menu.spec.ts
@@ -49,6 +49,7 @@ beforeAll(() => {
   tray = {
     setContextMenu: vi.fn(),
     on: vi.fn(),
+    isDestroyed: vi.fn().mockReturnValue(false),
   } as unknown as Tray;
   animatedTray = {
     setStatus: vi.fn(),

--- a/packages/main/src/tray-menu.ts
+++ b/packages/main/src/tray-menu.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2023 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,8 +55,8 @@ export class TrayMenu {
   private menuContainerProviderConnectionItems = new Map<string, ProviderContainerConnectionInfoMenuItem>();
 
   constructor(
-    private readonly tray: Tray,
-    private readonly animatedTray: AnimatedTray,
+    private readonly tray: Tray | undefined,
+    private readonly animatedTray: AnimatedTray | undefined,
   ) {
     ipcMain.on(
       'tray:add-provider-menu-item',
@@ -140,7 +140,7 @@ export class TrayMenu {
     });
 
     if (isWindows()) {
-      tray.on('click', this.showMainWindow.bind(this));
+      tray?.on('click', this.showMainWindow.bind(this));
     }
 
     // create menu first time
@@ -244,6 +244,8 @@ export class TrayMenu {
   }
 
   private updateMenu(): void {
+    if (!this.tray || this.tray.isDestroyed()) return;
+
     const generatedMenuTemplate: MenuItemConstructorOptions[] = [];
     for (const [, item] of this.menuProviderItems) {
       generatedMenuTemplate.push(this.createProviderMenuItem(item));
@@ -309,7 +311,7 @@ export class TrayMenu {
     } else {
       this.globalStatus = 'initialized';
     }
-    this.animatedTray.setStatus(this.globalStatus);
+    this.animatedTray?.setStatus(this.globalStatus);
   }
 
   private createProviderMenuItem(item: ProviderMenuItem): MenuItemConstructorOptions {


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Adds a new **"Show Tray Icon"** preference (`preferences.ShowTrayIcon`) that allows users to hide the Podman Desktop system tray icon. When the tray icon is disabled:

- The tray icon is not created on startup (reads the setting from `settings.json` before the tray is initialized)
- Closing the window always quits the application (since there is no tray to keep it running in the background)
- The setting requires a restart to take effect

Implementation details:
- New `TrayVisibility` class registers the boolean configuration (default: `true`) in the configuration registry
- `readShowTrayIconSetting()` reads the setting directly from the settings file at startup, before the plugin system is initialized
- `TrayMenu` constructor now accepts `Tray | undefined` and `AnimatedTray | undefined`, with guards throughout to handle the no-tray case
- `mainWindow.ts` forces `ExitOnClose = true` when the tray icon is disabled

### Screenshot / video of UI

<img width="2108" height="1398" alt="CleanShot 2026-05-12 at 4  46 29@2x" src="https://github.com/user-attachments/assets/dec7030b-695a-4560-b6f1-e6f9e845cf90" />

### What issues does this PR fix or reference?

Closes #5845 

### How to test this PR?

1. Start Podman Desktop and verify the tray icon appears as usual (default: enabled)
2. Go to **Settings > Preferences**, find **"Show Tray Icon"** and toggle it off
3. Restart the application
4. Verify the system tray icon is **no longer visible**
5. Close the application window and verify the app **quits entirely** instead of minimizing to tray
6. Re-enable the setting, restart, and verify the tray icon is back with normal close-to-tray behavior

- [x] Tests are covering the bug fix or the new feature

This PR was tested on Linux (Fedora 44) and Mac (Tahoe 26.4.1)