### PR TITLE
fix: toolbar buttons use semantic color tokens instead of button-primary-bg

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -114,6 +114,10 @@ class TestColorRegistry extends ColorRegistry {
   override initProgressBar(): void {
     super.initProgressBar();
   }
+
+  override initActionButton(): void {
+    super.initActionButton();
+  }
 }
 
 const _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
@@ -1739,6 +1743,35 @@ describe('initProgressBar', () => {
       light: tailwindColorPalette.accent1[500],
       hcDark: tailwindColorPalette.white,
       hcLight: tailwindColorPalette.black,
+    });
+  });
+});
+
+describe('initActionButton', () => {
+  let spyOnRegisterColor: MockInstance<(colorId: string, definition: ColorDefinition) => void>;
+
+  beforeEach(() => {
+    spyOnRegisterColor = vi.spyOn(colorRegistry, 'registerColor');
+    spyOnRegisterColor.mockReturnValue(undefined);
+
+    colorRegistry.initActionButton();
+  });
+
+  test('registers action-button-primary-text with hcDark and hcLight', () => {
+    expect(spyOnRegisterColor).toBeCalledWith('action-button-primary-text', {
+      dark: tailwindColorPalette.gray[275],
+      light: tailwindColorPalette.accent1[500],
+      hcDark: tailwindColorPalette.accent1[500],
+      hcLight: tailwindColorPalette.accent1[700],
+    });
+  });
+
+  test('registers action-button-primary-hover-text with hcDark and hcLight', () => {
+    expect(spyOnRegisterColor).toBeCalledWith('action-button-primary-hover-text', {
+      dark: tailwindColorPalette.gray[275],
+      light: tailwindColorPalette.accent1[500],
+      hcDark: tailwindColorPalette.accent1[500],
+      hcLight: tailwindColorPalette.accent1[700],
     });
   });
 });

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -1615,13 +1615,17 @@ export class ColorRegistry {
     });
 
     this.registerColor(`${ab}primary-text`, {
-      dark: accent1[400],
+      dark: gray[275],
       light: accent1[500],
+      hcDark: accent1[500],
+      hcLight: accent1[700],
     });
 
     this.registerColor(`${ab}primary-hover-text`, {
-      dark: accent1[400],
+      dark: gray[275],
       light: accent1[500],
+      hcDark: accent1[500],
+      hcLight: accent1[700],
     });
 
     this.registerColor(`${ab}disabled-text`, {

--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
@@ -56,7 +56,7 @@ async function clear(): Promise<void> {
 <div class="absolute top-0 right-2 px-1 z-50 m-1 opacity-50 space-x-1">
   <button title="Clear logs" onclick={clear} class="">
     <Icon
-      class="cursor-pointer rounded-full bg-[var(--pd-button-disabled)] min-h-8 w-8 p-1.5 hover:bg-[var(--pd-button-primary-hover-bg)]"
+      class="cursor-pointer rounded-full bg-[var(--pd-button-disabled)] min-h-8 w-8 p-1.5 hover:bg-[var(--pd-button-close-hover-bg)]"
       icon={faEraser}
     />
   </button>

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -85,7 +85,7 @@ async function openGitHub(): Promise<void> {
           size="1.5x"
           class="cursor-pointer {smileyRating === 1
             ? 'text-(--pd-action-button-primary-text)'
-            : 'text-[var(--pd-button-disabled-text)]'}"
+            : 'text-(--pd-button-disabled-text)'}"
           icon={faFrown} />
       </button>
       <button aria-label="sad-smiley" onclick={(): void => selectSmiley(2)}>
@@ -93,7 +93,7 @@ async function openGitHub(): Promise<void> {
           size="1.5x"
           class="cursor-pointer {smileyRating === 2
             ? 'text-(--pd-action-button-primary-text)'
-            : 'text-[var(--pd-button-disabled-text)]'}"
+            : 'text-(--pd-button-disabled-text)'}"
           icon={faMeh} />
       </button>
       <button aria-label="happy-smiley" onclick={(): void => selectSmiley(3)}>
@@ -101,7 +101,7 @@ async function openGitHub(): Promise<void> {
           size="1.5x"
           class="cursor-pointer {smileyRating === 3
             ? 'text-(--pd-action-button-primary-text)'
-            : 'text-[var(--pd-button-disabled-text)]'}"
+            : 'text-(--pd-button-disabled-text)'}"
           icon={faSmile} />
       </button>
       <button aria-label="very-happy-smiley" onclick={(): void => selectSmiley(4)}>
