### PR TITLE
fix: resolve CVE-2026-48068 in @grpc/grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,8 @@
       "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
       "mermaid": ">=11.15.0",
       "ws@^8": ">=8.20.1",
-      "concurrently>shell-quote": ">=1.8.4"
+      "concurrently>shell-quote": ">=1.8.4",
+      "dockerode>@grpc/grpc-js": ">=1.14.4"
     }
   },
   "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,7 @@ overrides:
   mermaid: '>=11.15.0'
   ws@^8: '>=8.20.1'
   concurrently>shell-quote: '>=1.8.4'
+  dockerode>@grpc/grpc-js: '>=1.14.4'
 
 importers:
 
@@ -3014,8 +3015,8 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.7.15':
@@ -15447,7 +15448,7 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@grpc/grpc-js@1.14.3':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
@@ -19906,7 +19907,7 @@ snapshots:
   dockerode@5.0.0:
     dependencies:
       '@balena/dockerignore': 1.0.2
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
       protobufjs: 7.5.8


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-48068 in `@grpc/grpc-js`.

**Advisory**: @grpc/grpc-js: A malformed request can cause a server crash
**Vulnerable versions**: >=1.14.0 <1.14.4
**Patched versions**: >=1.14.4
**Advisory URL**: https://github.com/advisories/GHSA-5375-pq7m-f5r2

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-48068: _@grpc/grpc-js: A malformed request can cause a server crash_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-48068 is no longer reported