### PR TITLE
fix(ui): use two-word verb form "set up" in action-oriented UI text

### DIFF
--- a/extensions/compose/package.json
+++ b/extensions/compose/package.json
@@ -184,7 +184,7 @@
         "podman.compose.cli.support.missing": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Without compose support in podman you won't be able to use compose projects using the podman CLI. :button[Setup...]{command=compose.openComposeOnboarding}",
+          "markdownDescription": "Without compose support in podman you won't be able to use compose projects using the podman CLI. :button[Set up...]{command=compose.openComposeOnboarding}",
           "when": "(isMac || isWindows) && !compose.isComposeInstalledSystemWide && !compose.isPodmanComposeInstalledSystemWide",
           "group": "podman-desktop.podman",
           "scope": "DockerCompatibility"

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -60,7 +60,7 @@
           "type": "boolean",
           "default": true,
           "scope": "KubernetesProviderConnectionFactory",
-          "description": "Setup an ingress controller (Contour https://projectcontour.io)"
+          "description": "Set up an ingress controller (Contour https://projectcontour.io)"
         },
         "kind.cluster.creation.controlPlaneImage": {
           "type": "string",

--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -50,7 +50,7 @@
       },
       {
         "command": "podman.setupRegistry",
-        "title": "Podman: Setup registry"
+        "title": "Podman: Set up registry"
       },
       {
         "command": "podman.uninstallLegacyPodmanInstaller",
@@ -440,7 +440,7 @@
       "dashboard/container-connection": [
         {
           "command": "podman.setupRegistry",
-          "title": "Setup registry configuration",
+          "title": "Set up registry configuration",
           "when": "selectedProviderConnectionType === 'podman' && selectedProviderConnectionStatus === 'started'"
         }
       ]

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -591,7 +591,7 @@ describe.each<{
     };
     onboardingList.set([onboarding]);
     render(PreferencesResourcesRendering, {});
-    const button = screen.getByRole('button', { name: 'Setup foo-provider' });
+    const button = screen.getByRole('button', { name: 'Set up foo-provider' });
     expect(button).toBeInTheDocument();
     await userEvent.click(button);
     // redirect to create new page
@@ -620,7 +620,7 @@ describe.each<{
     render(PreferencesResourcesRendering, {});
 
     // Expect the setup button to appear
-    const button = screen.getByRole('button', { name: 'Setup foobar' });
+    const button = screen.getByRole('button', { name: 'Set up foobar' });
     expect(button).toBeInTheDocument();
   });
 
@@ -663,7 +663,7 @@ describe.each<{
     };
     onboardingList.set([onboarding]);
     render(PreferencesResourcesRendering, {});
-    const button = screen.getByRole('button', { name: 'Setup foo-provider' });
+    const button = screen.getByRole('button', { name: 'Set up foo-provider' });
     expect(button).toBeInTheDocument();
     await userEvent.click(button);
     // redirect to create new page
@@ -693,7 +693,7 @@ describe.each<{
     };
     onboardingList.set([onboarding]);
     render(PreferencesResourcesRendering, {});
-    const button = screen.queryByRole('button', { name: 'Setup foo-provider' });
+    const button = screen.queryByRole('button', { name: 'Set up foo-provider' });
     expect(button).not.toBeInTheDocument();
   });
 
@@ -710,7 +710,7 @@ describe.each<{
 
     onboardingList.set([]);
     render(PreferencesResourcesRendering, {});
-    const button = screen.queryByRole('button', { name: 'Setup foo-provider' });
+    const button = screen.queryByRole('button', { name: 'Set up foo-provider' });
     expect(button).not.toBeInTheDocument();
   });
 
@@ -736,7 +736,7 @@ describe.each<{
     };
     onboardingList.set([onboarding]);
     render(PreferencesResourcesRendering, {});
-    const button = screen.getByRole('button', { name: 'Setup foo-provider' });
+    const button = screen.getByRole('button', { name: 'Set up foo-provider' });
     expect(button).toBeInTheDocument();
     await userEvent.click(button);
     // redirect to create new page

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
@@ -89,7 +89,7 @@ describe('ProviderActionButtons', () => {
       hasAnyConfiguration,
     });
 
-    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    const setupButton = screen.getByRole('button', { name: `Set up ${provider.name}` });
     expect(setupButton).toBeInTheDocument();
 
     const createButton = screen.queryByText(/Create new/i);
@@ -115,7 +115,7 @@ describe('ProviderActionButtons', () => {
       hasAnyConfiguration,
     });
 
-    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    const setupButton = screen.getByRole('button', { name: `Set up ${provider.name}` });
     expect(setupButton).toBeInTheDocument();
   });
 
@@ -138,7 +138,7 @@ describe('ProviderActionButtons', () => {
       hasAnyConfiguration: vi.fn().mockReturnValue(false),
     });
 
-    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    const setupButton = screen.getByRole('button', { name: `Set up ${provider.name}` });
     await userEvent.click(setupButton);
 
     expect(router.goto).toHaveBeenCalledWith('/preferences/onboarding/podman-extension');
@@ -163,7 +163,7 @@ describe('ProviderActionButtons', () => {
       hasAnyConfiguration,
     });
 
