### PR TITLE
fix(test): reduce registry E2E flakiness with dialog wait and timeout increases

### DIFF
--- a/tests/playwright/src/model/pages/registries-page.ts
+++ b/tests/playwright/src/model/pages/registries-page.ts
@@ -54,8 +54,8 @@ export class RegistriesPage extends SettingsPage {
     this.preferredRepositoriesField = page.locator(`input[name="${Registries.PREFERRED_INPUT_NAME}"]`);
   }
 
-  async createRegistry(url: string, username: string, pswd: string): Promise<void> {
-    return test.step('Create a new registry', async () => {
+  async submitRegistryForm(url: string, username: string, pswd: string): Promise<void> {
+    return test.step('Submit registry form', async () => {
       await this.page.waitForTimeout(4_000);
       await playExpect(this.addRegistryButton).toBeEnabled();
       await this.addRegistryButton.click();
@@ -68,6 +68,13 @@ export class RegistriesPage extends SettingsPage {
 
       await playExpect(this.confirmDialogButton).toBeEnabled();
       await this.confirmDialogButton.click();
+    });
+  }
+
+  async createRegistry(url: string, username: string, pswd: string): Promise<void> {
+    return test.step('Create a new registry', async () => {
+      await this.submitRegistryForm(url, username, pswd);
+      await playExpect(this.addRegistryDialog).toBeHidden({ timeout: 30_000 });
     });
   }
 

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -142,7 +142,7 @@ test.describe
 
           const registryBox = await registryPage.getRegistryRowByName('GitHub');
           const username = registryBox.getByText(registryUsername);
-          await playExpect(username).toBeVisible();
+          await playExpect(username).toBeVisible({ timeout: 10_000 });
         });
 
         test('Push manifest to registry', async ({ navigationBar }) => {

--- a/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
@@ -71,7 +71,7 @@ test.describe
 
       const registryBox = registryPage.registriesTable.getByLabel('GitHub');
       const username = registryBox.getByText(registryUsername);
-      await playExpect(username).toBeVisible();
+      await playExpect(username).toBeVisible({ timeout: 10_000 });
     });
 
     test('Pull image', async ({ navigationBar }) => {
@@ -156,6 +156,6 @@ test.describe
       await registryPage.removeRegistry(registryName);
       const registryBox = registryPage.registriesTable.getByLabel(registryName);
       const username = registryBox.getByText(registryUsername);
-      await playExpect(username).toBeHidden();
+      await playExpect(username).toBeHidden({ timeout: 10_000 });
     });
   });

--- a/tests/playwright/src/specs/registry.spec.ts
+++ b/tests/playwright/src/specs/registry.spec.ts
@@ -73,20 +73,20 @@ test.describe
       const settingsBar = await navigationBar.openSettings();
       const registryPage = await settingsBar.openTabPage(RegistriesPage);
 
-      await registryPage.createRegistry('invalidUrl', 'invalidName', 'invalidPswd');
+      await registryPage.submitRegistryForm('invalidUrl', 'invalidName', 'invalidPswd');
       const urlErrorMsg = page.getByText(
         /Unable to find auth info for https:\/\/invalidUrl\/v2\/\. Error: RequestError: getaddrinfo [A-Z_]+ invalidurl$/,
       );
       await playExpect(urlErrorMsg).toBeVisible({ timeout: 60_000 });
-      await playExpect(registryPage.cancelDialogButton).toBeEnabled();
       await registryPage.cancelDialogButton.click();
+      await playExpect(registryPage.addRegistryDialog).toBeHidden({ timeout: 10_000 });
 
-      await registryPage.createRegistry(registryUrl, 'invalidName', 'invalidPswd');
+      await registryPage.submitRegistryForm(registryUrl, 'invalidName', 'invalidPswd');
       const credsErrorMsg = page.getByRole('dialog', { name: 'Add Registry' }).getByLabel('Error Message Content');
       await playExpect(credsErrorMsg).toBeVisible({ timeout: 30_000 });
       await playExpect(credsErrorMsg).toContainText('Wrong Username or Password', { ignoreCase: true });
-      await playExpect(registryPage.cancelDialogButton).toBeEnabled();
       await registryPage.cancelDialogButton.click();
+      await playExpect(registryPage.addRegistryDialog).toBeHidden({ timeout: 10_000 });
     });
 
     test.describe
@@ -120,7 +120,7 @@ test.describe
           await registryPage.removeRegistry(registryName);
           const registryBox = registryPage.registriesTable.getByLabel(registryName);
           const username = registryBox.getByText(registryUsername);
-          await playExpect(username).toBeHidden();
+          await playExpect(username).toBeHidden({ timeout: 10_000 });
         });
       });
   });


### PR DESCRIPTION
### What does this PR do?

Fixes intermittent registry E2E test failures by:
- Adding a dialog closure wait (`toBeHidden({ timeout: 30_000 })`) in `createRegistry()` after clicking "Add" — ensures the async credential check and registry creation complete before returning
- Increasing assertion timeouts from default 5000ms to 10_000ms for registry username visibility/hidden checks in 3 spec files

### Screenshot / video of UI

N/A — test-only changes, no UI modifications.

### What issues does this PR fix or reference?

Addresses intermittent failures in 5 consecutive `e2e-tests-main` runs (attempt 1):
- https://github.com/podman-desktop/podman-desktop/actions/runs/25792763286/job/75762302007
- https://github.com/podman-desktop/podman-desktop/actions/runs/25803441142/job/75799504004
- https://github.com/podman-desktop/podman-desktop/actions/runs/25803597310/job/75800089825
- https://github.com/podman-desktop/podman-desktop/actions/runs/25808205781/job/75816871081
- https://github.com/podman-desktop/podman-desktop/actions/runs/25768181234/job/75685365565

[Full analysis report](https://gist.github.com/ScrewTSW/5e41e0931998b1c7bc35bd14a16c59f6)

### How to test this PR?

1. Run registry-related E2E tests: `registry.spec.ts`, `image-push-to-registry-smoke.spec.ts`, `image-manifest-smoke.spec.ts`
2. Verify `createRegistry()` now waits for the dialog to close before returning
3. Monitor CI runs for reduced flakiness in registry tests

- [x] Tests are covering the bug fix or the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)