### PR TITLE
chore: add trigger for update e2e tests for general code changes

### DIFF
--- a/.github/code-change-patterns.txt
+++ b/.github/code-change-patterns.txt
@@ -1,0 +1,25 @@
+# Patterns to trigger update E2E tests on code changes
+# These are grep patterns that match file paths
+# Lines starting with # are ignored
+
+# Core directories
+^extensions/
+^packages/
+^schemas/
+^scripts/
+^types/
+
+# Build and configuration files
+^\.electron-builder\.config\.cjs$
+^package\.json$
+^pnpm-lock\.yaml$
+^featured\.json$
+^product\.json$
+^svelte\.config\.js$
+^tailwind\.config\.cjs$
+^vitest\.config\.js$
+^playwright\.config\.ts$
+^eslint\.config\.mjs$
+
+# CI/CD workflow files
+^\.github/workflows/pr-check\.yaml$

--- a/.github/code-change-patterns.txt
+++ b/.github/code-change-patterns.txt
@@ -23,3 +23,4 @@
 
 # CI/CD workflow files
 ^\.github/workflows/pr-check\.yaml$
+^\.github/code-change-patterns\.txt$

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -526,11 +526,11 @@ jobs:
 
   detect_pnpm_changes:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci') || !github.event.pull_request.draft }}
+    # name should not change since it is a required rule pattern
     name: Detect pnpm lock or pr-check files changes
     runs-on: ubuntu-24.04
     outputs:
