### PR TITLE
fix(ci): update podman org in TF install script

### DIFF
--- a/tests/tmt/scripts/install-podman.sh
+++ b/tests/tmt/scripts/install-podman.sh
@@ -36,7 +36,7 @@ if [[ "$PODMAN_VERSION" == "nightly" ]]; then
 else
     # For "latest" or specific version, fetch version if needed and install from RPM
     if [[ "$PODMAN_VERSION" == "latest" ]]; then
-        PODMAN_VERSION="$(curl -sL https://api.github.com/repos/podman-container-tools/podman/releases/latest | jq -r .tag_name | sed 's/^v//')"
+        PODMAN_VERSION="$(curl -s https://api.github.com/repos/podman-container-tools/podman/releases/latest | jq -r .tag_name | sed 's/^v//')"
     fi
     CUSTOM_PODMAN_URL="https://kojipkgs.fedoraproject.org//packages/podman/${PODMAN_VERSION}/1.${COMPOSE_VERSION}/${ARCH}/podman-${PODMAN_VERSION}-1.${COMPOSE_VERSION}.${ARCH}.rpm"
     curl -Lo podman.rpm "$CUSTOM_PODMAN_URL"

--- a/tests/tmt/scripts/install-podman.sh
+++ b/tests/tmt/scripts/install-podman.sh
@@ -36,7 +36,7 @@ if [[ "$PODMAN_VERSION" == "nightly" ]]; then
 else
     # For "latest" or specific version, fetch version if needed and install from RPM
     if [[ "$PODMAN_VERSION" == "latest" ]]; then
-        PODMAN_VERSION="$(curl -s https://api.github.com/repos/containers/podman/releases/latest | jq -r .tag_name | sed 's/^v//')"
+        PODMAN_VERSION="$(curl -sL https://api.github.com/repos/podman-container-tools/podman/releases/latest | jq -r .tag_name | sed 's/^v//')"
     fi
     CUSTOM_PODMAN_URL="https://kojipkgs.fedoraproject.org//packages/podman/${PODMAN_VERSION}/1.${COMPOSE_VERSION}/${ARCH}/podman-${PODMAN_VERSION}-1.${COMPOSE_VERSION}.${ARCH}.rpm"
     curl -Lo podman.rpm "$CUSTOM_PODMAN_URL"


### PR DESCRIPTION
The Podman project moved to the podman-container-tools GitHub org.

### What does this PR do?
Updates podman project's organization

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/17679