### PR TITLE
fix(winget): set installer scope to user instead of machine

### DIFF
--- a/.github/workflows/publish-to-winget.yaml
+++ b/.github/workflows/publish-to-winget.yaml
@@ -69,5 +69,5 @@ jobs:
         env:
           TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
           VERSION: ${{ needs.version.outputs.desktopVersion }}
-          URL_X64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup-x64.exe|x64', needs.version.outputs.desktopVersion) }}
-          URL_ARM64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup-arm64.exe|arm64', needs.version.outputs.desktopVersion) }}
+          URL_X64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup-x64.exe|x64|user', needs.version.outputs.desktopVersion) }}
+          URL_ARM64: ${{ format('https://github.com/containers/podman-desktop/releases/download/v{0}/podman-desktop-{0}-setup-arm64.exe|arm64|user', needs.version.outputs.desktopVersion) }}


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Sets the winget installer scope to `user` instead of `machine` by adding the `|user` scope override to the `wingetcreate update` URLs in the publish workflow. The NSIS installer only supports per-user installation in silent mode, so the manifest should reflect that.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes #14475 

### How to test this PR?

Run `wingetcreate update` locally with the updated URL format and `-o ./output` to inspect the generated manifest:
   ```powershell
   wingetcreate.exe update RedHat.Podman-Desktop -u 'https://github.com/containers/podman-desktop/releases/download/v1.27.1/podman-desktop-1.27.1-setup-x64.exe|x64|user' 'https://github.com/containers/podman-desktop/releases/download/v1.27.1/podman-desktop-1.27.1-setup-arm64.exe|arm64|user' -v 1.27.1 -o ./output
   ```
2. Verify the generated `RedHat.Podman-Desktop.installer.yaml` has `Scope: user` instead of `Scope: machine`

- [x] Tests are covering the bug fix or the new feature

### Additional Info

We should probably also make a PR to Microsoft repo to update current version to support user-only version