### PR TITLE
feat(updating): add setting to disable app updates

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -1229,3 +1229,77 @@ test(`clicking What's new in update command should open release notes`, async ()
 
   expect(shell.openExternal).toHaveBeenCalled();
 });
+
+describe('appUpdate configuration', () => {
+  test('init should skip update setup when appUpdate is disabled', () => {
+    mockConfiguration({ 'update.appUpdate': false, 'update.reminder': 'never' });
+
+    const updater = new Updater(
+      messageBoxMock,
+      configurationRegistryMock,
+      statusBarRegistryMock,
+      commandRegistryMock,
+      taskManagerMock,
+      apiSenderMock,
+    );
+    updater.init();
+
+    expect(autoUpdater.on).not.toHaveBeenCalled();
+    expect(autoUpdater.checkForUpdates).not.toHaveBeenCalled();
+    expect(statusBarRegistryMock.setEntry).toHaveBeenCalled();
+
+    const registeredCommands = vi.mocked(commandRegistryMock.registerCommand).mock.calls.map(call => call[0]);
+    expect(registeredCommands).toContain('version');
+    expect(registeredCommands).not.toContain('update');
+  });
+
+  test('init should proceed with update setup when appUpdate is true', () => {
+    mockConfiguration({ 'update.appUpdate': true, 'update.reminder': 'never' });
+
+    const updater = new Updater(
+      messageBoxMock,
+      configurationRegistryMock,
+      statusBarRegistryMock,
+      commandRegistryMock,
+      taskManagerMock,
+      apiSenderMock,
+    );
+    updater.init();
+
+    expect(autoUpdater.on).toHaveBeenCalled();
+    expect(autoUpdater.checkForUpdates).toHaveBeenCalled();
+  });
+
+  test('updateAvailable should return false when appUpdate is disabled', () => {
+    mockConfiguration({ 'update.appUpdate': false, 'update.reminder': 'never' });
+
+    const updater = new Updater(
+      messageBoxMock,
+      configurationRegistryMock,
+      statusBarRegistryMock,
+      commandRegistryMock,
+      taskManagerMock,
+      apiSenderMock,
+    );
+    updater.init();
+
+    expect(updater.updateAvailable()).toBe(false);
+  });
+
+  test('registerConfiguration should include preferences.update.appUpdate', () => {
+    const updater = new Updater(
+      messageBoxMock,
+      configurationRegistryMock,
+      statusBarRegistryMock,
+      commandRegistryMock,
+      taskManagerMock,
+      apiSenderMock,
+    );
+    updater.init();
+
+    expect(configurationRegistryMock.registerConfigurations).toHaveBeenCalled();
+    const configurations = vi.mocked(configurationRegistryMock.registerConfigurations).mock.calls[0]![0]!;
+    const properties = configurations.flatMap(config => Object.keys(config.properties ?? {}));
+    expect(properties).toContain('preferences.update.appUpdate');
+  });
+});

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -476,6 +476,7 @@ export class Updater {
 
   public updateAvailable(): boolean {
     if (!this.getAppUpdateEnabled()) {
+      console.log('Application update is disabled with preferences.update.appUpdate settings');
       return false;
     }
     return !!this.#nextVersion;

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -335,6 +335,12 @@ export class Updater {
             default: isWindows(),
             hidden: true,
           },
+          ['preferences.update.appUpdate']: {
+            description: 'Check for application updates',
+            type: 'boolean',
+            default: true,
+            hidden: false,
+          },
         },
       },
     ]);
@@ -348,6 +354,10 @@ export class Updater {
     return this.configurationRegistry
       .getConfiguration('preferences')
       .get<boolean>('update.disableDifferentialDownload', isWindows());
+  }
+
+  private getAppUpdateEnabled(): boolean {
+    return this.configurationRegistry.getConfiguration('preferences').get<boolean>('update.appUpdate', true);
   }
 
   /**
@@ -465,6 +475,9 @@ export class Updater {
   }
 
   public updateAvailable(): boolean {
+    if (!this.getAppUpdateEnabled()) {
+      return false;
+    }
     return !!this.#nextVersion;
   }
 
@@ -490,6 +503,7 @@ export class Updater {
     autoUpdater.disableDifferentialDownload = this.getDisableDifferentialDownloadConfigurationValue();
 
     this.registerDefaultCommands();
+    this.registerConfiguration();
 
     // Only check on production builds for Windows and macOS users
     if (!import.meta.env.PROD || isLinux()) {
@@ -497,8 +511,12 @@ export class Updater {
       return Disposable.noop();
     }
 
+    if (!this.getAppUpdateEnabled()) {
+      this.defaultVersionEntry();
+      return Disposable.noop();
+    }
+
     this.registerCommands();
-    this.registerConfiguration();
 
     // setup the event listeners
     autoUpdater.on('update-available', this.onUpdateAvailable.bind(this));


### PR DESCRIPTION
feat(updating): add setting to disable app updates

### What does this PR do?

Adds a `preferences.update.appUpdate` setting (defaults true), for app updating.

When disabled, we will not check for application updates on start /
register for any update checks.

### Screenshot / video of UI

<img width="1225" height="828" alt="Screenshot 2026-06-01 at 2 51 42 PM" src="https://github.com/user-attachments/assets/c67eed57-ebf0-4909-aaf7-cf50ef7d26c9" />


### What issues does this PR fix or reference?

Closes #16483

### How to test this PR?

1. Disable the setting in Preferences > Settings > App Update
2. Restart Podman Desktop
3. Verify no app update notification / checking for updates.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
