### PR TITLE
feat(ci): automate SchemaStore sync for extension schema 

### DIFF
--- a/.github/workflows/schemastore-sync-extension-schema.yaml
+++ b/.github/workflows/schemastore-sync-extension-schema.yaml
@@ -1,0 +1,143 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Sync extension schema to SchemaStore
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Prepare release metadata
+    runs-on: ubuntu-24.04
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      schemaMinorVersion: ${{ steps.version.outputs.schemaMinorVersion }}
+    steps:
+      - name: Resolve tag and release type
+        id: version
+        run: |
+          echo "GITHUB_REF=${GITHUB_REF}"
+          echo "GITHUB_REF_TYPE=${GITHUB_REF_TYPE}"
+          echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"
+
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "This workflow only supports tag refs."
+            exit 1
+          fi
+
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          SCHEMA_MINOR_VERSION="$(echo "${VERSION}" | cut -d. -f1,2)"
+
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "schemaMinorVersion=${SCHEMA_MINOR_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved schema source tag: ${TAG}"
+
+  sync-schemastore:
+    name: Sync schema to SchemaStore
+    runs-on: ubuntu-24.04
+    needs: prepare
+    environment: ${{ github.ref_type == 'tag' && 'schemastore-publication' || '' }}
+    permissions:
+      contents: read
+    env:
+      PODMAN_DESKTOP_BOT_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+      RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+      SCHEMA_MINOR_VERSION: ${{ needs.prepare.outputs.schemaMinorVersion }}
+      VERSIONED_SCHEMA_FILE_NAME: podman-desktop-extension-${{ needs.prepare.outputs.schemaMinorVersion }}.json
+      SCHEMASTORE_REPOSITORY: SchemaStore/schemastore
+      SOURCE_REPOSITORY: podman-desktop/podman-desktop
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          persist-credentials: false
+
+      - name: Validate local schema file exists
+        run: |
+          if [ ! -f "schemas/extension-schema.json" ]; then
+            echo "Missing schemas/extension-schema.json in release tag ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Checkout SchemaStore repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ env.SCHEMASTORE_REPOSITORY }}
+          token: ${{ env.PODMAN_DESKTOP_BOT_TOKEN }}
+          path: schemastore
+          ref: master
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        name: Install pnpm
+        with:
+          run_install: false
+          package_json_file: package.json
+
+      - name: Execute pnpm
+        run: pnpm install --ignore-scripts
+
+      - name: Apply and format schema updates
+        working-directory: schemastore
+        run: |
+          set -euo pipefail
+          ../scripts/schemastore-sync-extension-schema.sh \
+            --versioned-schema-file-name "${VERSIONED_SCHEMA_FILE_NAME}" \
+            --schema-minor-version "${SCHEMA_MINOR_VERSION}"
+
+      - name: Push branch and create SchemaStore pull request
+        working-directory: schemastore
+        env:
+          GH_TOKEN: ${{ env.PODMAN_DESKTOP_BOT_TOKEN }}
+          GIT_ACTOR: ${{ github.actor }}
+          GIT_ACTOR_ID: ${{ github.actor_id }}
+        run: |
+          set -euo pipefail
+
+          BRANCH_NAME="podman-desktop-extension-schema-${RELEASE_TAG#v}-${GITHUB_RUN_ID}"
+          git checkout -b "${BRANCH_NAME}"
+
+          git config --local user.name "${GIT_ACTOR}"
+          git config --local user.email "${GIT_ACTOR_ID}+${GIT_ACTOR}@users.noreply.github.com"
+
+          git add "src/schemas/json/podman-desktop-extension.json" "src/schemas/json/${VERSIONED_SCHEMA_FILE_NAME}" src/api/json/catalog.json src/schema-validation.jsonc
+
+          if git diff --cached --quiet; then
+            echo "No changes detected for SchemaStore sync."
+            exit 0
+          fi
+
+          git commit -m "Update Podman Desktop extension schema for ${SCHEMA_MINOR_VERSION}"
+          git push origin "${BRANCH_NAME}"
+
+          gh pr create \
+            --repo "${SCHEMASTORE_REPOSITORY}" \
+            --title "Update Podman Desktop extension schema for ${SCHEMA_MINOR_VERSION}" \
+            --body "Sync schema from ${SOURCE_REPOSITORY} ${RELEASE_TAG}. This updates the stable and version-specific schema files and appends the matching catalog.json versions entry." \
+            --base "master" \
+            --head "${BRANCH_NAME}"

