### PR TITLE
fix(statusbar): force dark theme context for all statusbar content

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBar.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBar.spec.ts
@@ -25,6 +25,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import Providers from '/@/lib/statusbar/Providers.svelte';
 import StatusBar from '/@/lib/statusbar/StatusBar.svelte';
+import { isHighContrast } from '/@/stores/appearance';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import { statusBarEntries } from '/@/stores/statusbar';
 import { tasksInfo } from '/@/stores/tasks';
@@ -44,6 +45,7 @@ beforeEach(() => {
 
   // reset stores
   statusBarEntries.set([]);
+  isHighContrast.set(false);
   tasksInfo.set([
     {
       name: 'Dummy Task',
@@ -97,6 +99,24 @@ test('providers should be visible when isExperimentalConfigurationEnabled is tru
   await vi.waitFor(() => {
     expect(Providers).toHaveBeenCalled();
   });
+});
+
+test('statusbar has data-pd-force-theme set to dark in non-hc mode', async () => {
+  isHighContrast.set(false);
+
+  const { getByRole } = render(StatusBar);
+
+  const statusBar = getByRole('contentinfo');
+  expect(statusBar).toHaveAttribute('data-pd-force-theme', 'dark');
+});
+
+test('statusbar has data-pd-force-theme set to hc-dark in high-contrast mode', async () => {
+  isHighContrast.set(true);
+
+  const { getByRole } = render(StatusBar);
+
+  const statusBar = getByRole('contentinfo');
+  expect(statusBar).toHaveAttribute('data-pd-force-theme', 'hc-dark');
 });
 
 describe('providers', () => {

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -4,6 +4,7 @@ import { ExperimentalTasksSettings } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 
 import TaskIndicator from '/@/lib/statusbar/TaskIndicator.svelte';
+import { isHighContrast } from '/@/stores/appearance';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
 import { statusBarEntries } from '/@/stores/statusbar';
 
@@ -81,7 +82,8 @@ onDestroy(() => {
 <div
   class="flex justify-between px-1 bg-[var(--pd-statusbar-bg)] text-[var(--pd-statusbar-text)] text-sm space-x-2 z-40"
   role="contentinfo"
-  aria-label="Status Bar">
+  aria-label="Status Bar"
+  data-pd-force-theme={$isHighContrast ? 'hc-dark' : 'dark'}>
   <div class="flex flex-nowrap gap-x-1.5 h-full text-ellipsis whitespace-nowrap">
     {#if experimentalProvidersStatusBar}
       <Providers/>

--- a/packages/renderer/src/lib/style/ColorsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/ColorsStyle.spec.ts
@@ -42,16 +42,23 @@ test('Check colors are added in the css style', async () => {
     cssVar: '--pd-my-custom-color',
   };
 
+  // sets the colors
   colorsInfos.set([color]);
   darkContextColorsInfos.set([]);
   hcDarkContextColorsInfos.set([]);
 
   render(ColorsStyle);
 
+  // expect to have the generated style for the colors
   const style = document.querySelector('style');
   expect(style).toBeInTheDocument();
+  // should have css type
   expect(style).toHaveAttribute('type', 'text/css');
+
+  // check the id
   expect(style).toHaveAttribute('id', 'podman-desktop-colors-styles');
+
+  // check content
   expect(style).toHaveTextContent(':root { --pd-my-custom-color: #123456; }');
 });
 

--- a/packages/renderer/src/lib/style/ColorsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/ColorsStyle.spec.ts
@@ -24,7 +24,7 @@ import type { ColorInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
-import { colorsInfos } from '/@/stores/colors';
+import { colorsInfos, darkContextColorsInfos, hcDarkContextColorsInfos } from '/@/stores/colors';
 
 import ColorsStyle from './ColorsStyle.svelte';
 
@@ -42,20 +42,33 @@ test('Check colors are added in the css style', async () => {
     cssVar: '--pd-my-custom-color',
   };
 
-  // sets the colors
   colorsInfos.set([color]);
+  darkContextColorsInfos.set([]);
+  hcDarkContextColorsInfos.set([]);
 
   render(ColorsStyle);
 
-  // expect to have the generated style for the colors
   const style = document.querySelector('style');
   expect(style).toBeInTheDocument();
-  // should have css type
   expect(style).toHaveAttribute('type', 'text/css');
-
-  // check the id
   expect(style).toHaveAttribute('id', 'podman-desktop-colors-styles');
-
-  // check content
   expect(style).toHaveTextContent(':root { --pd-my-custom-color: #123456; }');
+});
+
+test('Check scoped dark and hc-dark blocks are emitted', async () => {
+  const currentColor: ColorInfo = { id: 'c', value: '#cur', cssVar: '--pd-c' };
+  const darkColor: ColorInfo = { id: 'd', value: '#drk', cssVar: '--pd-d' };
+  const hcDarkColor: ColorInfo = { id: 'h', value: '#hcd', cssVar: '--pd-h' };
+
+  colorsInfos.set([currentColor]);
+  darkContextColorsInfos.set([darkColor]);
+  hcDarkContextColorsInfos.set([hcDarkColor]);
+
+  render(ColorsStyle);
+
+  const style = document.querySelector('style');
+  expect(style).toBeInTheDocument();
+  expect(style).toHaveTextContent(':root { --pd-c: #cur; }');
+  expect(style).toHaveTextContent('[data-pd-force-theme="dark"] { --pd-d: #drk; }');
+  expect(style).toHaveTextContent('[data-pd-force-theme="hc-dark"] { --pd-h: #hcd; }');
 });

--- a/packages/renderer/src/lib/style/ColorsStyle.svelte
+++ b/packages/renderer/src/lib/style/ColorsStyle.svelte
@@ -1,74 +1,29 @@
 <script lang="ts">
 import type { ColorInfo } from '@podman-desktop/core-api';
-import { onDestroy, onMount } from 'svelte';
-import type { Unsubscriber } from 'svelte/store';
 
 import { colorsInfos, darkContextColorsInfos, hcDarkContextColorsInfos } from '/@/stores/colors';
 
-let style: HTMLStyleElement;
+function toVars(infos: ColorInfo[]): string {
+  return infos.map((color): string => `${color.cssVar}: ${color.value};`).join('\n    ');
+}
 
-let unsubscribeCurrent: Unsubscriber;
-let unsubscribeDark: Unsubscriber;
-let unsubscribeHcDark: Unsubscriber;
-
-let currentInfos: ColorInfo[] = [];
-let darkInfos: ColorInfo[] = [];
-let hcDarkInfos: ColorInfo[] = [];
-
-function createStyleSheet(): HTMLStyleElement {
-  style = document.createElement('style');
+$effect(() => {
+  const style = document.createElement('style');
   style.type = 'text/css';
   style.id = 'podman-desktop-colors-styles';
   style.media = 'screen';
-
-  document.head.append(style);
-
-  style.textContent = '';
-
-  return style;
-}
-
-function toVars(infos: ColorInfo[]): string {
-  return infos.map(color => `${color.cssVar}: ${color.value};`).join('\n    ');
-}
-
-function regenerateCSS(): void {
   style.textContent = `
   :root {
-    ${toVars(currentInfos)}
+    ${toVars($colorsInfos)}
   }
   [data-pd-force-theme="dark"] {
-    ${toVars(darkInfos)}
+    ${toVars($darkContextColorsInfos)}
   }
   [data-pd-force-theme="hc-dark"] {
-    ${toVars(hcDarkInfos)}
+    ${toVars($hcDarkContextColorsInfos)}
   }
 `;
-}
-
-onMount(() => {
-  createStyleSheet();
-
-  unsubscribeCurrent = colorsInfos.subscribe(infos => {
-    currentInfos = infos;
-    regenerateCSS();
-  });
-
-  unsubscribeDark = darkContextColorsInfos.subscribe(infos => {
-    darkInfos = infos;
-    regenerateCSS();
-  });
-
-  unsubscribeHcDark = hcDarkContextColorsInfos.subscribe(infos => {
-    hcDarkInfos = infos;
-    regenerateCSS();
-  });
-});
-
-onDestroy(() => {
-  style?.remove();
-  unsubscribeCurrent?.();
-  unsubscribeDark?.();
-  unsubscribeHcDark?.();
+  document.head.append(style);
+  return (): void => style.remove();
 });
 </script>

--- a/packages/renderer/src/lib/style/ColorsStyle.svelte
+++ b/packages/renderer/src/lib/style/ColorsStyle.svelte
@@ -3,11 +3,17 @@ import type { ColorInfo } from '@podman-desktop/core-api';
 import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
-import { colorsInfos } from '/@/stores/colors';
+import { colorsInfos, darkContextColorsInfos, hcDarkContextColorsInfos } from '/@/stores/colors';
 
 let style: HTMLStyleElement;
 
-let unsubscribe: Unsubscriber;
+let unsubscribeCurrent: Unsubscriber;
+let unsubscribeDark: Unsubscriber;
+let unsubscribeHcDark: Unsubscriber;
+
+let currentInfos: ColorInfo[] = [];
+let darkInfos: ColorInfo[] = [];
+let hcDarkInfos: ColorInfo[] = [];
 
 function createStyleSheet(): HTMLStyleElement {
   style = document.createElement('style');
@@ -22,31 +28,47 @@ function createStyleSheet(): HTMLStyleElement {
   return style;
 }
 
+function toVars(infos: ColorInfo[]): string {
+  return infos.map(color => `${color.cssVar}: ${color.value};`).join('\n    ');
+}
+
+function regenerateCSS(): void {
+  style.textContent = `
+  :root {
+    ${toVars(currentInfos)}
+  }
+  [data-pd-force-theme="dark"] {
+    ${toVars(darkInfos)}
+  }
+  [data-pd-force-theme="hc-dark"] {
+    ${toVars(hcDarkInfos)}
+  }
+`;
+}
+
 onMount(() => {
   createStyleSheet();
 
-  // update icon rules
-  unsubscribe = colorsInfos.subscribe(infos => {
-    const styles: string[] = [];
-    infos.forEach((color: ColorInfo) => {
-      const cssVar = color.cssVar;
-      const colorValue = color.value;
+  unsubscribeCurrent = colorsInfos.subscribe(infos => {
+    currentInfos = infos;
+    regenerateCSS();
+  });
 
-      styles.push(`${cssVar}: ${colorValue};`);
-    });
+  unsubscribeDark = darkContextColorsInfos.subscribe(infos => {
+    darkInfos = infos;
+    regenerateCSS();
+  });
 
-    style.textContent = `
-  :root {
-    ${styles.join('\n')}
-  }
-`;
+  unsubscribeHcDark = hcDarkContextColorsInfos.subscribe(infos => {
+    hcDarkInfos = infos;
+    regenerateCSS();
   });
 });
 
 onDestroy(() => {
-  // remove old style tag from the head
   style?.remove();
-
-  unsubscribe?.();
+  unsubscribeCurrent?.();
+  unsubscribeDark?.();
+  unsubscribeHcDark?.();
 });
 </script>

--- a/packages/renderer/src/stores/appearance.spec.ts
+++ b/packages/renderer/src/stores/appearance.spec.ts
@@ -20,7 +20,7 @@ import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
-import { isDark } from './appearance';
+import { isDark, isHighContrast } from './appearance';
 import { configurationProperties } from './configurationProperties';
 
 // mock window.getConfigurationValue
@@ -89,4 +89,32 @@ test('Expect dark mode using hc-dark configuration', async () => {
   configurationProperties.set([]);
 
   await vi.waitFor(() => expect(get(isDark)).toBe(true));
+});
+
+test('Expect not high contrast using light configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightEnumValue);
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isHighContrast)).toBe(false));
+});
+
+test('Expect not high contrast using dark configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkEnumValue);
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isHighContrast)).toBe(false));
+});
+
+test('Expect high contrast using hc-light configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.LightHCEnumValue);
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isHighContrast)).toBe(true));
+});
+
+test('Expect high contrast using hc-dark configuration', async () => {
+  getConfigurationValueMock.mockResolvedValue(AppearanceSettings.DarkHCEnumValue);
+  configurationProperties.set([]);
+
+  await vi.waitFor(() => expect(get(isHighContrast)).toBe(true));
 });

--- a/packages/renderer/src/stores/appearance.ts
+++ b/packages/renderer/src/stores/appearance.ts
@@ -22,6 +22,7 @@ import { type Writable, writable } from 'svelte/store';
 import { configurationProperties } from './configurationProperties';
 
 export const isDark: Writable<boolean> = writable(false);
+export const isHighContrast: Writable<boolean> = writable(false);
 
 configurationProperties.subscribe(() => {
   if (window?.getConfigurationValue) {
@@ -29,7 +30,7 @@ configurationProperties.subscribe(() => {
       ?.getConfigurationValue<string>(AppearanceSettings.SectionName + '.' + AppearanceSettings.Appearance)
       ?.then(value => {
         if (value) {
-          updateIsDark(value);
+          updateAppearance(value);
         }
       })
       ?.catch((err: unknown) =>
@@ -41,13 +42,21 @@ configurationProperties.subscribe(() => {
   }
 });
 
-function updateIsDark(appearance: string): void {
+function updateAppearance(appearance: string): void {
   if (appearance === AppearanceSettings.SystemEnumValue) {
-    // need to read the system default theme using the window.matchMedia
     isDark.set(window.matchMedia('(prefers-color-scheme: dark)').matches);
-  } else if (appearance === AppearanceSettings.LightEnumValue || appearance === AppearanceSettings.LightHCEnumValue) {
+    isHighContrast.set(false);
+  } else if (appearance === AppearanceSettings.LightEnumValue) {
     isDark.set(false);
-  } else if (appearance === AppearanceSettings.DarkEnumValue || appearance === AppearanceSettings.DarkHCEnumValue) {
+    isHighContrast.set(false);
+  } else if (appearance === AppearanceSettings.LightHCEnumValue) {
+    isDark.set(false);
+    isHighContrast.set(true);
+  } else if (appearance === AppearanceSettings.DarkEnumValue) {
     isDark.set(true);
+    isHighContrast.set(false);
+  } else if (appearance === AppearanceSettings.DarkHCEnumValue) {
+    isDark.set(true);
+    isHighContrast.set(true);
   }
 }

--- a/packages/renderer/src/stores/colors.spec.ts
+++ b/packages/renderer/src/stores/colors.spec.ts
@@ -36,7 +36,7 @@ const eventEmitter = {
 
 vi.mock(import('/@/lib/appearance/appearance-util'));
 
-const listColorsMock: Mock<() => Promise<ColorInfo[]>> = vi.fn();
+const listColorsMock: Mock<(theme: string) => Promise<ColorInfo[]>> = vi.fn();
 
 Object.defineProperty(global, 'window', {
   value: {

--- a/packages/renderer/src/stores/colors.spec.ts
+++ b/packages/renderer/src/stores/colors.spec.ts
@@ -25,7 +25,7 @@ import { beforeEach, expect, test, vi } from 'vitest';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 
-import { colorsEventStore, colorsInfos } from './colors';
+import { colorsEventStore, colorsInfos, darkContextColorsInfos, hcDarkContextColorsInfos } from './colors';
 
 const callbacks = new Map<string, any>();
 const eventEmitter = {
@@ -56,15 +56,18 @@ beforeEach(() => {
 });
 
 test('grab colors', async () => {
-  // initial view
-  listColorsMock.mockResolvedValue([
-    {
-      id: 'color1',
-      value: '#123',
-      cssVar: '--pd-color1',
-    },
-    { id: 'color2', value: '#456', cssVar: '--pd-color2' },
-  ]);
+  listColorsMock.mockImplementation((theme: string) => {
+    if (theme === 'dark') {
+      return Promise.resolve([{ id: 'color-dark', value: '#dark01', cssVar: '--pd-color-dark' }]);
+    }
+    if (theme === 'hc-dark') {
+      return Promise.resolve([{ id: 'color-hcdark', value: '#hcd01', cssVar: '--pd-color-hcdark' }]);
+    }
+    return Promise.resolve([
+      { id: 'color1', value: '#123', cssVar: '--pd-color1' },
+      { id: 'color2', value: '#456', cssVar: '--pd-color2' },
+    ]);
+  });
   colorsEventStore.setup();
 
   const callback = callbacks.get('extensions-already-started');
@@ -77,15 +80,27 @@ test('grab colors', async () => {
     await new Promise(resolve => setTimeout(resolve, 100));
   }
 
-  // now get list
+  // now get the current-theme list
   const colors = get(colorsInfos);
   expect(colors.length).toBe(2);
-
-  // check colors values
   expect(colors[0].id).toBe('color1');
   expect(colors[0].value).toBe('#123');
   expect(colors[0].cssVar).toBe('--pd-color1');
   expect(colors[1].id).toBe('color2');
   expect(colors[1].value).toBe('#456');
   expect(colors[1].cssVar).toBe('--pd-color2');
+
+  // dark context store should be populated with dark-theme values
+  const darkColors = get(darkContextColorsInfos);
+  expect(darkColors.length).toBe(1);
+  expect(darkColors[0].id).toBe('color-dark');
+  expect(darkColors[0].value).toBe('#dark01');
+  expect(darkColors[0].cssVar).toBe('--pd-color-dark');
+
+  // hc-dark context store should be populated with hc-dark-theme values
+  const hcDarkColors = get(hcDarkContextColorsInfos);
+  expect(hcDarkColors.length).toBe(1);
+  expect(hcDarkColors[0].id).toBe('color-hcdark');
+  expect(hcDarkColors[0].value).toBe('#hcd01');
+  expect(hcDarkColors[0].cssVar).toBe('--pd-color-hcdark');
 });

--- a/packages/renderer/src/stores/colors.ts
+++ b/packages/renderer/src/stores/colors.ts
@@ -27,13 +27,22 @@ const windowEvents = ['color-updated', 'extension-stopped', 'extensions-started'
 const windowListeners = ['appearance-changed', 'extensions-already-started', 'system-ready'];
 
 export const colorsInfos: Writable<ColorInfo[]> = writable([]);
+export const darkContextColorsInfos: Writable<ColorInfo[]> = writable([]);
+export const hcDarkContextColorsInfos: Writable<ColorInfo[]> = writable([]);
 
 const appearanceUtil: AppearanceUtil = new AppearanceUtil();
 
 // use helper here as window methods are initialized after the store in tests
 const listColors = async (): Promise<ColorInfo[]> => {
   const themeName = await appearanceUtil.getTheme();
-  return window.listColors(themeName);
+  const [current, dark, hcDark] = await Promise.all([
+    window.listColors(themeName),
+    window.listColors('dark'),
+    window.listColors('hc-dark'),
+  ]);
+  darkContextColorsInfos.set(dark);
+  hcDarkContextColorsInfos.set(hcDark);
+  return current;
 };
 
 export const colorsEventStore = new EventStore<ColorInfo[]>(


### PR DESCRIPTION
### What does this PR do?

The statusbar always has a black background across all four app themes (light, dark, hc-light, hc-dark), but `--pd-*` CSS custom properties are resolved flat into `:root` with a single value for the active theme. In light and hc-light modes, components like `ProgressBar` would pick up light-background token values, making them illegible against the dark statusbar.

Rather than patching individual components, this PR makes the statusbar container enforce a dark-context theme for all its children automatically, so any current or future component placed in the statusbar renders correctly without further changes.

**How it works:**

`ColorsStyle.svelte` now fetches the `dark` and `hc-dark` color sets in parallel with the current theme (using `window.listColors`, which already accepts any theme name) and generates two additional scoped CSS blocks:

```css
[data-pd-force-theme="dark"]    { /* dark-theme variable overrides */ }
[data-pd-force-theme="hc-dark"] { /* hc-dark-theme variable overrides */ }
```

The statusbar `<div>` is assigned `data-pd-force-theme="dark"` in normal/dark mode and
`data-pd-force-theme="hc-dark"` in high-contrast mode, driven by a new `isHighContrast`
store in `stores/appearance.ts`.

No changes to `packages/main`, `packages/api`, or `packages/preload`.

### Before:

Light (too dark progress bar and notification dots):

<img alt="1781247852-screenshot-light@2x" src="https://github.com/user-attachments/assets/c00f281d-cde4-4915-a76d-4cb79f217335" />

Dark (correct):

<img alt="1781247852-screenshot-dark@2x" src="https://github.com/user-attachments/assets/d0937de2-2a69-4913-b4bd-10495d3530d2" />

HC Light (completely wrong progress bar and very hard to see notification dots):

<img width="1408" height="500" alt="1781247852-screenshot-hc-light@2x" src="https://github.com/user-attachments/assets/7a97d868-bcea-45e3-b693-a9f0ac0ac40c" />

HC Dark (correct):

<img width="1408" height="500" alt="1781247852-screenshot-hc-dark@2x" src="https://github.com/user-attachments/assets/44467a4d-78af-4bbc-a76e-08edb2db4fcd" />

### Now (only changes):

Light (fixed progress bar and notification dots):

<img width="1408" height="500" alt="image" src="https://github.com/user-attachments/assets/633f65f8-67e7-40f3-a2c1-0b934d1cc9c5" />

HC Light (fixed progress bar and notification dots):

<img width="1408" height="500" alt="image" src="https://github.com/user-attachments/assets/fe195f17-3a16-4c83-889c-ff510282ae4c" />

### What issues does this PR fix or reference?

- Resolves: #17647

### How to test this PR?

1. Enable the experimental task statusbar: open **Settings → Preferences**, search for    "Tasks status bar", enable it
2. Start any long-running operation (e.g. pull an image) to trigger a running task
3. While the progress bar is visible in the statusbar, cycle through all four themes    (**Settings → Preferences → Appearance**): Light, Dark, High Contrast Light, High Contrast Dark
4. In all four themes the progress bar should render with dark-context colors — a light   bar on a dark background, never a dark bar on a dark background

- [x] Tests are covering the bug fix or the new feature

Assisted-by: Claude Code <noreply@anthropic.com>