### PR TITLE
feat(renderer): add prototype switcher for dashboard background experiment

### DIFF
--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { ListOrganizer, type ListOrganizerItem, NavPage, tablePersistence } from '@podman-desktop/ui-svelte';
-import { onMount } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
 import {
@@ -10,8 +10,38 @@ import {
   defaultSection,
   setupDashboardPageRegistry,
 } from '/@/stores/dashboard/dashboard-page-registry.svelte';
+import { registerPrototype, unregisterPrototype } from '/@/stores/prototype';
 
 import NotificationsBox from './NotificationsBox.svelte';
+
+interface DashboardBgOverride {
+  bgColor: string | undefined;
+}
+
+const prototypeOverride = registerPrototype<DashboardBgOverride>({
+  name: 'Dashboard Background',
+  screens: [
+    { value: 'user-default', label: 'User Default' },
+    { value: 'red', label: 'Red Background' },
+    { value: 'blue', label: 'Blue Background' },
+    { value: 'green', label: 'Green Background' },
+  ],
+  overrides: {
+    'user-default': { bgColor: undefined },
+    red: { bgColor: '#dc2626' },
+    blue: { bgColor: '#2563eb' },
+    green: { bgColor: '#16a34a' },
+  },
+});
+
+let currentBgOverride = $state<DashboardBgOverride | undefined>();
+const unsubscribePrototype = prototypeOverride.subscribe(value => {
+  currentBgOverride = value;
+});
+onDestroy(() => {
+  unsubscribePrototype();
+  unregisterPrototype();
+});
 
 // Dashboard section configuration managed by dashboard page registry
 let dashboardSections = $state<ListOrganizerItem[]>([]);
@@ -180,7 +210,10 @@ function handleDashboardToggle(itemId: string, enabled: boolean): void {
   {/snippet}
   
   {#snippet content()}
-  <div class="flex flex-col min-w-full h-full bg-[var(--pd-content-bg)] py-5">
+  <div
+    class="flex flex-col min-w-full h-full py-5"
+    class:bg-[var(--pd-content-bg)]={!currentBgOverride?.bgColor}
+    style:background-color={currentBgOverride?.bgColor}>
     <div class="min-w-full flex-1">
       <NotificationsBox />
       <div class="px-5 space-y-5 h-full">

--- a/packages/renderer/src/lib/ui/PrototypeSelector.svelte
+++ b/packages/renderer/src/lib/ui/PrototypeSelector.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+import { Dropdown } from '@podman-desktop/ui-svelte';
+
+import { activePrototype, currentScreen } from '/@/stores/prototype';
+
+// Dropdown.onChange is (val: string) => void per packages/ui Dropdown Props.
+let prototype = $derived($activePrototype);
+let selectedScreen = $derived($currentScreen);
+
+function handleChange(value: string): void {
+  currentScreen.set(value);
+}
+</script>
+
+{#if prototype}
+  <div class="flex items-center gap-2 pr-2" style="-webkit-app-region: none;">
+    <span class="text-sm font-medium text-lime-400 whitespace-nowrap select-none">
+      Prototype: {prototype.name}
+    </span>
+
+    <div class="prototype-dropdown">
+      <Dropdown
+        ariaLabel="Prototype screen selector"
+        name="prototype-screen"
+        class="min-w-60"
+        value={selectedScreen}
+        onChange={handleChange}
+        options={prototype.screens} />
+    </div>
+  </div>
+{/if}
+
+<style>
+  .prototype-dropdown :global(button) {
+    border: 1px solid rgb(239 68 68);
+    border-radius: 4px;
+  }
+</style>

--- a/packages/renderer/src/lib/ui/TitleBar.svelte
+++ b/packages/renderer/src/lib/ui/TitleBar.svelte
@@ -6,6 +6,7 @@ import DesktopIcon from '/@/lib/images/DesktopIcon.svelte';
 import NavigationButtons from '/@/lib/ui/NavigationButtons.svelte';
 import WindowControlButtons from '/@/lib/window-control-buttons/ControlButtons.svelte';
 
+import PrototypeSelector from './PrototypeSelector.svelte';
 import SearchButton from './SearchButton.svelte';
 
 let platform: string = $state('');
@@ -50,7 +51,8 @@ function closeCommandPalette(): void {
     </div>
 
     <!-- right -->
-    <div class="flex flex-row grow justify-end">
+    <div class="flex flex-row grow justify-end items-center">
+      <PrototypeSelector />
       {#if platform !== 'darwin'}
         <WindowControlButtons platform={platform} />
       {/if}

--- a/packages/renderer/src/stores/prototype.ts
+++ b/packages/renderer/src/stores/prototype.ts
@@ -1,0 +1,150 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { derived, type Readable, writable } from 'svelte/store';
+
+export interface PrototypeScreen {
+  value: string;
+  label: string;
+}
+
+export interface PhaseSchedule {
+  delay: number;
+  phase: number;
+}
+
+/**
+ * Configuration for a prototype. The generic `T` is your override shape -
+ * each screen (and optional phase) maps to one `T` instance.
+ *
+ * @example
+ * ```ts
+ * interface MyOverride { color: string; showBadge: boolean }
+ *
+ * const override = registerPrototype<MyOverride>({
+ *   name: 'Badge experiment',
+ *   screens: [
+ *     { value: 'off', label: 'Badge hidden' },
+ *     { value: 'on', label: 'Badge visible' },
+ *     { value: 'animated', label: 'Badge animated (3s timeline)' },
+ *   ],
+ *   overrides: {
+ *     off: { color: 'gray', showBadge: false },
+ *     on: { color: 'red', showBadge: true },
+ *     animated: { color: 'red', showBadge: true },
+ *     'animated:1': { color: 'green', showBadge: false },
+ *   },
+ *   timelines: {
+ *     animated: [{ delay: 3000, phase: 1 }],
+ *   },
+ * });
+ * ```
+ */
+export interface PrototypeConfig<T> {
+  name: string;
+  screens: PrototypeScreen[];
+  overrides: Record<string, T>;
+  /** Optional timed phase transitions. Key = screen value, value = array of `{ delay, phase }`. */
+  timelines?: Record<string, PhaseSchedule[]>;
+}
+
+interface PrototypeState {
+  name: string;
+  screens: PrototypeScreen[];
+}
+
+export const activePrototype = writable<PrototypeState | undefined>();
+export const currentScreen = writable<string>('');
+
+const currentPhase = writable<number>(0);
+let phaseTimers: ReturnType<typeof setTimeout>[] = [];
+let currentTimelines: Record<string, PhaseSchedule[]> = {};
+let currentOverrides: Record<string, unknown> = {};
+let screenUnsubscribe: (() => void) | undefined;
+
+// Typed as unknown at the module level; callers get proper typing via registerPrototype<T>().
+export const currentOverride: Readable<unknown | undefined> = derived(
+  [currentScreen, currentPhase, activePrototype],
+  ([$screen, $phase]) => {
+    const key = $phase > 0 ? `${$screen}:${$phase}` : $screen;
+    return currentOverrides[key];
+  },
+);
+
+function clearPhaseTimers(): void {
+  phaseTimers.forEach(clearTimeout);
+  phaseTimers = [];
+}
+
+function startScreenSubscription(): void {
+  screenUnsubscribe?.();
+  screenUnsubscribe = currentScreen.subscribe(screen => {
+    clearPhaseTimers();
+    currentPhase.set(0);
+
+    const timeline = currentTimelines[screen];
+    if (timeline) {
+      for (const entry of timeline) {
+        phaseTimers.push(setTimeout(() => currentPhase.set(entry.phase), entry.delay));
+      }
+    }
+  });
+}
+
+/**
+ * Register a prototype. Activates the titlebar screen switcher and returns
+ * a typed readable store that emits the current override for the selected
+ * screen and phase. Call {@link unregisterPrototype} to tear down.
+ */
+export function registerPrototype<T>(config: PrototypeConfig<T>): Readable<T | undefined> {
+  if (!config.name?.trim()) {
+    throw new Error('registerPrototype: name must be a non-empty string');
+  }
+  if (!config.screens?.length) {
+    throw new Error('registerPrototype: screens must be a non-empty array');
+  }
+  if (config.timelines) {
+    for (const [screen, phases] of Object.entries(config.timelines)) {
+      for (const entry of phases) {
+        if (entry.delay <= 0) {
+          throw new Error(
+            `registerPrototype: timeline delay must be positive (screen "${screen}", got ${String(entry.delay)})`,
+          );
+        }
+      }
+    }
+  }
+  currentOverrides = config.overrides as Record<string, unknown>;
+  currentTimelines = config.timelines ?? {};
+  activePrototype.set({ name: config.name, screens: config.screens });
+  startScreenSubscription();
+  currentScreen.set(config.screens[0]?.value ?? '');
+  return currentOverride as Readable<T | undefined>;
+}
+
+/** Tear down the active prototype. Clears timers, overrides, and hides the titlebar selector. */
+export function unregisterPrototype(): void {
+  screenUnsubscribe?.();
+  screenUnsubscribe = undefined;
+  clearPhaseTimers();
+  currentOverrides = {};
+  currentTimelines = {};
+  activePrototype.set(undefined);
+  currentScreen.set('');
+  currentPhase.set(0);
+}


### PR DESCRIPTION
TEMP, WILL REMOVE, I AM SHOWING THE WORKFLOW TO SHIRAN

---

Add prototype infrastructure (store, titlebar selector) and wire a Dashboard Background prototype with four switchable states: red, blue, green, and user default. The titlebar dropdown lets designers compare background options without touching code.

Assisted-by: Claude Opus 4.6

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
