### PR TITLE
fix(ui): fix tooltip visibility when switching dropdowns

### DIFF
--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -22,7 +22,7 @@ import { autoUpdate, computePosition } from '@floating-ui/dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { tooltipHidden } from './tooltip-store';
+import { resetTooltipHideCount } from './tooltip-store';
 import TooltipTestComponent from './TooltipTestComponent.svelte';
 import TooltipTestWithSnippet from './TooltipTestWithSnippet.svelte';
 
@@ -45,13 +45,11 @@ beforeEach(() => {
 
 describe('Tooltip', () => {
   beforeEach(() => {
-    tooltipHidden.set(false);
+    resetTooltipHideCount();
     vi.clearAllMocks();
   });
 
   test('tooltip is hidden when tooltipHidden is true', async () => {
-    tooltipHidden.set(false);
-
     render(TooltipTestComponent, { tip: 'test 1' });
 
     const slot = screen.getByTestId('tooltip-trigger');
@@ -62,13 +60,15 @@ describe('Tooltip', () => {
       expect(screen.queryByText('test 1')).toBeInTheDocument();
     });
 
-    tooltipHidden.set(true);
+    // Simulate dropdown opening (hides tooltips)
+    window.dispatchEvent(new Event('tooltip-hide'));
 
     await waitFor(() => {
       expect(screen.queryByText('test 1')).not.toBeInTheDocument();
     });
 
-    tooltipHidden.set(false);
+    // Simulate dropdown closing (shows tooltips)
+    window.dispatchEvent(new Event('tooltip-show'));
     await fireEvent.mouseEnter(slot);
 
     await waitFor(() => {

--- a/packages/ui/src/lib/tooltip/tooltip-store.spec.ts
+++ b/packages/ui/src/lib/tooltip/tooltip-store.spec.ts
@@ -21,7 +21,7 @@
 import { get } from 'svelte/store';
 import { beforeEach, expect, test } from 'vitest';
 
-import { setup, tooltipHidden } from './tooltip-store';
+import { resetTooltipHideCount, setup, tooltipHidden } from './tooltip-store';
 
 const callbacks = new Map<string, any>();
 const eventEmitter = {
@@ -31,6 +31,8 @@ const eventEmitter = {
 };
 
 beforeEach(() => {
+  callbacks.clear();
+  resetTooltipHideCount();
   (window as any).addEventListener = eventEmitter.receive;
 });
 
@@ -53,4 +55,38 @@ test('tooltipHidden starts as false, then true on tooltip-hide and false on tool
   callback();
 
   expect(get(tooltipHidden)).toBeFalsy();
+});
+
+test('tooltipHidden handles multiple nested dropdowns correctly', async () => {
+  setup();
+
+  expect(get(tooltipHidden)).toBeFalsy();
+
+  // Open first dropdown
+  const hideCallback = callbacks.get('tooltip-hide');
+  const showCallback = callbacks.get('tooltip-show');
+
+  hideCallback(); // First dropdown opens
+  expect(get(tooltipHidden)).toBeTruthy();
+
+  hideCallback(); // Second dropdown opens while first is open
+  expect(get(tooltipHidden)).toBeTruthy();
+
+  showCallback(); // First dropdown closes
+  expect(get(tooltipHidden)).toBeTruthy(); // Should still be hidden because second is open
+
+  showCallback(); // Second dropdown closes
+  expect(get(tooltipHidden)).toBeFalsy(); // Now tooltips should show
+});
+
+test('tooltipHidden counter never goes below zero', async () => {
+  setup();
+
+  const showCallback = callbacks.get('tooltip-show');
+
+  showCallback(); // Call show without any hide
+  expect(get(tooltipHidden)).toBeFalsy(); // Should remain false, not go negative
+
+  showCallback(); // Call show again
+  expect(get(tooltipHidden)).toBeFalsy(); // Still false
 });

--- a/packages/ui/src/lib/tooltip/tooltip-store.ts
+++ b/packages/ui/src/lib/tooltip/tooltip-store.ts
@@ -16,20 +16,29 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { type Writable, writable } from 'svelte/store';
+import { derived, type Readable, writable } from 'svelte/store';
 
+// Internal counter tracking how many dropdowns/menus are currently open
+const tooltipHideCount = writable(0);
+
+// Public derived store - true when tooltips should be hidden (count > 0)
 export const tooltipHidden = setup();
 
-export function setup(): Writable<boolean> {
-  const store = writable(false);
+export function setup(): Readable<boolean> {
+  const derived$ = derived(tooltipHideCount, $count => $count > 0);
 
   window.addEventListener('tooltip-show', () => {
-    tooltipHidden.set(false);
+    tooltipHideCount.update(count => Math.max(0, count - 1));
   });
 
   window.addEventListener('tooltip-hide', () => {
-    tooltipHidden.set(true);
+    tooltipHideCount.update(count => count + 1);
   });
 
-  return store;
+  return derived$;
+}
+
+// Export for testing purposes only
+export function resetTooltipHideCount(): void {
+  tooltipHideCount.set(0);
 }


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Fixes a race condition in the tooltip visibility management system that caused tooltips to appear over dropdown menus when switching directly between multiple dropdowns (e.g., from RHEL VM's "More Options" to Podman machine's "More Options").

**Root cause:** The `tooltip-store.ts` used a simple boolean flag that would briefly enable tooltips when the first dropdown closed, before the second dropdown could disable them again.

**Solution:** Replaced the boolean flag with a counter-based system that tracks how many dropdowns are currently open. Tooltips remain hidden until ALL dropdowns are closed, eliminating the race condition.


### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes #13749 

### How to test this PR?

**Prerequisites:**
- Install RHEL VMs extension
- Create at least two connections (e.g., RHEL connection and Podman machine)

**Test steps:**

1. Navigate to Settings → Resources page
2. **Test single dropdown:**
   - Click "More Options" on RHEL connection -> dropdown opens
   - Hover over other buttons -> verify tooltips do NOT appear
   - Close dropdown -> verify tooltips now appear

3. **Test switching between dropdowns (the bug scenario):**
   - Click "More Options" on RHEL connection -> dropdown opens
   - Hover around -> verify no tooltips 
   - Click "More Options" on Podman machine -> RHEL dropdown closes, Podman dropdown opens
   - **Critical test:** Hover over buttons/dropdown items -> verify tooltips still do NOT appear
   - Close Podman dropdown -> verify tooltips now appear

- [ ] Tests are covering the bug fix or the new feature
