### PR TITLE
fix(renderer): race condition with restarting a resource (vm / container engine / kubernetes)

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -101,6 +101,26 @@ beforeEach(() => {
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: undefined });
 });
 
+test('restarting a container should call stop then start', async () => {
+  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
+
+  render(PreferencesConnectionActions, {
+    connectionStatus,
+    provider: customProviderInfo,
+    connection: containerConnection,
+    updateConnectionStatus,
+  });
+  const restartButton = screen.getByRole('button', { name: 'Restart' });
+  await fireEvent.click(restartButton);
+
+  expect(window.stopProviderConnectionLifecycle).toHaveBeenCalledOnce();
+  expect(window.startProviderConnectionLifecycle).toHaveBeenCalledOnce();
+
+  expect(window.startProviderConnectionLifecycle).toHaveBeenCalledAfter(
+    vi.mocked(window.stopProviderConnectionLifecycle),
+  );
+});
+
 test('if container connection has start lifecycle method, start button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'podman' };
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -90,10 +90,6 @@ const updateConnectionStatus = (): void => {
   //nothing
 };
 
-const addConnectionToRestartingQueue = (): void => {
-  //nothing
-};
-
 const connectionStatus: IConnectionStatus = {
   status: 'started',
   inProgress: false,
@@ -113,7 +109,6 @@ test('if container connection has start lifecycle method, start button has to be
     provider: customProviderInfo,
     connection: containerConnection,
     updateConnectionStatus,
-    addConnectionToRestartingQueue,
   });
   const button = screen.getByRole('button', { name: 'Start' });
   expect(button).toBeInTheDocument();
@@ -127,7 +122,6 @@ test('if container connection has stop lifecycle method, stop button has to be v
     provider: customProviderInfo,
     connection: containerConnection,
     updateConnectionStatus,
-    addConnectionToRestartingQueue,
   });
   const button = screen.getByRole('button', { name: 'Stop' });
   expect(button).toBeInTheDocument();
@@ -141,7 +135,6 @@ test('if container connection has start and stop lifecycle methods, restart butt
     provider: customProviderInfo,
     connection: containerConnection,
     updateConnectionStatus,
-    addConnectionToRestartingQueue,
   });
   const startButton = screen.getByRole('button', { name: 'Start' });
   expect(startButton).toBeInTheDocument();
@@ -160,7 +153,6 @@ describe('delete', () => {
       provider: customProviderInfo,
       connection: containerConnection,
       updateConnectionStatus,
-      addConnectionToRestartingQueue,
     });
     const button = screen.getByRole('button', { name: 'Delete' });
     expect(button).toBeInTheDocument();
@@ -172,7 +164,6 @@ describe('delete', () => {
       provider: containerProviderInfo,
       connection: containerConnection,
       updateConnectionStatus,
-      addConnectionToRestartingQueue,
     });
     const button = getByRole('button', { name: 'Delete' });
 
@@ -201,7 +192,6 @@ describe('delete', () => {
       provider: containerProviderInfo,
       connection: stoppedConnection,
       updateConnectionStatus,
-      addConnectionToRestartingQueue,
     });
     const button = getByRole('button', { name: 'Delete' });
 
@@ -226,7 +216,6 @@ test('if kubernetes connection has start lifecycle method, start button has to b
     provider: customProviderInfo,
     connection: kubernetesConnection,
     updateConnectionStatus,
-    addConnectionToRestartingQueue,
   });
   const button = screen.getByRole('button', { name: 'Start' });
   expect(button).toBeInTheDocument();
@@ -240,7 +229,6 @@ test('if kubernetes connection has stop lifecycle method, stop button has to be 
     provider: customProviderInfo,
     connection: kubernetesConnection,
     updateConnectionStatus,
-    addConnectionToRestartingQueue,
   });
   const button = screen.getByRole('button', { name: 'Stop' });
   expect(button).toBeInTheDocument();
@@ -254,7 +242,6 @@ test('if kubernetes connection has start and stop lifecycle methods, restart but
     provider: customProviderInfo,
     connection: kubernetesConnection,
     updateConnectionStatus,
-    addConnectionToRestartingQueue,
   });
   const startButton = screen.getByRole('button', { name: 'Start' });
   expect(startButton).toBeInTheDocument();
