### PR TITLE
fix(main): make internal JSONEvent status and id optional

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -112,8 +112,8 @@ export interface InternalContainerProvider {
 
 interface JSONEvent {
   type: string;
-  status: string;
-  id: string;
+  status?: string;
+  id?: string;
   Type?: string;
   Action?: string;
   Actor?: { ID: string };
@@ -121,8 +121,8 @@ interface JSONEvent {
 
 @injectable()
 export class ContainerProviderRegistry {
-  private readonly _onEvent = new Emitter<JSONEvent>();
-  readonly onEvent: Event<JSONEvent> = this._onEvent.event;
+  private readonly _onEvent = new Emitter<containerDesktopAPI.ContainerJSONEvent>();
+  readonly onEvent: Event<containerDesktopAPI.ContainerJSONEvent> = this._onEvent.event;
 
   private readonly _onApiAttached = new Emitter<string>();
   readonly onApiAttached: Event<string> = this._onApiAttached.event;


### PR DESCRIPTION
### What does this PR do?

Makes internal `JSONEvent.status` and `JSONEvent.id` optional in container registry handling for Docker API v1.52+ compatibility, where `/events` may provide `Action` and `Actor.ID` instead of top-level `status`/`id`.

It also updates the internal emitter typing for `onEvent` to keep extension-facing behavior unchanged:
- internal raw event type (`JSONEvent`) is now optional for `status`/`id`
- emitted event type remains `ContainerJSONEvent` after normalization

This is needed because after making `JSONEvent` optional, `onEvent` cannot stay typed as raw `JSONEvent` without breaking the extension loader contract (`onEvent` listeners expect normalized `ContainerJSONEvent` with required `status` and `id`).

### Screenshot / video of UI

N/A (internal typing/compatibility change only)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17232
Related: https://github.com/podman-desktop/podman-desktop/issues/17229
Related: https://github.com/podman-desktop/podman-desktop/issues/16405

### How to test this PR?

1. Run:
   - `pnpm typecheck:main`
2. Run:
   - `pnpm exec vitest run packages/main/src/plugin/container-registry.spec.ts`
3. Confirm no type errors around `containerProviderRegistry.onEvent(...)` and tests pass.

- [x] Tests are covering the bug fix or the new feature

Made with Cursor

Made with [Cursor](https://cursor.com)