### PR TITLE
refactor(ui): modernize LinearProgress component

### DIFF
--- a/packages/ui/src/lib/progress/LinearProgress.spec.ts
+++ b/packages/ui/src/lib/progress/LinearProgress.spec.ts
@@ -72,8 +72,8 @@ test('should propagate class to outer container', () => {
   expect(container.children[0]).toHaveClass('custom-class');
 });
 
-test('should propagate aria-label to outer container', () => {
-  const { getByLabelText } = render(LinearProgress, { 'aria-label': 'Loading page' });
-  const container = getByLabelText('Loading page');
-  expect(container).toBeDefined();
+test('should propagate aria-label to progressbar element', () => {
+  render(LinearProgress, { 'aria-label': 'Loading page' });
+  const progressBar = screen.getByRole('progressbar');
+  expect(progressBar).toHaveAttribute('aria-label', 'Loading page');
 });

--- a/packages/ui/src/lib/progress/LinearProgress.spec.ts
+++ b/packages/ui/src/lib/progress/LinearProgress.spec.ts
@@ -23,25 +23,57 @@ import { expect, test } from 'vitest';
 
 import LinearProgress from './LinearProgress.svelte';
 
-test('should render a progress element', () => {
+test('should render with role="progressbar"', () => {
   render(LinearProgress);
-  const progress = screen.getByRole('progressbar');
-  expect(progress).toBeInTheDocument();
+  const progressBar = screen.getByRole('progressbar');
+  expect(progressBar).toBeInTheDocument();
 });
 
-test('should use color-registry text color instead of hardcoded Tailwind color', () => {
+test('should have correct ARIA attributes for indeterminate mode', () => {
   render(LinearProgress);
-  const progress = screen.getByRole('progressbar');
-  expect(progress).toHaveClass('text-(--pd-progressBar-text)');
-  expect(progress).not.toHaveClass('text-purple-500');
+  const progressBar = screen.getByRole('progressbar');
+  expect(progressBar).toHaveAttribute('aria-valuemin', '0');
+  expect(progressBar).toHaveAttribute('aria-valuemax', '100');
+  expect(progressBar).not.toHaveAttribute('aria-valuenow');
 });
 
-test('should have full width and correct base classes', () => {
+test('should use color-registry background token on outer container', () => {
+  const { container } = render(LinearProgress);
+  expect(container.children[0]).toHaveClass('bg-(--pd-progressBar-bg)');
+});
+
+test('should use color-registry tokens on animated bar', () => {
   render(LinearProgress);
-  const progress = screen.getByRole('progressbar');
-  expect(progress).toHaveClass('w-full');
-  expect(progress).toHaveClass('appearance-none');
-  expect(progress).toHaveClass('border-none');
-  expect(progress).toHaveClass('h-0.5');
-  expect(progress).toHaveClass('pure-material-progress-linear');
+  const progressBar = screen.getByRole('progressbar');
+  expect(progressBar).toHaveClass('bg-(--pd-progressBar-in-progress-bg)');
+  expect(progressBar).toHaveClass('outline-(--pd-progressBar-in-progress-border)');
+});
+
+test('should have full width on outer container', () => {
+  const { container } = render(LinearProgress);
+  expect(container.children[0]).toHaveClass('w-full');
+});
+
+test('should have indeterminate animation class', () => {
+  render(LinearProgress);
+  const progressBar = screen.getByRole('progressbar');
+  expect(progressBar).toHaveClass('linear-progress-indeterminate');
+});
+
+test('should have high-contrast guide line element', () => {
+  const { container } = render(LinearProgress);
+  const outerDiv = container.children[0];
+  const hcLine = outerDiv.querySelector('.bg-\\(--pd-progressBar-hc-line-bg\\)');
+  expect(hcLine).toBeInTheDocument();
+});
+
+test('should propagate class to outer container', () => {
+  const { container } = render(LinearProgress, { class: 'custom-class' });
+  expect(container.children[0]).toHaveClass('custom-class');
+});
+
+test('should propagate aria-label to outer container', () => {
+  const { getByLabelText } = render(LinearProgress, { 'aria-label': 'Loading page' });
+  const container = getByLabelText('Loading page');
+  expect(container).toBeDefined();
 });

--- a/packages/ui/src/lib/progress/LinearProgress.svelte
+++ b/packages/ui/src/lib/progress/LinearProgress.svelte
@@ -34,12 +34,13 @@ import type { HTMLAttributes } from 'svelte/elements';
 let { class: className, ...restProps }: HTMLAttributes<HTMLElement> = $props();
 </script>
 
-<div class="w-full overflow-x-hidden overflow-y-auto relative bg-(--pd-progressBar-bg) {className}" {...restProps}>
+<div class="w-full overflow-x-hidden overflow-y-auto relative bg-(--pd-progressBar-bg) {className}">
   <div
     class="linear-progress-indeterminate w-full h-0.5 relative bg-(--pd-progressBar-in-progress-bg) outline-1 outline-(--pd-progressBar-in-progress-border) z-1"
     role="progressbar"
     aria-valuemin={0}
-    aria-valuemax={100}>
+    aria-valuemax={100}
+    {...restProps}>
   </div>
 
   <div class="w-full absolute top-1/2 -translate-y-1/2 h-px bg-(--pd-progressBar-hc-line-bg) z-0"></div>

--- a/packages/ui/src/lib/progress/LinearProgress.svelte
+++ b/packages/ui/src/lib/progress/LinearProgress.svelte
@@ -3,6 +3,7 @@
   animation: linearProgressAnimation 2s infinite linear;
   transform-origin: 0% 50%;
 }
+
 @keyframes linearProgressAnimation {
   0% {
     transform: translateX(0) scaleX(0);
@@ -13,6 +14,11 @@
   100% {
     transform: translateX(100%) scaleX(0.5);
   }
+}
+
+:global(.hc-light) .linear-progress-indeterminate,
+:global(.hc-dark) .linear-progress-indeterminate {
+  height: 4px;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -28,12 +34,13 @@ import type { HTMLAttributes } from 'svelte/elements';
 let { class: className, ...restProps }: HTMLAttributes<HTMLElement> = $props();
 </script>
 
-<div class="w-full h-0.5 relative bg-(--pd-progressBar-bg) overflow-hidden {className}" {...restProps}>
+<div class="w-full overflow-x-hidden overflow-y-auto relative bg-(--pd-progressBar-bg) {className}" {...restProps}>
   <div
-    class="w-full h-0.5 relative bg-(--pd-progressBar-in-progress-bg) linear-progress-indeterminate outline-1 outline-(--pd-progressBar-in-progress-border) z-1"
+    class="linear-progress-indeterminate w-full h-0.5 relative bg-(--pd-progressBar-in-progress-bg) outline-1 outline-(--pd-progressBar-in-progress-border) z-1"
     role="progressbar"
     aria-valuemin={0}
     aria-valuemax={100}>
   </div>
+
   <div class="w-full absolute top-1/2 -translate-y-1/2 h-px bg-(--pd-progressBar-hc-line-bg) z-0"></div>
 </div>

--- a/packages/ui/src/lib/progress/LinearProgress.svelte
+++ b/packages/ui/src/lib/progress/LinearProgress.svelte
@@ -1,56 +1,39 @@
 <style>
-.pure-material-progress-linear::-webkit-progress-bar {
-  background-color: transparent;
+.linear-progress-indeterminate {
+  animation: linearProgressAnimation 2s infinite linear;
+  transform-origin: 0% 50%;
 }
-
-/* Determinate */
-.pure-material-progress-linear::-webkit-progress-value {
-  background-color: currentColor;
-  transition: all 0.2s;
-}
-
-.pure-material-progress-linear::-ms-fill {
-  border: none;
-  background-color: currentColor;
-  transition: all 0.2s;
-}
-
-/* Indeterminate */
-.pure-material-progress-linear:indeterminate {
-  background-size: 200% 100%;
-  background-image: linear-gradient(
-    to right,
-    transparent 50%,
-    currentColor 50%,
-    currentColor 60%,
-    transparent 60%,
-    transparent 71.5%,
-    currentColor 71.5%,
-    currentColor 84%,
-    transparent 84%
-  );
-  animation: pure-material-progress-linear 2s infinite linear;
-}
-
-.pure-material-progress-linear:indeterminate::-ms-fill {
-  animation-name: none;
-}
-
-@keyframes pure-material-progress-linear {
+@keyframes linearProgressAnimation {
   0% {
-    background-size: 200% 100%;
-    background-position: left -31.25% top 0%;
+    transform: translateX(0) scaleX(0);
   }
-  50% {
-    background-size: 800% 100%;
-    background-position: left -49% top 0%;
+  20% {
+    transform: translateX(0) scaleX(0.25);
   }
   100% {
-    background-size: 400% 100%;
-    background-position: left -102% top 0%;
+    transform: translateX(100%) scaleX(0.5);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .linear-progress-indeterminate {
+    animation: none;
   }
 }
 </style>
 
-<progress class="w-full appearance-none border-none h-0.5 text-(--pd-progressBar-text) text-base pure-material-progress-linear"
-></progress>
+<script lang="ts">
+import type { HTMLAttributes } from 'svelte/elements';
+
+let { class: className, ...restProps }: HTMLAttributes<HTMLElement> = $props();
+</script>
+
+<div class="w-full h-0.5 relative bg-(--pd-progressBar-bg) overflow-hidden {className}" {...restProps}>
+  <div
+    class="w-full h-0.5 relative bg-(--pd-progressBar-in-progress-bg) linear-progress-indeterminate outline-1 outline-(--pd-progressBar-in-progress-border) z-1"
+    role="progressbar"
+    aria-valuemin={0}
+    aria-valuemax={100}>
+  </div>
+  <div class="w-full absolute top-1/2 -translate-y-1/2 h-px bg-(--pd-progressBar-hc-line-bg) z-0"></div>
+</div>


### PR DESCRIPTION
### What does this PR do?

Modernize the `LinearProgress` component to match the design system aesthetic established by the `ProgressBar` modernization (#17422).

- Replace HTML `<progress>` element with div-based structure
- Use color registry tokens (`progressBar-bg`, `progressBar-in-progress-bg`, `progressBar-in-progress-border`, `progressBar-hc-line-bg`) with full high-contrast support
- Add proper WAI-ARIA attributes (`role="progressbar"`, `aria-valuemin`, `aria-valuemax`)
- Add high-contrast guide line (visible only in HC themes)
- Add outline border for visual definition
- Add `prefers-reduced-motion` support
- Remove 39 lines of vendor-specific webkit/MS CSS
- Rewrite tests (3 → 9) covering ARIA, color tokens, animation, HC elements, and prop propagation

### Screenshot / video of UI

Before (dark and light theme):

https://github.com/user-attachments/assets/ef109cf3-c696-48df-9097-b61171fe17de

Now (dark, light, high contrast dark and light themes):

https://github.com/user-attachments/assets/fdbbb995-7308-4a9e-8413-b06ef831400e

Storybook (needs #17500):

<img alt="CleanShot 2026-05-13 at 10 59 24@2x" src="https://github.com/user-attachments/assets/fc028588-686d-4e1f-bc19-b18bb4ba0b97" />

### What issues does this PR fix or reference?

- Resolves: #17501
- Part of: #14214

### How to test this PR?

1. Run `pnpm --filter @podman-desktop/ui-svelte test` - all 312 tests pass
2. Run `pnpm --filter storybook dev` and check LinearProgress stories in all four themes (light, dark, hc-light, hc-dark)
3. Run `pnpm watch`, navigate to a page that uses `inProgress` (e.g. deploy pod to Kubernetes) and verify the progress bar renders correctly
4. Verify `Page.spec.ts` tests still pass (they check for `role="progressbar"`)

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>