### PR TITLE
fix(ui): wrap long error messages in ErrorMessage

### DIFF
--- a/packages/renderer/src/lib/dialogs/Dialog.svelte
+++ b/packages/renderer/src/lib/dialogs/Dialog.svelte
@@ -26,7 +26,7 @@ let { title, onclose, icon, content, validation, buttons }: Props = $props();
     {@render content?.()}
   </div>
 
-  <div class="px-5 py-5 mt-2 flex flex-row w-full space-x-5">
+  <div class="px-5 py-5 mt-2 flex flex-row w-full space-x-5 items-end">
     {#if validation}
       <div class="grow">
         {@render validation?.()}

--- a/packages/renderer/src/lib/dialogs/DialogSpec.spec.ts
+++ b/packages/renderer/src/lib/dialogs/DialogSpec.spec.ts
@@ -42,6 +42,7 @@ test('Expect validation is defined', async () => {
 
   const element = screen.getByLabelText('validation');
   expect(element).toBeInTheDocument();
+  expect(element.parentElement?.parentElement).toHaveClass('items-end');
 });
 
 test('Expect buttons is defined', async () => {

--- a/packages/ui/src/lib/alert/ErrorMessage.spec.ts
+++ b/packages/ui/src/lib/alert/ErrorMessage.spec.ts
@@ -35,4 +35,5 @@ test('Check error message', async () => {
   expect(errorMesssage).toHaveTextContent(error);
   expect(errorMesssage).toHaveClass('min-w-0');
   expect(errorMesssage).toHaveClass('[overflow-wrap:anywhere]');
+  expect(errorMesssage.parentElement).toHaveClass('items-start');
 });

--- a/packages/ui/src/lib/alert/ErrorMessage.spec.ts
+++ b/packages/ui/src/lib/alert/ErrorMessage.spec.ts
@@ -33,4 +33,6 @@ test('Check error message', async () => {
   const errorMesssage = screen.getByRole('alert', { name: 'Error Message Content' });
   expect(errorMesssage).toBeInTheDocument();
   expect(errorMesssage).toHaveTextContent(error);
+  expect(errorMesssage).toHaveClass('min-w-0');
+  expect(errorMesssage).toHaveClass('[overflow-wrap:anywhere]');
 });

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -40,6 +40,8 @@ onMount(() => {
     class="text-[var(--pd-state-error)] p-1 flex flex-row items-center {className}"
     class:opacity-0={error === undefined || error === ''}>
     <Icon icon={faExclamationCircle} size='1.1x' class="cursor-pointer text-[var(--pd-state-error)]" />
-    <div role="alert" aria-label={ariaLabel ?? 'Error Message Content'} class="ml-2">{error}</div>
+    <div role="alert" aria-label={ariaLabel ?? 'Error Message Content'} class="ml-2 min-w-0 [overflow-wrap:anywhere]">
+      {error}
+    </div>
   </div>
 {/if}

--- a/packages/ui/src/lib/alert/ErrorMessage.svelte
+++ b/packages/ui/src/lib/alert/ErrorMessage.svelte
@@ -37,7 +37,7 @@ onMount(() => {
   {/if}
 {:else}
   <div
-    class="text-[var(--pd-state-error)] p-1 flex flex-row items-center {className}"
+    class="text-[var(--pd-state-error)] p-1 flex flex-row items-start {className}"
     class:opacity-0={error === undefined || error === ''}>
     <Icon icon={faExclamationCircle} size='1.1x' class="cursor-pointer text-[var(--pd-state-error)]" />
     <div role="alert" aria-label={ariaLabel ?? 'Error Message Content'} class="ml-2 min-w-0 [overflow-wrap:anywhere]">


### PR DESCRIPTION
## Summary

Long error messages in the shared `ErrorMessage` component could force constrained dialogs wider instead of wrapping. This affected the Add Registry dialog when registry authentication returned a long unbroken error string.

This updates the alert text container so it can shrink inside flex layouts and wrap unbroken content (`min-w-0` + `overflow-wrap: anywhere`).

## Screenshots

**Before** — long error overflows the dialog (`documentScrollWidth: 1023` in a 520px viewport):

![before](https://files.catbox.moe/cnfadf.png)

**After** — text wraps cleanly, no overflow (`documentScrollWidth: 520`):

![after](https://files.catbox.moe/fafdmj.png)

## Verification

- `pnpm run test:ui`: 42 test files, 321 tests passing.
- `pnpm run build:ui`: completed successfully.

Fixes #16666
