### PR TITLE
feat(podman): add managed config to disable engine updates

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -133,6 +133,12 @@
           "when": "podman.podmanMachineEditRootfulSupported",
           "hidden": true
         },
+        "podman.engine.allowUpdate": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow checking for and registering Podman engine updates",
+          "hidden": true
+        },
         "podman.factory.machine.name": {
           "type": "string",
           "default": "podman-machine-default",

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1693,6 +1693,113 @@ test('should not register update when there are multiple Podman installations', 
   expect(registerUpdateMock).not.toHaveBeenCalled();
 });
 
+test('should not register update when podman.engine.allowUpdate is false', async () => {
+  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: (key: string) => {
+      if (key === 'engine.allowUpdate') {
+        return false;
+      }
+      return undefined;
+    },
+    has: () => true,
+    update: vi.fn(),
+  });
+
+  const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
+  const podmanInstall: PodmanInstall = new PodmanInstall(
+    extensionContext,
+    telemetryLogger,
+    {} as unknown as Installer,
+    undefined,
+    PODMAN_BINARY_MOCK,
+  );
+
+  vi.spyOn(podmanCli, 'findPodmanInstallations').mockResolvedValue(['/usr/local/bin/podman']);
+
+  vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+    hasUpdate: true,
+    bundledVersion: 'v5.0.0',
+    installedVersion: 'v4.9.0',
+  });
+
+  const result = await extension.registerUpdatesIfAny(provider, { version: '4.9.0' }, podmanInstall);
+
+  expect(result).toBeUndefined();
+  expect(podmanInstall.checkForUpdate).not.toHaveBeenCalled();
+  expect(registerUpdateMock).not.toHaveBeenCalled();
+});
+
+test('should register update when podman.engine.allowUpdate is true', async () => {
+  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: (key: string) => {
+      if (key === 'engine.allowUpdate') {
+        return true;
+      }
+      return undefined;
+    },
+    has: () => true,
+    update: vi.fn(),
+  });
+
+  const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
+  const podmanInstall: PodmanInstall = new PodmanInstall(
+    extensionContext,
+    telemetryLogger,
+    {} as unknown as Installer,
+    undefined,
+    PODMAN_BINARY_MOCK,
+  );
+
+  vi.spyOn(podmanCli, 'findPodmanInstallations').mockResolvedValue(['/usr/local/bin/podman']);
+
+  vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+    hasUpdate: true,
+    bundledVersion: 'v5.0.0',
+    installedVersion: 'v4.9.0',
+  });
+
+  await extension.registerUpdatesIfAny(provider, { version: '4.9.0' }, podmanInstall);
+
+  expect(registerUpdateMock).toHaveBeenCalled();
+});
+
+test('should register update when podman.engine.allowUpdate is undefined', async () => {
+  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: () => {
+      return undefined;
+    },
+    has: () => true,
+    update: vi.fn(),
+  });
+
+  const extensionContext = { subscriptions: [], storagePath: '' } as unknown as extensionApi.ExtensionContext;
+  const podmanInstall: PodmanInstall = new PodmanInstall(
+    extensionContext,
+    telemetryLogger,
+    {} as unknown as Installer,
+    undefined,
+    PODMAN_BINARY_MOCK,
+  );
+
+  vi.spyOn(podmanCli, 'findPodmanInstallations').mockResolvedValue(['/usr/local/bin/podman']);
+
+  vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+    hasUpdate: true,
+    bundledVersion: 'v5.0.0',
+    installedVersion: 'v4.9.0',
+  });
+
+  await extension.registerUpdatesIfAny(provider, { version: '4.9.0' }, podmanInstall);
+
+  expect(registerUpdateMock).toHaveBeenCalled();
+});
+
 test('should register update when there is single Podman installation', async () => {
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1016,6 +1016,11 @@ export async function registerUpdatesIfAny(
   installedPodman: InstalledPodman | undefined,
   podmanInstall: PodmanInstall,
 ): Promise<extensionApi.Disposable | undefined> {
+  const allowUpdate = extensionApi.configuration.getConfiguration('podman').get<boolean>('engine.allowUpdate') ?? true;
+  if (!allowUpdate) {
+    return undefined;
+  }
+
   const updateInfo = await podmanInstall.checkForUpdate(installedPodman);
   const warnings = await getMultiplePodmanInstallationsWarnings(installedPodman);
   if (updateInfo.hasUpdate && updateInfo.bundledVersion && warnings.length === 0) {


### PR DESCRIPTION
feat(podman): add managed config to disable engine updates

### What does this PR do?

Adds a hidden `podman.engine.allowUpdate` boolean setting
(default `true`).

When set to `false` via managed configuration
(`locked.json`), the Podman extension skips registering updates
so the update button never appears on the Resources page.

### Screenshot / video of UI

N/A - hidden setting, update button simply does not appear when disabled

### What issues does this PR fix or reference?

Closes #16484

### How to test this PR?

1. Create `locked.json` with `{"locked": ["podman.engine.allowUpdate"]}`
   and `default-settings.json` with `{"podman.engine.allowUpdate": false}`
   in the managed config directory
2. Start Podman Desktop with an outdated bundled Podman version
3. Verify the "Update to vX.X.X" button does not appear on the Resources page

- [x] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
