### PR TITLE
fix: update UI on pause and unpause container events

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3099,6 +3099,43 @@ describe('createContainer', () => {
   });
 });
 
+describe('unpauseContainer', () => {
+  test('test unpause Container', async () => {
+    const unpauseMock = vi.fn().mockResolvedValue({});
+
+    const fakeDockerodeContainer = {
+      unpause: unpauseMock,
+    } as unknown as Dockerode.Container;
+
+    vi.spyOn(containerRegistry, 'getMatchingContainer').mockReturnValue(fakeDockerodeContainer);
+
+    await containerRegistry.unpauseContainer('podman1', '1234');
+
+    expect(unpauseMock).toHaveBeenCalled();
+  });
+
+  test('test unpause Container for error handling', async () => {
+    const unpauseError = new Error('unpause failed');
+    const unpauseMock = vi.fn().mockRejectedValue(unpauseError);
+
+    const fakeDockerodeContainer = {
+      unpause: unpauseMock,
+    } as unknown as Dockerode.Container;
+
+    vi.spyOn(containerRegistry, 'getMatchingContainer').mockReturnValue(fakeDockerodeContainer);
+
+    await expect(containerRegistry.unpauseContainer('podman1', '1234')).rejects.toThrow(unpauseError);
+
+    expect(telemetry.track).toHaveBeenCalledWith(
+      'unpauseContainer',
+      expect.objectContaining({
+        error: unpauseError,
+      }),
+    );
+    expect(unpauseMock).toHaveBeenCalled();
+  });
+});
+
 describe('attach container', () => {
   test('container attach stream', async () => {
     // create a read/write stream

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -215,6 +215,12 @@ export class ContainerProviderRegistry {
       } else if (status === 'start' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been started
         this.apiSender.send('container-started-event', id);
+      } else if (status === 'pause' && jsonEvent?.Type === 'container') {
+        // need to notify that a container has been paused
+        this.apiSender.send('container-paused-event', id);
+      } else if (status === 'unpause' && jsonEvent?.Type === 'container') {
+        // need to notify that a container has been unpaused
+        this.apiSender.send('container-unpaused-event', id);
       } else if (status === 'destroy' && jsonEvent?.Type === 'container') {
         // need to notify that a container has been destroyed
         this.apiSender.send('container-stopped-event', id);

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1393,6 +1393,18 @@ export class ContainerProviderRegistry {
     }
   }
 
+  async unpauseContainer(engineId: string, id: string, abortController?: AbortController): Promise<void> {
+    let telemetryOptions = {};
+    try {
+      return await this.getMatchingContainer(engineId, id).unpause({ abortSignal: abortController?.signal });
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('unpauseContainer', telemetryOptions);
+    }
+  }
+
   async generatePodmanKube(engineId: string, names: string[]): Promise<string> {
     let telemetryOptions = {};
     try {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1149,6 +1149,12 @@ export class PluginSystem {
       },
     );
     this.ipcHandle(
+      'container-provider-registry:unpauseContainer',
+      async (_listener, engine: string, containerId: string): Promise<void> => {
+        return containerProviderRegistry.unpauseContainer(engine, containerId);
+      },
+    );
+    this.ipcHandle(
       'container-provider-registry:stopContainer',
       async (_listener, engine: string, containerId: string): Promise<void> => {
         return containerProviderRegistry.stopContainer(engine, containerId);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -451,6 +451,10 @@ export function initExposure(): void {
     return ipcInvoke('container-provider-registry:startContainer', engine, containerId);
   });
 
+  contextBridge.exposeInMainWorld('unpauseContainer', async (engine: string, containerId: string): Promise<void> => {
+    return ipcInvoke('container-provider-registry:unpauseContainer', engine, containerId);
+  });
+
   contextBridge.exposeInMainWorld(
     'pingContainerEngine',
     async (providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<unknown> => {

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -55,6 +55,7 @@ vi.mock(import('/@/lib/actions/ContributionActions.svelte'));
 
 beforeAll(() => {
   Object.defineProperty(window, 'startContainer', { value: vi.fn() });
+  Object.defineProperty(window, 'unpauseContainer', { value: vi.fn() });
   Object.defineProperty(window, 'stopContainer', { value: vi.fn() });
   Object.defineProperty(window, 'restartContainer', { value: vi.fn() });
   Object.defineProperty(window, 'deleteContainer', { value: vi.fn() });
@@ -92,6 +93,41 @@ test('Expect no error and status stopping container', async () => {
 
   expect(container.state).toEqual('STOPPING');
   expect(container.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status starting for paused container', async () => {
+  // set container state to paused
+  container.state = 'PAUSED';
+  render(ContainerActions, { container, onUpdate: updateMock });
+
+  // click on start button
+  const startButton = screen.getByRole('button', { name: 'Start Container' });
+  await fireEvent.click(startButton);
+
+  expect(container.state).toEqual('STARTING');
+  expect(window.unpauseContainer).toHaveBeenCalled();
+  expect(window.startContainer).not.toHaveBeenCalled();
+  expect(container.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect error and status error for unpausing container', async () => {
+  // set container state to paused
+  container.state = 'PAUSED';
+  const error = new Error('unpause failed');
+  render(ContainerActions, { container, onUpdate: updateMock });
+
+  vi.mocked(window.unpauseContainer).mockRejectedValue(error);
+
+  // click on start button
+  const startButton = screen.getByRole('button', { name: 'Start Container' });
+  await fireEvent.click(startButton);
+
+  expect(window.unpauseContainer).toHaveBeenCalled();
+  expect(window.startContainer).not.toHaveBeenCalled();
+  expect(container.actionError).toContain(error);
+  expect(container.state).toEqual('ERROR');
   expect(updateMock).toHaveBeenCalled();
 });
 

--- a/packages/renderer/src/lib/container/ContainerActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerActions.svelte
@@ -86,6 +86,17 @@ async function startContainer(): Promise<void> {
   }
 }
 
+async function unpauseContainer(): Promise<void> {
+  inProgress(true, 'STARTING');
+  try {
+    await window.unpauseContainer(container.engineId, container.id);
+  } catch (error) {
+    handleError(String(error));
+  } finally {
+    inProgress(false);
+  }
+}
+
 async function restartContainer(): Promise<void> {
   inProgress(true, 'RESTARTING');
   try {
@@ -186,7 +197,7 @@ if (dropdownMenu) {
 
 <ListItemButtonIcon
   title="Start Container"
-  onClick={startContainer}
+  onClick={container.state === 'PAUSED' ? unpauseContainer : startContainer}
   hidden={container.state === 'RUNNING' || container.state === 'STOPPING'}
   detailed={detailed}
   inProgress={container.actionInProgress && container.state === 'STARTING'}

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -30,6 +30,8 @@ const windowEvents = [
   'container-init-event',
   'container-created-event',
   'container-started-event',
+  'container-paused-event',
+  'container-unpaused-event',
   'container-removed-event',
   'provider-change',
   'provider-container-connection-update-status',


### PR DESCRIPTION
### What does this PR do?
Currently when a container is `paused/unpaused` there is no changes in the UI.

Reason: There are no events generated for `pause/unpause` here in [container-registry.ts](https://github.com/podman-desktop/podman-desktop/blob/main/packages/main/src/plugin/container-registry.ts#L205).

Steps taken to Resolve:
- Generate `pause/unpause` events in [container-registry.ts](https://github.com/podman-desktop/podman-desktop/blob/main/packages/main/src/plugin/container-registry.ts#L205).
- Add the events in window-events so that UI listens to those events and updates accordingly in [containers.ts](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/stores/containers.ts#L32).

### Screenshot / video of UI
Before:
<img width="1397" height="414" alt="image" src="https://github.com/user-attachments/assets/974bb9ec-2b93-4a55-aeb7-5160bf48c021" />

After:

https://github.com/user-attachments/assets/cca3944c-d643-49d7-bea8-abe49d760fdc

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes #17784 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
