### PR TITLE
fix: resolve CVE-2026-49982 in tmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
       "compression>on-headers": "^1.1.0",
       "electron-builder-notarize>js-yaml": "^3.14.2",
       "@kubernetes/client-node>js-yaml": "^4.1.1",
-      "tmp-promise>tmp": "^0.2.6",
+      "tmp-promise>tmp": "^0.2.7",
       "tar": "^7.5.3",
       "cheerio>undici": "^7.18.2",
       "minimatch>@isaacs/brace-expansion": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   compression>on-headers: ^1.1.0
   electron-builder-notarize>js-yaml: ^3.14.2
   '@kubernetes/client-node>js-yaml': ^4.1.1
-  tmp-promise>tmp: ^0.2.6
+  tmp-promise>tmp: ^0.2.7
   tar: ^7.5.3
   cheerio>undici: ^7.18.2
   minimatch>@isaacs/brace-expansion: ^5.0.1
@@ -11857,10 +11857,6 @@ packages:
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
-
-  tmp@0.2.6:
-    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
-    engines: {node: '>=14.14'}
 
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
@@ -25944,9 +25940,7 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.6
-
-  tmp@0.2.6: {}
+      tmp: 0.2.7
 
   tmp@0.2.7: {}
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-49982 in `tmp`.

**Advisory**: tmp: Type-confusion bypass of _assertPath allows path traversal via non-string prefix/postfix/template
**Vulnerable versions**: >=0.2.6 <0.2.7
**Patched versions**: >=0.2.7
**Advisory URL**: https://github.com/advisories/GHSA-7c78-jf6q-g5cm

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-49982: _tmp: Type-confusion bypass of _assertPath allows path traversal via non-string prefix/postfix/template_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-49982 is no longer reported