### PR TITLE
chore(deps): update to yauzl: '^3.3.1' for electron install

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
   },
   "pnpm": {
     "overrides": {
+      "extract-zip>yauzl": "^3.3.1",
       "@xmldom/xmldom": "^0.8.12",
       "rollup": "^4.59.0",
       "react-router>path-to-regexp": "^1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  extract-zip>yauzl: ^3.3.1
   '@xmldom/xmldom': ^0.8.12
   rollup: ^4.59.0
   react-router>path-to-regexp: ^1.9.0
@@ -7461,9 +7462,6 @@ packages:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
 
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -12518,8 +12516,9 @@ packages:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+  yauzl@3.3.1:
+    resolution: {integrity: sha512-RNPCUkiE/ZgO4w8i9U5yDQVHaFDdnzaFANElRvpJteCspvmv2VqrRb9lvS6odVD+jqI/zDsxAHJVsafpcheVQQ==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -20541,7 +20540,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       get-stream: 5.2.0
-      yauzl: 2.10.0
+      yauzl: 3.3.1
     optionalDependencies:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
@@ -20591,10 +20590,6 @@ snapshots:
   faye-websocket@0.11.4:
     dependencies:
       websocket-driver: 0.7.4
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -26692,10 +26687,10 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
-  yauzl@2.10.0:
+  yauzl@3.3.1:
     dependencies:
       buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
chore(deps): update to yauzl: '^3.3.1' for electron install

### What does this PR do?

There are issues when installing electron / using `pnpm watch`.

```
pnpm watch

> podman-desktop@1.28.0-next watch /Users/vladimirlazar/repos/podman-desktop
> node scripts/watch.mjs

Downloading Electron binary...
node:fs:441
    return binding.readFileUtf8(path, stringToFlags(options.flag));
                   ^

Error: ENOENT: no such file or directory, open '/Users/vladimirlazar/repos/podman-desktop/node_modules/electron/path.txt'
    at Object.readFileSync (node:fs:441:20)
    at getElectronPath (/Users/vladimirlazar/repos/podman-desktop/node_modules/electron/index.js:47:25)
    at Object.<anonymous> (/Users/vladimirlazar/repos/podman-desktop/node_modules/electron/index.js:52:18)
    at Module._compile (node:internal/modules/cjs/loader:1854:14)
    at Object..js (node:internal/modules/cjs/loader:1985:10)
    at Module.load (node:internal/modules/cjs/loader:1577:32)
    at Module._load (node:internal/modules/cjs/loader:1379:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at loadCJSModuleWithModuleLoad (node:internal/modules/esm/translators:326:3)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:231:7) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/vladimirlazar/repos/podman-desktop/node_modules/electron/path.txt'
}

Node.js v24.16.0
 ELIFECYCLE  Command failed with exit code 1.
```

There is an upstream issue here: where this is failing on the newer
electron verisons and node: https://github.com/electron/electron/issues/51619

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/;A

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

https://github.com/electron/electron/issues/51619

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

`rm -rf node_modules && rm -rf pnpm-lock.yaml && pnpm install`

and then

`pnpm watch`

and you should be able to use it now.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
