### PR TITLE
fix: resolve CVE-2026-8723 in qs

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
       "react-router>path-to-regexp": "^1.9.0",
       "serve-handler>path-to-regexp": "^3.3.0",
       "express>cookie": "^0.7.0",
-      "qs": "^6.15.0",
+      "qs": "^6.15.2",
       "dompurify@^3": "^3.4.0",
       "webpack-dev-server>http-proxy-middleware": "^2.0.9",
       "esbuild-register>esbuild": "^0.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   react-router>path-to-regexp: ^1.9.0
   serve-handler>path-to-regexp: ^3.3.0
   express>cookie: ^0.7.0
-  qs: ^6.15.0
+  qs: ^6.15.2
   dompurify@^3: ^3.4.0
   webpack-dev-server>http-proxy-middleware: ^2.0.9
   esbuild-register>esbuild: ^0.25.0
@@ -10365,8 +10365,8 @@ packages:
 
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -18146,7 +18146,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -18161,7 +18161,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -20241,7 +20241,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.1
@@ -20276,7 +20276,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -23829,7 +23829,7 @@ snapshots:
 
   q@1.5.1: {}
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-8723 in `qs`.

**Advisory**: qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set
**Vulnerable versions**: >=6.11.1 <=6.15.1
**Patched versions**: >=6.15.2
**Advisory URL**: https://github.com/advisories/GHSA-q8mj-m7cp-5q26

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-8723: _qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-8723 is no longer reported