### PR TITLE
chore(ci): add airgap asset validation to daily testing build

### DIFF
--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -103,7 +103,7 @@ jobs:
           token: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
 
   build:
-    name: Build / ${{ matrix.os }}
+    name: Build / ${{ matrix.os }} ${{ matrix.airgap == 'true' && '(Air Gap)' || '' }}
     needs: tag
     runs-on: ${{ matrix.os }}
     # do not run on forks
@@ -111,11 +111,19 @@ jobs:
     env:
       ELECTRON_ENABLE_INSPECT: true
       GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
+      AIRGAP_DOWNLOAD: ${{ matrix.airgap == 'true' && '1' || '' }}
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-15]
-    timeout-minutes: 60
+        include:
+          - os: ubuntu-24.04
+          - os: windows-2025
+          - os: windows-2025
+            airgap: 'true'
+          - os: macos-15
+          - os: macos-15
+            airgap: 'true'
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -145,9 +153,16 @@ jobs:
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
           flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
 
-      - name: Run Build and Compile on all platforms
+      - name: Run Build and Compile
         timeout-minutes: 60
         run: pnpm compile:next
+
+      - name: Validate airgap assets
+        if: matrix.airgap == 'true'
+        shell: bash
+        run: |
+          chmod +x tests/playwright/scripts/validate-airgap-assets.sh
+          tests/playwright/scripts/validate-airgap-assets.sh
 
   release:
     needs: [tag, build]
@@ -157,7 +172,7 @@ jobs:
     if: github.event.repository.fork == false && always()
     steps:
       - name: id
-        run: | 
+        run: |
           echo the release id is ${{ needs.tag.outputs.releaseId }}
           echo "The result of the build jobs: ${{ needs.build.result }}"
 

--- a/tests/playwright/scripts/validate-airgap-assets.sh
+++ b/tests/playwright/scripts/validate-airgap-assets.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+ASSETS_DIR="${REPO_ROOT}/extensions/podman/packages/extension/assets"
+PODMAN_JSON="${REPO_ROOT}/extensions/podman/packages/extension/src/podman5.json"
+
+ERRORS=0
+
+validate_file() {
+  local file="$1"
+  local path="${ASSETS_DIR}/${file}"
+
+  if [ ! -f "${path}" ]; then
+    echo "FAIL: missing ${file}"
+    ERRORS=$((ERRORS + 1))
+    return
+  fi
+
+  local size
+  size=$(wc -c < "${path}" | tr -d ' ')
+  if [ "${size}" -eq 0 ]; then
+    echo "FAIL: ${file} is empty"
+    ERRORS=$((ERRORS + 1))
+    return
+  fi
+
+  local human_size
+  if command -v numfmt &>/dev/null; then
+    human_size=$(numfmt --to=iec "${size}")
+  else
+    human_size="${size} bytes"
+  fi
+  echo "OK:   ${file}  (${human_size})"
+}
+
+echo "=== Airgap asset validation ==="
+echo "Assets dir: ${ASSETS_DIR}"
+
+if [ ! -d "${ASSETS_DIR}" ]; then
+  echo "FAIL: assets directory does not exist"
+  exit 1
+fi
+
+VERSION=$(jq -r '.version' "${PODMAN_JSON}")
+echo "Podman version: ${VERSION}"
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+echo "Platform: ${OS} / ${ARCH}"
+echo ""
+
+echo "--- Installer assets ---"
+case "${OS}" in
+  Darwin)
+    validate_file "podman-installer-macos-amd64-v${VERSION}.pkg"
+    validate_file "podman-installer-macos-aarch64-v${VERSION}.pkg"
+    validate_file "podman-installer-macos-universal-v${VERSION}.pkg"
+    ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    validate_file "podman-installer-windows-amd64.msi"
+    validate_file "podman-installer-windows-arm64.msi"
+    ;;
+  *)
+    echo "SKIP: no installer assets expected on ${OS}"
+    ;;
+esac
+
+echo ""
+echo "--- Airgap machine OS images ---"
+case "${OS}" in
+  Darwin|MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    validate_file "podman-image-arm64.zst"
+    validate_file "podman-image-x64.zst"
+    ;;
+  *)
+    echo "SKIP: no airgap machine OS images expected on ${OS}"
+    ;;
+esac
+
+echo ""
+if [ "${ERRORS}" -gt 0 ]; then
+  echo "FAILED: ${ERRORS} asset(s) missing or invalid"
+  exit 1
+fi
+
+echo "All airgap assets validated successfully"


### PR DESCRIPTION
### What does this PR do?

Adds airgap build variants (Windows, macOS) to the daily testing build matrix and a bash validation script that verifies the downloaded assets exist and are non-empty after building with `AIRGAP_DOWNLOAD=1`.

### Screenshot / video of UI

N/A — CI-only changes.

### What issues does this PR fix or reference?

Closes #13963

### How to test this PR?

1. Trigger a `workflow_dispatch` on the daily testing build
2. Verify the airgap matrix entries (`windows-2025 (Air Gap)`, `macos-15 (Air Gap)`) run and pass the validation step
3. Run the validation script locally after an `AIRGAP_DOWNLOAD=1` build: `tests/playwright/scripts/validate-airgap-assets.sh`

- [x] Tests are covering the bug fix or the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)