### PR TITLE
fix(podman): disable PowerShell profile loading when executing checks on Windows

### DIFF
--- a/extensions/podman/packages/extension/src/utils/powershell.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.spec.ts
@@ -23,6 +23,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { PowerShellClient } from './powershell';
 import { getPowerShellClient } from './powershell';
 
+vi.mock(import('@podman-desktop/api'));
+
 const TELEMETRY_LOGGER_MOCK = {
   logUsage: vi.fn(),
 } as unknown as TelemetryLogger;
@@ -83,5 +85,187 @@ describe('PowerShellClient#isUserAdmin', () => {
     const result = await client.isUserAdmin();
 
     expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PS flags: every exec call must include -NoProfile -NonInteractive -Command
+// ---------------------------------------------------------------------------
+
+const PS_FLAGS = ['-NoProfile', '-NonInteractive', '-Command'];
+
+describe('PowerShellClient PS flags', () => {
+  let client: PowerShellClient;
+
+  beforeEach(async () => {
+    client = await getPowerShellClient(TELEMETRY_LOGGER_MOCK);
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: '', stderr: '', command: 'powershell.exe' });
+  });
+
+  test.each<{ method: string; call: (c: PowerShellClient) => Promise<unknown> }>([
+    { method: 'isUserAdmin', call: (c: PowerShellClient): Promise<unknown> => c.isUserAdmin() },
+    {
+      method: 'isVirtualMachineAvailable',
+      call: (c: PowerShellClient): Promise<unknown> => c.isVirtualMachineAvailable(),
+    },
+    { method: 'isHyperVInstalled', call: (c: PowerShellClient): Promise<unknown> => c.isHyperVInstalled() },
+    { method: 'isHyperVRunning', call: (c: PowerShellClient): Promise<unknown> => c.isHyperVRunning() },
+    { method: 'isRunningElevated', call: (c: PowerShellClient): Promise<unknown> => c.isRunningElevated() },
+  ])('$method passes -NoProfile -NonInteractive -Command', async ({ call }) => {
+    await call(client);
+    const [exe, args] = vi.mocked(processAPI.exec).mock.calls[0];
+    expect(exe).toBe('powershell.exe');
+    expect(args).toEqual(expect.arrayContaining(PS_FLAGS));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Coverage for methods not tested above
+// ---------------------------------------------------------------------------
+
+describe('PowerShellClient#isVirtualMachineAvailable', () => {
+  let client: PowerShellClient;
+
+  beforeEach(async () => {
+    client = await getPowerShellClient(TELEMETRY_LOGGER_MOCK);
+  });
+
+  test('should return true when stdout contains VirtualMachinePlatform', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({
+      stdout: 'VirtualMachinePlatform',
+      stderr: '',
+      command: 'powershell.exe',
+    });
+
+    expect(await client.isVirtualMachineAvailable()).toBe(true);
+  });
+
+  test('should return false when stdout does not contain VirtualMachinePlatform', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: 'SomeOtherFeature', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isVirtualMachineAvailable()).toBe(false);
+  });
+
+  test('should return false and record telemetry when exec throws', async () => {
+    const error = Object.assign(new Error('exec failed'), {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'error output',
+      cancelled: false,
+      killed: false,
+      command: 'powershell.exe',
+    });
+    vi.mocked(processAPI.exec).mockRejectedValue(error);
+
+    expect(await client.isVirtualMachineAvailable()).toBe(false);
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      'check.isVirtualMachineAvailable',
+      expect.objectContaining({ error }),
+    );
+  });
+
+  test('should not log telemetry when feature is found (early return path)', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({
+      stdout: 'VirtualMachinePlatform',
+      stderr: '',
+      command: 'powershell.exe',
+    });
+
+    await client.isVirtualMachineAvailable();
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).not.toHaveBeenCalled();
+  });
+
+  test('should log telemetry when feature is not found', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({
+      stdout: 'SomeOtherFeature',
+      stderr: 'warn',
+      command: 'powershell.exe',
+    });
+
+    await client.isVirtualMachineAvailable();
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      'check.isVirtualMachineAvailable',
+      expect.objectContaining({ stdout: 'SomeOtherFeature', stderr: 'warn' }),
+    );
+  });
+});
+
+describe('PowerShellClient#isHyperVInstalled', () => {
+  let client: PowerShellClient;
+
+  beforeEach(async () => {
+    client = await getPowerShellClient(TELEMETRY_LOGGER_MOCK);
+  });
+
+  test('should return true when Get-Service vmms succeeds', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: '', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isHyperVInstalled()).toBe(true);
+  });
+
+  test('should return false when exec throws', async () => {
+    vi.mocked(processAPI.exec).mockRejectedValue(new Error('Cannot find service'));
+
+    expect(await client.isHyperVInstalled()).toBe(false);
+  });
+});
+
+describe('PowerShellClient#isHyperVRunning', () => {
+  let client: PowerShellClient;
+
+  beforeEach(async () => {
+    client = await getPowerShellClient(TELEMETRY_LOGGER_MOCK);
+  });
+
+  test('should return true when service status is Running', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: 'Running', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isHyperVRunning()).toBe(true);
+  });
+
+  test.each([
+    { name: 'should return false when status is Stopped', stdout: 'Stopped' },
+    { name: 'should return false when status is empty', stdout: '' },
+  ])('$name', async ({ stdout }) => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout, stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isHyperVRunning()).toBe(false);
+  });
+
+  test('should return false when exec throws', async () => {
+    vi.mocked(processAPI.exec).mockRejectedValue(new Error('Cannot find service'));
+
+    expect(await client.isHyperVRunning()).toBe(false);
+  });
+});
+
+describe('PowerShellClient#isRunningElevated', () => {
+  let client: PowerShellClient;
+
+  beforeEach(async () => {
+    client = await getPowerShellClient(TELEMETRY_LOGGER_MOCK);
+  });
+
+  test('should return true when process is elevated', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: 'True', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isRunningElevated()).toBe(true);
+  });
+
+  test.each([
+    { name: 'should return false when process is not elevated', stdout: 'False' },
+    { name: 'should return false with surrounding whitespace', stdout: '  False\n' },
+  ])('$name', async ({ stdout }) => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout, stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isRunningElevated()).toBe(false);
+  });
+
+  test('should return false when exec throws', async () => {
+    vi.mocked(processAPI.exec).mockRejectedValue(new Error('Access denied'));
+
+    expect(await client.isRunningElevated()).toBe(false);
   });
 });

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,16 @@ export interface PowerShellClient {
 }
 
 const PowerShell5Exe = 'powershell.exe';
