### PR TITLE
refactor(renderer): migrate NavItem component to Svelte 5 runes

### DIFF
--- a/packages/renderer/src/lib/ui/NavItem.svelte
+++ b/packages/renderer/src/lib/ui/NavItem.svelte
@@ -1,32 +1,37 @@
 <script lang="ts">
-/* eslint-disable import/no-duplicates */
-// https://github.com/import-js/eslint-plugin-import/issues/1479
 import { Tooltip } from '@podman-desktop/ui-svelte';
-import { getContext, onDestroy, onMount } from 'svelte';
+import { getContext, onDestroy, onMount, type Snippet } from 'svelte';
 import type { MouseEventHandler } from 'svelte/elements';
 import type { Writable } from 'svelte/store';
 import type { TinroRouteMeta } from 'tinro';
-/* eslint-disable import/no-duplicates */
 
-export let href: string;
-export let tooltip: string;
-export let ariaLabel: string | undefined = undefined;
-export let meta: TinroRouteMeta;
-export let onClick: MouseEventHandler<HTMLAnchorElement> | undefined = undefined;
-export let counter: number | undefined = undefined;
+interface Props {
+  href: string;
+  tooltip: string;
+  ariaLabel?: string;
+  meta: TinroRouteMeta;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  counter?: number;
+  children?: Snippet;
+}
 
-let inSection: boolean = false;
-let uri: string;
-$: uri = encodeURI(href);
-let selected: boolean;
-$: selected = meta.url === uri || (uri !== '/' && meta.url.startsWith(uri));
+let { href, tooltip, ariaLabel, meta = $bindable(), onClick, counter, children }: Props = $props();
 
 const navItems: Writable<number> = getContext('nav-items');
+const inSection = $navItems !== undefined;
+let uri = $derived(encodeURI(href));
+let selected = $derived(meta.url === uri || (uri !== '/' && meta.url.startsWith(uri)));
 
-$: tooltipText = counter ? `${tooltip} (${counter})` : tooltip;
+let tooltipText = $derived(counter ? `${tooltip} (${counter})` : tooltip);
+
+function handleClick(e: MouseEvent & { currentTarget: EventTarget & HTMLAnchorElement }): void {
+  if (onClick) {
+    e.preventDefault();
+    onClick(e);
+  }
+}
 
 onMount(() => {
-  inSection = $navItems !== undefined;
   navItems?.update(i => i + 1);
 });
 onDestroy(() => {
@@ -38,7 +43,7 @@ onDestroy(() => {
   href={onClick ? '#top' : uri}
   class=""
   aria-label={ariaLabel ?? tooltip}
-  on:click|preventDefault={onClick}>
+  onclick={handleClick}>
   <div
     class="flex py-2 justify-center items-center cursor-pointer min-h-9"
     class:border-x-[4px]={!inSection}
@@ -54,7 +59,7 @@ onDestroy(() => {
     class:hover:bg-[var(--pd-global-nav-icon-hover-bg)]={!selected || inSection}
     class:hover:border-[var(--pd-global-nav-icon-hover-bg)]={!selected && !inSection}>
     <Tooltip right tip={tooltipText} class="flex flex-col items-center">
-      <slot />
+      {@render children?.()}
     </Tooltip>
   </div>
 </a>

--- a/packages/renderer/src/lib/ui/NavItemTest.svelte
+++ b/packages/renderer/src/lib/ui/NavItemTest.svelte
@@ -1,12 +1,9 @@
 <script lang="ts">
-/* eslint-disable import/no-duplicates */
-// https://github.com/import-js/eslint-plugin-import/issues/1479
 import { setContext } from 'svelte';
 import { writable } from 'svelte/store';
 import type { TinroRouteMeta } from 'tinro';
 
 import NavItem from './NavItem.svelte';
-/* eslint-disable import/no-duplicates */
 
 let meta: TinroRouteMeta = { url: '/test' } as TinroRouteMeta;
 
@@ -14,4 +11,4 @@ let meta: TinroRouteMeta = { url: '/test' } as TinroRouteMeta;
 setContext('nav-items', writable(0));
 </script>
 
-<NavItem tooltip="Dashboard" href="/test" bind:meta={meta}></NavItem>
+<NavItem tooltip="Dashboard" href="/test" {meta}></NavItem>


### PR DESCRIPTION
### What does this PR do?
Replace legacy Svelte 4 patterns with Svelte 5 equivalents: $props() interface, $derived for reactive computations, snippet-based children, and native onclick handler.

### Screenshot / video of UI
Should be no visual/functional change 

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/17799

### How to test this PR?
Navigate through the app

- [x] Tests are covering the bug fix or the new feature
