### PR TITLE
chore(vite.config): source map config

### DIFF
--- a/.agents/skills/new-extension/SKILL.md
+++ b/.agents/skills/new-extension/SKILL.md
@@ -210,7 +210,7 @@ export default defineConfig({
     },
   },
   build: {
-    sourcemap: 'inline',
+    sourcemap: true,
     target: 'esnext',
     outDir: 'dist',
     assetsDir: '.',

--- a/extensions/vite.base.config.ts
+++ b/extensions/vite.base.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
     mainFields: ['module', 'jsnext:main', 'jsnext', 'main'],
   },
   build: {
-    sourcemap: 'inline',
+    sourcemap: true,
     target: 'esnext',
     outDir: 'dist',
     assetsDir: '.',

--- a/packages/api/vite.config.js
+++ b/packages/api/vite.config.js
@@ -44,7 +44,7 @@ const config = {
     }),
   ],
   build: {
-    sourcemap: 'inline',
+    sourcemap: true,
     target: `chrome${chrome}`,
     outDir: 'dist',
     assetsDir: '.',

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -42,7 +42,7 @@ const config = {
     },
   },
   build: {
-    sourcemap: 'inline',
+    sourcemap: true,
     target: `node${node}`,
     outDir: 'dist',
     assetsDir: '.',

--- a/packages/preload-docker-extension/vite.config.js
+++ b/packages/preload-docker-extension/vite.config.js
@@ -45,7 +45,7 @@ const config = {
        }),
    ],*/
   build: {
-    sourcemap: 'inline',
+    sourcemap: true,
     target: `chrome${chrome}`,
     outDir: 'dist',
     assetsDir: '.',

--- a/packages/preload-webview/vite.config.js
+++ b/packages/preload-webview/vite.config.js
@@ -36,7 +36,7 @@ const config = {
     },
   },
   build: {
-    sourcemap: 'inline',
+    sourcemap: true,
     target: `chrome${chrome}`,
     outDir: 'dist',
     assetsDir: '.',

--- a/packages/preload/vite.config.js
+++ b/packages/preload/vite.config.js
@@ -44,7 +44,7 @@ const config = {
       }),
   ],*/
   build: {
-    sourcemap: 'inline',
+    sourcemap: true,
     target: `chrome${chrome}`,
     outDir: 'dist',
     assetsDir: '.',

--- a/website/tutorial/creating-an-extension.md
+++ b/website/tutorial/creating-an-extension.md
@@ -239,7 +239,7 @@ You can build this extension by configuring `TypeScript` and `Vite`.
 
 ```javascript
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -270,12 +270,13 @@ const config = {
   root: PACKAGE_ROOT,
   envDir: process.cwd(),
   resolve: {
+    mainFields: ['module', 'jsnext:main', 'jsnext', 'main'],
     alias: {
       '/@/': join(PACKAGE_ROOT, 'src') + '/',
     },
   },
   build: {
-    sourcemap: 'inline',
+    sourcemap: true,
     target: 'esnext',
     outDir: 'dist',
     assetsDir: '.',
@@ -285,6 +286,7 @@ const config = {
       formats: ['cjs'],
     },
     rollupOptions: {
+      platform: 'node',
       external: ['@podman-desktop/api', ...builtinModules.flatMap(p => [p, `node:${p}`])],
       output: {
         entryFileNames: '[name].js',


### PR DESCRIPTION
### What does this PR do?

Update the `sourceMap` property of our vite.config.(js|ts) from `inline` to `true`, this has no impact on the source code, but it seems that the IDE are not supporting the inline for debugging mode.

Switching to `true` mean, instead of having the sourceMap inside the source code, it will be provided as a separate file (E.g. `extension.js.map`)

<img width="363" height="223" alt="image" src="https://github.com/user-attachments/assets/e6cdfa4b-c256-418d-9986-a95ec525ddcb" />

The main benefits is for debugging, as visible in the screenshots, it allows us to use the IDE to debug extensions

### Screenshot / video of UI

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/922ddb96-32e7-4207-ab8f-5617ae5c3a62" />


### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17822

### How to test this PR?

- Try to debug any of the built-in extensions
