### PR TITLE
feat(ui): add keyboard focus support to tooltip

### DIFF
--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -108,6 +108,44 @@ describe('Tooltip', () => {
     });
   });
 
+  test('tooltip shows on focusin and hides on focusout', async () => {
+    render(TooltipTestComponent, { tip: 'focus text' });
+
+    const slot = screen.getByTestId('tooltip-trigger');
+
+    expect(screen.queryByText('focus text')).not.toBeInTheDocument();
+
+    await fireEvent.focusIn(slot);
+
+    await waitFor(() => {
+      expect(screen.queryByText('focus text')).toBeInTheDocument();
+    });
+
+    await fireEvent.focusOut(slot);
+
+    await waitFor(() => {
+      expect(screen.queryByText('focus text')).not.toBeInTheDocument();
+    });
+  });
+
+  test('tooltip shows on keyboard focus and hides on mouse leave', async () => {
+    render(TooltipTestComponent, { tip: 'cross text' });
+
+    const slot = screen.getByTestId('tooltip-trigger');
+
+    await fireEvent.focusIn(slot);
+
+    await waitFor(() => {
+      expect(screen.queryByText('cross text')).toBeInTheDocument();
+    });
+
+    await fireEvent.mouseLeave(slot);
+
+    await waitFor(() => {
+      expect(screen.queryByText('cross text')).not.toBeInTheDocument();
+    });
+  });
+
   test('tooltip respects top placement prop', async () => {
     render(TooltipTestComponent, { tip: 'top tooltip', top: true });
 

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -128,6 +128,25 @@ describe('Tooltip', () => {
     });
   });
 
+  test('tooltip stays visible when focus moves between descendants inside trigger', async () => {
+    render(TooltipTestComponent, { tip: 'stay text' });
+
+    const slot = screen.getByTestId('tooltip-trigger');
+    const child = screen.getByText('Hover me');
+
+    await fireEvent.focusIn(slot);
+
+    await waitFor(() => {
+      expect(screen.queryByText('stay text')).toBeInTheDocument();
+    });
+
+    await fireEvent.focusOut(slot, { relatedTarget: child });
+
+    await waitFor(() => {
+      expect(screen.queryByText('stay text')).toBeInTheDocument();
+    });
+  });
+
   test('tooltip shows on keyboard focus and hides on mouse leave', async () => {
     render(TooltipTestComponent, { tip: 'cross text' });
 

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -154,7 +154,9 @@ $effect((): (() => void) => {
     class="group tooltip-slot {className}"
     bind:this={referenceElement}
     onmouseenter={handleMouseEnter}
-    onmouseleave={handleMouseLeave}>
+    onmouseleave={handleMouseLeave}
+    onfocusin={handleMouseEnter}
+    onfocusout={handleMouseLeave}>
     {@render children?.()}
   </span>
   {#if isVisible && !$tooltipHidden && (tip ?? tipSnippet)}

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -127,6 +127,11 @@ function handleMouseLeave(): void {
   }
 }
 
+function handleFocusOut(event: FocusEvent): void {
+  if (referenceElement?.contains(event.relatedTarget as Node)) return;
+  handleMouseLeave();
+}
+
 $effect((): (() => void) => {
   if (isVisible && referenceElement && tooltipElement) {
     // Initial positioning
@@ -156,7 +161,7 @@ $effect((): (() => void) => {
     onmouseenter={handleMouseEnter}
     onmouseleave={handleMouseLeave}
     onfocusin={handleMouseEnter}
-    onfocusout={handleMouseLeave}>
+    onfocusout={handleFocusOut}>
     {@render children?.()}
   </span>
   {#if isVisible && !$tooltipHidden && (tip ?? tipSnippet)}


### PR DESCRIPTION
### What does this PR do?

Adds `onfocusin` and `onfocusout` event handlers to the `Tooltip` trigger element so that tooltips appear when any focusable child receives keyboard focus, not just on mouse hover.

This addresses a WCAG 2.1.1 (Level A) accessibility failure: keyboard-only users currently have zero access to tooltip content. Level A is the minimum conformance level - failing it means the UI is fundamentally inaccessible to users who navigate without a mouse (motor impairments, power users, screen reader users).

The fix reuses the existing `handleMouseEnter`/`handleMouseLeave` functions. `focusin`/`focusout` are used instead of `focus`/`blur` because they bubble, correctly firing when any focusable descendant inside the tooltip slot gains or loses focus.

### Screenshot / video of UI

N/A - behavioral change only, no visual difference. The tooltip now appears on keyboard focus in addition to mouse hover.

### What issues does this PR fix or reference?

- Resolves: #15783

### How to test this PR?

1. Run `pnpm watch`
2. Tab through any UI area that contains tooltips (e.g. sidebar icons, action buttons)
3. Verify the tooltip appears when an element inside the tooltip wrapper receives keyboard focus
4. Verify the tooltip disappears when focus moves away
5. Verify mouse hover behavior is unchanged

Unit tests:

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>