### PR TITLE
feat(storybook): add statusbar tooltip contexts to Spinner and load FontAwesome CSS

### DIFF
--- a/storybook/.storybook/preview.ts
+++ b/storybook/.storybook/preview.ts
@@ -18,6 +18,7 @@
 
 import type { Preview } from '@storybook/svelte-vite';
 import { withThemeByClassName } from '@storybook/addon-themes';
+import '@fortawesome/fontawesome-free/css/all.min.css';
 import './main.css';
 import './themes.css';
 

--- a/storybook/src/stories/progress/Spinner.stories.svelte
+++ b/storybook/src/stories/progress/Spinner.stories.svelte
@@ -207,6 +207,48 @@ const accessibilityVariants: { heading: string; label?: string; containerClass?:
           Run command
         </button>
       </div>
+
+      <div class="flex flex-col gap-2">
+        <div class="text-sm font-semibold text-(--pd-content-header)">Statusbar provider tooltip (starting)</div>
+
+        <div class="rounded-[9px] border border-(--pd-tooltip-outer-border) shadow-[0_4px_12px_var(--pd-shadow-color)] text-[12px] leading-[16px] w-fit">
+          <div class="pt-[4px] pb-[5px] px-[8px] rounded-[9px] bg-(--pd-tooltip-bg) text-(--pd-tooltip-text) border border-(--pd-tooltip-inner-border) backdrop-blur-sm">
+            <div class="flex flex-col">
+              <div class="flex flex-row items-center h-fit">
+                <Spinner size="12px" label="Connection Status Icon" class="mr-1" />
+                <span class="text-[var(--pd-status-starting)]">Starting</span>
+                : Podman Machine
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <div class="text-sm font-semibold text-(--pd-content-header)">Statusbar provider tooltip (mixed states)</div>
+
+        <div class="rounded-[9px] border border-(--pd-tooltip-outer-border) shadow-[0_4px_12px_var(--pd-shadow-color)] text-[12px] leading-[16px] w-fit">
+          <div class="pt-[4px] pb-[5px] px-[8px] rounded-[9px] bg-(--pd-tooltip-bg) text-(--pd-tooltip-text) border border-(--pd-tooltip-inner-border) backdrop-blur-sm">
+            <div class="flex flex-col">
+              <div class="flex flex-row items-center h-fit">
+                <Spinner size="12px" label="Connection Status Icon" class="mr-1" />
+                <span class="text-[var(--pd-status-starting)]">Starting</span>
+                : Podman Machine
+              </div>
+              <div class="flex flex-row items-center h-fit">
+                <div class="fa-regular fa-circle-check max-h-3 mr-1 text-[var(--pd-status-running)]"></div>
+                <span class="text-[var(--pd-status-running)]">Running</span>
+                : Docker Desktop
+              </div>
+              <div class="flex flex-row items-center h-fit">
+                <Spinner size="12px" label="Connection Status Icon" class="mr-1" />
+                <span class="text-[var(--pd-status-terminated)]">Stopping</span>
+                : Lima VM
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   {:else}
     <Spinner {...args} />

--- a/storybook/src/stories/progress/Spinner.stories.svelte
+++ b/storybook/src/stories/progress/Spinner.stories.svelte
@@ -216,7 +216,7 @@ const accessibilityVariants: { heading: string; label?: string; containerClass?:
             <div class="flex flex-col">
               <div class="flex flex-row items-center h-fit">
                 <Spinner size="12px" label="Connection Status Icon" class="mr-1" />
-                <span class="text-[var(--pd-status-starting)]">Starting</span>
+                <span class="text-(--pd-status-starting)">Starting</span>
                 : Podman Machine
               </div>
             </div>
@@ -232,17 +232,17 @@ const accessibilityVariants: { heading: string; label?: string; containerClass?:
             <div class="flex flex-col">
               <div class="flex flex-row items-center h-fit">
                 <Spinner size="12px" label="Connection Status Icon" class="mr-1" />
-                <span class="text-[var(--pd-status-starting)]">Starting</span>
+                <span class="text-(--pd-status-starting)">Starting</span>
                 : Podman Machine
               </div>
               <div class="flex flex-row items-center h-fit">
-                <div class="fa-regular fa-circle-check max-h-3 mr-1 text-[var(--pd-status-running)]"></div>
-                <span class="text-[var(--pd-status-running)]">Running</span>
+                <div class="fa-regular fa-circle-check max-h-3 mr-1 text-(--pd-status-running)"></div>
+                <span class="text-(--pd-status-running)">Running</span>
                 : Docker Desktop
               </div>
               <div class="flex flex-row items-center h-fit">
                 <Spinner size="12px" label="Connection Status Icon" class="mr-1" />
-                <span class="text-[var(--pd-status-terminated)]">Stopping</span>
+                <span class="text-(--pd-status-terminated)">Stopping</span>
                 : Lima VM
               </div>
             </div>


### PR DESCRIPTION
### What does this PR do?

Adds two visual development aids to the Progress/Spinner Storybook Docs page in support of fixing #16900 (Spinner not centered in the statusbar provider tooltip).

#### 1. Statusbar tooltip stories (Spinner.stories.svelte)

Two new blocks added to the Contexts story that replicate the provider tooltip shown when hovering a statusbar button - using the exact CSS classes from `Tooltip.svelte` and the row structure from `ProviderWidget.svelte`:

- **Statusbar provider tooltip (starting):** Single connection in `starting` state; minimal reproduction of the centering bug
- **Statusbar provider tooltip (mixed states):** Three rows covering `starting` (spinner), running (`fa-regular fa-circle-check`), and `stopping` (spinner)

This removes the need for a live Podman or Docker engine to observe and iterate on the centering issue.

#### 2. FontAwesome CSS in Storybook preview (`preview.ts`)

Adds import `@fortawesome/fontawesome-free/css/all.min.css` to `.storybook/preview.ts`. The renderer loads this globally via `App.svelte`; without it, class-based FA icons render as empty elements in any story that uses them.

### Screenshot / video of UI

Light theme:

<img width="1949" height="1284" alt="spinner-docs-light" src="https://github.com/user-attachments/assets/6c4b4e5e-c44d-4ef3-a8b2-c225ab627b81" />

Dark theme:

<img width="1949" height="1284" alt="spinner-docs-dark" src="https://github.com/user-attachments/assets/7b677533-87a7-4972-802d-6d786d840d80" />

HC Light theme:

<img width="1949" height="1284" alt="spinner-docs-hc-light" src="https://github.com/user-attachments/assets/fe4af24f-75d0-43ef-9a78-41367daa5272" />

HC Dark theme:

<img width="1949" height="1284" alt="spinner-docs-hc-dark" src="https://github.com/user-attachments/assets/2b805940-1b8a-44a6-a664-9f33e7598760" />

### What issues does this PR fix or reference?

- Resolves #17676

### How to test this PR?

1. `pnpm storybook:dev`
2. Open Progress → Spinner → Docs in Storybook
3. Scroll to the Contexts section
4. Verify "Statusbar provider tooltip (starting)" renders a tooltip frame with a spinner and orange "Starting" label
5. Verify "Statusbar provider tooltip (mixed states)" renders three rows: spinner + Starting, circle-check + Running, spinner + Stopping
6. Verify the `fa-circle-check` icon is visible (not an empty box) - confirms FA CSS is loaded
7. Switch between all four themes (light, dark, hc-light, hc-dark) and confirm the tooltip frame colors and icon colors adapt correctly

- No tests needed, these are only Storybook changes.

Assisted-by: Claude Sonnet 4.6