### PR TITLE
fix(renderer): align text in PreferencesCliTool.svelte

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -238,7 +238,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
         {#if cliTool.version}
           <div
             class="flex flex-row justify-between align-center bg-[var(--pd-invert-content-bg)] p-2 rounded-lg min-w-[320px] w-fit">
-            <Tooltip aria-label="cli-full-path" bottomRight={true} tip="Path: {cliTool.path}">
+            <Tooltip containerClass="relative inline-block my-auto" aria-label="cli-full-path" bottomRight={true} tip="Path: {cliTool.path}">
               <div
                 class="flex text-[var(--pd-invert-content-card-text)] font-bold text-sm items-center"
                 aria-label="cli-version">


### PR DESCRIPTION
### What does this PR do?
Under `settings > CLI tools`, If a tool has updates available it shows current version and update available button, but the name and version text is not aligned in vertical center.
[PreferencesCliTool.svelte](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte#L241) : uses tooltip for provider name and version, 
the container(div) of tooltip is inline-block so the text stucks at top, 
I used the containerClass provided by the tooltip component to add `margin-y = auto`.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->
Before:

<img width="1372" height="995" alt="image" src="https://github.com/user-attachments/assets/73cbc262-386b-4171-8b09-7b6beeec0aeb" />

After:

<img width="1920" height="1140" alt="ui-fix" src="https://github.com/user-attachments/assets/cf989649-e579-4ffa-b1fc-84132c1dbf79" />


### What issues does this PR fix or reference?
fixes #17831 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
