### PR TITLE
refactor(agents): rewrite mcp-testing skill with operation references and single-agent architecture

### DIFF
--- a/.agents/skills/mcp-testing/SKILL.md
+++ b/.agents/skills/mcp-testing/SKILL.md
@@ -190,83 +190,53 @@ If the start script exits with a non-zero code, report the error output to the u
 
 Do not retry the script automatically — let the user decide after seeing the error.
 
-#### Connect and verify (both modes)
+#### Extract the CDP port
 
-When the start script prints `Ready — call mcp__podman-desktop-mcp__connect(...)`, extract the port number from that line and connect:
+When the start script prints `Ready — call mcp__podman-desktop-mcp__connect(...)`, extract the port number from that line. You will pass it to the Haiku agent in the next phase.
 
-```text
-mcp__podman-desktop-mcp__connect({ port: PORT })
-```
+### Phase 4: Execute task (Haiku agent)
 
-After connecting, check the window title:
+1. Read `.agents/skills/mcp-testing/agent-prompt.md`
 
-```text
-mcp__podman-desktop-mcp__evaluate({ script: "document.title" })
-```
+2. **Select relevant operation references.** Using the task description and the table below, select which files from `.agents/skills/mcp-testing/references/operations/` to include. Always include `navigation.md`. Use your judgment — if the task implies an area even without exact keywords, include its reference.
 
-The result should contain "Podman Desktop". If it contains "DevTools":
+   | File                | Covers                                                                                                                   |
+   | ------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+   | `navigation.md`     | **Always include.** Sidebar nav, welcome/onboarding page, dashboard, breadcrumbs, back/forward, status bar               |
+   | `images.md`         | Pull/build/push/save/delete/prune images, image details, edit/rename, Containerfile, platform selection, registry search |
+   | `containers.md`     | Create/run/start/stop/delete/export containers, container details, logs, terminal, port mapping, prune                   |
+   | `pods.md`           | Kube Play (YAML deploy), podify (create pod from containers), pod lifecycle, pod logs, prune                             |
+   | `volumes.md`        | Create/delete/prune volumes, volume details, gather sizes, usage status                                                  |
+   | `networks.md`       | Create/delete networks, subnet configuration, network details, bulk delete                                               |
+   | `extensions.md`     | View/install/enable/disable/delete extensions, catalog, custom OCI install, extension status                             |
+   | `settings.md`       | Preferences, proxy configuration, resources, CLI tools section, Kubernetes settings                                      |
+   | `registries.md`     | Add/remove/login to registries, credentials, authentication (under Settings)                                             |
+   | `kubernetes.md`     | Kubernetes contexts, namespaces, resource browsing (nodes/pods/deployments/services), apply YAML                         |
+   | `compose.md`        | Docker Compose onboarding, CLI tool install/uninstall/version check                                                      |
+   | `search-palette.md` | Command palette (F1), search commands, navigate via palette                                                              |
 
-1. Disconnect immediately: `mcp__podman-desktop-mcp__disconnect()`
-2. Re-run the startup script — it closes any DevTools targets automatically via `close_devtools_targets`, then reconnect.
+   **Cross-dependencies** — when one area implies another, include both:
+   - Container operations → also include `images.md` (creating a container requires an image)
+   - Pod operations → also include `containers.md` (podify requires selecting containers)
+   - Registry operations → also include `settings.md` (registries is under Settings)
+   - Settings exploration → also include `registries.md` (registries is a Settings subsection)
+   - Compose/CLI tools → also include `settings.md` (CLI tools is under Settings)
+   - Settings exploration → also include `compose.md` when CLI tools may be relevant
+   - Docker mentioned (docker, docker-compose, Docker Hub) → include `compose.md` + `containers.md` + `images.md` + `extensions.md` + `settings.md`
+   - Kubernetes settings → also include `kubernetes.md`
+   - Any image name in the task (httpd, nginx, alpine, redis, etc.) → include `images.md`
+   - Ambiguous or broad scope (no single area clearly implied) → include `navigation.md` + `containers.md` + `images.md` + `settings.md` + `extensions.md`
+   - General exploration or unknown scope → include all references
 
-### Phase 4: Initial Setup (automatic)
+3. Read the selected reference files and concatenate their contents into an **Operations Reference** block
 
-After connecting, perform these steps automatically without asking:
+4. Spawn an agent with `model: "haiku"`, passing: `CDP port: {PORT}. Task: {TASK}` followed by the full content of agent-prompt.md, then the operations reference block
 
-**1. Handle Onboarding Dialog** (appears on first launch — disable telemetry but do NOT close it):
+The agent uses operation references directly when they cover the elements needed for the task. It falls back to compact snapshots only for elements not in the reference, and full `snapshot()` as a last resort.
 
-```text
-mcp__podman-desktop-mcp__evaluate({
-  script: `
-    const skipButton = Array.from(document.querySelectorAll('button'))
-      .find(b => b.textContent.trim() === 'Skip');
-    if (skipButton) {
-      const telemetry = document.querySelector('input[aria-label="Enable telemetry"]');
-      if (telemetry?.checked) telemetry.click();
-      'Onboarding dialog present — telemetry disabled (dialog left open for testing)';
-    } else {
-      'No onboarding dialog found';
-    }
-  `
-})
-```
+The agent returns a summary of what it found or did, and optionally a structured workflow trace (for E2E test writing tasks). The agent handles connecting to CDP, initial setup (dialogs), and disconnecting — the orchestrator only needs to pass the port number.
 
-> **Do not close the onboarding dialog automatically.** Some test scenarios need to interact with it. The task in Phase 5 will decide whether to skip it or test it.
-
-**2. Close Feedback Dialog** (appears after onboarding is completed — safe to run when absent):
-
-```text
-mcp__podman-desktop-mcp__evaluate({
-  script: `
-    const dialog = document.querySelector('[role="dialog"][aria-label="Share your feedback"]');
-    if (dialog) {
-      dialog.querySelector('button[aria-label="Close"]')?.click();
-      'Closed feedback dialog';
-    } else {
-      'No feedback dialog';
-    }
-  `
-})
-```
-
-**3. Take Initial Snapshot:**
-
-```text
-mcp__podman-desktop-mcp__snapshot()
-```
-
-Summarize what's visible on the current page to the user (including whether the onboarding dialog is showing).
-
-### Phase 5: Execute Task
-
-Execute the task provided when the skill was invoked. The task can be anything — exploring a page, testing a feature, verifying a workflow, checking UI state, etc. Work autonomously:
-
-- Use MCP tools (`snapshot`, `screenshot`, `evaluate`, `click`, `getText`, etc.) as needed — don't ask permission for individual actions.
-- Take screenshots and snapshots at your own judgment to verify state and gather information.
-- If something fails or is unexpected, investigate and retry before giving up.
-- When the task is complete, summarize what you found or did.
-
-**After completing the task**, use `AskUserQuestion`:
+**After the agent returns**, use `AskUserQuestion`:
 
 - **Question:** `What would you like to do next?`
 - **Header:** `Next`
@@ -274,21 +244,13 @@ Execute the task provided when the skill was invoked. The task can be anything �
   1. `Continue testing` — Provide another task (user enters free text via "Other")
   2. `Done — finish testing` — Disconnect and clean up
 
-If the user continues, execute the new task the same way and ask again when done. If done, proceed to Phase 6.
+If the user continues, run Phase 4 again with the new task. If done, proceed to Phase 5.
 
-### Phase 6: Cleanup
-
-**Step 1 — Disconnect from MCP:**
-
-```text
-mcp__podman-desktop-mcp__disconnect()
-```
-
-**Step 2 — Ask about the app:**
+### Phase 5: Cleanup
 
 Use `AskUserQuestion`:
 
-- **Question:** `Disconnected from MCP. What should I do with the app?`
+- **Question:** `What should I do with the app?`
 - **Header:** `Cleanup`
 - **Options:**
   1. `Leave running` — Keep the app alive so you can reconnect later
