### PR TITLE
chore(website-argos): specify build-name argument

### DIFF
--- a/website-argos/package.json
+++ b/website-argos/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "screenshot": "playwright test",
-    "upload": "npx @argos-ci/cli upload ./screenshots"
+    "upload": "npx @argos-ci/cli upload --build-name website ./screenshots"
   },
   "devDependencies": {
     "@argos-ci/cli": "^5.0.5",


### PR DESCRIPTION
### What does this PR do?

Currently we are using only a single "build" with argos-ci. However for monorepo, we can specify `--build-name` argument, allowing us to tell argos-ci to differentiate different "build".

As we want to introduce the same mechanism for Podman Desktop, we should distinguish them.

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16304

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- Pipeline should be :green_circle: 

We should need to validate manually the new build as we updated its name
