### PR TITLE
fix(renderer): remove doubled "Error:" prefix in deletion error dialogs

### DIFF
--- a/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
+++ b/packages/renderer/src/lib/container/ContainerEmptyScreen.svelte
@@ -74,7 +74,7 @@ async function runContainer(commandLine: string): Promise<void> {
   } catch (err) {
     await window.showMessageBox({
       title: 'Run Container Failed',
-      message: `Error while executing ${commandLine}: ${String(err)}`,
+      message: `Error while executing ${commandLine}: ${err instanceof Error ? err.message : String(err)}`,
       buttons: ['Dismiss'],
     });
   }

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -27,16 +27,11 @@ import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import ImageActions from '/@/lib/image/ImageActions.svelte';
 import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 
+import { ImageUtils } from './image-utils';
+
 const getContributedMenusMock = vi.fn();
 
-vi.mock(import('./image-utils'), () => {
-  return {
-    ImageUtils: vi.fn().mockImplementation(() => ({
-      deleteImage: vi.fn().mockRejectedValue(new Error('Cannot delete image in test')),
-    })),
-  };
-});
-
+vi.mock(import('./image-utils'));
 vi.mock(import('/@/lib/dialogs/messagebox-utils'), () => ({
   withConfirmation: vi.fn(),
 }));
@@ -80,13 +75,11 @@ class Image {
 
 beforeEach(() => {
   vi.resetAllMocks();
+
+  vi.mocked(ImageUtils.prototype.deleteImage).mockRejectedValue(new Error('Cannot delete image in test'));
 });
 
 test('Expect error dialog with correct message when image deletion fails', async () => {
-  const { ImageUtils } = await import('./image-utils');
-  vi.mocked(ImageUtils).mockImplementation(function (this: Record<string, unknown>) {
-    this.deleteImage = vi.fn().mockRejectedValue(new Error('Cannot delete image in test'));
-  } as unknown as () => InstanceType<typeof ImageUtils>);
   vi.mocked(withConfirmation).mockImplementation(f => f());
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   getContributedMenusMock.mockResolvedValue([]);

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -82,8 +82,13 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('Expect showMessageBox to be called when error occurs', async () => {
+test('Expect error dialog with correct message when image deletion fails', async () => {
+  const { ImageUtils } = await import('./image-utils');
+  vi.mocked(ImageUtils).mockImplementation(function (this: Record<string, unknown>) {
+    this.deleteImage = vi.fn().mockRejectedValue(new Error('Cannot delete image in test'));
+  } as unknown as () => InstanceType<typeof ImageUtils>);
   vi.mocked(withConfirmation).mockImplementation(f => f());
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   getContributedMenusMock.mockResolvedValue([]);
 
   const image: ImageInfoUI = new Image('dummy', 'UNUSED') as unknown as ImageInfoUI;
@@ -100,6 +105,14 @@ test('Expect showMessageBox to be called when error occurs', async () => {
   await waitFor(() => {
     expect(window.showMessageBox).toHaveBeenCalledOnce();
   });
+
+  expect(window.showMessageBox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      title: 'Delete Image Failed',
+      message: 'Error while deleting image: Cannot delete image in test',
+      type: 'error',
+    }),
+  );
 
   expect(image.status).toBe('DELETING');
 });

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -70,7 +70,10 @@ async function deleteImage(): Promise<void> {
   try {
     await imageUtils.deleteImage(image);
   } catch (error) {
-    await onError(`Error while deleting image: ${String(error)}`, 'Delete Image Failed');
+    await onError(
+      `Error while deleting image: ${error instanceof Error ? error.message : String(error)}`,
+      'Delete Image Failed',
+    );
   }
 }
 

--- a/packages/renderer/src/lib/image/ManifestActions.spec.ts
+++ b/packages/renderer/src/lib/image/ManifestActions.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
@@ -48,8 +48,13 @@ beforeAll(() => {
 const fakedManifest: ImageInfoUI = {
   id: 'dummy',
   name: 'dummy',
+  engineId: 'engine1',
   isManifest: true,
 } as unknown as ImageInfoUI;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 test('Expect Delete Manifest to be there', async () => {
   render(ManifestActions, { manifest: fakedManifest, onPushManifest: vi.fn() });
@@ -88,5 +93,34 @@ test('Expect withConfirmation to be called with delete variant when clicking Del
       title: 'Delete Manifest?',
       variant: 'delete',
     });
+  });
+});
+
+test('Expect error dialog with correct message when manifest deletion fails', async () => {
+  const errorMessage = 'manifest not found';
+  vi.mocked(withConfirmation).mockImplementation(f => f());
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.removeManifest).mockRejectedValueOnce(new Error(errorMessage));
+  getContributedMenusMock.mockResolvedValue([]);
+
+  const manifest: ImageInfoUI = {
+    ...fakedManifest,
+    name: 'my-manifest',
+    status: 'UNUSED',
+  } as unknown as ImageInfoUI;
+
+  render(ManifestActions, { manifest, onPushManifest: vi.fn() });
+
+  const button = screen.getByRole('button', { name: 'Delete Manifest' });
+  await fireEvent.click(button);
+
+  await waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Delete Manifest Failed',
+        message: `Error while deleting manifest: ${errorMessage}`,
+        type: 'error',
+      }),
+    );
   });
 });