@@ -313,55 +275,6 @@ bash .agents/skills/mcp-testing/stop.sh
 pwsh .agents/skills/mcp-testing/stop.ps1
 ```
 
-## Selector Strategy
-
-When interacting with elements, prefer in this order:
-
-1. **ARIA roles and accessible names** (most stable)
-
-   ```javascript
-   document.querySelector('button[aria-label="Create"]').click();
-   ```
-
-2. **Text content**
-
-   ```javascript
-   Array.from(document.querySelectorAll('button'))
-     .find(b => b.textContent.includes('Pull'))
-     .click();
-   ```
-
-3. **data-testid attributes**
-
-   ```javascript
-   document.querySelector('[data-testid="help-menu"]').click();
-   ```
-
-4. **CSS / href selectors** (last resort)
-
-   ```javascript
-   document.querySelector('a[href="/containers"]').click();
-   ```
-
-## Common Navigation URLs
-
-- Dashboard: `/`
-- Containers: `/containers`
-- Pods: `/pods`
-- Images: `/images`
-- Volumes: `/volumes`
-- Networks: `/networks`
-- Kubernetes: `/kubernetes`
-- Extensions: `/extensions`
-
-Navigate using JavaScript evaluation:
-
-```text
-mcp__podman-desktop-mcp__evaluate({
-  script: `document.querySelector('a[href="/containers"]').click(); 'Navigated to Containers';`
-})
-```
-
 ## Troubleshooting
 
 ### `pnpm: command not found`
@@ -372,21 +285,9 @@ npm install -g pnpm
 
 Then re-open your terminal and verify with `pnpm --version`.
 
-### Connected to DevTools Instead of App
-
-**Symptom:** `connect` returns `Window title: DevTools`.
-
-**Fix:**
-
-1. `mcp__podman-desktop-mcp__disconnect()`
-2. Re-run the startup script for your mode — it closes DevTools targets automatically via `close_devtools_targets`
-3. `mcp__podman-desktop-mcp__connect({ port: PORT })`
-
 ### Production App Without CDP
 
 **Symptom:** Probe shows `PROD_RUNNING=true` but `PROD_CDP_PORT=none`.
-
-**Cause:** The production app was launched without the `--remote-debugging-port` flag.
 
 **Fix:** Run `start.sh --mode prod` (or `start.ps1 -Mode prod`) — it detects this case automatically, closes the running app, and relaunches it with CDP enabled.
 
@@ -396,54 +297,12 @@ Then re-open your terminal and verify with `pnpm --version`.
 
 **If startup still times out after 120s:** the production app may have restarted in the gap between detection and the kill, or a non-Podman-Desktop process holds port 9222. Run the stop script, verify port 9222 is free (`lsof -ti :9222`), then re-run the start script.
 
-### MCP Tools Become Unavailable Mid-Session
-
-**Symptom:** `mcp__podman-desktop-mcp__*` tools return errors.
-
-**Do not ask the user to restart the MCP server.** Try reconnecting:
-
-```text
-mcp__podman-desktop-mcp__connect({ port: PORT })
-```
-
-If the port is gone, re-run the startup script.
-
-### Element Not Found
-
-1. Use `snapshot()` to see current page structure
-2. Wait for page load: `mcp__podman-desktop-mcp__wait({ selector: 'main', timeout: 5000 })`
-3. Check if element is in a different frame or webview
-
-### Test Isolation (dev mode)
-
-Each `pnpm watch` session uses the same user data directory. For a clean state:
-
-```bash
-PODMAN_DESKTOP_HOME_DIR=/tmp/pd-dev-test pnpm watch
-```
-
-### "Too Many Open Files" Error (dev mode)
-
-```bash
-ulimit -n 65536
-```
-
-Add to `~/.bashrc` or `~/.zshrc` to make it permanent.
-
 ## Quick Reference
 
-| Command                                                   | Purpose                                        |
-| --------------------------------------------------------- | ---------------------------------------------- |
-| `bash probe.sh`                                           | Detect environment (what's running, CDP ports) |
-| `bash start.sh --mode dev`                                | Full dev startup                               |
-| `bash start.sh --mode dev-fast`                           | Fast-path (dev already running)                |
-| `bash start.sh --mode prod`                               | Launch/connect production app                  |
-| `mcp__podman-desktop-mcp__connect({ port: PORT })`        | Connect to app                                 |
-| `mcp__podman-desktop-mcp__disconnect()`                   | Disconnect from MCP                            |
-| `mcp__podman-desktop-mcp__snapshot()`                     | Get accessibility tree                         |
-| `mcp__podman-desktop-mcp__evaluate({ script: '...' })`    | Run JavaScript in renderer                     |
-| `mcp__podman-desktop-mcp__screenshot({ fullPage: true })` | Capture screenshot                             |
-
-## Additional Resources
-
-- **Example commands and selectors:** `examples.md` — Ready-to-use MCP command examples and selectors reference derived from Playwright Page Object Models
+| Command                                                    | Purpose                                        |
+| ---------------------------------------------------------- | ---------------------------------------------- |
+| `bash .agents/skills/mcp-testing/probe.sh`                 | Detect environment (what's running, CDP ports) |
+| `bash .agents/skills/mcp-testing/start.sh --mode dev`      | Full dev startup                               |
+| `bash .agents/skills/mcp-testing/start.sh --mode dev-fast` | Fast-path (dev already running)                |
+| `bash .agents/skills/mcp-testing/start.sh --mode prod`     | Launch/connect production app                  |
+| `bash .agents/skills/mcp-testing/stop.sh`                  | Stop app and free port                         |

--- a/.agents/skills/mcp-testing/agent-prompt.md
+++ b/.agents/skills/mcp-testing/agent-prompt.md
@@ -1,0 +1,276 @@
+You interact with a running Podman Desktop Electron app via MCP tools connected over Chrome DevTools Protocol (CDP). Your prompt will include a **CDP port number** and a **task**. You connect, set up the app, execute the task, and return results.
+
+## Connect and verify
+
+Extract the port number from the prompt and connect:
+
+```text
+mcp__podman-desktop-mcp__connect({ port: PORT })
+```
+
+After connecting, check the window title:
+
+```text
+mcp__podman-desktop-mcp__evaluate({ script: "document.title" })
+```
+
+The result should contain "Podman Desktop". If it contains "DevTools":
+
+1. Disconnect immediately: `mcp__podman-desktop-mcp__disconnect()`
+2. Report the problem back: return a message like `"Connected to DevTools instead of the app. The orchestrator needs to rerun the startup script."` — do not attempt to run shell scripts yourself.
+
+## Initial Setup (automatic)
+
+After connecting, perform these steps automatically without asking:
+
+**1. Handle Dialogs** (onboarding + feedback — combined into a single call):
+
+```text
+mcp__podman-desktop-mcp__evaluate({
+  script: `
+    const results = [];
+    const skipButton = Array.from(document.querySelectorAll('button'))
+      .find(b => b.textContent.trim() === 'Skip' || b.textContent.trim() === 'Skip this entire setup');
+    if (skipButton) {
+      const telemetry = document.querySelector('input[aria-label="Enable telemetry"]');
+      if (telemetry?.checked) telemetry.click();
+      results.push('Onboarding: telemetry disabled, dialog left open');
+    } else {
+      results.push('No onboarding dialog');
+    }
+    const feedbackDialog = document.querySelector('[role="dialog"][aria-label="Share your feedback"]');
+    if (feedbackDialog) {
+      feedbackDialog.querySelector('button[aria-label="Close"]')?.click();
+      results.push('Feedback dialog: closed');
+    } else {
+      results.push('No feedback dialog');
+    }
+    results.join(' | ');
+  `
+})
+```
+
+> **Do not close the onboarding dialog automatically.** Some test scenarios need to interact with it. The task will decide whether to skip it or test it.
+
+**2. Take Initial Snapshot** (conditional — only if needed):
+
+If the operation references cover the elements you need for the task, **skip the initial snapshot** and proceed directly to executing the task. Only take a compact snapshot (see **Compact Snapshot** in the Selector Strategy section below) if you need to discover elements not in the reference. Use full `snapshot()` only as a last resort.
+
+## Using the Operations Reference
+
+An **Operations Reference** section is appended to your prompt. It contains exact selectors, page structures, and step-by-step operations for Podman Desktop UI areas relevant to your task.
+
+**Strategy — reference first, snapshots as fallback:**
+
+1. **Reference selectors** — use these directly via `evaluate` when they cover the elements you need. No snapshot required.
+2. **Compact snapshot** — fall back to this only for elements not in the reference (e.g., dynamically generated content, new UI areas).
+3. **Full `snapshot()`** — last resort, only when the compact snapshot also misses elements you need (e.g., deeply nested table rows, dialog internals).
+
+## Execute Task
+
+### Step 1: Execute the Task
+
+Execute the task provided in the prompt. The task can be anything — exploring a page, testing a feature, verifying a workflow, checking UI state, etc. Work autonomously:
+
+- Use selectors from the reference when they cover the elements you need — no snapshotting required.
+- Fall back to compact snapshots for elements not in the reference, and full `snapshot()` only as a last resort.
+- Use MCP tools as needed — don't ask permission for individual actions.
+- If something fails or is unexpected, investigate and retry before giving up.
+- When the task is complete, summarize what you found or did.
+
+### Tool Selection (Token Optimization)
+
+| Need                             | Tool                                 | Why                                               |
+| -------------------------------- | ------------------------------------ | ------------------------------------------------- |
+| Interact with a known element    | Reference selectors via `evaluate`   | Zero-cost discovery, no extra API call            |
+| Discover unknown elements        | `evaluate` (compact snapshot script) | 80-95% fewer tokens than `snapshot()`             |
+| Full element tree with all roles | `snapshot()`                         | Only when compact snapshot misses elements        |
+| Read specific text               | `getText` with CSS selector          | Single element, minimal tokens                    |
+| Check if element exists/state    | `evaluate` with querySelector        | Single boolean, cheapest option                   |
+| Verify visual appearance         | `screenshot`                         | Only for visual bugs, never for element discovery |
+| Check element attribute          | `getAttribute`                       | Targeted, no image tokens                         |
+
+Prefer reference selectors first, then `evaluate` for discovery. Use `snapshot()` only when you need the full tree. Use `screenshot()` only when visual verification is specifically required.
+
+### Workflow Trace Output
+
+When exploring a workflow that will be used to write an E2E test, produce a structured trace after completing the workflow:
+
+```markdown
+## Workflow: {description}
+
+### Step 1: {action}
+
+- Page: {current page/URL}
+- Action: {what was done — clicked button, filled input, etc.}
+- Element: {aria-label or text of the element interacted with}
+- Result: {what happened — page changed, dialog appeared, state changed}
+- State after: {relevant state — container running, image appeared in list, etc.}
+
+### Step 2: {action}
+
+...
+
+## Prerequisites
+
+- {what must exist before this workflow — images pulled, engine running, etc.}
+
+## Final State
+
+- {what the app looks like after the workflow completes}
+```
+
+This trace gives the playwright-testing skill everything it needs to write the test: the sequence of actions, the elements involved, and the expected states at each step.
+
+## Selector Strategy
+
+### Compact Snapshot
+
+For discovering what's on a page, prefer the compact snapshot over `snapshot()`. It returns only actionable elements as a small JSON blob (2-5KB vs 20-100KB for the full accessibility tree):
+
+```text
+mcp__podman-desktop-mcp__evaluate({
+  script: `
+    const collect = (sel, type) =>
+      [...document.querySelectorAll(sel)].map(el => ({
+        type,
+        name: el.getAttribute('aria-label') || el.textContent?.trim().slice(0, 60) || el.getAttribute('title') || '',
+        enabled: !el.disabled,
+        visible: el.offsetParent !== null,
+      })).filter(e => e.visible && e.name);
+    JSON.stringify({
+      title: document.title,
+      url: sessionStorage.getItem('last-route') || location.href,
+      buttons: collect('button', 'button'),
+      links: collect('a[role=\\"link\\"], nav a', 'link'),
+      inputs: collect('input, textarea', 'input'),
+      headings: collect('[role=\\"heading\\"], h1, h2, h3', 'heading'),
+      regions: [...document.querySelectorAll('[role=\\"region\\"]')]
+        .map(r => r.getAttribute('aria-label')).filter(Boolean),
+    }, null, 2);
+  `
+})
+```
+
+Use full `snapshot()` only when you need the complete element tree with all roles and nested structure (e.g., table row contents, dialog internals).
+
+### Playwright Selectors vs CSS Selectors
+
+The operation references use two kinds of selectors — know which one you're looking at:
+
+- **Playwright selectors** (used with `click`, `wait`, `fill`, `getText` MCP tools): support `:has-text()`, `button:has-text("Pull")`, and other Playwright pseudo-selectors. Pass these directly to the MCP tool.
+- **CSS selectors** (used inside `evaluate` JavaScript): only standard CSS works. `:has-text()` will throw a `SyntaxError` inside `querySelector`.
+
+When the Operations Reference shows `click('button:has-text("Pull")')`, use it with the `click` MCP tool directly. If you need the same element in `evaluate`, convert to standard JavaScript:
+
+```javascript
+// WRONG — :has-text() is not valid CSS
+document.querySelector('button:has-text("Pull")').click();
+
+// CORRECT — use textContent matching instead
+Array.from(document.querySelectorAll('button'))
+  .find(b => b.textContent.trim() === 'Pull')
+  ?.click();
+
+// CORRECT — or use aria-label if available
+document.querySelector('button[aria-label="Pull"]').click();
+```
+
+### Element Selection Priority
+
+When interacting with elements, prefer in this order:
+
+1. **ARIA roles and accessible names** (most stable)
+
+   ```javascript
+   document.querySelector('button[aria-label="Create"]').click();
+   ```
+
+2. **Text content** (for elements without aria-label)
+
+   ```javascript
+   Array.from(document.querySelectorAll('button'))
+     .find(b => b.textContent.includes('Pull'))
+     .click();
+   ```
+
+3. **data-testid attributes**
+
+   ```javascript
+   document.querySelector('[data-testid="help-menu"]').click();
+   ```
+
+4. **CSS / href selectors** (last resort)
+
+   ```javascript
+   document.querySelector('a[href="/containers"]').click();
+   ```
+
+## Common Navigation URLs
+
+- Dashboard: `/`
+- Containers: `/containers`
+- Pods: `/pods`
+- Images: `/images`
+- Volumes: `/volumes`
+- Networks: `/networks`
+- Kubernetes: `/kubernetes`
+- Extensions: `/extensions`
+
+Navigate using JavaScript evaluation:
+
+```text
+mcp__podman-desktop-mcp__evaluate({
+  script: `document.querySelector('a[href="/containers"]').click(); 'Navigated to Containers';`
+})
+```
+
+## Troubleshooting
+
+### MCP Tools Become Unavailable Mid-Session
+
+**Symptom:** `mcp__podman-desktop-mcp__*` tools return errors.
+
+**Do not ask the user to restart the MCP server.** Try reconnecting:
+
+```text
+mcp__podman-desktop-mcp__connect({ port: PORT })
+```
+
+If the port is gone, report the error — the parent agent will re-run the startup script.
+
+### Element Not Found
+
+1. Use `snapshot()` to see current page structure
+2. Wait for page load: `mcp__podman-desktop-mcp__wait({ selector: 'main', timeout: 5000 })`
+3. Check if element is in a different frame or webview
+
+### Test Isolation (dev mode)
+
+Each `pnpm watch` session uses the same user data directory. For a clean state:
+
+```bash
+PODMAN_DESKTOP_HOME_DIR=/tmp/pd-dev-test pnpm watch
+```
+
+### "Too Many Open Files" Error (dev mode)
+
+```bash
+ulimit -n 65536
+```
+
+Add to `~/.bashrc` or `~/.zshrc` to make it permanent.
+
+## Quick Reference
+
+| Command                                                   | Purpose                    |
+| --------------------------------------------------------- | -------------------------- |
+| `mcp__podman-desktop-mcp__connect({ port: PORT })`        | Connect to app             |
+| `mcp__podman-desktop-mcp__disconnect()`                   | Disconnect from MCP        |
+| `mcp__podman-desktop-mcp__snapshot()`                     | Get accessibility tree     |
+| `mcp__podman-desktop-mcp__evaluate({ script: '...' })`    | Run JavaScript in renderer |
+| `mcp__podman-desktop-mcp__screenshot({ fullPage: true })` | Capture screenshot         |
+
+## Additional Resources
+
+- **Example commands:** `.agents/skills/mcp-testing/examples.md` — Ready-to-use MCP command examples for common workflows

--- a/.agents/skills/mcp-testing/evals/evals.json
+++ b/.agents/skills/mcp-testing/evals/evals.json
@@ -1,0 +1,71 @@
+{
+  "skill_name": "mcp-testing",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Pull the image ghcr.io/podmandesktop-ci/hello and verify it appears in the Images list",
+      "expected_output": "Agent navigates to Images page, pulls the specified image, waits for completion, and verifies it appears in the image list",
+      "files": [],
+      "scenario_type": "well-structured",
+      "expectations": [
+        "The agent loads navigation.md and images.md references",
+        "The agent connects to the app on the correct CDP port",
+        "The agent handles onboarding/feedback dialogs if present",
+        "The agent navigates to the Images page using a known selector",
+        "The agent clicks the Pull button and enters the image name",
+        "The agent verifies the image appears in the list after pull completes",
+        "The agent uses reference selectors rather than full snapshot() calls",
+        "The agent disconnects from MCP when done"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Navigate through all the main pages and tell me what's on each one",
+      "expected_output": "Agent visits Dashboard, Containers, Pods, Images, Volumes, Networks, Kubernetes, Extensions, and summarizes the content of each page",
+      "files": [],
+      "scenario_type": "exploratory",
+      "expectations": [
+        "The agent loads all or most operation references (exploration scope)",
+        "The agent visits at least 6 of the 8 main navigation pages",
+        "The agent takes snapshots or screenshots to report page contents",
+        "The agent provides a summary of what's visible on each page",
+        "The agent uses compact snapshots rather than full snapshot() for token efficiency",
+        "The agent disconnects from MCP when done"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Check if there are any issues with the settings",
+      "expected_output": "Agent navigates to Settings, explores the various sections (Preferences, Resources, Proxy, Registries, etc.), and reports what it finds",
+      "files": [],
+      "scenario_type": "vague",
+      "expectations": [
+        "The agent loads navigation.md and settings.md references (minimum)",
+        "The agent also loads registries.md (registries is under Settings)",
+        "The agent navigates to Settings page",
+        "The agent explores multiple Settings subsections",
+        "The agent reports on the state of each section it visits",
+        "The agent doesn't just check one section and stop",
+        "The agent disconnects from MCP when done"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Check Docker compatibility — can I run docker-compose and use Docker images?",
+      "expected_output": "Agent checks compose CLI tool status, Docker extension presence, container engine compatibility, and reports Docker compatibility status",
+      "files": [],
+      "scenario_type": "cross-cutting",
+      "expectations": [
+        "The agent loads compose.md reference (docker-compose CLI tool check)",
+        "The agent loads extensions.md reference (Docker extension status)",
+        "The agent loads containers.md and images.md (Docker image/container compatibility)",
+        "The agent loads settings.md reference (CLI tools section)",
+        "The agent checks if docker-compose CLI tool is installed via Settings > CLI Tools",
+        "The agent checks Docker extension status in Extensions page",
+        "The agent reports on Docker socket or compatibility mode availability",
+        "The agent provides a clear summary of Docker compatibility status",
+        "The agent disconnects from MCP when done"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/mcp-testing/references/operations/compose.md
+++ b/.agents/skills/mcp-testing/references/operations/compose.md
@@ -1,0 +1,125 @@
+# Compose Operations
+
+## Navigation
+
+| Target          | Selector                                                          |
+| --------------- | ----------------------------------------------------------------- |
+| Extensions page | `nav[aria-label="AppNavigation"] a[aria-label="Extensions"]`      |
+| Settings page   | `nav[aria-label="AppNavigation"] a[aria-label="Settings"]`        |
+| CLI Tools       | `nav[aria-label="PreferencesNavigation"] a:has-text("CLI Tools")` |
+
+## Page Structure
+
+### OnboardingPage (shared pattern)
+
+```
+[role="region"][aria-label="Onboarding Body"]
+├── [aria-label="Onboarding Component"]
+├── [aria-label="Onboarding Status Message"]
+├── button:has-text("Next Step")
+├── button:has-text("Cancel Setup")
+└── button:has-text("Skip this entire setup")
+```
+
+### CLIToolsPage
+
+```
+[role="region"][aria-label="CLI Tools"]
+├── [role="heading"]:has-text("CLI Tools")
+└── [role="table"][aria-label="cli-tools"]
+    └── [role="row"][aria-label="{toolName}"]
+        ├── [aria-label="cli-version"]
+        ├── [aria-label="Install"]
+        └── [aria-label="Uninstall"]
+```
+
+## Locators
+
+### OnboardingPage
+
+| Element              | Selector                                        |
+| -------------------- | ----------------------------------------------- |
+| Body region          | `[role="region"][aria-label="Onboarding Body"]` |
+| Skip entire setup    | `button:has-text("Skip this entire setup")`     |
+| Onboarding component | `[aria-label="Onboarding Component"]`           |
+| Status message       | `[aria-label="Onboarding Status Message"]`      |
+| Next step            | `button:has-text("Next Step")`                  |
+| Cancel setup         | `button:has-text("Cancel Setup")`               |
+
+### CLIToolsPage
+
+| Element          | Selector                                                                       |
+| ---------------- | ------------------------------------------------------------------------------ |
+| Main region      | `[role="region"][aria-label="CLI Tools"]`                                      |
+| Heading          | `[role="heading"]:has-text("CLI Tools")`                                       |
+| Tools table      | `[role="table"][aria-label="cli-tools"]`                                       |
+| Tool row         | `[role="table"][aria-label="cli-tools"] [role="row"][aria-label="{toolName}"]` |
+| Install button   | `[role="row"][aria-label="{toolName}"] [aria-label="Install"]`                 |
+| Uninstall button | `[role="row"][aria-label="{toolName}"] [aria-label="Uninstall"]`               |
+| Version label    | `[role="row"][aria-label="{toolName}"] [aria-label="cli-version"]`             |
+| No version       | `[role="row"][aria-label="{toolName}"] [aria-label="no-cli-version"]`          |
+| Version dialog   | `[role="dialog"][aria-label="drop-down-dialog"]`                               |
+| Version input    | `[role="dialog"][aria-label="drop-down-dialog"] [role="textbox"]`              |
+
+## Operations
+
+### Run Compose onboarding
+
+1. Navigate to Extensions page
+2. Find Compose extension and open its details
+3. Start onboarding from extension's onboarding tab
+4. Wait for onboarding: `wait('[role="region"][aria-label="Onboarding Body"]')`
+5. Click Next Step: `click('button:has-text("Next Step")')`
+6. Repeat Next Step for each onboarding screen
+7. Check status: `getText('[aria-label="Onboarding Status Message"]')`
+
+### Skip Compose onboarding
+
+1. Start onboarding (steps 1-4)
+2. Click Skip: `click('button:has-text("Skip this entire setup")')`
+
+### Cancel onboarding
+
+1. Start onboarding (steps 1-4)
+2. Click Cancel: `click('button:has-text("Cancel Setup")')`
+
+### Navigate to CLI Tools
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Settings"]')`
+2. Wait for settings: `wait('nav[aria-label="PreferencesNavigation"]')`
+3. Click CLI Tools: `click('nav[aria-label="PreferencesNavigation"] a:has-text("CLI Tools")')`
+4. Wait for page: `wait('[role="heading"]:has-text("CLI Tools")')`
+
+### Install CLI tool
+
+1. Navigate to CLI Tools (steps 1-4)
+2. Click Install: `click('[role="row"][aria-label="{toolName}"] [aria-label="Install"]')`
+3. Check for version dialog: `evaluate('!!document.querySelector(\'[role="dialog"][aria-label="drop-down-dialog"]\')')` — returns `true` if multiple versions are available
+4. If dialog appeared, select version and confirm
+5. Wait for install: check version label appears
+
+### Uninstall CLI tool
+
+1. Navigate to CLI Tools
+2. Click Uninstall: `click('[role="row"][aria-label="{toolName}"] [aria-label="Uninstall"]')`
+
+### Check CLI tool version
+
+```
+getText('[role="row"][aria-label="{toolName}"] [aria-label="cli-version"]')
+```
+
+### Check if CLI tool is installed
+
+```
+evaluate('!!document.querySelector(\'[role="row"][aria-label="{toolName}"] [aria-label="cli-version"]\')')
+```
+
+## Gotchas
+
+- Onboarding is a shared pattern used by Compose, Podman, and other extensions
+- The onboarding wizard is multi-step — each "Next Step" advances to the next screen
+- CLI Tools page is under Settings > CLI Tools, not a standalone page
+- Version dialog appears when multiple versions are available for installation
+- Tool names in the CLI tools table vary — use the exact display name
+- Compose onboarding may require Docker Compose binary to be available on PATH

