### PR TITLE
chore(test): add breadcrumb validation e2e tests

### DIFF
--- a/tests/playwright/src/index.ts
+++ b/tests/playwright/src/index.ts
@@ -92,6 +92,7 @@ export * from './model/pages/registries-page';
 export * from './model/pages/resource-card-page';
 export * from './model/pages/resource-cli-card-page';
 export * from './model/pages/resource-connection-card-page';
+export * from './model/pages/resource-creation-page';
 export * from './model/pages/resource-details-page';
 export * from './model/pages/resources-page';
 export * from './model/pages/run-image-page';

--- a/tests/playwright/src/model/pages/resource-creation-page.ts
+++ b/tests/playwright/src/model/pages/resource-creation-page.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
+
+import { BasePage } from './base-page';
+import { ResourcesPage } from './resources-page';
+
+/**
+ * Represents the provider resource creation page (FormPage layout)
+ * accessible from Settings > Resources > Create new {provider}.
+ *
+ * Captures the breadcrumb navigation and close button shared across
+ * all provider creation pages (Podman machine, Kind cluster, etc.).
+ */
+export class ResourceCreationPage extends BasePage {
+  readonly breadcrumb: Locator;
+  readonly backLink: Locator;
+  readonly closeButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.breadcrumb = this.page.getByRole('navigation', { name: 'Breadcrumb' });
+    this.backLink = this.breadcrumb.getByRole('link', { name: 'Back' });
+    this.closeButton = this.breadcrumb.getByRole('button', { name: 'Close' });
+  }
+
+  async navigateToResourcesViaBreadcrumb(timeout = 10_000): Promise<ResourcesPage> {
+    return test.step('Navigate back to Resources via breadcrumb link', async () => {
+      await playExpect(this.backLink).toBeVisible();
+      await this.backLink.click();
+      const resourcesPage = new ResourcesPage(this.page);
+      await playExpect(resourcesPage.heading).toBeVisible({ timeout });
+      return resourcesPage;
+    });
+  }
+
+  async navigateToResourcesViaCloseButton(timeout = 10_000): Promise<ResourcesPage> {
+    return test.step('Navigate back to Resources via close button', async () => {
+      await playExpect(this.closeButton).toBeVisible();
+      await this.closeButton.click();
+      const resourcesPage = new ResourcesPage(this.page);
+      await playExpect(resourcesPage.heading).toBeVisible({ timeout });
+      return resourcesPage;
+    });
+  }
+}

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -19,10 +19,14 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { expect as playExpect } from '@playwright/test';
+import { expect as playExpect, type Page } from '@playwright/test';
 
 import { KubernetesResourceState } from '/@/model/core/states';
 import { KubernetesResources } from '/@/model/core/types';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourceCreationPage } from '/@/model/pages/resource-creation-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import type { NavigationBar } from '/@/model/workbench/navigation';
 import { canRunKindTests } from '/@/setupFiles/setup-kind';
 import { createKindCluster, deleteCluster } from '/@/utility/cluster-operations';
 import { test } from '/@/utility/fixtures';
@@ -137,6 +141,21 @@ test.afterAll(async ({ runner, page }) => {
     await runner.close();
   }
 });
+
+test.describe
+  .serial('Kind provider creation page navigation', { tag: ['@k8s_e2e', '@k8s_sanity'] }, () => {
+    test('Resources breadcrumb navigates back to Resources page', async ({ page, navigationBar }) => {
+      await openKindCreationPage(page, navigationBar);
+      const creationPage = new ResourceCreationPage(page);
+      await creationPage.navigateToResourcesViaBreadcrumb();
+    });
+
+    test('Close button navigates back to Resources page', async ({ page, navigationBar }) => {
+      await openKindCreationPage(page, navigationBar);
+      const creationPage = new ResourceCreationPage(page);
+      await creationPage.navigateToResourcesViaCloseButton();
+    });
+  });
 
 test.describe
   .serial('Kubernetes resources End-to-End test', { tag: ['@k8s_e2e', '@k8s_sanity'] }, () => {
@@ -381,3 +400,17 @@ test.describe
         });
       });
   });
+
+// Helper functions
+
+async function openKindCreationPage(page: Page, navigationBar: NavigationBar): Promise<void> {
+  await test.step('Open resources page and go to kind creation page', async () => {
+    const settingsBar = await navigationBar.openSettings();
+    const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
+    await playExpect(resourcesPage.heading).toBeVisible({ timeout: 10_000 });
+    await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+    const kindResourceCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, CLUSTER_NAME);
+    await playExpect(kindResourceCard.createButton).toBeVisible();
+    await kindResourceCard.createButton.click();
+  });
+}

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -19,7 +19,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { expect as playExpect, type Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 import { KubernetesResourceState } from '/@/model/core/states';
 import { KubernetesResources } from '/@/model/core/types';
@@ -29,7 +29,7 @@ import { ResourcesPage } from '/@/model/pages/resources-page';
 import type { NavigationBar } from '/@/model/workbench/navigation';
 import { canRunKindTests } from '/@/setupFiles/setup-kind';
 import { createKindCluster, deleteCluster } from '/@/utility/cluster-operations';
-import { test } from '/@/utility/fixtures';
+import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
   applyKubernetesYaml,
   checkDeploymentReplicasInfo,
@@ -408,7 +408,9 @@ async function openKindCreationPage(page: Page, navigationBar: NavigationBar): P
     const settingsBar = await navigationBar.openSettings();
     const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
     await playExpect(resourcesPage.heading).toBeVisible({ timeout: 10_000 });
-    await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+    await playExpect
+      .poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME), { timeout: 25_000 })
+      .toBeTruthy();
     const kindResourceCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, CLUSTER_NAME);
     await playExpect(kindResourceCard.createButton).toBeVisible();
     await kindResourceCard.createButton.click();

