### PR TITLE
chore: check for github link for github love/like message in feedback form

### DIFF
--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -79,9 +79,7 @@ test('Expect confirmation dialog to be displayed if content changed', async () =
     });
   });
 
-  // Get the last call (after onMount completed)
-  const lastCallIndex = vi.mocked(DirectFeedback).mock.calls.length - 1;
-  const { onCloseForm, contentChange } = vi.mocked(DirectFeedback).mock.calls[lastCallIndex][1];
+  const { onCloseForm, contentChange } = vi.mocked(DirectFeedback).mock.calls[0][1];
 
   // 1. simulate content change
   contentChange(true);
@@ -113,9 +111,7 @@ test('Expect no confirmation dialog to be displayed if content has not changed',
     });
   });
 
-  // Get the last call (after onMount completed)
-  const lastCallIndex = vi.mocked(DirectFeedback).mock.calls.length - 1;
-  const { onCloseForm } = vi.mocked(DirectFeedback).mock.calls[lastCallIndex][1];
+  const { onCloseForm } = vi.mocked(DirectFeedback).mock.calls[0][1];
 
   // 2. close
   onCloseForm(true);

--- a/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/SendFeedback.spec.ts
@@ -43,6 +43,7 @@ beforeEach(() => {
   vi.mocked(window.getGitHubFeedbackLinks).mockResolvedValue({
     bug: '/bug/link',
     feature: '/feature/link',
+    baseRepository: 'https://github.com/test/repo',
   });
 });
 