--- a/.agents/skills/mcp-testing/references/operations/containers.md
+++ b/.agents/skills/mcp-testing/references/operations/containers.md
@@ -1,0 +1,221 @@
+# Container Operations
+
+## Navigation
+
+| Target          | Selector                                                     |
+| --------------- | ------------------------------------------------------------ |
+| Containers page | `nav[aria-label="AppNavigation"] a[aria-label="Containers"]` |
+
+## Page Structure
+
+### ContainersPage (list)
+
+```
+[role="region"][aria-label="containers"]
+├── [role="region"][aria-label="header"]
+│   ├── [role="heading"]                        ← "Containers"
+│   └── [role="group"][aria-label="additionalActions"]
+│       ├── button:has-text("Create")
+│       └── button:has-text("Prune")
+├── [role="region"][aria-label="search"]
+│   └── [role="group"][aria-label="bottomAdditionalActions"]
+└── [role="region"][aria-label="content"]
+    └── [role="table"]
+        └── [role="row"][aria-label="{containerName}"]
+```
+
+### ContainerDetailsPage
+
+```
+[role="region"][aria-label="Header"]
+├── [role="navigation"][aria-label="Breadcrumb"]
+├── [role="heading"]                            ← container name
+├── [role="status"]                             ← state (title attr)
+└── [role="group"][aria-label="Control Actions"]
+[role="region"][aria-label="Tabs"]
+└── a:has-text("{tabName}")                     ← Summary, Logs, Inspect, Kube, Terminal
+[role="region"][aria-label="Tab Content"]
+```
+
+## Locators
+
+### ContainersPage
+
+| Element       | Selector                                                                           |
+| ------------- | ---------------------------------------------------------------------------------- |
+| Page heading  | `[role="region"][aria-label="containers"] [role="heading"]`                        |
+| Create button | `[aria-label="additionalActions"] button:has-text("Create")`                       |
+| Prune button  | `[aria-label="additionalActions"] button:has-text("Prune")`                        |
+| Prune confirm | `button:has-text("Prune")`                                                         |
+| Run all       | `[aria-label="Run selected containers and pods"]`                                  |
+| Container row | `[role="row"][aria-label="{containerName}"]`                                       |
+| Name cell     | `[role="row"][aria-label="{containerName}"] [role="cell"]:nth-child(4)`            |
+| Image cell    | `[role="row"][aria-label="{containerName}"] [role="cell"]:nth-child(6)`            |
+| Start (row)   | `[role="row"][aria-label="{containerName}"] button[aria-label="Start Container"]`  |
+| Stop (row)    | `[role="row"][aria-label="{containerName}"] button[aria-label="Stop Container"]`   |
+| Delete (row)  | `[role="row"][aria-label="{containerName}"] button[aria-label="Delete Container"]` |
+| Environment   | `[role="row"][aria-label="{containerName}"] [data-testid="tooltip-trigger"]`       |
+| Create Pod    | `button:has-text("Create Pod")`                                                    |
+
+### Create Container Dialog
+
+| Element        | Selector                                                                    |
+| -------------- | --------------------------------------------------------------------------- |
+| Dialog         | `[role="dialog"][aria-label="Create a new container"]`                      |
+| Close dialog   | `[role="dialog"][aria-label="Create a new container"] [aria-label="Close"]` |
+| Existing image | `[role="dialog"] button:has-text("Existing image")`                         |
+| Containerfile  | `[role="dialog"] button:has-text("Containerfile or Dockerfile")`            |
+
+### SelectImagePage
+
+| Element      | Selector                                             |
+| ------------ | ---------------------------------------------------- |
+| Heading      | `[role="heading"]:has-text("Select an image")`       |
+| Image input  | `[placeholder="Select or enter an image to run"]`    |
+| Run Image    | `button:has-text("Run Image")`                       |
+| Pull and Run | `button:has-text("Pull Image and Run")`              |
+| Cancel       | `button:has-text("Cancel")`                          |
+| Error alert  | `[role="alert"][aria-label="Error Message Content"]` |
+
+### RunImagePage
+
+| Element               | Selector                                                   |
+| --------------------- | ---------------------------------------------------------- |
+| Heading               | `[role="heading"]:has-text("{imageName}")`                 |
+| Container Name        | `[aria-label="Container Name"]`                            |
+| Entrypoint            | `[aria-label="Entrypoint"]`                                |
+| Command               | `[aria-label="Command"]`                                   |
+| Start Container       | `[aria-label="Start Container"]`                           |
+| Close link            | `a:has-text("Close")`                                      |
+| Error alert           | `[role="alert"][aria-label="Error Message Content"]`       |
+| Basic tab             | `a:has-text("Basic")`                                      |
+| Advanced tab          | `a:has-text("Advanced")`                                   |
+| Networking tab        | `a:has-text("Networking")`                                 |
+| Add port mapping      | `[aria-label="Add custom port mapping"]`                   |
+| Host port             | `[aria-label="host port"]`                                 |
+| Container port        | `[aria-label="container port"]`                            |
+| Volume host path      | `[placeholder="Path on the host"]`                         |
+| Volume container path | `[placeholder="Path inside the container"]`                |
+| Attach terminal       | `[role="checkbox"][aria-label="Attach a pseudo terminal"]` |
+| Interactive           | `[role="checkbox"][aria-label="Use interactive"]`          |
+
+### ContainerDetailsPage
+
+| Element          | Selector                                                                 |
+| ---------------- | ------------------------------------------------------------------------ |
+| Heading          | `[aria-label="Header"] [role="heading"]:has-text("{containerName}")`     |
+| State            | `[aria-label="Header"] [role="status"]` (read `title` attr)              |
+| Start            | `[aria-label="Control Actions"] button:has-text("Start Container")`      |
+| Stop             | `[aria-label="Control Actions"] button[aria-label="Stop Container"]`     |
+| Delete           | `[aria-label="Control Actions"] button[aria-label="Delete Container"]`   |
+| Export           | `[aria-label="Control Actions"] button:has-text("Export Container")`     |
+| Deploy to K8s    | `[aria-label="Control Actions"] button:has-text("Deploy to Kubernetes")` |
+| Image link       | `[aria-label="Header"] a:has-text("Image Details")`                      |
+| Summary tab      | `[aria-label="Tabs"] a:has-text("Summary")`                              |
+| Logs tab         | `[aria-label="Tabs"] a:has-text("Logs")`                                 |
+| Inspect tab      | `[aria-label="Tabs"] a:has-text("Inspect")`                              |
+| Kube tab         | `[aria-label="Tabs"] a:has-text("Kube")`                                 |
+| Terminal tab     | `[aria-label="Tabs"] a:has-text("Terminal")`                             |
+| Terminal input   | `[aria-label="Terminal input"]`                                          |
+| Terminal content | `.xterm-rows`                                                            |
+| Find in logs     | `[aria-label="Tab Content"] [aria-label="Find"]`                         |
+| Clear logs       | `[title="Clear logs"]`                                                   |
+| Export path      | `#input-export-container-name`                                           |
+| Export browse    | `[aria-label="Select output file"]`                                      |
+| Confirm export   | `button:has-text("Export container")`                                    |
+
+## Operations
+
+### Create container from existing image
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Containers"]')`
+2. Wait for page: `wait('[role="region"][aria-label="containers"] [role="heading"]')`
+3. Click Create: `click('[aria-label="additionalActions"] button:has-text("Create")')`
+4. Wait for dialog: `wait('[role="dialog"][aria-label="Create a new container"]')`
+5. Click Existing image: `click('[role="dialog"] button:has-text("Existing image")')`
+6. Wait for select page: `wait('[role="heading"]:has-text("Select an image")')`
+7. Fill image: `fill('[placeholder="Select or enter an image to run"]', '{imageName}')`
+8. Click Run Image: `click('button:has-text("Run Image")')` (or `click('button:has-text("Pull Image and Run")')` if image is not local)
+9. Wait for run page: `wait('[aria-label="Container Name"]')`
+10. Optionally set name: `fill('[aria-label="Container Name"]', '{containerName}')`
+11. Click Start: `click('[aria-label="Start Container"]')`
+12. Wait for details: `wait('[aria-label="Header"] [role="heading"]')`
+
+### Start container (from list)
+
+1. Navigate to Containers page (steps 1-2)
+2. Click Start: `click('[role="row"][aria-label="{containerName}"] button[aria-label="Start Container"]')`
+
+### Stop container (from list)
+
+1. Navigate to Containers page
+2. Click Stop: `click('[role="row"][aria-label="{containerName}"] button[aria-label="Stop Container"]')`
+
+### Delete container (from list)
+
+1. Navigate to Containers page
+2. Click Delete: `click('[role="row"][aria-label="{containerName}"] button[aria-label="Delete Container"]')`
+
+### Open container details
+
+1. Navigate to Containers page
+2. Click row: `click('[role="row"][aria-label="{containerName}"]')`
+3. Wait for details: `wait('[aria-label="Header"] [role="heading"]:has-text("{containerName}")')`
+
+### Start/Stop/Delete from details
+
+1. Open container details
+2. Start: `click('[aria-label="Control Actions"] button:has-text("Start Container")')`
+3. Stop: `click('[aria-label="Control Actions"] button[aria-label="Stop Container"]')`
+4. Delete: `click('[aria-label="Control Actions"] button[aria-label="Delete Container"]')`
+
+### View container logs
+
+1. Open container details
+2. Click Logs tab: `click('[aria-label="Tabs"] a:has-text("Logs")')`
+3. Wait for content: `wait('[aria-label="Tab Content"]')`
+4. Read logs: `getText('.xterm-rows')`
+
+### Open container terminal
+
+1. Open container details (container must be running)
+2. Click Terminal tab: `click('[aria-label="Tabs"] a:has-text("Terminal")')`
+3. Wait for terminal: `wait('[aria-label="Terminal input"]')`
+4. Type command: `fill('[aria-label="Terminal input"]', '{command}')`
+5. Press Enter: `press('Enter')`
+6. Read output: `getText('.xterm-rows')`
+
+### Export container
+
+1. Open container details (container must be stopped)
+2. Click Export: `click('[aria-label="Control Actions"] button:has-text("Export Container")')`
+3. Fill path: `fill('#input-export-container-name', '{exportPath}')`
+4. Click Export: `click('button:has-text("Export container")')`
+
+### Prune containers
+
+1. Navigate to Containers page
+2. Click Prune: `click('[aria-label="additionalActions"] button:has-text("Prune")')`
+3. Confirm: `click('button:has-text("Prune")')`
+
+### Check container state
+
+```
+evaluate('document.querySelector(\'[role="row"][aria-label="{containerName}"] [role="status"]\')?.title')
+```
+
+Returns: `RUNNING`, `STOPPED`, `EXITED`, etc.
+
+## Test Data
+
+- Lightweight image: `ghcr.io/podmandesktop-ci/hello`
+- Timeouts: start 30s, stop 30s, terminal 10s, export 60s
+
+## Gotchas
+
+- Container must be running before Terminal tab works
+- Container must be stopped before Export is available
+- Create dialog has two paths: "Existing image" and "Containerfile" — most tests use existing
+- Row action buttons change based on container state (Start vs Stop)
+- The Create Pod button appears in bulk actions when containers are selected
+- "Run Image" button becomes "Pull Image and Run" when the image is not available locally — try both selectors