@@ -109,7 +109,7 @@ async function openGitHub(): Promise<void> {
           size="1.5x"
           class="cursor-pointer {smileyRating === 4
             ? 'text-(--pd-action-button-primary-text)'
-            : 'text-[var(--pd-button-disabled-text)]'}"
+            : 'text-(--pd-button-disabled-text)'}"
           icon={faGrinStars} />
       </button>
     </div>

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -84,7 +84,7 @@ async function openGitHub(): Promise<void> {
         <Icon
           size="1.5x"
           class="cursor-pointer {smileyRating === 1
-            ? 'text-[var(--pd-action-button-primary-text)]'
+            ? 'text-(--pd-action-button-primary-text)'
             : 'text-[var(--pd-button-disabled-text)]'}"
           icon={faFrown} />
       </button>
@@ -92,7 +92,7 @@ async function openGitHub(): Promise<void> {
         <Icon
           size="1.5x"
           class="cursor-pointer {smileyRating === 2
-            ? 'text-[var(--pd-action-button-primary-text)]'
+            ? 'text-(--pd-action-button-primary-text)'
             : 'text-[var(--pd-button-disabled-text)]'}"
           icon={faMeh} />
       </button>
@@ -100,7 +100,7 @@ async function openGitHub(): Promise<void> {
         <Icon
           size="1.5x"
           class="cursor-pointer {smileyRating === 3
-            ? 'text-[var(--pd-action-button-primary-text)]'
+            ? 'text-(--pd-action-button-primary-text)'
             : 'text-[var(--pd-button-disabled-text)]'}"
           icon={faSmile} />
       </button>
@@ -108,7 +108,7 @@ async function openGitHub(): Promise<void> {
         <Icon
           size="1.5x"
           class="cursor-pointer {smileyRating === 4
-            ? 'text-[var(--pd-action-button-primary-text)]'
+            ? 'text-(--pd-action-button-primary-text)'
             : 'text-[var(--pd-button-disabled-text)]'}"
           icon={faGrinStars} />
       </button>

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -84,7 +84,7 @@ async function openGitHub(): Promise<void> {
         <Icon
           size="1.5x"
           class="cursor-pointer {smileyRating === 1
-            ? 'text-[var(--pd-button-primary-bg)]'
+            ? 'text-[var(--pd-action-button-primary-text)]'
             : 'text-[var(--pd-button-disabled-text)]'}"
           icon={faFrown} />
       </button>
@@ -92,7 +92,7 @@ async function openGitHub(): Promise<void> {
         <Icon
           size="1.5x"
           class="cursor-pointer {smileyRating === 2
-            ? 'text-[var(--pd-button-primary-bg)]'
+            ? 'text-[var(--pd-action-button-primary-text)]'
             : 'text-[var(--pd-button-disabled-text)]'}"
           icon={faMeh} />
       </button>
@@ -100,7 +100,7 @@ async function openGitHub(): Promise<void> {
         <Icon
           size="1.5x"
           class="cursor-pointer {smileyRating === 3
-            ? 'text-[var(--pd-button-primary-bg)]'
+            ? 'text-[var(--pd-action-button-primary-text)]'
             : 'text-[var(--pd-button-disabled-text)]'}"
           icon={faSmile} />
       </button>
