### PR TITLE
test(e2e): create podman machine from enhanced dashboard

### DIFF
--- a/tests/playwright/src/model/pages/dashboard-page.ts
+++ b/tests/playwright/src/model/pages/dashboard-page.ts
@@ -23,6 +23,7 @@ import type { PodmanVirtualizationProviders } from '/@/model/core/types';
 
 import { BasePage } from './base-page';
 import { PodmanOnboardingPage } from './podman-onboarding-page';
+import { ResourceDetailsPage } from './resource-details-page';
 
 export class DashboardPage extends BasePage {
   readonly mainPage: Locator;
@@ -147,6 +148,14 @@ export class DashboardPage extends BasePage {
         virtualizationProvider,
       });
     });
+  }
+
+  public async checkSystemOverviewResourceDetails(resourceName: string): Promise<void> {
+    const navigateToResourceButton = this.getNavigateToConnectionButton(resourceName);
+    await playExpect(navigateToResourceButton).toBeEnabled();
+    await navigateToResourceButton.click();
+    const resourceDetails = new ResourceDetailsPage(this.page, resourceName);
+    await playExpect(resourceDetails.heading).toBeVisible();
   }
 
   public getPodmanStatusLocator(): Locator {

--- a/tests/playwright/src/model/pages/dashboard-page.ts
+++ b/tests/playwright/src/model/pages/dashboard-page.ts
@@ -17,8 +17,12 @@
  ***********************************************************************/
 
 import type { Locator, Page } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
+
+import type { PodmanVirtualizationProviders } from '/@/model/core/types';
 
 import { BasePage } from './base-page';
+import { PodmanOnboardingPage } from './podman-onboarding-page';
 
 export class DashboardPage extends BasePage {
   readonly mainPage: Locator;
@@ -97,6 +101,51 @@ export class DashboardPage extends BasePage {
     return this.systemOverview.getByRole('button', {
       name: `Navigate to ${connectionName}`,
       exact: true,
+    });
+  }
+
+  public async expandSystemOverview(expanded: boolean): Promise<void> {
+    const isExpanded = (await this.systemOverviewButton.getAttribute('aria-expanded')) === 'true';
+    if (isExpanded !== expanded) {
+      await this.systemOverviewButton.scrollIntoViewIfNeeded();
+      await this.systemOverviewButton.click();
+      await playExpect(this.systemOverviewButton).toHaveAttribute('aria-expanded', String(expanded));
+    }
+  }
+
+  public async createPodmanMachineFromSystemOverview(
+    machineName: string,
+    {
+      isRootful = false,
+      enableUserNet = false,
+      startNow = true,
+      virtualizationProvider,
+    }: {
+      isRootful?: boolean;
+      enableUserNet?: boolean;
+      startNow?: boolean;
+      virtualizationProvider?: PodmanVirtualizationProviders;
+    } = {},
+  ): Promise<void> {
+    return test.step(`Create Podman machine '${machineName}' from System Overview`, async () => {
+      await playExpect(this.setUpPodmanButton).toBeEnabled();
+      await this.setUpPodmanButton.scrollIntoViewIfNeeded();
+      await this.setUpPodmanButton.click();
+      const podmanOnboardingPage = new PodmanOnboardingPage(this.page);
+      await playExpect(podmanOnboardingPage.header).toBeVisible();
+      await playExpect(podmanOnboardingPage.mainPage).toBeVisible();
+      await podmanOnboardingPage.nextStepButton.click();
+      await playExpect(podmanOnboardingPage.onboardingStatusMessage).toHaveText(
+        `We could not find any Podman machine. Let's create one!`,
+        { timeout: 10_000 },
+      );
+      await podmanOnboardingPage.nextStepButton.click();
+      await podmanOnboardingPage.machineCreationForm.setupAndCreateMachine(machineName, {
+        isRootful,
+        enableUserNet,
+        startNow,
+        virtualizationProvider,
+      });
     });
   }
 

--- a/tests/playwright/src/model/pages/dashboard-page.ts
+++ b/tests/playwright/src/model/pages/dashboard-page.ts
@@ -134,15 +134,7 @@ export class DashboardPage extends BasePage {
       await this.setUpPodmanButton.scrollIntoViewIfNeeded();
       await this.setUpPodmanButton.click();
       const podmanOnboardingPage = new PodmanOnboardingPage(this.page);
-      await playExpect(podmanOnboardingPage.header).toBeVisible();
-      await playExpect(podmanOnboardingPage.mainPage).toBeVisible();
-      await podmanOnboardingPage.nextStepButton.click();
-      await playExpect(podmanOnboardingPage.onboardingStatusMessage).toHaveText(
-        `We could not find any Podman machine. Let's create one!`,
-        { timeout: 10_000 },
-      );
-      await podmanOnboardingPage.nextStepButton.click();
-      await podmanOnboardingPage.machineCreationForm.setupAndCreateMachine(machineName, {
+      await podmanOnboardingPage.createMachine(machineName, {
         isRootful,
         enableUserNet,
         startNow,
@@ -152,12 +144,14 @@ export class DashboardPage extends BasePage {
   }
 
   public async checkSystemOverviewResourceDetails(resourceName: string): Promise<void> {
-    await this.expandSystemOverview(true);
-    const navigateToResourceButton = this.getNavigateToConnectionButton(resourceName);
-    await playExpect(navigateToResourceButton).toBeEnabled();
-    await navigateToResourceButton.click();
-    const resourceDetails = new ResourceDetailsPage(this.page, resourceName);
-    await playExpect(resourceDetails.heading).toBeVisible();
+    return test.step(`Check System Overview resource details for '${resourceName}'`, async () => {
+      await this.expandSystemOverview(true);
+      const navigateToResourceButton = this.getNavigateToConnectionButton(resourceName);
+      await playExpect(navigateToResourceButton).toBeEnabled();
+      await navigateToResourceButton.click();
+      const resourceDetails = new ResourceDetailsPage(this.page, resourceName);
+      await playExpect(resourceDetails.heading).toBeVisible();
+    });
   }
 
   public getPodmanStatusLocator(): Locator {

--- a/tests/playwright/src/model/pages/dashboard-page.ts
+++ b/tests/playwright/src/model/pages/dashboard-page.ts
@@ -129,6 +129,7 @@ export class DashboardPage extends BasePage {
     } = {},
   ): Promise<void> {
     return test.step(`Create Podman machine '${machineName}' from System Overview`, async () => {
+      await this.expandSystemOverview(true);
       await playExpect(this.setUpPodmanButton).toBeEnabled();
       await this.setUpPodmanButton.scrollIntoViewIfNeeded();
       await this.setUpPodmanButton.click();
@@ -151,6 +152,7 @@ export class DashboardPage extends BasePage {
   }
 
   public async checkSystemOverviewResourceDetails(resourceName: string): Promise<void> {
+    await this.expandSystemOverview(true);
     const navigateToResourceButton = this.getNavigateToConnectionButton(resourceName);
     await playExpect(navigateToResourceButton).toBeEnabled();
     await navigateToResourceButton.click();

--- a/tests/playwright/src/model/pages/podman-onboarding-page.ts
+++ b/tests/playwright/src/model/pages/podman-onboarding-page.ts
@@ -17,6 +17,9 @@
  ***********************************************************************/
 
 import type { Locator, Page } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
+
+import type { PodmanVirtualizationProviders } from '/@/model/core/types';
 
 import { MachineCreationForm } from './forms/machine-creation-form';
 import { OnboardingPage } from './onboarding-page';
@@ -37,5 +40,37 @@ export class PodmanOnboardingPage extends OnboardingPage {
     this.machineCreationForm = new MachineCreationForm(this.page);
     this.podmanMachineShowLogsButton = this.mainPage.getByRole('button', { name: 'Show Logs' });
     this.goBackButton = this.page.getByRole('button', { name: 'Go back to resources' });
+  }
+
+  public async createMachine(
+    machineName: string,
+    {
+      isRootful = false,
+      enableUserNet = false,
+      startNow = true,
+      virtualizationProvider,
+    }: {
+      isRootful?: boolean;
+      enableUserNet?: boolean;
+      startNow?: boolean;
+      virtualizationProvider?: PodmanVirtualizationProviders;
+    } = {},
+  ): Promise<void> {
+    return test.step(`Create Podman machine '${machineName}' from onboarding`, async () => {
+      await playExpect(this.header).toBeVisible();
+      await playExpect(this.mainPage).toBeVisible();
+      await this.nextStepButton.click();
+      await playExpect(this.onboardingStatusMessage).toHaveText(
+        `We could not find any Podman machine. Let's create one!`,
+        { timeout: 10_000 },
+      );
+      await this.nextStepButton.click();
+      await this.machineCreationForm.setupAndCreateMachine(machineName, {
+        isRootful,
+        enableUserNet,
+        startNow,
+        virtualizationProvider,
+      });
+    });
   }
 }

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -19,7 +19,6 @@
 import { ResourceElementActions } from '/@/model/core/operations';
 import { SystemOverviewState } from '/@/model/core/states';
 import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
-import { ResourceDetailsPage } from '/@/model/pages/resource-details-page';
 import { ResourcesPage } from '/@/model/pages/resources-page';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
@@ -133,11 +132,7 @@ test.describe
         await dashboardPage.statusButton.scrollIntoViewIfNeeded();
         await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Stopped, { timeout: 10_000 });
         // click on 'navigate to...' button, verify it goes to machine details
-        const navigateToPodmanMachineButton = dashboardPage.getNavigateToConnectionButton('Podman Machine');
-        await playExpect(navigateToPodmanMachineButton).toBeEnabled();
-        await navigateToPodmanMachineButton.click();
-        const podmanMachine1Details = new ResourceDetailsPage(page, PODMAN_MACHINE_VISIBLE_NAME);
-        await playExpect(podmanMachine1Details.heading).toBeVisible();
+        await dashboardPage.checkSystemOverviewResourceDetails(PODMAN_MACHINE_VISIBLE_NAME);
         // come back to dashboard, click on status button, verify it goes to resources
         await navigationBar.openDashboard();
         await dashboardPage.statusButton.scrollIntoViewIfNeeded();

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -73,26 +73,12 @@ test.describe
     test('Enable/disable experimental feature', async ({ navigationBar, page }) => {
       // assert assets state before enabling it (disabled by default for the time being)
       await setEnhancedDashboardFeature(page, navigationBar, false);
-      let dashboardPage = await navigationBar.openDashboard();
+      const dashboardPage = await navigationBar.openDashboard();
       await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
       await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: 10_000 });
       await dashboardPage.podmanProvider.scrollIntoViewIfNeeded();
       // enable the feature
       await setEnhancedDashboardFeature(page, navigationBar, true);
-      // 'System Overview' card may take a moment to load; refresh the view by navigating away and back
-      await playExpect
-        .poll(
-          async () => {
-            dashboardPage = await navigationBar.openDashboard();
-            if (await dashboardPage.systemOverviewButton.isVisible()) {
-              return true;
-            }
-            await navigationBar.openContainers();
-            return false;
-          },
-          { timeout: 30_000 },
-        )
-        .toBeTruthy();
       // assert assets state after enabling it
       await playExpect(dashboardPage.systemOverviewButton).toBeEnabled();
       await dashboardPage.systemOverviewButton.scrollIntoViewIfNeeded();
@@ -105,20 +91,6 @@ test.describe
       await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled();
       // disable the feature and assert everything went back to the expected state
       await setEnhancedDashboardFeature(page, navigationBar, false);
-      dashboardPage = await navigationBar.openDashboard();
-      await playExpect
-        .poll(
-          async () => {
-            dashboardPage = await navigationBar.openDashboard();
-            if (await dashboardPage.podmanProvider.isVisible()) {
-              return true;
-            }
-            await navigationBar.openContainers();
-            return false;
-          },
-          { timeout: 30_000 },
-        )
-        .toBeTruthy();
       await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
       await dashboardPage.podmanProvider.scrollIntoViewIfNeeded();
     });
@@ -127,7 +99,8 @@ test.describe
       test.setTimeout(320_000);
 
       await test.step('Open dashboard and initialize Podman machine', async () => {
-        let dashboardPage = await navigationBar.openDashboard();
+        // enable the feature
+        let dashboardPage = await setEnhancedDashboardFeature(page, navigationBar, true);
         await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled({ timeout: 5_000 });
         await dashboardPage.setUpPodmanButton.scrollIntoViewIfNeeded();
         await dashboardPage.setUpPodmanButton.click();

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -18,7 +18,6 @@
 
 import { ResourceElementActions } from '/@/model/core/operations';
 import { SystemOverviewState } from '/@/model/core/states';
-import { PodmanOnboardingPage } from '/@/model/pages/podman-onboarding-page';
 import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
 import { ResourceDetailsPage } from '/@/model/pages/resource-details-page';
 import { ResourcesPage } from '/@/model/pages/resources-page';
@@ -81,8 +80,7 @@ test.describe
       await setEnhancedDashboardFeature(page, navigationBar, true);
       // assert assets state after enabling it
       await playExpect(dashboardPage.systemOverviewButton).toBeEnabled();
-      await dashboardPage.systemOverviewButton.scrollIntoViewIfNeeded();
-      await dashboardPage.systemOverviewButton.click();
+      await dashboardPage.expandSystemOverview(true);
       await playExpect(dashboardPage.systemOverview).toBeVisible({ timeout: 10_000 });
       await playExpect(dashboardPage.podmanProvider).not.toBeVisible();
       await playExpect(dashboardPage.statusButton).toBeEnabled();
@@ -103,20 +101,7 @@ test.describe
         await setEnhancedDashboardFeature(page, navigationBar, true);
         // go to dashboard
         let dashboardPage = await navigationBar.openDashboard();
-        await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled({ timeout: 5_000 });
-        await dashboardPage.setUpPodmanButton.scrollIntoViewIfNeeded();
-        await dashboardPage.setUpPodmanButton.click();
-        // handle podman machine onboarding process, start the machine
-        const podmanOnboardingPage = new PodmanOnboardingPage(page);
-        await playExpect(podmanOnboardingPage.header).toBeVisible();
-        await playExpect(podmanOnboardingPage.mainPage).toBeVisible();
-        await podmanOnboardingPage.nextStepButton.click();
-        await playExpect(podmanOnboardingPage.onboardingStatusMessage).toHaveText(
-          `We could not find any Podman machine. Let's create one!`,
-          { timeout: 10_000 },
-        );
-        await podmanOnboardingPage.nextStepButton.click();
-        await podmanOnboardingPage.machineCreationForm.setupAndCreateMachine(PODMAN_MACHINE_NAME, {
+        await dashboardPage.createPodmanMachineFromSystemOverview(PODMAN_MACHINE_NAME, {
           isRootful: false,
           enableUserNet: false,
           startNow: true,

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -16,7 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { ResourceElementActions } from '/@/model/core/operations';
 import { SystemOverviewState } from '/@/model/core/states';
+import { PodmanOnboardingPage } from '/@/model/pages/podman-onboarding-page';
+import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
+import { ResourceDetailsPage } from '/@/model/pages/resource-details-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
   createPodmanMachineFromCLI,
@@ -25,9 +30,11 @@ import {
   setEnhancedDashboardFeature,
 } from '/@/utility/operations';
 import { isLinux } from '/@/utility/platform';
+import { getVirtualizationProvider } from '/@/utility/provider';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const PODMAN_MACHINE_NAME: string = 'podman-machine-default';
+const PODMAN_MACHINE_VISIBLE_NAME: string = 'Podman Machine';
 
 test.skip(
   isLinux || process.env.TEST_PODMAN_MACHINE !== 'true',
@@ -62,7 +69,7 @@ test.afterAll(async ({ runner, page }) => {
 });
 
 test.describe
-  .serial('Enhanced dashboard experimental feature', { tag: '@experimental' }, () => {
+  .serial('Enhanced dashboard experimental feature', { tag: ['@experimental'] }, () => {
     test('Enable/disable experimental feature', async ({ navigationBar, page }) => {
       // assert assets state before enabling it (disabled by default for the time being)
       await setEnhancedDashboardFeature(page, navigationBar, false);
@@ -114,5 +121,68 @@ test.describe
         .toBeTruthy();
       await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
       await dashboardPage.podmanProvider.scrollIntoViewIfNeeded();
+    });
+
+    test('Create Podman machine from Dashboard', async ({ page, navigationBar }) => {
+      test.setTimeout(320_000);
+
+      await test.step('Open dashboard and initialize Podman machine', async () => {
+        let dashboardPage = await navigationBar.openDashboard();
+        await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled({ timeout: 5_000 });
+        await dashboardPage.setUpPodmanButton.scrollIntoViewIfNeeded();
+        await dashboardPage.setUpPodmanButton.click();
+        // handle podman machine onboarding process, start the machine
+        const podmanOnboardingPage = new PodmanOnboardingPage(page);
+        await playExpect(podmanOnboardingPage.header).toBeVisible();
+        await playExpect(podmanOnboardingPage.mainPage).toBeVisible();
+        await podmanOnboardingPage.nextStepButton.click();
+        await playExpect(podmanOnboardingPage.onboardingStatusMessage).toHaveText(
+          `We could not find any Podman machine. Let's create one!`,
+          { timeout: 10_000 },
+        );
+        await podmanOnboardingPage.nextStepButton.click();
+        await podmanOnboardingPage.machineCreationForm.setupAndCreateMachine(PODMAN_MACHINE_NAME, {
+          isRootful: false,
+          enableUserNet: false,
+          startNow: true,
+          virtualizationProvider: getVirtualizationProvider(),
+        });
+        // systemOverview button -> starting up; status label -> starting (missing aria-label)
+        dashboardPage = await navigationBar.openDashboard();
+        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Starting, { timeout: 300_000 });
+        // systemOverview button -> systems operational; status label -> running (missing aria-label)
+        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Operational, {
+          timeout: 300_000,
+        });
+        // click on 'status' button to go to podman machine in settings/resources
+        await playExpect(dashboardPage.statusButton).toBeEnabled();
+        await dashboardPage.statusButton.click();
+        let resourcesPage = new ResourcesPage(page);
+        await playExpect
+          .poll(async () => resourcesPage.resourceCardIsVisible('podman'), { timeout: 30_000 })
+          .toBeTruthy();
+        const resourcesPodmanConnections = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME);
+        await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: 10_000 });
+        // stop machine
+        await resourcesPodmanConnections.performConnectionAction(ResourceElementActions.Stop);
+        // come back to dashboard, button -> some systems are stopped
+        await navigationBar.openDashboard();
+        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Stopped, { timeout: 10_000 });
+        // click on 'navigate to...' button, verify it goes to machine details
+        const navigateToPodmanMachineButton = dashboardPage.getNavigateToConnectionButton('Podman Machine');
+        await playExpect(navigateToPodmanMachineButton).toBeEnabled();
+        await navigateToPodmanMachineButton.click();
+        const podmanMachine1Details = new ResourceDetailsPage(page, PODMAN_MACHINE_VISIBLE_NAME);
+        await playExpect(podmanMachine1Details.heading).toBeVisible();
+        // come back to dashboard, click on status button, verify it goes to resources
+        await navigationBar.openDashboard();
+        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+        await playExpect(dashboardPage.statusButton).toBeEnabled();
+        await dashboardPage.statusButton.click();
+        resourcesPage = new ResourcesPage(page);
+        await playExpect(resourcesPage.header).toBeVisible();
+      });
     });
   });

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -100,7 +100,9 @@ test.describe
 
       await test.step('Open dashboard and initialize Podman machine', async () => {
         // enable the feature
-        let dashboardPage = await setEnhancedDashboardFeature(page, navigationBar, true);
+        await setEnhancedDashboardFeature(page, navigationBar, true);
+        // go to dashboard
+        let dashboardPage = await navigationBar.openDashboard();
         await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled({ timeout: 5_000 });
         await dashboardPage.setUpPodmanButton.scrollIntoViewIfNeeded();
         await dashboardPage.setUpPodmanButton.click();

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -26,6 +26,7 @@ import {
   deletePodmanMachine,
   resetPodmanMachinesFromCLI,
   setEnhancedDashboardFeature,
+  waitForDashboardState,
 } from '/@/utility/operations';
 import { isLinux } from '/@/utility/platform';
 import { getVirtualizationProvider } from '/@/utility/provider';
@@ -71,14 +72,14 @@ test.describe
     test('Enable/disable experimental feature', async ({ navigationBar, page }) => {
       // assert assets state before enabling it (disabled by default for the time being)
       await setEnhancedDashboardFeature(page, navigationBar, false);
-      const dashboardPage = await navigationBar.openDashboard();
+      let dashboardPage = await waitForDashboardState(navigationBar, false);
       await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
       await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: 10_000 });
       await dashboardPage.podmanProvider.scrollIntoViewIfNeeded();
       // enable the feature
       await setEnhancedDashboardFeature(page, navigationBar, true);
+      dashboardPage = await waitForDashboardState(navigationBar, true);
       // assert assets state after enabling it
-      await navigationBar.openDashboard();
       await playExpect(dashboardPage.systemOverviewButton).toBeEnabled();
       await dashboardPage.expandSystemOverview(true);
       await playExpect(dashboardPage.systemOverview).toBeVisible({ timeout: 10_000 });
@@ -89,7 +90,7 @@ test.describe
       await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled();
       // disable the feature and assert everything went back to the expected state
       await setEnhancedDashboardFeature(page, navigationBar, false);
-      await navigationBar.openDashboard();
+      dashboardPage = await waitForDashboardState(navigationBar, false);
       await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
       await dashboardPage.podmanProvider.scrollIntoViewIfNeeded();
     });
@@ -100,8 +101,7 @@ test.describe
       await test.step('Open dashboard and initialize Podman machine', async () => {
         // enable the feature
         await setEnhancedDashboardFeature(page, navigationBar, true);
-        // go to dashboard
-        let dashboardPage = await navigationBar.openDashboard();
+        let dashboardPage = await waitForDashboardState(navigationBar, true);
         await dashboardPage.createPodmanMachineFromSystemOverview(PODMAN_MACHINE_NAME, {
           isRootful: false,
           enableUserNet: false,

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -79,6 +79,7 @@ test.describe
       // enable the feature
       await setEnhancedDashboardFeature(page, navigationBar, true);
       // assert assets state after enabling it
+      await navigationBar.openDashboard();
       await playExpect(dashboardPage.systemOverviewButton).toBeEnabled();
       await dashboardPage.expandSystemOverview(true);
       await playExpect(dashboardPage.systemOverview).toBeVisible({ timeout: 10_000 });
@@ -89,6 +90,7 @@ test.describe
       await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled();
       // disable the feature and assert everything went back to the expected state
       await setEnhancedDashboardFeature(page, navigationBar, false);
+      await navigationBar.openDashboard();
       await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
       await dashboardPage.podmanProvider.scrollIntoViewIfNeeded();
     });

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -26,6 +26,7 @@ import { ResourceElementState } from '/@/model/core/states';
 import type { PodmanVirtualizationProviders } from '/@/model/core/types';
 import { matchesProviderVariant, PodmanMachinePrivileges } from '/@/model/core/types';
 import { CLIToolsPage } from '/@/model/pages/cli-tools-page';
+import type { DashboardPage } from '/@/model/pages/dashboard-page';
 import { ExperimentalPage } from '/@/model/pages/experimental-page';
 import { PreferencesPage } from '/@/model/pages/preferences-page';
 import { RegistriesPage } from '/@/model/pages/registries-page';
@@ -621,11 +622,31 @@ export async function setEnhancedDashboardFeature(
   page: Page,
   navigationBar: NavigationBar,
   enable: boolean,
-): Promise<void> {
+): Promise<DashboardPage> {
   await navigationBar.openSettings();
   const settingsBar = new SettingsBar(page);
   const experimentalPage = await settingsBar.openTabPage(ExperimentalPage);
   await experimentalPage.setExperimentalCheckbox(experimentalPage.enhancedDashboardCheckbox, enable);
+  //assets in the dashboard take a bit to load, poll until they do
+  // if the feature is enabled -> systemOverviewButton is expected
+  // if the feature is disabled -> podmanProvider card is expected
+  let dashboardPage!: DashboardPage;
+  const getExpectedElement = (dashboard: DashboardPage): Locator =>
+    enable ? dashboard.systemOverviewButton : dashboard.podmanProvider;
+  await playExpect
+    .poll(
+      async () => {
+        dashboardPage = await navigationBar.openDashboard();
+        if (await getExpectedElement(dashboardPage).isVisible()) {
+          return true;
+        }
+        await navigationBar.openContainers();
+        return false;
+      },
+      { timeout: 30_000 },
+    )
+    .toBeTruthy();
+  return dashboardPage;
 }
 
 export async function readFileInVolumeFromCLI(volumeName: string, fileName: string): Promise<string> {

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -622,27 +622,24 @@ export async function setEnhancedDashboardFeature(
   page: Page,
   navigationBar: NavigationBar,
   enable: boolean,
-): Promise<ExperimentalPage> {
+): Promise<void> {
   await navigationBar.openSettings();
   const settingsBar = new SettingsBar(page);
   const experimentalPage = await settingsBar.openTabPage(ExperimentalPage);
   await experimentalPage.setExperimentalCheckbox(experimentalPage.enhancedDashboardCheckbox, enable);
-
-  await waitForDashboardState(navigationBar, enable);
-  await navigationBar.openSettings();
-  return settingsBar.openTabPage(ExperimentalPage);
 }
 
-export async function waitForDashboardState(navigationBar: NavigationBar, enable: boolean): Promise<void> {
+export async function waitForDashboardState(navigationBar: NavigationBar, enable: boolean): Promise<DashboardPage> {
   // Assets in the dashboard take a bit to load, poll until they do.
   // If the enhanced dashboard feature is enabled -> systemOverviewButton is expected.
   // If the enhanced dashboard feature is disabled -> podmanProvider card is expected.
   const getExpectedElement = (dashboard: DashboardPage): Locator =>
     enable ? dashboard.systemOverviewButton : dashboard.podmanProvider;
+  let dashboardPage!: DashboardPage;
   await playExpect
     .poll(
       async () => {
-        const dashboardPage = await navigationBar.openDashboard();
+        dashboardPage = await navigationBar.openDashboard();
         if (await getExpectedElement(dashboardPage).isVisible()) {
           return true;
         }
@@ -652,6 +649,7 @@ export async function waitForDashboardState(navigationBar: NavigationBar, enable
       { timeout: 30_000 },
     )
     .toBeTruthy();
+  return dashboardPage;
 }
 
 export async function readFileInVolumeFromCLI(volumeName: string, fileName: string): Promise<string> {

--- a/tests/playwright/src/utility/operations.ts
+++ b/tests/playwright/src/utility/operations.ts
@@ -622,21 +622,27 @@ export async function setEnhancedDashboardFeature(
   page: Page,
   navigationBar: NavigationBar,
   enable: boolean,
-): Promise<DashboardPage> {
+): Promise<ExperimentalPage> {
   await navigationBar.openSettings();
   const settingsBar = new SettingsBar(page);
   const experimentalPage = await settingsBar.openTabPage(ExperimentalPage);
   await experimentalPage.setExperimentalCheckbox(experimentalPage.enhancedDashboardCheckbox, enable);
-  //assets in the dashboard take a bit to load, poll until they do
-  // if the feature is enabled -> systemOverviewButton is expected
-  // if the feature is disabled -> podmanProvider card is expected
-  let dashboardPage!: DashboardPage;
+
+  await waitForDashboardState(navigationBar, enable);
+  await navigationBar.openSettings();
+  return settingsBar.openTabPage(ExperimentalPage);
+}
+
+export async function waitForDashboardState(navigationBar: NavigationBar, enable: boolean): Promise<void> {
+  // Assets in the dashboard take a bit to load, poll until they do.
+  // If the enhanced dashboard feature is enabled -> systemOverviewButton is expected.
+  // If the enhanced dashboard feature is disabled -> podmanProvider card is expected.
   const getExpectedElement = (dashboard: DashboardPage): Locator =>
     enable ? dashboard.systemOverviewButton : dashboard.podmanProvider;
   await playExpect
     .poll(
       async () => {
-        dashboardPage = await navigationBar.openDashboard();
+        const dashboardPage = await navigationBar.openDashboard();
         if (await getExpectedElement(dashboardPage).isVisible()) {
           return true;
         }
@@ -646,7 +652,6 @@ export async function setEnhancedDashboardFeature(
       { timeout: 30_000 },
     )
     .toBeTruthy();
-  return dashboardPage;
 }
 
 export async function readFileInVolumeFromCLI(volumeName: string, fileName: string): Promise<string> {


### PR DESCRIPTION
### What does this PR do?
Adds an E2E test that checks the ability to create a podman machine through the enhanced dashboard experimental feature

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #17591 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
`pnpm test:e2e:experimental`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
