### PR TITLE
fix(extensions/podman): throttle socket disguise failure telemetry

### DIFF
--- a/telemetry.json
+++ b/telemetry.json
@@ -7,6 +7,10 @@
     {
       "event": "container-events-failure",
       "frequency": "dailyPerInstance"
+    },
+    {
+      "event": "checkIfSocketDisguisedFailed",
+      "frequency": "dailyPerInstance"
     }
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Adds a telemetry rule for `checkIfSocketDisguisedFailed` in `telemetry.json` so the
central telemetry pipeline applies `dailyPerInstance` frequency control to this
error event.

### Screenshot / video of UI

N/A (telemetry configuration change only)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17321

### How to test this PR?

1. Open `telemetry.json` and verify this rule exists:
   - `event`: `checkIfSocketDisguisedFailed`
   - `frequency`: `dailyPerInstance`
2. (Optional) Run related unit tests:
   - `pnpm exec vitest run packages/main/src/plugin/telemetry/telemetry.spec.ts`

- [x] Tests are covering the bug fix or the new feature