### PR TITLE
chore: exclude storybook from Codecov coverage reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,5 +15,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+coverage:
+  ignore:
+    - "storybook/**"
+
 comment:
   require_changes: true  # Only post a comment if coverage changes

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,3 +21,4 @@ coverage:
 
 comment:
   require_changes: true  # Only post a comment if coverage changes
+


### PR DESCRIPTION
### What does this PR do?

Adds `storybook/**` to the `coverage.ignore` list in `codecov.yml`. Storybook stories are UI showcases with no test coverage by design, so Codecov was consistently flagging PRs with false coverage-drop warnings. This change silences that noise and keeps coverage comments meaningful.

### Screenshot / video of UI

N/A - configuration change only.

### What issues does this PR fix or reference?

- Resolves #17797

### How to test this PR?

- Open any PR that touches the `storybook/` directory and confirm Codecov no longer reports a coverage drop for story files.
- Alternatively, verify the updated `codecov.yml` passes validation at codecov.io/validate.

- [ ] Tests are covering the bug fix or the new feature