### PR TITLE
test(e2e): fix k8s e2e tests failing on azure wsl machines

### DIFF
--- a/tests/playwright/src/specs/kind.spec.ts
+++ b/tests/playwright/src/specs/kind.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'node:url';
 
 import { ResourceElementActions } from '/@/model/core/operations';
 import { ContainerState, ExtensionState, ResourceElementState } from '/@/model/core/states';
-import type { ContainerInteractiveParams } from '/@/model/core/types';
+import { type ContainerInteractiveParams, PodmanVirtualizationProviders } from '/@/model/core/types';
 import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
 import { ResourcesPage } from '/@/model/pages/resources-page';
 import { canRunKindTests } from '/@/setupFiles/setup-kind';
@@ -36,6 +36,7 @@ import {
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { deployContainerToCluster } from '/@/utility/kubernetes';
 import { deleteContainer, deleteImage, ensureCliInstalled } from '/@/utility/operations';
+import { getVirtualizationProvider } from '/@/utility/provider';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const RESOURCE_NAME: string = 'kind';
@@ -71,6 +72,9 @@ let kindResourceCard: ResourceConnectionCardPage;
 
 const skipKindInstallation = process.env.SKIP_KIND_INSTALL === 'true';
 const providerTypeGHA = process.env.KIND_PROVIDER_GHA ?? '';
+
+const skipKindClusterLifecycleOnWsl =
+  'Kind cluster stop/start/restart is not working on Podman/WSL -> https://github.com/podman-desktop/podman-desktop/issues/4801 ';
 
 test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
 
@@ -155,27 +159,40 @@ test.describe('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
         await deployContainerToCluster(page, CONTAINER_NAME, KUBERNETES_CONTEXT, DEPLOYED_POD_NAME);
       });
 
-      test('Kind cluster operations - STOP', async ({ page }) => {
-        await resourceConnectionAction(page, kindResourceCard, ResourceElementActions.Stop, ResourceElementState.Off);
-      });
+      test.describe
+        .serial('Kind cluster lifecycle', () => {
+          test.skip(
+            () => getVirtualizationProvider() === PodmanVirtualizationProviders.WSL,
+            skipKindClusterLifecycleOnWsl,
+          );
 
-      test('Kind cluster operations - START', async ({ page }) => {
-        await resourceConnectionAction(
-          page,
-          kindResourceCard,
-          ResourceElementActions.Start,
-          ResourceElementState.Running,
-        );
-      });
+          test('Kind cluster operations - STOP', async ({ page }) => {
+            await resourceConnectionAction(
+              page,
+              kindResourceCard,
+              ResourceElementActions.Stop,
+              ResourceElementState.Off,
+            );
+          });
 
-      test('Kind cluster operations - RESTART', async ({ page }) => {
-        await resourceConnectionAction(
-          page,
-          kindResourceCard,
-          ResourceElementActions.Restart,
-          ResourceElementState.Running,
-        );
-      });
+          test('Kind cluster operations - START', async ({ page }) => {
+            await resourceConnectionAction(
+              page,
+              kindResourceCard,
+              ResourceElementActions.Start,
+              ResourceElementState.Running,
+            );
+          });
+
+          test('Kind cluster operations - RESTART', async ({ page }) => {
+            await resourceConnectionAction(
+              page,
+              kindResourceCard,
+              ResourceElementActions.Restart,
+              ResourceElementState.Running,
+            );
+          });
+        });
 
       test('Kind cluster operations - DELETE', async ({ page }) => {
         await deleteCluster(page, RESOURCE_NAME, KIND_CONTAINER, CLUSTER_NAME);
@@ -192,35 +209,43 @@ test.describe('Kind End-to-End Tests', { tag: '@k8s_e2e' }, () => {
         });
       });
 
-      test('Kind cluster operations details - STOP', async ({ page }) => {
-        await resourceConnectionActionDetails(
-          page,
-          kindResourceCard,
-          CLUSTER_NAME,
-          ResourceElementActions.Stop,
-          ResourceElementState.Off,
-        );
-      });
+      test.describe
+        .serial('Kind cluster lifecycle details', () => {
+          test.skip(
+            () => getVirtualizationProvider() === PodmanVirtualizationProviders.WSL,
+            skipKindClusterLifecycleOnWsl,
+          );
 
-      test('Kind cluster operations details - START', async ({ page }) => {
-        await resourceConnectionActionDetails(
-          page,
-          kindResourceCard,
-          CLUSTER_NAME,
-          ResourceElementActions.Start,
-          ResourceElementState.Running,
-        );
-      });
+          test('Kind cluster operations details - STOP', async ({ page }) => {
+            await resourceConnectionActionDetails(
+              page,
+              kindResourceCard,
+              CLUSTER_NAME,
+              ResourceElementActions.Stop,
+              ResourceElementState.Off,
+            );
+          });
 
-      test('Kind cluster operations details - RESTART', async ({ page }) => {
-        await resourceConnectionActionDetails(
-          page,
-          kindResourceCard,
-          CLUSTER_NAME,
-          ResourceElementActions.Restart,
-          ResourceElementState.Running,
-        );
-      });
+          test('Kind cluster operations details - START', async ({ page }) => {
+            await resourceConnectionActionDetails(
+              page,
+              kindResourceCard,
+              CLUSTER_NAME,
+              ResourceElementActions.Start,
+              ResourceElementState.Running,
+            );
+          });
+
+          test('Kind cluster operations details - RESTART', async ({ page }) => {
+            await resourceConnectionActionDetails(
+              page,
+              kindResourceCard,
+              CLUSTER_NAME,
+              ResourceElementActions.Restart,
+              ResourceElementState.Running,
+            );
+          });
+        });
 
       test('Kind cluster operations details - DELETE', async ({ page }) => {
         await deleteClusterFromDetails(page, RESOURCE_NAME, KIND_CONTAINER, CLUSTER_NAME);

--- a/tests/playwright/src/utility/provider.ts
+++ b/tests/playwright/src/utility/provider.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@
 import { PodmanVirtualizationProviders } from '/@/model/core/types';
 import { isMac, isWindows } from '/@/utility/platform';
 
-export const envProvider = process.env.CONTAINERS_MACHINE_PROVIDER;
-
 const PROVIDER_MAP: Record<string, PodmanVirtualizationProviders> = {
   wsl: PodmanVirtualizationProviders.WSL,
   hyperv: PodmanVirtualizationProviders.HyperV,
@@ -30,7 +28,8 @@ const PROVIDER_MAP: Record<string, PodmanVirtualizationProviders> = {
 };
 
 export function getVirtualizationProvider(): PodmanVirtualizationProviders | undefined {
-  return envProvider ? PROVIDER_MAP[envProvider?.toLowerCase()] : undefined;
+  const provider = process.env.CONTAINERS_MACHINE_PROVIDER;
+  return provider ? PROVIDER_MAP[provider.toLowerCase()] : undefined;
 }
 
 export function getDefaultVirtualizationProvider(): PodmanVirtualizationProviders {


### PR DESCRIPTION
### What does this PR do?
Adds a workaround for a persistent issue on the k8s e2e tests that makes it impossible to start a stopped kind cluster
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/17544
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
