### PR TITLE
test(visual-testing): logic scaffold

### DIFF
--- a/.github/workflows/argos-podman-desktop.yaml
+++ b/.github/workflows/argos-podman-desktop.yaml
@@ -1,0 +1,102 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Visual Testing
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  podman-desktop:
+    name: podman desktop
+    runs-on: ubuntu-24.04
+    # disable on forks as secrets are not available
+    if: github.event.repository.fork == false
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Podman v5 using external action
+        # Use the action from the other repository
+        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup testenv using external action
+        uses: podman-desktop/e2e/.github/actions/pde2e-testenv-prepare@13e2c57c759137bfc1f437f221967461e8a98e2a
+
+      - name: Remove pre-installed Docker images
+        run: |
+          echo "Removing pre-installed Docker images to prevent E2E test flakiness"
+          docker image ls
+          docker image rm --force $(docker image ls -q) 2>/dev/null || true
+          docker system prune --all --force 2>/dev/null || true
+          echo "Docker images after cleanup:"
+          docker image ls
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Execute pnpm
+        run: pnpm install
+
+      - name: Build production binary
+        env:
+          ELECTRON_ENABLE_INSPECT: true
+        run: |
+          pnpm compile:current --linux dir
+          path=$(realpath ./dist/linux-unpacked/podman-desktop)
+          echo "Podman Desktop built binary: $path"
+          echo "PODMAN_DESKTOP_BINARY=$path" >> $GITHUB_ENV
+
+      - name: Run visual testing screenshots
+        run: pnpm test:e2e:screenshots
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: podman-desktop-screenshots
+          path: |
+            tests/playwright/output/screenshots
+
+      - name: Upload screenshots to Argos
+        continue-on-error: true
+        working-directory: tests/playwright
+        run: pnpm run argos-ci:upload
+        env:
+          ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}

--- a/.github/workflows/argos-podman-desktop.yaml
+++ b/.github/workflows/argos-podman-desktop.yaml
@@ -31,6 +31,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'extensions/**'
+      - 'tests/playwright/**'
       - 'packages/**'
   pull_request:
     branches:
@@ -40,6 +41,7 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'extensions/**'
+      - 'tests/playwright/**'
       - 'packages/**'
 
 permissions:

--- a/.github/workflows/argos-podman-desktop.yaml
+++ b/.github/workflows/argos-podman-desktop.yaml
@@ -18,7 +18,7 @@
 name: Visual Testing
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/argos-podman-desktop.yaml
+++ b/.github/workflows/argos-podman-desktop.yaml
@@ -26,9 +26,21 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/argos-podman-desktop.yaml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'extensions/**'
+      - 'packages/**'
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/argos-podman-desktop.yaml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'extensions/**'
+      - 'packages/**'
 
 permissions:
   contents: read
@@ -69,7 +81,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
 
       - name: Execute pnpm

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "test:e2e:remote:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/podman-remote/ -g @podman-remote",
     "test:e2e:update": "pnpm run test:e2e:build && pnpm run test:e2e:update:run",
     "test:e2e:update:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/installation/ -g @update-install",
+    "test:e2e:screenshots": "pnpm run test:e2e:build && pnpm run test:e2e:screenshots:run",
+    "test:e2e:screenshots:run": "cross-env PLAYWRIGHT_SCREENSHOTS_PATH=./tests/playwright/output/screenshots xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/visual-testing/",
     "test:e2e:managed-configuration": "pnpm run test:e2e:build && pnpm run test:e2e:managed-configuration:run",
     "test:e2e:managed-configuration:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/managed-configuration/ -g @managed-configuration",
     "test:core-api": "vitest --run --project=@podman-desktop/core-api --passWithNoTests",

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -19,7 +19,8 @@
     "build": "vite build",
     "package": "npm run build && npm link && npm pack",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "publish:next": "pnpm publish --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version 0.0.1-\"$(date +%s)\""
+    "publish:next": "pnpm publish --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version 0.0.1-\"$(date +%s)\"",
+    "argos-ci:upload": "npx @argos-ci/cli upload --build-name podman-desktop-e2e ./output/screenshots"
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",

--- a/tests/playwright/src/model/pages/base-page.ts
+++ b/tests/playwright/src/model/pages/base-page.ts
@@ -39,6 +39,7 @@ export abstract class BasePage {
 
     await this.page.screenshot({
       path: join(path, `${options.name}-${platform()}-${arch()}.png`),
+      mask: options.mask,
     });
   }
 }

