### PR TITLE
fix(flatpak): update bugtracker URL to current GitHub organisation

### DIFF
--- a/.flatpak-appdata.xml
+++ b/.flatpak-appdata.xml
@@ -9,7 +9,7 @@
   <summary>Manage Podman and other container engines from a single UI</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <url type="homepage">https://podman-desktop.io/</url>
-  <url type="bugtracker">https://github.com/containers/podman-desktop/issues</url>
+  <url type="bugtracker">https://github.com/podman-desktop/podman-desktop/issues</url>
   <url type="help">https://podman-desktop.io/docs/intro</url>
   <description>
     <p>Podman Desktop is an open source graphical tool enabling you to seamlessly work with containers and Kubernetes from your local environment.</p>


### PR DESCRIPTION
### What does this PR do?

Updates the bugtracker URL in `.flatpak-appdata.xml` from the old `containers` GitHub organisation to the current canonical `podman-desktop` organisation:

```diff
-<url type="bugtracker">https://github.com/containers/podman-desktop/issues</url>
+<url type="bugtracker">https://github.com/podman-desktop/podman-desktop/issues</url>
```

This metadata is consumed by Linux software centers (GNOME Software, KDE Discover) and the Flathub website. Using the canonical URL avoids unnecessary redirects and potential breakage.

### Screenshot / video of UI

N/A — metadata-only change.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11489

### How to test this PR?

1. Open `.flatpak-appdata.xml`
2. Verify line 12 now reads `https://github.com/podman-desktop/podman-desktop/issues`


Made with [Cursor](https://cursor.com)