@@ -108,7 +108,7 @@ async function openGitHub(): Promise<void> {
         <Icon
           size="1.5x"
           class="cursor-pointer {smileyRating === 4
-            ? 'text-[var(--pd-button-primary-bg)]'
+            ? 'text-[var(--pd-action-button-primary-text)]'
             : 'text-[var(--pd-button-disabled-text)]'}"
           icon={faGrinStars} />
       </button>

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -32,7 +32,7 @@ async function openLink(): Promise<void> {
     {/if}
   </div>
   <div class="grid grid-cols-{activeCount !== undefined ? '3' : '2'} gap-4 w-full grow items-end">
-    <div class="justify-self-center text-[var(--pd-action-button-primary-text)]"><KubernetesIcon kind={kind} size='40'/></div>
+    <div class="justify-self-center text-(--pd-action-button-primary-text)"><KubernetesIcon kind={kind} size="40"/></div>
     {#if activeCount !== undefined}
     <div class="flex flex-col">
       <span class="text-[var(--pd-invert-content-card-text)]">Active</span>

--- a/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboardResourceCard.svelte
@@ -32,7 +32,7 @@ async function openLink(): Promise<void> {
     {/if}
   </div>
   <div class="grid grid-cols-{activeCount !== undefined ? '3' : '2'} gap-4 w-full grow items-end">
-    <div class="justify-self-center text-[var(--pd-button-primary-bg)]"><KubernetesIcon kind={kind} size='40'/></div>
+    <div class="justify-self-center text-[var(--pd-action-button-primary-text)]"><KubernetesIcon kind={kind} size='40'/></div>
     {#if activeCount !== undefined}
     <div class="flex flex-col">
       <span class="text-[var(--pd-invert-content-card-text)]">Active</span>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -47,9 +47,9 @@ async function copyLogsToClipboard(): Promise<void> {
     <div class="text-xl">Logs</div>
     <div class="flex flex-1 justify-end items-center gap-1">
       <Button title="Toggle Timestamps" on:click={async (): Promise<void> => { showTimestamps = !showTimestamps; await window.updateConfigurationValue(TIMESTAMPS_CONFIG_KEY, showTimestamps); }} type="link"
-        ><Icon class="h-5 w-5 cursor-pointer text-xl {showTimestamps ? 'text-[var(--pd-button-primary-bg)]' : 'text-[var(--pd-content-text)]'}" icon={faClock} /></Button>
+        ><Icon class="h-5 w-5 cursor-pointer text-xl {showTimestamps ? 'text-[var(--pd-action-button-primary-text)]' : 'text-[var(--pd-content-text)]'}" icon={faClock} /></Button>
       <Button title="Copy To Clipboard" on:click={async (): Promise<void> => await copyLogsToClipboard()} type="link"
-        ><Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faPaste} /></Button>
+        ><Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-action-button-primary-text)]" icon={faPaste} /></Button>
     </div>
   </div>
   {#if logs.length > 0}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -47,9 +47,9 @@ async function copyLogsToClipboard(): Promise<void> {
     <div class="text-xl">Logs</div>
     <div class="flex flex-1 justify-end items-center gap-1">
       <Button title="Toggle Timestamps" on:click={async (): Promise<void> => { showTimestamps = !showTimestamps; await window.updateConfigurationValue(TIMESTAMPS_CONFIG_KEY, showTimestamps); }} type="link"
-        ><Icon class="h-5 w-5 cursor-pointer text-xl {showTimestamps ? 'text-[var(--pd-action-button-primary-text)]' : 'text-[var(--pd-content-text)]'}" icon={faClock} /></Button>
+        ><Icon class="h-5 w-5 cursor-pointer text-xl {showTimestamps ? 'text-(--pd-action-button-primary-text)' : 'text-(--pd-content-text)'}" icon={faClock} /></Button>
       <Button title="Copy To Clipboard" on:click={async (): Promise<void> => await copyLogsToClipboard()} type="link"
-        ><Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-action-button-primary-text)]" icon={faPaste} /></Button>
+        ><Icon class="h-5 w-5 cursor-pointer text-xl text-(--pd-action-button-primary-text)" icon={faPaste} /></Button>
     </div>
   </div>
   {#if logs.length > 0}

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageKubernetes.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageKubernetes.svelte
@@ -22,7 +22,7 @@ async function refresh(): Promise<void> {
     <div role="status" aria-label="stores" class="text-xl">Kubernetes monitoring</div>
     <div class="flex flex-1 justify-end">
       <Button title="Refresh" class="ml-5" on:click={refresh} type="link"
-        ><Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faRefresh} /></Button>
+        ><Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-action-button-primary-text)]" icon={faRefresh} /></Button>
     </div>
   </div>
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageKubernetes.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageKubernetes.svelte
@@ -22,7 +22,7 @@ async function refresh(): Promise<void> {
     <div role="status" aria-label="stores" class="text-xl">Kubernetes monitoring</div>
     <div class="flex flex-1 justify-end">
       <Button title="Refresh" class="ml-5" on:click={refresh} type="link"
-        ><Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-action-button-primary-text)]" icon={faRefresh} /></Button>
+        ><Icon class="h-5 w-5 cursor-pointer text-xl text-(--pd-action-button-primary-text)" icon={faRefresh} /></Button>
     </div>
   </div>
 

