### PR TITLE
feat(renderer): add onboarding wizard shell foundation 

### DIFF
--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardShell.spec.ts
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardShell.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { createRawSnippet, type Snippet } from 'svelte';
+import { describe, expect, test } from 'vitest';
+
+import OnboardingWizardShell from './OnboardingWizardShell.svelte';
+
+function textSnippet(text: string, role: string): Snippet<[]> {
+  return createRawSnippet(() => ({
+    render: () => `<div role="${role}">${text}</div>`,
+  }));
+}
+
+describe('OnboardingWizardShell', () => {
+  test('renders default shell title', async () => {
+    const { findByText, getByRole } = render(OnboardingWizardShell);
+
+    expect(await findByText('Get started')).toBeInTheDocument();
+    expect(getByRole('region', { name: 'Content' })).toBeInTheDocument();
+  });
+
+  test('renders all snippet areas when provided', async () => {
+    render(OnboardingWizardShell, {
+      leftSidebar: textSnippet('left content', 'region'),
+      leftSidebarFooter: textSnippet('footer content', 'note'),
+      rightContent: textSnippet('right content', 'main'),
+      footer: textSnippet('actions', 'group'),
+      sidebarTitle: 'Custom title',
+    });
+
+    expect(await screen.findByText('Custom title')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: '' })).toHaveTextContent('left content');
+    expect(screen.getByRole('note')).toHaveTextContent('footer content');
+    expect(screen.getByRole('main')).toHaveTextContent('right content');
+    expect(screen.getByRole('group')).toHaveTextContent('actions');
+  });
+});

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardShell.svelte
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardShell.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+import type { Snippet } from 'svelte';
+import type { HTMLAttributes } from 'svelte/elements';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  leftSidebar: Snippet;
+  leftSidebarFooter: Snippet;
+  rightContent: Snippet;
+  footer: Snippet;
+  sidebarTitle?: string;
+}
+
+let {
+  leftSidebar,
+  leftSidebarFooter,
+  rightContent,
+  footer,
+  sidebarTitle = 'Get started',
+  class: className,
+  ...restProps
+}: Props = $props();
+</script>
+
+<div class={['flex h-full w-full overflow-hidden', className]} {...restProps}>
+  <aside
+    class="flex min-h-full w-90 min-w-90 shrink-0 flex-col border-r border-(--pd-content-card-border) bg-(--pd-content-bg)">
+    <div class="flex h-full flex-col justify-between px-8 pt-12 pb-8">
+      <div class="flex min-h-0 flex-1 flex-col gap-8">
+        <div class="text-3xl font-semibold leading-none text-(--pd-content-header)">{sidebarTitle}</div>
+        <div class="min-h-0 flex-1 overflow-y-auto">
+          {@render leftSidebar?.()}
+        </div>
+      </div>
+      {#if leftSidebarFooter}
+        <div class="max-w-xs">
+          {@render leftSidebarFooter()}
+        </div>
+      {/if}
+    </div>
+  </aside>
+
+  <section
+    aria-label="Content"
+    class="relative flex min-h-full min-w-0 flex-1 flex-col overflow-hidden bg-linear-to-br from-(--pd-content-bg) via-(--pd-content-card-bg) to-(--pd-content-bg)">
+    <div
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 bg-linear-to-br from-transparent via-transparent to-(--pd-button-primary-bg) opacity-10">
+    </div>
+    <div class="relative z-10 min-h-0 flex-1 overflow-y-auto p-8 lg:p-10">
+      {@render rightContent?.()}
+    </div>
+    {#if footer}
+      <footer class="relative z-10 border-t border-(--pd-content-card-border) bg-transparent px-8 py-5 lg:px-10">
+        {@render footer()}
+      </footer>
+    {/if}
+  </section>
+</div>

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardSteps.constants.ts
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardSteps.constants.ts
@@ -1,0 +1,10 @@
+export interface OnboardingWizardStep {
+  label: string;
+  status: 'completed' | 'active' | 'upcoming';
+}
+
+export const ONBOARDING_WIZARD_DEFAULT_STEPS: OnboardingWizardStep[] = [
+  { label: 'Install podman', status: 'upcoming' },
+  { label: 'Create machine', status: 'upcoming' },
+  { label: 'Install CLI tools', status: 'upcoming' },
+];

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardSteps.spec.ts
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardSteps.spec.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+
+import { ONBOARDING_WIZARD_DEFAULT_STEPS } from './OnboardingWizardSteps.constants';
+import OnboardingWizardSteps from './OnboardingWizardSteps.svelte';
+
+describe('OnboardingWizardSteps', () => {
+  test('renders completed, active, and upcoming steps', () => {
+    render(OnboardingWizardSteps, {
+      steps: [
+        { label: 'Install podman', status: 'completed' },
+        { label: 'Create machine', status: 'active' },
+        { label: 'Install CLI tools', status: 'upcoming' },
+      ],
+    });
+
+    expect(screen.getByText('Install podman')).toBeInTheDocument();
+    expect(screen.getByText('Create machine')).toBeInTheDocument();
+    expect(screen.getByText('Install CLI tools')).toBeInTheDocument();
+  });
+
+  test('renders default constant steps when no props are passed', () => {
+    render(OnboardingWizardSteps);
+
+    for (const step of ONBOARDING_WIZARD_DEFAULT_STEPS) {
+      expect(screen.getByText(step.label)).toBeInTheDocument();
+    }
+  });
+
+  test('applies completed marker without text decoration', () => {
+    render(OnboardingWizardSteps, {
+      steps: [{ label: 'Install podman', status: 'completed' }],
+    });
+
+    const completedText = screen.getByText('Install podman');
+    expect(completedText).not.toHaveClass('line-through');
+    expect(screen.getByText('✓')).toBeInTheDocument();
+  });
+
+  test('applies active emphasis and non-active opacity', () => {
+    render(OnboardingWizardSteps, {
+      steps: [
+        { label: 'Install podman', status: 'completed' },
+        { label: 'Create machine', status: 'active' },
+        { label: 'Install CLI tools', status: 'upcoming' },
+      ],
+    });
+
+    expect(screen.getByText('Create machine').parentElement).toHaveClass('font-semibold');
+    expect(screen.getByText('Install CLI tools').parentElement).toHaveClass('opacity-70');
+    expect(screen.getByText('Create machine').closest('li')).toHaveAttribute('aria-current', 'step');
+  });
+
+  test('renders numbered markers when markerStyle is numbered', () => {
+    render(OnboardingWizardSteps, {
+      markerStyle: 'numbered',
+      steps: [
+        { label: 'Install podman', status: 'upcoming' },
+        { label: 'Create machine', status: 'upcoming' },
+        { label: 'Install CLI tools', status: 'upcoming' },
+      ],
+    });
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+});

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardSteps.svelte
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWizardSteps.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+import { ONBOARDING_WIZARD_DEFAULT_STEPS, type OnboardingWizardStep } from './OnboardingWizardSteps.constants';
+
+interface Props {
+  steps?: OnboardingWizardStep[];
+  class?: string;
+  markerStyle?: 'default' | 'numbered';
+}
+
+let { steps = ONBOARDING_WIZARD_DEFAULT_STEPS, class: className = '', markerStyle = 'default' }: Props = $props();
+</script>
+
+<ol class={`space-y-4 pl-1 text-base leading-snug ${className}`}>
+  {#each steps as step, index (step.label)}
+    <li
+      aria-current={step.status === 'active' ? 'step' : undefined}
+      class={`flex items-center gap-3 text-(--pd-content-header) ${
+        markerStyle === 'numbered'
+          ? step.status === 'upcoming'
+            ? 'opacity-70'
+            : step.status === 'active'
+              ? 'font-semibold'
+              : ''
+          : step.status === 'active'
+            ? 'font-semibold'
+            : 'opacity-70'
+      }`}>
+      {#if step.status === 'completed'}
+        <span
+          class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-(--pd-button-primary-bg) text-xs font-semibold text-(--pd-button-primary-text)">
+          ✓
+        </span>
+        <span class="whitespace-nowrap">{step.label}</span>
+      {:else if markerStyle === 'numbered'}
+        <span
+          class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-(--pd-content-card-border) text-xs font-semibold text-(--pd-content-card-text)">
+          {index + 1}
+        </span>
+        <span class="whitespace-nowrap">{step.label}</span>
+      {:else}
+        <span aria-hidden="true" class="inline-flex h-5 w-5 shrink-0"></span>
+        <span class="whitespace-nowrap">{step.label}</span>
+      {/if}
+    </li>
+  {/each}
+</ol>


### PR DESCRIPTION
### What does this PR do?

Introduces reusable onboarding shell primitives for renderer onboarding screens:

- `OnboardingWizardShell` for shared layout/branding
- `OnboardingWizardSteps` for reusable step rendering
- Figma-aligned shell styling (logo lockup, step states, right-panel violet gradient)

### Screenshot / video of UI

<!-- Add screenshots here -->
<img width="1483" height="900" alt="Screenshot 2026-06-24 at 19 21 41" src="https://github.com/user-attachments/assets/415d838e-7bad-483c-ad4b-5f8a59c14432" />

<img width="1483" height="900" alt="Screenshot 2026-06-24 at 19 21 53" src="https://github.com/user-attachments/assets/1d8de88f-4ced-4e55-b0c5-dbe49037c7f4" />




### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/17464

### How to test this PR?

- Checkout this branch and run `pnpm watch`
- Validate shell components in:
  - `packages/renderer/src/lib/onboarding/OnboardingWizardShell.svelte`
  - `packages/renderer/src/lib/onboarding/OnboardingWizardSteps.svelte`
- Compare screenshots against Figma for shell-only items (logo, steps, gradient)

Figma designs: [Onboarding](https://www.figma.com/design/yhotDw5xJnTUirSWe0bBKT/Onboarding?node-id=115-561&p=f) — see all frames (1.1 through 5) for the shared shell layout.

Reference-only demo branch (already pushed, not in this PR scope):
https://github.com/simonrey1/podman-desktop/tree/feat/onboarding-wizard-shell-demo-17464

Run in the Developer Tools Console
```
window.__pdGoto('/onboarding-shell-demo')
```
to open the Demo onboarding page.

- [ ] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)