### PR TITLE
fix(renderer): hide Open Pod button when kubernetes-dashboard feature is active

### DIFF
--- a/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.spec.ts
@@ -28,6 +28,7 @@ import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { lastPage } from '/@/stores/breadcrumb';
+import { registeredFeatures } from '/@/stores/registered-features';
 
 import DeployPodToKube from './DeployPodToKube.svelte';
 
@@ -39,6 +40,7 @@ vi.mock(import('tinro'));
 beforeEach(() => {
   vi.resetAllMocks();
   vi.useRealTimers();
+  registeredFeatures.set([]);
 
   // podYaml with volumes
   const podYaml = {
@@ -526,6 +528,56 @@ test('Done button should go back to previous page', async () => {
   lastPage.set({ name: 'perious page', path: '/last' });
   await fireEvent.click(doneButton);
   expect(router.goto).toHaveBeenCalledWith(`/last`);
+});
+
+test('Should hide Open Pod button when kubernetes-dashboard feature is active', async () => {
+  registeredFeatures.set(['kubernetes-dashboard']);
+  vi.mocked(window.kubernetesGetCurrentContextName).mockResolvedValue('default');
+
+  await waitRender({});
+  const createButton = screen.getByRole('button', { name: 'Deploy' });
+
+  vi.mocked(window.kubernetesCreatePod).mockResolvedValue({
+    metadata: { name: 'my-pod', namespace: 'default' },
+  });
+  vi.mocked(window.kubernetesReadNamespacedPod).mockResolvedValue({
+    metadata: { name: 'my-pod', namespace: 'default' },
+    status: { phase: 'Running' },
+  });
+
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  await fireEvent.click(createButton);
+  await vi.runAllTimersAsync();
+
+  expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Open Pod' })).toBeNull();
+});
+
+test('Should show Open Pod button when kubernetes-dashboard feature becomes inactive', async () => {
+  registeredFeatures.set(['kubernetes-dashboard']);
+  vi.mocked(window.kubernetesGetCurrentContextName).mockResolvedValue('default');
+
+  await waitRender({});
+  const createButton = screen.getByRole('button', { name: 'Deploy' });
+
+  vi.mocked(window.kubernetesCreatePod).mockResolvedValue({
+    metadata: { name: 'my-pod', namespace: 'default' },
+  });
+  vi.mocked(window.kubernetesReadNamespacedPod).mockResolvedValue({
+    metadata: { name: 'my-pod', namespace: 'default' },
+    status: { phase: 'Running' },
+  });
+
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  await fireEvent.click(createButton);
+  await vi.runAllTimersAsync();
+
+  expect(screen.queryByRole('button', { name: 'Open Pod' })).toBeNull();
+
+  registeredFeatures.set([]);
+  await vi.waitFor(() => {
+    expect(screen.getByRole('button', { name: 'Open Pod' })).toBeInTheDocument();
+  });
 });
 
 test('ImagePullBackOff error should be reported', async () => {

--- a/packages/renderer/src/lib/pod/DeployPodToKube.svelte
+++ b/packages/renderer/src/lib/pod/DeployPodToKube.svelte
@@ -12,6 +12,7 @@ import { ensureRestrictedSecurityContext } from '/@/lib/pod/pod-utils';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import WarningMessage from '/@/lib/ui/WarningMessage.svelte';
 import { lastPage } from '/@/stores/breadcrumb';
+import { registeredFeatures } from '/@/stores/registered-features';
 
 export let resourceId: string;
 export let engineId: string;
@@ -41,6 +42,8 @@ let ingressPort: number;
 let containerPortArray: string[] = [];
 
 let createdRoutes: V1Route[] = [];
+
+$: kubernetesDashboardActive = $registeredFeatures.includes('kubernetes-dashboard');
 
 onMount(async () => {
   // If type = compose
@@ -641,10 +644,12 @@ function updateKubeResult(): void {
     {#if deployFinished}
       <div class="pt-4 flex flex-row space-x-2 justify-end">
         <Button on:click={goBackToHistory} aria-label="Done">Done</Button>
-        <Button
-          on:click={openPodDetails}
-          disabled={!createdPod?.metadata?.name || !createdPod?.metadata?.namespace}
-          aria-label="Open Pod">Open Pod</Button>
+        {#if !kubernetesDashboardActive}
+          <Button
+            on:click={openPodDetails}
+            disabled={!createdPod?.metadata?.name || !createdPod?.metadata?.namespace}
+            aria-label="Open Pod">Open Pod</Button>
+        {/if}
       </div>
     {/if}
   </div>


### PR DESCRIPTION
### What does this PR do?

When the kubernetes-dashboard extension is active, the Open Pod button is hidden after deploying a pod to Kubernetes, since the dashboard provides its own navigation.

Using the svelte4 format as the component is not migrated to svelte5

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #17191 

### How to test this PR?

See steps to reproduce on #17191 

- [x] Tests are covering the bug fix or the new feature
