### PR TITLE
chore(ci): pin anchore/sbom-action to commit SHA

### DIFF
--- a/.github/workflows/release-generate-sbom.yaml
+++ b/.github/workflows/release-generate-sbom.yaml
@@ -44,7 +44,7 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
 
       - name: Generate sbom file
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: ./
           output-file: ./podman-desktop-sbom.spdx.json


### PR DESCRIPTION
### What does this PR do?

Pins `anchore/sbom-action@v0` to its commit SHA (`e22c389` / v0.24.0) in `release-generate-sbom.yaml`, resolving the last unpinned third-party action in the repository.

### Screenshot / video of UI

N/A — CI-only change.

### What issues does this PR fix or reference?

Fixes #16848

### How to test this PR?

1. Verify the SHA `e22c389904149dbc22b58101806040fa8d37a610` matches `anchore/sbom-action` v0.24.0
2. Confirm no other unpinned actions remain: `grep -rn "uses:" .github/workflows/ | grep -v "@[0-9a-f]\{40\}" | grep -v "\./"`

- [x] Tests are covering the bug fix or the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)