### PR TITLE
chore(logging): show stderr in exec output by default

### DIFF
--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -585,6 +585,32 @@ describe('exec', () => {
     expect(stdout).toContain('Hello, World!');
     expect(setEncodingMock).toBeCalledWith('utf16le');
   });
+
+  test('should include stderr in error message on non-zero exit code', async () => {
+    const command = 'failing-cmd';
+
+    const stdoutOn = vi
+      .fn()
+      .mockImplementation((_event: string, _cb: (arg0: string) => void) => {}) as unknown as Readable;
+    const stderrOn = vi.fn().mockImplementation((event: string, cb: (arg0: string) => void) => {
+      if (event === 'data') {
+        cb('permission denied');
+      }
+    }) as unknown as Readable;
+    vi.mocked(spawn).mockReturnValue({
+      stdout: { on: stdoutOn, setEncoding: setEncodingMock },
+      stderr: { on: stderrOn, setEncoding: setEncodingMock },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'close') {
+          cb(1);
+        }
+      }),
+    } as unknown as ChildProcess);
+
+    await expect(exec.exec(command)).rejects.toThrowError(
+      'Command execution failed with exit code 1: permission denied',
+    );
+  });
 });
 
 describe('getInstallationPath', () => {

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -241,14 +241,18 @@ export class Exec {
           };
           resolve(result);
         } else {
-          options?.logger?.error(`Command execution failed with exit code ${exitCode}`);
+          const stderr = output.stderr.trim();
+          const message = stderr
+            ? `Command execution failed with exit code ${exitCode}: ${stderr}`
+            : `Command execution failed with exit code ${exitCode}`;
+          options?.logger?.error(message);
           const errResult: RunError = new RunErrorImpl(
-            `Command execution failed with exit code ${exitCode}`,
-            `Command execution failed with exit code ${exitCode}`,
+            message,
+            message,
             exitCode ?? 1,
             command,
             output.stdout.trim(),
-            output.stderr.trim(),
+            stderr,
             false,
             childProcess.killed,
           );


### PR DESCRIPTION
chore(logging): show stderr in exec output by default

### What does this PR do?

In our exec error output, we just get the exit code, which does not
provide a lot of information, instead, we should be showing stderr.

Instead of:
```
main ↪️  [bootc] Error: Command execution failed with exit code 125
```

for example, with bootc exec, we now get:

```
  main ↪️  [bootc] Error: Command execution failed with exit code 125: machine did not transition
  into running state: ssh error: ssh: handshake failed: ssh: unable to authenticate, attempted
  methods [none publickey], no supported methods remain
```

Which gives more information on why our command had failed.

### Screenshot / video of UI

N/A, no changes to UI, more just for log output.

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/8321

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature

1. Purposely from an extension, trigger a command that will fail (try to
   start kind, start a VM on bootc without proper credentials, etc.)
2. See that now you have more information than just an error exit code
   125.

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