--- a/packages/renderer/src/lib/ui/RefreshButton.spec.ts
+++ b/packages/renderer/src/lib/ui/RefreshButton.spec.ts
@@ -32,8 +32,8 @@ test('Expect basic styling', async () => {
   const button = screen.getByRole('button', { name: label });
   expect(button).toBeInTheDocument();
   expect(button).toHaveAttribute('title', label);
-  expect(button).toHaveClass('text-[var(--pd-action-button-primary-text)]');
-  expect(button).toHaveClass('hover:text-[var(--pd-action-button-primary-hover-text)]');
+  expect(button).toHaveClass('text-(--pd-action-button-primary-text)');
+  expect(button).toHaveClass('hover:text-(--pd-action-button-primary-hover-text)');
 });
 
 test('Expect click', async () => {

--- a/packages/renderer/src/lib/ui/RefreshButton.spec.ts
+++ b/packages/renderer/src/lib/ui/RefreshButton.spec.ts
@@ -32,8 +32,8 @@ test('Expect basic styling', async () => {
   const button = screen.getByRole('button', { name: label });
   expect(button).toBeInTheDocument();
   expect(button).toHaveAttribute('title', label);
-  expect(button).toHaveClass('text-[var(--pd-button-primary-bg)]');
-  expect(button).toHaveClass('hover:text-[var(--pd-button-primary-hover-bg)]');
+  expect(button).toHaveClass('text-[var(--pd-action-button-primary-text)]');
+  expect(button).toHaveClass('hover:text-[var(--pd-action-button-primary-hover-text)]');
 });
 
 test('Expect click', async () => {

--- a/packages/renderer/src/lib/ui/RefreshButton.svelte
+++ b/packages/renderer/src/lib/ui/RefreshButton.svelte
@@ -9,7 +9,7 @@ let { label, onclick }: Props = $props();
 <button
   onclick={onclick}
   title={label}
-  class="text-xs text-[var(--pd-button-primary-bg)] hover:text-[var(--pd-button-primary-hover-bg)]"
+  class="text-xs text-[var(--pd-action-button-primary-text)] hover:text-[var(--pd-action-button-primary-hover-text)]"
   aria-label={label}>
   <i class="fas fa-undo" aria-hidden="true"></i>
 </button>

--- a/packages/renderer/src/lib/ui/RefreshButton.svelte
+++ b/packages/renderer/src/lib/ui/RefreshButton.svelte
@@ -9,7 +9,7 @@ let { label, onclick }: Props = $props();
 <button
   onclick={onclick}
   title={label}
-  class="text-xs text-[var(--pd-action-button-primary-text)] hover:text-[var(--pd-action-button-primary-hover-text)]"
+  class="text-xs text-(--pd-action-button-primary-text) hover:text-(--pd-action-button-primary-hover-text)"
   aria-label={label}>
   <i class="fas fa-undo" aria-hidden="true"></i>
 </button>

--- a/packages/ui/src/lib/button/CloseButton.spec.ts
+++ b/packages/ui/src/lib/button/CloseButton.spec.ts
@@ -37,7 +37,7 @@ test('Check button styling', async () => {
   expect(button).toHaveClass('no-underline');
   expect(button).toHaveClass('cursor-pointer');
   expect(button).toHaveClass('outline-transparent');
-  expect(button).toHaveClass('focus:outline-[var(--pd-button-primary-hover-bg)]');
+  expect(button).toHaveClass('focus:outline-[var(--pd-button-focus-ring)]');
 
   const img = within(button).getByRole('img', { hidden: true });
   expect(img).toBeInTheDocument();

--- a/packages/ui/src/lib/button/CloseButton.svelte
+++ b/packages/ui/src/lib/button/CloseButton.svelte
@@ -21,7 +21,7 @@ const dispatch = createEventDispatcher<{ click: undefined }>();
 
 <button
   type="button"
-  class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-primary-hover-bg)] {className}"
+  class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-focus-ring)] {className}"
   onclick={onclick}
   title="Close"
   aria-label="Close">

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -91,7 +91,7 @@ let copyTextDivElement = $state<HTMLDivElement>();
           {commandline}
         </div>
         <Button title="Copy To Clipboard" class="ml-5" on:click={handleClick} type="link">
-          <Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-button-primary-bg)]" icon={faPaste}/>
+          <Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-action-button-primary-text)]" icon={faPaste}/>
         </Button>
       </div>
     {/if}

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -91,7 +91,7 @@ let copyTextDivElement = $state<HTMLDivElement>();
           {commandline}
         </div>
         <Button title="Copy To Clipboard" class="ml-5" on:click={handleClick} type="link">
