### PR TITLE
chore: add product.json file to kind extension

### DIFF
--- a/extensions/kind/product.json
+++ b/extensions/kind/product.json
@@ -1,5 +1,3 @@
 {
-  "links": {
-    "kindMarkdown": "Podman Desktop can help you run Kind-powered local Kubernetes clusters on a container engine, such as Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/kind)"
-  }
+  "kindMarkdown": "Podman Desktop can help you run Kind-powered local Kubernetes clusters on a container engine, such as Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/kind)"
 }

--- a/extensions/kind/product.json
+++ b/extensions/kind/product.json
@@ -1,0 +1,5 @@
+{
+  "links": {
+    "kindMarkdown": "Podman Desktop can help you run Kind-powered local Kubernetes clusters on a container engine, such as Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/kind)"
+  }
+}

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -22,7 +22,6 @@ import * as path from 'node:path';
 import { KubeConfig, loadAllYaml } from '@kubernetes/client-node';
 import type { AuditRecord, AuditRequestItems, AuditResult, CancellationToken } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
-// @ts-expect-error ignore type error https://github.com/janl/mustache.js/issues/797
 import mustache from 'mustache';
 import type { Tags } from 'yaml';
 import { parseAllDocuments, stringify } from 'yaml';

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -24,6 +24,7 @@ import type { AuditRequestItems, CancellationToken, CliTool, Logger } from '@pod
 import * as extensionApi from '@podman-desktop/api';
 import { window } from '@podman-desktop/api';
 
+import product from '../product.json' with { type: 'json' };
 import { connectionAuditor, createCluster } from './create-cluster';
 import type { ImageInfo } from './image-handler';
 import { ImageHandler } from './image-handler';
@@ -39,7 +40,7 @@ import {
 
 const KIND_CLI_NAME = 'kind';
 const KIND_DISPLAY_NAME = 'Kind';
-const KIND_MARKDOWN = `Podman Desktop can help you run Kind-powered local Kubernetes clusters on a container engine, such as Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/kind)`;
+const KIND_MARKDOWN = product.links?.kindMarkdown ?? '';
 
 const API_KIND_INTERNAL_API_PORT = 6443;
 

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -40,7 +40,7 @@ import {
 
 const KIND_CLI_NAME = 'kind';
 const KIND_DISPLAY_NAME = 'Kind';
-const KIND_MARKDOWN = product.links?.kindMarkdown ?? '';
+const KIND_MARKDOWN = product.kindMarkdown ?? '';
 
 const API_KIND_INTERNAL_API_PORT = 6443;
 

--- a/extensions/kind/tsconfig.json
+++ b/extensions/kind/tsconfig.json
@@ -10,7 +10,8 @@
     "rootDirs": ["src", "scripts"],
     "outDir": "dist",
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src", "types/*.d.ts", "../../types/**/*.d.ts", "scripts"]
 }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds a `product.json` file to the Kind extension and updates the CLI page text to be configurable

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/17702

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Update the text in `product.json` and assert that the same text shows up in the CLI page for Kind

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
