### PR TITLE
fix(extensions): fallback to default docker config when unset

### DIFF
--- a/extensions/docker/packages/extension/src/docker-config.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-config.spec.ts
@@ -50,6 +50,16 @@ test('check path if there is a config', async () => {
   expect(path).toBe(myFakeConfig);
 });
 
+test('check default path if config is an empty string', async () => {
+  vi.mocked(configuration.getConfiguration).mockReturnValue({
+    get: vi.fn(() => ''),
+  } as unknown as Configuration);
+
+  const dockerConfig = new DockerConfig();
+  const path = dockerConfig.getPath();
+  expect(path).toBe(DockerConfig.DEFAULT_CONFIG_FOLDER);
+});
+
 test('check path is updated if the config changes', async () => {
   // mock configuration.getConfiguration with an undefined value
   vi.mocked(configuration.getConfiguration).mockReturnValue({

--- a/extensions/docker/packages/extension/src/docker-config.ts
+++ b/extensions/docker/packages/extension/src/docker-config.ts
@@ -43,7 +43,11 @@ export class DockerConfig {
   }
 
   protected readConfiguration(): string {
-    return configuration.getConfiguration('docker').get('config') ?? DockerConfig.DEFAULT_CONFIG_FOLDER;
+    const dockerConfigPath = configuration.getConfiguration('docker').get<string>('config');
+    if (dockerConfigPath === undefined || dockerConfigPath.trim() === '') {
+      return DockerConfig.DEFAULT_CONFIG_FOLDER;
+    }
+    return dockerConfigPath;
   }
 
   // Returns the path to the Docker configuration file.


### PR DESCRIPTION
### What does this PR do?

Fixes Docker context sync on Windows when `docker.config` is an empty string.

When `docker.config` resolves to `""`, the Docker extension currently treats it as a valid path and writes context metadata relative to the app install directory instead of the user Docker config directory.

This PR makes empty/blank `docker.config` fallback to `DockerConfig.DEFAULT_CONFIG_FOLDER` (`~/.docker`) using an explicit `if` check.

### Screenshot / video of UI

N/A (no UI change)

### What issues does this PR fix or reference?

- Fixes #17305
- Fixes https://github.com/podman-desktop/podman-desktop/issues/16433 

### How to test this PR?

Reproduction steps (from issue):
1. Install latest Docker Desktop release
2. Install Podman and Podman Desktop
3. Create a Podman machine if you don't have one already
4. Go to `Settings > Preferences > Docker Compatibility` and make sure the option is toggled on
5. Go to `Settings > Docker Compatibility` and verify status
6. Open a new CLI session and run `docker context ls`

Before fix (Windows repro):
- `docker context ls` does not list `podman-*` context
- Podman Desktop logs show `createContext()` called, but resulting `meta.json` is written under app install path (`...AppData/Local/Programs/Podman Desktop/...`) instead of `%USERPROFILE%\\.docker\\contexts\\meta`

After fix (tested):
- Podman context metadata is written under `%USERPROFILE%\\.docker\\contexts\\meta`
- `docker context ls` shows the Podman context

Automated tests:
- `pnpm exec vitest run extensions/docker/packages/extension/src/docker-config.spec.ts`

- [x] Tests are covering the bug fix or the new feature