--- a/.agents/skills/mcp-testing/references/operations/extensions.md
+++ b/.agents/skills/mcp-testing/references/operations/extensions.md
@@ -1,0 +1,148 @@
+# Extension Operations
+
+## Navigation
+
+| Target          | Selector                                                     |
+| --------------- | ------------------------------------------------------------ |
+| Extensions page | `nav[aria-label="AppNavigation"] a[aria-label="Extensions"]` |
+
+## Page Structure
+
+### ExtensionsPage
+
+```
+[role="region"][aria-label="extensions"]
+├── [role="region"][aria-label="header"]
+│   ├── [role="heading"]                        ← "Extensions"
+│   └── button:has-text("Installed")          ← tab buttons
+│       button:has-text("Catalog")
+│       button:has-text("Local Extensions")
+├── [role="region"][aria-label="content"]
+│   └── [role="region"][aria-label="{extensionId}"]     ← extension cards
+```
+
+## Locators
+
+### ExtensionsPage
+
+| Element               | Selector                                                        |
+| --------------------- | --------------------------------------------------------------- |
+| Page heading          | `[aria-label="header"] [role="heading"]:has-text("extensions")` |
+| Installed tab         | `button:has-text("Installed")`                                  |
+| Catalog tab           | `button:has-text("Catalog")`                                    |
+| Local Extensions tab  | `button:has-text("Local Extensions")`                           |
+| Install custom button | `[aria-label="Install custom"]`                                 |
+
+### Install Custom Extension Dialog
+
+| Element         | Selector                                                                                                                       |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Dialog          | `[role="dialog"][aria-label="Install Custom Extension"]`                                                                       |
+| OCI image input | `[role="dialog"][aria-label="Install Custom Extension"] [role="textbox"][aria-label="Image name to install custom extension"]` |
+| Install button  | `[role="dialog"][aria-label="Install Custom Extension"] button:has-text("Install")`                                            |
+| Done button     | `[role="dialog"][aria-label="Install Custom Extension"] button:has-text("Done")`                                               |
+
+### ExtensionCard (per extension in Installed list)
+
+| Element         | Selector                                                                                                        |
+| --------------- | --------------------------------------------------------------------------------------------------------------- |
+| Card region     | `[aria-label="content"] [role="region"][aria-label="{extensionId}"]`                                            |
+| Details link    | `[role="region"][aria-label="{extensionId}"] button[aria-label="{extensionName} extension details"]`            |
+| Status          | `[role="region"][aria-label="{extensionId}"] [aria-label="Extension Status Label"]`                             |
+| Start (enable)  | `[role="region"][aria-label="{extensionId}"] [aria-label="Extension Actions"] button[aria-label="Start"]`       |
+| Stop (disable)  | `[role="region"][aria-label="{extensionId}"] [aria-label="Extension Actions"] button[aria-label="Stop"]`        |
+| Delete (remove) | `[role="region"][aria-label="{extensionId}"] [aria-label="Extension Actions"] button[aria-label="Delete"]`      |
+| Edit properties | `[role="region"][aria-label="{extensionId}"] button[aria-label="Edit properties of {extensionName} extension"]` |
+
+### ExtensionDetailsPage
+
+| Element           | Selector                                                      |
+| ----------------- | ------------------------------------------------------------- |
+| Heading           | `[aria-label="Header"] h1`                                    |
+| Start             | `[aria-label="Header"] button[aria-label="Start"]`            |
+| Stop              | `[aria-label="Header"] button[aria-label="Stop"]`             |
+| Delete            | `[aria-label="Header"] button[aria-label="Delete"]`           |
+| Status            | `[aria-label="Header"] [aria-label="Extension Status Label"]` |
+| Tab activation    | `[aria-label="Tabs"] button:has-text("{tabName}")`            |
+| Error stack trace | `[aria-label="Tab Content"] [aria-label="Stack Trace"]`       |
+
+### ExtensionCatalogCard (per extension in Catalog)
+
+| Element           | Selector                                                                       |
+| ----------------- | ------------------------------------------------------------------------------ |
+| Card              | `[role="group"][aria-label="{extensionName}"]`                                 |
+| More details      | `[role="group"][aria-label="{extensionName}"] button:has-text("More details")` |
+| Install button    | `[role="group"][aria-label="{extensionName}"] button:has-text("Install")`      |
+| Already installed | text "Already installed" within card                                           |
+
+## Operations
+
+### View installed extensions
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Extensions"]')`
+2. Wait for page: `wait('[aria-label="header"] [role="heading"]:has-text("extensions")')`
+3. Click Installed: `click('button:has-text("Installed")')`
+
+### View extension catalog
+
+1. Navigate to Extensions page (steps 1-2)
+2. Click Catalog: `click('button:has-text("Catalog")')`
+3. Wait for catalog cards: `wait('[role="group"][aria-label] button:has-text("More details")')`
+
+### Install extension from catalog
+
+1. View extension catalog (steps 1-3)
+2. Click Install: `click('[role="group"][aria-label="{extensionName}"] button:has-text("Install")')`
+3. Wait for installed: `wait('[role="group"][aria-label="{extensionName}"] text="Already installed"', { timeout: 60000 })`
+
+### Install custom extension (OCI)
+
+1. Navigate to Extensions page
+2. Click Install custom: `click('[aria-label="Install custom"]')`
+3. Wait for dialog: `wait('[role="dialog"][aria-label="Install Custom Extension"]')`
+4. Fill OCI image: `fill('[role="dialog"][aria-label="Install Custom Extension"] [role="textbox"][aria-label="Image name to install custom extension"]', '{ociImage}')`
+5. Click Install: `click('[role="dialog"][aria-label="Install Custom Extension"] button:has-text("Install")')`
+6. Wait for Done: `wait('[role="dialog"][aria-label="Install Custom Extension"] button:has-text("Done")', { timeout: 120000 })`
+7. Click Done: `click('[role="dialog"][aria-label="Install Custom Extension"] button:has-text("Done")')`
+
+### Open extension details
+
+1. Navigate to Extensions page, Installed tab
+2. Click details: `click('[role="region"][aria-label="{extensionId}"] button[aria-label="{extensionName} extension details"]')`
+3. Wait for details: `wait('[aria-label="Header"] h1')`
+
+### Enable/Disable extension
+
+1. **From card** (Installed tab):
+   - Start: `click('[role="region"][aria-label="{extensionId}"] [aria-label="Extension Actions"] button[aria-label="Start"]')`
+   - Stop: `click('[role="region"][aria-label="{extensionId}"] [aria-label="Extension Actions"] button[aria-label="Stop"]')`
+
+2. **From details page**:
+   - Start: `click('[aria-label="Header"] button[aria-label="Start"]')`
+   - Stop: `click('[aria-label="Header"] button[aria-label="Stop"]')`
+
+### Delete extension
+
+1. **From card**: `click('[role="region"][aria-label="{extensionId}"] [aria-label="Extension Actions"] button[aria-label="Delete"]')`
+2. **From details**: `click('[aria-label="Header"] button[aria-label="Delete"]')`
+
+### Check extension status
+
+```
+getText('[role="region"][aria-label="{extensionId}"] [aria-label="Extension Status Label"]')
+```
+
+Replace `{extensionId}` with the extension's full ID (e.g., "podman-desktop.podman" — used for the installed card's ARIA region) and `{extensionName}` with the extension's short name (e.g., "podman" — used in button aria-labels). For catalog cards, `{extensionName}` is the display name (e.g., "Podman AI Lab").
+
+Returns: `ACTIVE`, `DISABLED`, `FAILED`, etc.
+
+## Gotchas
+
+- Installed extension cards use `extension.id` (e.g., "podman-desktop.podman") for the ARIA label, not the display name
+- Start/Stop/Delete buttons on cards are icon-only — use `button[aria-label="Start"]`, not `button:has-text("Start")`
+- `{extensionId}` = the full extension ID for installed cards, `{extensionName}` = short name for button aria-labels (e.g., "podman"), display name for catalog cards
+- Catalog cards use `[role="group"]`, installed cards use `[role="region"]`
+- Install from catalog can take 30-120s depending on extension size
+- Custom OCI install dialog stays open until you click Done
+- Start/Stop buttons swap based on current state — check status first
+- Built-in extensions (podman, docker, compose) cannot be deleted

