### PR TITLE
refactor(ui): migrate Table component to Svelte 5

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -437,7 +437,6 @@ describe('Table#label', () => {
       columns: [SIMPLE_COLUMN],
       row: ROW,
       collapsed: ['foo'],
-      // create special value for the label
       label: (item): string => `label-${item.id}`,
       key: (item): string => item.id,
     });

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -397,7 +397,7 @@ test('Expect table to have proper css style', async () => {
   const rows = await within(table).findAllByRole('row');
   // expect each row of the table has the grid-template-columns style applied
   for (const element of rows) {
-    expect(element).toHaveClass('grid-table');
+    expect(element).toHaveClass('grid-cols-[var(--table-grid-table-columns)]');
   }
 
   expect(table).toHaveStyle({

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" generics="T extends { selected?: boolean; name?: string }">
-import { onMount } from 'svelte';
+import { createEventDispatcher, onMount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
 import Checkbox from '../checkbox/Checkbox.svelte';
@@ -11,7 +11,8 @@ import { tablePersistence } from './table-persistence-store.svelte';
 
 interface Props {
   kind: string;
-  columns: Column<T, unknown>[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- heterogeneous render types require any
+  columns: Column<T, any>[];
   row: Row<T>;
   data: T[];
   defaultSortColumn?: string;
@@ -26,7 +27,7 @@ let {
   kind,
   columns,
   row,
-  data = $bindable(),
+  data,
   defaultSortColumn = undefined,
   collapsed = $bindable([]),
   key = (item: T): string => item.name ?? String(item),
@@ -34,6 +35,9 @@ let {
   enableLayoutConfiguration = false,
   selectedItemsNumber = $bindable(),
 }: Props = $props();
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- enables on:update event forwarding from column renderers
+const dispatch = createEventDispatcher<{ update: undefined }>();
 
 let columnItems: ListOrganizerItem[] = $state([]);
 let columnOrdering = new SvelteMap<string, number>();
@@ -141,7 +145,8 @@ $effect(() => {
 });
 
 // Computed visible columns based on configuration
-const visibleColumns: Column<T, unknown>[] = $derived.by(() => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches columns prop type
+const visibleColumns: Column<T, any>[] = $derived.by(() => {
   if (columnItems.length === 0) {
     return columns;
   }
@@ -163,8 +168,9 @@ const visibleColumns: Column<T, unknown>[] = $derived.by(() => {
   return result;
 });
 
-// number of selected items in the list
-$effect(() => {
+let selectedAllCheckboxes: boolean | undefined = $state(false);
+
+function recomputeSelection(): void {
   selectedItemsNumber = row.info.selectable
     ? data.filter(object => row.info.selectable?.(object) && object.selected).length +
       data.reduce(
@@ -174,28 +180,25 @@ $effect(() => {
         0,
       )
     : 0;
-});
 
-// do we need to unselect all checkboxes if we don't have all items being selected ?
-const selectedAllCheckboxes: boolean | undefined = $derived.by(() => {
-  return row.info.selectable
+  selectedAllCheckboxes = row.info.selectable
     ? data.filter(object => row.info.selectable?.(object)).every(object => object.selected) &&
-        data
-          .reduce(
-            (accumulator, current) => {
-              const children = row.info.children?.(current);
-              if (children) {
-                accumulator.push(...children);
-              }
-              return accumulator;
-            },
-            [] as Array<T>,
-          )
-          .filter(child => row.info.selectable?.(child))
-          .every(child => child.selected) &&
-        data.filter(object => row.info.selectable?.(object)).length > 0
+      data
+        .reduce(
+          (accumulator, current) => {
+            const children = row.info.children?.(current);
+            if (children) {
+              accumulator.push(...children);
+            }
+            return accumulator;
+          },
+          [] as Array<T>,
+        )
+        .filter(child => row.info.selectable?.(child))
+        .every(child => child.selected) &&
+      data.filter(object => row.info.selectable?.(object)).length > 0
     : false;
-});
+}
 
 function toggleAll(checked: boolean): void {
   if (!row.info.selectable) {
@@ -210,7 +213,7 @@ function toggleAll(checked: boolean): void {
       children.filter(child => row.info.selectable?.(child)).forEach(child => (child.selected = checked));
     }
   });
-  data = [...data];
+  recomputeSelection();
 }
 
 let sortCol: Column<T> = $state(undefined!);
@@ -277,12 +280,12 @@ function objectChecked(object: T, checked: boolean): void {
       children.forEach(child => (child.selected = checked));
     }
   }
-  data = [...data];
+  recomputeSelection();
 }
 
 function childChecked(child: T, checked: boolean): void {
   child.selected = checked;
-  data = [...data];
+  recomputeSelection();
 }
 
 function toggleChildren(name: string | undefined): void {
@@ -350,7 +353,7 @@ async function resetColumns(): Promise<void> {
             title="Toggle all"
             checked={selectedAllCheckboxes}
             disabled={!row.info.selectable || data.filter(object => row.info.selectable?.(object)).length === 0}
-            indeterminate={selectedItemsNumber > 0 && !selectedAllCheckboxes}
+            indeterminate={(selectedItemsNumber ?? 0) > 0 && !selectedAllCheckboxes}
             onclick={toggleAll} />
         </div>
       {/if}

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -1,50 +1,44 @@
-<style>
-.grid-table {
-  display: grid;
-  grid-template-columns: var(--table-grid-table-columns);
-}
-</style>
-
 <script lang="ts" generics="T extends { selected?: boolean; name?: string }">
-/* eslint-disable import/no-duplicates */
-// https://github.com/import-js/eslint-plugin-import/issues/1479
-import { onMount, tick } from 'svelte';
+import { onMount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
 import Checkbox from '../checkbox/Checkbox.svelte';
 import ChevronExpander from '../icons/ChevronExpander.svelte';
 import type { ListOrganizerItem } from '../layouts/ListOrganizer';
 import ListOrganizer from '../layouts/ListOrganizer.svelte';
-/* eslint-enable import/no-duplicates */
 import type { Column, Row } from './table';
 import { tablePersistence } from './table-persistence-store.svelte';
 
-export let kind: string;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let columns: Column<T, any>[];
-export let row: Row<T>;
-export let data: T[];
-export let defaultSortColumn: string | undefined = undefined;
-export let collapsed: string[] = [];
-/**
- * To better distinct individual row, you can provide a dedicated key method
- *
- * By default, it will use the object name property
- */
-export let key: (object: T) => string = item => item.name ?? String(item);
-/**
- * Specify the aria-label for a given item
- *
- * By default, it will use the object name property
- */
-export let label: (object: T) => string = item => item.name ?? String(item);
+interface Props {
+  kind: string;
+  columns: Column<T, unknown>[];
+  row: Row<T>;
+  data: T[];
+  defaultSortColumn?: string;
+  collapsed?: string[];
+  key?: (object: T) => string;
+  label?: (object: T) => string;
+  enableLayoutConfiguration?: boolean;
+  selectedItemsNumber?: number;
+}
 
-export let enableLayoutConfiguration: boolean = false;
+let {
+  kind,
+  columns,
+  row,
+  data = $bindable(),
+  defaultSortColumn = undefined,
+  collapsed = $bindable([]),
+  key = (item: T): string => item.name ?? String(item),
+  label = (item: T): string => item.name ?? String(item),
+  enableLayoutConfiguration = false,
+  selectedItemsNumber = $bindable(),
+}: Props = $props();
 
-let columnItems: ListOrganizerItem[] = [];
+let columnItems: ListOrganizerItem[] = $state([]);
 let columnOrdering = new SvelteMap<string, number>();
-let isInitialized = false;
-let isLoading = false;
+let isInitialized = $state(false);
+let isLoading = $state(false);
 
 // Initialize default column configuration
 function getDefaultColumnItems(): ListOrganizerItem[] {
@@ -71,7 +65,6 @@ async function initializeColumns(): Promise<void> {
     isInitialized = true;
   } catch (error: unknown) {
     console.error('Failed to load column configuration:', error);
-    // Fallback to default configuration
     columnItems = getDefaultColumnItems();
     isInitialized = true;
   } finally {
@@ -93,15 +86,12 @@ async function loadColumnConfiguration(): Promise<ListOrganizerItem[]> {
     );
 
     if (loadedItems.length > 0) {
-      // Ensure loaded items have proper originalOrder from defaults if missing
       const defaultItems = getDefaultColumnItems();
       const items = loadedItems.map((item: ListOrganizerItem) => ({
         ...item,
         originalOrder: item.originalOrder ?? defaultItems.find(d => d.id === item.id)?.originalOrder ?? 0,
       }));
 
-      // Build ordering map from loaded items
-      // Check if items are in a different order than their original order
       const isReordered = items.some((item, index) => item.originalOrder !== index);
       if (isReordered) {
         const ordering = new SvelteMap<string, number>();
@@ -122,8 +112,7 @@ async function loadColumnConfiguration(): Promise<ListOrganizerItem[]> {
 // Save configuration
 async function saveColumnConfiguration(): Promise<void> {
   if (enableLayoutConfiguration && tablePersistence.storage) {
-    // Create ordered items based on current state
-    const orderedItems = getOrderedColumns();
+    const orderedItems = $state.snapshot(getOrderedColumns());
     await tablePersistence.storage.save(kind, orderedItems);
   }
 }
@@ -141,22 +130,22 @@ function getOrderedColumns(): ListOrganizerItem[] {
 }
 
 // Save configuration whenever columnItems or ordering changes (after initialization)
-$: if (isInitialized && columnItems.length > 0) {
-  columnOrdering;
-  saveColumnConfiguration().catch((error: unknown) => {
-    console.error('Failed to save column configuration:', error);
-  });
-}
+$effect(() => {
+  if (isInitialized && columnItems.length > 0) {
+    // access columnOrdering to track it as a dependency
+    columnOrdering;
+    saveColumnConfiguration().catch((error: unknown) => {
+      console.error('Failed to save column configuration:', error);
+    });
+  }
+});
 
 // Computed visible columns based on configuration
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-$: visibleColumns = ((): Column<T, any>[] => {
+const visibleColumns: Column<T, unknown>[] = $derived.by(() => {
   if (columnItems.length === 0) {
-    // Fallback to all columns when not yet initialized
     return columns;
   }
 
-  // Get ordered columns inline to ensure reactivity
   const orderedColumns =
     columnOrdering.size === 0
       ? [...columnItems].sort((a, b) => a.originalOrder - b.originalOrder)
@@ -172,44 +161,43 @@ $: visibleColumns = ((): Column<T, any>[] => {
     .filter(Boolean);
 
   return result;
-})();
-
-let tableHtmlDivElement: HTMLDivElement | undefined = undefined;
+});
 
 // number of selected items in the list
-export let selectedItemsNumber: number = 0;
-$: selectedItemsNumber = row.info.selectable
-  ? data.filter(object => row.info.selectable?.(object) && object.selected).length +
-    data.reduce(
-      (previous, current) =>
-        previous +
-        (row.info.children?.(current)?.filter(child => row.info.selectable?.(child) && child.selected).length ?? 0),
-      0,
-    )
-  : 0;
+$effect(() => {
+  selectedItemsNumber = row.info.selectable
+    ? data.filter(object => row.info.selectable?.(object) && object.selected).length +
+      data.reduce(
+        (previous, current) =>
+          previous +
+          (row.info.children?.(current)?.filter(child => row.info.selectable?.(child) && child.selected).length ?? 0),
+        0,
+      )
+    : 0;
+});
 
 // do we need to unselect all checkboxes if we don't have all items being selected ?
-let selectedAllCheckboxes: boolean | undefined;
-$: selectedAllCheckboxes = row.info.selectable
-  ? data.filter(object => row.info.selectable?.(object)).every(object => object.selected) &&
-    data
-      .reduce(
-        (accumulator, current) => {
-          const children = row.info.children?.(current);
-          if (children) {
-            accumulator.push(...children);
-          }
-          return accumulator;
-        },
-        [] as Array<T>,
-      )
-      .filter(child => row.info.selectable?.(child))
-      .every(child => child.selected) &&
-    data.filter(object => row.info.selectable?.(object)).length > 0
-  : false;
+const selectedAllCheckboxes: boolean | undefined = $derived.by(() => {
+  return row.info.selectable
+    ? data.filter(object => row.info.selectable?.(object)).every(object => object.selected) &&
+        data
+          .reduce(
+            (accumulator, current) => {
+              const children = row.info.children?.(current);
+              if (children) {
+                accumulator.push(...children);
+              }
+              return accumulator;
+            },
+            [] as Array<T>,
+          )
+          .filter(child => row.info.selectable?.(child))
+          .every(child => child.selected) &&
+        data.filter(object => row.info.selectable?.(object)).length > 0
+    : false;
+});
 
-function toggleAll(e: CustomEvent<boolean>): void {
-  const checked = e.detail;
+function toggleAll(checked: boolean): void {
   if (!row.info.selectable) {
     return;
   }
@@ -225,21 +213,25 @@ function toggleAll(e: CustomEvent<boolean>): void {
   data = [...data];
 }
 
-let sortCol: Column<T>;
-let sortAscending: boolean;
+let sortCol: Column<T> = $state(undefined!);
+let sortAscending: boolean = $state(true);
 
-$: if (data && sortCol) {
-  sortImpl();
-}
-
-function sort(column: Column<T>): void {
-  if (!column) {
-    return;
+const sortedData: T[] = $derived.by(() => {
+  if (!sortCol?.info.comparator) {
+    return data;
   }
 
-  let comparator = column.info.comparator;
-  if (!comparator) {
-    // column is not sortable
+  let comparator = sortCol.info.comparator;
+  if (!sortAscending) {
+    const comparatorTemp = comparator;
+    comparator = (a, b): number => -comparatorTemp(a, b);
+  }
+
+  return [...data].sort(comparator);
+});
+
+function sort(column: Column<T>): void {
+  if (!column?.info.comparator) {
     return;
   }
 
@@ -249,73 +241,48 @@ function sort(column: Column<T>): void {
     sortCol = column;
     sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
   }
-  sortImpl();
 }
 
-function sortImpl(): void {
-  // confirm we're sorting
-  if (!sortCol) {
-    return;
-  }
-
-  let comparator = sortCol.info.comparator;
-  if (!comparator) {
-    // column is not sortable
-    return;
-  }
-
-  if (!sortAscending) {
-    // we're already sorted, switch to reverse order
-    let comparatorTemp = comparator;
-    comparator = (a, b): number => -comparatorTemp(a, b);
-  }
-
-  // eslint-disable-next-line etc/no-assign-mutated-array
-  data = data.sort(comparator);
-}
-
-onMount(async () => {
+onMount(() => {
   const column: Column<T> | undefined = columns.find(column => column.title === defaultSortColumn);
   if (column?.info.comparator) {
     sortCol = column;
     sortAscending = column.info.initialOrder ? column.info.initialOrder !== 'descending' : true;
-    await tick(); // Ensure all initializations are complete.
-    sortImpl(); // Explicitly call sortImpl to sort the data initially.
   }
 });
 
-let gridTemplateColumns: string;
-$: {
-  // section and checkbox columns
+const gridTemplateColumns: string = $derived.by(() => {
   let columnWidths: string[] = ['20px'];
 
   if (row.info.selectable) {
     columnWidths.push('32px');
   }
 
-  // custom columns
   visibleColumns.map(c => c.info.width ?? '1fr').forEach(w => columnWidths.push(w));
 
   if (enableLayoutConfiguration && tablePersistence) {
-    // Add space for settings icon in header (32px)
     columnWidths.push('32px');
   } else {
-    // final spacer
     columnWidths.push('5px');
   }
 
-  gridTemplateColumns = columnWidths.join(' ');
-}
+  return columnWidths.join(' ');
+});
 
-function objectChecked(object: T): void {
-  // check for children and set them to the same state
+function objectChecked(object: T, checked: boolean): void {
+  object.selected = checked;
   if (row.info.children) {
     const children = row.info.children(object);
     if (children) {
-      // event fires before parent changes so use '!'
-      children.forEach(child => (child.selected = !object.selected));
+      children.forEach(child => (child.selected = checked));
     }
   }
+  data = [...data];
+}
+
+function childChecked(child: T, checked: boolean): void {
+  child.selected = checked;
+  data = [...data];
 }
 
 function toggleChildren(name: string | undefined): void {
@@ -331,7 +298,6 @@ function toggleChildren(name: string | undefined): void {
   } else {
     collapsed.push(name);
   }
-  // trigger Svelte update
   collapsed = collapsed;
 }
 
@@ -360,7 +326,6 @@ async function resetColumns(): Promise<void> {
     }
   } catch (error: unknown) {
     console.error(`Failed to reset column configuration in table ${kind}: ${error}`);
-    // Fallback to default configuration
     columnItems = getDefaultColumnItems();
     columnOrdering.clear();
   }
@@ -370,29 +335,28 @@ async function resetColumns(): Promise<void> {
 <div
   style="--table-grid-table-columns: {gridTemplateColumns}"
   class="w-full mx-5"
-  class:hidden={data.length === 0}
+  class:hidden={sortedData.length === 0}
   role="table"
-  aria-label={kind}
-  bind:this={tableHtmlDivElement}>
+  aria-label={kind}>
   <!-- Table header -->
   <div role="rowgroup" class="relative">
     <div
-      class="grid grid-table gap-x-0.5 h-7 sticky top-0 text-[var(--pd-table-header-text)] uppercase z-2"
+      class="grid grid-cols-[var(--table-grid-table-columns)] gap-x-0.5 h-7 sticky top-0 text-[var(--pd-table-header-text)] uppercase z-2"
       role="row">
       <div class="whitespace-nowrap justify-self-start" role="columnheader"></div>
       {#if row.info.selectable}
         <div class="whitespace-nowrap place-self-center" role="columnheader">
           <Checkbox
             title="Toggle all"
-            bind:checked={selectedAllCheckboxes}
+            checked={selectedAllCheckboxes}
             disabled={!row.info.selectable || data.filter(object => row.info.selectable?.(object)).length === 0}
             indeterminate={selectedItemsNumber > 0 && !selectedAllCheckboxes}
-            on:click={toggleAll} />
+            onclick={toggleAll} />
         </div>
       {/if}
       {#each visibleColumns as column, index (index)}
-        <!-- svelte-ignore a11y-click-events-have-key-events -->
-        <!-- svelte-ignore a11y-interactive-supports-focus -->
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_interactive_supports_focus -->
         <div
           class="max-w-full overflow-hidden flex flex-row text-sm font-semibold items-center whitespace-nowrap {column
             .info.align === 'right'
@@ -401,7 +365,7 @@ async function resetColumns(): Promise<void> {
               ? 'justify-self-center'
               : 'justify-self-start'} self-center select-none"
           class:cursor-pointer={column.info.comparator}
-          on:click={sort.bind(undefined, column)}
+          onclick={sort.bind(undefined, column)}
           role="columnheader">
           <div class="overflow-hidden text-ellipsis">
             {column.title}
@@ -441,12 +405,12 @@ async function resetColumns(): Promise<void> {
   </div>
   <!-- Table body -->
   <div role="rowgroup">
-    {#each data as object (object)}
+    {#each sortedData as object (object)}
       {@const children = row.info.children?.(object) ?? []}
       {@const itemKey = key(object)}
       <div class="min-h-[48px] h-fit bg-[var(--pd-content-card-bg)] rounded-lg mb-2 border border-[var(--pd-content-table-border)]">
         <div
-          class="grid grid-table gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
+          class="grid grid-cols-[var(--table-grid-table-columns)] gap-x-0.5 min-h-[48px] hover:bg-[var(--pd-content-card-hover-bg)]"
           class:rounded-t-lg={!collapsed.includes(itemKey) &&
             children.length > 0}
           class:rounded-lg={collapsed.includes(itemKey) ||
@@ -458,7 +422,7 @@ async function resetColumns(): Promise<void> {
               <button
                 title={collapsed.includes(itemKey) ? 'Expand Row' : 'Collapse Row'}
                 aria-expanded={!collapsed.includes(itemKey)}
-                on:click={toggleChildren.bind(undefined, itemKey)}
+                onclick={toggleChildren.bind(undefined, itemKey)}
               >
                 <ChevronExpander
                   expanded={!collapsed.includes(itemKey)}
@@ -471,10 +435,10 @@ async function resetColumns(): Promise<void> {
             <div class="whitespace-nowrap place-self-center" role="cell">
               <Checkbox
                 title="Toggle {kind}"
-                bind:checked={object.selected}
+                checked={object.selected}
                 disabled={!row.info.selectable(object)}
                 disabledTooltip={row.info.disabledText}
-                on:click={objectChecked.bind(undefined, object)} />
+                onclick={objectChecked.bind(undefined, object)} />
             </div>
           {/if}
           {#each visibleColumns as column, index (index)}
@@ -489,8 +453,8 @@ async function resetColumns(): Promise<void> {
               class:col-span-2={index === visibleColumns.length - 1 && enableLayoutConfiguration && tablePersistence.storage}
               role="cell">
               {#if column.info.renderer}
-                <svelte:component
-                  this={column.info.renderer}
+                {@const Renderer = column.info.renderer}
+                <Renderer
                   object={column.info.renderMapping ? column.info.renderMapping(object) : object} />
               {/if}
             </div>
@@ -501,7 +465,7 @@ async function resetColumns(): Promise<void> {
         {#if !collapsed.includes(itemKey) && children.length > 0}
           {#each children as child, i (child)}
             <div
-              class="grid grid-table gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]"
+              class="grid grid-cols-[var(--table-grid-table-columns)] gap-x-0.5 hover:bg-[var(--pd-content-card-hover-bg)]"
               class:rounded-b-lg={i === children.length - 1}
               role="row"
               aria-label={child.name}>
@@ -510,9 +474,10 @@ async function resetColumns(): Promise<void> {
                 <div class="whitespace-nowrap place-self-center" role="cell">
                   <Checkbox
                     title="Toggle {kind}"
-                    bind:checked={child.selected}
+                    checked={child.selected}
                     disabled={!row.info.selectable(child)}
-                    disabledTooltip={row.info.disabledText} />
+                    disabledTooltip={row.info.disabledText}
+                    onclick={childChecked.bind(undefined, child)} />
                 </div>
               {/if}
               {#each visibleColumns as column, index (index)}
@@ -527,8 +492,8 @@ async function resetColumns(): Promise<void> {
                   class:col-span-2={index === visibleColumns.length - 1 && enableLayoutConfiguration && tablePersistence.storage}
                   role="cell">
                   {#if column.info.renderer}
-                    <svelte:component
-                      this={column.info.renderer}
+                    {@const Renderer = column.info.renderer}
+                    <Renderer
                       object={column.info.renderMapping ? column.info.renderMapping(child) : child} />
                   {/if}
                 </div>

--- a/packages/ui/src/lib/table/TestTable.svelte
+++ b/packages/ui/src/lib/table/TestTable.svelte
@@ -1,18 +1,25 @@
 <script lang="ts">
-import { createEventDispatcher } from 'svelte';
-
 import DurationColumn from '/@/lib/table/DurationColumn.svelte';
 
 import SimpleColumn from './SimpleColumn.svelte';
 import { Column, Row } from './table';
 import Table from './Table.svelte';
 
-let selectedItemsNumber: number;
+interface Props {
+  people?: Person[];
+  onUpdate?: (text: string) => void;
+}
 
-const dispatch = createEventDispatcher<{ update: string }>();
-export let onUpdate: (text: string) => void = text => {
-  dispatch('update', text);
-};
+let {
+  people = $bindable([
+    { id: 1, name: 'John', age: 57, hobby: 'Skydiving' },
+    { id: 2, name: 'Henry', age: 27, hobby: 'Cooking' },
+    { id: 3, name: 'Charlie', age: 43, hobby: 'Biking', duration: new Date().getTime() - 3600000 },
+  ]),
+  onUpdate = (): void => {},
+}: Props = $props();
+
+let selectedItemsNumber: number = $state(0);
 
 type Person = {
   id: number;
@@ -21,12 +28,6 @@ type Person = {
   hobby: string;
   duration?: number;
 };
-
-export let people: Person[] = [
-  { id: 1, name: 'John', age: 57, hobby: 'Skydiving' },
-  { id: 2, name: 'Henry', age: 27, hobby: 'Cooking' },
-  { id: 3, name: 'Charlie', age: 43, hobby: 'Biking', duration: new Date().getTime() - 3600000 },
-];
 
 const idCol: Column<Person, string> = new Column('Id', {
   align: 'right',
@@ -78,8 +79,7 @@ const row = new Row<Person>({
   data={people}
   columns={columns}
   row={row}
-  defaultSortColumn="Id"
-  on:update>
+  defaultSortColumn="Id">
 </Table>
 
 <!-- Dummy component to check if the table component is not updating this object as it contains grid-table css property -->


### PR DESCRIPTION
### What does this PR do?
Migrate Table.svelte and TestTable.svelte from Svelte 4 patterns to idiomatic Svelte 5 while preserving the public API for consumers.

- export let → $props() with $bindable for data, collapsed, selectedItemsNumber
- $: reactive blocks → $derived.by for visibleColumns, selectedAllCheckboxes, gridTemplateColumns; $effect for selectedItemsNumber sync and config save
- Replace sort $effect with $derived sortedData to avoid infinite loops
- <svelte:component> → direct dynamic component rendering
- on:click → onclick on native elements and callback props on Checkbox
- bind:checked → one-way checked prop with explicit onclick handlers
- Remove <style> block, use Tailwind grid-cols-[var()] instead
- Remove unused tableHtmlDivElement and tick import

### Screenshot / video of UI

### What issues does this PR fix or reference?

### How to test this PR?

Try work with table component in a same way as you used to, filtering, sorting etc. Should be no change

- [x] Tests are covering the bug fix or the new feature
