### PR TITLE
feat(renderer): add webview in-page navigation history tracking

### DIFF
--- a/packages/renderer/src/lib/webview/Webview.spec.ts
+++ b/packages/renderer/src/lib/webview/Webview.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,20 @@ import '@testing-library/jest-dom/vitest';
 import type { WebviewInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import {
+  consumePendingWebviewSubRoute,
+  extractSubPath,
+  pushWebviewSubRoute,
+  replaceWebviewSubRoute,
+  titleFromSubPath,
+} from '/@/stores/navigation-history.svelte';
 import { webviews } from '/@/stores/webviews';
 
 import Webview from './Webview.svelte';
+
+vi.mock(import('/@/stores/navigation-history.svelte'));
 
 const makeDefaultWebviewVisibleMock = vi.fn();
 const getWebviewPreloadPathMock = vi.fn();
@@ -73,11 +82,15 @@ beforeEach(() => {
     }),
   };
 
-  // provide preload path
   getWebviewPreloadPathMock.mockResolvedValue('/path/to/preload');
-
-  // provide registry port
   getWebviewRegistryHttpPortMock.mockResolvedValue(5678);
+
+  vi.mocked(consumePendingWebviewSubRoute).mockReturnValue(undefined);
+  vi.mocked(extractSubPath).mockImplementation(url => url.split('#')[1] ?? '');
+  vi.mocked(titleFromSubPath).mockImplementation(path => {
+    const last = path.split('/').filter(Boolean).pop();
+    return last ? last.charAt(0).toUpperCase() + last.slice(1) : 'Home';
+  });
 
   webviews.set(webviewTestList);
 });
@@ -165,4 +178,110 @@ test('check open devtools', async () => {
 
   //  check if send method has been called
   expect(openDevtoolsMock).toHaveBeenCalled();
+});
+
+describe('did-navigate-in-page integration', () => {
+  test('should register did-navigate-in-page listener when webview element appears', async () => {
+    await waitRender({ id: webviewTestList[0].id });
+
+    const webview = screen.getByRole('document', { name: 'Webview Podman Desktop1' });
+
+    const navEvent = Object.assign(new Event('did-navigate-in-page'), {
+      url: 'http://uuid1.webview.localhost:5678/#/home',
+      isMainFrame: true,
+    });
+    webview.dispatchEvent(navEvent);
+
+    expect(replaceWebviewSubRoute).toHaveBeenCalled();
+  });
+
+  test('should call pushWebviewSubRoute on did-navigate-in-page after initial recording', async () => {
+    await waitRender({ id: webviewTestList[0].id });
+
+    const webview = screen.getByRole('document', { name: 'Webview Podman Desktop1' });
+    webview.dispatchEvent(new Event('dom-ready'));
+
+    const navEvent1 = Object.assign(new Event('did-navigate-in-page'), {
+      url: 'http://uuid1.webview.localhost:5678/#/home',
+      isMainFrame: true,
+    });
+    webview.dispatchEvent(navEvent1);
+
+    expect(replaceWebviewSubRoute).toHaveBeenCalledWith(
+      'webviewId1',
+      '/home',
+      'Home',
+      'Podman Desktop1',
+      'http://uuid1.webview.localhost:5678/#/home',
+    );
+
+    const navEvent2 = Object.assign(new Event('did-navigate-in-page'), {
+      url: 'http://uuid1.webview.localhost:5678/#/services',
+      isMainFrame: true,
+    });
+    webview.dispatchEvent(navEvent2);
+
+    expect(pushWebviewSubRoute).toHaveBeenCalledWith(
+      'webviewId1',
+      '/services',
+      'Services',
+      'Podman Desktop1',
+      'http://uuid1.webview.localhost:5678/#/services',
+    );
+  });
+
+  test('should use page-title-updated title for history entries', async () => {
+    await waitRender({ id: webviewTestList[0].id });
+
+    const webview = screen.getByRole('document', { name: 'Webview Podman Desktop1' });
+    webview.dispatchEvent(new Event('dom-ready'));
+
+    const initialNav = Object.assign(new Event('did-navigate-in-page'), {
+      url: 'http://uuid1.webview.localhost:5678/#/home',
+      isMainFrame: true,
+    });
+    webview.dispatchEvent(initialNav);
+
+    expect(replaceWebviewSubRoute).toHaveBeenCalled();
+    vi.mocked(replaceWebviewSubRoute).mockClear();
+    vi.mocked(pushWebviewSubRoute).mockClear();
+
+    const titleEvent = Object.assign(new Event('page-title-updated'), {
+      title: 'My Custom Page',
+    });
+    webview.dispatchEvent(titleEvent);
+
+    const navEvent = Object.assign(new Event('did-navigate-in-page'), {
+      url: 'http://uuid1.webview.localhost:5678/#/custom-page',
+      isMainFrame: true,
+    });
+    webview.dispatchEvent(navEvent);
+
+    expect(pushWebviewSubRoute).toHaveBeenCalledWith(
+      'webviewId1',
+      '/custom-page',
+      'My Custom Page',
+      'Podman Desktop1',
+      'http://uuid1.webview.localhost:5678/#/custom-page',
+    );
+  });
+
+  test('should ignore did-navigate-in-page for non-main frame', async () => {
+    await waitRender({ id: webviewTestList[0].id });
+
+    const webview = screen.getByRole('document', { name: 'Webview Podman Desktop1' });
+    webview.dispatchEvent(new Event('dom-ready'));
+
+    vi.mocked(pushWebviewSubRoute).mockClear();
+    vi.mocked(replaceWebviewSubRoute).mockClear();
+
+    const navEvent = Object.assign(new Event('did-navigate-in-page'), {
+      url: 'http://uuid1.webview.localhost:5678/#/services',
+      isMainFrame: false,
+    });
+    webview.dispatchEvent(navEvent);
+
+    expect(pushWebviewSubRoute).not.toHaveBeenCalled();
+    expect(replaceWebviewSubRoute).not.toHaveBeenCalled();
+  });
 });

--- a/packages/renderer/src/lib/webview/Webview.svelte
+++ b/packages/renderer/src/lib/webview/Webview.svelte
@@ -3,6 +3,14 @@ import type { WebviewInfo } from '@podman-desktop/core-api';
 import { onDestroy } from 'svelte';
 
 import Route from '/@/Route.svelte';