--- a/.agents/skills/mcp-testing/references/operations/images.md
+++ b/.agents/skills/mcp-testing/references/operations/images.md
@@ -1,0 +1,222 @@
+# Image Operations
+
+## Navigation
+
+| Target      | Selector                                                 |
+| ----------- | -------------------------------------------------------- |
+| Images page | `nav[aria-label="AppNavigation"] a[aria-label="Images"]` |
+
+## Page Structure
+
+### ImagesPage (list)
+
+```
+[role="region"][aria-label="images"]
+├── [role="region"][aria-label="header"]
+│   ├── [role="heading"]                        ← "Images"
+│   └── [role="group"][aria-label="additionalActions"]
+│       ├── button:has-text("Pull")
+│       ├── button:has-text("Build")
+│       └── button:has-text("Prune")
+├── [role="region"][aria-label="search"]
+│   └── [role="group"][aria-label="bottomAdditionalActions"]
+│       └── button:has-text("Delete")           ← bulk delete
+└── [role="region"][aria-label="content"]
+    └── [role="table"]
+        └── [role="row"][aria-label="{imageName}"]
+```
+
+### ImageDetailsPage
+
+```
+[role="region"][aria-label="Header"]
+├── [role="navigation"][aria-label="Breadcrumb"]
+├── [role="heading"]                            ← image name
+└── [role="group"][aria-label="Control Actions"]
+[role="region"][aria-label="Tabs"]
+└── a:has-text("{tabName}")                     ← Summary, History, Inspect
+[role="region"][aria-label="Tab Content"]
+```
+
+## Locators
+
+### ImagesPage
+
+| Element             | Selector                                                                     |
+| ------------------- | ---------------------------------------------------------------------------- |
+| Page heading        | `[role="region"][aria-label="images"] [role="heading"]`                      |
+| Pull button         | `[aria-label="additionalActions"] button:has-text("Pull")`                   |
+| Build button        | `[aria-label="additionalActions"] button:has-text("Build")`                  |
+| Prune button        | `[aria-label="additionalActions"] button:has-text("Prune")`                  |
+| Load Images button  | `[aria-label="Load Images"]`                                                 |
+| Import Image button | `[aria-label="Import Image"]`                                                |
+| Image row           | `[role="row"][aria-label="{imageName}"]`                                     |
+| Image name cell     | `[role="row"][aria-label="{imageName}"] [role="cell"]:nth-child(4)`          |
+| Image status        | `[role="row"][aria-label="{imageName}"] [role="status"]` (read `title` attr) |
+| Select all checkbox | `[role="checkbox"][aria-label="Toggle all"]`                                 |
+| Delete selected     | `[aria-label="bottomAdditionalActions"] button:has-text("Delete")`           |
+| Prune confirm       | `button:has-text("All unused images")`                                       |
+| No Container Engine | `[role="heading"]:has-text("No Container Engine")`                           |
+
+### PullImagePage
+
+| Element              | Selector                                                     |
+| -------------------- | ------------------------------------------------------------ |
+| Heading              | `[role="heading"]:has-text("Pull Image From a Registry")`    |
+| Image name input     | `#imageName`                                                 |
+| Pull button          | `button:has-text("Pull image")`                              |
+| Close link           | `a:has-text("Close")`                                        |
+| Go back to Images    | `a:has-text("Go back to Images")`                            |
+| Manage registries    | `button:has-text("Manage registries")`                       |
+| Search results rows  | `[aria-label="Tab Content"] [role="row"]`                    |
+| Close (after pull)   | `[aria-label="Tab Content"] button:has-text("Close")`        |
+| Cancel (during pull) | `[aria-label="Tab Content"] button:has-text("Cancel")`       |
+| View details         | `[aria-label="Tab Content"] button:has-text("View details")` |
+| Run (after pull)     | `[aria-label="Tab Content"] button:has-text("Run")`          |
+
+### ImageDetailsPage
+
+| Element         | Selector                                                         |
+| --------------- | ---------------------------------------------------------------- |
+| Heading         | `[aria-label="Header"] [role="heading"]:has-text("{imageName}")` |
+| Run Image       | `[aria-label="Control Actions"] button:has-text("Run Image")`    |
+| Delete Image    | `[aria-label="Control Actions"] button:has-text("Delete Image")` |
+| Edit Image      | `[aria-label="Control Actions"] button:has-text("Edit Image")`   |
+| Push Image      | `[aria-label="Control Actions"] button:has-text("Push Image")`   |
+| Save Image      | `[aria-label="Control Actions"] button:has-text("Save Image")`   |
+| Kebab menu      | `button[aria-label="kebab menu"]`                                |
+| Summary tab     | `[aria-label="Tabs"] a:has-text("Summary")`                      |
+| History tab     | `[aria-label="Tabs"] a:has-text("History")`                      |
+| Inspect tab     | `[aria-label="Tabs"] a:has-text("Inspect")`                      |
+| Save output dir | `#input-output-directory`                                        |
+| Confirm save    | `[aria-label="Save images"]`                                     |
+| Browse folder   | `[aria-label="Select output folder"]`                            |
+
+### EditImagePage (dialog)
+
+| Element          | Selector                                                             |
+| ---------------- | -------------------------------------------------------------------- |
+| Dialog           | `[role="dialog"][aria-label="Edit Image"]`                           |
+| Image name input | `[role="dialog"][aria-label="Edit Image"] [aria-label="imageName"]`  |
+| Image tag input  | `[role="dialog"][aria-label="Edit Image"] [aria-label="imageTag"]`   |
+| Cancel           | `[role="dialog"][aria-label="Edit Image"] button:has-text("Cancel")` |
+| Save             | `[role="dialog"][aria-label="Edit Image"] button:has-text("Save")`   |
+
+### BuildImagePage
+
+| Element             | Selector                                                              |
+| ------------------- | --------------------------------------------------------------------- |
+| Heading             | `[role="heading"]:has-text("Build Image from Containerfile")`         |
+| Containerfile input | `[placeholder="Containerfile to build"]`                              |
+| Context dir input   | `[placeholder="Directory to build in"]`                               |
+| Image name input    | `[placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"]` |
+| Build button        | `button:has-text("Build")`                                            |
+| Done button         | `button:has-text("Done")`                                             |
+| Cancel button       | `button:has-text("Cancel")`                                           |
+| Platform region     | `[aria-label="Build Platform Options"]`                               |
+| ARM64 checkbox      | `[aria-label="Build Platform Options"] [aria-label="linux/arm64"]`    |
+| AMD64 checkbox      | `[aria-label="Build Platform Options"] [aria-label="linux/amd64"]`    |
+| Terminal output     | `.xterm-rows`                                                         |
+
+## Operations
+
+### Pull image
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Images"]')`
+2. Wait for page: `wait('[role="region"][aria-label="images"] [role="heading"]')`
+3. Click Pull: `click('[aria-label="additionalActions"] button:has-text("Pull")')`
+4. Wait for pull page: `wait('[role="heading"]:has-text("Pull Image From a Registry")')`
+5. Fill image name: `fill('#imageName', '{imageName}')`
+6. Click Pull image: `click('button:has-text("Pull image")')`
+7. Wait for completion: `wait('[aria-label="Tab Content"] button:has-text("Close")', { timeout: 60000 })`
+8. Click Close: `click('[aria-label="Tab Content"] button:has-text("Close")')`
+
+### Pull image and view details
+
+1. Follow steps 1-6 from "Pull image"
+2. Wait for View details: `wait('[aria-label="Tab Content"] button:has-text("View details")', { timeout: 60000 })`
+3. Click View details: `click('[aria-label="Tab Content"] button:has-text("View details")')`
+4. Wait for details: `wait('[aria-label="Header"] [role="heading"]')`
+
+### Cancel pull
+
+1. Follow steps 1-6 from "Pull image"
+2. Click Cancel: `click('[aria-label="Tab Content"] button:has-text("Cancel")')`
+
+### Open image details
+
+1. Navigate to Images page (steps 1-2 from "Pull image")
+2. Click image row: `click('[role="row"][aria-label="{imageName}"]')`
+3. Wait for details: `wait('[aria-label="Header"] [role="heading"]:has-text("{imageName}")')`
+
+### Check image details tabs
+
+1. Open image details (above)
+2. Verify Summary: `wait('[aria-label="Tabs"] a:has-text("Summary")')`
+3. Verify History: `wait('[aria-label="Tabs"] a:has-text("History")')`
+4. Verify Inspect: `wait('[aria-label="Tabs"] a:has-text("Inspect")')`
+
+### Rename image (edit)
+
+1. Open image details
+2. Click Edit: `click('[aria-label="Control Actions"] button:has-text("Edit Image")')`
+3. Wait for dialog: `wait('[role="dialog"][aria-label="Edit Image"]')`
+4. Clear name: `fill('[role="dialog"][aria-label="Edit Image"] [aria-label="imageName"]', '{newName}')`
+5. Clear tag: `fill('[role="dialog"][aria-label="Edit Image"] [aria-label="imageTag"]', '{newTag}')`
+6. Click Save: `click('[role="dialog"][aria-label="Edit Image"] button:has-text("Save")')`
+7. Wait for list: `wait('[role="region"][aria-label="images"] [role="heading"]')`
+
+### Delete image
+
+1. Open image details
+2. Click Delete: `click('[aria-label="Control Actions"] button:has-text("Delete Image")')`
+3. Wait for list: `wait('[role="region"][aria-label="images"] [role="heading"]')`
+
+### Build image
+
+1. Navigate to Images page
+2. Click Build: `click('[aria-label="additionalActions"] button:has-text("Build")')`
+3. Wait for build page: `wait('[role="heading"]:has-text("Build Image from Containerfile")')`
+4. Fill Containerfile: `fill('[placeholder="Containerfile to build"]', '{containerfilePath}')`
+5. Fill context dir: `fill('[placeholder="Directory to build in"]', '{contextDirectory}')`
+6. Fill image name: `fill('[placeholder="Image name (e.g. quay.io/namespace/my-custom-image)"]', '{imageName}')`
+7. Click Build: `click('button:has-text("Build")')`
+8. Wait for Done: `wait('button:has-text("Done")', { timeout: 300000 })`
+9. Click Done: `click('button:has-text("Done")')`
+
+### Save image as tar
+
+1. Open image details
+2. Click Save: `click('[aria-label="Control Actions"] button:has-text("Save Image")')`
+3. Fill output path: `fill('#input-output-directory', '{tarFilePath}')`
+4. Click Save: `click('[aria-label="Save images"]')`
+5. Wait for completion: `wait('[role="region"][aria-label="images"] [role="heading"]', { timeout: 60000 })`
+
+### Prune images
+
+1. Navigate to Images page
+2. Click Prune: `click('[aria-label="additionalActions"] button:has-text("Prune")')`
+3. Confirm: `click('button:has-text("All unused images")')`
+
+### Check image status
+
+```
+evaluate('document.querySelector(\'[role="row"][aria-label="{imageName}"] [role="status"]\')?.title')
+```
+
+Returns: `UNUSED`, `USED`, `IN USE`, etc.
+
+## Test Data
+
+- Lightweight pull test: `ghcr.io/podmandesktop-ci/hello`
+- Search test: `ghcr.io/linuxcontainers/alpine` (tag: `latest`)
+- Built image names get `docker.io/library/` prefix automatically
+- Timeouts: pull 60s, build 300s, delete 60s, prune 180s
+
+## Gotchas
+
+- After pulling, wait for `Close` or `View details` button before navigating away
+- Built images are prefixed with `docker.io/library/` — use this in row selectors
+- Image name input on PullImagePage triggers a search — wait briefly after filling before clicking Pull
+- Save/Load operations require file system paths that the app can access
+- Prune only deletes unused images — images with running containers are kept

--- a/.agents/skills/mcp-testing/references/operations/kubernetes.md
+++ b/.agents/skills/mcp-testing/references/operations/kubernetes.md
@@ -1,0 +1,160 @@
+# Kubernetes Operations
+
+## Navigation
+
+| Target          | Selector                                                     |
+| --------------- | ------------------------------------------------------------ |
+| Kubernetes page | `nav[aria-label="AppNavigation"] a[aria-label="Kubernetes"]` |
+
+## Page Structure
+
+### KubernetesBar (sidebar)
+
+```
+nav[aria-label="Kubernetes Navigation Bar"]
+├── a:has-text("Dashboard")
+├── a:has-text("Nodes")
+├── a:has-text("Pods")
+├── a:has-text("Deployments")
+├── a:has-text("Services")
+├── a:has-text("Ingresses & Routes")
+├── a:has-text("Persistent Volume Claims")
+├── a:has-text("ConfigMaps & Secrets")
+├── a:has-text("Jobs")
+├── a:has-text("CronJobs")
+└── a:has-text("Port Forwarding")
+```
+
+### KubernetesResourcePage (shared for all resource types)
+
+```
+[role="region"][aria-label="{resourceType}"]
+├── [role="region"][aria-label="header"]
+│   ├── [role="heading"]
+│   └── [role="group"][aria-label="additionalActions"]
+│       └── button:has-text("Apply YAML")
+└── [role="region"][aria-label="content"]
+    └── [role="table"]
+        └── [role="row"][aria-label="{resourceName}"]
+```
+
+## Locators
+
+### KubernetesBar
+
+| Element     | Selector                                                                             |
+| ----------- | ------------------------------------------------------------------------------------ |
+| Kube nav    | `nav[aria-label="Kubernetes Navigation Bar"]`                                        |
+| Dashboard   | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Dashboard")`                |
+| Nodes       | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Nodes")`                    |
+| Pods        | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Pods")`                     |
+| Deployments | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Deployments")`              |
+| Services    | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Services")`                 |
+| Ingresses   | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Ingresses & Routes")`       |
+| PVCs        | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Persistent Volume Claims")` |
+| ConfigMaps  | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("ConfigMaps & Secrets")`     |
+| Jobs        | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Jobs")`                     |
+| CronJobs    | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("CronJobs")`                 |
+| Port Fwd    | `nav[aria-label="Kubernetes Navigation Bar"] a:has-text("Port Forwarding")`          |
+
+### KubernetesContextPage
+
+| Element           | Selector                                                             |
+| ----------------- | -------------------------------------------------------------------- |
+| Title             | `[aria-label="Title"]`                                               |
+| Contexts table    | `[aria-label="Contexts"]`                                            |
+| Context row       | `[aria-label="Contexts"] [aria-label="{contextName}"]`               |
+| Current context   | `[aria-label="{contextName}"] [aria-label="Current Context"]`        |
+| Context reachable | `[aria-label="{contextName}"] [aria-label="Context Reachable"]`      |
+| Set as current    | `[aria-label="{contextName}"] [aria-label="Set as Current Context"]` |
+| Delete context    | `[aria-label="{contextName}"] [aria-label="Delete Context"]`         |
+| Duplicate context | `[aria-label="{contextName}"] [aria-label="Duplicate Context"]`      |
+| Edit context      | `[aria-label="{contextName}"] [aria-label="Edit Context"]`           |
+| No contexts       | `[role="heading"]:has-text("No Kubernetes contexts found")`          |
+
+### Edit Context Dialog
+
+| Element            | Selector                                                                |
+| ------------------ | ----------------------------------------------------------------------- |
+| Dialog             | `[role="dialog"][aria-label="Edit Context"]`                            |
+| Context name input | `[role="dialog"][aria-label="Edit Context"] [aria-label="contextName"]` |
+| Save button        | `[role="dialog"][aria-label="Edit Context"] button:has-text("Save")`    |
+
+### KubernetesDashboardPage
+
+| Element              | Selector                                                           |
+| -------------------- | ------------------------------------------------------------------ |
+| Namespace dropdown   | `[aria-label="Kubernetes Namespace"]`                              |
+| Namespace button     | `[aria-label="Kubernetes Namespace"] button:has-text("Namespace")` |
+| Hidden input (value) | `[aria-label="Kubernetes Namespace"] [aria-label="hidden input"]`  |
+
+### KubernetesResourcePage (shared)
+
+| Element           | Selector                                                              |
+| ----------------- | --------------------------------------------------------------------- |
+| Apply YAML button | `[aria-label="additionalActions"] button:has-text("Apply YAML")`      |
+| Resource row      | `[role="row"][aria-label="{resourceName}"]`                           |
+| Delete (row)      | `[role="row"][aria-label="{resourceName}"] button:has-text("Delete")` |
+
+## Operations
+
+### Navigate to Kubernetes
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Kubernetes"]')`
+2. Wait for kube nav: `wait('nav[aria-label="Kubernetes Navigation Bar"]')`
+
+### Navigate to Kubernetes section
+
+1. Navigate to Kubernetes (steps 1-2)
+2. Click section: `click('nav[aria-label="Kubernetes Navigation Bar"] a:has-text("{sectionName}")')`
+
+### View Kubernetes contexts
+
+Contexts are NOT in the Kubernetes sidebar nav. Access them via the status bar:
+
+1. Click context in status bar: `click('[title="Current Kubernetes context"]')`
+2. Wait for contexts: `wait('[aria-label="Contexts"]')`
+
+### Set current context
+
+1. View Kubernetes contexts (steps 1-3)
+2. Click Set as current: `click('[aria-label="{contextName}"] [aria-label="Set as Current Context"]')`
+
+### Edit context
+
+1. View Kubernetes contexts
+2. Click Edit: `click('[aria-label="{contextName}"] [aria-label="Edit Context"]')`
+3. Wait for dialog: `wait('[role="dialog"][aria-label="Edit Context"]')`
+4. Fill name: `fill('[role="dialog"][aria-label="Edit Context"] [aria-label="contextName"]', '{newName}')`
+5. Click Save: `click('[role="dialog"][aria-label="Edit Context"] button:has-text("Save")')`
+
+### Delete context
+
+1. View Kubernetes contexts
+2. Click Delete: `click('[aria-label="{contextName}"] [aria-label="Delete Context"]')`
+
+### Change namespace
+
+1. Navigate to Kubernetes Dashboard
+2. Click namespace dropdown: `click('[aria-label="Kubernetes Namespace"] button:has-text("Namespace")')`
+3. Click the namespace option: `click('[aria-label="Kubernetes Namespace"] button:has-text("{namespace}")')`
+
+### Apply YAML to cluster
+
+1. Navigate to any Kubernetes resource page
+2. Click Apply YAML: `click('[aria-label="additionalActions"] button:has-text("Apply YAML")')`
+
+### Check current namespace
+
+```
+getAttribute('[aria-label="Kubernetes Namespace"] [aria-label="hidden input"]', 'value')
+```
+
+## Gotchas
+
+- Kubernetes page has its own sub-navigation (`Kubernetes Navigation Bar`), separate from main nav and settings nav
+- Context operations require a valid kubeconfig — without one, the page shows "No Kubernetes contexts found"
+- The namespace dropdown uses a hidden input to store the selected value
+- Resource pages (Pods, Deployments, etc.) share the same structure — only the data differs
+- "Set as Current Context" is only visible on non-current contexts
+- Contexts page is NOT in the Kubernetes sidebar nav — access it from the status bar

