### PR TITLE
fix(Markdown): sanitize unsafe HTML content

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -27,7 +27,7 @@
     "@types/validator": "^13.15.10",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@xterm/addon-serialize": "^0.14.0",
-    "dompurify": "^3.4.8",
+    "dompurify": "^3.4.10",
     "eslint-plugin-svelte": "^3.19.0",
     "filesize": "^11.0.17",
     "humanize-duration": "^3.33.2",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -27,6 +27,7 @@
     "@types/validator": "^13.15.10",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@xterm/addon-serialize": "^0.14.0",
+    "dompurify": "^3.4.8",
     "eslint-plugin-svelte": "^3.19.0",
     "filesize": "^11.0.17",
     "humanize-duration": "^3.33.2",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -27,7 +27,7 @@
     "@types/validator": "^13.15.10",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@xterm/addon-serialize": "^0.14.0",
-    "dompurify": "^3.4.10",
+    "dompurify": "^3.4.11",
     "eslint-plugin-svelte": "^3.19.0",
     "filesize": "^11.0.17",
     "humanize-duration": "^3.33.2",

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -185,6 +185,18 @@ describe('Custom image', () => {
     );
   });
 
+  test('Expect base64 image to be rendered as a image', async () => {
+    const src = 'data:image/gif;base64,R0lGODlhAQABAAAAACw=';
+    const alt = 'Base 64 Image';
+
+    await waitRender({ markdown: `:image[${alt}]{src="${src}"}` });
+
+    const img = screen.getByRole('img', { name: alt });
+    expect(img).toBeInTheDocument();
+
+    expect(img).toHaveAttribute('src', src);
+  });
+
   test('Expect image to be rendered as a image with all attributes', async () => {
     await waitRender({
       markdown: ':image[Name of the image]{src=path/to/image.png title="Image title" width="300" height="200"}',

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -165,13 +165,15 @@ describe('Custom link', () => {
     expect(markdownContent).toContainHTML('<a href="/containers">containers</a>');
   });
 
-  test('expect unknown protocol to be left as is', async () => {
+  test('expect unknown protocol to be removed', async () => {
     await waitRender({
-      markdown: 'See <a href="foo://bar">foo</a>',
+      markdown: 'See <a title="Foo link" href="foo://bar">foo</a>',
     });
     const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
-    expect(markdownContent).toBeInTheDocument();
-    expect(markdownContent).toContainHTML('<a href="foo://bar">foo</a>');
+
+    const link = within(markdownContent).getByTitle('Foo link');
+    expect(link).toBeInTheDocument();
+    expect(link).not.toHaveAttribute('href');
   });
 });
 

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -294,6 +294,226 @@ describe('Custom warnings', () => {
     const buttonFailedStatus = await screen.findByText('command title failed');
     expect(buttonFailedStatus).toBeDefined();
   });
+
+  test('XSS prevention - comprehensive attack vectors', async () => {
+    // Test multiple XSS attack vectors in different fields
+    const attackVectors = [
+      // Script injections
+      {
+        state: 'successful',
+        description: '<script>alert(1)</script>',
+        command: { id: 'cmd1', title: 'safe' },
+      },
+      {
+        state: 'failed',
+        description: '<script src=//evil.com></script>',
+        command: { id: 'cmd2', title: 'safe' },
+      },
+      // Event handler injections
+      {
+        state: 'successful',
+        description: '<img src=x onerror=alert(1)>',
+        command: { id: 'cmd3', title: 'safe' },
+      },
+      {
+        state: 'failed',
+        description: '<svg onload=alert(1)>',
+        command: { id: 'cmd4', title: 'safe' },
+      },
+      {
+        state: 'successful',
+        description: '<body onload=alert(1)>',
+        command: { id: 'cmd5', title: 'safe' },
+      },
+      {
+        state: 'failed',
+        description: '<input onfocus=alert(1) autofocus>',
+        command: { id: 'cmd6', title: 'safe' },
+      },
+      // JavaScript protocol
+      {
+        state: 'successful',
+        description: 'safe',
+        docLinks: [{ url: 'javascript:alert(1)', title: 'click' }],
+      },
+      {
+        state: 'failed',
+        description: 'safe',
+        docLinks: [{ url: 'JaVaScRiPt:alert(1)', title: 'click' }],
+      },
+      // Data URIs
+      {
+        state: 'successful',
+        description: 'safe',
+        docLinks: [{ url: 'data:text/html,<script>alert(1)</script>', title: 'click' }],
+      },
+      // Iframe injection
+      {
+        state: 'failed',
+        command: { id: 'cmd7', title: '<iframe src=javascript:alert(1)></iframe>' },
+      },
+      // HTML entity encoding bypass attempts
+      {
+        state: 'successful',
+        description: '<img src=x onerror=&#97;&#108;&#101;&#114;&#116;(1)>',
+        command: { id: 'cmd8', title: 'safe' },
+      },
+      // Object/embed tags
+      {
+        state: 'failed',
+        description: '<object data=javascript:alert(1)>',
+        command: { id: 'cmd9', title: 'safe' },
+      },
+      {
+        state: 'successful',
+        description: '<embed src=javascript:alert(1)>',
+        command: { id: 'cmd10', title: 'safe' },
+      },
+      // Meta refresh
+      {
+        state: 'failed',
+        description: '<meta http-equiv=refresh content=0;url=javascript:alert(1)>',
+        command: { id: 'cmd11', title: 'safe' },
+      },
+      // Form action
+      {
+        state: 'successful',
+        description: '<form action=javascript:alert(1)><button>click</button></form>',
+        command: { id: 'cmd12', title: 'safe' },
+      },
+      // Link stylesheet
+      {
+        state: 'failed',
+        description: '<link rel=stylesheet href=javascript:alert(1)>',
+        command: { id: 'cmd13', title: 'safe' },
+      },
+      // Style tag
+      {
+        state: 'successful',
+        description: '<style>body{background:url(javascript:alert(1))}</style>',
+        command: { id: 'cmd14', title: 'safe' },
+      },
+      // Base tag
+      {
+        state: 'failed',
+        description: '<base href=javascript:alert(1)//>',
+        command: { id: 'cmd15', title: 'safe' },
+      },
+      // OnError in command title
+      {
+        state: 'successful',
+        command: { id: 'cmd16', title: '<img src=x onerror=alert(1)>' },
+      },
+      // Multiple event handlers
+      {
+        state: 'failed',
+        description: '<div onclick=alert(1) onmouseover=alert(2) onfocus=alert(3)>test</div>',
+        command: { id: 'cmd17', title: 'safe' },
+      },
+      // SVG with various attacks
+      {
+        state: 'successful',
+        docDescription: '<svg><script>alert(1)</script></svg>',
+      },
+      {
+        state: 'failed',
+        docDescription: '<svg><animate onbegin=alert(1)>',
+      },
+      // DocLinks title XSS
+      {
+        state: 'successful',
+        docLinks: [{ url: '#', title: '<script>alert(1)</script>' }],
+      },
+      {
+        state: 'failed',
+        docLinks: [{ url: '#', title: '<img src=x onerror=alert(1)>' }],
+      },
+      // Template tag
+      {
+        state: 'successful',
+        description: '<template><script>alert(1)</script></template>',
+        command: { id: 'cmd18', title: 'safe' },
+      },
+      // HTML comments with script
+      {
+        state: 'failed',
+        description: '<!--<script>alert(1)</script>-->',
+        command: { id: 'cmd19', title: 'safe' },
+      },
+      // CDATA section
+      {
+        state: 'successful',
+        description: '<![CDATA[<script>alert(1)</script>]]>',
+        command: { id: 'cmd20', title: 'safe' },
+      },
+    ];
+
+    await waitRender({ markdown: `:warnings[${JSON.stringify(attackVectors)}]` });
+
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+
+    // Verify no script tags made it through
+    expect(markdownContent.querySelectorAll('script').length).toBe(0);
+
+    // Verify no iframes
+    expect(markdownContent.querySelectorAll('iframe').length).toBe(0);
+
+    // Verify no dangerous elements
+    expect(markdownContent.querySelectorAll('object').length).toBe(0);
+    expect(markdownContent.querySelectorAll('embed').length).toBe(0);
+    expect(markdownContent.querySelectorAll('meta').length).toBe(0);
+    expect(markdownContent.querySelectorAll('base').length).toBe(0);
+    expect(markdownContent.querySelectorAll('link[rel="stylesheet"]').length).toBe(0);
+
+    // Verify no event handlers on any elements
+    const allElements = markdownContent.querySelectorAll('*');
+    const dangerousEvents = [
+      'onload',
+      'onerror',
+      'onclick',
+      'onmouseover',
+      'onfocus',
+      'onbegin',
+      'onmouseout',
+      'onkeydown',
+      'onkeyup',
+      'onchange',
+      'onsubmit',
+      'onanimationstart',
+      'onanimationend',
+      'ontransitionend',
+    ];
+
+    for (const el of allElements) {
+      for (const event of dangerousEvents) {
+        expect(el.hasAttribute(event)).toBe(false);
+      }
+      // Also check that no inline event handlers exist in the element's attributes
+      for (let i = 0; i < el.attributes.length; i++) {
+        const attrName = el.attributes[i].name.toLowerCase();
+        expect(attrName.startsWith('on')).toBe(false);
+      }
+    }
+
+    // Verify no javascript: protocols in links
+    const links = markdownContent.querySelectorAll('a');
+    for (const link of links) {
+      const href = link.getAttribute('href');
+      if (href) {
+        expect(href.toLowerCase()).not.toContain('javascript:');
+        expect(href.toLowerCase()).not.toContain('data:text/html');
+      }
+    }
+
+    // Verify no dangerous protocols in other elements
+    const imgs = markdownContent.querySelectorAll('img');
+    for (const img of imgs) {
+      const src = img.getAttribute('src');
+      if (src) {
+        expect(src.toLowerCase()).not.toContain('javascript:');
+      }
+    }
+  });
 });
 
 describe('jump to TOC section', () => {

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -87,7 +87,7 @@ let html: string = $derived.by(() => {
   // remove href values in each anchor using # for links
   // and set the attribute data-pd-jump-in-page
   const parser = new DOMParser();
-  const doc = parser.parseFromString(DOMPurify.sanitize(decode(html)), 'text/html');
+  const doc = parser.parseFromString(decode(DOMPurify.sanitize(html)), 'text/html');
   const links = doc.querySelectorAll('a');
   links.forEach(link => {
     const currentHref = link.getAttribute('href');

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -45,6 +45,7 @@ UI guidelines -->
 </style>
 
 <script lang="ts">
+import DOMPurify from 'dompurify';
 import { micromark } from 'micromark';
 import { directive, directiveHtml } from 'micromark-extension-directive';
 import { onDestroy, onMount } from 'svelte';
@@ -86,7 +87,7 @@ let html: string = $derived.by(() => {
   // remove href values in each anchor using # for links
   // and set the attribute data-pd-jump-in-page
   const parser = new DOMParser();
-  const doc = parser.parseFromString(decode(html), 'text/html');
+  const doc = parser.parseFromString(DOMPurify.sanitize(decode(html)), 'text/html');
   const links = doc.querySelectorAll('a');
   links.forEach(link => {
     const currentHref = link.getAttribute('href');

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -87,7 +87,12 @@ let html: string = $derived.by(() => {
   // remove href values in each anchor using # for links
   // and set the attribute data-pd-jump-in-page
   const parser = new DOMParser();
-  const doc = parser.parseFromString(decode(DOMPurify.sanitize(html)), 'text/html');
+  const doc = parser.parseFromString(
+    DOMPurify.sanitize(decode(html), {
+      ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|podman-desktop):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
+    }),
+    'text/html',
+  );
   const links = doc.querySelectorAll('a');
   links.forEach(link => {
     const currentHref = link.getAttribute('href');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,6 +851,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      dompurify:
+        specifier: ^3.4.10
+        version: 3.4.10
       eslint-plugin-svelte:
         specifier: ^3.19.0
         version: 3.19.0(eslint@10.5.0(jiti@2.7.0))(svelte@5.53.7)


### PR DESCRIPTION
### What does this PR do?

Prevent Cross-Site Scripting (XSS), let's say someone put a malicious description in a README or anything with some execution script, `DOMPurify.sanitize` will handle it

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/16575

Require rebase after 
- https://github.com/podman-desktop/podman-desktop/issues/17778
- https://github.com/podman-desktop/podman-desktop/pull/17913

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

:warning: the test cases was generated by Claude