### PR TITLE
fix(renderer): resolve custom theme isDark detection for scrollbar color 

### DIFF
--- a/packages/api/src/theme-info.ts
+++ b/packages/api/src/theme-info.ts
@@ -27,3 +27,8 @@ export const RawThemeContributionSchema = z.object({
 });
 
 export type RawThemeContribution = z.output<typeof RawThemeContributionSchema>;
+
+export interface ThemeInfo {
+  isDark: boolean;
+  isHighContrast: boolean;
+}

--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -499,6 +499,118 @@ describe('isDarkTheme', () => {
   });
 });
 
+describe('isHighContrastTheme', () => {
+  beforeEach(() => {
+    const fakeExtension = {
+      id: 'foo.bar',
+    } as unknown as AnalyzedExtension;
+
+    colorRegistry.initColors();
+
+    colorRegistry.registerExtensionThemes(fakeExtension, [
+      {
+        id: 'hc-dark-custom',
+        name: 'HC Dark Custom',
+        parent: 'hc-dark',
+        colors: { titlebarBg: '#000' },
+      },
+      {
+        id: 'hc-light-custom',
+        name: 'HC Light Custom',
+        parent: 'hc-light',
+        colors: { titlebarBg: '#fff' },
+      },
+      {
+        id: 'dark-custom',
+        name: 'Dark Custom',
+        parent: 'dark',
+        colors: { titlebarBg: '#111' },
+      },
+    ]);
+  });
+
+  test('light is not high contrast', () => {
+    expect(colorRegistry.isHighContrastTheme('light')).toBeFalsy();
+  });
+
+  test('dark is not high contrast', () => {
+    expect(colorRegistry.isHighContrastTheme('dark')).toBeFalsy();
+  });
+
+  test('hc-light is high contrast', () => {
+    expect(colorRegistry.isHighContrastTheme('hc-light')).toBeTruthy();
+  });
+
+  test('hc-dark is high contrast', () => {
+    expect(colorRegistry.isHighContrastTheme('hc-dark')).toBeTruthy();
+  });
+
+  test('custom with parent hc-dark is high contrast', () => {
+    expect(colorRegistry.isHighContrastTheme('hc-dark-custom')).toBeTruthy();
+  });
+
+  test('custom with parent hc-light is high contrast', () => {
+    expect(colorRegistry.isHighContrastTheme('hc-light-custom')).toBeTruthy();
+  });
+
+  test('custom with parent dark is not high contrast', () => {
+    expect(colorRegistry.isHighContrastTheme('dark-custom')).toBeFalsy();
+  });
+
+  test('unknown theme is not high contrast', () => {
+    expect(colorRegistry.isHighContrastTheme('unknown-theme')).toBeFalsy();
+  });
+});
+
+describe('getThemeInfo', () => {
+  beforeEach(() => {
+    const fakeExtension = {
+      id: 'foo.bar',
+    } as unknown as AnalyzedExtension;
+
+    colorRegistry.initColors();
+
+    colorRegistry.registerExtensionThemes(fakeExtension, [
+      {
+        id: 'dark-theme1',
+        name: 'Dark Theme 1',
+        parent: 'dark',
+        colors: { titlebarBg: '#111' },
+      },
+      {
+        id: 'hc-dark-theme1',
+        name: 'HC Dark Theme 1',
+        parent: 'hc-dark',
+        colors: { titlebarBg: '#000' },
+      },
+    ]);
+  });
+
+  test('light returns isDark false and isHighContrast false', () => {
+    expect(colorRegistry.getThemeInfo('light')).toStrictEqual({ isDark: false, isHighContrast: false });
+  });
+
+  test('dark returns isDark true and isHighContrast false', () => {
+    expect(colorRegistry.getThemeInfo('dark')).toStrictEqual({ isDark: true, isHighContrast: false });
+  });
+
+  test('hc-light returns isDark false and isHighContrast true', () => {
+    expect(colorRegistry.getThemeInfo('hc-light')).toStrictEqual({ isDark: false, isHighContrast: true });
+  });
+
+  test('hc-dark returns isDark true and isHighContrast true', () => {
+    expect(colorRegistry.getThemeInfo('hc-dark')).toStrictEqual({ isDark: true, isHighContrast: true });
+  });
+
+  test('custom dark theme returns isDark true and isHighContrast false', () => {
+    expect(colorRegistry.getThemeInfo('dark-theme1')).toStrictEqual({ isDark: true, isHighContrast: false });
+  });
+
+  test('custom hc-dark theme returns isDark true and isHighContrast true', () => {
+    expect(colorRegistry.getThemeInfo('hc-dark-theme1')).toStrictEqual({ isDark: true, isHighContrast: true });
+  });
+});
+
 describe('registerExtensionThemes', () => {
   const fakeExtension = {
     id: 'foo.bar',

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type * as extensionApi from '@podman-desktop/api';
-import type { ColorDefinition, ColorInfo, RawThemeContribution } from '@podman-desktop/core-api';
+import type { ColorDefinition, ColorInfo, RawThemeContribution, ThemeInfo } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 
@@ -241,25 +241,42 @@ export class ColorRegistry {
     return new ColorBuilder(colorId);
   }
 
-  // check if the given theme is dark
-  // if light or dark it's easy
-  // else we check the parent theme
   isDarkTheme(themeId: string): boolean {
     if (themeId === 'light') {
       return false;
     } else if (themeId === 'dark') {
       return true;
     } else {
-      // get the parent theme
       const parent = this.#parentThemes.get(themeId);
       if (parent) {
         return this.isDarkTheme(parent);
       } else {
         console.error(`Theme ${themeId} does not exist.`);
-        // return dark by default
         return true;
       }
     }
+  }
+
+  isHighContrastTheme(themeId: string): boolean {
+    if (themeId === 'hc-light' || themeId === 'hc-dark') {
+      return true;
+    } else if (themeId === 'light' || themeId === 'dark') {
+      return false;
+    } else {
+      const parent = this.#parentThemes.get(themeId);
+      if (parent) {
+        return this.isHighContrastTheme(parent);
+      } else {
+        return false;
+      }
+    }
+  }
+
+  getThemeInfo(themeId: string): ThemeInfo {
+    return {
+      isDark: this.isDarkTheme(themeId),
+      isHighContrast: this.isHighContrastTheme(themeId),
+    };
   }
 
   /**

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -118,6 +118,7 @@ import type {
   SimpleContainerInfo,
   StatusBarEntryDescriptor,
   TelemetryMessages,
+  ThemeInfo,
   V1Route,
   ViewInfoUI,
   VolumeCreateOptions,
@@ -3188,8 +3189,8 @@ export class PluginSystem {
       return colorRegistry.listColors(themeId);
     });
 
-    this.ipcHandle('colorRegistry:isDarkTheme', async (_listener, themeId: string): Promise<boolean> => {
-      return colorRegistry.isDarkTheme(themeId);
+    this.ipcHandle('colorRegistry:getThemeInfo', async (_listener, themeId: string): Promise<ThemeInfo> => {
+      return colorRegistry.getThemeInfo(themeId);
     });
 
     this.ipcHandle('viewRegistry:listViewsContributions', async (_listener): Promise<ViewInfoUI[]> => {

--- a/packages/preload-webview/src/webview-preload.spec.ts
+++ b/packages/preload-webview/src/webview-preload.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ColorInfo, WebviewInfo } from '@podman-desktop/core-api';
+import type { ColorInfo, ThemeInfo, WebviewInfo } from '@podman-desktop/core-api';
 import type { WebviewApi } from '@podman-desktop/webview-api';
 import type { ContextBridge, IpcMain, IpcRenderer, IpcRendererEvent } from 'electron';
 import { contextBridge, ipcRenderer } from 'electron';
@@ -52,8 +52,8 @@ class TestWebwiewPreload extends WebviewPreload {
   async getColors(themeId: string): Promise<ColorInfo[]> {
     return super.getColors(themeId);
   }
-  async isDarkTheme(theme: string): Promise<boolean> {
-    return super.isDarkTheme(theme);
+  async getThemeInfo(theme: string): Promise<ThemeInfo> {
+    return super.getThemeInfo(theme);
   }
 }
 
@@ -188,9 +188,8 @@ describe('changeContent', () => {
     const spyGetColors = vi.spyOn(webviewPreload, 'getColors');
     spyGetColors.mockResolvedValue([{ id: 'my-color', value: 'test', cssVar: '--pd-my-color' }]);
 
-    // spy isDarkTheme method
-    const spyIsDarkTheme = vi.spyOn(webviewPreload, 'isDarkTheme');
-    spyIsDarkTheme.mockResolvedValue(false);
+    const spyGetThemeInfo = vi.spyOn(webviewPreload, 'getThemeInfo');
+    spyGetThemeInfo.mockResolvedValue({ isDark: false, isHighContrast: false });
 
     // override window.addEventListener to keep the callback
     const spyAddEventListener = vi.spyOn(window, 'addEventListener');
@@ -240,9 +239,8 @@ describe('changeContent', () => {
     const spyGetColors = vi.spyOn(webviewPreload, 'getColors');
     spyGetColors.mockResolvedValue([{ id: 'my-color', value: 'test', cssVar: '--pd-my-color' }]);
 
-    // spy isDarkTheme method
-    const spyIsDarkTheme = vi.spyOn(webviewPreload, 'isDarkTheme');
-    spyIsDarkTheme.mockResolvedValue(true);
+    const spyGetThemeInfo = vi.spyOn(webviewPreload, 'getThemeInfo');
+    spyGetThemeInfo.mockResolvedValue({ isDark: true, isHighContrast: false });
 
     // override window.addEventListener to keep the callback
     const spyAddEventListener = vi.spyOn(window, 'addEventListener');

--- a/packages/preload-webview/src/webview-preload.ts
+++ b/packages/preload-webview/src/webview-preload.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ColorInfo, WebviewInfo } from '@podman-desktop/core-api';
+import type { ColorInfo, ThemeInfo, WebviewInfo } from '@podman-desktop/core-api';
 import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 import type { WebviewApi } from '@podman-desktop/webview-api';
 import type { IpcRendererEvent } from 'electron';
@@ -96,8 +96,8 @@ export class WebviewPreload {
       userTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
     }
 
-    const isDarkTheme = await this.isDarkTheme(userTheme);
-    const colorSchemeValue = isDarkTheme ? 'dark' : 'light';
+    const themeInfo = await this.getThemeInfo(userTheme);
+    const colorSchemeValue = themeInfo.isDark ? 'dark' : 'light';
 
     // grab colors from the main process
     const colors = await this.getColors(userTheme);
@@ -169,8 +169,8 @@ export class WebviewPreload {
     return this.ipcInvoke('colorRegistry:listColors', themeId) as Promise<ColorInfo[]>;
   }
 
-  protected isDarkTheme(themeId: string): Promise<boolean> {
-    return this.ipcInvoke('colorRegistry:isDarkTheme', themeId) as Promise<boolean>;
+  protected getThemeInfo(themeId: string): Promise<ThemeInfo> {
+    return this.ipcInvoke('colorRegistry:getThemeInfo', themeId) as Promise<ThemeInfo>;
   }
 
   protected getWebviews(): Promise<WebviewInfo[]> {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1778,6 +1778,13 @@ export function initExposure(): void {
     return ipcInvoke('colorRegistry:listColors', themeId);
   });
 
+  contextBridge.exposeInMainWorld(
+    'getThemeInfo',
+    async (themeId: string): Promise<{ isDark: boolean; isHighContrast: boolean }> => {
+      return ipcInvoke('colorRegistry:getThemeInfo', themeId);
+    },
+  );
+
   // Handle callback to open devtools for extensions
   // by delegating to the renderer process
   ipcRenderer.on('dev-tools:open-extension', (_, extensionId: string) => {

--- a/packages/renderer/src/stores/appearance.spec.ts
+++ b/packages/renderer/src/stores/appearance.spec.ts
@@ -23,8 +23,14 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { isDark, isHighContrast } from './appearance';
 import { configurationProperties } from './configurationProperties';
 
+// mock window.getConfigurationValue
+const getConfigurationValueMock = vi.fn();
+const getThemeInfoMock = vi.fn();
+
 beforeEach(() => {
-  vi.resetAllMocks();
+  vi.clearAllMocks();
+  Object.defineProperty(window, 'getConfigurationValue', { value: getConfigurationValueMock });
+  Object.defineProperty(window, 'getThemeInfo', { value: getThemeInfoMock, configurable: true });
 });
 
 test('Expect light mode using system when OS is set to light', async () => {
@@ -113,4 +119,44 @@ test('Expect high contrast using hc-dark configuration', async () => {
   configurationProperties.set([]);
 
   await vi.waitFor(() => expect(get(isHighContrast)).toBe(true));
+});
+
+test('Expect dark mode for custom theme with dark parent', async () => {
+  getThemeInfoMock.mockResolvedValue({ isDark: true, isHighContrast: false });
+  getConfigurationValueMock.mockResolvedValue('zenburn');
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isDark)).toBe(true));
+  await vi.waitFor(() => expect(get(isHighContrast)).toBe(false));
+  expect(getThemeInfoMock).toHaveBeenCalledWith('zenburn');
+});
+
+test('Expect light mode for custom theme with light parent', async () => {
+  getThemeInfoMock.mockResolvedValue({ isDark: false, isHighContrast: false });
+  getConfigurationValueMock.mockResolvedValue('solarized-light');
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isDark)).toBe(false));
+  await vi.waitFor(() => expect(get(isHighContrast)).toBe(false));
+  expect(getThemeInfoMock).toHaveBeenCalledWith('solarized-light');
+});
+
+test('Expect high contrast for custom theme with hc-dark parent', async () => {
+  getThemeInfoMock.mockResolvedValue({ isDark: true, isHighContrast: true });
+  getConfigurationValueMock.mockResolvedValue('my-hc-dark-theme');
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isDark)).toBe(true));
+  await vi.waitFor(() => expect(get(isHighContrast)).toBe(true));
+  expect(getThemeInfoMock).toHaveBeenCalledWith('my-hc-dark-theme');
+});
+
+test('Expect high contrast for custom theme with hc-light parent', async () => {
+  getThemeInfoMock.mockResolvedValue({ isDark: false, isHighContrast: true });
+  getConfigurationValueMock.mockResolvedValue('my-hc-light-theme');
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isDark)).toBe(false));
+  await vi.waitFor(() => expect(get(isHighContrast)).toBe(true));
+  expect(getThemeInfoMock).toHaveBeenCalledWith('my-hc-light-theme');
 });

--- a/packages/renderer/src/stores/appearance.ts
+++ b/packages/renderer/src/stores/appearance.ts
@@ -58,5 +58,13 @@ function updateAppearance(appearance: string): void {
   } else if (appearance === AppearanceSettings.DarkHCEnumValue) {
     isDark.set(true);
     isHighContrast.set(true);
+  } else {
+    window.getThemeInfo(appearance).then(
+      info => {
+        isDark.set(info.isDark);
+        isHighContrast.set(info.isHighContrast);
+      },
+      (err: unknown) => console.error(`Error getting theme info for ${appearance}`, err),
+    );
   }
 }


### PR DESCRIPTION
fix(renderer): resolve custom theme isDark detection for scrollbar color

### What does this PR do?

Custom themes (ex. my zenburn theme) did not update the isDark store because
updateIsDark only handled built-in themes.

This caused color-scheme toremain stale, breaking native scrollbar 
colors on refresh and when switching from a light theme to a custom dark-based theme.

Expose an IPC handler so we can actually check isDark and set it
accordingly.

If we don't have this, then the scrollbar will permanently have the
default theme until you close / reopen podman desktop.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:

https://github.com/user-attachments/assets/6739c4a9-bb03-451b-9b00-3feb6a953262

After:


https://github.com/user-attachments/assets/862fd870-7dbc-45fd-a64b-3f2a11b8ad6c




### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/17641

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. Install a custom theme
2. ctrl+shift+r within podman desktop
3. Watch it doesn't rever the scrollbar back to default

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
