### PR TITLE
fix(renderer): avoid detailsPage ref in delete-redirect effects

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -35,7 +35,7 @@
     "micromark-extension-directive": "^4.0.0",
     "moment": "^2.30.1",
     "monaco-editor": "^0.55.1",
-    "svelte": "5.53.7",
+    "svelte": "5.56.3",
     "svelte-check": "^4.6.0",
     "svelte-eslint-parser": "^1.8.0",
     "svelte-fa": "^4.0.4",

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -10,6 +10,7 @@ import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import StateChange from '/@/lib/ui/StateChange.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
 import { containersInfos } from '/@/stores/containers';
 
 import { ContainerUtils } from './container-utils';
@@ -33,6 +34,7 @@ const containerUtils = new ContainerUtils();
 
 let detailsPage = $state<DetailsPage | undefined>();
 let displayTty: boolean = $state(false);
+let hasSeenContainer = $state(false);
 
 let container: ContainerInfoUI | undefined = $derived(
   getContainerInfoUI($containersInfos.find(c => c.Id === containerID)),
@@ -40,6 +42,7 @@ let container: ContainerInfoUI | undefined = $derived(
 
 $effect(() => {
   if (container) {
+    hasSeenContainer = true;
     window
       .getContainerInspect(container.engineId, container.id)
       .then(inspect => {
@@ -55,8 +58,8 @@ $effect(() => {
         }
       })
       .catch((err: unknown) => console.error(`Error getting container inspect ${container?.id}: ${err}`));
-  } else {
-    detailsPage?.close();
+  } else if (hasSeenContainer) {
+    router.goto($lastPage.path);
   }
 });
 

--- a/packages/renderer/src/lib/image/ImageDetails.svelte
+++ b/packages/renderer/src/lib/image/ImageDetails.svelte
@@ -14,6 +14,7 @@ import {
   IMAGE_VIEW_ICONS,
 } from '/@/lib/view/views';
 import Route from '/@/Route.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
 import { containersInfos } from '/@/stores/containers';
 import { context } from '/@/stores/context';
 import { imageCheckerProviders } from '/@/stores/image-checker-providers';
@@ -74,14 +75,16 @@ let image: ImageInfoUI | undefined = $derived(
     : undefined,
 );
 let detailsPage: DetailsPage | undefined = $state();
+let hasSeenImage = $state(false);
 
 let showCheckTab: boolean = $derived($imageCheckerProviders.length > 0);
 let showFilesTab: boolean = $derived($imageFilesProviders.length > 0);
 
 $effect(() => {
-  if (!image) {
-    // the image has been deleted
-    detailsPage?.close();
+  if (image) {
+    hasSeenImage = true;
+  } else if (hasSeenImage) {
+    router.goto($lastPage.path);
   }
 });
 </script>

--- a/packages/renderer/src/lib/network/NetworkDetails.svelte
+++ b/packages/renderer/src/lib/network/NetworkDetails.svelte
@@ -6,6 +6,7 @@ import NetworkIcon from '/@/lib/images/NetworkIcon.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
 import { networksListInfo } from '/@/stores/networks';
 
 import { NetworkUtils } from './network-utils';
@@ -31,10 +32,13 @@ let network: NetworkInfoUI | undefined = $derived(
   matchingNetwork ? networkUtils.toNetworkInfoUI(matchingNetwork) : undefined,
 );
 let detailsPage: DetailsPage | undefined = $state();
+let hasSeenNetwork = $state(false);
 
 $effect(() => {
-  if (!network && detailsPage) {
-    detailsPage.close();
+  if (network) {
+    hasSeenNetwork = true;
+  } else if (hasSeenNetwork) {
+    router.goto($lastPage.path);
   }
 });
 </script>

--- a/packages/renderer/src/lib/volume/VolumeDetails.svelte
+++ b/packages/renderer/src/lib/volume/VolumeDetails.svelte
@@ -6,6 +6,7 @@ import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
+import { lastPage } from '/@/stores/breadcrumb';
 import { volumeListInfos } from '/@/stores/volumes';
 
 import VolumeDetailsSummary from '././VolumeDetailsSummary.svelte';
@@ -22,6 +23,7 @@ let { volumeName, engineId }: Props = $props();
 
 const volumeUtils = new VolumeUtils();
 let detailsPage = $state<DetailsPage>();
+let hasSeenVolume = $state(false);
 
 let volume: VolumeInfoUI | undefined = $derived.by(() => {
   const allVolumes = $volumeListInfos.map(volumeListInfo => volumeListInfo.Volumes).flat();
@@ -37,7 +39,11 @@ let volume: VolumeInfoUI | undefined = $derived.by(() => {
 });
 
 $effect(() => {
-  if (!volume) detailsPage?.close();
+  if (volume) {
+    hasSeenVolume = true;
+  } else if (hasSeenVolume) {
+    router.goto($lastPage.path);
+  }
 });
 </script>
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -178,7 +178,7 @@
     "@typescript-eslint/eslint-plugin": "^8.61.0",
     "eslint-plugin-svelte": "^3.19.0",
     "jsdom": "^29.1.1",
-    "svelte": "5.53.7",
+    "svelte": "5.56.3",
     "svelte-check": "^4.6.0",
     "svelte-eslint-parser": "^1.8.0",
     "tailwindcss": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,7 +779,7 @@ importers:
         version: link:../ui
       '@zerodevx/svelte-toast':
         specifier: ^0.9.6
-        version: 0.9.6(svelte@5.53.7)
+        version: 0.9.6(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       electron-context-menu:
         specifier: 4.1.2
         version: 4.1.2
@@ -810,7 +810,7 @@ importers:
         version: 7.2.0
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -822,7 +822,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+        version: 5.3.1(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -852,7 +852,7 @@ importers:
         version: 6.0.0
       eslint-plugin-svelte:
         specifier: ^3.19.0
-        version: 3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.53.7)
+        version: 3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       filesize:
         specifier: ^11.0.17
         version: 11.0.17
@@ -875,17 +875,17 @@ importers:
         specifier: ^0.55.1
         version: 0.55.1
       svelte:
-        specifier: 5.53.7
-        version: 5.53.7
+        specifier: 5.56.3
+        version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-check:
         specifier: ^4.6.0
-        version: 4.6.0(picomatch@4.0.4)(svelte@5.53.7)(typescript@5.9.3)
+        version: 4.6.0(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)
       svelte-eslint-parser:
         specifier: ^1.8.0
-        version: 1.8.0(svelte@5.53.7)
+        version: 1.8.0(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       svelte-fa:
         specifier: ^4.0.4
-        version: 4.0.4(svelte@5.53.7)
+        version: 4.0.4(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       svelte-steps:
         specifier: 2.4.1
         version: 2.4.1
@@ -936,14 +936,14 @@ importers:
         version: 2.30.1
       svelte-fa:
         specifier: ^4.0.4
-        version: 4.0.4(svelte@5.53.7)
+        version: 4.0.4(svelte@5.56.3(@typescript-eslint/types@8.61.0))
     devDependencies:
       '@sveltejs/package':
         specifier: ^2.5.8
-        version: 2.5.8(svelte@5.53.7)(typescript@5.9.3)
+        version: 2.5.8(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -955,7 +955,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.3.1
-        version: 5.3.1(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+        version: 5.3.1(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
@@ -967,19 +967,19 @@ importers:
         version: 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.1(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-svelte:
         specifier: ^3.19.0
-        version: 3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.53.7)
+        version: 3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       svelte:
-        specifier: 5.53.7
-        version: 5.53.7
+        specifier: 5.56.3
+        version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-check:
         specifier: ^4.6.0
-        version: 4.6.0(picomatch@4.0.4)(svelte@5.53.7)(typescript@5.9.3)
+        version: 4.6.0(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)
       svelte-eslint-parser:
         specifier: ^1.8.0
-        version: 1.8.0(svelte@5.53.7)
+        version: 1.8.0(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1020,7 +1020,7 @@ importers:
         version: 10.4.1(jiti@2.7.0)
       svelte-fa:
         specifier: ^4.0.4
-        version: 4.0.4(svelte@5.53.7)
+        version: 4.0.4(svelte@5.56.3(@typescript-eslint/types@8.61.0))
     devDependencies:
       '@storybook/addon-a11y':
         specifier: ^10.4.3
@@ -1033,19 +1033,19 @@ importers:
         version: 10.4.3(@types/react@18.3.12)(react@18.2.0)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))
       '@storybook/addon-svelte-csf':
         specifier: 5.1.2
-        version: 5.1.2(@storybook/svelte@10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 5.1.2(@storybook/svelte@10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
       '@storybook/addon-themes':
         specifier: ^10.4.3
         version: 10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))
       '@storybook/svelte-vite':
         specifier: ^10.4.3
-        version: 10.4.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.25.12)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.0(esbuild@0.25.12))
+        version: 10.4.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.25.12)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.0(esbuild@0.25.12))
       '@sveltejs/package':
         specifier: ^2.5.8
-        version: 2.5.8(svelte@5.53.7)(typescript@5.9.3)
+        version: 2.5.8(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1066,7 +1066,7 @@ importers:
         version: 10.4.4(eslint@10.4.1(jiti@2.7.0))(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
       eslint-plugin-svelte:
         specifier: ^3.19.0
-        version: 3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.53.7)
+        version: 3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       postcss:
         specifier: ^8.5.12
         version: 8.5.15
@@ -1083,11 +1083,11 @@ importers:
         specifier: ^10.4.2
         version: 10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       svelte:
-        specifier: 5.53.7
-        version: 5.53.7
+        specifier: 5.56.3
+        version: 5.56.3(@typescript-eslint/types@8.61.0)
       svelte-check:
         specifier: ^4.6.0
-        version: 4.6.0(picomatch@4.0.4)(svelte@5.53.7)(typescript@5.9.3)
+        version: 4.6.0(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1126,19 +1126,19 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: ^3.10.0
-        version: 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+        version: 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/plugin-client-redirects':
         specifier: ^3.10.0
-        version: 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+        version: 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/preset-classic':
         specifier: ^3.10.0
-        version: 3.10.1(@algolia/client-search@5.42.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 3.10.1(@algolia/client-search@5.42.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)
       '@docusaurus/theme-common':
         specifier: ^3.10.0
-        version: 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@docusaurus/theme-mermaid':
         specifier: ^3.10.0
-        version: 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+        version: 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@fortawesome/fontawesome-svg-core':
         specifier: ^7.2.0
         version: 7.2.0
@@ -1181,13 +1181,13 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.10.0
-        version: 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@docusaurus/tsconfig':
         specifier: ^3.10.0
         version: 3.10.1
       '@docusaurus/types':
         specifier: ^3.10.0
-        version: 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+        version: 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -2027,24 +2027,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.16':
     resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.16':
     resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.16':
     resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.16':
     resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
@@ -3091,89 +3095,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3626,48 +3646,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -3743,41 +3771,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -3930,36 +3966,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -4075,66 +4117,79 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -4379,8 +4434,8 @@ packages:
       storybook: ^10.4.3
       svelte: ^5.0.0
 
-  '@sveltejs/acorn-typescript@1.0.9':
-    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+  '@sveltejs/acorn-typescript@1.0.10':
+    resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -4529,24 +4584,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -4787,9 +4846,6 @@ packages:
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -5181,51 +5237,61 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -5435,8 +5501,8 @@ packages:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -6928,8 +6994,8 @@ packages:
     engines: {node: '>= 4.0.0'}
     hasBin: true
 
-  devalue@5.6.4:
-    resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -7487,8 +7553,13 @@ packages:
   esrap@1.4.9:
     resolution: {integrity: sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g==}
 
-  esrap@2.2.3:
-    resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
+  esrap@2.2.11:
+    resolution: {integrity: sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -8917,24 +8988,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -11621,8 +11696,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0 || ^6.0.0
 
-  svelte@5.53.7:
-    resolution: {integrity: sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==}
+  svelte@5.56.3:
+    resolution: {integrity: sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==}
     engines: {node: '>=18'}
 
   svg-parser@2.0.4:
@@ -14201,7 +14276,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/babel@3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/babel@3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/generator': 7.26.10
@@ -14213,7 +14288,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@babel/traverse': 7.26.10
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.5
       tslib: 2.8.1
@@ -14227,14 +14302,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/bundler@3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.26.10
-      '@docusaurus/babel': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/babel': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@docusaurus/cssnano-preset': 3.10.1
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       babel-loader: 9.2.1(@babel/core@7.26.10)(webpack@5.105.0(esbuild@0.25.12))
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.105.0(esbuild@0.25.12))
@@ -14269,15 +14344,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/core@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/bundler': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/babel': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/bundler': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/mdx-loader': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@mdx-js/react': 3.1.1(@types/react@18.3.12)(react@18.2.0)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -14345,12 +14420,12 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/mdx-loader@3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@mdx-js/mdx': 3.1.0(acorn@8.16.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@mdx-js/mdx': 3.1.0(acorn@8.17.0)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.3.3
@@ -14381,9 +14456,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/module-type-aliases@3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -14400,13 +14475,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-client-redirects@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-client-redirects@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       eta: 2.2.0
       fs-extra: 11.3.4
       lodash: 4.18.1
@@ -14432,17 +14507,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-blog@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/mdx-loader': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
@@ -14475,17 +14550,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/mdx-loader': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.5
@@ -14516,13 +14591,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-pages@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/mdx-loader': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/mdx-loader': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       fs-extra: 11.3.5
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -14547,12 +14622,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -14575,11 +14650,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-debug@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       fs-extra: 11.3.5
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -14604,11 +14679,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-analytics@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
       tslib: 2.8.1
@@ -14631,11 +14706,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-gtag@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/gtag.js': 0.0.20
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -14659,11 +14734,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-tag-manager@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
       tslib: 2.8.1
@@ -14686,14 +14761,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-sitemap@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       fs-extra: 11.3.5
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -14718,12 +14793,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/plugin-svgr@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
       react: 18.2.0
@@ -14749,23 +14824,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.42.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.42.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-debug': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-google-analytics': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-google-gtag': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-google-tag-manager': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-sitemap': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-svgr': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/theme-classic': 3.10.1(@types/react@18.3.12)(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.42.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-debug': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-google-analytics': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-google-gtag': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-google-tag-manager': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-sitemap': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-svgr': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/theme-classic': 3.10.1(@types/react@18.3.12)(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.42.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
     transitivePeerDependencies:
@@ -14795,21 +14870,21 @@ snapshots:
       '@types/react': 18.3.12
       react: 18.2.0
 
-  '@docusaurus/theme-classic@3.10.1(@types/react@18.3.12)(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/theme-classic@3.10.1(@types/react@18.3.12)(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/mdx-loader': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/mdx-loader': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@mdx-js/react': 3.1.1(@types/react@18.3.12)(react@18.2.0)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -14844,13 +14919,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/module-type-aliases': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/mdx-loader': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/module-type-aliases': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
       '@types/react': 18.3.12
       '@types/react-router-config': 5.0.11
@@ -14869,13 +14944,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-mermaid@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
+  '@docusaurus/theme-mermaid@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/module-type-aliases': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/module-type-aliases': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       mermaid: 11.15.0
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
@@ -14900,17 +14975,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.42.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.42.0)(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(@types/react@18.3.12)(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.19.8(@algolia/client-search@5.42.0)(algoliasearch@5.42.0)(search-insights@2.17.3)
       '@docsearch/react': 3.9.0(@algolia/client-search@5.42.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(search-insights@2.17.3)
-      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/core': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-docs': 3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.2.0))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)(typescript@5.9.3))(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-validation': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       algoliasearch: 5.42.0
       algoliasearch-helper: 3.26.0(algoliasearch@5.42.0)
       clsx: 2.1.1
@@ -14950,9 +15025,9 @@ snapshots:
 
   '@docusaurus/tsconfig@3.10.1': {}
 
-  '@docusaurus/types@3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/types@3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@mdx-js/mdx': 3.1.0(acorn@8.16.0)
+      '@mdx-js/mdx': 3.1.0(acorn@8.17.0)
       '@types/history': 4.7.11
       '@types/mdast': 4.0.4
       '@types/react': 18.3.12
@@ -14972,9 +15047,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/utils-common@3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -14986,11 +15061,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/utils-validation@3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       fs-extra: 11.3.5
       joi: 17.13.3
       js-yaml: 4.2.0
@@ -15006,11 +15081,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
+  '@docusaurus/utils@3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-common': 3.10.1(acorn@8.17.0)(esbuild@0.25.12)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
       file-loader: 6.2.0(webpack@5.105.0(esbuild@0.25.12))
@@ -15751,7 +15826,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/mdx@3.1.0(acorn@8.16.0)':
+  '@mdx-js/mdx@3.1.0(acorn@8.17.0)':
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
@@ -15765,7 +15840,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.2
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.0(acorn@8.16.0)
+      recma-jsx: 1.0.0(acorn@8.17.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.0
@@ -16767,18 +16842,18 @@ snapshots:
       '@types/react': 18.3.12
       react: 18.2.0
 
-  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@storybook/addon-svelte-csf@5.1.2(@storybook/svelte@10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@storybook/csf': 0.1.13
-      '@storybook/svelte': 10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/svelte': 10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
       dedent: 1.7.2
       es-toolkit: 1.45.1
       esrap: 1.4.9
       magic-string: 0.30.21
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      svelte: 5.53.7
-      svelte-ast-print: 0.4.2(svelte@5.53.7)
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
+      svelte-ast-print: 0.4.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       vite: 8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)
       zimmerframe: 1.1.4
     transitivePeerDependencies:
@@ -16829,15 +16904,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.12
 
-  '@storybook/svelte-vite@10.4.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.25.12)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.0(esbuild@0.25.12))':
+  '@storybook/svelte-vite@10.4.3(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)))(esbuild@0.25.12)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.0(esbuild@0.25.12))':
     dependencies:
       '@storybook/builder-vite': 10.4.3(esbuild@0.25.12)(rollup@4.61.1)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.105.0(esbuild@0.25.12))
-      '@storybook/svelte': 10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@storybook/svelte': 10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
       magic-string: 0.30.21
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      svelte: 5.53.7
-      svelte2tsx: 0.7.56(svelte@5.53.7)(typescript@5.9.3)
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
+      svelte2tsx: 0.7.56(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)
       typescript: 5.9.3
       vite: 8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -16845,36 +16920,36 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/svelte@10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.53.7)':
+  '@storybook/svelte@10.4.3(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0))':
     dependencies:
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@18.3.12)(prettier@3.8.4)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
       ts-dedent: 2.2.0
       type-fest: 5.7.0
 
-  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.17.0)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   '@sveltejs/load-config@0.1.1': {}
 
-  '@sveltejs/package@2.5.8(svelte@5.53.7)(typescript@5.9.3)':
+  '@sveltejs/package@2.5.8(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)':
     dependencies:
       chokidar: 5.0.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.8.4
-      svelte: 5.53.7
-      svelte2tsx: 0.7.56(svelte@5.53.7)(typescript@5.9.3)
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
+      svelte2tsx: 0.7.56(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
       vite: 8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
 
@@ -17077,15 +17152,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/svelte-core@1.0.0(svelte@5.53.7)':
+  '@testing-library/svelte-core@1.0.0(svelte@5.56.3(@typescript-eslint/types@8.61.0))':
     dependencies:
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
 
-  '@testing-library/svelte@5.3.1(svelte@5.53.7)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
+  '@testing-library/svelte@5.3.1(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      '@testing-library/svelte-core': 1.0.0(svelte@5.53.7)
-      svelte: 5.53.7
+      '@testing-library/svelte-core': 1.0.0(svelte@5.56.3(@typescript-eslint/types@8.61.0))
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.9.2)(typescript@5.9.3))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.12)(jiti@2.7.0)(terser@5.36.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -17315,8 +17390,6 @@ snapshots:
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
-
-  '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
 
@@ -18048,9 +18121,9 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@zerodevx/svelte-toast@0.9.6(svelte@5.53.7)':
+  '@zerodevx/svelte-toast@0.9.6(svelte@5.56.3(@typescript-eslint/types@8.61.0))':
     dependencies:
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
 
   abbrev@3.0.1: {}
 
@@ -18064,19 +18137,19 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-import-phases@1.0.4(acorn@8.16.0):
+  acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
-  acorn@8.16.0: {}
+  acorn@8.17.0: {}
 
   address@1.2.2: {}
 
@@ -19705,7 +19778,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  devalue@5.6.4: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -20151,7 +20224,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.16.0
+      acorn: 8.17.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
 
@@ -20370,7 +20443,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-svelte@3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.53.7):
+  eslint-plugin-svelte@3.19.0(eslint@10.4.1(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.61.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -20382,9 +20455,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.15)
       postcss-safe-parser: 7.0.1(postcss@8.5.15)
       semver: 7.8.4
-      svelte-eslint-parser: 1.8.0(svelte@5.53.7)
+      svelte-eslint-parser: 1.8.0(svelte@5.56.3(@typescript-eslint/types@8.61.0))
     optionalDependencies:
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
     transitivePeerDependencies:
       - ts-node
 
@@ -20471,14 +20544,14 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
@@ -20496,9 +20569,11 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  esrap@2.2.3:
+  esrap@2.2.11(@typescript-eslint/types@8.61.0):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.61.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -22740,8 +22815,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       micromark-extension-mdx-expression: 3.0.0
       micromark-extension-mdx-jsx: 3.0.1
       micromark-extension-mdx-md: 2.0.0
@@ -23011,7 +23086,7 @@ snapshots:
 
   mlly@1.8.2:
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4
@@ -24420,9 +24495,9 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.0(acorn@8.16.0):
+  recma-jsx@1.0.0(acorn@8.17.0):
     dependencies:
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -25502,13 +25577,13 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-ast-print@0.4.2(svelte@5.53.7):
+  svelte-ast-print@0.4.2(svelte@5.56.3(@typescript-eslint/types@8.61.0)):
     dependencies:
       esrap: 1.2.2
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
       zimmerframe: 1.1.2
 
-  svelte-check@4.6.0(picomatch@4.0.4)(svelte@5.53.7)(typescript@5.9.3):
+  svelte-check@4.6.0(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       '@sveltejs/load-config': 0.1.1
@@ -25516,12 +25591,12 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.8.0(svelte@5.53.7):
+  svelte-eslint-parser@1.8.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -25531,39 +25606,41 @@ snapshots:
       postcss-selector-parser: 7.1.1
       semver: 7.8.4
     optionalDependencies:
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
 
-  svelte-fa@4.0.4(svelte@5.53.7):
+  svelte-fa@4.0.4(svelte@5.56.3(@typescript-eslint/types@8.61.0)):
     dependencies:
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
 
   svelte-steps@2.4.1: {}
 
-  svelte2tsx@0.7.56(svelte@5.53.7)(typescript@5.9.3):
+  svelte2tsx@0.7.56(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.53.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
       typescript: 5.9.3
 
-  svelte@5.53.7:
+  svelte@5.56.3(@typescript-eslint/types@8.61.0):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@types/estree': 1.0.8
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
+      '@types/estree': 1.0.9
       '@types/trusted-types': 2.0.7
-      acorn: 8.16.0
+      acorn: 8.17.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1
-      devalue: 5.6.4
+      devalue: 5.8.1
       esm-env: 1.2.2
-      esrap: 2.2.3
+      esrap: 2.2.11(@typescript-eslint/types@8.61.0)
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21
       zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
 
   svg-parser@2.0.4: {}
 
@@ -25674,7 +25751,7 @@ snapshots:
   terser@5.36.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -26086,7 +26163,7 @@ snapshots:
   unplugin@2.3.11:
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      acorn: 8.16.0
+      acorn: 8.17.0
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
@@ -26419,7 +26496,7 @@ snapshots:
   webpack-bundle-analyzer@4.10.2:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      acorn: 8.16.0
+      acorn: 8.17.0
       acorn-walk: 8.3.4
       commander: 7.2.0
       debounce: 1.2.1
@@ -26507,8 +26584,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.23.0

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -41,7 +41,7 @@
     "react": "18.2.0",
     "react-dom": "18.3.1",
     "storybook": "^10.4.2",
-    "svelte": "5.53.7",
+    "svelte": "5.56.3",
     "svelte-check": "^4.6.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## What

Fixes 4 unit test failures introduced by the Svelte 5.53.7 → 5.56.3 bump (PR #17770).

## Root cause

Svelte 5.56 changed the ordering of DOM teardown relative to `$effect` execution. When a resource (container, image, network, volume) is deleted:

1. The `{#if resource}` block unmounts — `bind:this` cleanup clears the `detailsPage` reference
2. The `$effect` then fires and calls `detailsPage?.close()` — but `detailsPage` is now `undefined`, so it's a no-op
3. `router.goto($lastPage.path)` is never called → test fails

In Svelte 5.53.7 the effect ran before DOM teardown so `detailsPage` was still valid. This was an implicit dependency on implementation-specific ordering.

## Fix

Replace `detailsPage?.close()` (which just calls `router.goto($lastPage.path)` internally) with the direct call in the `$effect`, removing the dependency on the `bind:this` reference surviving teardown.

Affected components:
- `ContainerDetails.svelte`
- `ImageDetails.svelte`
- `NetworkDetails.svelte`
- `VolumeDetails.svelte`

## Tests

All 4 previously failing test files now pass:

```
✓ src/lib/container/ContainerDetails.spec.ts (3 tests)
✓ src/lib/image/ImageDetails.spec.ts (12 tests)
✓ src/lib/network/NetworkDetails.spec.ts (3 tests)
✓ src/lib/volume/VolumeDetails.spec.ts (1 test)
Test Files  4 passed (4) | Tests  19 passed (19)
```

Signed-off-by: Denis Golovin <dgolovin@redhat.com>
Co-authored-by: Claude <noreply@anthropic.com>

Made with [Cursor](https://cursor.com)