### PR TITLE
fix(renderer): clear saved route after one-shot restoration

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -94,8 +94,8 @@ router.mode.memory();
 const LAST_ROUTE_KEY = 'last-route';
 const SETTINGS_PAGE_KEY = 'settings-page';
 
-const savedRoute = sessionStorage.getItem(LAST_ROUTE_KEY);
-const savedSettingsPage = sessionStorage.getItem(SETTINGS_PAGE_KEY);
+let savedRoute: string | undefined = sessionStorage.getItem(LAST_ROUTE_KEY) ?? undefined;
+let savedSettingsPage: string | undefined = sessionStorage.getItem(SETTINGS_PAGE_KEY) ?? undefined;
 
 //remember from where we come to preference pages
 let nonSettingsPage = savedRoute ?? '/';
@@ -111,9 +111,15 @@ router.subscribe(function (navigation) {
   if (navigation.url === undefined || navigation.url.includes('.html')) return;
   if (!navigation.url.startsWith('/')) return;
 
-  if ((savedRoute !== null || savedSettingsPage !== null) && navigation.url === '/') {
-    if (savedRoute) router.goto(savedRoute);
-    if (savedSettingsPage) router.goto(savedSettingsPage);
+  if ((savedRoute !== undefined || savedSettingsPage !== undefined) && navigation.url === '/') {
+    if (savedRoute) {
+      router.goto(savedRoute);
+      savedRoute = undefined;
+    }
+    if (savedSettingsPage) {
+      router.goto(savedSettingsPage);
+      savedSettingsPage = undefined;
+    }
     return;
   }
 


### PR DESCRIPTION
### What does this PR do?
`savedRoute` and `savedSettingsPage` are captured once at module load and never cleared. Every subsequent navigation to `/` re-triggers restoration, preventing users from intentionally visiting the Dashboard.

Make them mutable and null after restoring so the restore logic fires only once per reload.

### What issues does this PR fix or reference?

This is a port of a bug fix for a Kaiden issue found by coderabbit: https://github.com/openkaiden/kaiden/pull/1907#pullrequestreview-4317664772

### How to test this PR?

- open podman desktop
- navigate to some page
- reload (Ctrl+R)
- try accessing the dashboard

- [ ] Tests are covering the bug fix or the new feature
