### PR TITLE
fix(extension/kind): incorrect polyfill of node-fetch

### DIFF
--- a/extensions/vite.base.config.ts
+++ b/extensions/vite.base.config.ts
@@ -26,6 +26,9 @@ const WORKSPACE_ROOT = join(__dirname, '..');
 export default defineConfig({
   mode: process.env.MODE,
   envDir: process.cwd(),
+  resolve: {
+    mainFields: ['module', 'jsnext:main', 'jsnext', 'main'],
+  },
   build: {
     sourcemap: 'inline',
     target: 'esnext',


### PR DESCRIPTION
### What does this PR do?


For the 1.28.0 release [Podman Desktop throws an error when trying to create a kind cluster #17814](https://github.com/podman-desktop/podman-desktop/issues/17814) has been raised, the hidden error was the following

```
code: UNABLE_TO_VERIFY_LEAF_SIGNATURE
Error: unable to verify the first certificate; if the root CA is installed locally, try running Node.js with --use-system-ca
    at TLSSocket.onConnectSecure (node:internal/tls/wrap:1656:34)
    at TLSSocket.emit (node:events:509:28)
    at TLSSocket._finishInit (node:internal/tls/wrap:1102:8)
    at ssl.onhandshakedone (node:internal/tls/wrap:888:12)
    at TLSWrap.callbackTrampoline (node:internal/async_hooks:130:17)
```

Using git bisect I was able to identify the commit responsible of the regression (https://github.com/podman-desktop/podman-desktop/commit/189d37d91ca83cb987334c3d62a95fb4a091d5bc) I was able to find the root issue.

Since https://github.com/podman-desktop/podman-desktop/pull/17726 we are using vite 8. Vite 8 has many breaking internal difference from the prior version.

When we migrated to vite 8 we added the following in the `packages/main/vite.config.js`

https://github.com/podman-desktop/podman-desktop/blob/189d37d91ca83cb987334c3d62a95fb4a091d5bc/packages/main/vite.config.js#L33-L37

The same problem as explained in the comment in the code snippet happen for kind, the `node-fetch` get polyfilled as browser, but the fetch of the browser does not support Agents from `node:http`, and as you need a custom Certificate to connect to the cluster, this was leading to the error above.  

### Screenshot / video of UI

<img width="1101" height="423" alt="image" src="https://github.com/user-attachments/assets/8011fa2b-02bf-42bf-a1b3-77a46a2c15be" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17814

### How to test this PR?

- Create a Kind cluster 