--- a/packages/renderer/src/lib/image/ManifestActions.svelte
+++ b/packages/renderer/src/lib/image/ManifestActions.svelte
@@ -29,7 +29,7 @@ async function deleteManifest(): Promise<void> {
   try {
     await window.removeManifest(manifest.engineId, manifest.name);
   } catch (error) {
-    await onError(`Error while deleting manifest: ${String(error)}`);
+    await onError(`Error while deleting manifest: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 

--- a/packages/renderer/src/lib/network/NetworkActions.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkActions.spec.ts
@@ -88,6 +88,7 @@ test('Expect error dialog when network deletion fails', async () => {
     expect(window.showMessageBox).toHaveBeenCalledWith(
       expect.objectContaining({
         title: 'Delete Network Failed',
+        message: `Error while deleting network ${network1.name}: ${errorMessage}`,
         type: 'error',
       }),
     );

--- a/packages/renderer/src/lib/network/NetworkActions.svelte
+++ b/packages/renderer/src/lib/network/NetworkActions.svelte
@@ -26,7 +26,7 @@ async function removeNetwork(): Promise<void> {
     object.status = oldStatus;
     await window.showMessageBox({
       title: 'Delete Network Failed',
-      message: `Error while deleting network ${object.name}: ${String(error)}`,
+      message: `Error while deleting network ${object.name}: ${error instanceof Error ? error.message : String(error)}`,
       type: 'error',
       buttons: ['Dismiss'],
     });


### PR DESCRIPTION
## What does this PR do?

Fixes the doubled `Error:` prefix shown in deletion error dialogs at runtime, e.g.:

> Error while deleting network bridge: Error: (HTTP code 500) server error - ...

`String(error)` on an `Error` object returns `"Error: <message>"`, while the surrounding template literal already provides context (`"Error while deleting..."`). This results in a confusing doubled prefix.

### Changes

Replace `String(error)` with `error instanceof Error ? error.message : String(error)` in 4 error message sites:

- `NetworkActions.svelte` — network deletion
- `ImageActions.svelte` — image deletion
- `ManifestActions.svelte` — manifest deletion
- `ContainerEmptyScreen.svelte` — container run from empty screen

### Tests

Added/updated unit tests to assert the exact error message content (no doubled `Error:` prefix):

- `NetworkActions.spec.ts` — added `message` assertion to existing error dialog test
- `ImageActions.spec.ts` — enhanced test with message content verification
- `ManifestActions.spec.ts` — added new error dialog test

## Verification

- [x] All 14 unit tests pass across 3 spec files
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint:check` — 0 errors

Fixes https://github.com/podman-desktop/podman-desktop/issues/17434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>