--- a/.agents/skills/mcp-testing/references/operations/navigation.md
+++ b/.agents/skills/mcp-testing/references/operations/navigation.md
@@ -1,0 +1,141 @@
+# Navigation Operations
+
+## Navigation
+
+| Target     | Selector                                                     |
+| ---------- | ------------------------------------------------------------ |
+| Dashboard  | `nav[aria-label="AppNavigation"] a[aria-label="Dashboard"]`  |
+| Containers | `nav[aria-label="AppNavigation"] a[aria-label="Containers"]` |
+| Pods       | `nav[aria-label="AppNavigation"] a[aria-label="Pods"]`       |
+| Images     | `nav[aria-label="AppNavigation"] a[aria-label="Images"]`     |
+| Volumes    | `nav[aria-label="AppNavigation"] a[aria-label="Volumes"]`    |
+| Networks   | `nav[aria-label="AppNavigation"] a[aria-label="Networks"]`   |
+| Kubernetes | `nav[aria-label="AppNavigation"] a[aria-label="Kubernetes"]` |
+| Extensions | `nav[aria-label="AppNavigation"] a[aria-label="Extensions"]` |
+| Settings   | `nav[aria-label="AppNavigation"] a[aria-label="Settings"]`   |
+| Back       | `button[aria-label="Back (hold for history)"]`               |
+| Forward    | `button[aria-label="Forward (hold for history)"]`            |
+
+## Page Structure
+
+### Navigation bar
+
+```
+nav[aria-label="AppNavigation"]
+├── a[aria-label="{Page}"]         ← sidebar links (Dashboard, Containers, etc.)
+button[aria-label="Back (hold for history)"]
+button[aria-label="Forward (hold for history)"]
+```
+
+### Detail page breadcrumb
+
+```
+[role="navigation"][aria-label="Breadcrumb"]
+├── a[aria-label="Back"]           ← go to previous page
+├── button[aria-label="Close"]     ← go to list page
+└── [aria-label="Page Name"]
+```
+
+### Dashboard
+
+```
+[role="region"][aria-label="Dashboard"]
+├── [role="region"][aria-label="header"]
+├── [role="region"][aria-label="content"]
+│   ├── [role="region"][aria-label="Notifications Box"]
+│   └── [role="region"][aria-label="Podman Provider"]
+└── [role="region"][aria-label="FeaturedExtensions"]
+```
+
+### Status bar
+
+```
+[role="contentinfo"][aria-label="Status Bar"]
+├── [title="Current Kubernetes context"]
+├── button matching /^v\d+\.\d+\.\d+/     ← version
+├── [title="Update available"]
+├── [title="Share your feedback"]
+├── [title="Troubleshooting"]
+├── [title="Tasks"]
+└── [title="Help"]
+```
+
+## Locators
+
+### Welcome page
+
+| Element              | Selector                                         |
+| -------------------- | ------------------------------------------------ |
+| Welcome message      | text matching `/Welcome to.*Podman Desktop/`     |
+| Telemetry checkbox   | `input[aria-label="Enable telemetry"]`           |
+| Skip button          | `button:has-text("Skip")` (exact)                |
+| Initializing heading | `[role="heading"]:has-text("Initializing...")`   |
+| Start onboarding     | `button:has-text("Start onboarding")`            |
+| Next step            | `button:has-text("Next Step")`                   |
+| Cancel setup         | `button:has-text("Cancel Setup")`                |
+| Onboarding status    | `[aria-label="Onboarding Status Message"]`       |
+| Skip setup popup     | `[role="dialog"][aria-label="Skip Setup Popup"]` |
+| OK (popup)           | popup `button:has-text("OK")`                    |
+| Markdown content     | `[aria-label="markdown-content"]`                |
+
+### Dashboard
+
+| Element             | Selector                                                                                |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| Page heading        | `[role="heading"]:has-text("Dashboard")`                                                |
+| Notifications box   | `[role="region"][aria-label="Notifications Box"]`                                       |
+| Featured extensions | `[role="region"][aria-label="FeaturedExtensions"]`                                      |
+| Podman provider     | `[role="region"][aria-label="Podman Provider"]`                                         |
+| Podman status       | `[role="region"][aria-label="Podman Provider"] [aria-label="Connection Status Label"]`  |
+| Initialize & start  | `[role="region"][aria-label="Podman Provider"] button:has-text("Initialize and start")` |
+| Transitioning state | `[role="region"][aria-label="Podman Provider"] [aria-label="Transitioning State"]`      |
+
+### Status bar
+
+| Element            | Selector                                        |
+| ------------------ | ----------------------------------------------- |
+| Status bar         | `[role="contentinfo"][aria-label="Status Bar"]` |
+| Kubernetes context | `[title="Current Kubernetes context"]`          |
+| Version button     | button matching `/^v\d+\.\d+\.\d+/`             |
+| Update available   | `[title="Update available"]`                    |
+| Feedback           | `[title="Share your feedback"]`                 |
+| Troubleshooting    | `[title="Troubleshooting"]`                     |
+| Tasks              | `[title="Tasks"]`                               |
+| Help               | `[title="Help"]`                                |
+
+## Operations
+
+### Handle welcome page (skip)
+
+1. Check for Skip button: `evaluate('!!Array.from(document.querySelectorAll("button")).find(b => b.textContent.trim() === "Skip")')`
+2. Disable telemetry: `evaluate('const t = document.querySelector("input[aria-label=\\"Enable telemetry\\"]"); if (t?.checked) t.click(); "done"')`
+3. Click Skip: `click('button:has-text("Skip")')`
+4. Wait for dashboard: `wait('[role="heading"]:has-text("Dashboard")')`
+
+### Navigate to a page
+
+1. Click nav link: `click('nav[aria-label="AppNavigation"] a[aria-label="{Page}"]')`
+2. Wait for heading: `wait('h1:has-text("{Page}")')`
+
+### Back/forward navigation
+
+1. Go back: `click('button[aria-label="Back (hold for history)"]')`
+2. Go forward: `click('button[aria-label="Forward (hold for history)"]')`
+
+### Navigate back from detail page
+
+1. Back link: `click('[role="navigation"][aria-label="Breadcrumb"] a[aria-label="Back"]')` — goes to previous page
+2. Close button: `click('[role="navigation"][aria-label="Breadcrumb"] button[aria-label="Close"]')` — goes to list page
+
+### Reset navigation state
+
+1. Clear session: `evaluate('sessionStorage.clear()')`
+2. Reload: `evaluate('location.reload()')`
+3. Wait: `wait('nav[aria-label="AppNavigation"]')`
+
+## Gotchas
+
+- Clicking the same nav link twice does NOT add a duplicate to the history stack
+- Navigating to a new page from the middle of the history stack truncates forward history
+- `handleWelcomePage(true)` in POM equals: disable telemetry → click Skip
+- Back/Forward buttons are disabled when at the start/end of history — check before clicking

--- a/.agents/skills/mcp-testing/references/operations/networks.md
+++ b/.agents/skills/mcp-testing/references/operations/networks.md
@@ -1,0 +1,115 @@
+# Network Operations
+
+## Navigation
+
+| Target        | Selector                                                   |
+| ------------- | ---------------------------------------------------------- |
+| Networks page | `nav[aria-label="AppNavigation"] a[aria-label="Networks"]` |
+
+## Page Structure
+
+### NetworksPage (list)
+
+```
+[role="region"][aria-label="networks"]
+├── [role="region"][aria-label="header"]
+│   ├── [role="heading"]                        ← "Networks"
+│   └── [role="group"][aria-label="additionalActions"]
+│       └── button:has-text("Create")
+├── [role="region"][aria-label="search"]
+│   └── [role="group"][aria-label="bottomAdditionalActions"]
+│       └── button[title*="Delete"]              ← bulk delete (icon-only)
+└── [role="region"][aria-label="content"]
+    └── [role="table"]
+        └── [role="row"][aria-label="{networkName}"]
+```
+
+### NetworkDetailsPage
+
+```
+[role="region"][aria-label="Header"]
+├── [role="navigation"][aria-label="Breadcrumb"]
+├── [role="heading"]                            ← network name
+└── [role="group"][aria-label="Control Actions"]
+[role="region"][aria-label="Tabs"]
+└── a:has-text("{tabName}")                     ← Summary, Inspect
+[role="region"][aria-label="Tab Content"]
+```
+
+## Locators
+
+### NetworksPage
+
+| Element         | Selector                                                              |
+| --------------- | --------------------------------------------------------------------- |
+| Page heading    | `[role="region"][aria-label="networks"] [role="heading"]`             |
+| Create button   | `[aria-label="additionalActions"] button:has-text("Create")`          |
+| Delete selected | `[aria-label="bottomAdditionalActions"] button[title*="Delete"]`      |
+| Network row     | `[role="row"][aria-label="{networkName}"]`                            |
+| Name cell       | `[role="row"][aria-label="{networkName}"] [role="cell"]:nth-child(4)` |
+
+### CreateNetworkPage
+
+| Element       | Selector                                        |
+| ------------- | ----------------------------------------------- |
+| Heading       | `[role="heading"]:has-text("Create a network")` |
+| Name input    | `input#networkName`                             |
+| Subnet input  | `input#subnet`                                  |
+| Basic tab     | `button:has-text("Basic")`                      |
+| Advanced tab  | `button:has-text("Advanced")`                   |
+| Create button | `button:has-text("Create")`                     |
+| Cancel button | `button:has-text("Cancel")`                     |
+
+### NetworkDetailsPage
+
+| Element        | Selector                                                             |
+| -------------- | -------------------------------------------------------------------- |
+| Heading        | `[aria-label="Header"] [role="heading"]:has-text("{networkName}")`   |
+| Update Network | `[aria-label="Control Actions"] button[aria-label="Update Network"]` |
+| Delete Network | `[aria-label="Control Actions"] button[aria-label="Delete Network"]` |
+| Summary tab    | `[aria-label="Tabs"] a:has-text("Summary")`                          |
+| Inspect tab    | `[aria-label="Tabs"] a:has-text("Inspect")`                          |
+
+## Operations
+
+### Create network
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Networks"]')`
+2. Wait for page: `wait('[role="region"][aria-label="networks"] [role="heading"]')`
+3. Click Create: `click('[aria-label="additionalActions"] button:has-text("Create")')`
+4. Wait for create page: `wait('[role="heading"]:has-text("Create a network")')`
+5. Fill name: `fill('input#networkName', '{networkName}')`
+6. Click Create: `click('button:has-text("Create")')`
+7. Wait for list: `wait('[role="region"][aria-label="networks"] [role="heading"]')`
+
+### Create network with subnet
+
+1. Follow steps 1-5 from "Create network"
+2. Click Advanced: `click('button:has-text("Advanced")')`
+3. Fill subnet: `fill('input#subnet', '{subnet}')`
+4. Click Create: `click('button:has-text("Create")')`
+
+### Open network details
+
+1. Navigate to Networks page (steps 1-2)
+2. Click network row: `click('[role="row"][aria-label="{networkName}"]')`
+3. Wait for details: `wait('[aria-label="Header"] [role="heading"]:has-text("{networkName}")')`
+
+### Delete network (from details)
+
+1. Open network details
+2. Click Delete: `click('[aria-label="Control Actions"] button[aria-label="Delete Network"]')`
+3. Wait for list: `wait('[role="region"][aria-label="networks"] [role="heading"]')`
+
+### Delete networks (bulk)
+
+1. Navigate to Networks page
+2. Select networks: `click('[role="row"][aria-label="{networkName}"] input[aria-label="Toggle network"]')`
+3. Click Delete: `click('[aria-label="bottomAdditionalActions"] button[title*="Delete"]')`
+
+## Gotchas
+
+- Networks have only two tabs: Summary and Inspect
+- The default network (`podman`) cannot be deleted
+- Create page has Basic/Advanced tabs — subnet is under Advanced
+- Bulk delete uses bottomAdditionalActions, not the same Delete as single-row delete

