### PR TITLE
test(e2e): skip cross-arch and docker tests on RHEL in CI

### DIFF
--- a/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
+++ b/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
@@ -23,7 +23,7 @@ import { ResourcesPage } from '/@/model/pages/resources-page';
 import { SettingsBar } from '/@/model/pages/settings-bar';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { createPodmanMachineFromCLI, setDockerCompatibilityFeature } from '/@/utility/operations';
-import { isWindows } from '/@/utility/platform';
+import { isCI, isRHEL, isWindows } from '/@/utility/platform';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const defaultMachine = 'Podman Machine';
@@ -45,6 +45,7 @@ test.afterAll(async ({ runner, page }) => {
 
 //Feature unstable on mac and linux atm
 test.skip(!isWindows, 'Testing only on Windows');
+test.skip(!!isCI && isRHEL, 'Docker Engine is not officially supported on RHEL');
 
 test.describe
   .serial('Verify docker compatibility feature', { tag: '@smoke' }, () => {

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -31,7 +31,7 @@ import { NavigationBar } from '/@/model/workbench/navigation';
 import { canTestRegistry, setupRegistry } from '/@/setupFiles/setup-registry';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { deleteImage, deleteRegistry, ensureNoImagesPresentCLI } from '/@/utility/operations';
-import { archType, isWindows } from '/@/utility/platform';
+import { archType, isCI, isRHEL, isWindows } from '/@/utility/platform';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const architectures: string[] = [ArchitectureType.AMD64, ArchitectureType.ARM64];
@@ -49,6 +49,11 @@ let registryUrl: string;
 let registryUsername: string;
 let registryPswdSecret: string;
 const manifestLabelComplex: string = `localhost/${imageNameComplex}`;
+
+test.skip(
+  !!isCI && isRHEL,
+  'Cross-architecture image builds are not supported on RHEL — qemu-user-static is unavailable',
+);
 
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   test.setTimeout(180_000);

--- a/tests/playwright/src/utility/platform.ts
+++ b/tests/playwright/src/utility/platform.ts
@@ -25,3 +25,4 @@ export const archType = os.arch();
 
 // powershell $true value is 'True', we need to make it a lowercase first
 export const isCI = String(process.env.CI).toLowerCase() === 'true';
+export const isRHEL = String(process.env.IS_RHEL).toLowerCase() === 'true';

--- a/tests/playwright/src/utility/platform.ts
+++ b/tests/playwright/src/utility/platform.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import * as fs from 'node:fs';
 import * as os from 'node:os';
 
 export const isLinux = os.platform() === 'linux';
@@ -25,4 +26,16 @@ export const archType = os.arch();
 
 // powershell $true value is 'True', we need to make it a lowercase first
 export const isCI = String(process.env.CI).toLowerCase() === 'true';
-export const isRHEL = String(process.env.IS_RHEL).toLowerCase() === 'true';
+
+function detectRHEL(): boolean {
+  if (os.platform() !== 'linux') return false;
+  try {
+    // eslint-disable-next-line n/no-sync
+    const content = fs.readFileSync('/etc/os-release', 'utf-8');
+    return /^ID="?rhel"?$/m.test(content);
+  } catch {
+    return false;
+  }
+}
+
+export const isRHEL = detectRHEL();


### PR DESCRIPTION
# What does this PR do?
- Adds`isRHEL` platform detection utility using `IS_RHEL` environment variable
- Skips cross-architecture image build tests on RHEL CI (qemu-user-static is unavailable)
- Skips docker compatibility tests on RHEL CI (Docker Engine is not officially supported)

# What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-internal/issues/963


🤖 Generated with [Claude Code](https://claude.com/claude-code)