--- a/.github/workflows/schemastore-sync-extension-schema.yaml
+++ b/.github/workflows/schemastore-sync-extension-schema.yaml
@@ -61,12 +61,10 @@ jobs:
     permissions:
       contents: read
     env:
-      PODMAN_DESKTOP_BOT_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
       RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
       SCHEMA_MINOR_VERSION: ${{ needs.prepare.outputs.schemaMinorVersion }}
       VERSIONED_SCHEMA_FILE_NAME: podman-desktop-extension-${{ needs.prepare.outputs.schemaMinorVersion }}.json
       SCHEMASTORE_REPOSITORY: SchemaStore/schemastore
-      SOURCE_REPOSITORY: podman-desktop/podman-desktop
     steps:
       - name: Checkout source repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -85,22 +83,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ env.SCHEMASTORE_REPOSITORY }}
-          token: ${{ env.PODMAN_DESKTOP_BOT_TOKEN }}
+          token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
           path: schemastore
           ref: master
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
-
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        name: Install pnpm
-        with:
-          run_install: false
-          package_json_file: package.json
-
-      - name: Execute pnpm
-        run: pnpm install --ignore-scripts
+          node-version-file: '.nvmrc'
 
       - name: Apply and format schema updates
         working-directory: schemastore
@@ -113,7 +102,7 @@ jobs:
       - name: Push branch and create SchemaStore pull request
         working-directory: schemastore
         env:
-          GH_TOKEN: ${{ env.PODMAN_DESKTOP_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
           GIT_ACTOR: ${{ github.actor }}
           GIT_ACTOR_ID: ${{ github.actor_id }}
         run: |
@@ -138,6 +127,6 @@ jobs:
           gh pr create \
             --repo "${SCHEMASTORE_REPOSITORY}" \
             --title "Update Podman Desktop extension schema for ${SCHEMA_MINOR_VERSION}" \
-            --body "Sync schema from ${SOURCE_REPOSITORY} ${RELEASE_TAG}. This updates the stable and version-specific schema files and appends the matching catalog.json versions entry." \
+            --body "Sync schema from podman-desktop/podman-desktop ${RELEASE_TAG}. This updates the stable and version-specific schema files and appends the matching catalog.json versions entry." \
             --base "master" \
             --head "${BRANCH_NAME}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -52,6 +52,15 @@ Below is what a typical release week may look like (This is just an example of t
    - Check `npmjs-publish.yaml` then click on `Approve and Deploy`
    - Cancel any other pending run (If you did one or several re-spin, previous release tag will also wait, we should not publish them).
 
+1. Approve `schemastore-sync-extension-schema.yaml` workflow
+
+   The workflow will be waiting for manual approval
+   - Go to https://github.com/podman-desktop/podman-desktop/actions/workflows/schemastore-sync-extension-schema.yaml?query=is%3Awaiting
+   - Click on `View details` of the run corresponding to the release you wish to sync
+   - Click on `Review Deployment`
+   - Check `schemastore-sync-extension-schema.yaml` then click on `Approve and Deploy`
+   - Cancel any other pending run (If you did one or several re-spin, previous release tag will also wait, we should not sync them).
+
 ## Test release before it is rolling out.
 
 The release is a **pre-release**, it means it is not yet the latest version, so no clients will automatically update to this version.

--- a/scripts/schemastore-sync-extension-schema.sh
+++ b/scripts/schemastore-sync-extension-schema.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+forwarded_args=("$@")
+
+incoming_file="../source-repo/schemas/extension-schema.json"
+schema_dir="src/schemas/json"
+catalog_file="src/api/json/catalog.json"
+schema_validation_file="src/schema-validation.jsonc"
+schema_file_name="podman-desktop-extension.json"
+versioned_schema_file_name=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --versioned-schema-file-name)
+      versioned_schema_file_name="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$versioned_schema_file_name" ]]; then
+  echo "Missing required argument --versioned-schema-file-name" >&2
+  exit 1
+fi
+
+node --experimental-strip-types "${REPO_ROOT}/scripts/schemastore-sync-extension-schema.ts" \
+  --incoming-file "${incoming_file}" \
+  --schema-dir "${schema_dir}" \
+  --catalog-file "${catalog_file}" \
+  --schema-validation-file "${schema_validation_file}" \
+  --schema-file-name "${schema_file_name}" \
+  "${forwarded_args[@]}"
+npm install --no-audit --no-fund --ignore-scripts
+npx prettier \
+  --write \
+  --config .prettierrc.cjs \
+  "${schema_dir%/}/${schema_file_name}" \
+  "${schema_dir%/}/${versioned_schema_file_name}" \
+  "${catalog_file}" \
+  "${schema_validation_file}"