-          <Icon class="h-5 w-5 cursor-pointer text-xl text-[var(--pd-action-button-primary-text)]" icon={faPaste}/>
+          <Icon class="h-5 w-5 cursor-pointer text-xl text-(--pd-action-button-primary-text)" icon={faPaste}/>
         </Button>
       </div>
     {/if}


### PR DESCRIPTION
### What does this PR do?

Toolbar icon buttons across the codebase were using `--pd-button-primary-bg` (a background color token) as their text/icon color. This is semantically incorrect and causes very low contrast in high-contrast dark mode because `button-primary-bg` resolves to a dark accent value against dark backgrounds.

This PR:
- Replaces `text-[var(--pd-button-primary-bg)]` with `text-[var(--pd-action-button-primary-text)]` in all toolbar/action icon buttons
- Adds `hcDark` and `hcLight` values to `action-button-primary-text` and `action-button-primary-hover-text` tokens
- Fixes `CloseButton` focus ring to use `--pd-button-focus-ring` instead of `--pd-button-primary-hover-bg`
   Fixes `ContainerDetailsLogsClear` hover background to use `--pd-button-close-hover-bg`

### Screenshot / video of UI

<img width="2554" height="2652" alt="image" src="https://github.com/user-attachments/assets/77793171-4d86-40b2-be07-c5139ebbcedc" />

### What issues does this PR fix or reference?

- Resolves: #17375

### How to test this PR?

1. Build and run Podman Desktop
2. Switch between dark, light, hc-dark, and hc-light themes
3. Verify toolbar icon buttons are visible with good contrast in all themes:
   - Refresh buttons (e.g. on Kubernetes troubleshooting page)
   - Copy-to-clipboard buttons (e.g. on empty screens, troubleshooting logs)
   - Feedback smiley icons (Help → Report a Bug / Feature)
   - Kubernetes dashboard resource card icons
   - Close button focus ring (tab to a close button)
   - Container logs clear button hover state
4. Run unit tests: `pnpm exec vitest run packages/main/src/plugin/color-registry.spec.ts`

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>