--- a/.agents/skills/mcp-testing/references/operations/pods.md
+++ b/.agents/skills/mcp-testing/references/operations/pods.md
@@ -1,0 +1,170 @@
+# Pod Operations
+
+## Navigation
+
+| Target    | Selector                                               |
+| --------- | ------------------------------------------------------ |
+| Pods page | `nav[aria-label="AppNavigation"] a[aria-label="Pods"]` |
+
+## Page Structure
+
+### PodsPage (list)
+
+```
+[role="region"][aria-label="pods"]
+├── [role="region"][aria-label="header"]
+│   ├── [role="heading"]                        ← "Pods"
+│   └── [role="group"][aria-label="additionalActions"]
+│       ├── button:has-text("Podman Kube Play")
+│       └── button:has-text("Prune")
+├── [role="region"][aria-label="search"]
+└── [role="region"][aria-label="content"]
+    └── [role="table"]
+        └── [role="row"][aria-label="{podName}"]
+```
+
+### PodDetailsPage
+
+```
+[role="region"][aria-label="Header"]
+├── [role="navigation"][aria-label="Breadcrumb"]
+├── [role="heading"]                            ← pod name
+├── [role="status"]                             ← state (title attr)
+└── [role="group"][aria-label="Control Actions"]
+[role="region"][aria-label="Tabs"]
+└── a:has-text("{tabName}")                     ← Summary, Logs, Inspect, Kube
+[role="region"][aria-label="Tab Content"]
+```
+
+## Locators
+
+### PodsPage
+
+| Element          | Selector                                                               |
+| ---------------- | ---------------------------------------------------------------------- |
+| Page heading     | `[role="region"][aria-label="pods"] [role="heading"]`                  |
+| Kube Play button | `[aria-label="additionalActions"] button:has-text("Podman Kube Play")` |
+| Prune button     | `[aria-label="additionalActions"] button:has-text("Prune")`            |
+| Prune confirm    | `button:has-text("Prune")`                                             |
+| Pod row          | `[role="row"][aria-label="{podName}"]`                                 |
+| Pod name button  | `[role="row"][aria-label="{podName}"] button:has-text("{podName}")`    |
+| Select pod       | `[role="row"][aria-label="{podName}"] [role="cell"]:nth-child(2)`      |
+| Kebab menu       | `[role="row"][aria-label="{podName}"] button[aria-label="kebab menu"]` |
+| Environment      | `[role="row"][aria-label="{podName}"] [data-testid="tooltip-trigger"]` |
+
+### PodDetailsPage
+
+| Element      | Selector                                                          |
+| ------------ | ----------------------------------------------------------------- |
+| Heading      | `[aria-label="Header"] [role="heading"]:has-text("{podName}")`    |
+| State        | `[aria-label="Header"] [role="status"]` (read `title` attr)       |
+| Start        | `[aria-label="Control Actions"] button[aria-label="Start Pod"]`   |
+| Stop         | `[aria-label="Control Actions"] button[aria-label="Stop Pod"]`    |
+| Restart      | `[aria-label="Control Actions"] button[aria-label="Restart Pod"]` |
+| Delete       | `[aria-label="Control Actions"] button[aria-label="Delete Pod"]`  |
+| Summary tab  | `[aria-label="Tabs"] a:has-text("Summary")`                       |
+| Logs tab     | `[aria-label="Tabs"] a:has-text("Logs")`                          |
+| Inspect tab  | `[aria-label="Tabs"] a:has-text("Inspect")`                       |
+| Kube tab     | `[aria-label="Tabs"] a:has-text("Kube")`                          |
+| Find in logs | `[aria-label="Tab Content"] [aria-label="Find"]`                  |
+
+### CreatePodPage
+
+| Element           | Selector                                                |
+| ----------------- | ------------------------------------------------------- |
+| Heading           | `[role="heading"]:has-text("Copy containers to a pod")` |
+| Pod name input    | `[role="textbox"][aria-label="Pod name"]`               |
+| Create Pod button | `button:has-text("Create Pod")`                         |
+| Close button      | `button:has-text("Close")`                              |
+
+### PodmanKubePlayPage
+
+| Element               | Selector                                                               |
+| --------------------- | ---------------------------------------------------------------------- |
+| Heading               | `[role="heading"]:has-text("Create pods from a Kubernetes YAML file")` |
+| YAML path input       | `[placeholder="Select a .yaml file to play"]`                          |
+| Browse button         | `button[aria-label="browse"]`                                          |
+| Create from scratch   | `button:has-text("Create a file from scratch")`                        |
+| YAML editor           | `#custom-yaml-editor`                                                  |
+| Play button           | `button:has-text("Play")`                                              |
+| Done button           | `button:has-text("Done")`                                              |
+| Error alert           | `[aria-label="Error Message Content"]`                                 |
+| Enable build checkbox | `[role="checkbox"][aria-label="Enable build"]`                         |
+| Replace checkbox      | `[role="checkbox"][aria-label="Replace"]`                              |
+
+## Operations
+
+### Open Kube Play
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Pods"]')`
+2. Wait for page: `wait('[role="region"][aria-label="pods"] [role="heading"]')`
+3. Click Kube Play: `click('[aria-label="additionalActions"] button:has-text("Podman Kube Play")')`
+4. Wait for page: `wait('[role="heading"]:has-text("Create pods from a Kubernetes YAML file")')`
+
+### Kube Play from YAML file
+
+1. Open Kube Play (steps 1-4)
+2. Fill YAML path: `fill('[placeholder="Select a .yaml file to play"]', '{yamlFilePath}')`
+3. Click Play: `click('button:has-text("Play")')`
+4. Wait for Done: `wait('button:has-text("Done")', { timeout: 60000 })`
+5. Click Done: `click('button:has-text("Done")')`
+
+### Kube Play from scratch
+
+1. Open Kube Play (steps 1-4)
+2. Click Create from scratch: `click('button:has-text("Create a file from scratch")')`
+3. Wait for editor: `wait('#custom-yaml-editor')`
+4. Fill YAML: `fill('#custom-yaml-editor', '{yamlContent}')`
+5. Click Play: `click('button:has-text("Play")')`
+6. Wait for Done: `wait('button:has-text("Done")', { timeout: 60000 })`
+7. Click Done: `click('button:has-text("Done")')`
+
+### Create pod from containers (podify)
+
+1. Navigate to Containers page
+2. Select containers: `click('[role="row"][aria-label="{containerName}"] input[aria-label="Toggle container"]')`
+3. Click Create Pod: `click('button:has-text("Create Pod")')`
+4. Wait for create page: `wait('[role="heading"]:has-text("Copy containers to a pod")')`
+5. Set pod name: `fill('[role="textbox"][aria-label="Pod name"]', '{podName}')`
+6. Click Create: `click('button:has-text("Create Pod")')`
+7. Wait for completion: `wait('button:has-text("Close")', { timeout: 60000 })`
+
+### Open pod details
+
+1. Navigate to Pods page
+2. Click pod name: `click('[role="row"][aria-label="{podName}"] button:has-text("{podName}")')`
+3. Wait for details: `wait('[aria-label="Header"] [role="heading"]:has-text("{podName}")')`
+
+### Start/Stop/Restart/Delete pod
+
+1. Open pod details
+2. Start: `click('[aria-label="Control Actions"] button[aria-label="Start Pod"]')`
+3. Stop: `click('[aria-label="Control Actions"] button[aria-label="Stop Pod"]')`
+4. Restart: `click('[aria-label="Control Actions"] button[aria-label="Restart Pod"]')`
+5. Delete: `click('[aria-label="Control Actions"] button[aria-label="Delete Pod"]')`
+
+### View pod logs
+
+1. Open pod details
+2. Click Logs tab: `click('[aria-label="Tabs"] a:has-text("Logs")')`
+3. Wait for content: `wait('[aria-label="Tab Content"]')`
+
+### Prune pods
+
+1. Navigate to Pods page
+2. Click Prune: `click('[aria-label="additionalActions"] button:has-text("Prune")')`
+3. Confirm: `click('button:has-text("Prune")')`
+
+### Check pod state
+
+```
+evaluate('document.querySelector(\'[role="row"][aria-label="{podName}"] [role="status"]\')?.title')
+```
+
+## Gotchas
+
+- Pods contain multiple containers — the pod row expands to show them
+- Kube Play requires a running container engine
+- The YAML editor (`#custom-yaml-editor`) may need `evaluate` to set content reliably
+- Pod lifecycle actions affect all containers inside the pod
+- Create Pod from containers requires selecting containers first via their checkboxes

--- a/.agents/skills/mcp-testing/references/operations/registries.md
+++ b/.agents/skills/mcp-testing/references/operations/registries.md
@@ -1,0 +1,94 @@
+# Registry Operations
+
+## Navigation
+
+| Target             | Selector                                                           |
+| ------------------ | ------------------------------------------------------------------ |
+| Settings page      | `nav[aria-label="AppNavigation"] a[aria-label="Settings"]`         |
+| Registries section | `nav[aria-label="PreferencesNavigation"] a:has-text("Registries")` |
+
+## Page Structure
+
+### RegistriesPage
+
+```
+[role="table"][aria-label="Registries"]
+└── [role="row"][aria-label="{registryName}"]
+    ├── button[aria-label="kebab menu"]
+    ├── [title="Edit password"]
+    └── [title="Remove"]
+```
+
+## Locators
+
+### RegistriesPage
+
+| Element             | Selector                                                                            |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| Add registry button | `button:has-text("Add registry")`                                                   |
+| Registries table    | `[role="table"][aria-label="Registries"]`                                           |
+| Registry row        | `[role="table"][aria-label="Registries"] [role="row"][aria-label="{registryName}"]` |
+| Kebab menu          | `[role="row"][aria-label="{registryName}"] button[aria-label="kebab menu"]`         |
+| Edit password       | `[role="row"][aria-label="{registryName}"] [title="Edit password"]`                 |
+| Remove              | `[role="row"][aria-label="{registryName}"] [title="Remove"]`                        |
+
+### Add Registry Dialog
+
+| Element        | Selector                                                                         |
+| -------------- | -------------------------------------------------------------------------------- |
+| Dialog         | `[role="dialog"][aria-label="Add Registry"]`                                     |
+| URL input      | `[role="dialog"][aria-label="Add Registry"] [placeholder="https://registry.io"]` |
+| Username input | `[role="dialog"][aria-label="Add Registry"] [placeholder="username"]`            |
+| Password input | `[role="dialog"][aria-label="Add Registry"] [placeholder="Password"]`            |
+| Cancel button  | `[role="dialog"][aria-label="Add Registry"] button:has-text("Cancel")`           |
+| Add button     | `[role="dialog"][aria-label="Add Registry"] button:has-text("Add")`              |
+
+### Registry Row (edit mode)
+
+| Element        | Selector                                                             |
+| -------------- | -------------------------------------------------------------------- |
+| Username field | `[role="row"][aria-label="{registryName}"] [aria-label="Username"]`  |
+| Password field | `[role="row"][aria-label="{registryName}"] [aria-label^="Password"]` |
+| Login button   | `[role="row"][aria-label="{registryName}"] button:has-text("Login")` |
+
+## Operations
+
+### Navigate to Registries
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Settings"]')`
+2. Wait for settings: `wait('nav[aria-label="PreferencesNavigation"]')`
+3. Click Registries: `click('nav[aria-label="PreferencesNavigation"] a:has-text("Registries")')`
+4. Wait for table: `wait('[role="table"][aria-label="Registries"]')`
+
+### Add registry
+
+1. Navigate to Registries (steps 1-4)
+2. Click Add: `click('button:has-text("Add registry")')`
+3. Wait for dialog: `wait('[role="dialog"][aria-label="Add Registry"]')`
+4. Fill URL: `fill('[role="dialog"][aria-label="Add Registry"] [placeholder="https://registry.io"]', '{registryUrl}')`
+5. Fill username: `fill('[role="dialog"][aria-label="Add Registry"] [placeholder="username"]', '{username}')`
+6. Fill password: `fill('[role="dialog"][aria-label="Add Registry"] [placeholder="Password"]', '{password}')`
+7. Click Add: `click('[role="dialog"][aria-label="Add Registry"] button:has-text("Add")')`
+
+### Login to registry
+
+1. Navigate to Registries
+2. Open kebab menu: `click('[role="row"][aria-label="{registryName}"] button[aria-label="kebab menu"]')`
+3. Click Edit password: `click('[role="row"][aria-label="{registryName}"] [title="Edit password"]')`
+4. Fill username: `fill('[role="row"][aria-label="{registryName}"] [aria-label="Username"]', '{username}')`
+5. Fill password: `fill('[role="row"][aria-label="{registryName}"] [aria-label^="Password"]', '{password}')`
+6. Click Login: `click('[role="row"][aria-label="{registryName}"] button:has-text("Login")')`
+
+### Remove registry
+
+1. Navigate to Registries
+2. Open kebab menu: `click('[role="row"][aria-label="{registryName}"] button[aria-label="kebab menu"]')`
+3. Click Remove: `click('[role="row"][aria-label="{registryName}"] [title="Remove"]')`
+
+## Gotchas
+
+- Registries page is under Settings, not a top-level nav item
+- Kebab menu must be clicked to reveal Edit/Remove options
+- Default registries (docker.io, quay.io, ghcr.io) are pre-configured and cannot be removed
+- Login credentials are stored per-session — they don't persist across app restarts in dev mode
+- The Add dialog validates URL format before allowing submission

--- a/.agents/skills/mcp-testing/references/operations/search-palette.md
+++ b/.agents/skills/mcp-testing/references/operations/search-palette.md
@@ -1,0 +1,134 @@
+# Search & Command Palette Operations
+
+## Navigation
+
+| Target                  | Selector                    |
+| ----------------------- | --------------------------- |
+| Open palette (keyboard) | `press('F1')`               |
+| Open palette (button)   | `click('[title="Search"]')` |
+
+## Page Structure
+
+### Command Palette
+
+```
+[aria-label="Command palette command input"]    ← search input
+├── button matching /\bAll\b/                   ← tab: All (may include badge count)
+├── button matching /\bCommands\b/              ← tab: Commands
+├── button matching /\bDocumentation\b/         ← tab: Documentation
+├── button matching /\bGo to\b/                 ← tab: Go to
+└── li > button                                 ← result items
+    └── li > button.selected                    ← currently selected item
+```
+
+## Locators
+
+### CommandPalette
+
+| Element       | Selector                                       |
+| ------------- | ---------------------------------------------- |
+| Input field   | `[aria-label="Command palette command input"]` |
+| Clear button  | `[aria-label="clear"]`                         |
+| Selected item | `li > button.selected`                         |
+| Result items  | `li > button`                                  |
+
+### Tabs
+
+| Element           | Selector                                        |
+| ----------------- | ----------------------------------------------- |
+| All tab           | button with text matching `/\bAll\b/`           |
+| Commands tab      | button with text matching `/\bCommands\b/`      |
+| Documentation tab | button with text matching `/\bDocumentation\b/` |
+| Go to tab         | button with text matching `/\bGo to\b/`         |
+
+Use `evaluate` to click tabs since they use regex matching:
+
+```
+evaluate('Array.from(document.querySelectorAll("button")).find(b => /\\bAll\\b/.test(b.textContent))?.click()')
+```
+
+### Status
+
+| Element    | Selector                                       |
+| ---------- | ---------------------------------------------- |
+| No results | text matching `/No results matching .+ found/` |
+
+## Operations
+
+### Open command palette
+
+**Via keyboard:**
+
+1. Press F1: `press('F1')`
+2. Wait for input: `wait('[aria-label="Command palette command input"]')`
+
+**Via button:**
+
+1. Click Search: `click('[title="Search"]')`
+2. Wait for input: `wait('[aria-label="Command palette command input"]')`
+
+### Search for a command
+
+1. Open command palette
+2. Fill search: `fill('[aria-label="Command palette command input"]', '{searchTerm}')`
+3. Wait for results: `wait('li > button')`
+
+### Execute a command from palette
+
+1. Search for command (steps 1-3)
+2. Click result: `click('li > button.selected')` or find specific result by text
+
+### Navigate to a page via palette
+
+1. Open command palette
+2. Switch to Go to tab:
+   ```
+   evaluate('Array.from(document.querySelectorAll("button")).find(b => /\\bGo to\\b/.test(b.textContent))?.click()')
+   ```
+3. Fill destination: `fill('[aria-label="Command palette command input"]', '{pageName}')`
+4. Click result: `click('li > button.selected')`
+
+### Switch palette tab
+
+Use `evaluate` with regex matching:
+
+```
+evaluate('Array.from(document.querySelectorAll("button")).find(b => /\\b{TabName}\\b/.test(b.textContent))?.click()')
+```
+
+Replace `{TabName}` with: `All`, `Commands`, `Documentation`, or `Go to`
+
+### Clear search
+
+1. Click clear: `click('[aria-label="clear"]')`
+
+### Close palette
+
+1. Press Escape: `press('Escape')`
+
+### Check for no results
+
+```
+evaluate('/No results matching .+ found/.test(document.body.textContent)')
+```
+
+### Get selected result text
+
+```
+getText('li > button.selected')
+```
+
+### Count results
+
+```
+evaluate('document.querySelectorAll("li > button").length')
+```
+
+## Gotchas
+
+- Palette tabs use count badges (e.g., "All 42") — match with `/\bAll\b/` regex, not exact text
+- F1 toggles the palette — pressing again closes it
+- The palette overlays the current page — it doesn't navigate away
+- Results update as you type — wait briefly after filling input before clicking
+- The selected item (`.selected` class) changes with arrow key navigation
+- Tab switching preserves the search text