@@ -272,7 +259,6 @@ test('if kubernetes connection has delete lifecycle method, delete button has to
     provider: customProviderInfo,
     connection: kubernetesConnection,
     updateConnectionStatus,
-    addConnectionToRestartingQueue,
   });
   const button = screen.getByRole('button', { name: 'Delete' });
   expect(button).toBeInTheDocument();

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -13,7 +13,7 @@ import {
   eventCollect,
   registerConnectionCallback,
 } from './preferences-connection-rendering-task';
-import { type IConnectionRestart, type IConnectionStatus } from './Util';
+import { type IConnectionStatus } from './Util';
 
 interface Props {
   connectionStatus: IConnectionStatus | undefined;
@@ -26,18 +26,10 @@ interface Props {
     error?: string,
     inProgress?: boolean,
   ) => void;
-  addConnectionToRestartingQueue: (connection: IConnectionRestart) => void;
   advanced_actions?: Snippet;
 }
 
-let {
-  connectionStatus,
-  provider,
-  connection,
-  updateConnectionStatus,
-  addConnectionToRestartingQueue,
-  advanced_actions,
-}: Props = $props();
+let { connectionStatus, provider, connection, updateConnectionStatus, advanced_actions }: Props = $props();
 
 async function startConnectionProvider(
   provider: ProviderInfo,
@@ -75,11 +67,13 @@ async function restartConnectionProvider(
       loggerHandlerKey,
       eventCollect,
     );
-    addConnectionToRestartingQueue({
-      container: providerConnectionInfo.name,
-      provider: provider.internalId,
+
+    await window.startProviderConnectionLifecycle(
+      provider.internalId,
+      $state.snapshot(providerConnectionInfo),
       loggerHandlerKey,
-    });
+      eventCollect,
+    );
   }
 }
 
@@ -148,6 +142,7 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
 }
 </script>
 