--- a/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
@@ -23,6 +23,7 @@ import { PodmanMachinePrivileges } from '/@/model/core/types';
 import { PodmanMachineDetails } from '/@/model/pages/podman-machine-details-page';
 import { PodmanOnboardingPage } from '/@/model/pages/podman-onboarding-page';
 import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourceCreationPage } from '/@/model/pages/resource-creation-page';
 import { ResourcesPage } from '/@/model/pages/resources-page';
 import type { NavigationBar } from '/@/model/workbench/navigation';
 import { expect as playExpect, test } from '/@/utility/fixtures';
@@ -83,6 +84,21 @@ test.afterAll(async ({ runner, page }) => {
 
   await runner.close();
 });
+
+test.describe
+  .serial('Podman provider creation page navigation', { tag: '@pdmachine' }, () => {
+    test('Resources breadcrumb navigates back to Resources page', async ({ page, navigationBar }) => {
+      await openPodmanCreationPage(page, navigationBar);
+      const creationPage = new ResourceCreationPage(page);
+      await creationPage.navigateToResourcesViaBreadcrumb();
+    });
+
+    test('Close button navigates back to Resources page', async ({ page, navigationBar }) => {
+      await openPodmanCreationPage(page, navigationBar);
+      const creationPage = new ResourceCreationPage(page);
+      await creationPage.navigateToResourcesViaCloseButton();
+    });
+  });
 
 test.describe
   .serial('Podman machine switching validation ', { tag: '@pdmachine' }, () => {
@@ -259,6 +275,19 @@ async function handlePodmanConfirmationDialogs(page: Page): Promise<void> {
 async function openResourcesPage(navigationBar: NavigationBar): Promise<void> {
   const settingsBar = await navigationBar.openSettings();
   await settingsBar.resourcesTab.click();
+}
+
+/**
+ * Navigates to the Podman machine creation page from the Resources page
+ */
+async function openPodmanCreationPage(page: Page, navigationBar: NavigationBar): Promise<void> {
+  await test.step('Open resources page and go to podman creation page', async () => {
+    await openResourcesPage(navigationBar);
+    const resourcesPage = new ResourcesPage(page);
+    await playExpect(resourcesPage.heading).toBeVisible();
+    await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+    await resourcesPage.goToCreateNewResourcePage(RESOURCE_NAME);
+  });
 }
 
 /**

--- a/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-tests.spec.ts
@@ -86,7 +86,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe
-  .serial('Podman provider creation page navigation', { tag: '@pdmachine' }, () => {
+  .serial('Podman provider creation page navigation', { tag: ['@pdmachine'] }, () => {
     test('Resources breadcrumb navigates back to Resources page', async ({ page, navigationBar }) => {
       await openPodmanCreationPage(page, navigationBar);
       const creationPage = new ResourceCreationPage(page);
@@ -285,7 +285,9 @@ async function openPodmanCreationPage(page: Page, navigationBar: NavigationBar):
     await openResourcesPage(navigationBar);
     const resourcesPage = new ResourcesPage(page);
     await playExpect(resourcesPage.heading).toBeVisible();
-    await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+    await playExpect
+      .poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME), { timeout: 25_000 })
+      .toBeTruthy();
     await resourcesPage.goToCreateNewResourcePage(RESOURCE_NAME);
   });
 }

--- a/tests/playwright/src/utility/kubernetes.ts
+++ b/tests/playwright/src/utility/kubernetes.ts
@@ -61,14 +61,14 @@ export async function createKubernetesResource(
     // workaround for missing option to deploy kube yaml into cluster via UI
     // test kubectl is present
     try {
-      // eslint-disable-next-line sonarjs/no-os-command-from-path
+      // eslint-disable-next-line sonarjs/no-os-command-from-path, n/no-sync
       const version = execSync('kubectl version').toString();
       console.log(`Kubectl version stdout: ${version}`);
     } catch (error) {
       throw new Error(`Kubectl is not installed: ${error}`);
     }
     try {
-      // eslint-disable-next-line sonarjs/os-command
+      // eslint-disable-next-line sonarjs/os-command, n/no-sync
       const kubectlApply = execSync(`kubectl apply -f ${resourceYamlPath}`).toString();
       console.log(`Kube yaml ${resourceYamlPath} applied successfully via cli: ${kubectlApply}`);
     } catch (error) {


### PR DESCRIPTION
### What does this PR do?
Adds e2e validation tests for resource creation page breadcrumbs.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/17245