-      pnpm_lock_changed: ${{ steps.pnpm_changed.outputs.PNPM_LOCK_CHANGED }}
-      code_changed: ${{ steps.code_changed.outputs.CODE_CHANGED }}
+      trigger_update_tests: ${{ steps.detect_changes.outputs.TRIGGER_UPDATE_TESTS }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -538,65 +538,38 @@ jobs:
           fetch-depth: 2
 
       - name: Evaluate changes in files
-        id: pnpm_changed
+        id: detect_changes
         run: |
           BASE_REF="${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || 'main' }}"
           BASE_REF="${BASE_REF#refs/heads/}"  # Strip 'refs/heads/' if present
           git fetch origin ${BASE_REF}
           git diff --name-only origin/${BASE_REF} HEAD > changes.txt
-          if grep -q  -e 'pnpm-lock.yaml' -e 'pr-check.yaml' changes.txt; then
-            echo "PNPM_LOCK_CHANGED=true" >> $GITHUB_OUTPUT
-          else
-            echo "PNPM_LOCK_CHANGED=false" >> $GITHUB_OUTPUT
-          fi
 
-      - name: Detect code changes (matching include patterns)
-        id: code_changed
-        run: |
-          BASE_REF="${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || 'main' }}"
-          BASE_REF="${BASE_REF#refs/heads/}"  # Strip 'refs/heads/' if present
-          git fetch origin ${BASE_REF}
-          git diff --name-only origin/${BASE_REF} HEAD > all_changes.txt
-
-          # Define patterns to include for code change detection
-          INCLUDE_PATTERNS=(
-            '^extensions/'
-            '^packages/'
-            '^schemas/'
-            '^scripts/'
-            '^types/'
-            '^\.electron-builder\.config\.cjs$'
-            '^package\.json$'
-            '^featured\.json$'
-            '^product\.json$'
-            '^svelte\.config\.js$'
-            '^tailwind\.config\.cjs$'
-            '^vitest\.config\.js$'
-            '^playwright\.config\.ts$'
-            '^eslint\.config\.mjs$'
-          )
-
-          # Build grep command with inclusion patterns
+          # Read patterns from file and build grep arguments
+          PATTERNS_FILE=".github/code-change-patterns.txt"
           GREP_ARGS=""
-          for pattern in "${INCLUDE_PATTERNS[@]}"; do
-            GREP_ARGS="$GREP_ARGS -e $pattern"
-          done
+          while IFS= read -r line; do
+            # Skip comments and empty lines
+            [[ "$line" =~ ^#.*$ ]] && continue
+            [[ -z "$line" ]] && continue
+            GREP_ARGS="$GREP_ARGS -e $line"
+          done < "$PATTERNS_FILE"
 
           # Check if there are any code changes matching the include patterns
-          if grep $GREP_ARGS all_changes.txt | grep -q .; then
-            echo "CODE_CHANGED=true" >> $GITHUB_OUTPUT
+          if grep $GREP_ARGS changes.txt | grep -q .; then
+            echo "TRIGGER_UPDATE_TESTS=true" >> $GITHUB_OUTPUT
           else
-            echo "CODE_CHANGED=false" >> $GITHUB_OUTPUT
+            echo "TRIGGER_UPDATE_TESTS=false" >> $GITHUB_OUTPUT
           fi
 
   win-update-e2e-test:
     name: ${{ matrix.os }} update e2e tests
     needs: detect_pnpm_changes
-    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true' || needs.detect_pnpm_changes.outputs.code_changed == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.trigger_update_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ needs.detect_pnpm_changes.outputs.code_changed == 'true' && fromJSON('["windows-2025"]') || fromJSON('["windows-2025", "windows-11-arm"]') }}
+        os: ["windows-2025", "windows-11-arm"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -668,11 +641,11 @@ jobs:
   mac-update-e2e-test:
     name: ${{ matrix.os }} update e2e tests
     needs: detect_pnpm_changes
-    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true' || needs.detect_pnpm_changes.outputs.code_changed == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.trigger_update_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ needs.detect_pnpm_changes.outputs.code_changed == 'true' && fromJSON('["macos-26"]') || fromJSON('["macos-26", "macos-15-intel"]') }}
+        os: ["macos-26", "macos-15-intel"]
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -530,6 +530,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       pnpm_lock_changed: ${{ steps.pnpm_changed.outputs.PNPM_LOCK_CHANGED }}
+      code_changed: ${{ steps.code_changed.outputs.CODE_CHANGED }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -549,14 +550,53 @@ jobs:
             echo "PNPM_LOCK_CHANGED=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Detect code changes (matching include patterns)
+        id: code_changed
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref || 'main' }}"
+          BASE_REF="${BASE_REF#refs/heads/}"  # Strip 'refs/heads/' if present
+          git fetch origin ${BASE_REF}
+          git diff --name-only origin/${BASE_REF} HEAD > all_changes.txt
+
+          # Define patterns to include for code change detection
+          INCLUDE_PATTERNS=(
+            '^extensions/'
+            '^packages/'
+            '^schemas/'
+            '^scripts/'
+            '^types/'
+            '^\.electron-builder\.config\.cjs$'
+            '^package\.json$'
+            '^featured\.json$'
+            '^product\.json$'
+            '^svelte\.config\.js$'
+            '^tailwind\.config\.cjs$'
+            '^vitest\.config\.js$'
+            '^playwright\.config\.ts$'
+            '^eslint\.config\.mjs$'
+          )
+
+          # Build grep command with inclusion patterns
+          GREP_ARGS=""
+          for pattern in "${INCLUDE_PATTERNS[@]}"; do
+            GREP_ARGS="$GREP_ARGS -e $pattern"
+          done
+
+          # Check if there are any code changes matching the include patterns
+          if grep $GREP_ARGS all_changes.txt | grep -q .; then
+            echo "CODE_CHANGED=true" >> $GITHUB_OUTPUT
+          else
+            echo "CODE_CHANGED=false" >> $GITHUB_OUTPUT
+          fi
+
   win-update-e2e-test:
     name: ${{ matrix.os }} update e2e tests
     needs: detect_pnpm_changes
-    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true' || needs.detect_pnpm_changes.outputs.code_changed == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2025, windows-11-arm]
+        os: ${{ needs.detect_pnpm_changes.outputs.code_changed == 'true' && fromJSON('["windows-2025"]') || fromJSON('["windows-2025", "windows-11-arm"]') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
@@ -628,11 +668,11 @@ jobs:
   mac-update-e2e-test:
     name: ${{ matrix.os }} update e2e tests
     needs: detect_pnpm_changes
-    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'area/update') || needs.detect_pnpm_changes.outputs.pnpm_lock_changed == 'true' || needs.detect_pnpm_changes.outputs.code_changed == 'true'
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26, macos-15-intel]
+        os: ${{ needs.detect_pnpm_changes.outputs.code_changed == 'true' && fromJSON('["macos-26"]') || fromJSON('["macos-26", "macos-15-intel"]') }}
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What does this PR do?
When important change is being proposed - usually the one with a potential to break app startup or update functions, we would like to run an update e2e tests on windows and mac. This change should be doing exactly that. There is a new file `.github/code-change-patterns.txt` with a list of patterns/globs to watch and trigger update e2e tests.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#16598.
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
