### PR TITLE
fix(main): resolve feedback dialog race condition on startup

### DIFF
--- a/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
@@ -167,18 +167,17 @@ describe('init', () => {
     expect(setReminderSpy).not.toBeCalled();
   });
 
-  test('should load existing configurations and show dialog', async () => {
+  test('should load existing configurations without showing dialog', async () => {
     const conf = { remindAt: 123456, disabled: false };
     configurationGetMock.mockReturnValue(conf);
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
-    const showFeedbackDialogSpy = vi.spyOn(feedbackForm, 'showFeedbackDialog').mockResolvedValue(undefined);
     await feedbackForm.init();
 
     expect(setReminderSpy).not.toHaveBeenCalled();
 
     expect(feedbackForm.experimentalFeatures.get('feat.feature1')).toEqual(conf);
-    expect(showFeedbackDialogSpy).toBeCalled();
+    expect(messageBox.showMessageBox).not.toHaveBeenCalled();
   });
 
   test(`should skip disabled features with 'false' value`, async () => {
@@ -196,6 +195,30 @@ describe('init', () => {
     expect(setSpy).not.toHaveBeenCalled();
     expect(saveSpy).not.toHaveBeenCalled();
     expect(feedbackForm.experimentalFeatures.get('feat.feature1')).toBe(undefined);
+  });
+
+  test('should load features with past remindAt and show dialog when showFeedbackDialog is called separately', async () => {
+    vi.useFakeTimers();
+    const MOCK_NOW = new Date('2026-05-01T12:00:00.000Z');
+    vi.setSystemTime(MOCK_NOW);
+
+    const pastTimestamp = new Date('2025-12-28T00:00:00.000Z').getTime();
+    const conf = { remindAt: pastTimestamp, disabled: false };
+    configurationGetMock.mockReturnValue(conf);
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
+    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
+    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 1 });
+
+    // init() should only populate the map, not show dialog
+    await feedbackForm.init();
+    expect(messageBox.showMessageBox).not.toHaveBeenCalled();
+    expect(feedbackForm.experimentalFeatures.get('feat.feature1')).toEqual(conf);
+
+    // showFeedbackDialog() called separately should show the dialog
+    await feedbackForm.showFeedbackDialog();
+    expect(messageBox.showMessageBox).toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 });
 

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -123,8 +123,6 @@ export class ExperimentalFeatureFeedbackHandler {
         this.setReminder(configurationKey);
       }
     }
-    // When are all features set, show dialog
-    await this.showFeedbackDialog();
   }
 
   /**
@@ -175,7 +173,7 @@ export class ExperimentalFeatureFeedbackHandler {
   /**
    * Goes through each enabled experimental feature and shows dialog if current timestamp is greater than stored value
    */
-  protected async showFeedbackDialog(): Promise<void> {
+  async showFeedbackDialog(): Promise<void> {
     const configurationProperties = this.#configurationRegistry.getConfigurationProperties();
     const feedbackEnabled = this.#configurationRegistry.getConfiguration('feedback').get<boolean>('dialog', true);
     if (!feedbackEnabled) {

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -41,6 +41,7 @@ import { ContainerProviderRegistry } from './container-registry.js';
 import { DefaultConfiguration } from './default-configuration.js';
 import { Directories } from './directories.js';
 import { Emitter } from './events/emitter.js';
+import { ExperimentalFeatureFeedbackHandler } from './experimental-feature-feedback-handler.js';
 import { ImageRegistry } from './image-registry.js';
 import type { LoggerWithEnd } from './index.js';
 import { PluginSystem } from './index.js';
@@ -1158,4 +1159,17 @@ describe('container-provider-registry:playKube', () => {
     expect(createdTask.status).toBe('failure');
     expect(createdTask.error).toBe('Error: Dummy Foo');
   });
+});
+
+test('feedback:triggerStartupDialogs calls showFeedbackDialog', async () => {
+  const handle = handlers.get('feedback:triggerStartupDialogs');
+  expect(handle).toBeDefined();
+
+  const showFeedbackDialogSpy = vi
+    .spyOn(ExperimentalFeatureFeedbackHandler.prototype, 'showFeedbackDialog')
+    .mockResolvedValue();
+
+  await handle(undefined);
+
+  expect(showFeedbackDialogSpy).toHaveBeenCalledOnce();
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -858,6 +858,10 @@ export class PluginSystem {
     );
     await experimentalFeatureFeedbackHandler.init();
 
+    this.ipcHandle('feedback:triggerStartupDialogs', async (): Promise<void> => {
+      await experimentalFeatureFeedbackHandler.showFeedbackDialog();
+    });
+
     await this.setupSecurityRestrictionsOnLinks(messageBox);
 
     this.ipcHandle('tasks:clear-all', async (): Promise<void> => {

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -305,6 +305,16 @@ describe('collect calls to exposeInMainWorld and ipcRenderer.on and calls initEx
     expect(logger).toHaveBeenCalledWith('key1', 'log', data);
   });
 
+  test('triggerStartupFeedbackDialogs', async () => {
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
+
+    const triggerStartupFeedbackDialogsExposure = getInMainWorld('triggerStartupFeedbackDialogs');
+
+    await triggerStartupFeedbackDialogsExposure();
+
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('feedback:triggerStartupDialogs');
+  });
+
   test('logger passed to deleteProviderConnectionLifecycle is called during provider-registry:taskConnection-onData', async () => {
     vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
     const deleteProviderConnectionLifecycleExposure = getInMainWorld('deleteProviderConnectionLifecycle');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -259,6 +259,10 @@ export function initExposure(): void {
     return ipcInvoke('extension-system:isExtensionsStarted');
   });
 
+  contextBridge.exposeInMainWorld('triggerStartupFeedbackDialogs', async (): Promise<void> => {
+    return ipcInvoke('feedback:triggerStartupDialogs');
+  });
+
   contextBridge.exposeInMainWorld('getDashboardSystemOverviewStatus', async (): Promise<SystemOverviewStatusInfo> => {
     return ipcInvoke('dashboard:getSystemOverviewStatus');
   });

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -4,6 +4,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 
 import type { KubernetesNavigationRequest, NavigationRequest } from '@podman-desktop/core-api';
 import { tablePersistence } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { parseExtensionListRequest } from '/@/lib/extensions/extension-list';
@@ -154,6 +155,10 @@ window.events?.receive('kubernetes-navigation', (args: unknown) => {
 
 // Initialize table persistence callbacks immediately
 tablePersistence.storage = new PodmanDesktopStoragePersist();
+
+onMount(async () => {
+  await window.triggerStartupFeedbackDialogs();
+});
 </script>
 
 <Route path="/*" breadcrumb="Home" let:meta>


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition that prevented the experimental feature feedback dialog from ever being shown on startup.

**Root cause:** `showFeedbackDialog()` was called inside `init()`, which runs before the renderer is fully mounted. The `showMessageBox:open` event was queued and flushed in the same synchronous batch as `starting-extensions`, so `<MessageBox />` component wasn't listening yet when the event fired — the event was lost.

**Fix:** Switch from a push pattern (fire-and-forget event during init) to a pull pattern:
1. `init()` now only populates the experimental features map without showing any dialogs
2. A new IPC handler `feedback:triggerStartupDialogs` is registered in the main process
3. The renderer triggers the dialog via IPC from `App.svelte`'s `onMount`, which guarantees `MessageBox` is already mounted and listening (Svelte mounts children before parent)

### Screenshot / video of UI

<!-- The feedback dialog now correctly appears on startup when `remindAt` timestamp is in the past -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17221

### How to test this PR?

1. Enable an experimental feature (e.g., "Show providers in the status bar") in Settings > Experimental
2. Close the application
3. Edit `settings.json` and set `remindAt` to a past timestamp (e.g., `1700000000000`), `disabled: false`
4. Start the application
5. **Expected:** The "Share Feedback" dialog appears

Additional scenarios verified:
- "Remind me tomorrow" sets `remindAt` to ~+1 day
- "Remind me in 2 days" sets `remindAt` to ~+2 days
- "Don't show again" sets `disabled: true`, dialog no longer appears
- "Share Feedback on GitHub" opens the link and clears `remindAt`
- Global `feedback.dialog: false` suppresses the dialog
- First-time feature enable sets `remindAt` ~2 days in the future

- [x] Tests are covering the bug fix or the new feature