### PR TITLE
chore: use product name for update reminder preference

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -224,6 +224,26 @@ test('expect init to register configuration', () => {
   expect(configurationRegistryMock.registerConfigurations).toHaveBeenCalled();
 });
 
+test('expect configuration description to use product name', () => {
+  vi.mocked(product).name = 'Custom Product Name';
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  expect(configurationRegistryMock.registerConfigurations).toHaveBeenCalled();
+  const configurationNode = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]?.[0]?.[0];
+  expect(configurationNode?.id).toBe('preferences.update');
+  expect(configurationNode?.properties?.['preferences.update.reminder']?.description).toBe(
+    'Configure whether you receive update reminders when starting Custom Product Name',
+  );
+});
+
 describe('differential download', () => {
   type TestCase = {
     platform: 'windows' | 'macos';

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -324,7 +324,7 @@ export class Updater {
         type: 'object',
         properties: {
           ['preferences.update.reminder']: {
-            description: 'Configure whether you receive update reminders when starting Podman Desktop',
+            description: `Configure whether you receive update reminders when starting ${product.name}`,
             type: 'string',
             default: 'startup',
             enum: ['startup', 'never'],


### PR DESCRIPTION
### What does this PR do?
Uses product name from product.json in the update reminder preference description

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes https://github.com/podman-desktop/podman-desktop/issues/17381

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
