### PR TITLE
fix(test): update feedback dialog toggle label to match renamed description - [managed-configuration]

### DIFF
--- a/tests/playwright/src/model/core/settings/preferences.ts
+++ b/tests/playwright/src/model/core/settings/preferences.ts
@@ -27,7 +27,7 @@ enum PreferenceLabels {
 
 export class Preferences {
   static readonly Labels = PreferenceLabels;
-  static readonly FEEDBACK_DIALOG_TOGGLE_BUTTON_LABEL = 'Show feedback dialog for experimental features';
+  static readonly FEEDBACK_DIALOG_TOGGLE_BUTTON_LABEL = 'Show periodic feedback reminder for experimental features';
   static readonly TOAST_NOTIFICATION_TOGGLE_BUTTON_LABEL = 'Display a notification toast when task is created';
   static readonly EXIT_ON_CLOSE_TOGGLE_BUTTON_LABEL =
     'Quit the app when the close button is clicked instead of minimizing to the tray.';


### PR DESCRIPTION
### What does this PR do?

Updates the `FEEDBACK_DIALOG_TOGGLE_BUTTON_LABEL` constant in the E2E test framework to match the renamed description introduced in commit 9eba50866245 (`fix(main): clarify feedback dialog setting description`).

The upstream commit changed the `feedback.dialog` description from `'Show feedback dialog for experimental features'` to `'Show periodic feedback reminder for experimental features'`, which broke the Playwright `getByLabel()` locator used in managed configuration tests.

### Screenshot / video of UI

N/A — test-only change, no UI modifications.

### What issues does this PR fix or reference?

Fixes the CI failure in `managed-configuration-combined.spec.ts`:
https://github.com/podman-desktop/podman-desktop/actions/runs/25790293759/job/75753819225

Broken by commit: 9eba50866245132cb7705d83505d200a5d9cb7b4

### How to test this PR?

Run the managed configuration E2E test suite and verify the "Feedback Dialog" preference tests pass:
```bash
npx playwright test tests/playwright/src/special-specs/managed-configuration/managed-configuration-combined.spec.ts
```

- [x] Tests are covering the bug fix or the new feature