### PR TITLE
fix(renderer): add duplicate volume name validation on create form 

### DIFF
--- a/packages/renderer/src/lib/volume/CreateVolume.spec.ts
+++ b/packages/renderer/src/lib/volume/CreateVolume.spec.ts
@@ -65,6 +65,7 @@ test('Expect Create button is working', async () => {
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [
@@ -93,6 +94,7 @@ test('Expect Create with a custom name', async () => {
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [
@@ -140,6 +142,7 @@ test('Expect error message when volume creation fails', async () => {
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [
@@ -171,6 +174,7 @@ test('Expect Create with a custom name and multiple providers', async () => {
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [
@@ -182,6 +186,7 @@ test('Expect Create with a custom name and multiple providers', async () => {
     } as unknown as ProviderInfo,
     {
       name: 'docker',
+      id: 'docker',
       status: 'started',
       internalId: 'docker-internal-id',
       containerConnections: [
@@ -230,6 +235,7 @@ test('Expect error and disabled button when volume name already exists', async (
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [
@@ -266,6 +272,7 @@ test('Expect no error when volume name is unique', async () => {
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [
@@ -302,6 +309,7 @@ test('Expect no error when volume name is empty', async () => {
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [
@@ -341,6 +349,7 @@ test('Expect revalidation when provider changes', async () => {
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [
@@ -352,6 +361,7 @@ test('Expect revalidation when provider changes', async () => {
     } as unknown as ProviderInfo,
     {
       name: 'docker',
+      id: 'docker',
       status: 'started',
       internalId: 'docker-internal-id',
       containerConnections: [
@@ -393,10 +403,72 @@ test('Expect revalidation when provider changes', async () => {
   expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
 });
 
+test('Expect no false positive when providers share connection name', async () => {
+  providerInfos.set([
+    {
+      name: 'podman',
+      id: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'Docker',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+    {
+      name: 'docker',
+      id: 'docker',
+      status: 'started',
+      internalId: 'docker-internal-id',
+      containerConnections: [
+        {
+          name: 'Docker',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  volumeListInfos.set([
+    {
+      engineId: 'docker.Docker',
+      engineName: 'docker',
+      Volumes: [{ Name: 'my-vol' }],
+      Warnings: [],
+    } as unknown as VolumeListInfo,
+    {
+      engineId: 'podman.Docker',
+      engineName: 'podman',
+      Volumes: [],
+      Warnings: [],
+    } as unknown as VolumeListInfo,
+  ]);
+
+  render(CreateVolume, {});
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.type(nameInput, 'my-vol');
+
+  // podman.Docker is selected first — no volume named 'my-vol' there
+  expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+
+  // switch to docker.Docker — 'my-vol' exists there
+  const providerSelect = screen.getByRole('combobox', { name: 'Provider Choice' });
+  const options = providerSelect.querySelectorAll('option');
+  await userEvent.selectOptions(providerSelect, options[1] as HTMLOptionElement);
+
+  expect(screen.getByText(/already exists/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+});
+
 test('Expect error clears when name is corrected', async () => {
   providerInfos.set([
     {
       name: 'podman',
+      id: 'podman',
       status: 'started',
       internalId: 'podman-internal-id',
       containerConnections: [

--- a/packages/renderer/src/lib/volume/CreateVolume.spec.ts
+++ b/packages/renderer/src/lib/volume/CreateVolume.spec.ts
@@ -255,7 +255,7 @@ test('Expect error and disabled button when volume name already exists', async (
   const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
   await userEvent.type(nameInput, 'existing-volume');
 
-  const errorMessage = screen.getByText('The name existing-volume already exists. Please choose a different name.');
+  const errorMessage = screen.getByText('The name "existing-volume" already exists. Please choose a different name.');
   expect(errorMessage).toBeInTheDocument();
 
   const createButton = screen.getByRole('button', { name: createButtonTitle });
@@ -335,6 +335,62 @@ test('Expect no error when volume name is empty', async () => {
 
   const createButton = screen.getByRole('button', { name: createButtonTitle });
   expect(createButton).toBeEnabled();
+});
+
+test('Expect revalidation when provider changes', async () => {
+  providerInfos.set([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+    {
+      name: 'docker',
+      status: 'started',
+      internalId: 'docker-internal-id',
+      containerConnections: [
+        {
+          name: 'docker',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  volumeListInfos.set([
+    {
+      engineId: 'podman.podman-machine-default',
+      engineName: 'podman',
+      Volumes: [{ Name: 'shared-name' }],
+      Warnings: [],
+    } as unknown as VolumeListInfo,
+    {
+      engineId: 'docker.docker',
+      engineName: 'docker',
+      Volumes: [],
+      Warnings: [],
+    } as unknown as VolumeListInfo,
+  ]);
+
+  render(CreateVolume, {});
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.type(nameInput, 'shared-name');
+
+  expect(screen.getByText(/already exists/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+
+  const providerSelect = screen.getByRole('combobox', { name: 'Provider Choice' });
+  await userEvent.selectOptions(providerSelect, 'docker');
+
+  expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
 });
 
 test('Expect error clears when name is corrected', async () => {

--- a/packages/renderer/src/lib/volume/CreateVolume.spec.ts
+++ b/packages/renderer/src/lib/volume/CreateVolume.spec.ts
@@ -20,12 +20,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { ProviderInfo } from '@podman-desktop/core-api';
+import type { ProviderInfo, VolumeListInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
+import { volumeListInfos } from '/@/stores/volumes';
 
 import CreateVolume from './CreateVolume.svelte';
 
@@ -34,6 +35,11 @@ const createVolumeMock = vi.fn();
 // fake the window.events object
 beforeAll(() => {
   (window as any).createVolume = createVolumeMock;
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  volumeListInfos.set([]);
 });
 
 const createButtonTitle = 'Create';
@@ -218,4 +224,154 @@ test('Expect Create with a custom name and multiple providers', async () => {
   expect(createVolumeMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'docker' }), {
     Name: customVolumeName,
   });
+});
+
+test('Expect error and disabled button when volume name already exists', async () => {
+  providerInfos.set([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  volumeListInfos.set([
+    {
+      engineId: 'podman.podman-machine-default',
+      engineName: 'podman',
+      Volumes: [{ Name: 'existing-volume' }],
+      Warnings: [],
+    } as unknown as VolumeListInfo,
+  ]);
+
+  render(CreateVolume, {});
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.type(nameInput, 'existing-volume');
+
+  const errorMessage = screen.getByText('The name existing-volume already exists. Please choose a different name.');
+  expect(errorMessage).toBeInTheDocument();
+
+  const createButton = screen.getByRole('button', { name: createButtonTitle });
+  expect(createButton).toBeDisabled();
+});
+
+test('Expect no error when volume name is unique', async () => {
+  providerInfos.set([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  volumeListInfos.set([
+    {
+      engineId: 'podman.podman-machine-default',
+      engineName: 'podman',
+      Volumes: [{ Name: 'existing-volume' }],
+      Warnings: [],
+    } as unknown as VolumeListInfo,
+  ]);
+
+  render(CreateVolume, {});
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.type(nameInput, 'new-volume');
+
+  const errorMessage = screen.queryByText(/already exists/);
+  expect(errorMessage).not.toBeInTheDocument();
+
+  const createButton = screen.getByRole('button', { name: createButtonTitle });
+  expect(createButton).toBeEnabled();
+});
+
+test('Expect no error when volume name is empty', async () => {
+  providerInfos.set([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  volumeListInfos.set([
+    {
+      engineId: 'podman.podman-machine-default',
+      engineName: 'podman',
+      Volumes: [{ Name: 'existing-volume' }],
+      Warnings: [],
+    } as unknown as VolumeListInfo,
+  ]);
+
+  render(CreateVolume, {});
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.type(nameInput, 'existing-volume');
+
+  expect(screen.getByText(/already exists/)).toBeInTheDocument();
+
+  await userEvent.clear(nameInput);
+
+  expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+
+  const createButton = screen.getByRole('button', { name: createButtonTitle });
+  expect(createButton).toBeEnabled();
+});
+
+test('Expect error clears when name is corrected', async () => {
+  providerInfos.set([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        },
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  volumeListInfos.set([
+    {
+      engineId: 'podman.podman-machine-default',
+      engineName: 'podman',
+      Volumes: [{ Name: 'my-volume' }],
+      Warnings: [],
+    } as unknown as VolumeListInfo,
+  ]);
+
+  render(CreateVolume, {});
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.type(nameInput, 'my-volume');
+
+  expect(screen.getByText(/already exists/)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+
+  await userEvent.clear(nameInput);
+  await userEvent.type(nameInput, 'my-volume-2');
+
+  expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
 });

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -43,10 +43,15 @@ function checkVolumeName(nameValue: string, provider: ProviderContainerConnectio
     return;
   }
 
-  const volumeAlreadyExists = $volumeListInfos
-    .filter(vli => vli.engineId.endsWith(`.${provider.name}`))
-    .flatMap(vli => vli.Volumes)
-    .some(volume => volume.Name === nameValue);
+  const parentProvider = providers.find(p => p.containerConnections.includes(provider));
+  const engineId = parentProvider ? `${parentProvider.id}.${provider.name}` : undefined;
+
+  const volumeAlreadyExists = engineId
+    ? $volumeListInfos
+        .filter(vli => vli.engineId === engineId)
+        .flatMap(vli => vli.Volumes)
+        .some(volume => volume.Name === nameValue)
+    : false;
 
   if (volumeAlreadyExists) {
     volumeNameError = `The name "${nameValue}" already exists. Please choose a different name.`;

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -26,7 +26,7 @@ onMount(async () => {
     .flat()
     .filter(providerContainerConnection => providerContainerConnection.status === 'started');
 
-  const selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
+  selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
   selectedProvider = !selectedProvider && selectedProviderConnection ? selectedProviderConnection : selectedProvider;
 });
 
@@ -36,12 +36,9 @@ let volumeNameError: string | undefined = undefined;
 let invalidName = false;
 onDestroy(() => {});
 
-function checkVolumeName(event: Event & { currentTarget: HTMLInputElement }): void {
-  const nameValue = event.currentTarget.value;
-
-  const provider = selectedProvider;
+function checkVolumeName(nameValue: string, provider: ProviderContainerConnectionInfo | undefined): void {
   if (!nameValue || !provider) {
-    volumeNameError = '';
+    volumeNameError = undefined;
     invalidName = false;
     return;
   }
@@ -52,17 +49,19 @@ function checkVolumeName(event: Event & { currentTarget: HTMLInputElement }): vo
     .some(volume => volume.Name === nameValue);
 
   if (volumeAlreadyExists) {
-    volumeNameError = `The name ${nameValue} already exists. Please choose a different name.`;
+    volumeNameError = `The name "${nameValue}" already exists. Please choose a different name.`;
     invalidName = true;
   } else {
-    volumeNameError = '';
+    volumeNameError = undefined;
     invalidName = false;
   }
 }
 
+$: checkVolumeName(volumeName, selectedProvider);
+
 async function createVolume(providerConnectionInfo: ProviderContainerConnectionInfo): Promise<void> {
   createError = undefined;
-  volumeNameError = '';
+  volumeNameError = undefined;
   invalidName = false;
   createVolumeInProgress = true;
   try {
@@ -97,7 +96,7 @@ export let volumeName = '';
     <div>
       <label for="containerBuildContextDirectory" class="block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
         >Volume name:</label>
-      <Input clearable aria-label="Volume Name" disabled={createVolumeFinished} bind:value={volumeName} oninput={checkVolumeName} error={volumeNameError} required />
+      <Input clearable aria-label="Volume Name" disabled={createVolumeFinished} bind:value={volumeName} error={volumeNameError} aria-invalid={invalidName || undefined} required />
     </div>
     <div class:hidden={providerConnections.length < 2}>
       {#if providerConnections.length > 1}

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -12,6 +12,7 @@ import { router } from 'tinro';
 import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import { providerInfos } from '/@/stores/providers';
+import { volumeListInfos } from '/@/stores/volumes';
 
 let providers: ProviderInfo[] = [];
 let providerConnections: ProviderContainerConnectionInfo[] = [];
@@ -31,10 +32,38 @@ onMount(async () => {
 
 let createVolumeInProgress = false;
 let createError: string | undefined = undefined;
+let volumeNameError: string | undefined = undefined;
+let invalidName = false;
 onDestroy(() => {});
+
+function checkVolumeName(event: Event & { currentTarget: HTMLInputElement }): void {
+  const nameValue = event.currentTarget.value;
+
+  const provider = selectedProvider;
+  if (!nameValue || !provider) {
+    volumeNameError = '';
+    invalidName = false;
+    return;
+  }
+
+  const volumeAlreadyExists = $volumeListInfos
+    .filter(vli => vli.engineId.endsWith(`.${provider.name}`))
+    .flatMap(vli => vli.Volumes)
+    .some(volume => volume.Name === nameValue);
+
+  if (volumeAlreadyExists) {
+    volumeNameError = `The name ${nameValue} already exists. Please choose a different name.`;
+    invalidName = true;
+  } else {
+    volumeNameError = '';
+    invalidName = false;
+  }
+}
 
 async function createVolume(providerConnectionInfo: ProviderContainerConnectionInfo): Promise<void> {
   createError = undefined;
+  volumeNameError = '';
+  invalidName = false;
   createVolumeInProgress = true;
   try {
     await window.createVolume(providerConnectionInfo, { Name: volumeName });
@@ -68,7 +97,7 @@ export let volumeName = '';
     <div>
       <label for="containerBuildContextDirectory" class="block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
         >Volume name:</label>
-      <Input clearable aria-label="Volume Name" disabled={createVolumeFinished} bind:value={volumeName} required />
+      <Input clearable aria-label="Volume Name" disabled={createVolumeFinished} bind:value={volumeName} oninput={checkVolumeName} error={volumeNameError} required />
     </div>
     <div class:hidden={providerConnections.length < 2}>
       {#if providerConnections.length > 1}
@@ -95,7 +124,7 @@ export let volumeName = '';
         {@const connection = selectedProvider}
         <Button
           on:click={(): Promise<void> => createVolume(connection)}
-          disabled={createVolumeInProgress}
+          disabled={createVolumeInProgress || invalidName}
           class="w-full"
           inProgress={createVolumeInProgress}
           icon={faPlusCircle}>


### PR DESCRIPTION
### What does this PR do?
Adds client-side validation that checks the volume name against existing volumes scoped to the selected provider engine, showing an inline error and disabling the Create button when a duplicate is detected.

### Screenshot / video of UI
<img width="905" height="460" alt="Screenshot 2026-05-27 at 11 53 08" src="https://github.com/user-attachments/assets/52fbd085-4dbd-4029-9ec3-1ae6a245f0ec" />


### What issues does this PR fix or reference?

#16356

### How to test this PR?

`pnpm exec vitest run packages/renderer/src/lib/volume/CreateVolume.spec.ts`


- [x] Tests are covering the bug fix or the new feature