--- a/.agents/skills/mcp-testing/references/operations/settings.md
+++ b/.agents/skills/mcp-testing/references/operations/settings.md
@@ -1,0 +1,124 @@
+# Settings Operations
+
+## Navigation
+
+| Target        | Selector                                                   |
+| ------------- | ---------------------------------------------------------- |
+| Settings page | `nav[aria-label="AppNavigation"] a[aria-label="Settings"]` |
+
+## Page Structure
+
+### Settings (with sidebar)
+
+```
+nav[aria-label="PreferencesNavigation"]         ← settings sidebar
+├── a:has-text("Resources")
+├── a:has-text("Proxy")
+├── a:has-text("Registries")
+├── a:has-text("Authentication")
+├── a:has-text("preferences")
+├── a:has-text("CLI Tools")
+└── a:has-text("Kubernetes")
+```
+
+## Locators
+
+### SettingsBar (sidebar)
+
+| Element        | Selector                                                               |
+| -------------- | ---------------------------------------------------------------------- |
+| Settings nav   | `nav[aria-label="PreferencesNavigation"]`                              |
+| Resources      | `nav[aria-label="PreferencesNavigation"] a:has-text("Resources")`      |
+| Proxy          | `nav[aria-label="PreferencesNavigation"] a:has-text("Proxy")`          |
+| Registries     | `nav[aria-label="PreferencesNavigation"] a:has-text("Registries")`     |
+| Authentication | `nav[aria-label="PreferencesNavigation"] a:has-text("Authentication")` |
+| Preferences    | `nav[aria-label="PreferencesNavigation"] a:has-text("preferences")`    |
+| CLI Tools      | `nav[aria-label="PreferencesNavigation"] a:has-text("CLI Tools")`      |
+| Kubernetes     | `nav[aria-label="PreferencesNavigation"] a:has-text("Kubernetes")`     |
+
+### PreferencesPage
+
+| Element          | Selector                                                                                                 |
+| ---------------- | -------------------------------------------------------------------------------------------------------- |
+| Title            | `[aria-label="Title"]`                                                                                   |
+| Search input     | `[aria-label="search preferences"]`                                                                      |
+| Kubeconfig path  | `[aria-label="Path to the Kubeconfig file for accessing clusters. (Default is usually ~/.kube/config)"]` |
+| Reset to default | `button:has-text("Reset to default value")`                                                              |
+
+### ProxyPage
+
+| Element       | Selector                                                       |
+| ------------- | -------------------------------------------------------------- |
+| Heading       | `[role="heading"]:has-text("Proxy Settings")`                  |
+| Proxy mode    | `#toggle-proxy` (3-state dropdown: Disabled / Manual / System) |
+| HTTP proxy    | `#httpProxy`                                                   |
+| HTTPS proxy   | `#httpsProxy`                                                  |
+| No proxy      | `#noProxy`                                                     |
+| Update button | `button:has-text("Update")`                                    |
+| Error alert   | `[role="alert"][aria-label="Error Message Content"]`           |
+
+## Operations
+
+### Navigate to settings section
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Settings"]')`
+2. Wait for settings: `wait('nav[aria-label="PreferencesNavigation"]')`
+3. Click section: `click('nav[aria-label="PreferencesNavigation"] a:has-text("{sectionName}")')`
+
+### Open Proxy settings
+
+1. Navigate to settings (steps 1-2)
+2. Click Proxy: `click('nav[aria-label="PreferencesNavigation"] a:has-text("Proxy")')`
+3. Wait for page: `wait('[role="heading"]:has-text("Proxy Settings")')`
+
+### Configure proxy
+
+1. Open Proxy settings (steps 1-3)
+2. Check current state: `getText('#toggle-proxy')` — returns "Disabled", "Manual", or "System"
+3. Switch to Manual (if not already): `click('#toggle-proxy')`, then `click('button:has-text("Manual")')`
+4. Fill HTTP proxy: `fill('#httpProxy', '{httpProxy}')`
+5. Fill HTTPS proxy: `fill('#httpsProxy', '{httpsProxy}')`
+6. Fill No proxy: `fill('#noProxy', '{noProxy}')`
+7. Click Update: `click('button:has-text("Update")')`
+
+### Open Preferences
+
+1. Navigate to settings
+2. Click Preferences: `click('nav[aria-label="PreferencesNavigation"] a:has-text("preferences")')`
+3. Wait for page: `wait('[aria-label="Title"]')`
+
+### Search preferences
+
+1. Open Preferences
+2. Fill search: `fill('[aria-label="search preferences"]', '{searchTerm}')`
+
+### Reset preference to default
+
+1. Open Preferences
+2. Find the preference row
+3. Click Reset: `click('button:has-text("Reset to default value")')`
+
+### Open Resources
+
+1. Navigate to settings
+2. Click Resources: `click('nav[aria-label="PreferencesNavigation"] a:has-text("Resources")')`
+
+### Open CLI Tools
+
+1. Navigate to settings
+2. Click CLI Tools: `click('nav[aria-label="PreferencesNavigation"] a:has-text("CLI Tools")')`
+3. Wait for page: `wait('[role="heading"]:has-text("CLI Tools")')`
+
+### Open Kubernetes settings
+
+1. Navigate to settings
+2. Click Kubernetes: `click('nav[aria-label="PreferencesNavigation"] a:has-text("Kubernetes")')`
+
+## Gotchas
+
+- Settings page has its own sub-navigation (`PreferencesNavigation`), separate from the main nav
+- Proxy selector (`#toggle-proxy`) is a 3-state dropdown (Disabled / Manual / System), not a binary toggle — read its text to check state before changing
+- Proxy input fields (httpProxy, httpsProxy, noProxy) are only enabled when state is "Manual"
+- Preferences search is case-insensitive and filters in real-time
+- CLI Tools page is also accessible via Settings sidebar (see compose.md for CLI tool details)
+- The "preferences" link text is lowercase in the UI

--- a/.agents/skills/mcp-testing/references/operations/volumes.md
+++ b/.agents/skills/mcp-testing/references/operations/volumes.md
@@ -1,0 +1,126 @@
+# Volume Operations
+
+## Navigation
+
+| Target       | Selector                                                  |
+| ------------ | --------------------------------------------------------- |
+| Volumes page | `nav[aria-label="AppNavigation"] a[aria-label="Volumes"]` |
+
+## Page Structure
+
+### VolumesPage (list)
+
+```
+[role="region"][aria-label="volumes"]
+├── [role="region"][aria-label="header"]
+│   ├── [role="heading"]                        ← "Volumes"
+│   └── [role="group"][aria-label="additionalActions"]
+│       ├── button:has-text("Create")
+│       ├── button:has-text("Prune")
+│       └── button:has-text("Gather volume sizes")
+├── [role="region"][aria-label="search"]
+└── [role="region"][aria-label="content"]
+    └── [role="table"]
+        └── [role="row"][aria-label="{volumeName}"]
+```
+
+### VolumeDetailsPage
+
+```
+[role="region"][aria-label="Header"]
+├── [role="navigation"][aria-label="Breadcrumb"]
+├── [role="heading"]                            ← volume name
+└── [role="group"][aria-label="Control Actions"]
+[role="region"][aria-label="Tabs"]
+└── a:has-text("{tabName}")                     ← Summary, Inspect
+[role="region"][aria-label="Tab Content"]
+```
+
+## Locators
+
+### VolumesPage
+
+| Element       | Selector                                                                     |
+| ------------- | ---------------------------------------------------------------------------- |
+| Page heading  | `[role="region"][aria-label="volumes"] [role="heading"]`                     |
+| Create button | `[aria-label="additionalActions"] button:has-text("Create")`                 |
+| Prune button  | `[aria-label="additionalActions"] button:has-text("Prune")`                  |
+| Gather sizes  | `[aria-label="additionalActions"] button:has-text("Gather volume sizes")`    |
+| Volume row    | `[role="row"][aria-label="{volumeName}"]`                                    |
+| Name cell     | `[role="row"][aria-label="{volumeName}"] [role="cell"]:nth-child(4)`         |
+| Delete (row)  | `[role="row"][aria-label="{volumeName}"] button[aria-label="Delete Volume"]` |
+
+### CreateVolumePage
+
+| Element           | Selector                                       |
+| ----------------- | ---------------------------------------------- |
+| Heading           | `[role="heading"]:has-text("Create a volume")` |
+| Volume name input | `[aria-label="Volume Name"]`                   |
+| Create button     | `button:has-text("Create")`                    |
+| Done button       | `button:has-text("Done")`                      |
+| Close link        | `a:has-text("Close")`                          |
+| Close button      | `button:has-text("Close")`                     |
+
+### VolumeDetailsPage
+
+| Element       | Selector                                                          |
+| ------------- | ----------------------------------------------------------------- |
+| Heading       | `[aria-label="Header"] [role="heading"]:has-text("{volumeName}")` |
+| Delete Volume | `[aria-label="Control Actions"] button:has-text("Delete Volume")` |
+| Used status   | `[aria-label="Header"] [title="USED"]`                            |
+| Summary tab   | `[aria-label="Tabs"] a:has-text("Summary")`                       |
+| Inspect tab   | `[aria-label="Tabs"] a:has-text("Inspect")`                       |
+
+## Operations
+
+### Create volume
+
+1. Navigate: `click('nav[aria-label="AppNavigation"] a[aria-label="Volumes"]')`
+2. Wait for page: `wait('[role="region"][aria-label="volumes"] [role="heading"]')`
+3. Click Create: `click('[aria-label="additionalActions"] button:has-text("Create")')`
+4. Wait for create page: `wait('[role="heading"]:has-text("Create a volume")')`
+5. Fill name: `fill('[aria-label="Volume Name"]', '{volumeName}')`
+6. Click Create: `click('button:has-text("Create")')`
+7. Wait for Done: `wait('button:has-text("Done")')`
+8. Click Done: `click('button:has-text("Done")')`
+
+### Open volume details
+
+1. Navigate to Volumes page (steps 1-2)
+2. Click volume row: `click('[role="row"][aria-label="{volumeName}"]')`
+3. Wait for details: `wait('[aria-label="Header"] [role="heading"]:has-text("{volumeName}")')`
+
+### Delete volume (from details)
+
+1. Open volume details
+2. Click Delete: `click('[aria-label="Control Actions"] button:has-text("Delete Volume")')`
+3. Wait for list: `wait('[role="region"][aria-label="volumes"] [role="heading"]')`
+
+### Delete volume (from list)
+
+1. Navigate to Volumes page
+2. Click Delete: `click('[role="row"][aria-label="{volumeName}"] button[aria-label="Delete Volume"]')`
+
+### Prune volumes
+
+1. Navigate to Volumes page
+2. Click Prune: `click('[aria-label="additionalActions"] button:has-text("Prune")')`
+3. Confirm: `click('button:has-text("Prune")')`
+
+### Gather volume sizes
+
+1. Navigate to Volumes page
+2. Click Gather sizes: `click('[aria-label="additionalActions"] button:has-text("Gather volume sizes")')`
+
+### Check if volume is used
+
+```
+evaluate('!!document.querySelector(\'[role="row"][aria-label="{volumeName}"] [title="USED"]\')')
+```
+
+## Gotchas
+
+- Volumes have only two tabs: Summary and Inspect (no Logs or Terminal)
+- Volume names are user-defined or auto-generated hashes
+- Prune deletes all unused volumes — volumes mounted to containers are kept
+- Gather volume sizes triggers a background scan that updates size column


### PR DESCRIPTION
### What does this PR do?

Rewrites the `mcp-testing` skill with two major improvements:

1. **Single-agent architecture** — Merges the two-agent (scout→executor) pipeline into a single Haiku agent, eliminating inter-agent overhead. Benchmarked across 25 runs: 36% faster and 94% cheaper than the Opus baseline, 24% faster and 41% cheaper than the previous two-agent setup.

2. **Operation reference files** — Adds 13 structured reference files covering all Podman Desktop UI areas (containers, images, pods, volumes, networks, extensions, compose, kubernetes, settings, registries, navigation, search palette). These replace the monolithic selectors reference and are loaded selectively based on task context, reducing token usage.

**Changes:**

- **SKILL.md**: Merged scout+executor phases into a single agent spawn. Added smart cross-reference loading rules (e.g., Docker-related tasks load compose + containers + images + extensions + settings). Removed dependency on examples.md selectors reference.
- **agent-prompt.md** (new): Dedicated agent prompt with CDP connection, dialog handling, selector strategy (Playwright vs CSS), compact snapshot fallback, and workflow trace output for E2E test writing.
- **references/operations/*.md** (new, 13 files): Per-area operation guides with page structure, element locators, and step-by-step workflows derived from Playwright Page Object Models.
- **evals/evals.json** (new): Four evaluation scenarios (well-structured, exploratory, vague, cross-cutting) for benchmarking skill performance.
- **scout-prompt.md**: Deleted — no longer needed with single-agent architecture.

### Performance Comparison

Benchmarked across 5 test scenarios (3 unknown-area + 2 reference-covered):

| Config | Avg Time | Avg Tokens | Avg Tools | Est. Cost (5 runs) | Reliability |
|--------|----------|------------|-----------|---------------------|-------------|
| Baseline (Opus inline, main branch) | 291.2s | 50,777 | 56.6 | ~$3.81 | 5/5 |
| Two agents + Haiku (before) | 245.5s | 82,246 | 73.4 | ~$0.41 | 5/5 |
| **Single agent + Haiku (after)** | **186.4s** | **48,688** | **58.8** | **~$0.24** | **5/5** |

### Screenshot / video of UI

N/A — no UI changes, agent skill files only.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/17570

### How to test this PR?

1. Run the `/mcp-testing` skill with any task (e.g., "navigate to Images and report what you see")
2. Verify a single Haiku agent is spawned (no scout phase)
3. Verify the agent connects, handles dialogs, uses operation references for known selectors, falls back to compact snapshots for unknown elements, executes the task, and disconnects
4. Run the evals via `/skill-creator` to validate against the four benchmark scenarios

- [ ] Tests are covering the bug fix or the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)