--- a/scripts/schemastore-sync-extension-schema.sh
+++ b/scripts/schemastore-sync-extension-schema.sh
@@ -24,8 +24,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
 forwarded_args=("$@")
-
-incoming_file="../source-repo/schemas/extension-schema.json"
+incoming_file="../schemas/extension-schema.json"
 schema_dir="src/schemas/json"
 catalog_file="src/api/json/catalog.json"
 schema_validation_file="src/schema-validation.jsonc"

--- a/scripts/schemastore-sync-extension-schema.sh
+++ b/scripts/schemastore-sync-extension-schema.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck shell=bash
 
 #
 # Copyright (C) 2026 Red Hat, Inc.

--- a/scripts/schemastore-sync-extension-schema.sh
+++ b/scripts/schemastore-sync-extension-schema.sh
@@ -22,12 +22,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+SCHEMASTORE_ROOT="$(pwd)"
 
 forwarded_args=("$@")
-incoming_file="../schemas/extension-schema.json"
-schema_dir="src/schemas/json"
-catalog_file="src/api/json/catalog.json"
-schema_validation_file="src/schema-validation.jsonc"
+incoming_file="${REPO_ROOT}/schemas/extension-schema.json"
+schema_dir="${SCHEMASTORE_ROOT}/src/schemas/json"
+catalog_file="${SCHEMASTORE_ROOT}/src/api/json/catalog.json"
+schema_validation_file="${SCHEMASTORE_ROOT}/src/schema-validation.jsonc"
 schema_file_name="podman-desktop-extension.json"
 versioned_schema_file_name=""
 
@@ -48,6 +49,8 @@ if [[ -z "$versioned_schema_file_name" ]]; then
   exit 1
 fi
 
+npm install --no-audit --no-fund --ignore-scripts
+
 node --experimental-strip-types "${REPO_ROOT}/scripts/schemastore-sync-extension-schema.ts" \
   --incoming-file "${incoming_file}" \
   --schema-dir "${schema_dir}" \
@@ -55,7 +58,6 @@ node --experimental-strip-types "${REPO_ROOT}/scripts/schemastore-sync-extension
   --schema-validation-file "${schema_validation_file}" \
   --schema-file-name "${schema_file_name}" \
   "${forwarded_args[@]}"
-npm install --no-audit --no-fund --ignore-scripts
 npx prettier \
   --write \
   --config .prettierrc.cjs \

