### PR TITLE
feat(api): add err callback to exec api

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4593,6 +4593,14 @@ declare module '@podman-desktop/api' {
      * if Podman Desktop exits. Stdout/stderr will not be captured.
      */
     detached?: boolean;
+
+    /**
+     * Optional callback invoked whenever stdout or stderr data is received from the process.
+     * This allows streaming output in real-time rather than waiting for the process to complete.
+     * @param event - Either 'stdout' or 'stderr' indicating which stream the data came from.
+     * @param data - The string data received from the process.
+     */
+    callback?: (event: 'stdout' | 'stderr', data: string) => void;
   }
 
   /**

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -585,6 +585,93 @@ describe('exec', () => {
     expect(stdout).toContain('Hello, World!');
     expect(setEncodingMock).toBeCalledWith('utf16le');
   });
+
+  test('should invoke callback with stdout data', async () => {
+    const command = 'echo';
+    const args = ['Hello'];
+    const callback = vi.fn();
+
+    const stdoutOn = vi.fn().mockImplementation((event: string, cb: (arg0: string) => void) => {
+      if (event === 'data') {
+        cb('chunk1');
+        cb('chunk2');
+      }
+    }) as unknown as Readable;
+    const stderrOn = vi.fn().mockImplementation((event: string, cb: (arg0: string) => void) => {
+      if (event === 'data') {
+        cb('warn1');
+      }
+    }) as unknown as Readable;
+    vi.mocked(spawn).mockReturnValue({
+      stdout: { on: stdoutOn, setEncoding: setEncodingMock },
+      stderr: { on: stderrOn, setEncoding: setEncodingMock },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'close') {
+          cb(0);
+        }
+      }),
+    } as unknown as ChildProcess);
+
+    await exec.exec(command, args, { callback });
+
+    expect(callback).toHaveBeenCalledWith('stdout', 'chunk1');
+    expect(callback).toHaveBeenCalledWith('stdout', 'chunk2');
+    expect(callback).toHaveBeenCalledWith('stderr', 'warn1');
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  test('should invoke callback with stderr data on failure', async () => {
+    const command = 'failing-cmd';
+    const callback = vi.fn();
+
+    const stdoutOn = vi
+      .fn()
+      .mockImplementation((_event: string, _cb: (arg0: string) => void) => {}) as unknown as Readable;
+    const stderrOn = vi.fn().mockImplementation((event: string, cb: (arg0: string) => void) => {
+      if (event === 'data') {
+        cb('error details');
+      }
+    }) as unknown as Readable;
+    vi.mocked(spawn).mockReturnValue({
+      stdout: { on: stdoutOn, setEncoding: setEncodingMock },
+      stderr: { on: stderrOn, setEncoding: setEncodingMock },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'close') {
+          cb(1);
+        }
+      }),
+    } as unknown as ChildProcess);
+
+    await expect(exec.exec(command, [], { callback })).rejects.toThrowError(/exit code 1/);
+
+    expect(callback).toHaveBeenCalledWith('stderr', 'error details');
+  });
+
+  test('should include stderr in error message on non-zero exit code', async () => {
+    const command = 'failing-cmd';
+
+    const stdoutOn = vi
+      .fn()
+      .mockImplementation((_event: string, _cb: (arg0: string) => void) => {}) as unknown as Readable;
+    const stderrOn = vi.fn().mockImplementation((event: string, cb: (arg0: string) => void) => {
+      if (event === 'data') {
+        cb('permission denied');
+      }
+    }) as unknown as Readable;
+    vi.mocked(spawn).mockReturnValue({
+      stdout: { on: stdoutOn, setEncoding: setEncodingMock },
+      stderr: { on: stderrOn, setEncoding: setEncodingMock },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'close') {
+          cb(1);
+        }
+      }),
+    } as unknown as ChildProcess);
+
+    await expect(exec.exec(command)).rejects.toThrowError(
+      'Command execution failed with exit code 1: permission denied',
+    );
+  });
 });
 
 describe('getInstallationPath', () => {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -165,13 +165,29 @@ export class Exec {
     childProcess.stderr.setEncoding(options?.encoding ?? 'utf8');
 
     childProcess.stdout.on('data', data => {
-      output.stdout += data.toString();
+      const str = data.toString();
+      output.stdout += str;
       options?.logger?.log(data);
+      if (options?.callback) {
+        try {
+          options.callback('stdout', str);
+        } catch (error: unknown) {
+          options?.logger?.error(`RunOptions callback failed on stdout: ${String(error)}`);
+        }
+      }
     });
 
     childProcess.stderr.on('data', data => {
-      output.stderr += data.toString();
+      const str = data.toString();
+      output.stderr += str;
       options?.logger?.warn(data);
+      if (options?.callback) {
+        try {
+          options.callback('stderr', str);
+        } catch (error: unknown) {
+          options?.logger?.error(`RunOptions callback failed on stderr: ${String(error)}`);
+        }
+      }
     });
 
     return this.awaitChildProcess(childProcess, command, output, options);
@@ -241,14 +257,18 @@ export class Exec {
           };
           resolve(result);
         } else {
-          options?.logger?.error(`Command execution failed with exit code ${exitCode}`);
+          const stderr = output.stderr.trim();
+          const message = stderr
+            ? `Command execution failed with exit code ${exitCode}: ${stderr}`
+            : `Command execution failed with exit code ${exitCode}`;
+          options?.logger?.error(message);
           const errResult: RunError = new RunErrorImpl(
-            `Command execution failed with exit code ${exitCode}`,
-            `Command execution failed with exit code ${exitCode}`,
+            message,
+            message,
             exitCode ?? 1,
             command,
             output.stdout.trim(),
-            output.stderr.trim(),
+            stderr,
             false,
             childProcess.killed,
           );


### PR DESCRIPTION
feat(api): add err callback to exec api

### What does this PR do?

Similar to our streaming API, this adds a proper callback so that we can
have stderr output whenever a command fails.

Instead of:
```
main ↪️  [bootc] Error: Command execution failed with exit code 125
```

for example, with bootc exec, we now get:

```
  main ↪️  [bootc] Error: Command execution failed with exit code 125: machine did not transition
  into running state: ssh error: ssh: handshake failed: ssh: unable to authenticate, attempted
  methods [none publickey], no supported methods remain
```

Which gives more information on why our command had failed.

### Screenshot / video of UI

N/A, no changes to UI, more just for log output.

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/8321

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature

1. Purposely from an extension, trigger a command that will fail (try to
   start kind, start a VM on bootc without proper credentials, etc.)
2. See that now you have more information than just an error exit code
   125.
