### PR TITLE
chore(pnpm): set minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,3 +21,5 @@ onlyBuiltDependencies:
   - ssh2
   - svelte-preprocess
   - win-ca
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
### What does this PR do?

To be able to migrate to `pnpm@11` we first need to enforce some settings. The main blocking one is `minimumReleaseAge` which will default to `1440` compare to `0` currently


### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/17794

### How to test this PR?

- CI should be :green_circle: 