--- a/scripts/schemastore-sync-extension-schema.spec.ts
+++ b/scripts/schemastore-sync-extension-schema.spec.ts
@@ -1,0 +1,275 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { describe, expect, test } from 'vitest';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  applySchemaUpdates,
+  buildSchemaOutputs,
+  parseArgs,
+  updateCatalogText,
+  updateSchemaValidationText,
+} from './schemastore-sync-extension-schema';
+
+describe('sync-schemastore-extension-schema', () => {
+  test('buildSchemaOutputs sets stable and versioned ids', () => {
+    const incoming = JSON.stringify({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      title: 'Podman Desktop Extension Manifest',
+      description: 'Schema for Podman Desktop extension package.json files',
+      allOf: [{ $ref: 'https://json.schemastore.org/package.json' }],
+    });
+
+    const outputs = buildSchemaOutputs(incoming, 'podman-desktop-extension.json', 'podman-desktop-extension-1.28.json');
+    const stable = JSON.parse(outputs.stableSchemaText);
+    const versioned = JSON.parse(outputs.versionedSchemaText);
+
+    expect(stable.$id).toBe('https://json.schemastore.org/podman-desktop-extension.json');
+    expect(versioned.$id).toBe('https://json.schemastore.org/podman-desktop-extension-1.28.json');
+    expect(versioned.title).toBe(stable.title);
+  });
+
+  test('updateCatalogText updates only podman entry version map', () => {
+    const catalogText = JSON.stringify(
+      {
+        schemas: [
+          {
+            name: 'Other',
+            description: 'Rocket \\u2014 keep escaped text',
+            versions: { '10': 'https://www.schemastore.org/other-10.json' },
+          },
+          {
+            name: 'Podman Desktop Extension',
+            url: 'https://www.schemastore.org/podman-desktop-extension.json',
+            versions: { '1.27': 'https://www.schemastore.org/podman-desktop-extension-1.27.json' },
+          },
+        ],
+      },
+      null,
+      2,
+    );
+
+    const updated = updateCatalogText(
+      catalogText,
+      'podman-desktop-extension.json',
+      'podman-desktop-extension-1.28.json',
+      '1.28',
+    );
+    const parsed = JSON.parse(updated);
+
+    expect(parsed.schemas[1].url).toBe('https://www.schemastore.org/podman-desktop-extension.json');
+    expect(parsed.schemas[1].versions['1.27']).toBe('https://www.schemastore.org/podman-desktop-extension-1.27.json');
+    expect(parsed.schemas[1].versions['1.28']).toBe('https://www.schemastore.org/podman-desktop-extension-1.28.json');
+    expect(updated).toContain('Rocket \\\\u2014 keep escaped text');
+  });
+
+  test('updateCatalogText throws when schemas array is missing', () => {
+    expect(() =>
+      updateCatalogText(
+        JSON.stringify({ somethingElse: [] }),
+        'podman-desktop-extension.json',
+        'podman-desktop-extension-1.28.json',
+        '1.28',
+      ),
+    ).toThrowError('Invalid SchemaStore catalog format: missing schemas array.');
+  });
+
+  test('updateCatalogText throws when podman entry is missing', () => {
+    expect(() =>
+      updateCatalogText(
+        JSON.stringify({ schemas: [{ name: 'Other schema' }] }),
+        'podman-desktop-extension.json',
+        'podman-desktop-extension-1.28.json',
+        '1.28',
+      ),
+    ).toThrowError('Podman Desktop catalog entry is missing in SchemaStore.');
+  });
+
+  test('updateSchemaValidationText adds options from previous podman entry and ajv list entry', () => {
+    const schemaValidation = `{
+  "ajvNotStrictMode": [
+    "pnpm-workspace.json",
+    "podman-desktop-extension.json"
+  ],
+  "options": {
+    "package.json": {
+      "externalSchema": ["package.json", "eslintrc.json"],
+      "unknownKeywords": ["exec", "tsType"]
+    },
+    "podman-desktop-extension.json": {
+      "externalSchema": ["package.json", "eslintrc.json"],
+      "unknownKeywords": ["exec", "tsType"]
+    }
+  }
+}
+`;
+
+    const updated = updateSchemaValidationText(schemaValidation, ['podman-desktop-extension-1.28.json']);
+    const parsed = JSON.parse(updated);
+
+    expect(parsed.options['podman-desktop-extension-1.28.json']).toEqual(
+      parsed.options['podman-desktop-extension.json'],
+    );
+    expect(parsed.ajvNotStrictMode).toContain('podman-desktop-extension-1.28.json');
+  });
+
+  test('updateSchemaValidationText throws when options are missing', () => {
+    const invalidSchemaValidation = `{
+  "ajvNotStrictMode": []
+}
+`;
+    expect(() =>
+      updateSchemaValidationText(invalidSchemaValidation, ['podman-desktop-extension-1.28.json']),
+    ).toThrowError('Could not find options object in schema-validation.jsonc');
+  });
+
+  test('updateSchemaValidationText throws when ajvNotStrictMode is missing', () => {
+    const invalidSchemaValidation = `{
+  "options": {}
+}
+`;
+    expect(() =>
+      updateSchemaValidationText(invalidSchemaValidation, ['podman-desktop-extension-1.28.json']),
+    ).toThrowError('Could not find ajvNotStrictMode array in schema-validation.jsonc');
+  });
+
+  test('updateSchemaValidationText throws when source options are missing', () => {
+    const schemaValidation = `{
+  "ajvNotStrictMode": [],
+  "options": {}
+}
+`;
+    expect(() => updateSchemaValidationText(schemaValidation, ['podman-desktop-extension-1.28.json'])).toThrowError(
+      'Could not find package.json options in schema-validation.jsonc',
+    );
+  });
+
+  test('parseArgs validates required args', () => {
+    const args = parseArgs([
+      '--incoming-file',
+      '../schemas/extension-schema.json',
+      '--schema-dir',
+      'src/schemas/json',
+      '--catalog-file',
+      'src/api/json/catalog.json',
+      '--schema-validation-file',
+      'src/schema-validation.jsonc',
+      '--schema-file-name',
+      'podman-desktop-extension.json',
+      '--versioned-schema-file-name',
+      'podman-desktop-extension-1.28.json',
+      '--schema-minor-version',
+      '1.28',
+    ]);
+
+    expect(args.schemaMinorVersion).toBe('1.28');
+    expect(args.versionedSchemaFileName).toBe('podman-desktop-extension-1.28.json');
+  });
+
+  test('parseArgs throws when required args are missing', () => {
+    expect(() => parseArgs(['--incoming-file', '../schemas/extension-schema.json'])).toThrowError(
+      'Missing required argument --schema-dir',
+    );
+  });
+
+  test('applySchemaUpdates writes expected files', async () => {
+    const tmpRoot = await mkdtemp(join(tmpdir(), 'sync-schema-test-'));
+    try {
+      const incomingFile = join(tmpRoot, 'schemas', 'extension-schema.json');
+      const schemaDir = join(tmpRoot, 'schemastore', 'src', 'schemas', 'json');
+      const catalogFile = join(tmpRoot, 'schemastore', 'src', 'api', 'json', 'catalog.json');
+      const schemaValidationFile = join(tmpRoot, 'schemastore', 'src', 'schema-validation.jsonc');
+
+      await mkdir(join(tmpRoot, 'schemas'), { recursive: true });
+      await mkdir(schemaDir, { recursive: true });
+      await mkdir(join(tmpRoot, 'schemastore', 'src', 'api', 'json'), { recursive: true });
+
+      await writeFile(
+        incomingFile,
+        JSON.stringify({
+          title: 'Podman',
+          allOf: [{ $ref: 'https://json.schemastore.org/package.json' }],
+        }),
+        'utf8',
+      );
+      await writeFile(
+        catalogFile,
+        JSON.stringify(
+          {
+            schemas: [
+              {
+                name: 'Podman Desktop Extension',
+                url: 'https://www.schemastore.org/podman-desktop-extension.json',
+                versions: {},
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+        'utf8',
+      );
+      await writeFile(
+        schemaValidationFile,
+        `{
+  "ajvNotStrictMode": [],
+  "options": {
+    "package.json": {
+      "externalSchema": ["package.json"],
+      "unknownKeywords": ["exec", "tsType"]
+    }
+  }
+}
+`,
+        'utf8',
+      );
+
+      await applySchemaUpdates({
+        incomingFile,
+        schemaDir,
+        catalogFile,
+        schemaValidationFile,
+        schemaFileName: 'podman-desktop-extension.json',
+        versionedSchemaFileName: 'podman-desktop-extension-1.28.json',
+        schemaMinorVersion: '1.28',
+      });
+
+      const stableSchema = JSON.parse(await readFile(join(schemaDir, 'podman-desktop-extension.json'), 'utf8'));
+      const versionedSchema = JSON.parse(await readFile(join(schemaDir, 'podman-desktop-extension-1.28.json'), 'utf8'));
+      expect(stableSchema.$id).toBe('https://json.schemastore.org/podman-desktop-extension.json');
+      expect(versionedSchema.$id).toBe('https://json.schemastore.org/podman-desktop-extension-1.28.json');
+    } finally {
+      await rm(tmpRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('applySchemaUpdates throws when incoming schema is missing', async () => {
+    await expect(
+      applySchemaUpdates({
+        incomingFile: '/tmp/definitely-missing-file.json',
+        schemaDir: '/tmp',
+        catalogFile: '/tmp/catalog.json',
+        schemaValidationFile: '/tmp/schema-validation.jsonc',
+        schemaFileName: 'podman-desktop-extension.json',
+        versionedSchemaFileName: 'podman-desktop-extension-1.28.json',
+        schemaMinorVersion: '1.28',
+      }),
+    ).rejects.toThrowError('Missing source schema at /tmp/definitely-missing-file.json');
+  });
+});

--- a/scripts/schemastore-sync-extension-schema.ts
+++ b/scripts/schemastore-sync-extension-schema.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { access, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { applyEdits, modify, parse } from 'jsonc-parser';
+import minimist from 'minimist';
+
+const jsonFormattingOptions = {
+  insertSpaces: true,
+  tabSize: 2,
+  eol: '\n',
+};
+
+export interface SyncArgs {
+  incomingFile: string;
+  schemaDir: string;
+  catalogFile: string;
+  schemaValidationFile: string;
+  schemaFileName: string;
+  versionedSchemaFileName: string;
+  schemaMinorVersion: string;
+}
+
+export function buildSchemaOutputs(
+  incomingText: string,
+  stableFileName: string,
+  versionedFileName: string,
+): { stableSchemaText: string; versionedSchemaText: string } {
+  const stableId = `https://json.schemastore.org/${stableFileName}`;
+  const versionedId = `https://json.schemastore.org/${versionedFileName}`;
+
+  const stableSchema = JSON.parse(incomingText);
+  stableSchema.$id = stableId;
+  const versionedSchema = structuredClone(stableSchema);
+  versionedSchema.$id = versionedId;
+
+  return {
+    stableSchemaText: `${JSON.stringify(stableSchema, null, 2)}\n`,
+    versionedSchemaText: `${JSON.stringify(versionedSchema, null, 2)}\n`,
+  };
+}
+
+export function updateCatalogText(
+  catalogText: string,
+  stableFileName: string,
+  versionedFileName: string,
+  schemaMinorVersion: string,
+): string {
+  const catalog = JSON.parse(catalogText);
+  if (!Array.isArray(catalog.schemas)) {
+    throw new Error('Invalid SchemaStore catalog format: missing schemas array.');
+  }
+
+  const podmanEntryIndex = catalog.schemas.findIndex(schema => schema?.name === 'Podman Desktop Extension');
+  if (podmanEntryIndex === -1) {
+    throw new Error('Podman Desktop catalog entry is missing in SchemaStore.');
+  }
+
+  const stableUrl = `https://www.schemastore.org/${stableFileName}`;
+  const versionedUrl = `https://www.schemastore.org/${versionedFileName}`;
+
+  let updatedCatalogText = catalogText;
+  const applyCatalogEdit = (targetPath: (string | number)[], value: unknown): void => {
+    const edits = modify(updatedCatalogText, targetPath, value, { formattingOptions: jsonFormattingOptions });
+    updatedCatalogText = applyEdits(updatedCatalogText, edits);
+  };
+
+  applyCatalogEdit(['schemas', podmanEntryIndex, 'url'], stableUrl);
+
+  const currentVersions = catalog.schemas[podmanEntryIndex]?.versions;
+  if (!currentVersions || typeof currentVersions !== 'object') {
+    applyCatalogEdit(['schemas', podmanEntryIndex, 'versions'], {});
+  }
+  applyCatalogEdit(['schemas', podmanEntryIndex, 'versions', schemaMinorVersion], versionedUrl);
+
+  return updatedCatalogText;
+}
+
+function parseSchemaValidationText(text: string): Record<string, unknown> {
+  const errors = [];
+  const parsed = parse(text, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+  if (errors.length > 0) {
+    throw new Error(`Could not parse schema-validation.jsonc (errors: ${errors.length})`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export function updateSchemaValidationText(schemaValidationText: string, schemaTargets: string[]): string {
+  let updatedText = schemaValidationText;
+
+  const applyJsoncEdit = (targetPath: (string | number)[], value: unknown): void => {
+    const edits = modify(updatedText, targetPath, value, { formattingOptions: jsonFormattingOptions });
+    updatedText = applyEdits(updatedText, edits);
+  };
+
+  for (const target of schemaTargets) {
+    const parsed = parseSchemaValidationText(updatedText);
+    const options = parsed.options as Record<string, unknown> | undefined;
+    const ajvNotStrictMode = parsed.ajvNotStrictMode as string[] | undefined;
+
+    if (!options || typeof options !== 'object') {
+      throw new Error('Could not find options object in schema-validation.jsonc');
+    }
+    if (!Array.isArray(ajvNotStrictMode)) {
+      throw new Error('Could not find ajvNotStrictMode array in schema-validation.jsonc');
+    }
+
+    if (!options[target]) {
+      const podmanOptionKeys = Object.keys(options).filter(
+        key => /^podman-desktop-extension(?:-[0-9]+\.[0-9]+)?\.json$/.test(key) && key !== target,
+      );
+      const sourceFilename = podmanOptionKeys[podmanOptionKeys.length - 1] ?? 'package.json';
+      const sourceOption = options[sourceFilename];
+      if (!sourceOption) {
+        throw new Error(`Could not find ${sourceFilename} options in schema-validation.jsonc`);
+      }
+      applyJsoncEdit(['options', target], structuredClone(sourceOption));
+    }
+
+    if (!ajvNotStrictMode.includes(target)) {
+      applyJsoncEdit(['ajvNotStrictMode', ajvNotStrictMode.length], target);
+    }
+  }
+
+  return updatedText;
+}
+
+export async function applySchemaUpdates(args: SyncArgs): Promise<void> {
+  try {
+    await access(args.incomingFile);
+  } catch {
+    throw new Error(`Missing source schema at ${args.incomingFile}`);
+  }
+
+  const incomingText = await readFile(args.incomingFile, 'utf8');
+  const { stableSchemaText, versionedSchemaText } = buildSchemaOutputs(
+    incomingText,
+    args.schemaFileName,
+    args.versionedSchemaFileName,
+  );
+
+  await writeFile(join(args.schemaDir, args.schemaFileName), stableSchemaText, 'utf8');
+  await writeFile(join(args.schemaDir, args.versionedSchemaFileName), versionedSchemaText, 'utf8');
+
+  const catalogText = await readFile(args.catalogFile, 'utf8');
+  const updatedCatalogText = updateCatalogText(
+    catalogText,
+    args.schemaFileName,
+    args.versionedSchemaFileName,
+    args.schemaMinorVersion,
+  );
+  await writeFile(args.catalogFile, updatedCatalogText, 'utf8');
+
+  const schemaValidationText = await readFile(args.schemaValidationFile, 'utf8');
+  const updatedSchemaValidationText = updateSchemaValidationText(schemaValidationText, [
+    args.schemaFileName,
+    args.versionedSchemaFileName,
+  ]);
+  await writeFile(args.schemaValidationFile, updatedSchemaValidationText, 'utf8');
+}
+
+export function parseArgs(argv: string[]): SyncArgs {
+  const parsed = minimist(argv);
+
+  const required = [
+    'incoming-file',
+    'schema-dir',
+    'catalog-file',
+    'schema-validation-file',
+    'schema-file-name',
+    'versioned-schema-file-name',
+    'schema-minor-version',
+  ];
+
+  for (const key of required) {
+    const value = parsed[key];
+    if (value === undefined || value === null || value === '') {
+      throw new Error(`Missing required argument --${key}`);
+    }
+  }
+
+  return {
+    incomingFile: String(parsed['incoming-file']),
+    schemaDir: String(parsed['schema-dir']),
+    catalogFile: String(parsed['catalog-file']),
+    schemaValidationFile: String(parsed['schema-validation-file']),
+    schemaFileName: String(parsed['schema-file-name']),
+    versionedSchemaFileName: String(parsed['versioned-schema-file-name']),
+    schemaMinorVersion: String(parsed['schema-minor-version']),
+  };
+}
+
+if (!process.env.VITEST) {
+  const args = parseArgs(process.argv.slice(2));
+  applySchemaUpdates(args).catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'scripts',
+    include: ['**/*.spec.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
### What does this PR do?

Automates syncing the Podman Desktop extension schema to SchemaStore whenever a release is published.

- adds a dedicated sync workflow
- supports both release trigger and manual trigger
- updates stable + versioned schema files in SchemaStore
- updates SchemaStore catalog and validation metadata
- opens a SchemaStore PR automatically

### Screenshot / video of UI

N/A (CI/workflow-only change).

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16051

Reference bootstrap PR:
- https://github.com/SchemaStore/schemastore/pull/5712

Latest proof PRs:
- intentional change (`v1.28.101`): https://github.com/simonrey1/schemastore/pull/71
- clean release (`v1.28.100`): https://github.com/simonrey1/schemastore/pull/73
- override/respin (`v1.27.99`): https://github.com/simonrey1/schemastore/pull/72

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature