### PR TITLE
fix(renderer): remove overflow-hidden from nav to unclip accounts dropdown

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -151,7 +151,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
 
 <svelte:window />
 <nav
-  class="group w-leftnavbar {minNavbarWidth} h-full flex flex-col overflow-hidden bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
+  class="group w-leftnavbar {minNavbarWidth} h-full flex flex-col bg-[var(--pd-global-nav-bg)] border-[var(--pd-global-nav-bg-border)] border-r-[1px]"
   aria-label="AppNavigation">
   <NavItem href="/" tooltip="Dashboard" bind:meta={meta}>
     <div class="relative w-full">


### PR DESCRIPTION
### What does this PR do?

Removes `overflow-hidden` from the `<nav>` element in `AppNavigation.svelte`.

The class was added in #16294 to support the scrollable navigation region, but it also clips absolutely positioned descendants - most visibly the Accounts dropdown menu. The inner scroll region (`flex-1 min-h-0 overflow-y-auto`) already manages its own overflow bounds correctly without requiring `overflow-hidden` on the outer nav.

### Screenshot / video of UI

Before:

<img width="1730" height="1400" alt="Image" src="https://github.com/user-attachments/assets/1ba46ac2-ae2b-4e94-ae6c-a5cd7757b8b6" />

Now:

<img width="1730" height="1400" alt="image" src="https://github.com/user-attachments/assets/f98399b6-cc57-46c1-8ec8-801a8152d77d" />

### What issues does this PR fix or reference?

- Resolves #17897
- Related: #16294 (scrollable nav, source of the regression)
- Related: #17829 (reverted for 1.28.x)

### How to test this PR?

1. Install several extensions so the left navigation bar has many items
2. Click the Accounts icon at the bottom of the left nav
3. Verify the dropdown menu renders fully without being clipped by the navigation boundary

- [ ] Tests are covering the bug fix or the new feature
