### PR TITLE
refactor(ui): migrate markdown to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -84,7 +84,7 @@ onDestroy(async () => {
         {#if notesInfo?.summary}
           <div
             class="text-[var(--pd-content-card-text)] truncate text-ellipsis overflow-hidden whitespace-pre-line line-clamp-6">
-            <Markdown markdown={notesInfo?.summary}></Markdown>
+            <Markdown markdown={notesInfo?.summary}/>
           </div>
         {/if}
         <div class="flex flex-row justify-end items-center gap-3 mt-2">

--- a/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
+++ b/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
@@ -58,11 +58,11 @@ describe('MessageBox', () => {
     const title = await screen.findByText(messageBoxOptions.title);
     expect(title).toBeInTheDocument();
     const message = await screen.findAllByText(messageBoxOptions.message ?? '');
-    expect(message[1]).toBeInTheDocument();
+    expect(message[0]).toBeInTheDocument();
     const detail = await screen.findByText(messageBoxOptions.detail ?? '');
     expect(detail).toBeInTheDocument();
     const footerMarkdownDescription = await screen.findAllByText(messageBoxOptions.footerMarkdownDescription ?? '');
-    expect(footerMarkdownDescription[1]).toBeInTheDocument();
+    expect(footerMarkdownDescription[0]).toBeInTheDocument();
     const button1 = await screen.findByText((messageBoxOptions.buttons?.[0] as string) ?? '');
     expect(button1).toBeInTheDocument();
     const button2 = await screen.findByText((messageBoxOptions.buttons?.[1] as string) ?? '');

--- a/packages/renderer/src/lib/markdown/Markdown.spec.ts
+++ b/packages/renderer/src/lib/markdown/Markdown.spec.ts
@@ -155,6 +155,24 @@ describe('Custom link', () => {
     expect(markdownContent).toBeInTheDocument();
     expect(markdownContent).toContainHTML('<a href="/some/link">click here to test</a>');
   });
+
+  test('expect internal protocol to be simplified', async () => {
+    await waitRender({
+      markdown: 'See <a href="podman-desktop://containers">containers</a>',
+    });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent).toContainHTML('<a href="/containers">containers</a>');
+  });
+
+  test('expect unknown protocol to be left as is', async () => {
+    await waitRender({
+      markdown: 'See <a href="foo://bar">foo</a>',
+    });
+    const markdownContent = screen.getByRole('region', { name: 'markdown-content' });
+    expect(markdownContent).toBeInTheDocument();
+    expect(markdownContent).toContainHTML('<a href="foo://bar">foo</a>');
+  });
 });
 
 describe('Custom image', () => {

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -55,51 +55,30 @@ import { link } from './micromark-link-directive';
 import { createListener } from './micromark-listener-handler';
 import { warnings } from './micromark-warnings-directive';
 
-let text: string;
-let html: string;
+interface Props {
+  markdown: string;
 
-// Optional attribute to specify the markdown to use
-// the user can use: <Markdown>**bold</Markdown> or <Markdown markdown="**bold**" /> syntax
-export let markdown = '';
-
-// Button micromark related:
-//
-// In progress execution callbacks for all markdown buttons.
-export let inProgressMarkdownCommandExecutionCallback: (
-  command: string,
-  state: 'starting' | 'failed' | 'successful',
-  value?: unknown,
-) => void = () => {};
-
-// Create an event listener for updating the in-progress markdown command execution callback
-const eventListeners: EventListener[] = [];
-
-// Render the markdown or the html+micromark markdown reactively
-$: markdown
-  ? (html = micromark(markdown, {
-      extensions: [directive()],
-      htmlExtensions: [directiveHtml({ button, image, link, warnings })],
-    }))
-  : undefined;
-
-function decode(htmlString: string): string {
-  let textArea = document.createElement('textarea');
-  textArea.innerHTML = htmlString;
-  return textArea.value;
+  /**
+   * Button micromark related:
+   * In progress execution callbacks for all markdown buttons.
+   */
+  inProgressMarkdownCommandExecutionCallback?: (
+    command: string,
+    state: 'starting' | 'failed' | 'successful',
+    value?: unknown,
+  ) => void;
 }
 
-onMount(async () => {
-  if (markdown) {
-    text = markdown;
-  }
+let { markdown, inProgressMarkdownCommandExecutionCallback = (): void => {} }: Props = $props();
 
+let urlProtocol: string = $derived(await window.getUrlProtocol());
+let html: string = $derived.by(() => {
   // Provide micromark + extensions
-  html = micromark(text, {
+  const html = micromark(markdown, {
     extensions: [directive()],
     htmlExtensions: [directiveHtml({ button, image, link, warnings })],
   });
 
-  const urlProtocol: string = await window.getUrlProtocol();
   const protocolPrefix = `${urlProtocol}://`;
 
   // remove href values in each anchor using # for links
@@ -138,8 +117,19 @@ onMount(async () => {
     }
   });
 
-  html = doc.body.innerHTML;
+  return doc.body.innerHTML;
+});
 
+// Create an event listener for updating the in-progress markdown command execution callback
+const eventListeners: EventListener[] = [];
+
+function decode(htmlString: string): string {
+  let textArea = document.createElement('textarea');
+  textArea.innerHTML = htmlString;
+  return textArea.value;
+}
+
+onMount(async () => {
   // We create a click listener in order to execute any internal micromark commands
   // We add the clickListener here since we're unable to add it in the directive typescript file.
   const clickListener = createListener(inProgressMarkdownCommandExecutionCallback);
@@ -154,11 +144,6 @@ onDestroy(() => {
   eventListeners.forEach(listener => document.removeEventListener('click', listener));
 });
 </script>
-
-<!-- Placeholder to grab the content if people are using <Markdown>**bold</Markdown> -->
-<span contenteditable="false" bind:textContent={text} class="hidden">
-  <slot />
-</span>
 
 <section class="markdown" aria-label="markdown-content">
   <!-- eslint-disable-next-line svelte/no-at-html-tags -->

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -56,7 +56,7 @@ import { createListener } from './micromark-listener-handler';
 import { warnings } from './micromark-warnings-directive';
 
 interface Props {
-  markdown: string;
+  markdown?: string;
 
   /**
    * Button micromark related:
@@ -73,6 +73,8 @@ let { markdown, inProgressMarkdownCommandExecutionCallback = (): void => {} }: P
 
 let urlProtocol: string = $derived(await window.getUrlProtocol());
 let html: string = $derived.by(() => {
+  if (!markdown) return '';
+
   // Provide micromark + extensions
   const html = micromark(markdown, {
     extensions: [directive()],

--- a/packages/renderer/src/lib/markdown/Markdown.svelte
+++ b/packages/renderer/src/lib/markdown/Markdown.svelte
@@ -71,7 +71,7 @@ interface Props {
 
 let { markdown, inProgressMarkdownCommandExecutionCallback = (): void => {} }: Props = $props();
 
-let urlProtocol: string = $derived(await window.getUrlProtocol());
+let urlProtocol: string = $state('');
 let html: string = $derived.by(() => {
   if (!markdown) return '';
 
@@ -132,6 +132,7 @@ function decode(htmlString: string): string {
 }
 
 onMount(async () => {
+  urlProtocol = await window.getUrlProtocol();
   // We create a click listener in order to execute any internal micromark commands
   // We add the clickListener here since we're unable to add it in the directive typescript file.
   const clickListener = createListener(inProgressMarkdownCommandExecutionCallback);

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionsEmptyRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionsEmptyRendering.spec.ts
@@ -31,17 +31,18 @@ afterEach(() => {
 });
 
 const LINK_TEXT = 'link-text';
-const MESSAGE = `No connections yet [${LINK_TEXT}](link-url)`;
+const MESSAGE_TEXT = 'No connections yet';
+const MESSAGE_MARKDOWN = `${MESSAGE_TEXT} [${LINK_TEXT}](link-url)`;
 
 test('Message is not visible when component is hidden ', () => {
-  render(PreferencesConnectionsEmptyRendering, { message: MESSAGE, hidden: true });
-  const noProvidersText = screen.queryByText(MESSAGE);
+  render(PreferencesConnectionsEmptyRendering, { message: MESSAGE_MARKDOWN, hidden: true });
+  const noProvidersText = screen.queryByText(MESSAGE_MARKDOWN);
   expect(noProvidersText).not.toBeInTheDocument();
 });
 
 test('Message is visible when component is not hidden', async () => {
-  render(PreferencesConnectionsEmptyRendering, { message: MESSAGE, hidden: false });
-  const noProvidersText = screen.getByText(MESSAGE);
+  render(PreferencesConnectionsEmptyRendering, { message: MESSAGE_MARKDOWN, hidden: false });
+  const noProvidersText = screen.getByText(MESSAGE_TEXT);
   expect(noProvidersText).toBeInTheDocument();
   const link = screen.getByText(LINK_TEXT);
   expect(link).toBeInTheDocument();


### PR DESCRIPTION
### What does this PR do?

Migrate the Markdown component to Svelte5; moreover remove unused / hacky capability of the component to render markdown from children. See details in https://github.com/podman-desktop/podman-desktop/issues/17778#issuecomment-4647527989

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17778
Required for
- https://github.com/podman-desktop/podman-desktop/issues/16575

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

You can try the onboarding, or navigate to the extension catalog to see no change
