### PR TITLE
chore(test): decrease version before testing app update by 2

### DIFF
--- a/tests/playwright/scripts/version-util.cjs
+++ b/tests/playwright/scripts/version-util.cjs
@@ -42,7 +42,7 @@ function decreaseMinorVersion(packageJsonPath, shouldUpdate) {
   const originalVersion = packageJson.version;
   const versionParts = parseVersion(originalVersion);
   const [major, minor] = versionParts;
-  const newMinor = minor - 1;
+  const newMinor = minor - 2;
   let newVersion = `${major}.${newMinor}.0`;
   if (newMinor < 0) {
     console.log(`Minor cannot be less than 0, defaults to 1.20.0`);


### PR DESCRIPTION
### What does this PR do?
Decreases the version before testing the update by 2, so that in cases like bump up version (https://github.com/podman-desktop/podman-desktop/pull/17801) PR will not fail on update e2e tests. 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#17806 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
All update e2e tests should be passing.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