--- a/tests/playwright/src/model/pages/base-page.ts
+++ b/tests/playwright/src/model/pages/base-page.ts
@@ -16,7 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Page } from '@playwright/test';
+import { arch, platform } from 'node:os';
+import { join } from 'node:path';
+
+import type { Locator, Page } from '@playwright/test';
 
 export abstract class BasePage {
   readonly page: Page;
@@ -28,5 +31,14 @@ export abstract class BasePage {
 
   public getPage(): Page {
     return this.page;
+  }
+
+  public async screenshot(options: { name: string; mask?: Array<Locator> }): Promise<void> {
+    const path = process.env.PLAYWRIGHT_SCREENSHOTS_PATH;
+    if (!path) return;
+
+    await this.page.screenshot({
+      path: join(path, `${options.name}-${platform()}-${arch()}.png`),
+    });
   }
 }

--- a/tests/playwright/src/special-specs/visual-testing/visual-testing.spec.ts
+++ b/tests/playwright/src/special-specs/visual-testing/visual-testing.spec.ts
@@ -30,20 +30,23 @@ test.afterAll(async ({ runner, navigationBar }) => {
   const containersPage = await navigationBar.openContainers();
   await playExpect(containersPage.heading).toBeVisible();
 
-  // Select all containers through the checkbox
-  const toggleAll = containersPage.page.getByRole('checkbox', { name: 'Toggle all' });
-  await playExpect(toggleAll).toBeVisible();
-  await toggleAll.click();
+  const count = await containersPage.getAllTableRows();
+  if (count.length > 0) {
+    // Select all containers through the checkbox
+    const toggleAll = containersPage.page.getByRole('checkbox', { name: 'Toggle all' });
+    await playExpect(toggleAll).toBeVisible();
+    await toggleAll.click();
 
-  // Get the bulk delete button
-  const bulkDelete = containersPage.page.getByRole('button', { name: 'Delete selected containers and pods' });
-  await playExpect(bulkDelete).toBeVisible();
-  await bulkDelete.click();
+    // Get the bulk delete button
+    const bulkDelete = containersPage.page.getByRole('button', { name: 'Delete selected containers and pods' });
+    await playExpect(bulkDelete).toBeVisible();
+    await bulkDelete.click();
 
-  await handleConfirmationDialog(containersPage.page, 'Delete Containers?', true, 'Delete');
+    await handleConfirmationDialog(containersPage.page, 'Delete Containers?', true, 'Delete');
 
-  // Wait until none are remaining
-  await playExpect.poll(async () => await containersPage.getAllTableRows()).toHaveLength(0);
+    // Wait until none are remaining
+    await playExpect.poll(async () => await containersPage.getAllTableRows()).toHaveLength(0);
+  }
 
   await runner.close(45_000);
 });

--- a/tests/playwright/src/special-specs/visual-testing/visual-testing.spec.ts
+++ b/tests/playwright/src/special-specs/visual-testing/visual-testing.spec.ts
@@ -55,18 +55,6 @@ test.describe
       'Skipping screenshots if PLAYWRIGHT_SCREENSHOTS_PATH is not set.',
     );
 
-    test('dashboard screenshot', async ({ navigationBar }) => {
-      const dashboardPage = await navigationBar.openDashboard();
-      await playExpect(dashboardPage.heading).toBeVisible();
-
-      // focus on the content
-      await dashboardPage.content.focus();
-
-      await dashboardPage.screenshot({
-        name: 'dashboard',
-      });
-    });
-
     /**
      * Containers
      */

--- a/tests/playwright/src/special-specs/visual-testing/visual-testing.spec.ts
+++ b/tests/playwright/src/special-specs/visual-testing/visual-testing.spec.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { handleConfirmationDialog } from '/@/utility/operations';
+
+test.beforeAll(async ({ runner, welcomePage }) => {
+  runner.setVideoAndTraceName('screenshots');
+  await welcomePage.handleWelcomePage(true);
+});
+
+test.afterAll(async ({ runner, navigationBar }) => {
+  test.setTimeout(180_000);
+
+  // Go to containers page
+  const containersPage = await navigationBar.openContainers();
+  await playExpect(containersPage.heading).toBeVisible();
+
+  // Select all containers through the checkbox
+  const toggleAll = containersPage.page.getByRole('checkbox', { name: 'Toggle all' });
+  await playExpect(toggleAll).toBeVisible();
+  await toggleAll.click();
+
+  // Get the bulk delete button
+  const bulkDelete = containersPage.page.getByRole('button', { name: 'Delete selected containers and pods' });
+  await playExpect(bulkDelete).toBeVisible();
+  await bulkDelete.click();
+
+  await handleConfirmationDialog(containersPage.page, 'Delete Containers?', true, 'Delete');
+
+  // Wait until none are remaining
+  await playExpect.poll(async () => await containersPage.getAllTableRows()).toHaveLength(0);
+
+  await runner.close(45_000);
+});
+
+test.describe
+  .serial('Podman Desktop visual testing', { tag: [] }, () => {
+    test.skip(
+      !process.env.PLAYWRIGHT_SCREENSHOTS_PATH,
+      'Skipping screenshots if PLAYWRIGHT_SCREENSHOTS_PATH is not set.',
+    );
+
+    test('dashboard screenshot', async ({ navigationBar }) => {
+      const dashboardPage = await navigationBar.openDashboard();
+      await playExpect(dashboardPage.heading).toBeVisible();
+
+      // focus on the content
+      await dashboardPage.content.focus();
+
+      await dashboardPage.screenshot({
+        name: 'dashboard',
+      });
+    });
+
+    /**
+     * Containers
+     */
+    test.describe
+      .serial('containers', () => {
+        test('containers empty', async ({ navigationBar }) => {
+          const containersPage = await navigationBar.openContainers();
+          await playExpect(containersPage.heading).toBeVisible();
+
+          // Screenshot empty containers list
+          await containersPage.screenshot({
+            name: 'containers-empty',
+          });
+        });
+      });
+  });