+
+// Always prepend these flags so PowerShell never loads a user profile
+// (-NoProfile) and never blocks waiting for interactive input (-NonInteractive).
+// A slow or interactive profile is a known hang source during extension startup.
+const PS_FLAGS = ['-NoProfile', '-NonInteractive', '-Command'];
+
+function psArgs(script: string): string[] {
+  return [...PS_FLAGS, script];
+}
+
 class PowerShell5Client implements PowerShellClient {
   constructor(private telemetryLogger: extensionApi.TelemetryLogger) {}
 
@@ -39,9 +49,9 @@ class PowerShell5Client implements PowerShellClient {
       // set CurrentUICulture to force output in english
       const res = await extensionApi.process.exec(
         PowerShell5Exe,
-        [
+        psArgs(
           '[System.Console]::OutputEncoding = [System.Text.Encoding]::Unicode; (Get-WmiObject -Query "Select * from Win32_OptionalFeature where InstallState = \'1\'").Name | select-string VirtualMachinePlatform',
-        ],
+        ),
         { encoding: 'utf16le' },
       );
       telemetry['command'] = res.command;
@@ -68,9 +78,12 @@ class PowerShell5Client implements PowerShellClient {
 
   async isUserAdmin(): Promise<boolean> {
     try {
-      const { stdout: res } = await extensionApi.process.exec(PowerShell5Exe, [
-        '$null -ne (& "$env:WINDIR\\System32\\whoami.exe" /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})',
-      ]);
+      const { stdout: res } = await extensionApi.process.exec(
+        PowerShell5Exe,
+        psArgs(
+          '$null -ne (& "$env:WINDIR\\System32\\whoami.exe" /groups /fo csv | ConvertFrom-Csv | Where-Object {$_.SID -eq "S-1-5-32-544"})',
+        ),
+      );
       return res.trim() === 'True';
     } catch (err: unknown) {
       return false;
@@ -79,7 +92,7 @@ class PowerShell5Client implements PowerShellClient {
 
   async isHyperVInstalled(): Promise<boolean> {
     try {
-      await extensionApi.process.exec(PowerShell5Exe, ['Get-Service vmms']);
+      await extensionApi.process.exec(PowerShell5Exe, psArgs('Get-Service vmms'));
       return true;
     } catch (err: unknown) {
       return false;
@@ -88,7 +101,7 @@ class PowerShell5Client implements PowerShellClient {
 
   async isHyperVRunning(): Promise<boolean> {
     try {
-      const result = await extensionApi.process.exec(PowerShell5Exe, ['@(Get-Service vmms).Status']);
+      const result = await extensionApi.process.exec(PowerShell5Exe, psArgs('@(Get-Service vmms).Status'));
       return result.stdout === 'Running';
     } catch (err: unknown) {
       return false;
@@ -97,9 +110,12 @@ class PowerShell5Client implements PowerShellClient {
 
   async isRunningElevated(): Promise<boolean> {
     try {
-      const { stdout: res } = await extensionApi.process.exec(PowerShell5Exe, [
-        '(New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)',
-      ]);
+      const { stdout: res } = await extensionApi.process.exec(
+        PowerShell5Exe,
+        psArgs(
+          '(New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)',
+        ),
+      );
       return res.trim() === 'True';
     } catch (err: unknown) {
       return false;


### PR DESCRIPTION
## Summary

Fixes the hang that prevents `setContainerProviderConnectionFactory()` from
being called during extension startup on Windows, which surfaces as:

> This extension does not provide a component of type "createContainerProviderConnection"

### Root cause

Every call to `powershell.exe` in `PowerShell5Client` was missing the
`-NoProfile` and `-NonInteractive` flags. PowerShell loads and executes the
user's `$PROFILE` on every invocation before running the requested script. A
slow, interactive, or misconfigured profile (e.g. one that runs `Read-Host`,
spawns a watcher loop, or triggers Windows Store prompts) would block all five
checks indefinitely because the `stdin` pipe is never closed.

### Changes

- **`powershell.ts`**: introduced a `PS_FLAGS` constant
  (`-NoProfile -NonInteractive -Command`) and a small `psArgs()` helper that
  prepends them to every script argument. All five `PowerShell5Client` methods
  now use `psArgs()`.
- **`powershell.spec.ts`**: added a `test.each` block that asserts all five
  methods pass the required flags, plus full coverage for the previously
  untested `isVirtualMachineAvailable`, `isHyperVInstalled`, `isHyperVRunning`,
  and `isRunningElevated` methods.

Fixes #16725

🤖 AI-assisted PR

Made with [Cursor](https://cursor.com)