+import {
+  consumePendingWebviewSubRoute,
+  extractSubPath,
+  pushWebviewSubRoute,
+  replaceWebviewSubRoute,
+  titleFromSubPath,
+  updateCurrentWebviewSubRouteUrl,
+} from '/@/stores/navigation-history.svelte';
 import { webviews } from '/@/stores/webviews';
 
 import { webviewLifecycle } from './webview-directive';
@@ -12,6 +20,11 @@ interface Props {
   id: string;
 }
 let { id }: Props = $props();
+
+interface WebviewElement extends HTMLElement {
+  getURL?: () => string;
+  loadURL?: (url: string) => Promise<void>;
+}
 
 // script to load for the webview
 let preloadPath = $derived(await window.getWebviewPreloadPath());
@@ -28,13 +41,159 @@ let webviewInfo: WebviewInfo | undefined = $derived($webviews.find(webview => we
 // reactive options for webview lifecycle directive - updates when webviewInfo changes
 let lifecycleOptions = $derived({ webviewInfo });
 
+// navigation history tracking state
+let latestPageTitle: string | undefined;
+let isNavigatingWebviewHistory = false;
+let initialUrlRecorded = false;
+let lastRecordedSubPath: string | undefined;
+let previousWebviewId: string | undefined;
+// Timestamp of the last history navigation. During a brief cooldown after
+// a history nav, any webview-initiated navigation uses replaceWebviewSubRoute
+// instead of pushWebviewSubRoute to avoid creating spurious entries when the
+// webview's internal router redirects after loading.
+let lastHistoryNavTime = 0;
+const HISTORY_NAV_COOLDOWN_MS = 1000;
+
 $effect(() => {
+  if (id !== previousWebviewId) {
+    previousWebviewId = id;
+    latestPageTitle = undefined;
+    isNavigatingWebviewHistory = false;
+    initialUrlRecorded = false;
+    lastRecordedSubPath = undefined;
+  }
   if (webviewInfo) {
     window
       .makeDefaultWebviewVisible(webviewInfo.id)
       .catch((err: unknown) => console.error(`Error make default webview visible ${webviewInfo?.id}`, err));
   }
 });
+
+// handle in-page navigation events from the webview to track history
+function handleDidNavigateInPage(event: Event): void {
+  const e = event as Event & { url?: string; isMainFrame?: boolean };
+
+  if (e.isMainFrame === false) return;
+
+  if (isNavigatingWebviewHistory) {
+    lastHistoryNavTime = Date.now();
+    if (e.url) {
+      lastRecordedSubPath = extractSubPath(e.url);
+    }
+    isNavigatingWebviewHistory = false;
+    return;
+  }
+
+  if (!webviewInfo || !e.url) return;
+
+  const subPath = extractSubPath(e.url);
+
+  if (subPath === lastRecordedSubPath) {
+    updateCurrentWebviewSubRouteUrl(id, e.url);
+    return;
+  }
+
+  const title = latestPageTitle ?? titleFromSubPath(subPath);
+  lastRecordedSubPath = subPath;
+
+  // After a history navigation (back/forward), the webview's internal router
+  // may redirect to a different page (e.g. path-based webviews that can't
+  // restore a sub-route from URL alone). Suppress all tracking during the
+  // cooldown so those redirects don't overwrite the history entry.
+  if (Date.now() - lastHistoryNavTime < HISTORY_NAV_COOLDOWN_MS) {
+    return;
+  }
+
+  if (!initialUrlRecorded) {
+    initialUrlRecorded = true;
+    replaceWebviewSubRoute(id, subPath, title, webviewInfo.name, e.url);
+  } else {
+    pushWebviewSubRoute(id, subPath, title, webviewInfo.name, e.url);
+  }
+
+  latestPageTitle = undefined;
+}
+
+// Handle full page navigations (path-based webviews like Hummingbird).
+// For hash-based webviews, loadURL triggers did-navigate-in-page directly,
+// but for path-based webviews it triggers did-navigate instead.
+// This handler clears the history navigation flag and records the sub-path
+// so subsequent did-navigate-in-page events from the webview's internal
+// router don't create spurious history entries.
+function handleDidNavigate(event: Event): void {
+  const e = event as Event & { url?: string };
+  if (!isNavigatingWebviewHistory) return;
+  lastHistoryNavTime = Date.now();
+  if (e.url) {
+    lastRecordedSubPath = extractSubPath(e.url);
+  }
+  isNavigatingWebviewHistory = false;
+}
+
+function handlePageTitleUpdated(event: Event): void {
+  const e = event as Event & { title?: string };
+  if (e.title) {
+    latestPageTitle = e.title;
+  }
+}
+
+// navigate the webview to a specific sub-route using loadURL
+function navigateWebview(path: string, storedUrl?: string): void {
+  const wv = webviewElement as WebviewElement;
+  if (!wv?.getURL || !wv.loadURL) {
+    isNavigatingWebviewHistory = false;
+    return;
+  }
+  const currentUrl = wv.getURL();
+  let targetUrl: string;
+  if (storedUrl) {
+    try {
+      const parsed = new URL(storedUrl);
+      if (!parsed.searchParams.has('webviewId')) {
+        parsed.searchParams.set('webviewId', id);
+      }
+      targetUrl = parsed.toString();
+    } catch {
+      targetUrl = storedUrl;
+    }
+  } else {
+    // Strip both hash fragments and query parameters (e.g. ?wvpath=) from
+    // the webview's current URL before appending the target sub-path.
+    // This works in both hash-mode and path-mode routing.
+    const hashIdx = currentUrl.indexOf('#');
+    const urlWithoutHash = hashIdx >= 0 ? currentUrl.substring(0, hashIdx) : currentUrl;
+    const qIdx = urlWithoutHash.indexOf('?');
+    const base = qIdx >= 0 ? urlWithoutHash.substring(0, qIdx) : urlWithoutHash;
+    targetUrl = `${base}#${path.replace(/^#/, '')}`;
+  }
+  if (targetUrl === currentUrl) {
+    isNavigatingWebviewHistory = false;
+    return;
+  }
+  wv.loadURL(targetUrl).catch((err: unknown) => {
+    console.error('Error loading webview URL', err);
+    isNavigatingWebviewHistory = false;
+  });
+}
+
+// handle sub-route navigation requests from the navigation history store
+function handleSubrouteNavigation(event: Event): void {
+  const { webviewId, path, webviewUrl } = (
+    event as CustomEvent<{ webviewId: string; path: string; webviewUrl?: string }>
+  ).detail;
+  const wv = webviewElement as WebviewElement;
+  if (webviewId !== id || !wv?.getURL) {
+    return;
+  }
+
+  const currentSubPath = extractSubPath(wv.getURL());
+  if (path === currentSubPath) {
+    return;
+  }
+
+  isNavigatingWebviewHistory = true;
+  navigateWebview(path, webviewUrl);
+}
 
 // function to notify webview when messages are coming
 const postMessageToWebview = (webviewEvent: unknown): void => {
@@ -65,10 +224,11 @@ const updateHtmlOfWebview = (webviewEvent: unknown): void => {
 };
 
 const webviewUpdateHtmlDisposable = window.events?.receive('webview-update:html', updateHtmlOfWebview);
+window.addEventListener('webview-navigate-to-subroute', handleSubrouteNavigation);
 
-const openDevtoolsDisposable = window.events?.receive('dev-tools:open-webview', (id: unknown) => {
+const openDevtoolsDisposable = window.events?.receive('dev-tools:open-webview', (devToolsId: unknown) => {
   if (
-    id === webviewInfo?.id &&
+    devToolsId === webviewInfo?.id &&
     webviewElement &&
     'openDevTools' in webviewElement &&
     typeof webviewElement.openDevTools === 'function'
@@ -77,15 +237,43 @@ const openDevtoolsDisposable = window.events?.receive('dev-tools:open-webview', 
   }
 });
 
+// register webview-specific event listeners on the webview element
+function navigationListeners(node: HTMLElement): { destroy: () => void } {
+  node.addEventListener('did-navigate-in-page', handleDidNavigateInPage);
+  node.addEventListener('did-navigate', handleDidNavigate);
+  node.addEventListener('page-title-updated', handlePageTitleUpdated);
+  node.addEventListener('dom-ready', handleWebviewDomReady);
+  return {
+    destroy(): void {
+      node.removeEventListener('did-navigate-in-page', handleDidNavigateInPage);
+      node.removeEventListener('did-navigate', handleDidNavigate);
+      node.removeEventListener('page-title-updated', handlePageTitleUpdated);
+      node.removeEventListener('dom-ready', handleWebviewDomReady);
+    },
+  };
+}
+
+// consume pending sub-route after webview loads (for cross-page back/forward navigation)
+function handleWebviewDomReady(): void {
+  if (!webviewElement) return;
+
+  const pending = consumePendingWebviewSubRoute(id);
+  if (pending && (pending.webviewUrl || pending.path !== '/')) {
+    isNavigatingWebviewHistory = true;
+    navigateWebview(pending.path, pending.webviewUrl);
+  }
+}
+
 onDestroy(() => {
   webviewPostMessageDisposable.dispose();
   webviewUpdateHtmlDisposable.dispose();
   openDevtoolsDisposable.dispose();
+  window.removeEventListener('webview-navigate-to-subroute', handleSubrouteNavigation);
 
   // no webviews are visible anymore
   window
     .makeDefaultWebviewVisible('')
-    .catch((err: unknown) => console.error('Error make default webviews visible', err));
+    .catch((err: unknown) => console.error('Error making default webviews visible', err));
 });
 </script>
 
@@ -94,6 +282,7 @@ onDestroy(() => {
     <webview
       bind:this={webviewElement}
       use:webviewLifecycle={lifecycleOptions}
+      use:navigationListeners
       aria-label="Webview {webviewInfo?.name}"
       role="document"
       httpreferrer="http://{webviewInfo?.uuid}.webview.localhost:{webViewPort}"

--- a/packages/renderer/src/stores/navigation-history.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.spec.ts
@@ -16,28 +16,23 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { writable } from 'svelte/store';
-import { router, type TinroRoute } from 'tinro';
-import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
-import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
+import { type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
 import {
+  consumePendingWebviewSubRoute,
   getBackEntries,
   getForwardEntries,
+  getWebviewSubRouteMetadata,
   goBack,
   goForward,
   goToHistoryIndex,
   navigationHistory,
+  parseWebviewSubRoute,
+  pushWebviewSubRoute,
+  replaceWebviewSubRoute,
 } from '/@/stores/navigation-history.svelte';
 
-let routerSubscribeCallback = vi.hoisted(() => {
-  return vi.fn() as unknown as (navigation: TinroRoute) => void;
-});
-
-vi.mock(import('tinro'));
-
-vi.mock(import('/@/stores/kubernetes-no-current-context'));
 vi.mock(import('/@/stores/navigation/navigation-registry'));
 
 vi.mock(import('/@/PreferencesNavigation'), () => ({
@@ -93,187 +88,93 @@ vi.mock(import('/@/stores/navigation/navigation-registry'), async () => {
   };
 });
 
-beforeAll(() => {
-  expect(router.subscribe).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
-  routerSubscribeCallback = vi.mocked(router.subscribe).mock.calls[0][0];
-});
-
 beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
-  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(true);
 
-  vi.mocked(navigationRegistry).set([
-    { type: 'root', link: '/', title: 'Dashboard' } as unknown as NavigationRegistryEntry,
-    { type: 'submenu', link: '/kubernetes', title: 'Kubernetes' } as unknown as NavigationRegistryEntry,
-    {
-      title: 'Kubernetes Dashboard',
-      link: '/kubernetes/dashboard',
-      type: 'entry',
-    } as unknown as NavigationRegistryEntry,
-  ]);
-
-  // Reset navigation history state
   navigationHistory.stack = [];
   navigationHistory.index = -1;
 });
 
 describe('goBack', () => {
-  beforeEach(() => {
-    vi.spyOn(router, 'goto').mockReturnValue(undefined);
-  });
+  test('should navigate back and track telemetry', () => {
+    navigationHistory.stack = ['/', '/containers', '/images'];
+    navigationHistory.index = 2;
 
-  test('should not navigate when history is empty', () => {
     goBack();
 
-    expect(router.goto).not.toHaveBeenCalled();
-    expect(window.telemetryTrack).not.toHaveBeenCalled();
+    expect(navigationHistory.index).toBe(1);
+    expect(window.telemetryTrack).toHaveBeenCalledWith('navigation.back');
   });
 
-  test('should not navigate when at first entry', () => {
-    navigationHistory.stack = ['/containers'];
+  test('should not navigate when at start of history', () => {
+    navigationHistory.stack = ['/'];
     navigationHistory.index = 0;
 
     goBack();
 
-    expect(router.goto).not.toHaveBeenCalled();
-    expect(window.telemetryTrack).not.toHaveBeenCalled();
-  });
-
-  test('should navigate to previous entry', () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 1;
-
-    goBack();
-
     expect(navigationHistory.index).toBe(0);
-    expect(router.goto).toHaveBeenCalledWith('/containers');
-    expect(window.telemetryTrack).toHaveBeenCalledWith('navigation.back');
+    expect(window.telemetryTrack).not.toHaveBeenCalled();
   });
 });
 
 describe('goForward', () => {
-  beforeEach(() => {
-    vi.spyOn(router, 'goto').mockReturnValue(undefined);
-  });
-
-  test('should not navigate when history is empty', () => {
-    goForward();
-
-    expect(router.goto).not.toHaveBeenCalled();
-    expect(window.telemetryTrack).not.toHaveBeenCalled();
-  });
-
-  test('should not navigate when at last entry', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
-
-    goForward();
-
-    expect(router.goto).not.toHaveBeenCalled();
-    expect(window.telemetryTrack).not.toHaveBeenCalled();
-  });
-
-  test('should navigate to next entry', () => {
-    navigationHistory.stack = ['/containers', '/images'];
+  test('should navigate forward and track telemetry', () => {
+    navigationHistory.stack = ['/', '/containers', '/images'];
     navigationHistory.index = 0;
 
     goForward();
 
     expect(navigationHistory.index).toBe(1);
-    expect(router.goto).toHaveBeenCalledWith('/images');
     expect(window.telemetryTrack).toHaveBeenCalledWith('navigation.forward');
   });
-});
 
-describe('kubernetes dashboard submenu', () => {
-  test('/kubernetes submenu base route should NOT be added to history stack when kubernetes context exists', () => {
-    // When cluster exists (kubernetesNoCurrentContext = false)
-    // /kubernetes route should be skipped because it redirects to /kubernetes/dashboard
-    vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
+  test('should not navigate when at end of history', () => {
+    navigationHistory.stack = ['/', '/containers'];
+    navigationHistory.index = 1;
 
-    routerSubscribeCallback({ url: '/' } as TinroRoute);
-    routerSubscribeCallback({ url: '/kubernetes' } as TinroRoute);
-    // Simulate redirect to /kubernetes/dashboard
-    routerSubscribeCallback({ url: '/kubernetes/dashboard' } as TinroRoute);
+    goForward();
 
-    // Stack should contain / and /kubernetes/dashboard, but NOT /kubernetes
-    expect(navigationHistory.stack).toEqual(['/', '/kubernetes/dashboard']);
     expect(navigationHistory.index).toBe(1);
-  });
-
-  test('/kubernetes submenu base route SHOULD be added to history stack when kubernetes context does NOT exist', () => {
-    // When no cluster exists (kubernetesNoCurrentContext = true)
-    // /kubernetes route should be added because user stays on the empty page
-    vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(true);
-
-    routerSubscribeCallback({ url: '/' } as TinroRoute);
-    routerSubscribeCallback({ url: '/kubernetes' } as TinroRoute);
-
-    // Stack should contain both / and /kubernetes
-    expect(navigationHistory.stack).toEqual(['/', '/kubernetes']);
-    expect(navigationHistory.index).toBe(1);
-  });
-});
-
-describe('router navigation events', () => {
-  test('should not store index.html in the history stack', () => {
-    // Simulate navigation: /index.html -> / when starting the app in production mode
-    // The /index.html route should not be stored in the navigation history
-    routerSubscribeCallback({ url: '/index.html' } as TinroRoute);
-    routerSubscribeCallback({ url: '/' } as TinroRoute);
-
-    expect(navigationHistory.stack).not.toContain('/index.html');
-    expect(navigationHistory.stack).toContain('/');
-    expect(navigationHistory.index).toBe(0);
+    expect(window.telemetryTrack).not.toHaveBeenCalled();
   });
 });
 
 describe('goToHistoryIndex', () => {
-  beforeEach(() => {
-    vi.spyOn(router, 'goto').mockReturnValue(undefined);
-  });
-
-  test('should not navigate to invalid negative index', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
-    goToHistoryIndex(-1);
-
-    expect(router.goto).not.toHaveBeenCalled();
-  });
-
-  test('should not navigate to index beyond stack', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
-
-    goToHistoryIndex(5);
-
-    expect(router.goto).not.toHaveBeenCalled();
-  });
-
-  test('should not navigate to current index', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
-
-    goToHistoryIndex(0);
-
-    expect(router.goto).not.toHaveBeenCalled();
-  });
-
-  test('should navigate to valid index', () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
+  test('should navigate to the given index', () => {
+    navigationHistory.stack = ['/', '/containers', '/images'];
     navigationHistory.index = 2;
 
     goToHistoryIndex(0);
 
     expect(navigationHistory.index).toBe(0);
-    expect(router.goto).toHaveBeenCalledWith('/containers');
+  });
+
+  test('should not navigate to invalid index', () => {
+    navigationHistory.stack = ['/', '/containers'];
+    navigationHistory.index = 1;
+
+    goToHistoryIndex(5);
+
+    expect(navigationHistory.index).toBe(1);
+  });
+
+  test('should not navigate to current index', () => {
+    navigationHistory.stack = ['/', '/containers'];
+    navigationHistory.index = 1;
+
+    goToHistoryIndex(1);
+
+    expect(navigationHistory.index).toBe(1);
   });
 });
 
 describe('getBackEntries', () => {
   test('should return empty array when no history', () => {
+    navigationHistory.stack = [];
+    navigationHistory.index = -1;
+
     const entries = getBackEntries();
     expect(entries).toEqual([]);
   });
@@ -297,10 +198,24 @@ describe('getBackEntries', () => {
       { index: 0, name: 'Containers', icon: {} },
     ]);
   });
+
+  test('should include all previous entries without filtering', () => {
+    navigationHistory.stack = ['/', '/kubernetes/pods', '/containers'];
+    navigationHistory.index = 2;
+
+    const entries = getBackEntries();
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].name).toBe('Kubernetes > Pods');
+    expect(entries[1].name).toBe('Dashboard');
+  });
 });
 
 describe('getForwardEntries', () => {
   test('should return empty array when no history', () => {
+    navigationHistory.stack = [];
+    navigationHistory.index = -1;
+
     const entries = getForwardEntries();
     expect(entries).toEqual([]);
   });
@@ -326,28 +241,22 @@ describe('getForwardEntries', () => {
   });
 });
 
-describe('submenu navigation', () => {
+describe('submenu navigation display names', () => {
   test('should show submenu parent > resource type breadcrumb', () => {
-    // Simulate navigation: Dashboard -> Kubernetes Pods list -> Specific pod
     navigationHistory.stack = ['/', '/kubernetes/pods', '/kubernetes/pods/nginx-pod/default/summary'];
     navigationHistory.index = 2;
 
     const backEntries = getBackEntries();
 
     expect(backEntries.length).toBe(2);
-    // getBackEntries returns in reverse order, so [0] is index 1, [1] is index 0
-    // backEntries[0] = '/kubernetes/pods' - should show full breadcrumb from registry
     expect(backEntries[0].name).toBe('Kubernetes > Pods');
-    // backEntries[1] = '/' - should show Dashboard
     expect(backEntries[1].name).toBe('Dashboard');
 
-    // The current entry (detail page) should show full breadcrumb with resource name
     const forwardEntries = getForwardEntries();
-    expect(forwardEntries.length).toBe(0); // We're at the end
+    expect(forwardEntries.length).toBe(0);
   });
 
   test('should preserve special characters in submenu breadcrumbs', () => {
-    // Test ConfigMaps & Secrets with special character '&'
     navigationHistory.stack = [
       '/',
       '/kubernetes/configmapsSecrets',
@@ -358,15 +267,11 @@ describe('submenu navigation', () => {
     const backEntries = getBackEntries();
 
     expect(backEntries.length).toBe(2);
-    // backEntries[0] = '/kubernetes/configmapsSecrets' base route
-    // Should show proper name from registry with '&' preserved
     expect(backEntries[0].name).toBe('Kubernetes > ConfigMaps & Secrets');
-    // backEntries[1] = '/' Dashboard
     expect(backEntries[1].name).toBe('Dashboard');
   });
 
   test('should show full breadcrumb for detail pages including tab', () => {
-    // Test detail page shows: parent > resource type > resource name > tab
     navigationHistory.stack = [
       '/kubernetes/configmapsSecrets/my-config/default/summary',
       '/kubernetes/configmapsSecrets',
@@ -379,42 +284,18 @@ describe('submenu navigation', () => {
   });
 });
 
-describe('tab navigation for detail pages', () => {
-  test('should add new entry for each tab change', () => {
-    // Start by navigating to containers list
-    routerSubscribeCallback({ url: '/containers' } as TinroRoute);
-    expect(navigationHistory.stack).toEqual(['/containers']);
-    expect(navigationHistory.index).toBe(0);
-
-    // Navigate to container detail page summary tab (should add new entry)
-    routerSubscribeCallback({ url: '/containers/abc123/summary' } as TinroRoute);
-    expect(navigationHistory.stack).toEqual(['/containers', '/containers/abc123/summary']);
-    expect(navigationHistory.index).toBe(1);
-
-    // Switch to logs tab (should ADD a new entry)
-    routerSubscribeCallback({ url: '/containers/abc123/logs' } as TinroRoute);
-
-    // Stack should now have 3 entries (each tab is a separate history entry)
-    expect(navigationHistory.stack).toEqual(['/containers', '/containers/abc123/summary', '/containers/abc123/logs']);
-    expect(navigationHistory.stack.length).toBe(3);
-    expect(navigationHistory.index).toBe(2);
-  });
-
+describe('tab navigation display names', () => {
   test('should show tab name in display for different tabs', () => {
-    // Set up stack with different tabs
     navigationHistory.stack = ['/containers', '/containers/abc123/inspect'];
     navigationHistory.index = 0;
 
     const entries = getForwardEntries();
 
-    // Should show resource name WITH tab name
     expect(entries).toEqual([{ index: 1, name: 'Containers > abc123 > Inspect', icon: {} }]);
-    // Tab name should appear in display
     expect(entries[0].name).toContain('Inspect');
   });
 
   test('should show resource name with tab for submenu resources', () => {
-    // Kubernetes pod with tab navigation
     navigationHistory.stack = ['/kubernetes/pods', '/kubernetes/pods/nginx-pod/default/logs'];
     navigationHistory.index = 0;
 
@@ -422,5 +303,150 @@ describe('tab navigation for detail pages', () => {
 
     expect(entries.length).toBe(1);
     expect(entries[0].name).toBe('Kubernetes > Pods > nginx-pod > Logs');
+  });
+});
+
+describe('parseWebviewSubRoute', () => {
+  test('should return undefined for non-webview URLs', () => {
+    expect(parseWebviewSubRoute('/containers')).toBeUndefined();
+    expect(parseWebviewSubRoute('/images')).toBeUndefined();
+    expect(parseWebviewSubRoute('/')).toBeUndefined();
+  });
+
+  test('should return undefined for webview URL without hash', () => {
+    expect(parseWebviewSubRoute('/webviews/0')).toBeUndefined();
+  });
+
+  test('should parse webview sub-route with hash', () => {
+    const result = parseWebviewSubRoute('/webviews/0#/services');
+    expect(result).toEqual({
+      baseUrl: '/webviews/0',
+      subPath: '/services',
+      webviewId: '0',
+    });
+  });
+
+  test('should parse webview sub-route with nested path', () => {
+    const result = parseWebviewSubRoute('/webviews/2#/catalog/models');
+    expect(result).toEqual({
+      baseUrl: '/webviews/2',
+      subPath: '/catalog/models',
+      webviewId: '2',
+    });
+  });
+
+  test('should return undefined for hash in non-webview URL', () => {
+    expect(parseWebviewSubRoute('/containers#something')).toBeUndefined();
+  });
+});
+
+describe('pushWebviewSubRoute', () => {
+  test('should add entry to stack and store metadata', () => {
+    navigationHistory.stack = ['/containers'];
+    navigationHistory.index = 0;
+
+    pushWebviewSubRoute('0', '/services', 'Services', 'AI Lab');
+
+    expect(navigationHistory.stack).toEqual(['/containers', '/webviews/0#/services']);
+    expect(navigationHistory.index).toBe(1);
+
+    const metadata = getWebviewSubRouteMetadata('/webviews/0#/services');
+    expect(metadata).toEqual({ title: 'Services', webviewName: 'AI Lab', webviewUrl: undefined });
+  });
+
+  test('should not push duplicate entry', () => {
+    navigationHistory.stack = ['/containers', '/webviews/0#/catalog'];
+    navigationHistory.index = 1;
+
+    pushWebviewSubRoute('0', '/catalog', 'Catalog', 'AI Lab');
+
+    expect(navigationHistory.stack).toEqual(['/containers', '/webviews/0#/catalog']);
+    expect(navigationHistory.index).toBe(1);
+  });
+
+  test('should truncate forward history when pushing', () => {
+    navigationHistory.stack = ['/containers', '/images', '/pods'];
+    navigationHistory.index = 0;
+
+    pushWebviewSubRoute('0', '/services', 'Services', 'AI Lab');
+
+    expect(navigationHistory.stack).toEqual(['/containers', '/webviews/0#/services']);
+    expect(navigationHistory.index).toBe(1);
+  });
+
+  test('should clean up orphaned metadata when truncating forward history', () => {
+    navigationHistory.stack = ['/containers'];
+    navigationHistory.index = 0;
+
+    pushWebviewSubRoute('0', '/page1', 'Page 1', 'AI Lab');
+    pushWebviewSubRoute('0', '/page2', 'Page 2', 'AI Lab');
+
+    expect(getWebviewSubRouteMetadata('/webviews/0#/page1')).toBeDefined();
+    expect(getWebviewSubRouteMetadata('/webviews/0#/page2')).toBeDefined();
+
+    navigationHistory.index = 0;
+    pushWebviewSubRoute('1', '/new-page', 'New Page', 'Bootc');
+
+    expect(getWebviewSubRouteMetadata('/webviews/0#/page1')).toBeUndefined();
+    expect(getWebviewSubRouteMetadata('/webviews/0#/page2')).toBeUndefined();
+    expect(getWebviewSubRouteMetadata('/webviews/1#/new-page')).toBeDefined();
+  });
+});
+
+describe('replaceWebviewSubRoute', () => {
+  test('should replace current entry when same webview', () => {
+    navigationHistory.stack = ['/containers', '/webviews/0#/home'];
+    navigationHistory.index = 1;
+
+    replaceWebviewSubRoute('0', '/catalog', 'Catalog', 'AI Lab');
+
+    expect(navigationHistory.stack).toEqual(['/containers', '/webviews/0#/catalog']);
+    expect(navigationHistory.index).toBe(1);
+
+    const metadata = getWebviewSubRouteMetadata('/webviews/0#/catalog');
+    expect(metadata).toEqual({ title: 'Catalog', webviewName: 'AI Lab', webviewUrl: undefined });
+  });
+
+  test('should replace base webview URL', () => {
+    navigationHistory.stack = ['/containers', '/webviews/0'];
+    navigationHistory.index = 1;
+
+    replaceWebviewSubRoute('0', '/catalog', 'Catalog', 'AI Lab');
+
+    expect(navigationHistory.stack).toEqual(['/containers', '/webviews/0#/catalog']);
+    expect(navigationHistory.index).toBe(1);
+  });
+
+  test('should clean up old metadata when replacing', () => {
+    navigationHistory.stack = ['/containers', '/webviews/0#/services'];
+    navigationHistory.index = 1;
+
+    pushWebviewSubRoute('0', '/services', 'Services', 'AI Lab');
+    replaceWebviewSubRoute('0', '/catalog', 'Catalog', 'AI Lab');
+
+    expect(getWebviewSubRouteMetadata('/webviews/0#/services')).toBeUndefined();
+    expect(getWebviewSubRouteMetadata('/webviews/0#/catalog')).toBeDefined();
+  });
+
+  test('should push when current entry is different webview', () => {
+    navigationHistory.stack = ['/containers'];
+    navigationHistory.index = 0;
+
+    replaceWebviewSubRoute('0', '/catalog', 'Catalog', 'AI Lab');
+
+    expect(navigationHistory.stack).toEqual(['/containers', '/webviews/0#/catalog']);
+    expect(navigationHistory.index).toBe(1);
+  });
+});
+
+describe('consumePendingWebviewSubRoute', () => {
+  test('should return undefined when no pending sub-route', () => {
+    const pending = consumePendingWebviewSubRoute('0');
+    expect(pending).toBeUndefined();
+  });
+
+  test('should return undefined for wrong webview id', () => {
+    const pending = consumePendingWebviewSubRoute('1');
+    expect(pending).toBeUndefined();
   });
 });

--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -54,6 +54,160 @@ export const navigationHistory = $state<{
 
 let isNavigatingHistory = false;
 
+export interface WebviewSubRouteMetadata {
+  title: string;
+  webviewName: string;
+  webviewUrl?: string;
+}
+
+const webviewSubRouteMetadata = new Map<string, WebviewSubRouteMetadata>();
+
+let pendingWebviewSubRoute: { webviewId: string; path: string; webviewUrl?: string } | undefined;
+
+/**
+ * Parse a history URL that may contain a webview sub-route fragment.
+ * @returns The base URL and optional sub-path, or undefined if not a webview sub-route.
+ * @example
+ * parseWebviewSubRoute('/webviews/0#/services')
+ * // => { baseUrl: '/webviews/0', subPath: '/services', webviewId: '0' }
+ *
+ * parseWebviewSubRoute('/containers')
+ * // => undefined
+ */
+export function parseWebviewSubRoute(url: string): { baseUrl: string; subPath: string; webviewId: string } | undefined {
+  const hashIndex = url.indexOf('#');
+  if (hashIndex === -1) return undefined;
+  const baseUrl = url.substring(0, hashIndex);
+  const subPath = url.substring(hashIndex + 1);
+  const match = /^\/webviews\/(.+)$/.exec(baseUrl);
+  if (!match) return undefined;
+  return { baseUrl, subPath, webviewId: match[1] };
+}
+
+function getCurrentBaseUrl(): string {
+  const currentUrl = navigationHistory.stack[navigationHistory.index];
+  if (!currentUrl) return '';
+  const hashIndex = currentUrl.indexOf('#');
+  return hashIndex === -1 ? currentUrl : currentUrl.substring(0, hashIndex);
+}
+
+/**
+ * Truncate forward history from the current position, clean up orphaned
+ * metadata, and append a new entry.
+ */
+function truncateAndPush(entry: string): void {
+  if (navigationHistory.index < navigationHistory.stack.length - 1) {
+    for (let i = navigationHistory.index + 1; i < navigationHistory.stack.length; i++) {
+      webviewSubRouteMetadata.delete(navigationHistory.stack[i]);
+    }
+    navigationHistory.stack = navigationHistory.stack.slice(0, navigationHistory.index + 1);
+  }
+  navigationHistory.stack = [...navigationHistory.stack, entry];
+  navigationHistory.index = navigationHistory.stack.length - 1;
+}
+
+/**
+ * Push a webview internal navigation entry onto the history stack.
+ * Called when an extension webview notifies us of an internal page change.
+ */
+export function pushWebviewSubRoute(
+  webviewId: string,
+  path: string,
+  title: string,
+  webviewName: string,
+  webviewUrl?: string,
+): void {
+  const entry = `/webviews/${webviewId}#${path}`;
+  if (navigationHistory.stack[navigationHistory.index] === entry) return;
+
+  truncateAndPush(entry);
+  webviewSubRouteMetadata.set(entry, { title, webviewName, webviewUrl });
+}
+
+/**
+ * Replace the current history entry with a webview sub-route.
+ * Only replaces if the current entry belongs to the same webview.
+ */
+export function replaceWebviewSubRoute(
+  webviewId: string,
+  path: string,
+  title: string,
+  webviewName: string,
+  webviewUrl?: string,
+): void {
+  const entry = `/webviews/${webviewId}#${path}`;
+  const currentUrl = navigationHistory.stack[navigationHistory.index];
+  const currentParsed = currentUrl ? parseWebviewSubRoute(currentUrl) : undefined;
+  const isBaseWebviewUrl = currentUrl === `/webviews/${webviewId}`;
+
+  if (currentParsed?.webviewId === webviewId || isBaseWebviewUrl) {
+    webviewSubRouteMetadata.delete(currentUrl);
+    navigationHistory.stack[navigationHistory.index] = entry;
+    navigationHistory.stack = [...navigationHistory.stack];
+  } else {
+    truncateAndPush(entry);
+  }
+  webviewSubRouteMetadata.set(entry, { title, webviewName, webviewUrl });
+}
+
+/**
+ * Update only the stored webviewUrl for the current history entry without
+ * creating or replacing any entry. Used when the webview redirects to the
+ * same logical page with different query parameters (e.g. adding providerId).
+ */
+export function updateCurrentWebviewSubRouteUrl(webviewId: string, webviewUrl: string): void {
+  const currentUrl = navigationHistory.stack[navigationHistory.index];
+  if (!currentUrl) return;
+  const parsed = parseWebviewSubRoute(currentUrl);
+  if (parsed?.webviewId !== webviewId) return;
+  const existing = webviewSubRouteMetadata.get(currentUrl);
+  if (existing) {
+    webviewSubRouteMetadata.set(currentUrl, { ...existing, webviewUrl });
+  }
+}
+
+/**
+ * Consume the pending webview sub-route (set when navigating back/forward to a
+ * webview from a different page). Called by Webview.svelte after mount.
+ */
+export function consumePendingWebviewSubRoute(webviewId: string): { path: string; webviewUrl?: string } | undefined {
+  if (pendingWebviewSubRoute?.webviewId === webviewId) {
+    const result = { path: pendingWebviewSubRoute.path, webviewUrl: pendingWebviewSubRoute.webviewUrl };
+    pendingWebviewSubRoute = undefined;
+    return result;
+  }
+  return undefined;
+}
+
+export function getWebviewSubRouteMetadata(url: string): WebviewSubRouteMetadata | undefined {
+  return webviewSubRouteMetadata.get(url);
+}
+
+export function extractSubPath(fullUrl: string): string {
+  const hashIndex = fullUrl.indexOf('#');
+  if (hashIndex !== -1) return fullUrl.substring(hashIndex + 1);
+  try {
+    return fullUrl.split('?')[0].replace(/^https?:\/\/[^/]+/, '');
+  } catch {
+    return fullUrl;
+  }
+}
+
+export function titleFromSubPath(path: string, webviewName?: string): string {
+  const segments = path.split('/').filter(Boolean);
+  if (segments.length === 0) {
+    return webviewName ? `${webviewName} - Home` : 'Home';
+  }
+  // Replace hyphens/underscores with spaces for readability, then capitalize
+  const raw = segments[segments.length - 1].replace(/[-_]+/g, ' ');
+  const label = truncate(capitalize(raw), 20);
+  return webviewName ? `${webviewName} - ${label}` : label;
+}
+
+// ---------------------------------------------------------------------------
+// Display-name resolution utilities
+// ---------------------------------------------------------------------------
+
 interface ParsedUrl {
   path: string;
   parts: string[];
@@ -265,22 +419,41 @@ function matchesRoute(url: string, routeHref: string): boolean {
 
 /**
  * Get display name and icon for a URL from navigation registry or fallback to URL parsing
- * @param url - The URL to get entry info for
- * @returns Object with display name and optional icon
- * @example
- * getEntryInfo('/')
- * // => { name: 'Dashboard', icon: { iconComponent: DashboardIcon } }
- *
- * getEntryInfo('/containers')
- * // => { name: 'Containers', icon: { ... } }
- *
- * getEntryInfo('/containers/abc123/logs')
- * // => { name: 'Containers > abc123', icon: { ... } }
- *
- * getEntryInfo('/preferences/default/resources')
- * // => { name: 'Resources', icon: { iconComponent: SettingsIcon } }
  */
-function getEntryInfo(url: string): { name: string; icon?: HistoryEntryIcon } {
+export function getEntryInfo(url: string): { name: string; icon?: HistoryEntryIcon } {
+  // Handle webview sub-routes (e.g. /webviews/0#/services)
+  const subRoute = parseWebviewSubRoute(url);
+  if (subRoute) {
+    const registry = get(navigationRegistry);
+    const webviewEntry = findNavigationEntry(subRoute.baseUrl, registry);
+    const icon = webviewEntry?.entry.icon;
+    const webviewBreadcrumb = webviewEntry?.breadcrumb ?? [];
+    const webviewDisplayName =
+      (webviewBreadcrumb[0] === 'Extensions' && webviewBreadcrumb.length > 1
+        ? webviewBreadcrumb.slice(1)
+        : webviewBreadcrumb
+      ).join(' > ') || `Webview ${subRoute.webviewId}`;
+
+    const isHome = subRoute.subPath === '/' || subRoute.subPath === '';
+
+    const metadata = webviewSubRouteMetadata.get(url);
+    if (metadata) {
+      const titleMatchesName =
+        metadata.title === metadata.webviewName || metadata.title === `${metadata.webviewName} - Home`;
+      if (isHome || titleMatchesName) {
+        return { name: webviewDisplayName, icon };
+      }
+      return { name: `${webviewDisplayName} > ${truncate(metadata.title, 20)}`, icon };
+    }
+
+    if (isHome) {
+      return { name: webviewDisplayName, icon };
+    }
+    const segments = subRoute.subPath.split('/').filter(Boolean);
+    const subLabel = segments.length > 0 ? truncate(capitalize(segments[segments.length - 1]), 20) : undefined;
+    return { name: subLabel ? `${webviewDisplayName} > ${subLabel}` : webviewDisplayName, icon };
+  }
+
   const { path } = parseUrl(url);
 
   // Handle Dashboard
@@ -288,17 +461,55 @@ function getEntryInfo(url: string): { name: string; icon?: HistoryEntryIcon } {
     return { name: 'Dashboard', icon: { iconComponent: DashboardIcon } };
   }
 
-  // Handle Preferences
+  // Handle Preferences — include the specific settings page name
   if (path.startsWith('/preferences/default/')) {
+    const sortedSettings = [...settingsNavigationEntries].toSorted((a, b) => b.href.length - a.href.length);
+    for (const route of sortedSettings) {
+      if (matchesRoute(path, route.href)) {
+        return { name: `Preferences > ${route.title}`, icon: { iconComponent: SettingsIcon } };
+      }
+    }
     return { name: 'Preferences', icon: { iconComponent: SettingsIcon } };
+  }
+
+  // Handle Extension detail pages: show "extensionId > Tab" without the "Extensions" prefix
+  if (path.startsWith('/extensions/details/')) {
+    const { parts } = parseUrl(url);
+    const extensionId = parts[2] ? decodeURIComponent(parts[2]) : 'Extension';
+    const tab = parts[3] ? capitalize(parts[3]) : undefined;
+    return { name: tab ? `${extensionId} > ${tab}` : extensionId, icon: undefined };
   }
 
   // Check navigation registry
   const registry = get(navigationRegistry);
   const result = findNavigationEntry(url, registry);
   if (result) {
-    // Always use urlToDisplayName, passing registry breadcrumb for base routes
-    return { name: urlToDisplayName(url, result.breadcrumb), icon: result.entry.icon };
+    // Drop the "Extensions" prefix from breadcrumbs for extension-contributed pages
+    // (webviews, contributions) so "Extensions > AI Lab" becomes just "AI Lab"
+    const breadcrumb =
+      result.breadcrumb[0] === 'Extensions' && result.breadcrumb.length > 1
+        ? result.breadcrumb.slice(1)
+        : result.breadcrumb;
+
+    // Exact match: the breadcrumb already fully describes this page.
+    // Avoids appending the URL resource segment (e.g. numeric webview IDs like "2")
+    // to the breadcrumb when it adds no useful information.
+    if (path === result.entry.link) {
+      return { name: breadcrumb.join(' > '), icon: result.entry.icon };
+    }
+
+    const displayName = urlToDisplayName(url, breadcrumb);
+    // If urlToDisplayName only returned the breadcrumb (no resource info added),
+    // append the first path segment beyond the matched entry's link as a sub-page
+    // (e.g. /kubernetes/dashboard → "Kubernetes > Dashboard")
+    if (displayName === breadcrumb.join(' > ') && path.length > result.entry.link.length) {
+      const remaining = path.substring(result.entry.link.length + 1);
+      const subPage = remaining.split('/')[0];
+      if (subPage) {
+        return { name: `${displayName} > ${capitalize(subPage)}`, icon: result.entry.icon };
+      }
+    }
+    return { name: displayName, icon: result.entry.icon };
   }
 
   // Check settings navigation entries (sorted by specificity)
@@ -317,26 +528,47 @@ function getEntryInfo(url: string): { name: string; icon?: HistoryEntryIcon } {
 }
 
 /**
- * Navigate to a specific index in the history stack
- * @param index - The history stack index to navigate to
- * @returns True if navigation occurred, false if index is invalid or current
- * @example
- * // If history is ['/', '/containers', '/images'] and index is 1:
- * navigateToIndex(0) // navigates to '/', returns true
- * navigateToIndex(1) // already at index 1, returns false
- * navigateToIndex(5) // invalid index, returns false
+ * Navigate to a specific index in the history stack.
+ * Handles webview sub-route entries by dispatching custom events.
  */
 function navigateToIndex(index: number): boolean {
   if (index < 0 || index >= navigationHistory.stack.length || index === navigationHistory.index) {
     return false;
   }
 
+  const url = navigationHistory.stack[index];
+  if (!url) return false;
+
+  const subRoute = parseWebviewSubRoute(url);
+  const baseWebviewMatch = !subRoute ? /^\/webviews\/(.+)$/.exec(url) : undefined;
+
+  if (subRoute || baseWebviewMatch) {
+    const webviewId = subRoute ? subRoute.webviewId : baseWebviewMatch![1];
+    const baseUrl = subRoute ? subRoute.baseUrl : url;
+    const subPath = subRoute ? subRoute.subPath : '/';
+    const metadata = webviewSubRouteMetadata.get(url);
+    const webviewUrl = metadata?.webviewUrl;
+    const currentBase = getCurrentBaseUrl();
+
+    isNavigatingHistory = true;
+    navigationHistory.index = index;
+
+    if (currentBase === baseUrl) {
+      window.dispatchEvent(
+        new CustomEvent('webview-navigate-to-subroute', {
+          detail: { webviewId, path: subPath, webviewUrl },
+        }),
+      );
+    } else {
+      pendingWebviewSubRoute = { webviewId, path: subPath, webviewUrl };
+      router.goto(baseUrl);
+    }
+    return true;
+  }
+
   isNavigatingHistory = true;
   navigationHistory.index = index;
-  const url = navigationHistory.stack[index];
-  if (url) {
-    router.goto(url);
-  }
+  router.goto(url);
   return true;
 }
 
@@ -492,17 +724,8 @@ router.subscribe(navigation => {
       return;
     }
 
-    // Truncate forward history if we're not at the end
-    if (navigationHistory.index < navigationHistory.stack.length - 1) {
-      navigationHistory.stack = navigationHistory.stack.slice(0, navigationHistory.index + 1);
-    }
-
-    const currentUrl = navigationHistory.stack[navigationHistory.index];
-
-    // Add every URL change to history (including tab changes)
-    if (currentUrl !== navigation.url) {
-      navigationHistory.stack = [...navigationHistory.stack, navigation.url];
-      navigationHistory.index = navigationHistory.stack.length - 1;
+    if (navigationHistory.stack[navigationHistory.index] !== navigation.url) {
+      truncateAndPush(navigation.url);
     }
   }
 });


### PR DESCRIPTION
### What does this PR do?
Adds support for navigation in extensions 

### Screenshot / video of UI


https://github.com/user-attachments/assets/dcd1a91d-d73a-440f-a9af-9af799c20d22



### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/15835

### How to test this PR?
Download an extension try to navigate through it. Then use back/forward buttons to navigate through it 
PS: If you want to try the Hummingbird extension, you need to try latest main of this extension

- [x] Tests are covering the bug fix or the new feature
