### PR TITLE
test(e2e): fix ui stress tests on linux

### DIFF
--- a/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
+++ b/tests/playwright/src/special-specs/ui-stress/ui-stress.spec.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { expect as playExpect, test } from '/@/utility/fixtures';
-import { isLinux } from '/@/utility/platform';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const numberOfObjects = Number(process.env.OBJECT_NUM) || 100;
@@ -42,8 +41,8 @@ test.describe
 
       const images = await navigationBar.openImages();
       await playExpect(images.heading).toBeVisible({ timeout: 10_000 });
-      //count images => 1 original image + (1 tagged * numberOfObjects) + 1 localhost/podman-pause from pods (only ubuntu!) = numberOfObjects + 2
-      const expectedImages = isLinux ? numberOfObjects + 2 : numberOfObjects + 1;
+      //count images => 1 original image + (1 tagged * numberOfObjects) = 1 + numberOfObjects
+      const expectedImages = numberOfObjects + 1;
       await playExpect
         .poll(async () => await images.countRowsFromTable(), { timeout: 10_000 })
         .toBe(baselineImageCount + expectedImages);


### PR DESCRIPTION
### What does this PR do?
Fix the UI stress tests for the linux runner
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/e2e/issues/576 alongside https://github.com/podman-desktop/e2e/pull/577
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