+<span>inProgress? {connectionStatus?.inProgress}</span>
 {#if connectionStatus}
   {#if connection.lifecycleMethods && connection.lifecycleMethods.length > 0}
     <div class="mt-2 relative">

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.svelte
@@ -142,7 +142,6 @@ function getLoggerHandler(provider: ProviderInfo, containerConnectionInfo: Provi
 }
 </script>
 
-<span>inProgress? {connectionStatus?.inProgress}</span>
 {#if connectionStatus}
   {#if connection.lifecycleMethods && connection.lifecycleMethods.length > 0}
     <div class="mt-2 relative">

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -18,12 +18,11 @@ import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { providerInfos } from '/@/stores/providers';
 
-import { eventCollect } from './preferences-connection-rendering-task';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesConnectionDetailsLogs from './PreferencesConnectionDetailsLogs.svelte';
 import PreferencesConnectionDetailsTerminal from './PreferencesConnectionDetailsTerminal.svelte';
 import PreferencesContainerConnectionDetailsSummary from './PreferencesContainerConnectionDetailsSummary.svelte';
-import type { IConnectionRestart, IConnectionStatus } from './Util';
+import type { IConnectionStatus } from './Util';
 import { getProviderConnectionName } from './Util';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
@@ -37,7 +36,6 @@ let connectionStatus: IConnectionStatus;
 let noLog = true;
 let connectionInfo: ProviderContainerConnectionInfo | undefined;
 let providerInfo: ProviderInfo | undefined;
-let loggerHandlerKey: symbol | undefined;
 let configurationKeys: IConfigurationPropertyRecordedSchema[];
 $: configurationKeys = properties
   .filter(property => property.scope === 'ContainerConnection')
@@ -63,23 +61,11 @@ onMount(async () => {
     }
     const containerConnectionName = getProviderConnectionName(providerInfo, connectionInfo);
     if (containerConnectionName && connectionStatus?.status !== connectionInfo.status) {
-      if (loggerHandlerKey !== undefined) {
-        connectionStatus = {
-          inProgress: true,
-          action: 'restart',
-          status: connectionInfo.status,
-        };
-        startContainerProvider(providerInfo, connectionInfo, loggerHandlerKey).catch((err: unknown) =>
-          console.error(`Error starting provider ${connectionInfo?.name}`, err),
-        );
-        loggerHandlerKey = undefined;
-      } else {
-        connectionStatus = {
-          inProgress: false,
-          action: undefined,
-          status: connectionInfo.status,
-        };
-      }
+      connectionStatus = {
+        inProgress: false,
+        action: undefined,
+        status: connectionInfo.status,
+      };
     }
     connectionStatus = connectionStatus;
   });
@@ -91,18 +77,6 @@ onDestroy(() => {
   }
 });
 
-async function startContainerProvider(
-  provider: ProviderInfo,
-  containerConnectionInfo: ProviderContainerConnectionInfo,
-  loggerHandlerKey: symbol,
-): Promise<void> {
-  await window.startProviderConnectionLifecycle(
-    provider.internalId,
-    containerConnectionInfo,
-    loggerHandlerKey,
-    eventCollect,
-  );
-}
 function updateConnectionStatus(
   provider: ProviderInfo,
   containerConnectionInfo: ProviderConnectionInfo,
@@ -125,10 +99,6 @@ function updateConnectionStatus(
     };
   }
   connectionStatus = connectionStatus;
-}
-
-function addConnectionToRestartingQueue(container: IConnectionRestart): void {
-  loggerHandlerKey = container.loggerHandlerKey;
 }
 
 function setNoLogs(): void {
@@ -154,8 +124,7 @@ function setNoLogs(): void {
             provider={providerInfo}
             connection={connectionInfo}
             connectionStatus={connectionStatus}
-            updateConnectionStatus={updateConnectionStatus}
-            addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
+            updateConnectionStatus={updateConnectionStatus} />
         </div>
       {/if}
     {/snippet}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -18,11 +18,10 @@ import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { providerInfos } from '/@/stores/providers';
 
-import { eventCollect } from './preferences-connection-rendering-task';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesConnectionDetailsLogs from './PreferencesConnectionDetailsLogs.svelte';
 import PreferencesKubernetesConnectionDetailsSummary from './PreferencesKubernetesConnectionDetailsSummary.svelte';
-import type { IConnectionRestart, IConnectionStatus } from './Util';
+import type { IConnectionStatus } from './Util';
 import { getProviderConnectionName } from './Util';
 
 export let properties: IConfigurationPropertyRecordedSchema[] = [];
@@ -35,7 +34,6 @@ let connectionStatus: IConnectionStatus;
 let noLog = true;
 let connectionInfo: ProviderKubernetesConnectionInfo | undefined;
 let providerInfo: ProviderInfo | undefined;
-let loggerHandlerKey: symbol | undefined;
 let configurationKeys: IConfigurationPropertyRecordedSchema[];
 $: configurationKeys = properties
   .filter(property => property.scope === 'KubernetesConnection')
@@ -63,23 +61,11 @@ onMount(async () => {
     connectionName = connectionInfo.name;
     const kubernetesConnectionName = getProviderConnectionName(providerInfo, connectionInfo);
     if (kubernetesConnectionName && connectionStatus?.status !== connectionInfo.status) {
-      if (loggerHandlerKey !== undefined) {
-        connectionStatus = {
-          inProgress: true,
-          action: 'restart',
-          status: connectionInfo.status,
-        };
-        startConnectionProvider(providerInfo, connectionInfo, loggerHandlerKey).catch((err: unknown) =>
-          console.error(`Error starting provider ${connectionInfo?.name}`, err),
-        );
-        loggerHandlerKey = undefined;
-      } else {
-        connectionStatus = {
-          inProgress: false,
-          action: undefined,
-          status: connectionInfo.status,
-        };
-      }
+      connectionStatus = {
+        inProgress: false,
+        action: undefined,
+        status: connectionInfo.status,
+      };
     }
     connectionStatus = connectionStatus;
   });
@@ -90,14 +76,6 @@ onDestroy(() => {
     providersUnsubscribe();
   }
 });
-
-async function startConnectionProvider(
-  provider: ProviderInfo,
-  connectionInfo: ProviderKubernetesConnectionInfo,
-  loggerHandlerKey: symbol,
-): Promise<void> {
-  await window.startProviderConnectionLifecycle(provider.internalId, connectionInfo, loggerHandlerKey, eventCollect);
-}
 
 function updateConnectionStatus(
   provider: ProviderInfo,
@@ -123,10 +101,6 @@ function updateConnectionStatus(
   connectionStatus = connectionStatus;
 }
 
-function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
-  loggerHandlerKey = connection.loggerHandlerKey;
-}
-
 function setNoLogs(): void {
   noLog = false;
 }
@@ -150,8 +124,7 @@ function setNoLogs(): void {
             provider={providerInfo}
             connection={connectionInfo}
             connectionStatus={connectionStatus}
-            updateConnectionStatus={updateConnectionStatus}
-            addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
+            updateConnectionStatus={updateConnectionStatus} />
         </div>
       {/if}
     {/snippet}

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -35,7 +35,6 @@ import {
   RESOURCE_FORMATS,
   toDisplayMetrics,
 } from './connection-resource-metrics';
-import { eventCollect } from './preferences-connection-rendering-task';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesConnectionsEmptyRendering from './PreferencesConnectionsEmptyRendering.svelte';
 import PreferencesManagedInput from './PreferencesManagedInput.svelte';
@@ -46,7 +45,6 @@ import SettingsPage from './SettingsPage.svelte';
 import ThemedIcon from './ThemedIcon.svelte';
 import {
   getProviderConnectionName,
-  type IConnectionRestart,
   type IConnectionStatus,
   type IProviderConnectionConfigurationPropertyRecorded,
   isDefaultScope,
@@ -62,7 +60,6 @@ let providerToBeInstalled = $state<{ provider: ProviderInfo; displayName: string
 let doExecuteAfterInstallation: () => void;
 let preflightChecks = $state<CheckStatus[]>([]);
 
-let restartingQueue: IConnectionRestart[] = [];
 let globalContext = $state<ContextUI>();
 
 let providersUnsubscribe: Unsubscriber;
@@ -99,23 +96,11 @@ onMount(async () => {
           !containerConnectionStatus.has(containerConnectionName) ||
           containerConnectionStatus.get(containerConnectionName)?.status !== container.status
         ) {
-          const containerToRestart = getContainerRestarting(provider.internalId, container.name);
-          if (containerToRestart) {
-            containerConnectionStatus.set(containerConnectionName, {
-              inProgress: true,
-              action: 'restart',
-              status: container.status,
-            });
-            startConnectionProvider(provider, container, containerToRestart.loggerHandlerKey).catch((err: unknown) =>
-              console.error(`Error starting connection provider ${container.name}`, err),
-            );
-          } else {
-            containerConnectionStatus.set(containerConnectionName, {
-              inProgress: false,
-              action: undefined,
-              status: container.status,
-            });
-          }
+          containerConnectionStatus.set(containerConnectionName, {
+            inProgress: false,
+            action: undefined,
+            status: container.status,
+          });
         }
       });
       provider.kubernetesConnections.forEach(connection => {
@@ -126,23 +111,11 @@ onMount(async () => {
           !containerConnectionStatus.has(containerConnectionName) ||
           containerConnectionStatus.get(containerConnectionName)?.status !== connection.status
         ) {
-          const containerToRestart = getContainerRestarting(provider.internalId, connection.name);
-          if (containerToRestart) {
-            containerConnectionStatus.set(containerConnectionName, {
-              inProgress: true,
-              action: 'restart',
-              status: connection.status,
-            });
-            startConnectionProvider(provider, connection, containerToRestart.loggerHandlerKey).catch((err: unknown) =>
-              console.error(`Error starting connection provider ${connection.name}`, err),
-            );
-          } else {
-            containerConnectionStatus.set(containerConnectionName, {
-              inProgress: false,
-              action: undefined,
-              status: connection.status,
-            });
-          }
+          containerConnectionStatus.set(containerConnectionName, {
+            inProgress: false,
+            action: undefined,
+            status: connection.status,
+          });
         }
       });
       provider.vmConnections.forEach(connection => {
@@ -153,23 +126,11 @@ onMount(async () => {
           !containerConnectionStatus.has(vmConnectionName) ||
           containerConnectionStatus.get(vmConnectionName)?.status !== connection.status
         ) {
-          const containerToRestart = getContainerRestarting(provider.internalId, connection.name);
-          if (containerToRestart) {
-            containerConnectionStatus.set(vmConnectionName, {
-              inProgress: true,
-              action: 'restart',
-              status: connection.status,
-            });
-            startConnectionProvider(provider, connection, containerToRestart.loggerHandlerKey).catch((err: unknown) =>
-              console.error(`Error starting connection provider ${connection.name}`, err),
-            );
-          } else {
-            containerConnectionStatus.set(vmConnectionName, {
-              inProgress: false,
-              action: undefined,
-              status: connection.status,
-            });
-          }
+          containerConnectionStatus.set(vmConnectionName, {
+            inProgress: false,
+            action: undefined,
+            status: connection.status,
+          });
         }
       });
     });
@@ -197,14 +158,6 @@ onMount(async () => {
 
   contributionsContainerConnection = await window.getContributedMenus(MenuContext.DASHBOARD_CONTAINER_CONNECTION);
 });
-
-function getContainerRestarting(provider: string, container: string): IConnectionRestart {
-  const containerToRestart = restartingQueue.filter(c => c.provider === provider && c.container === container)[0];
-  if (containerToRestart) {
-    restartingQueue = restartingQueue.filter(c => c.provider !== provider && c.container !== container);
-  }
-  return containerToRestart;
-}
 
 onDestroy(() => {
   if (providersUnsubscribe) {
@@ -245,23 +198,6 @@ function updateContainerStatus(
       status: containerConnectionInfo.status,
     });
   }
-}
-
-function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
-  restartingQueue.push(connection);
-}
-
-async function startConnectionProvider(
-  provider: ProviderInfo,
-  containerConnectionInfo: ProviderConnectionInfo,
-  loggerHandlerKey: symbol,
-): Promise<void> {
-  await window.startProviderConnectionLifecycle(
-    provider.internalId,
-    $state.snapshot(containerConnectionInfo),
-    loggerHandlerKey,
-    eventCollect,
-  );
 }
 
 async function doCreateNew(provider: ProviderInfo, displayName: string): Promise<void> {
@@ -580,8 +516,7 @@ $effect(() => {
                 provider={provider}
                 connection={container}
                 connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, container))}
-                updateConnectionStatus={updateContainerStatus}
-                addConnectionToRestartingQueue={addConnectionToRestartingQueue}>
+                updateConnectionStatus={updateContainerStatus}>
                 {#snippet advanced_actions()}
                   <span  class:hidden={providers.length === 0}>
                     <Tooltip bottom tip="More Options">
@@ -647,8 +582,7 @@ $effect(() => {
                 provider={provider}
                 connection={kubeConnection}
                 connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, kubeConnection))}
-                updateConnectionStatus={updateContainerStatus}
-                addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
+                updateConnectionStatus={updateContainerStatus} />
             </div>
           {/each}
           {#each provider.vmConnections as vmConnection, index (index)}
@@ -681,8 +615,7 @@ $effect(() => {
               provider={provider}
               connection={vmConnection}
               connectionStatus={containerConnectionStatus.get(getProviderConnectionName(provider, vmConnection))}
-              updateConnectionStatus={updateContainerStatus}
-              addConnectionToRestartingQueue={addConnectionToRestartingQueue}>
+              updateConnectionStatus={updateContainerStatus}>
               {#snippet advanced_actions()}
                 <span  class:hidden={providers.length === 0}>
                   <Tooltip bottom tip="More Options">

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
@@ -22,13 +22,11 @@ import type { ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
-import { assert, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 
-import * as preferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesVmConnectionRendering from './PreferencesVmConnectionRendering.svelte';
-import type { IConnectionRestart } from './Util';
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -211,66 +209,4 @@ test('Expect to see error message if action fails', async () => {
 
   // expect to see the delete failed button
   expect(deleteFailedButton).toBeInTheDocument();
-});
-
-test('startProviderConnectionLifecycle is called when addConnectionToRestartingQueue is called by sub-component', async () => {
-  vi.spyOn(preferencesConnectionActions, 'default');
-  const providerInfo: ProviderInfo = {
-    id: 'vmprovider',
-    name: 'vmp',
-    images: {
-      icon: 'img',
-    },
-    status: 'started',
-    warnings: [],
-    containerProviderConnectionCreation: true,
-    detectionChecks: [],
-    containerConnections: [],
-    installationSupport: false,
-    internalId: '0',
-    vmConnections: [
-      {
-        connectionType: 'vm',
-        name: 'vm 1',
-        status: 'stopped',
-        lifecycleMethods: ['delete'],
-        canStart: false,
-        canStop: false,
-        canEdit: false,
-        canDelete: false,
-      },
-    ],
-    vmProviderConnectionCreation: true,
-    kubernetesConnections: [],
-    kubernetesProviderConnectionCreation: false,
-    vmProviderConnectionInitialization: false,
-    links: [],
-    containerProviderConnectionInitialization: false,
-    containerProviderConnectionCreationDisplayName: 'Podman machine',
-    kubernetesProviderConnectionInitialization: false,
-    extensionId: '',
-    cleanupSupport: false,
-    canStart: false,
-    canStop: false,
-  };
-
-  providerInfos.set([providerInfo]);
-  render(PreferencesVmConnectionRendering, {
-    connectionName: 'vm 1',
-    providerInternalId: '0',
-  });
-
-  // simulate PreferencesConnectionActions is calling addConnectionToRestartingQueue
-  expect(preferencesConnectionActions.default).toHaveBeenCalledOnce();
-  const params = vi.mocked(preferencesConnectionActions.default).mock.calls[0][1];
-  assert(params);
-  const addConnectionToRestartingQueue = params['addConnectionToRestartingQueue'];
-
-  addConnectionToRestartingQueue({
-    loggerHandlerKey: (): void => {},
-  } as unknown as IConnectionRestart);
-
-  providerInfo.vmConnections[0].status = 'started';
-  providerInfos.set([providerInfo]);
-  expect(window.startProviderConnectionLifecycle).toHaveBeenCalledOnce();
 });

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
@@ -16,11 +16,9 @@ import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { providerInfos } from '/@/stores/providers';
 
-import { eventCollect } from './preferences-connection-rendering-task';
 import PreferencesConnectionActions from './PreferencesConnectionActions.svelte';
 import PreferencesConnectionDetailsTerminal from './PreferencesConnectionDetailsTerminal.svelte';
-import type { IConnectionRestart, IConnectionStatus } from './Util';
-import { getProviderConnectionName } from './Util';
+import { getProviderConnectionName, type IConnectionStatus } from './Util';
 
 export let providerInternalId: string | undefined = undefined;
 export let connectionName = '';
@@ -28,7 +26,6 @@ export let connectionName = '';
 let connectionStatus: IConnectionStatus;
 let connectionInfo: ProviderVmConnectionInfo | undefined;
 let providerInfo: ProviderInfo | undefined;
-let loggerHandlerKey: symbol | undefined;
 
 let providersUnsubscribe: Unsubscriber;
 onMount(async () => {
@@ -48,23 +45,11 @@ onMount(async () => {
     }
     const vmConnectionName = getProviderConnectionName(providerInfo, connectionInfo);
     if (vmConnectionName && connectionStatus?.status !== connectionInfo.status) {
-      if (loggerHandlerKey !== undefined) {
-        connectionStatus = {
-          inProgress: true,
-          action: 'restart',
-          status: connectionInfo.status,
-        };
-        startConnectionProvider(providerInfo, connectionInfo, loggerHandlerKey).catch((err: unknown) =>
-          console.error(`Error starting provider ${connectionInfo?.name}`, err),
-        );
-        loggerHandlerKey = undefined;
-      } else {
-        connectionStatus = {
-          inProgress: false,
-          action: undefined,
-          status: connectionInfo.status,
-        };
-      }
+      connectionStatus = {
+        inProgress: false,
+        action: undefined,
+        status: connectionInfo.status,
+      };
     }
     connectionStatus = connectionStatus;
   });
@@ -76,16 +61,8 @@ onDestroy(() => {
   }
 });
 
-async function startConnectionProvider(
-  provider: ProviderInfo,
-  connectionInfo: ProviderVmConnectionInfo,
-  loggerHandlerKey: symbol,
-): Promise<void> {
-  await window.startProviderConnectionLifecycle(provider.internalId, connectionInfo, loggerHandlerKey, eventCollect);
-}
-
 function updateConnectionStatus(
-  provider: ProviderInfo,
+  _: ProviderInfo,
   connectionInfo: ProviderConnectionInfo,
   action?: string,
   error?: string,
@@ -107,10 +84,6 @@ function updateConnectionStatus(
   }
   connectionStatus = connectionStatus;
 }
-
-function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
-  loggerHandlerKey = connection.loggerHandlerKey;
-}
 </script>
 
 {#if connectionInfo}
@@ -131,8 +104,7 @@ function addConnectionToRestartingQueue(connection: IConnectionRestart): void {
             provider={providerInfo}
             connection={connectionInfo}
             connectionStatus={connectionStatus}
-            updateConnectionStatus={updateConnectionStatus}
-            addConnectionToRestartingQueue={addConnectionToRestartingQueue} />
+            updateConnectionStatus={updateConnectionStatus} />
         </div>
       {/if}
     {/snippet}

--- a/packages/renderer/src/lib/preferences/Util.ts
+++ b/packages/renderer/src/lib/preferences/Util.ts
@@ -47,12 +47,6 @@ export interface IConnectionStatus extends ILoadingStatus {
   error?: string;
 }
 
-export interface IConnectionRestart {
-  provider: string;
-  container: string;
-  loggerHandlerKey: symbol;
-}
-
 export function writeToTerminal(xterm: Terminal, data: unknown, colorPrefix: string): void {
   if (Array.isArray(data)) {
     writeArrayToTerminal(xterm, data, colorPrefix);

--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -33,7 +33,7 @@ import {
   verifyMachinePrivileges,
   verifyVirtualizationProvider,
 } from '/@/utility/operations';
-import { isCI, isLinux, isWindows } from '/@/utility/platform';
+import { isLinux, isWindows } from '/@/utility/platform';
 import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '/@/utility/provider';
 import { waitForPodmanMachineStartup, waitUntil } from '/@/utility/wait';
 
@@ -208,11 +208,6 @@ for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of mac
       });
 
       test('Restart the machine', async ({ page }) => {
-        test.skip(
-          isCI && userNet,
-          'Restarting podman machine is flaky in cicd pipeline with usermode networking. This issue is tracked in https://github.com/podman-desktop/podman-desktop/issues/15889',
-        );
-
         const machineCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, PODMAN_MACHINE_NAME);
         await machineCard.performConnectionAction(ResourceElementActions.Restart);
 


### PR DESCRIPTION
### What does this PR do?

Related to https://github.com/podman-desktop/podman-desktop/pull/17243

The code managing the restart logic of a resource, is really really complicated; instead of calling the `stop` then `start` the code is adding to a _queue_  a _restart_ request.

This request will be handled if a given connection will change their status (E.g. `running` to `stopped`), _in theory_ this is fine, but in reality this is not working. 

The `addConnectionToRestartingQueue` was registered after `stopProviderConnectionLifecycle`, however, due to some race condition, the status is already updated before `stopProviderConnectionLifecycle` finish, because of how the status is computed.

But, you should not register `addConnectionToRestartingQueue` before calling `stopProviderConnectionLifecycle` because then the `startProviderConnectionLifecycle` will called before `stopProviderConnectionLifecycle` has nicely finished, leading to problems.

Anyway, I would say the best solution is not to have this `restart` queue, reduce the complexity, and just call `stop` then `start` in the same linear function.

This will fix the minikube restart logic, however the _transition_ state is not great ( Check the video recording ) the main reason is because we don't have transition states, and when the component is refreshed, all states are discarded.

### Screenshot / video of UI

https://github.com/user-attachments/assets/1867d17a-b713-4511-84f4-c015c1e0a2c7

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15889

### How to test this PR?

- Restart minikube and wait
- Restart Podman and wait