### PR TITLE
feat(renderer): inject CSP in prod build

### DIFF
--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -52,7 +52,7 @@ export default defineConfig({
           "default-src 'self'",
           "script-src 'self'",
           "style-src 'self' 'unsafe-inline'",
-          "img-src 'self' data:",
+          "img-src 'self' https: data: blob:",
           "font-src 'self' data:",
           "connect-src 'self'",
           "object-src 'none'",

--- a/packages/renderer/vite.config.js
+++ b/packages/renderer/vite.config.js
@@ -37,7 +37,33 @@ export default defineConfig({
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
     },
   },
-  plugins: [tailwindcss(), svelte({ configFile: '../../svelte.config.js' }), svelteTesting()],
+  plugins: [
+    tailwindcss(),
+    svelte({ configFile: '../../svelte.config.js' }),
+    svelteTesting(),
+    {
+      name: 'inject-meta',
+      transformIndexHtml(html) {
+        if (process.env.MODE !== 'production') {
+          return html;
+        }
+
+        const csp = [
+          "default-src 'self'",
+          "script-src 'self'",
+          "style-src 'self' 'unsafe-inline'",
+          "img-src 'self' data:",
+          "font-src 'self' data:",
+          "connect-src 'self'",
+          "object-src 'none'",
+        ].join('; ');
+
+        const meta = `<meta http-equiv="Content-Security-Policy" content="${csp}">`;
+
+        return html.replace('</head>', `${meta}</head>`);
+      },
+    },
+  ],
   optimizeDeps: {
     exclude: ['tinro', '@podman-desktop/api'],
   },


### PR DESCRIPTION
### What does this PR do?

Kinda complicated to create a Content Security Policy (CSP), as denying something would lead to breaking the app. 

This PR will `inject` a `<meta>` tag specifying a CSP 

:warning: this will not be working in dev mode, because we load from the vite dev server

Some details

=> Scripts can only be loaded from `self` => file://
=> We are allowed to load font from base64 (We are loading some woff2 in some css)
=> We are allowed to load images from `https://registry.podman-desktop.io/*` (Extension icon in catalog)
=> We are allowed to load images from `https://github.com/*` (Extension README's images in catalog)

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16662

### How to test this PR?

1. Build Podman Desktop in PROD mode (`pnpm run compile:current`)
2. Start Podman Desktop
3. Assert everything is working fine

---

How to ensure the `<meta>` tag is here

1. Remove the condition preventing to open dev tools in PROD mode

https://github.com/podman-desktop/podman-desktop/blob/08f1e32c5aeb648fcfa3cb39a73c2fabb46082de/packages/main/src/open-dev-tools.ts#L25

2. Repeat the step above
3. Assert the dev tools opens
4. Check the `<head>` of the page

<img width="839" height="251" alt="image" src="https://github.com/user-attachments/assets/f7b45be1-eabb-49ae-8db3-8ec5ac4ee680" />