-    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    const setupButton = screen.getByRole('button', { name: `Set up ${provider.name}` });
     await userEvent.click(setupButton);
 
     expect(router.goto).toHaveBeenCalledWith('/preferences/default/preferences.podman-extension');
@@ -325,7 +325,7 @@ describe('ProviderActionButtons', () => {
       hasAnyConfiguration: vi.fn().mockReturnValue(false),
     });
 
-    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    const setupButton = screen.getByRole('button', { name: `Set up ${provider.name}` });
     expect(setupButton).toBeInTheDocument();
   });
 
@@ -347,7 +347,7 @@ describe('ProviderActionButtons', () => {
       hasAnyConfiguration,
     });
 
-    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    const setupButton = screen.getByRole('button', { name: `Set up ${provider.name}` });
     expect(setupButton).toBeInTheDocument();
   });
 
@@ -475,7 +475,7 @@ describe('ProviderActionButtons', () => {
     expect(createButton).toBeInTheDocument();
 
     // Should show Setup button
-    const setupButton = screen.getByRole('button', { name: `Setup ${provider.name}` });
+    const setupButton = screen.getByRole('button', { name: `Set up ${provider.name}` });
     expect(setupButton).toBeInTheDocument();
 
     // Should show Update button
@@ -522,7 +522,7 @@ describe('ProviderActionButtons', () => {
     });
 
     // Should not show onboarding Setup button (because globalContext is undefined)
-    const setupButtons = screen.queryAllByRole('button', { name: `Setup ${provider.name}` });
+    const setupButtons = screen.queryAllByRole('button', { name: `Set up ${provider.name}` });
     // Should either not exist or be in regular mode (not onboarding mode)
     // In this case, the component should show regular buttons mode
     expect(setupButtons.length).toBeLessThanOrEqual(1);

--- a/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
+++ b/packages/renderer/src/lib/preferences/ProviderActionButtons.svelte
@@ -94,10 +94,10 @@ function handleSetup(): void {
 <div class="text-center mt-10 {className}">
   {#if showOnboardingSetup}
     <Button
-      aria-label="Setup {provider.name}"
-      title="Setup {provider.name}"
+      aria-label="Set up {provider.name}"
+      title="Set up {provider.name}"
       onclick={handleSetup}>
-      Setup...
+      Set up...
     </Button>
   {:else}
     <div class="flex flex-row justify-around flex-wrap gap-2">
@@ -115,8 +115,8 @@ function handleSetup(): void {
 
       {#if showSetupButton}
         <Button
-          aria-label="Setup {provider.name}"
-          title="Setup {provider.name}"
+          aria-label="Set up {provider.name}"
+          title="Set up {provider.name}"
           onclick={handleSetup}>
           <Icon size="0.9x" icon={faGear} />
         </Button>

--- a/tests/playwright/src/model/pages/create-kind-cluster-page.ts
+++ b/tests/playwright/src/model/pages/create-kind-cluster-page.ts
@@ -41,7 +41,7 @@ export class CreateKindClusterPage extends CreateClusterBasePage {
     // Locator for the parent element of the ingress controller checkbox, used to change its value
     this.controllerCheckbox = this.clusterPropertiesInformation
       .getByRole('checkbox', {
-        name: 'Setup an ingress controller',
+        name: 'Set up an ingress controller',
       })
       .locator('..');
     this.providerType = this.clusterPropertiesInformation.getByLabel('Provider Type');


### PR DESCRIPTION
### What does this PR do?

Standardizes the use of "set up" vs "setup" across the UI by applying the correct grammatical form in each context:

- **Verb / imperative** (buttons, labels, action descriptions) - two words: "Set up"
- **Noun / adjective** (referring to the process or state) - one word: "setup"

**Changed files:**

- `packages/renderer/src/lib/preferences/ProviderActionButtons.svelte` - button text, `aria-label`, and `title` attributes: "Setup..." - > "Set up..."
- `extensions/podman/packages/extension/package.json` - command palette title "Podman: Setup registry" and dashboard menu title "Setup registry configuration"
- `extensions/kind/package.json` - cluster creation feature description
- `extensions/compose/package.json` - markdown notification button label

Test assertions in `ProviderActionButtons.spec.ts` and `PreferencesResourcesRendering.spec.ts` updated to match.

Noun-form usages ("Cancel Setup", "Skip the entire setup", onboarding wizard titles such as "Podman Setup") are intentionally left unchanged.

### Screenshot / video of UI

<!-- Before / after screenshots of the Settings > Resources page showing
the corrected button label would be helpful here. -->

### What issues does this PR fix or reference?

- Resolves #17764

### How to test this PR?

1. Run `pnpm watch` and open the application.
2. Go to **Settings > Resources** - confirm provider action buttons read "Set up..." (not "Setup...").
3. Hover over the gear icon button on a provider tile - confirm the tooltip reads "Set up \<provider>" (not "Setup \<provider>").
4. Open the Command Palette (Ctrl/Cmd+Shift+P) and search for "registry" - confirm the command title reads "Podman: Set up registry".
5. Run the unit tests to confirm no regressions:

```bash
pnpm exec vitest run packages/renderer/src/lib/preferences/ProviderActionButtons.spec.ts
pnpm exec vitest run packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
```

- [x] Tests are covering the bug fix or the new feature

Assisted-by: Claude Code <noreply@anthropic.com>