### PR TITLE
chore: use extensions catalog website from product.json for extensions update preference

### DIFF
--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -27,6 +27,7 @@ import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionsUpdaterSettings } from '/@/plugin/extension/updater/extensions-updater-settings.js';
 import { ExtensionInstaller } from '/@/plugin/install/extension-installer.js';
 import { Telemetry } from '/@/plugin/telemetry/telemetry.js';
+import product from '/@product.json' with { type: 'json' };
 
 @injectable()
 export class ExtensionsUpdater {
@@ -50,6 +51,7 @@ export class ExtensionsUpdater {
   async init(): Promise<void> {
     const autoCheckUpdatesKey = `${ExtensionsUpdaterSettings.SectionName}.${ExtensionsUpdaterSettings.AutoCheckUpdates}`;
     const autoUpdateKey = `${ExtensionsUpdaterSettings.SectionName}.${ExtensionsUpdaterSettings.AutoUpdate}`;
+    const extensionCatalog = product.catalog.website;
 
     const extensionLoaderConfiguration: IConfigurationNode = {
       id: 'preferences.extensions',
@@ -57,8 +59,7 @@ export class ExtensionsUpdater {
       type: 'object',
       properties: {
         [autoCheckUpdatesKey]: {
-          description:
-            'When enabled, automatically checks extensions for updates. The updates are fetched from registry.podman-desktop.io.',
+          description: `When enabled, automatically checks extensions for updates. The updates are fetched from ${extensionCatalog}`,
           type: 'boolean',
           default: true,
         },

--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -51,7 +51,8 @@ export class ExtensionsUpdater {
   async init(): Promise<void> {
     const autoCheckUpdatesKey = `${ExtensionsUpdaterSettings.SectionName}.${ExtensionsUpdaterSettings.AutoCheckUpdates}`;
     const autoUpdateKey = `${ExtensionsUpdaterSettings.SectionName}.${ExtensionsUpdaterSettings.AutoUpdate}`;
-    const updateFetchedText = product.catalog.website ? ` The updates are fetched from ${product.catalog.website}` : '';
+    const catalogTitle = new URL(product.catalog.default).hostname;
+    const updateFetchedText = catalogTitle ? ` The updates are fetched from ${catalogTitle}` : '';
 
     const extensionLoaderConfiguration: IConfigurationNode = {
       id: 'preferences.extensions',

--- a/packages/main/src/plugin/extension/updater/extensions-updater.ts
+++ b/packages/main/src/plugin/extension/updater/extensions-updater.ts
@@ -51,7 +51,7 @@ export class ExtensionsUpdater {
   async init(): Promise<void> {
     const autoCheckUpdatesKey = `${ExtensionsUpdaterSettings.SectionName}.${ExtensionsUpdaterSettings.AutoCheckUpdates}`;
     const autoUpdateKey = `${ExtensionsUpdaterSettings.SectionName}.${ExtensionsUpdaterSettings.AutoUpdate}`;
-    const extensionCatalog = product.catalog.website;
+    const updateFetchedText = product.catalog.website ? ` The updates are fetched from ${product.catalog.website}` : '';
 
     const extensionLoaderConfiguration: IConfigurationNode = {
       id: 'preferences.extensions',
@@ -59,7 +59,7 @@ export class ExtensionsUpdater {
       type: 'object',
       properties: {
         [autoCheckUpdatesKey]: {
-          description: `When enabled, automatically checks extensions for updates. The updates are fetched from ${extensionCatalog}`,
+          description: `When enabled, automatically checks extensions for updates.${updateFetchedText}`,
           type: 'boolean',
           default: true,
         },

--- a/product.json
+++ b/product.json
@@ -26,7 +26,8 @@
     }
   },
   "catalog": {
-    "default": "https://registry.podman-desktop.io/api/extensions.json"
+    "default": "https://registry.podman-desktop.io/api/extensions.json",
+    "website": "registry.podman-desktop.io"
   },
   "extensions": {
     "remote": []

--- a/product.json
+++ b/product.json
@@ -26,8 +26,7 @@
     }
   },
   "catalog": {
-    "default": "https://registry.podman-desktop.io/api/extensions.json",
-    "website": "registry.podman-desktop.io"
+    "default": "https://registry.podman-desktop.io/api/extensions.json"
   },
   "extensions": {
     "remote": []


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds the catalog website to `product.json` and uses it in the auto update for extensions preference description

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/17382

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