--- a/tests/playwright/src/special-specs/visual-testing/visual-testing.spec.ts
+++ b/tests/playwright/src/special-specs/visual-testing/visual-testing.spec.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import { expect as playExpect, test } from '/@/utility/fixtures';
-import { handleConfirmationDialog } from '/@/utility/operations';
 
 test.beforeAll(async ({ runner, welcomePage }) => {
   runner.setVideoAndTraceName('screenshots');
@@ -30,22 +29,22 @@ test.afterAll(async ({ runner, navigationBar }) => {
   const containersPage = await navigationBar.openContainers();
   await playExpect(containersPage.heading).toBeVisible();
 
-  const count = await containersPage.getAllTableRows();
-  if (count.length > 0) {
-    // Select all containers through the checkbox
-    const toggleAll = containersPage.page.getByRole('checkbox', { name: 'Toggle all' });
-    await playExpect(toggleAll).toBeVisible();
-    await toggleAll.click();
-
-    // Get the bulk delete button
-    const bulkDelete = containersPage.page.getByRole('button', { name: 'Delete selected containers and pods' });
-    await playExpect(bulkDelete).toBeVisible();
-    await bulkDelete.click();
-
-    await handleConfirmationDialog(containersPage.page, 'Delete Containers?', true, 'Delete');
-
-    // Wait until none are remaining
-    await playExpect.poll(async () => await containersPage.getAllTableRows()).toHaveLength(0);
+  try {
+    playExpect.poll(
+      async () => {
+        return await containersPage.pageIsEmpty();
+      },
+      { timeout: 10_000 },
+    );
+  } catch (err) {
+    console.log('We have some containers');
+    await containersPage.pruneContainers();
+    playExpect.poll(
+      async () => {
+        return await containersPage.pageIsEmpty();
+      },
+      { timeout: 20_000 },
+    );
   }
 
   await runner.close(45_000);


### PR DESCRIPTION
### What does this PR do?

One step closer to enable visual testing for Podman Desktop. Today in Podman Desktop we use [argos-ci](https://argos-ci.com/) to ensure we don't introduce visual regression in the website; as Argos CI support monorepo through the `--build-name` flag[^1] we can have both the website and Podman Desktop configured.

To be able to achieve visual testing on Podman Desktop we can use the E2E and Playwright builtin `screenshot` function. As we need to have a single folder with all the screenshots to upload at the end, I added a `screenshot` method in the [`BasePage`](https://github.com/podman-desktop/podman-desktop/blob/c774b0fee3dffae59007fb05e7e9e55dc729d504/tests/playwright/src/model/pages/base-page.ts) so every time we are on a given page (E.g. ContainerPage, DashboardPage etc. we can use our screenshot method, which is a wrapper around the Playwright screenshot).

We use a custom env `PLAYWRIGHT_SCREENSHOTS_PATH` to specify where the screenshots should be placed.

[^1]: https://argos-ci.com/docs/learn/how-to-guides/ci-pipelines/monorepos-setup

### Screenshot / video of UI

Currently this PR _only_ add the scaffold of the future full test. It takes a screenshot of the containers page when it is empty.

<img width="1050" height="700" alt="image" src="https://github.com/user-attachments/assets/badf4bb5-4ab8-4aad-a744-0bac4cc6bc96" />

You can find a full example with many screenshots in my fork https://app.argos-ci.com/axel7083/podman-desktop/builds/21/336236312

> It requires a bit more work to hide the areas that are flaky (E.g. durations).

To nicely distinguish website job from podman desktop, I updated the `argos.yaml` GitHub workflow

<img width="1060" height="468" alt="image" src="https://github.com/user-attachments/assets/1b916ce7-12f5-4c9c-8206-bd4d138af099" /> 

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16304

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle: 
