### PR TITLE
fix: set HOME env var for child processes on Windows

### DIFF
--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -585,6 +585,40 @@ describe('exec', () => {
     expect(stdout).toContain('Hello, World!');
     expect(setEncodingMock).toBeCalledWith('utf16le');
   });
+
+  test('should set HOME to homedir on Windows when HOME is not set', async () => {
+    const command = 'echo';
+    const args = ['test'];
+
+    const originalHome = process.env['HOME'];
+    delete process.env['HOME'];
+
+    vi.mocked(isWindows).mockReturnValue(true);
+
+    const on = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
+      if (event === 'data') {
+        cb('test');
+      }
+    }) as unknown as Readable;
+    const spawnMock = vi.mocked(spawn).mockReturnValue({
+      stdout: { on, setEncoding: setEncodingMock },
+      stderr: { on, setEncoding: setEncodingMock },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'close') {
+          cb(0);
+        }
+      }),
+    } as unknown as ChildProcess);
+
+    await exec.exec(command, args);
+
+    const spawnEnv = spawnMock.mock.calls[0]![2]!.env as Record<string, string>;
+    expect(spawnEnv['HOME']).toBe(homedir());
+
+    if (originalHome !== undefined) {
+      process.env['HOME'] = originalHome;
+    }
+  });
 });
 
 describe('getInstallationPath', () => {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -71,6 +71,10 @@ export class Exec {
       env['PATH'] = getInstallationPath(env['PATH']);
     }
 
+    if (isWindows() && !env['HOME']) {
+      env['HOME'] = homedir();
+    }
+
     // do we have an admin task ?
     // if yes, will use sudo-prompt on windows and osascript on mac and pkexec on linux
     if (options?.isAdmin) {


### PR DESCRIPTION
## Summary

Needed for Kaiden

- On Windows, `$HOME` is not a standard environment variable (`USERPROFILE` is used instead). Some CLI tools and extensions rely on `$HOME` to resolve paths like `~` or `$HOME/...`, causing failures when spawned as child processes from Podman Desktop.
- This sets `HOME` to `os.homedir()` in the `Exec` class when it is not already present in the environment on Windows, consistent with how `PATH` is already patched.
- Adds a unit test verifying the behavior.

Fixes: https://github.com/openkaiden/kdn/issues/528


## Test plan

- [x] Unit test added: `should set HOME to homedir on Windows when HOME is not set`
- [ ] Verify on Windows that CLI extensions relying on `$HOME` no longer fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)