### PR TITLE
refactor(main): return value instead of index in MessageBoxReturnValue

### DIFF
--- a/packages/api/src/dialog.ts
+++ b/packages/api/src/dialog.ts
@@ -75,6 +75,6 @@ export interface MessageBoxOptions {
 }
 
 export interface MessageBoxReturnValue {
-  response: number | undefined;
+  response: string | undefined;
   dropdownIndex?: number;
 }

--- a/packages/main/src/plugin/authentication.ts
+++ b/packages/main/src/plugin/authentication.ts
@@ -33,16 +33,16 @@ import { Emitter } from './events/emitter.js';
 import { MessageBox } from './message-box.js';
 
 // Sign Out dialog buttons
-export const SIGN_OUT_CANCEL = 0;
-export const SIGN_OUT_CONFIRM = 1;
+export const SIGN_OUT_CANCEL = 'Cancel';
+export const SIGN_OUT_CONFIRM = 'Sign Out';
 
 // Allow Access dialog buttons
-export const ALLOW_ACCESS_ALLOW = 0;
-export const ALLOW_ACCESS_DENY = 1;
+export const ALLOW_ACCESS_ALLOW = 'Allow';
+export const ALLOW_ACCESS_DENY = 'Deny';
 
 // Sign In dialog buttons
-export const SIGN_IN_CANCEL = 0;
-export const SIGN_IN_ALLOW = 1;
+export const SIGN_IN_CANCEL = 'Cancel';
+export const SIGN_IN_ALLOW = 'Allow';
 
 /**
  * Structure to save authentication provider information

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
@@ -299,7 +299,7 @@ describe('showFeedbackDialog', () => {
     const pastTimestamp = new Date('2020-01-01T00:00:00.000Z').getTime();
     const existingTimestamps = { remindAt: pastTimestamp, disabled: false };
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
-    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 1 });
+    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 'Share Feedback on GitHub' });
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
     const openExternalSpy = vi.spyOn(shell, 'openExternal').mockResolvedValue(undefined);
 
@@ -316,7 +316,7 @@ describe('showFeedbackDialog', () => {
     const pastTimestamp = new Date('2020-01-01T00:00:00.000Z').getTime();
     const existingTimestamps = { remindAt: pastTimestamp, disabled: false };
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
-    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 0, dropdownIndex: 0 });
+    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 'Remind me later', dropdownIndex: 0 });
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
     const openExternalSpy = vi.spyOn(shell, 'openExternal').mockResolvedValue(undefined);
 
@@ -332,7 +332,7 @@ describe('showFeedbackDialog', () => {
     const pastTimestamp = new Date('2020-01-01T00:00:00.000Z').getTime();
     const existingTimestamps = { remindAt: pastTimestamp, disabled: false };
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
-    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 0, dropdownIndex: 1 });
+    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 'Remind me later', dropdownIndex: 1 });
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
     const openExternalSpy = vi.spyOn(shell, 'openExternal').mockResolvedValue(undefined);
 
@@ -348,7 +348,7 @@ describe('showFeedbackDialog', () => {
     const pastTimestamp = new Date('2020-01-01T00:00:00.000Z').getTime();
     const existingTimestamps = { remindAt: pastTimestamp, disabled: false };
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
-    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 0, dropdownIndex: 2 });
+    vi.mocked(messageBox.showMessageBox).mockResolvedValue({ response: 'Remind me later', dropdownIndex: 2 });
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
     const openExternalSpy = vi.spyOn(shell, 'openExternal').mockResolvedValue(undefined);
 

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -224,13 +224,10 @@ export class ExperimentalFeatureFeedbackHandler {
         .then(async response => {
           if (response) {
             const telemetryOptions = { option: 'Share Feedback on GitHub' };
-            // Share Feedback on GitHub was selected
-            if (response.response === 1) {
+            if (response.response === 'Share Feedback on GitHub') {
               await shell.openExternal(featureGitHubLink);
               this.setTimestamp(key, undefined);
-            }
-            // Option from Dropdown was selected
-            else if (response.response === 0 && typeof response.dropdownIndex === 'number') {
+            } else if (response.response === 'Remind me later' && typeof response.dropdownIndex === 'number') {
               telemetryOptions.option = options[response.dropdownIndex] ?? 'Unknown option';
               switch (options[response.dropdownIndex]) {
                 case 'Remind me tomorrow':

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -155,7 +155,7 @@ test('Check SecurityRestrictions on Links and user accept', async () => {
   await pluginSystem.setupSecurityRestrictionsOnLinks(messageBox);
 
   // expect user click on Yes
-  showMessageBoxMock.mockResolvedValue({ response: 0 });
+  showMessageBoxMock.mockResolvedValue({ response: 'Open' });
 
   // call with a link
   const value = await securityRestrictionCurrentHandler.handler?.('https://www.my-custom-domain.io');
@@ -182,7 +182,7 @@ test('Check SecurityRestrictions on Links and user copy link', async () => {
   await pluginSystem.setupSecurityRestrictionsOnLinks(messageBox);
 
   // expect user click on Yes
-  showMessageBoxMock.mockResolvedValue({ response: 1 });
+  showMessageBoxMock.mockResolvedValue({ response: 'Copy Link' });
 
   // call with a link
   const value = await securityRestrictionCurrentHandler.handler?.('https://www.my-custom-domain.io');
@@ -211,7 +211,7 @@ test('Check SecurityRestrictions on Links and user refuses', async () => {
   await pluginSystem.setupSecurityRestrictionsOnLinks(messageBox);
 
   // expect user click on Yes
-  showMessageBoxMock.mockResolvedValue({ response: 2 });
+  showMessageBoxMock.mockResolvedValue({ response: 'Cancel' });
 
   // call with a link
   const value = await securityRestrictionCurrentHandler.handler?.('https://www.my-custom-domain.io');

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -471,12 +471,10 @@ export class PluginSystem {
         cancelId: 2,
       });
 
-      if (result.response === 0) {
-        // open externally the URL
+      if (result.response === 'Open') {
         await shell.openExternal(url);
         return true;
-      } else if (result.response === 1) {
-        // copy to clipboard
+      } else if (result.response === 'Copy Link') {
         clipboard.writeText(url);
       }
       return false;

--- a/packages/main/src/plugin/message-box.spec.ts
+++ b/packages/main/src/plugin/message-box.spec.ts
@@ -16,16 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { DropdownType } from '@podman-desktop/core-api';
+import type { DropdownType, IconButtonType } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
-import { expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { MessageBox } from './message-box.js';
 
 test('Should return first item if button clicked is the first', async () => {
   const messageBox = new MessageBox({} as ApiSenderType);
   vi.spyOn(messageBox, 'showMessageBox').mockResolvedValue({
-    response: 0,
+    response: 'ok',
   });
   const result = await messageBox.showDialog('info', 'title', 'message', ['ok', 'cancel']);
   expect(result).toBe('ok');
@@ -34,7 +34,7 @@ test('Should return first item if button clicked is the first', async () => {
 test('Should return second item if button clicked is the second', async () => {
   const messageBox = new MessageBox({} as ApiSenderType);
   vi.spyOn(messageBox, 'showMessageBox').mockResolvedValue({
-    response: 1,
+    response: 'cancel',
   });
   const result = await messageBox.showDialog('info', 'title', 'message', ['ok', 'cancel']);
   expect(result).toBe('cancel');
@@ -43,7 +43,7 @@ test('Should return second item if button clicked is the second', async () => {
 test('Should return option one if dropdown clicked is the first', async () => {
   const messageBox = new MessageBox({} as ApiSenderType);
   vi.spyOn(messageBox, 'showMessageBox').mockResolvedValue({
-    response: 0,
+    response: 'dropdown',
     dropdownIndex: 1,
   });
 
@@ -60,7 +60,7 @@ test('Should return option one if dropdown clicked is the first', async () => {
 test('Should return option one if dropdown clicked is the second', async () => {
   const messageBox = new MessageBox({} as ApiSenderType);
   vi.spyOn(messageBox, 'showMessageBox').mockResolvedValue({
-    response: 1,
+    response: 'dropdown',
     dropdownIndex: 0,
   });
 
@@ -72,4 +72,182 @@ test('Should return option one if dropdown clicked is the second', async () => {
 
   const result = await messageBox.showDialog('info', 'title', 'message', ['ok', dropdown]);
   expect(result).toBe('Monday');
+});
+
+describe('showMessageBox + onDidSelectButton integration', () => {
+  function createMessageBox(): { messageBox: MessageBox; getLastId: () => number } {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+    return {
+      messageBox,
+      getLastId: () => (vi.mocked(apiSender.send).mock.calls.at(-1)?.[1] as Record<string, unknown>)?.['id'] as number,
+    };
+  }
+
+  test('should resolve with string button label when string button is selected', async () => {
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      buttons: ['OK', 'Cancel'],
+      type: 'info',
+    });
+    await messageBox.onDidSelectButton(getLastId(), 0);
+    const result = await promise;
+    expect(result.response).toBe('OK');
+  });
+
+  test('should resolve with second string button label', async () => {
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      buttons: ['OK', 'Cancel'],
+      type: 'info',
+    });
+    await messageBox.onDidSelectButton(getLastId(), 1);
+    const result = await promise;
+    expect(result.response).toBe('Cancel');
+  });
+
+  test('should resolve with dropdown heading when dropdown button is selected', async () => {
+    const dropdown: DropdownType = {
+      heading: 'Choose day',
+      buttons: ['Mon', 'Tue'],
+      type: 'dropdownButton',
+    };
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      buttons: ['OK', dropdown],
+      type: 'info',
+    });
+    await messageBox.onDidSelectButton(getLastId(), 1, 0);
+    const result = await promise;
+    expect(result.response).toBe('Choose day');
+    expect(result.dropdownIndex).toBe(0);
+  });
+
+  test('should resolve with icon button label when icon button is selected', async () => {
+    const iconButton: IconButtonType = {
+      label: 'Delete',
+      icon: 'trash-icon',
+      type: 'iconButton',
+    };
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      buttons: [iconButton, 'Cancel'],
+      type: 'info',
+    });
+    await messageBox.onDidSelectButton(getLastId(), 0);
+    const result = await promise;
+    expect(result.response).toBe('Delete');
+  });
+
+  test('should resolve with undefined response when selectedIndex is undefined', async () => {
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      buttons: ['OK'],
+      type: 'info',
+    });
+    await messageBox.onDidSelectButton(getLastId());
+    const result = await promise;
+    expect(result.response).toBeUndefined();
+  });
+
+  test('should resolve with undefined response when selectedIndex is out of bounds', async () => {
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      buttons: ['OK'],
+      type: 'info',
+    });
+    await messageBox.onDidSelectButton(getLastId(), 5);
+    const result = await promise;
+    expect(result.response).toBeUndefined();
+  });
+
+  test('should resolve with undefined response when selectedIndex is negative', async () => {
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      buttons: ['OK'],
+      type: 'info',
+    });
+    await messageBox.onDidSelectButton(getLastId(), -1);
+    const result = await promise;
+    expect(result.response).toBeUndefined();
+  });
+
+  test('should not throw when callback id is unknown', async () => {
+    const { messageBox } = createMessageBox();
+    await expect(messageBox.onDidSelectButton(9999, 0)).resolves.toBeUndefined();
+  });
+
+  test('should remove callback after resolving', async () => {
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      buttons: ['OK'],
+      type: 'info',
+    });
+    const id = getLastId();
+    await messageBox.onDidSelectButton(id, 0);
+    await promise;
+    await expect(messageBox.onDidSelectButton(id, 0)).resolves.toBeUndefined();
+  });
+
+  test('should store buttons from options and default to empty array', async () => {
+    const { messageBox, getLastId } = createMessageBox();
+    const promise = messageBox.showMessageBox({
+      title: 'Test',
+      message: 'msg',
+      type: 'info',
+    });
+    await messageBox.onDidSelectButton(getLastId(), 0);
+    const result = await promise;
+    expect(result.response).toBeUndefined();
+  });
+});
+
+describe('showDialog without mocking showMessageBox', () => {
+  test('should return dropdown sub-button when dropdown is selected with dropdownIndex', async () => {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+
+    const dropdown: DropdownType = {
+      heading: 'Options',
+      buttons: ['Alpha', 'Beta', 'Gamma'],
+      type: 'dropdownButton',
+    };
+
+    const promise = messageBox.showDialog('info', 'title', 'message', [dropdown, 'cancel']);
+
+    const id = (vi.mocked(apiSender.send).mock.calls[0]?.[1] as Record<string, unknown>)?.['id'] as number;
+    await messageBox.onDidSelectButton(id, 0, 1);
+
+    const result = await promise;
+    expect(result).toBe('Beta');
+  });
+
+  test('should return response string directly when no dropdownIndex', async () => {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+
+    const promise = messageBox.showDialog('info', 'title', 'message', ['ok', 'cancel']);
+
+    const id = (vi.mocked(apiSender.send).mock.calls[0]?.[1] as Record<string, unknown>)?.['id'] as number;
+    await messageBox.onDidSelectButton(id, 1);
+
+    const result = await promise;
+    expect(result).toBe('cancel');
+  });
 });

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -19,29 +19,35 @@ import type {
   ButtonsType,
   DialogType,
   DropdownType,
+  IconButtonType,
   MessageBoxOptions,
   MessageBoxReturnValue,
 } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable } from 'inversify';
 
+interface MessageBoxCallback {
+  deferred: PromiseWithResolvers<MessageBoxReturnValue>;
+  buttons: ButtonsType[];
+}
+
 @injectable()
 export class MessageBox {
   private callbackId = 0;
 
-  private callbacksMessageBox = new Map<number, PromiseWithResolvers<MessageBoxReturnValue>>();
+  private callbacksMessageBox = new Map<number, MessageBoxCallback>();
 
   constructor(@inject(ApiSenderType) private apiSender: ApiSenderType) {}
 
   async showMessageBox(options: MessageBoxOptions): Promise<MessageBoxReturnValue> {
-    // keep track of this request
     this.callbackId++;
 
-    // create a promise that will be resolved when the frontend sends the result
     const deferred = Promise.withResolvers<MessageBoxReturnValue>();
 
-    // store the callback that will resolve the promise
-    this.callbacksMessageBox.set(this.callbackId, deferred);
+    this.callbacksMessageBox.set(this.callbackId, {
+      deferred,
+      buttons: options.buttons ?? [],
+    });
 
     const data = {
       id: this.callbackId,
@@ -55,10 +61,8 @@ export class MessageBox {
       footerMarkdownDescription: options.footerMarkdownDescription,
     };
 
-    // need to send the options to the frontend
     this.apiSender.send('showMessageBox:open', data);
 
-    // return the promise
     return deferred.promise;
   }
 
@@ -70,6 +74,13 @@ export class MessageBox {
       'buttons' in response &&
       Array.isArray((response as DropdownType).buttons)
     );
+  }
+
+  private getButtonLabel(button: ButtonsType): string {
+    if (typeof button === 'string') return button;
+    if (button.type === 'dropdownButton') return (button as DropdownType).heading;
+    if (button.type === 'iconButton') return (button as IconButtonType).label;
+    return '';
   }
 
   async showDialog(
@@ -85,34 +96,31 @@ export class MessageBox {
       type: type,
     });
 
-    if (result.response !== undefined && result.response >= 0) {
-      const response = items[result.response];
+    if (result.response !== undefined) {
       if (result.dropdownIndex !== undefined && result.dropdownIndex >= 0) {
-        if (this.isDropdownType(response)) return response.buttons[result.dropdownIndex];
+        const button = items.find(b => this.isDropdownType(b) && b.heading === result.response);
+        if (button && this.isDropdownType(button)) return button.buttons[result.dropdownIndex];
       }
-      if (typeof response === 'string') return response;
+      return result.response;
     }
 
     return undefined;
   }
 
-  // this method is called by the frontend when the user selected a button
   async onDidSelectButton(id: number, selectedIndex?: number, dropdownIndex?: number): Promise<void> {
-    // get the callback
-    const callback = this.callbacksMessageBox.get(id);
+    const entry = this.callbacksMessageBox.get(id);
 
-    // if there is a callback
-    if (callback) {
-      // grab item
-      const val: MessageBoxReturnValue = {
-        response: selectedIndex,
-        dropdownIndex: dropdownIndex,
-      };
-      // resolve the promise
-      callback.resolve(val);
+    if (entry) {
+      let response: string | undefined;
+      if (selectedIndex !== undefined && selectedIndex >= 0 && selectedIndex < entry.buttons.length) {
+        const button = entry.buttons[selectedIndex];
+        if (button !== undefined) {
+          response = this.getButtonLabel(button);
+        }
+      }
+      entry.deferred.resolve({ response, dropdownIndex });
     }
 
-    // remove the callback
     this.callbacksMessageBox.delete(id);
   }
 }

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -100,6 +100,7 @@ const configurationMock = {
 const configurationRegistryMock = {
   registerConfigurations: vi.fn(),
   getConfiguration: vi.fn(),
+  updateConfigurationValue: vi.fn(),
 } as unknown as ConfigurationRegistry;
 
 const statusBarRegistryMock = {
@@ -600,7 +601,7 @@ test('expect command update not to be called when configuration value on never',
 
 test('clicking on "Update Never" should set the configuration value to never', async () => {
   vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
-    response: 3, // Update never
+    response: `Don't show again`,
   });
 
   let mListener: (() => Promise<void>) | undefined;
@@ -630,7 +631,7 @@ describe('expect update command to depends on context', async () => {
   type UpdateCommandListener = (context: 'startup' | 'status-bar-entry') => Promise<void>;
   const getUpdateListener = async (): Promise<UpdateCommandListener> => {
     vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
-      response: 2, // Update never
+      response: 'Cancel',
     });
 
     vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
@@ -754,7 +755,7 @@ describe('download task and progress', async () => {
 
     // call the update command callback
     vi.mocked(messageBoxMock.showMessageBox).mockResolvedValueOnce({
-      response: 0,
+      response: 'Update now',
     });
 
     await updateCommandCallback?.('status-bar-entry');
@@ -775,7 +776,7 @@ describe('download task and progress', async () => {
 
     // user click on restart
     vi.mocked(messageBoxMock.showMessageBox).mockResolvedValueOnce({
-      response: 0,
+      response: 'Restart',
     });
 
     onUpdateDownloadedCallback?.(updatedDownloadedEvent);
@@ -820,7 +821,7 @@ describe('download task and progress', async () => {
 
     // call the update command callback
     vi.mocked(messageBoxMock.showMessageBox).mockResolvedValueOnce({
-      response: 0,
+      response: 'Update now',
     });
 
     // simulate download failure
@@ -1156,4 +1157,75 @@ test('versions are not numbered versions', async () => {
   await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
 
   expect(updater.updateAvailable()).toBeTruthy();
+});
+
+test('clicking View Release Notes in version command should show release notes', async () => {
+  vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
+    response: 'View Release Notes',
+  });
+
+  vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue(undefined);
+
+  let versionListener: (() => Promise<void>) | undefined;
+  vi.mocked(commandRegistryMock.registerCommand).mockImplementation(
+    (channel: string, listener: () => Promise<void>) => {
+      if (channel === 'version') versionListener = listener;
+      return Disposable.noop();
+    },
+  );
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+  expect(versionListener).toBeDefined();
+
+  await versionListener?.();
+
+  expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith('releaseNotesBanner.show', 'show');
+  expect(apiSenderMock.send).toHaveBeenCalledWith('show-release-notes');
+});
+
+test(`clicking What's new in update command should open release notes`, async () => {
+  vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
+    response: `What's new`,
+  });
+
+  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+    updateInfo: {
+      version: '2.0.0',
+    },
+  } as unknown as UpdateCheckResult);
+
+  type UpdateCommandListener = (context?: 'startup' | 'status-bar-entry') => Promise<void>;
+  let updateListener: UpdateCommandListener | undefined;
+  vi.mocked(commandRegistryMock.registerCommand).mockImplementation(
+    (channel: string, listener: () => Promise<void>) => {
+      if (channel === 'update') updateListener = listener;
+      return Disposable.noop();
+    },
+  );
+
+  vi.mocked(shell.openExternal).mockResolvedValue();
+
+  const updater = new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  );
+  updater.init();
+
+  await vi.waitUntil(() => updater.updateAvailable(), { interval: 500, timeout: 2000 });
+
+  expect(updateListener).toBeDefined();
+  await updateListener?.('status-bar-entry');
+
+  expect(shell.openExternal).toHaveBeenCalled();
 });

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -211,7 +211,7 @@ export class Updater {
         detail: detailMessage,
         buttons: ['View Release Notes'],
       });
-      if (result.response === 0) {
+      if (result.response === 'View Release Notes') {
         await this.configurationRegistry.updateConfigurationValue(`releaseNotesBanner.show`, 'show');
         this.apiSender.send('show-release-notes');
       }
@@ -231,7 +231,7 @@ export class Updater {
           cancelId: 1,
           buttons: ['Restart', 'Cancel'],
         });
-        if (result.response === 0) {
+        if (result.response === 'Restart') {
           setImmediate(() => autoUpdater.quitAndInstall());
         }
         return;
@@ -264,11 +264,11 @@ export class Updater {
         buttons: buttons,
         cancelId: 2,
       });
-      if (result.response === 3) {
+      if (result.response === `Don't show again`) {
         this.updateConfigurationValue('never');
-      } else if (result.response === 1) {
+      } else if (result.response === `What's new`) {
         await this.openReleaseNotes(updateVersion);
-      } else if (result.response === 0) {
+      } else if (result.response === 'Update now') {
         this.#updateInProgress = true;
         this.#updateAlreadyDownloaded = false;
 
@@ -409,7 +409,7 @@ export class Updater {
         buttons: ['Restart', 'Cancel'],
       })
       .then(result => {
-        if (result.response === 0) {
+        if (result.response === 'Restart') {
           setImmediate(() => autoUpdater.quitAndInstall());
         }
       })

--- a/packages/renderer/src/lib/compose/ComposeActions.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeActions.spec.ts
@@ -141,8 +141,8 @@ test('Expect no error and status restarting compose', async () => {
 });
 
 test('Expect no error and status deleting compose', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  // Mock the showMessageBox to return 'Delete' (confirmed)
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
   render(ComposeActions, { compose, onUpdate: updateMock });
 

--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.spec.ts
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapSecretActions.spec.ts
@@ -55,7 +55,7 @@ afterEach(() => {
 });
 
 test('Expect no error when deleting configmap', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   render(ConfigMapSecretActions, { configMapSecret: fakeConfigMap });
 
   // click on delete button
@@ -67,7 +67,7 @@ test('Expect no error when deleting configmap', async () => {
 });
 
 test('Expect no error when deleting secret', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   render(ConfigMapSecretActions, { configMapSecret: fakeSecret });
 
   // click on delete button

--- a/packages/renderer/src/lib/container/ContainerActions.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerActions.spec.ts
@@ -108,8 +108,8 @@ test('Expect no error and status restarting container', async () => {
 });
 
 test('Expect no error and status deleting container', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  // Mock the showMessageBox to return 'Delete' (confirmed)
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   render(ContainerActions, { container, onUpdate: updateMock });
 
   // click on delete button

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -116,8 +116,8 @@ test('Expect show tty if container has tty enabled', async () => {
 
 test('Expect redirect to previous page if container is deleted', async () => {
   getConfigurationValueMock.mockResolvedValue(undefined);
-  // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  // Mock the showMessageBox to return 'Delete' (confirmed)
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   router.goto('/');
 
   vi.mocked(window.getContainerInspect).mockResolvedValue({

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -801,7 +801,7 @@ test('Sort containers based on selected parameter', async () => {
 test('Expect user confirmation to pop up when preferences require', async () => {
   vi.mocked(window.listContainers).mockResolvedValue([]);
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
@@ -845,7 +845,7 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 
   expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.deleteContainer).toHaveBeenCalled());

--- a/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerListCompose.spec.ts
@@ -33,7 +33,7 @@ import ContainerList from './ContainerList.svelte';
 
 // Mocked window methods
 beforeAll(() => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   vi.mocked(window.listViewsContributions).mockResolvedValue([]);
   vi.mocked(window.onDidUpdateProviderStatus).mockResolvedValue(undefined);
   (window.events as unknown) = {

--- a/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobActions.spec.ts
@@ -44,8 +44,8 @@ beforeEach(() => {
 });
 
 test('Expect no error and status deleting cronjob', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  // Mock the showMessageBox to return 'Delete' (confirmed)
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   render(CronJobActions, { cronjob, detailed: false });
 
   // click on delete button

--- a/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentActions.spec.ts
@@ -67,7 +67,7 @@ afterEach(() => {
 });
 
 test('Expect no error and status deleting deployment', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
   render(DeploymentActions, { deployment });
 

--- a/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentDetails.spec.ts
@@ -87,7 +87,7 @@ describe.each<{
   });
 
   test('Expect redirect to previous page if deployment is deleted', async () => {
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
     const routerGotoSpy = vi.spyOn(router, 'goto');
 

--- a/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
+++ b/packages/renderer/src/lib/deployments/DeploymentsList.spec.ts
@@ -214,14 +214,14 @@ describe.each<{
 
     vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
 
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
     const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
     await fireEvent.click(deleteButton);
 
     expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
     await fireEvent.click(deleteButton);
     expect(window.showMessageBox).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(window.kubernetesDeleteDeployment).toHaveBeenCalled());

--- a/packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-utils.spec.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 });
 
 test('expect withConfirmation call callback if result OK', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Continue' });
 
   const callback = vi.fn();
   withConfirmation(callback, 'Destroy world', { title: 'Destroy World?' });
@@ -37,7 +37,7 @@ test('expect withConfirmation call callback if result OK', async () => {
 });
 
 test('expect withConfirmation not to call callback if result not OK', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const callback = vi.fn();
   withConfirmation(callback, 'Destroy world', { title: 'Destroy World?' });
@@ -62,7 +62,7 @@ test('expect withConfirmation to propagate error', async () => {
 });
 
 test('expect withConfirmation to use default variant', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Continue' });
 
   const callback = vi.fn();
   withConfirmation(callback, 'Destroy world', { title: 'Destroy World?' });
@@ -78,7 +78,7 @@ test('expect withConfirmation to use default variant', async () => {
 });
 
 test('expect withConfirmation to use explicit title when provided', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Destroy' });
 
   const callback = vi.fn();
   withConfirmation(callback, 'Destroy world', { title: 'Destroy World?', buttonLabel: 'Destroy' });
@@ -95,7 +95,7 @@ test('expect withConfirmation to use explicit title when provided', async () => 
 });
 
 test('expect withConfirmation to use delete variant with Delete button and danger type', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
   const callback = vi.fn();
   withConfirmation(callback, 'delete this resource', { title: 'Delete Resource?', variant: 'delete' });
@@ -112,7 +112,7 @@ test('expect withConfirmation to use delete variant with Delete button and dange
 });
 
 test('expect withConfirmation to use default variant explicitly', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Continue' });
 
   const callback = vi.fn();
   withConfirmation(callback, 'continue', { title: 'Continue?', variant: 'default', buttonLabel: 'Continue' });

--- a/packages/renderer/src/lib/dialogs/messagebox-utils.ts
+++ b/packages/renderer/src/lib/dialogs/messagebox-utils.ts
@@ -44,7 +44,7 @@ export function withConfirmation(func: (err?: unknown) => unknown, action: strin
       type: isDelete ? 'danger' : 'question',
     })
     .then(result => {
-      if (result?.response === 0) {
+      if (result?.response === activationButton) {
         func();
       }
     })

--- a/packages/renderer/src/lib/engine/Prune.spec.ts
+++ b/packages/renderer/src/lib/engine/Prune.spec.ts
@@ -50,10 +50,8 @@ describe('containers', () => {
       ],
     });
 
-    // mock the window.showMessageBox method to return "all"
-    const response = 1;
     vi.mocked(window.showMessageBox).mockResolvedValue({
-      response,
+      response: 'Prune',
     });
 
     // search for the button
@@ -95,10 +93,8 @@ describe('images', () => {
   test('prune all untagged images', async () => {
     imageRender();
 
-    // mock the window.showMessageBox method to return "all untaged images"
-    const response = IMAGE_BUTTONS.indexOf(ALL_UNTAGGED_IMAGES);
     vi.mocked(window.showMessageBox).mockResolvedValue({
-      response,
+      response: ALL_UNTAGGED_IMAGES,
     });
 
     // search for the button
@@ -120,10 +116,8 @@ describe('images', () => {
   test('prune all unused images', async () => {
     imageRender();
 
-    // mock the window.showMessageBox method to return "all unused images"
-    const response = IMAGE_BUTTONS.indexOf(ALL_UNUSED_IMAGES);
     vi.mocked(window.showMessageBox).mockResolvedValue({
-      response,
+      response: ALL_UNUSED_IMAGES,
     });
 
     // search for the button
@@ -145,10 +139,8 @@ describe('images', () => {
   test('prune nothing (click cancel)', async () => {
     imageRender();
 
-    // mock the window.showMessageBox method to return "Cancel"
-    const response = IMAGE_BUTTONS.indexOf(CANCEL_BUTTON);
     vi.mocked(window.showMessageBox).mockResolvedValue({
-      response,
+      response: CANCEL_BUTTON,
     });
 
     // search for the button

--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -44,9 +44,8 @@ async function openPruneDialog(): Promise<void> {
     buttons,
   });
 
-  const selectedItemLabel = buttons[result.response ?? 0];
-  if (selectedItemLabel !== cancel) {
-    await prune(type, selectedItemLabel);
+  if (result.response !== undefined && result.response !== cancel) {
+    await prune(type, result.response);
   }
 }
 

--- a/packages/renderer/src/lib/feedback/SendFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/SendFeedback.svelte
@@ -47,7 +47,7 @@ async function hideModal(confirm = true): Promise<void> {
     buttons: ['Close', 'Cancel'],
   });
 
-  if (result?.response === 0) {
+  if (result?.response === 'Close') {
     closeModal();
     hasContent = false;
   }

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -81,7 +81,7 @@ beforeEach(() => {
 
 test('Expect error dialog with correct message when image deletion fails', async () => {
   vi.mocked(withConfirmation).mockImplementation(f => f());
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Dismiss' });
   getContributedMenusMock.mockResolvedValue([]);
 
   const image: ImageInfoUI = new Image('dummy', 'UNUSED') as unknown as ImageInfoUI;

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -89,8 +89,8 @@ afterEach(() => {
 });
 
 test('Expect redirect to previous page if image is deleted', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  // Mock the showMessageBox to return 'Delete' (confirm)
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
   const routerGotoSpy = vi.spyOn(router, 'goto');
   listImagesMock.mockResolvedValue([myImage]);

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -648,14 +648,14 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
   await fireEvent.click(deleteButton);
 
   expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.deleteImage).toHaveBeenCalled());

--- a/packages/renderer/src/lib/image/ManifestActions.spec.ts
+++ b/packages/renderer/src/lib/image/ManifestActions.spec.ts
@@ -64,8 +64,8 @@ test('Expect Delete Manifest to be there', async () => {
 });
 
 test('Expect Push Manifest to be there', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  // Mock the showMessageBox to return 'Dismiss'
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Dismiss' });
   getContributedMenusMock.mockResolvedValue([]);
 
   render(ManifestActions, { manifest: fakedManifest, onPushManifest: vi.fn() });
@@ -99,7 +99,7 @@ test('Expect withConfirmation to be called with delete variant when clicking Del
 test('Expect error dialog with correct message when manifest deletion fails', async () => {
   const errorMessage = 'manifest not found';
   vi.mocked(withConfirmation).mockImplementation(f => f());
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Dismiss' });
   vi.mocked(window.removeManifest).mockRejectedValueOnce(new Error(errorMessage));
   getContributedMenusMock.mockResolvedValue([]);
 

--- a/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressDetails.spec.ts
@@ -81,7 +81,7 @@ describe.each<{
   });
 
   test('Expect redirect to previous page if ingress is deleted', async () => {
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
     const routerGotoSpy = vi.spyOn(router, 'goto');
 
     // mock object store

--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.spec.ts
@@ -52,7 +52,7 @@ class StatusHolder {
 }
 
 test('Expect no error and status deleting ingress', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 }); // Mock confirmation dialog
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' }); // Mock confirmation dialog
 
   const ingressUI: IngressUI = new StatusHolder('RUNNING') as unknown as IngressUI;
   ingressUI.name = 'my-ingress';
@@ -74,7 +74,7 @@ test('Expect no error and status deleting ingress', async () => {
 });
 
 test('Expect no error and status deleting route', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 }); // Mock confirmation dialog
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' }); // Mock confirmation dialog
 
   const routeUI: RouteUI = new StatusHolder('RUNNING') as unknown as RouteUI;
   routeUI.name = 'my-route';

--- a/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/IngressesRoutesList.spec.ts
@@ -178,14 +178,14 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
   await fireEvent.click(deleteButton);
 
   expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.kubernetesDeleteIngress).toHaveBeenCalled());

--- a/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
+++ b/packages/renderer/src/lib/ingresses-routes/RouteDetails.spec.ts
@@ -96,7 +96,7 @@ describe.each<{
   });
 
   test('Expect redirect to previous page if route is deleted', async () => {
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
     const routerGotoSpy = vi.spyOn(router, 'goto');
 
     // mock object store

--- a/packages/renderer/src/lib/job/JobActions.spec.ts
+++ b/packages/renderer/src/lib/job/JobActions.spec.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 
 test('Expect no error and status deleting job', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   render(JobActions, { job, detailed: false });
 
   // click on delete button

--- a/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodActions.spec.ts
@@ -73,7 +73,7 @@ beforeEach(() => {
 });
 
 test('Check deleting pod', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
   render(PodActions, { pod });
 
@@ -90,7 +90,7 @@ test('Check deleting pod', async () => {
 });
 
 test('Check restarting pod', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
   render(PodActions, { pod });
 

--- a/packages/renderer/src/lib/kube/pods/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodDetails.spec.ts
@@ -99,7 +99,7 @@ describe.each<{
   });
 
   test('Expect redirect to previous page if pod is deleted', async () => {
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
     const routerGotoSpy = vi.spyOn(router, 'goto');
 

--- a/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/PodsList.spec.ts
@@ -189,14 +189,14 @@ describe.each<{
 
     vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
 
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
     const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
     await fireEvent.click(deleteButton);
 
     expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
     await fireEvent.click(deleteButton);
     expect(window.showMessageBox).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(window.kubernetesDeletePod).toHaveBeenCalled());

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -47,9 +47,9 @@ beforeEach(() => {
   (window.deleteKubernetesPortForward as unknown) = vi.fn();
   (window.showMessageBox as unknown) = vi.fn();
 
-  // mock resolved `Yes`
+  // mock resolved `Delete`
   vi.mocked(window.showMessageBox).mockResolvedValue({
-    response: 0,
+    response: 'Delete',
   });
 });
 

--- a/packages/renderer/src/lib/network/NetworkActions.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkActions.spec.ts
@@ -61,7 +61,7 @@ beforeEach(() => {
 });
 
 test('Expect non-podman unused network to have delete option and disabled edit', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   render(NetworkActions, { object: network1 });
 
   expect(screen.queryByTitle('Delete Network')).toBeInTheDocument();
@@ -75,7 +75,7 @@ test('Expect non-podman unused network to have delete option and disabled edit',
 
 test('Expect error dialog when network deletion fails', async () => {
   const errorMessage = 'default network podman cannot be removed';
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   vi.mocked(window.removeNetwork).mockRejectedValueOnce(new Error(errorMessage));
 
   const network: NetworkInfoUI = { ...network1, status: 'UNUSED' };

--- a/packages/renderer/src/lib/network/NetworkDetails.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkDetails.spec.ts
@@ -78,7 +78,7 @@ test('Expect to have network name and shortId and network actions in Details pag
 test('Expect redirect to previous page if current network is deleted', async () => {
   const routerGotoSpy = vi.spyOn(router, 'goto');
   // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   vi.mocked(window.listNetworks).mockResolvedValue([network1]);
 
   window.dispatchEvent(new CustomEvent('extensions-already-started'));

--- a/packages/renderer/src/lib/network/NetworksList.spec.ts
+++ b/packages/renderer/src/lib/network/NetworksList.spec.ts
@@ -207,14 +207,14 @@ test('Expect user confirmation for bulk delete when required', async () => {
   await fireEvent.click(checkboxes[0]);
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
   await fireEvent.click(deleteButton);
 
   expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await waitFor(() => expect(window.removeNetwork).toHaveBeenCalled());

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -129,8 +129,8 @@ test('Expect no error and status restarting pod', async () => {
 });
 
 test('Expect no error and status deleting pod', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  // Mock the showMessageBox to return 'Delete' (confirmed)
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   listContainersMock.mockResolvedValue([]);
 
   render(PodActions, { pod: podmanPod, onUpdate: updateMock });

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
 
 test('Expect redirect to previous page if pod is deleted', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   const routerGotoSpy = vi.spyOn(router, 'goto');
   vi.mocked(window.listPods).mockResolvedValue([myPod]);
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
@@ -104,7 +104,7 @@ test('Expect redirect to previous page if pod is deleted', async () => {
 
 test('Expect redirect to logs', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   const routerGotoSpy = vi.spyOn(router, 'goto');
   const subscribeSpy = vi.spyOn(router, 'subscribe');
   subscribeSpy.mockImplementation(listener => {

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -558,14 +558,14 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
 
   (window as any).showMessageBox = vi.fn();
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
   await fireEvent.click(deleteButton);
 
   expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.removePod).toHaveBeenCalled());

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -139,6 +139,8 @@ beforeAll(() => {
   Object.defineProperty(global, 'window', {
     value: {
       updateCliTool: vi.fn(),
+      uninstallCliTool: vi.fn(),
+      showMessageBox: vi.fn(),
       executeCommand: vi.fn(),
       getUrlProtocol: vi.fn().mockResolvedValue('podman-desktop'),
       navigator: {
@@ -383,5 +385,19 @@ describe('CLI Tool item', () => {
     expect(updateLoadingButton).toBeEnabled();
     const installLoadingButton = screen.queryByRole('button', { name: 'Install' });
     expect(installLoadingButton).not.toBeInTheDocument();
+  });
+
+  test('cancelling uninstall confirmation should not call uninstallCliTool', async () => {
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
+
+    render(PreferencesCliTool, {
+      cliTool: cliToolInfoItem7,
+    });
+
+    const uninstallButton = screen.getByRole('button', { name: 'Uninstall' });
+    await fireEvent.click(uninstallButton);
+
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
+    expect(window.uninstallCliTool).not.toHaveBeenCalled();
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -109,7 +109,7 @@ async function uninstall(cliTool: CliToolInfo): Promise<void> {
     buttons: ['Uninstall', 'Cancel'],
   });
 
-  if (result?.response !== 0) {
+  if (result?.response !== 'Uninstall') {
     return;
   }
 

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -194,7 +194,7 @@ describe('delete', () => {
       status: 'stopped',
     };
     // mock Yes
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
     const { getByRole } = render(PreferencesConnectionActions, {
       connectionStatus,

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -65,7 +65,7 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(window.showMessageBox).mockResolvedValue({
-    response: 0,
+    response: 'Delete',
   });
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(window.showMessageBox).mockResolvedValue({
-    response: 0,
+    response: 'Delete',
   });
 });
 

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -163,7 +163,7 @@ test('Test that context-name2 is the current context', async () => {
 test('when deleting the current context, a popup should ask confirmation', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   render(PreferencesKubernetesContextsRendering, {});
   const currentContext = screen.getAllByRole('row')[1];
@@ -181,7 +181,7 @@ test('when deleting the current context, a popup should ask confirmation', async
 test('when deleting the non current context, no popup should ask confirmation', async () => {
   vi.mocked(kubernetesContextsState).kubernetesContextsState = readable<Map<string, ContextGeneralState>>(new Map());
   vi.mocked(kubernetesContextsState).kubernetesContextsCheckingStateDelayed = readable<Map<string, boolean>>(new Map());
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   render(PreferencesKubernetesContextsRendering, {});
   const currentContext = screen.getAllByRole('row')[0];

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -99,7 +99,7 @@ async function handleDeleteContext(contextName: string): Promise<void> {
         'You will delete the current context. If you delete it, you will need to switch to another context. Continue?',
       buttons: ['Delete', 'Cancel'],
     });
-    if (result.response !== 0) {
+    if (result.response !== 'Delete') {
       return;
     }
   }

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -531,7 +531,7 @@ describe('manual proxy settings persistence', () => {
     });
     vi.mocked(window.setProxyState).mockResolvedValue(undefined);
     vi.mocked(window.updateProxySettings).mockResolvedValue(undefined);
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Dismiss' });
 
     manualProxySettings.settings = undefined;
 

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -93,7 +93,9 @@ describe('PreferencesRegistriesEditing', () => {
     vi.mocked(window.checkImageCredentials)
       .mockRejectedValueOnce(new Error('unable to verify the first certificate'))
       .mockRejectedValueOnce(new Error('self signed certificate in certificate chain'));
-    vi.mocked(window.showMessageBox).mockResolvedValueOnce({ response: 1 }).mockResolvedValueOnce({ response: 0 });
+    vi.mocked(window.showMessageBox)
+      .mockResolvedValueOnce({ response: 'Cancel' })
+      .mockResolvedValueOnce({ response: 'Add' });
     await userEvent.click(button);
     button = screen.getByRole('button', { name: 'Add' });
     await waitFor(() => expect(button).toBeEnabled());

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -205,7 +205,7 @@ async function loginToRegistry(registry: containerDesktopAPI.Registry): Promise<
         message: 'The certificate for this registry is not trusted / verifiable. Would you like to still add it?',
         buttons: ['Add', 'Cancel'],
       });
-      if (result?.response === 0) {
+      if (result?.response === 'Add') {
         registry.insecure = true;
       } else {
         setErrorResponse(registry.serverUrl, error.message);

--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.spec.ts
@@ -34,7 +34,7 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(window.showMessageBox).mockResolvedValue({
-    response: 0,
+    response: 'Delete',
   });
 });
 

--- a/packages/renderer/src/lib/pvc/PVCActions.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCActions.spec.ts
@@ -63,7 +63,7 @@ afterEach(() => {
 });
 
 test('Expect no error and status deleting PVC', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   render(PVCActions, { pvc: fakePVC });
 
   // click on delete buttons

--- a/packages/renderer/src/lib/pvc/PVCList.spec.ts
+++ b/packages/renderer/src/lib/pvc/PVCList.spec.ts
@@ -87,13 +87,13 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.kubernetesDeletePersistentVolumeClaim).toHaveBeenCalled());

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.spec.ts
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.spec.ts
@@ -145,7 +145,7 @@ describe('backgrounds', () => {
 });
 
 test('opening messageBox and hiding banner', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Hide' });
 
   render(ExtensionBanner, {
     banner: gradientBackground,
@@ -174,7 +174,7 @@ test('opening messageBox and hiding banner', async () => {
 });
 
 test('opening messageBox and keeping banner', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Keep' });
 
   render(ExtensionBanner, {
     banner: gradientBackground,

--- a/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
+++ b/packages/renderer/src/lib/recommendation/ExtensionBanner.svelte
@@ -30,7 +30,7 @@ $effect(() => {
 });
 
 async function onClose(): Promise<void> {
-  let result: MessageBoxReturnValue = { response: -1 };
+  let result: MessageBoxReturnValue = { response: undefined };
   try {
     result = await window.showMessageBox({
       title: 'Hide Extension Recommendations?',
@@ -39,11 +39,11 @@ async function onClose(): Promise<void> {
       buttons: ['Keep', 'Hide'],
     });
 
-    if (result?.response === 1) {
+    if (result?.response === 'Hide') {
       await window.updateConfigurationValue(`extensions.ignoreBannerRecommendations`, true, 'DEFAULT');
     }
   } finally {
-    let choice: 'hide' | 'keep' = result?.response === 1 ? 'hide' : 'keep';
+    let choice: 'hide' | 'keep' = result?.response === 'Hide' ? 'hide' : 'keep';
     await window.telemetryTrack('hideRecommendationExtensionBanner', { choice });
   }
 }

--- a/packages/renderer/src/lib/service/ServiceActions.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceActions.spec.ts
@@ -62,8 +62,8 @@ afterEach(() => {
 });
 
 test('Expect no error and status deleting service', async () => {
-  // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  // Mock the showMessageBox to return 'Delete' (yes)
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   render(ServiceActions, { service });
 
   // click on delete button

--- a/packages/renderer/src/lib/service/ServiceDetails.spec.ts
+++ b/packages/renderer/src/lib/service/ServiceDetails.spec.ts
@@ -82,7 +82,7 @@ describe.each<{
     vi.mocked(resourcesListen.isKubernetesExperimentalMode).mockResolvedValue(experimental);
   });
   test('Expect redirect to previous page if service is deleted', async () => {
-    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
     const routerGotoSpy = vi.spyOn(router, 'goto');
 

--- a/packages/renderer/src/lib/service/ServicesList.spec.ts
+++ b/packages/renderer/src/lib/service/ServicesList.spec.ts
@@ -104,13 +104,13 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   });
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.kubernetesDeleteService).toHaveBeenCalled());

--- a/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.spec.ts
+++ b/packages/renderer/src/lib/task-manager/button/TaskManagerBulkDeleteButton.spec.ts
@@ -70,7 +70,7 @@ beforeEach(() => {
 
 test('Expect bulk button is bringing confirmation but not deleting anything', async () => {
   // return No for the confirmation
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   render(TaskManagerBulkDeleteButton, { title, bulkOperationTitle });
   // expect the button is there
@@ -92,7 +92,7 @@ test('Expect bulk button is bringing confirmation but not deleting anything', as
 
 test('Expect delete is called after confirming', async () => {
   // return Yes for the confirmation
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
   render(TaskManagerBulkDeleteButton, { title, bulkOperationTitle });
   // expect the button is there

--- a/packages/renderer/src/lib/task-manager/table/action/TaskManagerActionsCancel.spec.ts
+++ b/packages/renderer/src/lib/task-manager/table/action/TaskManagerActionsCancel.spec.ts
@@ -61,7 +61,7 @@ const inProgressCancellableTask: TaskInfoUI = {
 
 test('Expect cancellable action being displayed if cancellable', async () => {
   // return Yes for the confirmation
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel Task' });
 
   render(TaskManagerActionsCancel, { task: inProgressCancellableTask });
   const cancelButton = screen.getByRole('button', { name: 'Cancel task' });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -33,7 +33,7 @@ beforeAll(() => {
 });
 
 test('Check cleanupProviders is called and button is in progress', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean Up' });
 
   render(TroubleshootingRepairCleanup);
 
@@ -75,7 +75,7 @@ test('Check cleanupProviders is called and button is in progress', async () => {
 });
 
 test('Check errors are displayed with clipboard button', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean Up' });
 
   render(TroubleshootingRepairCleanup);
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
@@ -27,7 +27,7 @@ async function openCleanupDialog(): Promise<void> {
     buttons: ['Clean Up', 'Cancel'],
   });
 
-  if (result?.response === 0) {
+  if (result?.response === 'Clean Up') {
     await cleanup();
   }
 }

--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -50,7 +50,7 @@ beforeAll(() => {
 test('Expect prompt dialog and deletion', async () => {
   vi.mocked(window.getContributedMenus).mockResolvedValue([]);
   // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
   const volume: VolumeInfoUI = new VolumeInfoUIImpl('dummy', 'UNUSED') as unknown as VolumeInfoUI;
 

--- a/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeDetails.spec.ts
@@ -61,7 +61,7 @@ beforeAll(() => {
 
 test('Expect redirect to previous page if volume is deleted', async () => {
   // Mock the showMessageBox to return 0 (yes)
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   const routerGotoSpy = vi.spyOn(router, 'goto');
   listVolumesMock.mockResolvedValue([myVolume]);
   window.dispatchEvent(new CustomEvent('extensions-already-started'));

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -376,14 +376,14 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
   (window as any).showMessageBox = vi.fn();
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 1 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
   await fireEvent.click(deleteButton);
 
   expect(window.showMessageBox).toHaveBeenCalledOnce();
 
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   await fireEvent.click(deleteButton);
   expect(window.showMessageBox).toHaveBeenCalledTimes(2);
   await vi.waitFor(() => expect(window.removeVolume).toHaveBeenCalled());


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Changes `MessageBoxReturnValue.response` from a numeric button index (`number | undefined`) to the clicked button's label (`string | undefined`).

Before:
```typescript
const result = await messageBox.showMessageBox({
  buttons: ['Allow', 'Deny'],
});
if (result.response === 0) { /* Allow */ }
```

After:
```typescript
const result = await messageBox.showMessageBox({
  buttons: ['Allow', 'Deny'],
});
if (result.response === 'Allow') { /* Allow */ }
```

This makes `MessageBox` consistent with the extension API's `window.showInformationMessage` / `showWarningMessage`, which already return the button **value** (string). It also makes call sites more robust — reordering buttons no longer silently breaks logic — and more readable.

**Changes:**
- Updated `MessageBoxReturnValue` type in `packages/api/src/dialog.ts`
- Updated `MessageBox` implementation to resolve button labels instead of indices
- Updated all call sites across main process (`authentication.ts`, `updater.ts`, `index.ts`, `experimental-feature-feedback-handler.ts`) and renderer (`messagebox-utils.ts`, `Prune.svelte`, `SendFeedback.svelte`, `PreferencesRegistriesEditing.svelte`, `ExtensionBanner.svelte`, `PreferencesCliTool.svelte`, `PreferencesKubernetesContextsRendering.svelte`, `TroubleshootingRepairCleanup.svelte`)
- Updated all tests

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/17637

### How to test this PR?

- Start the app with `pnpm watch` and verify dialogs still work:
- Open an external link → confirm the Open / Copy Link / Cancel dialog works
- Delete a container/pod/volume → confirm the delete confirmation dialog works
- Check for updates (if available) → confirm the update dialog works
- Try signing in/out of an authentication provider if configured

- [x] Tests are covering the bug fix or the new feature
