### PR TITLE
fix(renderer): mark wheel event listener as passive 

### DIFF
--- a/packages/renderer/src/lib/ui/NavigationButtons.svelte
+++ b/packages/renderer/src/lib/ui/NavigationButtons.svelte
@@ -192,7 +192,7 @@ function handleKeyDown(e: KeyboardEvent): void {
 
 onMount(() => {
   window.addEventListener('mouseup', handleGlobalMouseUp);
-  window.addEventListener('wheel', handleWheel);
+  window.addEventListener('wheel', handleWheel, { passive: true });
   window.addEventListener('click', handleClickOutside);
   window.addEventListener('keydown', handleKeyDown);
 


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Fixes a browser console violation warning by marking the wheel event listener in `NavigationButtons` component as passive. The warning appeared when using trackpad swipe navigation and indicated that a non-passive listener was blocking scroll events unnecessarily.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes #16835 

### How to test this PR?

1. Open the browser DevTools console
2. Navigate through different pages in Podman Desktop (Containers, Images, Pods, etc.)
3. Use trackpad horizontal swipe gestures to navigate back/forward
4. **Expected results:**
   - No violation warning in the console
   - Trackpad swipe navigation works correctly (swipe right = back, swipe left = forward)
   - Mouse button 3/4 navigation still works

- [x] Tests are covering the bug fix or the new feature
