### PR TITLE
fix(ui): add keyboard navigation to Link component

### DIFF
--- a/packages/ui/src/lib/link/Link.spec.ts
+++ b/packages/ui/src/lib/link/Link.spec.ts
@@ -68,3 +68,51 @@ test('Check on:click action', async () => {
 
   expect(clickMock).toBeCalledTimes(1);
 });
+
+test('Link should be keyboard focusable', async () => {
+  render(Link, { children: SNIPPET_MOCK });
+
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveAttribute('tabindex', '0');
+});
+
+test('Link should be activated by Enter key', async () => {
+  const clickMock = vi.fn();
+  render(Link, { onclick: clickMock, children: SNIPPET_MOCK });
+
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+  expect(clickMock).not.toHaveBeenCalled();
+
+  await fireEvent.keyDown(link, { key: 'Enter' });
+
+  expect(clickMock).toBeCalledTimes(1);
+});
+
+test('Link should be activated by Space key', async () => {
+  const clickMock = vi.fn();
+  render(Link, { onclick: clickMock, children: SNIPPET_MOCK });
+
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+  expect(clickMock).not.toHaveBeenCalled();
+
+  await fireEvent.keyDown(link, { key: ' ' });
+
+  expect(clickMock).toBeCalledTimes(1);
+});
+
+test('Link should not be activated by other keys', async () => {
+  const clickMock = vi.fn();
+  render(Link, { onclick: clickMock, children: SNIPPET_MOCK });
+
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+
+  await fireEvent.keyDown(link, { key: 'a' });
+  await fireEvent.keyDown(link, { key: 'Escape' });
+  await fireEvent.keyDown(link, { key: 'Tab' });
+
+  expect(clickMock).not.toHaveBeenCalled();
+});

--- a/packages/ui/src/lib/link/Link.svelte
+++ b/packages/ui/src/lib/link/Link.svelte
@@ -25,13 +25,18 @@ let {
 }: Props = $props();
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_missing_attribute -->
-<!-- svelte-ignore a11y_interactive_supports_focus -->
 <a
   class="text-[var(--pd-link)] hover:bg-[var(--pd-link-hover-bg)] transition-all rounded-[4px] p-0.5 no-underline cursor-pointer {classes}"
   {onclick}
   role="link"
+  tabindex="0"
+  onkeydown={(e): void => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onclick();
+    }
+  }}
   aria-label={ariaLabel ?? ''}>
   {#if icon}
     <span class="flex flex-row space-x-2">


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Makes the `Link` component keyboard accessible by adding `tabindex="0"` and keyboard event handlers. This fixes the issue where interactive links in Container Details (and throughout the application) were not reachable via keyboard navigation.

Previously, the `<a>` tag rendered without an `href` attribute, making it non-focusable and excluding it from the keyboard tab order. Users could not navigate to or activate links (like the Image link or port links in Container Summary) using only the keyboard.

### What issues does this PR fix or reference?

Fixes #17463

### How to test this PR?

Keyboard navigation demonstration:
- Tab through Container Details tabs (Summary → Logs → Inspect → Terminal)
- Continue pressing Tab to reach links in the Summary content (Image link, port links)
- Links now show focus outline and can be activated with Enter/Space keys
- Tooltips display on keyboard focus

