### PR TITLE
chore(deps): add jsonc-parser for SchemaStore sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "get-tsconfig": "^4.14.0",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
+    "jsonc-parser": "^3.3.1",
     "lint-staged": "^17.0.7",
     "minimist": "^1.2.8",
     "msw": "^2.14.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       lint-staged:
         specifier: ^17.0.7
         version: 17.0.7


### PR DESCRIPTION
### What does this PR do?

Adds `jsonc-parser` as a direct dev dependency.

### Screenshot / video of UI

N/A.

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16051.

Why needed: the SchemaStore sync workflow updates
`schema-validation.jsonc`, which is JSONC (comments/trailing commas), so
we need a JSONC-aware parser/editor.

### How to test this PR?

- Confirm only `package.json` and `pnpm-lock.yaml` are changed.

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)