### PR TITLE
fix: broken pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8309,8 +8309,8 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
-  is-network-error@1.3.2:
-    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+  is-network-error@1.3.0:
+    resolution: {integrity: sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==}
     engines: {node: '>=16'}
 
   is-node-process@1.2.0:
@@ -10912,11 +10912,6 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -21534,7 +21529,7 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
-  is-network-error@1.3.2: {}
+  is-network-error@1.3.0: {}
 
   is-node-process@1.2.0: {}
 
@@ -23263,12 +23258,12 @@ snapshots:
   p-retry@6.2.1:
     dependencies:
       '@types/retry': 0.12.2
-      is-network-error: 1.3.2
+      is-network-error: 1.3.0
       retry: 0.13.1
 
   p-retry@8.0.0:
     dependencies:
-      is-network-error: 1.3.2
+      is-network-error: 1.3.0
 
   p-timeout@3.2.0:
     dependencies:
@@ -24691,8 +24686,6 @@ snapshots:
     optional: true
 
   semver@7.7.4: {}
-
-  semver@7.8.1: {}
 
   semver@7.8.1: {}
 


### PR DESCRIPTION
removes duplicated semver@7.8.1 entry

```
semver@7.8.1:
    resolution: {...}
    engines: {node: '>=10'}
    hasBin: true
```

### What does this PR do?

removes duplicate entry to unblock formater/linter in PR checks

### Screenshot / video of UI

<img width="927" height="611" alt="image" src="https://github.com/user-attachments/assets/2060ab69-8e05-48bf-91cb-878d89d94a5f" />

<img width="2286" height="530" alt="image" src="https://github.com/user-attachments/assets/b5a091e0-3343-49eb-a726-0b1e2abd4ebb" />


### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/actions/runs/26309254226/job/77453659808?pr=17511

https://github.com/redhat-developer/podman-desktop-redhat-account-ext/actions/runs/26308547576/job/77451488027?pr=1164

### How to test this PR?

Pull main branch and run `pnpm install`. It warns about broken pnpm-lock.yaml

```
podman-desktop % pnpm install
Scope: all 25 workspace projects
 WARN  Ignoring broken lockfile at /Users/eskimo/Sources/podman-desktop: The lockfile at "/Users/eskimo/Sources/podman-desktop/pnpm-lock.yaml" is broken: duplicated mapping key (10923:3)

 10920 |     engines: {node: '>=10'}
 10921 |     hasBin: true
 10922 | 
 10923 |   semver@7.8.1:
-----------^
 10924 |     resolution: {integrity: sha5 ...
 10925 |     engines: {node: '>=10'}
```

PR checks are failing on `formatter/linter` step.

Pull PR branch and run `pnpm install`

No changes in lock file and no warning above.  

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
