### PR TITLE
feat: add theme-aware icon component

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -12,6 +12,7 @@ import {
   eventCollect,
   registerConnectionCallback,
 } from './preferences-connection-rendering-task';
+import ThemedIcon from './ThemedIcon.svelte';
 import type { ILoadingStatus } from './Util';
 
 export let cliTool: CliToolInfo;
@@ -149,10 +150,9 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
       <div class="min-w-[170px] max-w-[200px] h-full flex flex-col justify-between">
         <div class="flex flex-row">
           {#if cliTool?.images?.icon ?? cliTool?.extensionInfo.icon}
-            {#if typeof cliTool.images?.icon === 'string'}
-              <img
-                src={cliTool.images.icon}
-                aria-label="cli-logo"
+            {#if cliTool?.images?.icon}
+              <ThemedIcon
+                icon={cliTool.images.icon}
                 alt="{cliTool.name} logo"
                 class="max-w-[40px] max-h-[40px] h-full" />
             {:else if typeof cliTool.extensionInfo.icon === 'string'}

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.spec.ts
@@ -141,12 +141,12 @@ suite('CLI Tool Prefernces page shows', () => {
   });
 
   test('tool`s logo is not shown if images.icon property is not present or images property is empty', () => {
-    expect(within(cliToolRows[0]).queryAllByLabelText('cli-logo').length).equals(0);
-    expect(within(cliToolRows[1]).queryAllByLabelText('cli-logo').length).equals(0);
+    expect(within(cliToolRows[0]).queryAllByAltText(/logo/).length).equals(0);
+    expect(within(cliToolRows[1]).queryAllByAltText(/logo/).length).equals(0);
   });
 
   test('tool`s logo is shown when images.icon property is present', () => {
-    expect(within(cliToolRows[2]).getAllByLabelText('cli-logo').length).equals(1);
+    expect(within(cliToolRows[2]).getAllByAltText(/logo/).length).equals(1);
   });
 
   test('test tools version is shown', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -42,6 +42,7 @@ import PreferencesProviderInstallationModal from './PreferencesProviderInstallat
 import PreferencesResourcesRenderingCopyButton from './PreferencesResourcesRenderingCopyButton.svelte';
 import ProviderActionButtons from './ProviderActionButtons.svelte';
 import SettingsPage from './SettingsPage.svelte';
+import ThemedIcon from './ThemedIcon.svelte';
 import {
   getProviderConnectionName,
   type IConnectionRestart,
@@ -480,14 +481,7 @@ $effect(() => {
           <!-- left col - provider icon/name + "create new" button -->
           <div class="min-w-[170px] max-w-[200px] pr-5 py-2">
             <div class="flex">
-              {#if provider.images.icon}
-                {#if typeof provider.images.icon === 'string'}
-                  <img src={provider.images.icon} alt={provider.name} class="max-w-[40px] h-full" />
-                  <!-- TODO check theme used for image, now use dark by default -->
-                {:else}
-                  <img src={provider.images.icon.dark} alt={provider.name} class="max-w-[40px]" />
-                {/if}
-              {/if}
+              <ThemedIcon icon={provider.images.icon} alt={provider.name} class="max-w-[40px]" />
               <span class="my-auto font-semibold text-[var(--pd-invert-content-card-header-text)] ml-3 break-words"
                 >{provider.name}</span>
               {#if provider.version}

--- a/packages/renderer/src/lib/preferences/ThemedIcon.svelte
+++ b/packages/renderer/src/lib/preferences/ThemedIcon.svelte
@@ -1,0 +1,31 @@
+<!--
+  Renders an icon with theme-aware light/dark support.
+  - String icons render as-is
+  - Object icons use light variant on light theme, dark variant on dark theme
+  - Falls back to alternate variant if preferred variant is missing
+-->
+<script lang="ts">
+import { isDark } from '/@/stores/appearance';
+
+interface Props {
+  icon: string | { light?: string; dark?: string } | undefined;
+  alt: string;
+  class?: string;
+}
+
+let { icon, alt, class: className = '' }: Props = $props();
+
+function getThemedSrc(icon: string | { light?: string; dark?: string } | undefined): string | undefined {
+  if (!icon) return undefined;
+  if (typeof icon === 'string') return icon;
+
+  return $isDark ? (icon.dark ?? icon.light) : (icon.light ?? icon.dark);
+}
+</script>
+
+{#if icon}
+  {@const src = getThemedSrc(icon)}
+  {#if src}
+    <img {src} {alt} class={className} />
+  {/if}
+{/if}

--- a/packages/renderer/src/lib/preferences/ThemedIcon.svelte.spec.ts
+++ b/packages/renderer/src/lib/preferences/ThemedIcon.svelte.spec.ts
@@ -1,0 +1,117 @@
+import { render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { isDark } from '/@/stores/appearance';
+
+import ThemedIcon from './ThemedIcon.svelte';
+
+describe('ThemedIcon.svelte', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('renders nothing when icon is undefined', () => {
+    const { container } = render(ThemedIcon, {
+      props: {
+        icon: undefined,
+        alt: 'test',
+      },
+    });
+
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  test('renders string icon as-is', () => {
+    const { container } = render(ThemedIcon, {
+      props: {
+        icon: '/path/to/icon.png',
+        alt: 'test icon',
+      },
+    });
+
+    const img = container.querySelector('img');
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute('src')).toBe('/path/to/icon.png');
+    expect(img?.getAttribute('alt')).toBe('test icon');
+  });
+
+  test('renders dark variant in dark mode', () => {
+    isDark.set(true);
+
+    const { container } = render(ThemedIcon, {
+      props: {
+        icon: { light: '/light.png', dark: '/dark.png' },
+        alt: 'themed icon',
+      },
+    });
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('/dark.png');
+  });
+
+  test('renders light variant in light mode', () => {
+    isDark.set(false);
+
+    const { container } = render(ThemedIcon, {
+      props: {
+        icon: { light: '/light.png', dark: '/dark.png' },
+        alt: 'themed icon',
+      },
+    });
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('/light.png');
+  });
+
+  test('falls back to light variant when dark is missing in dark mode', () => {
+    isDark.set(true);
+
+    const { container } = render(ThemedIcon, {
+      props: {
+        icon: { light: '/light.png', dark: undefined },
+        alt: 'themed icon',
+      },
+    });
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('/light.png');
+  });
+
+  test('falls back to dark variant when light is missing in light mode', () => {
+    isDark.set(false);
+
+    const { container } = render(ThemedIcon, {
+      props: {
+        icon: { light: undefined, dark: '/dark.png' },
+        alt: 'themed icon',
+      },
+    });
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('/dark.png');
+  });
+
+  test('renders nothing when both variants are missing', () => {
+    const { container } = render(ThemedIcon, {
+      props: {
+        icon: { light: undefined, dark: undefined },
+        alt: 'themed icon',
+      },
+    });
+
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  test('applies custom class to img element', () => {
+    const { container } = render(ThemedIcon, {
+      props: {
+        icon: '/icon.png',
+        alt: 'test',
+        class: 'max-h-10 custom-class',
+      },
+    });
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('class')).toBe('max-h-10 custom-class');
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Create ThemedIcon component for centralized light/dark icon selection
with automatic fallback. Update Resources page and CLI tool rendering
to use theme-aware icons.

- New ThemedIcon component handles light/dark selection and fallback
- Refactor PreferencesResourcesRendering and PreferencesCliTool
- Add unit tests for ThemedIcon

### What issues does this PR fix or reference?
required fix for downstream kaiden (see https://github.com/openkaiden/kaiden/issues/1477 and https://github.com/openkaiden/kaiden/pull/1955)

### How to test this PR?
Check extension icons look good in both dark and light themes

- [x] Tests are covering the bug fix or the new feature
