### PR TITLE
feat(podman): add error property support

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -2062,6 +2062,110 @@ test('provider is registered without edit capabilities on Linux', async () => {
   expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_MACHINE_EDIT_DISK_SIZE, false);
 });
 
+describe('connection error property on lifecycle methods', () => {
+  let registeredConnection: ContainerProviderConnection | undefined;
+  const spySetup = () => {
+    extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+    vi.mocked(provider.registerContainerProviderConnection).mockImplementation(connection => {
+      registeredConnection = connection;
+      return Disposable.from({ dispose: () => {} });
+    });
+  };
+
+  const registerConnection = async () => {
+    const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+    spyExecPromise.mockImplementation(
+      (_command, args) =>
+        new Promise<extensionApi.RunResult>((resolve, reject) => {
+          if (args?.[0] === 'machine' && args?.[1] === 'list') {
+            resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
+          } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
+            resolve({
+              stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Rootful: true }]),
+            } as extensionApi.RunResult);
+          } else {
+            reject(new Error('command failed'));
+          }
+        }),
+    );
+    await extension.registerProviderFor(provider, podmanConfiguration, machineInfo, 'socket');
+    return spyExecPromise;
+  };
+
+  test('start lifecycle clears error on success', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    spySetup();
+    await registerConnection();
+    expect(registeredConnection).toBeDefined();
+
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+    registeredConnection!.error = 'previous error';
+    await registeredConnection?.lifecycle?.start?.({} as extensionApi.LifecycleContext);
+    expect(registeredConnection!.error).toBeUndefined();
+  });
+
+  test('start lifecycle sets error on failure', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    spySetup();
+    await registerConnection();
+    expect(registeredConnection).toBeDefined();
+
+    vi.spyOn(extensionApi.process, 'exec').mockRejectedValue(new Error('start failed'));
+    await expect(registeredConnection?.lifecycle?.start?.({} as extensionApi.LifecycleContext)).rejects.toThrow(
+      'start failed',
+    );
+    expect(registeredConnection!.error).toBe('start failed');
+  });
+
+  test('stop lifecycle clears error on success', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    spySetup();
+    await registerConnection();
+    expect(registeredConnection).toBeDefined();
+
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+    registeredConnection!.error = 'previous error';
+    await registeredConnection?.lifecycle?.stop?.({} as extensionApi.LifecycleContext);
+    expect(registeredConnection!.error).toBeUndefined();
+  });
+
+  test('stop lifecycle sets error on failure', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    spySetup();
+    await registerConnection();
+    expect(registeredConnection).toBeDefined();
+
+    vi.spyOn(extensionApi.process, 'exec').mockRejectedValue(new Error('stop failed'));
+    await expect(registeredConnection?.lifecycle?.stop?.({} as extensionApi.LifecycleContext)).rejects.toThrow(
+      'stop failed',
+    );
+    expect(registeredConnection!.error).toBe('stop failed');
+  });
+
+  test('delete lifecycle clears error on success', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    spySetup();
+    await registerConnection();
+    expect(registeredConnection).toBeDefined();
+
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+    registeredConnection!.error = 'previous error';
+    await registeredConnection?.lifecycle?.delete?.();
+    expect(registeredConnection!.error).toBeUndefined();
+  });
+
+  test('delete lifecycle sets error on failure', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    spySetup();
+    await registerConnection();
+    expect(registeredConnection).toBeDefined();
+
+    vi.spyOn(extensionApi.process, 'exec').mockRejectedValue(new Error('delete failed'));
+    await expect(registeredConnection?.lifecycle?.delete?.()).rejects.toThrow('delete failed');
+    expect(registeredConnection!.error).toBe('delete failed');
+  });
+});
+
 test('Even with getJSONMachineList erroring, do not show setup notification on Linux', async () => {
   vi.mocked(extensionApi.env).isLinux = true;
   vi.spyOn(extensionApi.process, 'exec').mockRejectedValue({

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -759,15 +759,33 @@ export async function registerProviderFor(
 
   const lifecycle: extensionApi.ProviderConnectionLifecycle = {
     start: async (context, logger): Promise<void> => {
-      await startMachine(provider, podmanConfiguration, machineInfo, context, logger, undefined, false);
+      try {
+        await startMachine(provider, podmanConfiguration, machineInfo, context, logger, undefined, false);
+        containerProviderConnection.error = undefined;
+      } catch (err) {
+        containerProviderConnection.error = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
     },
     stop: async (context, logger): Promise<void> => {
-      await stopMachine(provider, machineInfo, context, logger);
+      try {
+        await stopMachine(provider, machineInfo, context, logger);
+        containerProviderConnection.error = undefined;
+      } catch (err) {
+        containerProviderConnection.error = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
     },
     delete: async (logger): Promise<void> => {
-      await execPodman(['machine', 'rm', '-f', machineInfo.name], machineInfo.vmType, {
-        logger,
-      });
+      try {
+        await execPodman(['machine', 'rm', '-f', machineInfo.name], machineInfo.vmType, {
+          logger,
+        });
+        containerProviderConnection.error = undefined;
+      } catch (err) {
+        containerProviderConnection.error = err instanceof Error ? err.message : String(err);
+        throw err;
+      }
     },
   };
   // support edit only on MacOS and Windows with limited editing capabilities for HyperV and WSL machines
@@ -807,6 +825,10 @@ export async function registerProviderFor(
           if (isRootful !== undefined) {
             telemetryLogger.logUsage('podman.machine.edit.rootful', { isRootful });
           }
+          containerProviderConnection.error = undefined;
+        } catch (err) {
+          containerProviderConnection.error = err instanceof Error ? err.message : String(err);
+          throw err;
         } finally {
           if (state === 'started') {
             await lifecycle.start?.(context, logger);


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Sets the `error` property on the Podman extension's `ContainerProviderConnection` during lifecycle operations (`start`, `stop`, `delete`, `edit`). On success the error is cleared; on failure it is set to the error message. This follows the pattern already established by the Kind extension.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/17223
Related to https://github.com/podman-desktop/podman-desktop/issues/17222

### How to test this PR?

1. Simulate a lifecycle error (e.g. corrupt a machine or force `podman machine start` to fail)
2. Observe the error indicator appears on the connection in the Resources page
3. Successfully start/stop the machine and confirm the error indicator clears

- [x] Tests are covering the bug fix or the new feature
