### PR TITLE
feat(renderer): add onboarding welcome setup mode page

### DIFF
--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeSetupMode.spec.ts
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeSetupMode.spec.ts
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import OnboardingWelcomeSetupMode from './OnboardingWelcomeSetupMode.svelte';
+import { DEFAULT_SETUP_SELECTION } from './OnboardingWelcomeSetupMode.types';
+
+describe('OnboardingWelcomeSetupMode', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(window.getPodmanDesktopVersion).mockResolvedValue('1.2.3');
+  });
+
+  test('renders welcome heading with setup mode options', async () => {
+    render(OnboardingWelcomeSetupMode);
+
+    expect(await screen.findByText('Welcome to Podman Desktop v1.2.3!')).toBeInTheDocument();
+    expect(screen.getByLabelText('Use recommended setup')).toBeInTheDocument();
+    expect(screen.getByLabelText('Use advanced setup')).toBeInTheDocument();
+  });
+
+  test('reveals advanced controls when advanced mode is selected', async () => {
+    render(OnboardingWelcomeSetupMode);
+    await fireEvent.click(await screen.findByLabelText('Use advanced setup'));
+
+    expect(screen.getByText('Container engine')).toBeInTheDocument();
+    expect(screen.getByText('kubectl')).toBeInTheDocument();
+    expect(screen.getByText('compose')).toBeInTheDocument();
+  });
+
+  test('surfaces setup selection changes to parent layer', async () => {
+    const onSelectionChange = vi.fn();
+    render(OnboardingWelcomeSetupMode, { onSelectionChange });
+
+    await vi.waitFor(() => expect(onSelectionChange).toHaveBeenCalledWith(DEFAULT_SETUP_SELECTION));
+
+    await fireEvent.click(screen.getByLabelText('Use advanced setup'));
+    await vi.waitFor(() =>
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          setupMode: 'advanced',
+        }),
+      ),
+    );
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'kubectl' }));
+    await vi.waitFor(() =>
+      expect(onSelectionChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          installKubectl: false,
+        }),
+      ),
+    );
+  });
+});

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeSetupMode.svelte
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeSetupMode.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+import { Checkbox, Dropdown } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+
+import { CONTAINER_ENGINES, DEFAULT_SETUP_SELECTION, isContainerEngine } from './OnboardingWelcomeSetupMode.types';
+
+type SetupSelection = typeof DEFAULT_SETUP_SELECTION;
+type SetupMode = SetupSelection['setupMode'];
+type ContainerEngine = (typeof CONTAINER_ENGINES)[number];
+
+interface Props {
+  onSelectionChange: (selection: SetupSelection) => void;
+}
+
+const engineOptions = CONTAINER_ENGINES.map(engine => ({ label: engine, value: engine }));
+let { onSelectionChange }: Props = $props();
+
+let setupMode: SetupMode = $state(DEFAULT_SETUP_SELECTION.setupMode);
+let selectedEngine: ContainerEngine = $state(DEFAULT_SETUP_SELECTION.selectedEngine);
+let installKubectl = $state(DEFAULT_SETUP_SELECTION.installKubectl);
+let installCompose = $state(DEFAULT_SETUP_SELECTION.installCompose);
+let podmanDesktopVersion = $derived(await window.getPodmanDesktopVersion());
+
+function emitSelectionChange(): void {
+  onSelectionChange({
+    setupMode,
+    selectedEngine,
+    installKubectl,
+    installCompose,
+  });
+}
+
+function setSetupMode(mode: SetupMode): void {
+  setupMode = mode;
+  emitSelectionChange();
+}
+
+function setSelectedEngine(value: string): void {
+  if (isContainerEngine(value)) {
+    selectedEngine = value;
+    emitSelectionChange();
+  }
+}
+
+function setInstallKubectl(checked: boolean): void {
+  installKubectl = checked;
+  emitSelectionChange();
+}
+
+function setInstallCompose(checked: boolean): void {
+  installCompose = checked;
+  emitSelectionChange();
+}
+
+onMount(() => {
+  emitSelectionChange();
+});
+</script>
+
+<div class="mx-auto w-full max-w-3xl space-y-6" aria-label="Welcome setup mode selection">
+  <div class="space-y-2">
+    <h1 class="text-3xl font-semibold text-(--pd-content-header)">Welcome to Podman Desktop v{podmanDesktopVersion}!</h1>
+    <p class="text-sm text-(--pd-content-card-text)">
+      Setup everything you need for seamless experience with containers and Kubernetes.
+    </p>
+    <p class="text-sm text-(--pd-content-card-text)">These configuration selections can be changed later in Settings.</p>
+  </div>
+
+  <div class="space-y-3">
+    <label class="flex cursor-pointer items-start gap-3">
+      <input
+        type="radio"
+        name="setup-mode"
+        checked={setupMode === 'recommended'}
+        onchange={(): void => setSetupMode('recommended')}
+        aria-label="Use recommended setup" />
+      <div class="space-y-1">
+        <div class="text-sm font-semibold text-(--pd-content-header)">
+          Use recommended setup.
+          <span class="font-normal">
+            Works for most users. This will install podman, create a podman machine and ensure Podman Desktop is
+            ready to use.
+          </span>
+        </div>
+      </div>
+    </label>
+
+    <label class="flex cursor-pointer items-start gap-3">
+      <input
+        type="radio"
+        name="setup-mode"
+        checked={setupMode === 'advanced'}
+        onchange={(): void => setSetupMode('advanced')}
+        aria-label="Use advanced setup" />
+      <div class="space-y-1">
+        <div class="text-sm font-semibold text-(--pd-content-header)">
+          Use advanced setup.
+          <span class="font-normal">Choose your own configurations, container engine and extensions.</span>
+        </div>
+      </div>
+    </label>
+  </div>
+
+  {#if setupMode === 'advanced'}
+    <div class="space-y-4">
+      <div class="flex items-center gap-8">
+        <div class="w-32 text-sm font-semibold text-(--pd-content-header)">Container engine</div>
+        <div class="w-full max-w-xs">
+          <Dropdown
+            ariaLabel="Container engine"
+            value={selectedEngine}
+            onChange={setSelectedEngine}
+            options={engineOptions}>
+          </Dropdown>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <div class="text-sm font-semibold text-(--pd-content-header)">Tools</div>
+        <div class="space-y-3">
+          <Checkbox bind:checked={installKubectl} title="kubectl" onclick={setInstallKubectl}>
+            <div class="space-y-1">
+              <div class="text-sm text-(--pd-content-header)">kubectl</div>
+              <div class="text-xs text-(--pd-content-card-text)">
+                Command-line interface (CLI) tool used to interact with Kubernetes clusters.
+              </div>
+            </div>
+          </Checkbox>
+          <Checkbox bind:checked={installCompose} title="compose" onclick={setInstallCompose}>
+            <div class="space-y-1">
+              <div class="text-sm text-(--pd-content-header)">compose</div>
+              <div class="text-xs text-(--pd-content-card-text)">Define and run multi-container applications.</div>
+            </div>
+          </Checkbox>
+        </div>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeSetupMode.types.ts
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeSetupMode.types.ts
@@ -1,0 +1,21 @@
+export type SetupMode = 'recommended' | 'advanced';
+export const CONTAINER_ENGINES = ['podman', 'docker'] as const;
+export type ContainerEngine = (typeof CONTAINER_ENGINES)[number];
+
+export interface SetupSelection {
+  setupMode: SetupMode;
+  selectedEngine: ContainerEngine;
+  installKubectl: boolean;
+  installCompose: boolean;
+}
+
+export const DEFAULT_SETUP_SELECTION: SetupSelection = {
+  setupMode: 'recommended',
+  selectedEngine: 'podman',
+  installKubectl: true,
+  installCompose: true,
+};
+
+export function isContainerEngine(value: string): value is ContainerEngine {
+  return (CONTAINER_ENGINES as readonly string[]).includes(value);
+}

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeSetupModePage.svelte
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeSetupModePage.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+import { faArrowRightLong } from '@fortawesome/free-solid-svg-icons';
+import { Button, Link } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import OnboardingWelcomeSetupMode from './OnboardingWelcomeSetupMode.svelte';
+import { DEFAULT_SETUP_SELECTION, type SetupSelection } from './OnboardingWelcomeSetupMode.types';
+import OnboardingWelcomeTelemetry from './OnboardingWelcomeTelemetry.svelte';
+import OnboardingWizardShell from './OnboardingWizardShell.svelte';
+import { ONBOARDING_WIZARD_DEFAULT_STEPS } from './OnboardingWizardSteps.constants';
+import OnboardingWizardSteps from './OnboardingWizardSteps.svelte';
+
+let setupSelection: SetupSelection = $state({
+  ...DEFAULT_SETUP_SELECTION,
+});
+
+function updateSetupSelection(selection: SetupSelection): void {
+  setupSelection = selection;
+}
+</script>
+
+<div class="h-full w-full">
+  <OnboardingWizardShell>
+    {#snippet leftSidebar()}
+      <OnboardingWizardSteps steps={ONBOARDING_WIZARD_DEFAULT_STEPS} markerStyle="numbered" />
+    {/snippet}
+
+    {#snippet leftSidebarFooter()}
+      <div class="rounded-lg border border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) p-4">
+        <OnboardingWelcomeTelemetry />
+      </div>
+    {/snippet}
+
+    {#snippet rightContent()}
+      <OnboardingWelcomeSetupMode onSelectionChange={updateSetupSelection} />
+    {/snippet}
+
+    {#snippet footer()}
+      <div class="flex w-full items-center justify-end gap-4">
+        <Link>Skip entire setup</Link>
+        <Button>
+          <span class="inline-flex items-center gap-2">
+            <Icon icon={faArrowRightLong} />
+            Start setup
+            <span class="sr-only">
+              Selected setup: {setupSelection.setupMode}, engine: {setupSelection.selectedEngine}, kubectl: {setupSelection.installKubectl
+                ? 'enabled'
+                : 'disabled'}, compose: {setupSelection.installCompose ? 'enabled' : 'disabled'}
+            </span>
+          </span>
+        </Button>
+      </div>
+    {/snippet}
+  </OnboardingWizardShell>
+</div>

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeTelemetry.spec.ts
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeTelemetry.spec.ts
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import OnboardingWelcomeTelemetry from './OnboardingWelcomeTelemetry.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.getTelemetryMessages).mockResolvedValue({
+    acceptMessage: 'Telemetry message',
+    privacy: { link: 'Privacy statement', url: 'https://example.test/privacy' },
+  });
+});
+
+test('persists telemetry using the actual checkbox checked value', async () => {
+  render(OnboardingWelcomeTelemetry);
+
+  const checkbox = await screen.findByRole('checkbox', { name: 'Enable telemetry' });
+  expect(checkbox).toBeChecked();
+
+  await fireEvent.click(checkbox);
+  await vi.waitFor(() => {
+    expect(vi.mocked(window.updateConfigurationValue)).toHaveBeenCalledWith(
+      'telemetry.enabled',
+      false,
+      expect.anything(),
+    );
+    expect(vi.mocked(window.updateConfigurationValue)).toHaveBeenCalledWith('telemetry.check', true, expect.anything());
+  });
+  expect(vi.mocked(window.telemetryConfigure)).not.toHaveBeenCalled();
+
+  vi.mocked(window.updateConfigurationValue).mockClear();
+  vi.mocked(window.telemetryConfigure).mockClear();
+
+  await fireEvent.click(checkbox);
+  await vi.waitFor(() => {
+    expect(vi.mocked(window.updateConfigurationValue)).toHaveBeenCalledWith(
+      'telemetry.enabled',
+      true,
+      expect.anything(),
+    );
+    expect(vi.mocked(window.updateConfigurationValue)).toHaveBeenCalledWith('telemetry.check', true, expect.anything());
+    expect(vi.mocked(window.telemetryConfigure)).toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeTelemetry.svelte
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingWelcomeTelemetry.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import { Checkbox, Link } from '@podman-desktop/ui-svelte';
+
+import { WelcomeUtils } from '/@/lib/welcome/welcome-utils';
+
+let telemetryEnabled = $state(true);
+let telemetryMessages = $derived(await window.getTelemetryMessages());
+const welcomeUtils = new WelcomeUtils();
+
+async function persistTelemetryChoice(checked: boolean): Promise<void> {
+  telemetryEnabled = checked;
+  await welcomeUtils.setTelemetry(checked);
+}
+
+function openTelemetryPrivacyLink(): Promise<void> | undefined {
+  if (telemetryMessages.privacy) {
+    return window.openExternal(telemetryMessages.privacy.url);
+  }
+}
+</script>
+
+<Checkbox
+  bind:checked={telemetryEnabled}
+  title="Enable telemetry"
+  class="items-start"
+  onclick={persistTelemetryChoice}>
+  <div class="space-y-1">
+    <div class="text-md font-medium text-(--pd-content-header)">Telemetry</div>
+    <div class="text-xs text-(--pd-content-card-text)">
+      {telemetryMessages.acceptMessage}
+      {#if telemetryMessages.privacy}
+        <span> </span>
+        <Link on:click={openTelemetryPrivacyLink}>
+          {telemetryMessages.privacy.link}
+        </Link>
+      {/if}
+    </div>
+  </div>
+</Checkbox>


### PR DESCRIPTION
### What does this PR do?

Implements onboarding issue #17465 welcome step UI using the new wizard primitives under `onboarding/wizard`.
Adds setup mode selection (recommended/advanced), container engine choice, CLI tools toggles, and telemetry section in the left footer.

### Screenshot / video of UI

<!-- Keep placeholders so screenshots can be added before ready-for-review -->


- Light theme screenshots
<img width="1385" height="900" alt="Screenshot 2026-06-25 at 11 17 20" src="https://github.com/user-attachments/assets/751214a6-3d24-43d9-b471-44defce639b4" />

<img width="1385" height="900" alt="Screenshot 2026-06-25 at 11 17 14" src="https://github.com/user-attachments/assets/4cf57315-b3f8-45b3-ac25-1c86988c724d" />

- Dark theme screenshots
<img width="1385" height="900" alt="Screenshot 2026-06-25 at 11 16 48" src="https://github.com/user-attachments/assets/6f5dc90b-d227-415a-bc4d-fecdb33dce44" />
<img width="1385" height="900" alt="Screenshot 2026-06-25 at 11 16 58" src="https://github.com/user-attachments/assets/4ea05bf4-4a0b-4344-b7f9-8bc52dd5799f" />



### What issues does this PR fix or reference?

- Partial fix of #17465

### How to test this PR?

1. Checkout the demo branch  [Demo branch link](https://github.com/simonrey1/podman-desktop/tree/feat/onboarding-17465-demo) and run Podman Desktop in dev mode.
2. Open the preview route from DevTools:
   - `window.__pdGoto('/onboarding-shell-demo')`
3. Verify welcome copy/layout, setup mode options, advanced section fields, tools toggles, telemetry block, and footer actions.

Figma designs: [Onboarding](https://www.figma.com/design/yhotDw5xJnTUirSWe0bBKT/Onboarding?node-id=115-561&p=f) — frames 1.1 (Recommended Setup) and 1.2 (Advanced Setup).

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)