### PR TITLE
chore(argos.yaml): rename worflow name and job

### DIFF
--- a/.github/workflows/argos-website.yaml
+++ b/.github/workflows/argos-website.yaml
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Argos CI Screenshots
+name: Visual Testing
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
@@ -36,7 +36,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/argos.yaml'
+      - 'argos-website.yaml'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'storybook/**'
@@ -47,8 +47,8 @@ permissions:
   contents: read
 
 jobs:
-  take-screenshots:
-    name: take screenshots
+  website:
+    name: website
     runs-on: ubuntu-22.04
     # disable on forks as secrets are not available
     if: github.event.repository.fork == false

--- a/.github/workflows/argos-website.yaml
+++ b/.github/workflows/argos-website.yaml
@@ -36,7 +36,7 @@ on:
     branches:
       - main
     paths:
-      - 'argos-website.yaml'
+      - '.github/workflows/argos-website.yaml'
       - 'package.json'
       - 'pnpm-lock.yaml'
       - 'storybook/**'


### PR DESCRIPTION
### What does this PR do?

With https://github.com/podman-desktop/podman-desktop/issues/16304 we will introduce a `argos-podman-desktop.yaml` workflow, and to have some consistency, we should rename the existing `argos.yaml` job, named `Argos CI Screenshots > take screenshots`.

My suggestions

- `argos-website.yaml`: `Visual Testing > Website`
- `argos-podman-desktop.yaml`: `Visual Testing > Podman Desktop`

:warning: We will need to update the `Required` check as this PR update the name of the action.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/16304

### How to test this PR?

- CI should be :green_circle: 
