### PR TITLE
feat(proxy): propagate proxy settings to containers via [containers].http_proxy

### DIFF
--- a/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-configuration.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,6 +193,106 @@ test('if provider is set default one (on CLI) and the file does NOT exist, do no
   await podmanConfiguration.updateMachineProviderSettings(VMTYPE.APPLEHV);
 
   expect(fs.promises.writeFile).not.toHaveBeenCalled();
+});
+
+describe('doUpdateProxySettings sets [containers].http_proxy', () => {
+  test('should set http_proxy = true in [containers] when creating new file with proxy', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+
+    const proxySettings: ProxySettings = {
+      httpProxy: 'http://proxy:8080',
+      httpsProxy: 'https://proxy:8443',
+      noProxy: '',
+    };
+
+    await podmanConfiguration.doUpdateProxySettings(proxySettings);
+
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
+      podmanConfiguration.getContainersFileLocation(),
+      expect.stringContaining('http_proxy = true'),
+    );
+  });
+
+  test('should not set http_proxy in [containers] when creating new file without proxy', async () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+
+    await podmanConfiguration.doUpdateProxySettings(undefined);
+
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
+      podmanConfiguration.getContainersFileLocation(),
+      expect.not.stringContaining('http_proxy'),
+    );
+  });
+
+  test('should set http_proxy = true in [containers] when updating existing file with proxy', async () => {
+    const configFileContent = `
+[engine]
+env = ["http_proxy=http://old-proxy:8080"]
+`;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(configFileContent);
+
+    const proxySettings: ProxySettings = {
+      httpProxy: 'http://proxy:8080',
+      httpsProxy: 'https://proxy:8443',
+      noProxy: '',
+    };
+
+    await podmanConfiguration.doUpdateProxySettings(proxySettings);
+
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
+      podmanConfiguration.getContainersFileLocation(),
+      expect.stringContaining('http_proxy = true'),
+    );
+  });
+
+  test('should remove http_proxy from [containers] when proxy is cleared on existing file', async () => {
+    const configFileContent = `
+[containers]
+http_proxy = true
+
+[engine]
+env = ["http_proxy=http://proxy:8080"]
+`;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(configFileContent);
+
+    await podmanConfiguration.doUpdateProxySettings(undefined);
+
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
+      podmanConfiguration.getContainersFileLocation(),
+      expect.not.stringContaining('http_proxy'),
+    );
+  });
+
+  test('should preserve existing [containers] settings when adding http_proxy', async () => {
+    const configFileContent = `
+[containers]
+log_driver = "journald"
+
+[engine]
+env = []
+`;
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs.promises, 'writeFile').mockResolvedValue();
+    vi.spyOn(podmanConfiguration, 'readContainersConfigFile').mockResolvedValue(configFileContent);
+
+    const proxySettings: ProxySettings = {
+      httpProxy: 'http://proxy:8080',
+      httpsProxy: 'https://proxy:8443',
+      noProxy: 'noProxy',
+    };
+
+    await podmanConfiguration.doUpdateProxySettings(proxySettings);
+
+    const writtenContent = vi.mocked(fs.promises.writeFile).mock.calls[0][1] as string;
+    expect(writtenContent).toContain('http_proxy = true');
+    expect(writtenContent).toContain('log_driver = "journald"');
+  });
 });
 
 test('doUpdateProxySettings should be called one at the time', async () => {

--- a/extensions/podman/packages/extension/src/utils/podman-configuration.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-configuration.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -318,6 +318,10 @@ export class PodmanConfiguration {
         containersConfContent['engine'].env.push(`no_proxy=${proxySettings.noProxy}`);
       }
 
+      if (containersConfContent['engine'].env.length > 0) {
+        containersConfContent['containers'] = { http_proxy: true };
+      }
+
       // write the file
       const content = toml.stringify(containersConfContent);
       await fs.promises.writeFile(this.getContainersFileLocation(), content);
@@ -401,6 +405,14 @@ export class PodmanConfiguration {
       }
 
       containersConfContent['engine'].env = engineEnv;
+
+      const containersSection = containersConfContent['containers'] as Record<string, unknown>;
+      if (engineEnv.some(item => /^(https?|no)_proxy=/.test(item))) {
+        containersConfContent['containers'] = { ...containersSection, http_proxy: true };
+      } else {
+        delete containersSection['http_proxy'];
+      }
+
       // write the file
       const content = toml.stringify(containersConfContent);
       await fs.promises.writeFile(this.getContainersFileLocation(), content);


### PR DESCRIPTION
### What does this PR do?

When proxy is configured in Podman Desktop, the extension now sets `http_proxy = true` in the `[containers]` section of containers.conf alongside the existing `[engine].env` entries. This tells Podman to forward proxy environment variables from the engine into all containers automatically, closing the gap where only the engine received proxy settings but running containers did not.
When proxy is cleared, `http_proxy` is removed from the `[containers]` section. Existing `[containers]` settings are preserved.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Resolves #17249

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
