### PR TITLE
fix(renderer): use correct CSS variables for extension download button

### DIFF
--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -77,7 +77,7 @@ async function installExtension(): Promise<void> {
   on:click={installExtension}
   hidden={!extension.fetchable}
   title="Install {extension.displayName} v{extension.fetchVersion} Extension"
-  class="border-2 relative rounded-sm border-[var(--pd-button-secondary)] text-[var(--pd-button-secondary)] hover:text-[var(--pd-button-text)] hover:bg-[var(--pd-button-secondary-hover)] hover:border-[var(--pd-button-secondary-hover)] w-10 p-2 text-center cursor-pointer flex flex-row justify-center">
+  class="border-2 relative rounded-sm border-[var(--pd-button-secondary-border)] text-[var(--pd-button-secondary-text)] hover:bg-[var(--pd-button-secondary-hover-bg)] w-10 p-2 text-center cursor-pointer flex flex-row justify-center">
   <LoadingIcon
     icon={faDownload}
     iconSize="1x"


### PR DESCRIPTION
### What does this PR do?

Replace deprecated `--pd-button-secondary` and `--pd-button-secondary-hover` CSS variables with the current granular ones (`--pd-button-secondary-border`, `--pd-button-secondary-text`, `--pd-button-secondary-hover-bg`) in the extension catalog download button.

The deprecated variables resolve to `stone[700]` in dark mode, making the button appear greyed out and disabled even though it is fully clickable.

### Screenshot / video of UI

<img width="1162" height="812" src="https://github.com/user-attachments/assets/13e025e1-f348-454e-9691-006f5862eaa5" />
<img width="1162" height="812" src="https://github.com/user-attachments/assets/e5673a23-f580-436e-9871-bfeef8fd8b85" />
<img width="1162" height="812" src="https://github.com/user-attachments/assets/a784e876-332b-49bf-83f7-e48935cd76ff" />
<img width="1162" height="812" src="https://github.com/user-attachments/assets/3e8a767e-b399-4681-966e-94c62654a28e" />


### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17170

### How to test this PR?

1. Open Podman Desktop in dark mode
2. Navigate to Extensions → Catalog
3. Verify download buttons have visible border and icon (not greyed out)
4. Hover over a download button — background should change
5. Click to install an extension — spinner and percentage overlay should work

- [x] Tests are covering the bug fix or the new feature