### PR TITLE
fix(extension/podman): update Podman GitHub org references

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full development guide.
 
 #### Multiple container engine support
 
-- [Podman container engine](https://github.com/containers/podman)
+- [Podman container engine](https://github.com/podman-container-tools/podman)
 - [crc](https://github.com/code-ready/crc)
 - [Lima: Linux Machines](https://github.com/lima-vm/lima)
 - [Docker container engine](https://github.com/docker/docker)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -251,7 +251,7 @@ Podman Desktop X.X is now available. [Click here to download it](/downloads)!
 
 <!-- EXAMPLE -->
 <!-- ### Podman v4.5.1 -->
-<!-- Podman Desktop 1.1 moves up to [Podman 4.5.1](https://github.com/containers/podman/releases/tag/v4.5.1). -->
+<!-- Podman Desktop 1.1 moves up to [Podman 4.5.1](https://github.com/podman-container-tools/podman/releases/tag/v4.5.1). -->
 
 <!-- WHEN DESCRIBING NAVBAR SECTIONS, INCLUDE ICON -->
 <!-- EXAMPLE -->

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -306,17 +306,19 @@ describe('DownloadAndCheckSha', () => {
       name: 'vFakeVersion',
       assets: [
         {
-          url: 'https://api.github.com/repos/containers/podman/releases/assets/456',
+          url: 'https://api.github.com/repos/podman-container-tools/podman/releases/assets/456',
           id: 456,
           name: 'podman-fake-binary',
-          browser_download_url: 'https://github.com/containers/podman/releases/download/vFakeVersion/podman-binary',
+          browser_download_url:
+            'https://github.com/podman-container-tools/podman/releases/download/vFakeVersion/podman-binary',
         },
 
         {
-          url: 'https://api.github.com/repos/containers/podman/releases/assets/789',
+          url: 'https://api.github.com/repos/podman-container-tools/podman/releases/assets/789',
           id: 789,
           name: 'shasums',
-          browser_download_url: 'https://github.com/containers/podman/releases/download/vFakeVersion/shasums',
+          browser_download_url:
+            'https://github.com/podman-container-tools/podman/releases/download/vFakeVersion/shasums',
         },
       ],
     };
@@ -324,12 +326,12 @@ describe('DownloadAndCheckSha', () => {
     const podmanBinaryContent = 'fake-binary-content';
 
     const handlers = [
-      http.get('https://api.github.com/repos/containers/podman/releases/tags/vFakeVersion', () =>
+      http.get('https://api.github.com/repos/podman-container-tools/podman/releases/tags/vFakeVersion', () =>
         HttpResponse.json(response),
       ),
 
       http.get(
-        'https://api.github.com/repos/containers/podman/releases/assets/789',
+        'https://api.github.com/repos/podman-container-tools/podman/releases/assets/789',
         () =>
           new HttpResponse(shasumContent, {
             status: 200,
@@ -343,7 +345,7 @@ describe('DownloadAndCheckSha', () => {
 
       // podman-binary content
       http.get(
-        'https://api.github.com/repos/containers/podman/releases/assets/456',
+        'https://api.github.com/repos/podman-container-tools/podman/releases/assets/456',
         () =>
           new HttpResponse(podmanBinaryContent, {
             status: 200,

--- a/extensions/podman/packages/extension/scripts/podman-download.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.ts
@@ -214,7 +214,7 @@ export class DownloadAndCheck {
     tagVersion: string,
     fileName: string,
     artifactName: string,
-    owner: string = 'containers',
+    owner: string = 'podman-container-tools',
     repo: string = 'podman',
   ): Promise<void> {
     if (this.#downloadAttempt >= this.MAX_DOWNLOAD_ATTEMPT) {

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -403,7 +403,7 @@ describe('performUpdate', () => {
     );
 
     expect(extensionApi.Uri.parse).toHaveBeenCalledWith(
-      'https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md',
+      'https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/podman-for-windows.md',
     );
     expect(extensionApi.env.openExternal).toHaveBeenCalled();
   });

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -267,7 +267,7 @@ export class PodmanInstall {
       }
 
       // Podman github link with information that 5.3.1 cant update to 5.4.X
-      // https://github.com/containers/podman/pull/25135
+      // https://github.com/podman-container-tools/podman/pull/25135
       // Podman Desktop link with proposed solution
       // https://github.com/podman-desktop/podman-desktop/issues/11720
       if (!updateInfo.bundledVersion) return;
@@ -285,7 +285,7 @@ export class PodmanInstall {
 
         if (result === 'Yes') {
           const url = extensionApi.Uri.parse(
-            'https://github.com/containers/podman/blob/main/docs/tutorials/podman-for-windows.md',
+            'https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/podman-for-windows.md',
           );
           await extensionApi.env.openExternal(url);
         }

--- a/extensions/podman/packages/extension/src/podman5.json
+++ b/extensions/podman/packages/extension/src/podman5.json
@@ -1,7 +1,7 @@
 {
   "version": "5.8.2",
   "releaseNotes": {
-    "href": "https://github.com/containers/podman/releases/tag/v5.8.2"
+    "href": "https://github.com/podman-container-tools/podman/releases/tag/v5.8.2"
   },
   "platform": {
     "win32": {

--- a/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-windows-legacy-installer.ts
@@ -69,7 +69,7 @@ export class PodmanWindowsLegacyInstaller implements Disposable {
 
   /**
    * To detect if we have an installation of Podman made through the legacy installer, we use the
-   * same logic made inside the new podman installer (https://github.com/containers/podman/pull/27284)
+   * same logic made inside the new podman installer (https://github.com/podman-container-tools/podman/pull/27284)
    *
    * We check in {@link LEGACY_PODMAN_REGISTRY_KEY} registry the existence of {@link LEGACY_PODMAN_REGISTRY_ITEM_NAME}
    */

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -764,12 +764,12 @@ export class ContainerProviderRegistry {
 
   async pruneImages(engineId: string, all: boolean): Promise<void> {
     // We have to use two different API calls for pruning images, because the Podman API does not respect the 'dangling' filter
-    // and instead uses 'all' and 'external'. See: https://github.com/containers/podman/issues/11576
+    // and instead uses 'all' and 'external'. See: https://github.com/podman-container-tools/podman/issues/11576
     // so for Dockerode we'll have to call pruneImages with the 'dangling' filter, and for Podman we'll have to call pruneImages
 
     // PODMAN:
     // Have to use podman API directly for pruning images
-    // TODO: Remove this once the Podman API respects the 'dangling' filter: https://github.com/containers/podman/issues/17614
+    // TODO: Remove this once the Podman API respects the 'dangling' filter: https://github.com/podman-container-tools/podman/issues/17614
     let telemetryOptions = {};
     try {
       const provider = this.internalProviders.get(engineId);
@@ -1584,7 +1584,7 @@ export class ContainerProviderRegistry {
   }
 
   /**
-   * @see https://github.com/containers/podman/issues/23337#issuecomment-2238704510
+   * @see https://github.com/podman-container-tools/podman/issues/23337#issuecomment-2238704510
    * @param containerToReplicate
    * @param updatedEnv
    * @private

--- a/packages/main/src/plugin/podman/kube.ts
+++ b/packages/main/src/plugin/podman/kube.ts
@@ -26,7 +26,7 @@ import tar from 'tar-fs';
 
 /**
  * This function is a re-implementation of the imageNamePrefix on the podman repository
- * https://github.com/containers/podman/blob/de856dab99ef8816392972347678fcb49ae57e50/pkg/domain/infra/abi/play.go#L1606
+ * https://github.com/podman-container-tools/podman/blob/de856dab99ef8816392972347678fcb49ae57e50/pkg/domain/infra/abi/play.go#L1606
  * @param content
  */
 export function getImageNamePrefix(content: string): string {

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -25,7 +25,7 @@ const GUESSED_MANIFEST_SIZE = 50 * KB;
 // This is because there is no clear way to now what a manifest
 // is in the Dockerode API / Podman API (yet). This is a workaround
 // until we have a better way to determine if an image is a manifest
-// See issue: https://github.com/containers/podman/issues/22184
+// See issue: https://github.com/podman-container-tools/podman/issues/22184
 //
 // We will "safely" determine if an image is a manifest by checking:
 // - VirtualSize is under 1MB, as the manifest is usually very small and only contains text

--- a/website/blog/2022-11-17-develop-podman-using-codespaces.md
+++ b/website/blog/2022-11-17-develop-podman-using-codespaces.md
@@ -90,7 +90,7 @@ COPY fluxbox /usr/share/fluxbox/init
 
 Then we need a special configuration to allow to have Podman working inside the container
 
-We add the `podman-desktop` user with correct range on subuid and subgid when running containers. I used the [tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration).
+We add the `podman-desktop` user with correct range on subuid and subgid when running containers. I used the [tutorial](https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration).
 
 ```docker
 RUN useradd -u 1000 podman-desktop && echo podman-desktop:10000:5000 > /etc/subuid && echo podman-desktop:10000:5000 > /etc/subgid

--- a/website/blog/2022-12-01-release-0.10-blog.md
+++ b/website/blog/2022-12-01-release-0.10-blog.md
@@ -55,7 +55,7 @@ The registries configuration UI has been revamped. Instead of using tiles for di
 
 ### Update to Podman 4.3.1 ([#913](https://github.com/containers/podman-desktop/issues/913))
 
-Podman Desktop 0.10 is now embedding [Podman 4.3.1](https://github.com/containers/podman/releases/tag/v4.3.1) in Windows and macOS installers.
+Podman Desktop 0.10 is now embedding [Podman 4.3.1](https://github.com/podman-container-tools/podman/releases/tag/v4.3.1) in Windows and macOS installers.
 
 ### UI/UX Improvements
 

--- a/website/blog/2023-02-15-release-0.12.md
+++ b/website/blog/2023-02-15-release-0.12.md
@@ -31,7 +31,7 @@ Podman Desktop 0.12 is now available. [Click here to download it](/downloads)!
 
 ### Update to Podman v4.4.1 [#1456](https://github.com/containers/podman-desktop/pull/1456)
 
-Podman Desktop 0.12 embeds [Podman 4.4.1](https://github.com/containers/podman/releases/tag/v4.4.1) in Windows and macOS installers. Make sure to upgrade to benefit from the latest Podman features and bug fixes.
+Podman Desktop 0.12 embeds [Podman 4.4.1](https://github.com/podman-container-tools/podman/releases/tag/v4.4.1) in Windows and macOS installers. Make sure to upgrade to benefit from the latest Podman features and bug fixes.
 
 ### Configuring port mappings when an image has no exported port [#1265](https://github.com/containers/podman-desktop/pull/1265)
 

--- a/website/blog/2023-03-29-release-0.13.md
+++ b/website/blog/2023-03-29-release-0.13.md
@@ -30,7 +30,7 @@ Podman Desktop 0.13 is now available. [Click here to download it](/downloads)!
 
 ### Update to Podman v4.4.4
 
-Podman Desktop 0.13 embeds [Podman 4.4.4](https://github.com/containers/podman/releases/tag/v4.4.4) in
+Podman Desktop 0.13 embeds [Podman 4.4.4](https://github.com/podman-container-tools/podman/releases/tag/v4.4.4) in
 Windows and macOS installers [#1456](https://github.com/containers/podman-desktop/pull/1456).
 
 ### Compose support

--- a/website/blog/2023-05-02-release-0.15.md
+++ b/website/blog/2023-05-02-release-0.15.md
@@ -35,7 +35,7 @@ Podman Desktop 0.15 is now available. [Click here to download it](/downloads)!
 
 ### Update to Podman v4.5.O
 
-Podman Desktop 0.15 embeds [Podman 4.5.0](https://github.com/containers/podman/releases/tag/v4.5.0) in
+Podman Desktop 0.15 embeds [Podman 4.5.0](https://github.com/podman-container-tools/podman/releases/tag/v4.5.0) in
 Windows and macOS installers [#2115](https://github.com/containers/podman-desktop/issues/2115).
 
 ### Kind Ingress

--- a/website/blog/2023-06-08-release-1.1.md
+++ b/website/blog/2023-06-08-release-1.1.md
@@ -34,7 +34,7 @@ Podman Desktop 1.1 is now available. [Click here to download it](/downloads)!
 
 ### Podman v4.5.1
 
-Podman Desktop 1.1 moves up to [Podman 4.5.1](https://github.com/containers/podman/releases/tag/v4.5.1).
+Podman Desktop 1.1 moves up to [Podman 4.5.1](https://github.com/podman-container-tools/podman/releases/tag/v4.5.1).
 
 ### Extensions
 

--- a/website/blog/2023-11-03-release-1.5.md
+++ b/website/blog/2023-11-03-release-1.5.md
@@ -15,7 +15,7 @@ Podman Desktop 1.5 Release! 🎉
 With this release of Podman Desktop, we're introducing **a new onboarding feature** that we hope will earn your 🦭 seal of approval! But wait... there's so much more!
 
 - **Onboarding**: Guided setup and configuration of **Podman** and **Compose**
-- **Podman 4.7.2**: [Podman 4.7.2](https://github.com/containers/podman/releases) is now included in Windows and Mac installers
+- **Podman 4.7.2**: [Podman 4.7.2](https://github.com/podman-container-tools/podman/releases) is now included in Windows and Mac installers
 - **Command Palette**: Gain easy access to various commands via a new keyboard-driven command palette
 - **Expanded "Summary" tab for Kubernetes pods**: Go deep with extended details on Kubernetes pods in the pod "Summary" tab
 - **Environment file support**: Chart out environment variables for new containers to access on creation

--- a/website/blog/2023-12-06-sharing-podman-images-with-kubernetes-cluster.md
+++ b/website/blog/2023-12-06-sharing-podman-images-with-kubernetes-cluster.md
@@ -46,7 +46,7 @@ In the kubernetes world, we need a container engine runtime. At the early stage,
 But to separate concerns and to be extensible, a new interface was added: CRI for "Container Runtime Interface". Using the CRI interface we can plug container engines. And there are several runtimes such as containerd, cri-o and others.
 [https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md)
 
-What is interesting to us is the cri-o project. This project is implementing the CRI interface but also adopting some projects of the [containers](https://github.com/containers) organization where [podman](https://github.com/containers/podman) and [podman-desktop](https://github.com/containers/podman-desktop) live.
+What is interesting to us is the cri-o project. This project is implementing the CRI interface but also adopting some projects of the [containers](https://github.com/containers) organization where [podman](https://github.com/podman-container-tools/podman) and [podman-desktop](https://github.com/containers/podman-desktop) live.
 
 So it means cri-o uses image management from [https://github.com/containers/image](https://github.com/containers/image) project and handle storage with [https://github.com/containers/storage](https://github.com/containers/storage) project.
 

--- a/website/blog/2023-12-18-release-1.6.md
+++ b/website/blog/2023-12-18-release-1.6.md
@@ -17,7 +17,7 @@ Podman Desktop 1.6 Release! 🎉
 This release introduces:
 
 - **Minikube Featured Extension**: Minikube extension to create local Kubernetes clusters in containers.
-- **Podman 4.8.2**: [Podman 4.8.2](https://github.com/containers/podman/releases) is now included in Windows and Mac installers.
+- **Podman 4.8.2**: [Podman 4.8.2](https://github.com/podman-container-tools/podman/releases) is now included in Windows and Mac installers.
 - **Setting Page for Command-Line Tools**: Manage and update your CLI tools.
 - **Kubernetes Contexts Manager**: Browse all your kubernetes contexts, set default and remove unused ones.
 - **Editable Podman Machine for MacOS**: Easy resize and reconfiguration of the Podman runtime environment.

--- a/website/blog/2024-01-24-release-1.7.md
+++ b/website/blog/2024-01-24-release-1.7.md
@@ -16,7 +16,7 @@ Podman Desktop 1.7 Release! 🎉
 
 We've got a new release with a ton of seal appeal! This release introduces:
 
-- **Podman 4.9.0**: [Podman 4.9.0](https://github.com/containers/podman/releases) is now included in both Windows and Mac installers.
+- **Podman 4.9.0**: [Podman 4.9.0](https://github.com/podman-container-tools/podman/releases) is now included in both Windows and Mac installers.
 - **Extension API Improvements**: A big update to the extension API enabling more goodness for 🦭 Podman Desktop's extensions.
 - **Experimental Kubernetes UI**: Get a sneak peek at the more advanced UI for working with Kubernetes clusters.
 - **Enhanced Builds, Pods List, and Troubleshooting Pages**: Build for different platforms, an upgraded pods view, and more.
@@ -34,9 +34,9 @@ If you've been floundering we highly recommend updating!
 
 If you are on a Mac M3, we are aware of a critical issue in Podman and expect to update very
 soon to pick up this fix:
-[#21353 - Update to new QEMU](https://github.com/containers/podman/issues/21353) (based on
+[#21353 - Update to new QEMU](https://github.com/podman-container-tools/podman/issues/21353) (based on
 [#1990 - QEMU issue on M3](https://gitlab.com/qemu-project/qemu/-/issues/1990)). If you are
-hitting this problem there is a workaround [here](/docs/troubleshooting/troubleshooting-podman-on-macos#on-apple-silicon-the-podman-machine-does-not-start) and [there](https://github.com/containers/podman/issues/21088#issuecomment-1871502921).
+hitting this problem there is a workaround [here](/docs/troubleshooting/troubleshooting-podman-on-macos#on-apple-silicon-the-podman-machine-does-not-start) and [there](https://github.com/podman-container-tools/podman/issues/21088#issuecomment-1871502921).
 
 ### Extension API Improvements
 

--- a/website/blog/2024-01-29-run-webassembly-wasm-workloads-windows-and-macos.md
+++ b/website/blog/2024-01-29-run-webassembly-wasm-workloads-windows-and-macos.md
@@ -203,7 +203,7 @@ And the rust program `src/main.rs`:
    ~~~~~~~  ~| =(Y_)=-  |
   ~~~~    ~~~|   U      |~~
 
-Project:   https://github.com/containers/podman
+Project:   https://github.com/podman-container-tools/podman
 Website:   https://podman.io
 Documents: https://docs.podman.io
 Twitter:   @Podman_io
@@ -312,7 +312,7 @@ WARNING: image platform (wasi/wasm/v8) does not match the expected platform (lin
    ~~~~~~~  ~| =(Y_)=-  |
   ~~~~    ~~~|   U      |~~
 
-Project:   https://github.com/containers/podman
+Project:   https://github.com/podman-container-tools/podman
 Website:   https://podman.io
 Documents: https://docs.podman.io
 Twitter:   @Podman_io

--- a/website/blog/2024-03-07-release-1.8.md
+++ b/website/blog/2024-03-07-release-1.8.md
@@ -16,7 +16,7 @@ Podman Desktop 1.8 Release! 🎉
 
 We've got a new release with a ton of seal appeal! This release introduces:
 
-- **Podman 4.9.3**: [Podman 4.9.3](https://github.com/containers/podman/releases/tag/v4.9.3) is now included in both Windows and Mac installers.
+- **Podman 4.9.3**: [Podman 4.9.3](https://github.com/podman-container-tools/podman/releases/tag/v4.9.3) is now included in both Windows and Mac installers.
 - **Kubernetes Explorer**: Advanced UI and new tools for working with Kubernetes clusters.
 - **Global Onboarding**: Configure and set up your environment without any hassle, with a set of guided workflows.
 - **Learning Center**: Discover new use cases and capabilities for developers.

--- a/website/blog/2024-04-05-release-1.9.md
+++ b/website/blog/2024-04-05-release-1.9.md
@@ -16,8 +16,8 @@ Podman Desktop 1.9 Release! 🎉
 
 This release introduces: 🦭 a splash of innovation, a wave of excitement, and an ocean of possibilities!
 
-- **Podman 5!** [Podman 5.0.1](https://github.com/containers/podman/releases/tag/v5.0.1) for new users (and as an experimental upgrade for 4.x users).
-- **Podman 4.9.4**: [Podman 4.9.4](https://github.com/containers/podman/releases/tag/v4.9.4) is now included in both Windows and macOS installers.
+- **Podman 5!** [Podman 5.0.1](https://github.com/podman-container-tools/podman/releases/tag/v5.0.1) for new users (and as an experimental upgrade for 4.x users).
+- **Podman 4.9.4**: [Podman 4.9.4](https://github.com/podman-container-tools/podman/releases/tag/v4.9.4) is now included in both Windows and macOS installers.
 - **Backup/Restore Images**: Save images or containers to tar archives and restore them.
 - **Kubernetes Pods Terminal**: Connect to a terminal within Kubernetes pods.
 - **Extension API Improvements**: Additional updates to the extension API used by 🦭 Podman Desktop's extensions.

--- a/website/blog/2024-04-30-release-1.10.md
+++ b/website/blog/2024-04-30-release-1.10.md
@@ -18,7 +18,7 @@ This release introduces:
 
 - **1 Million Downloads!**: Wow, we made it!
 - **Extension Catalog**: Redesigned extensions page and catalog to get the most out of Podman Desktop.
-- **Podman 5**: [Podman 5.0.2](https://github.com/containers/podman/releases/tag/v5.0.2) now recommended for all users.
+- **Podman 5**: [Podman 5.0.2](https://github.com/podman-container-tools/podman/releases/tag/v5.0.2) now recommended for all users.
 - **Multi-platform Builds**: Build for multiple platforms at once.
 - **Extension API Improvements**: Additional updates to the extension API used by 🦭 Podman Desktop's extensions.
 

--- a/website/blog/2024-06-24-release-1.11.md
+++ b/website/blog/2024-06-24-release-1.11.md
@@ -38,7 +38,7 @@ We're excited to announce the arrival of our most-requested feature: light mode!
 
 ### macOS Rosetta Support for Apple Silicon
 
-Podman Desktop 1.11 proudly introduces support for macOS Rosetta, facilitating seamless integration with Apple Silicon. This update, part of Podman 5.1, allows users to enable or disable Rosetta support directly through the Podman Settings. With this enhancement, running AMD64 image builds or containers achieves speeds that are nearly identical to those experienced on ARM64 architectures. For more details on the implementation, visit the [GitHub podman pull request](https://github.com/containers/podman/pull/21670).
+Podman Desktop 1.11 proudly introduces support for macOS Rosetta, facilitating seamless integration with Apple Silicon. This update, part of Podman 5.1, allows users to enable or disable Rosetta support directly through the Podman Settings. With this enhancement, running AMD64 image builds or containers achieves speeds that are nearly identical to those experienced on ARM64 architectures. For more details on the implementation, visit the [GitHub podman pull request](https://github.com/podman-container-tools/podman/pull/21670).
 
 ### Kubernetes Enhancements
 

--- a/website/blog/2024-08-08-release-1.12.md
+++ b/website/blog/2024-08-08-release-1.12.md
@@ -21,7 +21,7 @@ This release includes:
 - **Podman remote**: We now support remote Podman setups! Manage your remote Podman machines all within the UI.
 - **macOS GPU support**: Container GPU access on macOS is now available. [`libkrun`](https://github.com/containers/libkrun) is now a selectable provider type to allow GPU passthrough enablement.
 - **Windows GPU support**: Want to try out Windows GPU support too? Podman already supports it, but we are now showcasing it in our [AI Lab extension](https://podman-desktop.io/extensions/ai-lab)
-- **Podman 5.2.0**: This new version of Podman provides GPU access for macOS, as well as a host of [new features](https://github.com/containers/podman/releases/tag/v5.2.0).
+- **Podman 5.2.0**: This new version of Podman provides GPU access for macOS, as well as a host of [new features](https://github.com/podman-container-tools/podman/releases/tag/v5.2.0).
 - **Light mode out of experimental**: Our light mode has been well-received, and we have now marked it as non-experimental! Enjoy the new theme.
 - **Kubernetes features**: ConfigMaps, Secrets and multi-file Kubernetes YAML applying have now been added to our Kubernetes dashboard.
 - **Improved font consistency**: You'll notice a big difference in consistency this release, as we updated all font sizes throughout Podman Desktop.
@@ -38,7 +38,7 @@ You can enable this in the **Preferences** section of Podman Desktop:
 
 ![remote](img/podman-desktop-release-1.12/remote.png)
 
-To set up access to a remote machine, follow the official [Podman remote-client tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/remote_client.md).
+To set up access to a remote machine, follow the official [Podman remote-client tutorial](https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/remote_client.md).
 
 ### macOS GPU support
 

--- a/website/blog/2025-03-05-release-1.17.md
+++ b/website/blog/2025-03-05-release-1.17.md
@@ -65,7 +65,7 @@ sources={{
 
 ### Podman 5.4
 
-A new version of Podman is here. Check out the full details: [Podman 5.4.0 Release Notes](https://github.com/containers/podman/releases/tag/v5.4.0).  
+A new version of Podman is here. Check out the full details: [Podman 5.4.0 Release Notes](https://github.com/podman-container-tools/podman/releases/tag/v5.4.0).  
 :::warning[Breaking change]
 
 As mentioned in the podman 5.4 release notes, support for Mac/Intel is now on a best-effort basis.  
@@ -73,7 +73,7 @@ As mentioned in the podman 5.4 release notes, support for Mac/Intel is now on a 
 
 :::note[Note for 2020 Mac/Intel Users]
 
-There is an open issue where Podman Machine is not booting on certain setups. It is currently under investigation, and you can track the progress here: [Issue #25121](https://github.com/containers/podman/issues/25121).
+There is an open issue where Podman Machine is not booting on certain setups. It is currently under investigation, and you can track the progress here: [Issue #25121](https://github.com/podman-container-tools/podman/issues/25121).
 
 In the meantime, here is a quick workaround if 5.4 is not booting:
 

--- a/website/blog/2025-05-22-release-1.19.md
+++ b/website/blog/2025-05-22-release-1.19.md
@@ -33,7 +33,7 @@ This release brings exciting new features and improvements, including many exten
 Podman Desktop aims to work offline, so it ships alongside its binary, the Podman executable.
 In this release, the latest Podman 5.5 version provides new features, bug fixes, and better stability while using the tool.
 
-You can find the full changelog of Podman 5.5 on their release page [containers/podman/releases#v5.5.0](https://github.com/containers/podman/releases/tag/v5.5.0).
+You can find the full changelog of Podman 5.5 on their release page [podman-container-tools/podman/releases#v5.5.0](https://github.com/podman-container-tools/podman/releases/tag/v5.5.0).
 
 :::info
 

--- a/website/blog/2025-11-19-release-1.23.md
+++ b/website/blog/2025-11-19-release-1.23.md
@@ -114,7 +114,7 @@ sources={{
 
 Updated the Podman engine to version 5.7.0. This update fixes one critical bug [CVE-2025-52881](https://github.com/advisories/GHSA-cgrx-mc8f-2prm) as well as adding multiple features and bug fixes. Such as adding enhanced security support for the remote Podman client and `podman system service` API server, which now supports encrypting connections with TLS and mTLS, including client authentication by certificate; the `podman system connection add` command has been updated to use this capability when creating connections to TCP sockets.
 
-Check out the [Podman 5.7](https://github.com/containers/podman/releases/tag/v5.7.0) release.
+Check out the [Podman 5.7](https://github.com/podman-container-tools/podman/releases/tag/v5.7.0) release.
 
 ### Support for a managed configuration
 

--- a/website/docs/lima/customizing.md
+++ b/website/docs/lima/customizing.md
@@ -106,7 +106,7 @@ mountType: null
 
 You can install a container engine, in addition to the existing runtime.
 
-For instance you can install [Podman Engine](https://github.com/containers/podman),
+For instance you can install [Podman Engine](https://github.com/podman-container-tools/podman),
 or you can install [Docker Engine](https://github.com/docker/docker).
 After that you can port forward the socket, to the host `Dir`.
 

--- a/website/docs/migrating-from-docker/customizing-docker-compatibility.md
+++ b/website/docs/migrating-from-docker/customizing-docker-compatibility.md
@@ -216,4 +216,4 @@ Perform any of the following steps:
 #### Additional resources
 
 - [Managing Docker compatibility](/docs/migrating-from-docker/managing-docker-compatibility)
-- [`podman-mac-helper` source](https://github.com/containers/podman/tree/main/cmd/podman-mac-helper)
+- [`podman-mac-helper` source](https://github.com/podman-container-tools/podman/tree/main/cmd/podman-mac-helper)

--- a/website/docs/podman/accessing-podman-from-another-wsl-instance.md
+++ b/website/docs/podman/accessing-podman-from-another-wsl-instance.md
@@ -38,12 +38,12 @@ In foldable details, you can find alternative steps for least common contexts:
 
    With `podman-remote` you also enable the remote mode by default.
 
-   Check for the latest release which includes the `podman-remote` binary from the [Podman releases page](https://github.com/containers/podman/releases/latest).
+   Check for the latest release which includes the `podman-remote` binary from the [Podman releases page](https://github.com/podman-container-tools/podman/releases/latest).
 
    Download and unpack the binary:
 
    ```shell-session
-   $ wget https://github.com/containers/podman/releases/download/v4.9.1/podman-remote-static-linux_amd64.tar.gz
+   $ wget https://github.com/podman-container-tools/podman/releases/download/v4.9.1/podman-remote-static-linux_amd64.tar.gz
    $ sudo tar -C /usr/local -xzf podman-remote-static-linux_amd64.tar.gz
    ```
 

--- a/website/docs/podman/creating-a-podman-machine.md
+++ b/website/docs/podman/creating-a-podman-machine.md
@@ -25,7 +25,7 @@ Consider creating a custom Podman machine to:
 
   :::note
 
-  On the macOS ARM64 platform, you might get a warning that the `krunkit` binary is unavailable on the _Create Podman machine_ page. To resolve the warning, [install `krunkit` manually](https://github.com/containers/krunkit?tab=readme-ov-file#installation) or [install Podman using the GitHub installer](https://github.com/containers/podman/releases).
+  On the macOS ARM64 platform, you might get a warning that the `krunkit` binary is unavailable on the _Create Podman machine_ page. To resolve the warning, [install `krunkit` manually](https://github.com/containers/krunkit?tab=readme-ov-file#installation) or [install Podman using the GitHub installer](https://github.com/podman-container-tools/podman/releases).
 
   :::
 
@@ -44,7 +44,7 @@ Consider creating a custom Podman machine to:
       Select the disk size.
    1. Optional: Provide a bootable image using one of the following options:
       - **Image Path**: Select an image, such as `podman-machine.aarch64.applehv.raw.zst` from your local machine.
-      - **Image URL or image reference**: Enter an image URL or a registry path. You can use an image URL from the [Podman releases page](https://github.com/containers/podman/releases) or use a valid registry path in the format `registry/repo/image:version`.
+      - **Image URL or image reference**: Enter an image URL or a registry path. You can use an image URL from the [Podman releases page](https://github.com/podman-container-tools/podman/releases) or use a valid registry path in the format `registry/repo/image:version`.
    1. **Machine with root privileges**:
       Enable to use the rootful connection by default.
       Required to use Kind on Windows.

--- a/website/docs/podman/podman-remote.md
+++ b/website/docs/podman/podman-remote.md
@@ -31,7 +31,7 @@ Podman Desktop will automatically detect and show any `podman system connection 
 
 ![Enable the remote setting](img/remote.png)
 
-If you have not added a remote podman connection yet, you can follow the [official Podman guide](https://github.com/containers/podman/blob/main/docs/tutorials/remote_client.md) or follow the steps below:
+If you have not added a remote podman connection yet, you can follow the [official Podman guide](https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/remote_client.md) or follow the steps below:
 
 1. Generate a local ed25519 key:
 
@@ -147,4 +147,4 @@ You can also use the `--connection` argument to target only the connection you w
 
 #### Additional resources
 
-- [podman:docs/tutorials/remote_client.md](https://github.com/containers/podman/blob/main/docs/tutorials/remote_client.md)
+- [podman:docs/tutorials/remote_client.md](https://github.com/podman-container-tools/podman/blob/main/docs/tutorials/remote_client.md)

--- a/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
@@ -19,7 +19,7 @@ Error: unable to start host networking: "could not find \"gvproxy\" in one of [/
 #### Solution
 
 1. Download `gvproxy` from the [gvisor-tap-vsock release page](https://github.com/containers/gvisor-tap-vsock/releases).
-2. Build the `podman-mac-helper` from the source code on the [Podman GitHub page](https://github.com/containers/podman/tree/main/cmd/podman-mac-helper).
+2. Build the `podman-mac-helper` from the source code on the [Podman GitHub page](https://github.com/podman-container-tools/podman/tree/main/cmd/podman-mac-helper).
 3. Add the `helpers_binaries_dir` entry to `~/.config/containers/containers.conf`:
 
 ```sh
@@ -28,7 +28,7 @@ Error: unable to start host networking: "could not find \"gvproxy\" in one of [/
 helper_binaries_dir=["/Users/user/example_directory"]
 ```
 
-**NOTE**: A pre-built binary will be added to the Podman release page so you do not have to build `podman-mac-helper`. An [issue is open for this](https://github.com/containers/podman/issues/16746).
+**NOTE**: A pre-built binary will be added to the Podman release page so you do not have to build `podman-mac-helper`. An [issue is open for this](https://github.com/podman-container-tools/podman/issues/16746).
 
 ## Unable to locate Podman Engine
 
@@ -161,7 +161,7 @@ Keep your brew-based installation and apply one of these workarounds:
 #### Additional resources
 
 - [Homebrew issue #140244](https://github.com/Homebrew/homebrew-core/issues/140244).
-- [Podman issue #19708](https://github.com/containers/podman/issues/19708).
+- [Podman issue #19708](https://github.com/podman-container-tools/podman/issues/19708).
 
 ## On Apple silicon, the Podman Machine does not start
 
@@ -241,7 +241,7 @@ For M3 processors:
 
 #### Additional resources
 
-- [Issue #20776](https://github.com/containers/podman/issues/20776)
+- [Issue #20776](https://github.com/podman-container-tools/podman/issues/20776)
 
 ## `podman machine` CLI commands do not work with `libkrun` provider type without manual configuration
 


### PR DESCRIPTION
### What does this PR do?
Updates Podman extension references from `containers/podman` to `podman-container-tools/podman` for release-note links, download API defaults, and related tests/comments.

### Screenshot / video of UI

N/A (no UI changes)

### What issues does this PR fix or reference?
- containers/podman-desktop-internal#983

### How to test this PR?
- Run:
  - `npx vitest run \"src/installer/podman-install.spec.ts\" \"scripts/podman-download.spec.ts\"`
- Verify both specs pass.

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)