@@ -51,11 +52,14 @@ test('Expect developers feedback form to be rendered by default', async () => {
 
   await vi.waitFor(() => expect(window.getGitHubFeedbackLinks).toHaveBeenCalled());
 
-  expect(DirectFeedback).toHaveBeenCalledOnce();
-  expect(DirectFeedback).toHaveBeenCalledWith(expect.anything(), {
-    onCloseForm: expect.any(Function),
-    category: 'developers',
-    contentChange: expect.any(Function),
+  // Wait for onMount to complete and state to update
+  await vi.waitFor(() => {
+    expect(DirectFeedback).toHaveBeenLastCalledWith(expect.anything(), {
+      onCloseForm: expect.any(Function),
+      category: 'developers',
+      contentChange: expect.any(Function),
+      githubLink: 'https://github.com/test/repo',
+    });
   });
   expect(GitHubIssueFeedback).not.toHaveBeenCalled();
 });
@@ -65,13 +69,19 @@ test('Expect confirmation dialog to be displayed if content changed', async () =
 
   await vi.waitFor(() => expect(window.getGitHubFeedbackLinks).toHaveBeenCalled());
 
-  expect(DirectFeedback).toHaveBeenCalledWith(expect.anything(), {
-    onCloseForm: expect.any(Function),
-    category: 'developers',
-    contentChange: expect.any(Function),
+  // Wait for onMount to complete and state to update
+  await vi.waitFor(() => {
+    expect(DirectFeedback).toHaveBeenLastCalledWith(expect.anything(), {
+      onCloseForm: expect.any(Function),
+      category: 'developers',
+      contentChange: expect.any(Function),
+      githubLink: 'https://github.com/test/repo',
+    });
   });
 
-  const { onCloseForm, contentChange } = vi.mocked(DirectFeedback).mock.calls[0][1];
+  // Get the last call (after onMount completed)
+  const lastCallIndex = vi.mocked(DirectFeedback).mock.calls.length - 1;
+  const { onCloseForm, contentChange } = vi.mocked(DirectFeedback).mock.calls[lastCallIndex][1];
 
   // 1. simulate content change
   contentChange(true);
@@ -93,13 +103,19 @@ test('Expect no confirmation dialog to be displayed if content has not changed',
 
   await vi.waitFor(() => expect(window.getGitHubFeedbackLinks).toHaveBeenCalled());
 
-  expect(DirectFeedback).toHaveBeenCalledWith(expect.anything(), {
-    onCloseForm: expect.any(Function),
-    category: 'developers',
-    contentChange: expect.any(Function),
+  // Wait for onMount to complete and state to update
+  await vi.waitFor(() => {
+    expect(DirectFeedback).toHaveBeenLastCalledWith(expect.anything(), {
+      onCloseForm: expect.any(Function),
+      category: 'developers',
+      contentChange: expect.any(Function),
+      githubLink: 'https://github.com/test/repo',
+    });
   });
 
-  const { onCloseForm } = vi.mocked(DirectFeedback).mock.calls[0][1];
+  // Get the last call (after onMount completed)
+  const lastCallIndex = vi.mocked(DirectFeedback).mock.calls.length - 1;
+  const { onCloseForm } = vi.mocked(DirectFeedback).mock.calls[lastCallIndex][1];
 
   // 2. close
   onCloseForm(true);
@@ -127,6 +143,7 @@ test('Expect DirectFeedback form to be rendered when design category is selected
     onCloseForm: expect.any(Function),
     category: 'design',
     contentChange: expect.any(Function),
+    githubLink: 'https://github.com/test/repo',
   });
   expect(GitHubIssueFeedback).not.toHaveBeenCalled();
 });
@@ -151,6 +168,7 @@ test('Expect GitHubIssue feedback form to be rendered if category is not develop
     categoryLinks: {
       bug: '/bug/link',
       feature: '/feature/link',
+      baseRepository: 'https://github.com/test/repo',
     },
     category: 'bug',
     contentChange: expect.any(Function),
@@ -167,6 +185,7 @@ test('Expect GitHubIssue feedback form to be rendered if category is not develop
     categoryLinks: {
       bug: '/bug/link',
       feature: '/feature/link',
+      baseRepository: 'https://github.com/test/repo',
     },
     category: 'feature',
     contentChange: expect.any(Function),

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -13,8 +13,9 @@ let displayModal = $state(false);
 const DEFAULT_CATEGORY: FeedbackCategory = 'developers';
 let category: FeedbackCategory = $state(DEFAULT_CATEGORY);
 let hasContent: boolean = false;
-let categoryGitHubLinks: { [category: string]: string } | undefined = $state({});
+let githubFeedbackLinks: { [category: string]: string } | undefined = $state({});
 let feedbackLinks: { [category: string]: string } = $state({});
+let githubRepository = $state('');
 
 const feedbackCategories = new SvelteMap<FeedbackCategory, string>([
   ['developers', '💬 Direct your words to the developers'],
@@ -58,12 +59,12 @@ function handleUpdate(e: boolean): void {
 }
 
 onMount(async () => {
-  categoryGitHubLinks = await window.getGitHubFeedbackLinks();
-  if (categoryGitHubLinks && (categoryGitHubLinks.feature || categoryGitHubLinks.bug)) {
-    if (categoryGitHubLinks.feature) {
+  githubFeedbackLinks = await window.getGitHubFeedbackLinks();
+  if (githubFeedbackLinks && (githubFeedbackLinks.feature || githubFeedbackLinks.bug)) {
+    if (githubFeedbackLinks.feature) {
       feedbackCategories.set('feature', '🚀 Feature request');
     }
-    if (categoryGitHubLinks.bug) {
+    if (githubFeedbackLinks.bug) {
       feedbackCategories.set('bug', '🪲 Bug');
     }
   } else {
@@ -72,6 +73,8 @@ onMount(async () => {
       feedbackCategories.set('other', '❓ Other');
     }
   }
+
+  githubRepository = githubFeedbackLinks?.baseRepository ?? '';
 });
 </script>
 
@@ -91,9 +94,9 @@ onMount(async () => {
     </div>
 
     {#if category === 'developers' || category === 'design'}
-      <DirectFeedback onCloseForm={hideModal} category={category} contentChange={handleUpdate}/>
+      <DirectFeedback onCloseForm={hideModal} category={category} contentChange={handleUpdate} githubLink={githubRepository}/>
     {:else if category === 'bug' || category === 'feature'}
-      <GitHubIssueFeedback onCloseForm={hideModal} category={category} categoryLinks={categoryGitHubLinks} contentChange={handleUpdate}/>
+      <GitHubIssueFeedback onCloseForm={hideModal} category={category} categoryLinks={githubFeedbackLinks} contentChange={handleUpdate}/>
     {:else if category === 'other'}
       <FeedbackForm>
         <svelte:fragment slot="content">

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -46,14 +46,24 @@ beforeEach(() => {
 });
 
 test('Expect that the button is disabled when loading the page', async () => {
-  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+  render(DirectFeedback, {
+    category: 'developers',
+    contentChange: vi.fn(),
+    onCloseForm: vi.fn(),
+    githubLink: 'https://github.com/test/repo',
+  });
   const button = await screen.findByRole('button', { name: 'Send feedback' });
   expect(button).toBeInTheDocument();
   expect(button).toBeDisabled();
 });
 
 test('Expect that the button is enabled after clicking on a smiley', async () => {
-  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+  render(DirectFeedback, {
+    category: 'developers',
+    contentChange: vi.fn(),
+    onCloseForm: vi.fn(),
+    githubLink: 'https://github.com/test/repo',
+  });
   const button = await screen.findByRole('button', { name: 'Send feedback' });
 
   // expect to have indication why the button is disabled
@@ -71,7 +81,12 @@ test('Expect that the button is enabled after clicking on a smiley', async () =>
 });
 
 test('Expect very sad smiley errors without feedback', async () => {
-  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+  render(DirectFeedback, {
+    category: 'developers',
+    contentChange: vi.fn(),
+    onCloseForm: vi.fn(),
+    githubLink: 'https://github.com/test/repo',
+  });
   const button = await screen.findByRole('button', { name: 'Send feedback' });
   expect(button).toBeDisabled();
 
@@ -99,7 +114,12 @@ test('Expect very sad smiley errors without feedback', async () => {
 });
 
 test('Expect sad smiley warns without feedback', async () => {
-  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+  render(DirectFeedback, {
+    category: 'developers',
+    contentChange: vi.fn(),
+    onCloseForm: vi.fn(),
+    githubLink: 'https://github.com/test/repo',
+  });
   const button = await screen.findByRole('button', { name: 'Send feedback' });
   expect(button).toBeDisabled();
 
@@ -130,6 +150,7 @@ test('Expect message for very-happy-smiley to use love', async () => {
     category: 'developers',
     contentChange: vi.fn(),
     onCloseForm: vi.fn(),
+    githubLink: 'https://github.com/test/repo',
   });
 
   // click on a smiley
@@ -146,6 +167,7 @@ test('Expect message for happy-smiley to use like', async () => {
     category: 'developers',
     contentChange: vi.fn(),
     onCloseForm: vi.fn(),
+    githubLink: 'https://github.com/test/repo',
   });
 
   // click on a smiley
@@ -159,7 +181,12 @@ test('Expect message for happy-smiley to use like', async () => {
 
 test('Expect GitHub dialog visible when very-happy-smiley selected', async () => {
   const onCloseFormMock = vi.fn();
-  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: onCloseFormMock });
+  render(DirectFeedback, {
+    category: 'developers',
+    contentChange: vi.fn(),
+    onCloseForm: onCloseFormMock,
+    githubLink: 'https://github.com/test/repo',
+  });
 
   // click on a smiley
   const smiley = await screen.findByRole('button', { name: 'very-happy-smiley' });
@@ -173,7 +200,7 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
 
   await vi.waitFor(() => {
     expect(window.telemetryTrack).toHaveBeenCalledWith('feedback.openGitHub');
-    expect(window.openExternal).toHaveBeenCalledWith('https://github.com/containers/podman-desktop');
+    expect(window.openExternal).toHaveBeenCalledWith('https://github.com/test/repo');
   });
 
   expect(onCloseFormMock).not.toHaveBeenCalled();
@@ -181,7 +208,12 @@ test('Expect GitHub dialog visible when very-happy-smiley selected', async () =>
 
 test('Expect category to be sent', async () => {
   const closeMock = vi.fn();
-  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: closeMock });
+  render(DirectFeedback, {
+    category: 'developers',
+    contentChange: vi.fn(),
+    onCloseForm: closeMock,
+    githubLink: 'https://github.com/test/repo',
+  });
 
   // click on a smiley
   const smiley = await screen.findByRole('button', { name: 'very-happy-smiley' });
@@ -214,7 +246,12 @@ test('Expect category to be sent', async () => {
 
 test('Expect design category to be sent when design category is used', async () => {
   const closeMock = vi.fn();
-  render(DirectFeedback, { category: 'design', contentChange: vi.fn(), onCloseForm: closeMock });
+  render(DirectFeedback, {
+    category: 'design',
+    contentChange: vi.fn(),
+    onCloseForm: closeMock,
+    githubLink: 'https://github.com/test/repo',
+  });
 
   // click on a smiley
   const smiley = await screen.findByRole('button', { name: 'very-happy-smiley' });
@@ -246,7 +283,12 @@ test('Expect design category to be sent when design category is used', async () 
 });
 
 test('Expect email field has correct text', async () => {
-  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+  render(DirectFeedback, {
+    category: 'developers',
+    contentChange: vi.fn(),
+    onCloseForm: vi.fn(),
+    githubLink: 'https://github.com/test/repo',
+  });
 
   const emaillabel = await screen.findByLabelText(
     'Share your email address if we can follow up with you regarding your feedback. We will only use your email address for this purpose:',
@@ -257,4 +299,20 @@ test('Expect email field has correct text', async () => {
     'Enter email address, or leave blank for anonymous feedback',
   );
   expect(emailPlaceholder).toBeInTheDocument();
+});
+
+test('Expect GitHub link section hidden when githubLink is not provided', async () => {
+  render(DirectFeedback, {
+    category: 'developers',
+    contentChange: vi.fn(),
+    onCloseForm: vi.fn(),
+  });
+
+  // click on a very-happy smiley
+  const smiley = await screen.findByRole('button', { name: 'very-happy-smiley' });
+  await fireEvent.click(smiley);
+
+  // expect GitHub star text to NOT be visible
+  expect(screen.queryByLabelText('Like Podman Desktop? Give us a star on GitHub')).not.toBeInTheDocument();
+  expect(screen.queryByRole('link', { name: 'GitHub' })).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -19,6 +19,7 @@ interface Props {
   onCloseForm: (confirmation: boolean) => void;
   contentChange: (e: boolean) => void;
   category: DirectFeedbackCategory;
+  githubLink?: string;
 }
 
 // feedback of the user
@@ -30,7 +31,7 @@ let hasFeedback = $derived(
     (contactInformation && contactInformation.trim().length > 4),
 );
 
-let { onCloseForm, contentChange, category }: Props = $props();
+let { onCloseForm, contentChange, category, githubLink }: Props = $props();
 
 $effect(() => contentChange(Boolean(smileyRating || tellUsWhyFeedback || contactInformation)));
 
@@ -70,8 +71,10 @@ async function sendFeedback(): Promise<void> {
 }
 
 async function openGitHub(): Promise<void> {
-  await window.telemetryTrack('feedback.openGitHub');
-  await window.openExternal('https://github.com/containers/podman-desktop');
+  if (githubLink) {
+    await window.telemetryTrack('feedback.openGitHub');
+    await window.openExternal(githubLink);
+  }
 }
 </script>
 
@@ -145,7 +148,7 @@ async function openGitHub(): Promise<void> {
       <ErrorMessage class="text-xs" error="Please share contact info or details on how we can improve" />
     {:else if smileyRating === 2 && !hasFeedback}
       <WarningMessage class="text-xs" error="We would really appreciate knowing how we can improve" />
-    {:else if smileyRating > 2}
+    {:else if smileyRating > 2 && githubLink}
       <div class="text-[var(--pd-modal-text)] p-1 flex flex-row items-center text-xs">
         <Icon size="1.125x" class="cursor-pointer" icon={faQuestionCircle} />
         <span aria-label="{feedbackMessages?.gitHubStarsMessage}" class="flex items-center">

--- a/product.json
+++ b/product.json
@@ -161,7 +161,8 @@
   "GitHubFeedbackLinks": {
     "bug": "https://github.com/podman-desktop/podman-desktop/issues?q=is%3Aissue%20state%3Aopen%20type%3ABug",
     "feature": "https://github.com/podman-desktop/podman-desktop/issues?q=is%3Aissue%20state%3Aopen%20type%3AFeature",
-    "issues": "https://github.com/podman-desktop/podman-desktop/issues"
+    "issues": "https://github.com/podman-desktop/podman-desktop/issues",
+    "baseRepository": "https://github.com/podman-desktop/podman-desktop"
   },
   "feedbackLinks": {},
   "configuration": {


### PR DESCRIPTION
### What does this PR do?
This PR connects the `Love it? Give us a * on GitHub` message to the baseRepository link in `product.json`. If there is no baseRepository, the text will not show up

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/17494

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
