### PR TITLE
fix(statusbar): size FA icons via --fa-width custom property

### DIFF
--- a/packages/renderer/src/app.css
+++ b/packages/renderer/src/app.css
@@ -20,3 +20,7 @@ a {
     cursor: pointer;
   }
 }
+
+@utility fa-w-* {
+  --fa-width: --value([length], [percentage]);
+}

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
@@ -16,7 +16,7 @@ const faRegularIconStatus: string[] = ['ready', 'started', 'stopped', 'error', '
   {#if status === 'starting' || status === 'stopping'}
     <Spinner size="12px" label="Connection Status Icon" class={className} />
   {:else}
-    <div aria-label="Connection Status Icon" class="{className}" style="--fa-width: 12px;"
+    <div aria-label="Connection Status Icon" class="fa-w-[12px] {className}"
       class:fa-regular={faRegularIconStatus.includes(status)}
       class:fa={status === 'not-installed'}
       class:fa-circle-check={status === 'ready' || status === 'started'}

--- a/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
+++ b/packages/renderer/src/lib/statusbar/ProviderWidgetStatus.svelte
@@ -16,7 +16,7 @@ const faRegularIconStatus: string[] = ['ready', 'started', 'stopped', 'error', '
   {#if status === 'starting' || status === 'stopping'}
     <Spinner size="12px" label="Connection Status Icon" class={className} />
   {:else}
-    <div aria-label="Connection Status Icon" class="max-h-3 {className}"
+    <div aria-label="Connection Status Icon" class="{className}" style="--fa-width: 12px;"
       class:fa-regular={faRegularIconStatus.includes(status)}
       class:fa={status === 'not-installed'}
       class:fa-circle-check={status === 'ready' || status === 'started'}

--- a/storybook/.storybook/main.css
+++ b/storybook/.storybook/main.css
@@ -25,6 +25,10 @@ body.hc-dark {
   color: #fff;
 }
 
+@utility fa-w-* {
+  --fa-width: --value([length], [percentage]);
+}
+
 /* Docs page story preview containers */
 body.light .docs-story {
   background-color: #f6f6f6;

--- a/storybook/src/stories/progress/Spinner.stories.svelte
+++ b/storybook/src/stories/progress/Spinner.stories.svelte
@@ -236,7 +236,7 @@ const accessibilityVariants: { heading: string; label?: string; containerClass?:
                 : Podman Machine
               </div>
               <div class="flex flex-row items-center h-fit">
-                <div class="fa-regular fa-circle-check mr-1 text-(--pd-status-running)" style="--fa-width: 12px;"></div>
+                <div class="fa-regular fa-circle-check fa-w-[12px] mr-1 text-(--pd-status-running)"></div>
                 <span class="text-(--pd-status-running)">Running</span>
                 : Docker Desktop
               </div>

--- a/storybook/src/stories/progress/Spinner.stories.svelte
+++ b/storybook/src/stories/progress/Spinner.stories.svelte
@@ -236,7 +236,7 @@ const accessibilityVariants: { heading: string; label?: string; containerClass?:
                 : Podman Machine
               </div>
               <div class="flex flex-row items-center h-fit">
-                <div class="fa-regular fa-circle-check max-h-3 mr-1 text-(--pd-status-running)"></div>
+                <div class="fa-regular fa-circle-check mr-1 text-(--pd-status-running)" style="--fa-width: 12px;"></div>
                 <span class="text-(--pd-status-running)">Running</span>
                 : Docker Desktop
               </div>


### PR DESCRIPTION
### What does this PR do?

Replaces `max-h-3` with FontAwesome's own `--fa-width` CSS custom property to correctly constrain icon width in the provider statusbar tooltip. FontAwesome sets `width: var(--fa-width, 1.25em)` on all icon elements, so overriding this property is the intended sizing mechanism - no Tailwind `!important` overrides needed.

### Screenshot / video of UI

Before:

<img width="428" height="190" alt="Image" src="https://github.com/user-attachments/assets/e67e5839-5806-483f-aca2-5f48a158a449" />

Now:

<img width="428" height="190" alt="Image" src="https://github.com/user-attachments/assets/6ad3e3e6-7798-4634-8460-10c1d3c5b489" />

### What issues does this PR fix or reference?

Closes #17678

### How to test this PR?

1. Start the app with a provider that has mixed connection states (e.g. one starting, one running, one stopping)
2. Hover over the provider widget in the statusbar
3. Verify the FontAwesome status icons (circle-check, circle-dot, etc.) are properly sized and aligned with the Spinner icons
4. Check the Storybook "Contexts" story under Progress/Spinner for visual consistency

- [ ] No tests assert on `max-h-3` or `--fa-width`. No test updates needed.

/cc @simonrey1 

Assisted-by: Claude Sonnet 4.6