### PR TITLE
chore: use GitHub auth for Octokit instances

### DIFF
--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -21,31 +21,28 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
-import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ComposeGitHubReleases } from './compose-github-releases';
 
 vi.mock(import('node:fs'));
 
-vi.mock(import('@octokit/rest'), () => {
-  const Octokit = vi.fn();
-  Octokit.prototype.repos = {
+const mockOctokit = {
+  repos: {
     listReleases: vi.fn(),
     getReleaseAsset: vi.fn(),
-  };
-  Octokit.prototype.paginate = vi.fn();
-  return { Octokit } as any;
-});
+  },
+  paginate: vi.fn(),
+};
 
-vi.mock(import('@podman-desktop/api'));
+const mockOctokitFactory = vi.fn();
 
 let composeGitHubReleases: ComposeGitHubReleases;
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  composeGitHubReleases = new ComposeGitHubReleases();
+  vi.resetAllMocks();
+  mockOctokitFactory.mockResolvedValue(mockOctokit);
+  composeGitHubReleases = new ComposeGitHubReleases(mockOctokitFactory);
 });
 
 afterEach(() => {
@@ -53,26 +50,12 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test.each([
-  {
-    id: 'session1',
-    accessToken: '12345ABC',
-    account: {
-      id: 'account1',
-      label: 'Account 1',
-    },
-    scopes: [],
-  },
-  undefined,
-])('Auth token is passed to Octokit instance from github-authentication if there is one', async authToken => {
-  vi.mocked(extensionApi.authentication.getSession).mockResolvedValue(authToken);
-
-  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: [] });
+test('Auth token is passed to Octokit factory', async () => {
+  mockOctokit.repos.listReleases.mockResolvedValue({ data: [] });
 
   await composeGitHubReleases.grabLatestsReleasesMetadata();
 
-  expect(extensionApi.authentication.getSession).toHaveBeenCalledWith('github-authentication', []);
-  expect(Octokit).toHaveBeenCalledWith({ auth: authToken?.accessToken });
+  expect(mockOctokitFactory).toHaveBeenCalled();
 });
 
 test('expect grab 5 releases', async () => {
@@ -84,7 +67,7 @@ test('expect grab 5 releases', async () => {
     fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/compose-github-release-all.json'), 'utf8'),
   );
 
-  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
+  mockOctokit.repos.listReleases.mockResolvedValue({ data: resultREST });
 
   const result = await composeGitHubReleases.grabLatestsReleasesMetadata();
   expect(result).toBeDefined();
@@ -132,7 +115,7 @@ describe.each([
     // mock the result of listReleaseAssetsMock REST API
     const resultREST = JSON.parse(fsActual.readFileSync(path.resolve(__dirname, resource), 'utf8'));
 
-    vi.mocked((Octokit.prototype as any).paginate).mockReturnValue(resultREST);
+    mockOctokit.paginate.mockResolvedValue(resultREST);
   });
 
   test('macOS x86_64', async () => {
@@ -179,7 +162,7 @@ describe.each([
 });
 
 test('should download the file if parent folder does exist', async () => {
-  vi.mocked((Octokit.prototype as any).repos.getReleaseAsset).mockReturnValue({ data: 'foo' });
+  mockOctokit.repos.getReleaseAsset.mockResolvedValue({ data: 'foo' });
 
   // mock fs
   const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -197,7 +180,7 @@ test('should download the file if parent folder does exist', async () => {
 });
 
 test('should download the file if parent folder does not exist', async () => {
-  vi.mocked((Octokit.prototype as any).repos.getReleaseAsset).mockReturnValue({ data: 'foo' });
+  mockOctokit.repos.getReleaseAsset.mockResolvedValue({ data: 'foo' });
 
   // mock fs
   const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -19,29 +19,37 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import type { Octokit } from '@octokit/rest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ComposeGitHubReleases } from './compose-github-releases';
+import { Octokit } from '@octokit/rest';
 
 vi.mock(import('node:fs'));
 
+
+vi.mock(import('@octokit/rest'), () => {
+  const Octokit = vi.fn();
+  Octokit.prototype.repos = {
+    listReleases: vi.fn(),
+    getReleaseAsset: vi.fn(),
+  };
+  Octokit.prototype.paginate = vi.fn();
+  return { Octokit } as any;
+});
+
+vi.mock(import('@podman-desktop/api'), () => {
+  return {
+    authentication: {
+      getSession: vi.fn().mockResolvedValue({ accessToken: 'test-token' }),
+    },
+  } as any;
+});
+
 let composeGitHubReleases: ComposeGitHubReleases;
 
-const listReleaseAssetsMock = vi.fn();
-const listReleasesMock = vi.fn();
-const getReleaseAssetMock = vi.fn();
-const octokitMock: Octokit = {
-  repos: {
-    listReleases: listReleasesMock,
-    listReleaseAssets: listReleaseAssetsMock,
-    getReleaseAsset: getReleaseAssetMock,
-  },
-  paginate: vi.fn(),
-} as unknown as Octokit;
-
 beforeEach(() => {
-  composeGitHubReleases = new ComposeGitHubReleases(octokitMock);
+  vi.clearAllMocks();
+  composeGitHubReleases = new ComposeGitHubReleases();
 });
 
 afterEach(() => {
@@ -57,7 +65,8 @@ test('expect grab 5 releases', async () => {
   const resultREST = JSON.parse(
     fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/compose-github-release-all.json'), 'utf8'),
   );
-  listReleasesMock.mockReturnValue({ data: resultREST });
+
+  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
 
   const result = await composeGitHubReleases.grabLatestsReleasesMetadata();
   expect(result).toBeDefined();
@@ -105,7 +114,7 @@ describe.each([
     // mock the result of listReleaseAssetsMock REST API
     const resultREST = JSON.parse(fsActual.readFileSync(path.resolve(__dirname, resource), 'utf8'));
 
-    vi.mocked(octokitMock.paginate).mockReturnValue(resultREST);
+    vi.mocked((Octokit.prototype as any).paginate).mockReturnValue(resultREST);
   });
 
   test('macOS x86_64', async () => {
@@ -152,7 +161,7 @@ describe.each([
 });
 
 test('should download the file if parent folder does exist', async () => {
-  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
+  vi.mocked((Octokit.prototype as any).repos.getReleaseAsset).mockReturnValue({ data: 'foo' });
 
   // mock fs
   const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -170,7 +179,7 @@ test('should download the file if parent folder does exist', async () => {
 });
 
 test('should download the file if parent folder does not exist', async () => {
-  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
+  vi.mocked((Octokit.prototype as any).repos.getReleaseAsset).mockReturnValue({ data: 'foo' });
 
   // mock fs
   const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -16,16 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { Octokit } from '@octokit/rest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ComposeGitHubReleases } from './compose-github-releases';
-import { Octokit } from '@octokit/rest';
 
 vi.mock(import('node:fs'));
-
 
 vi.mock(import('@octokit/rest'), () => {
   const Octokit = vi.fn();

--- a/extensions/compose/src/compose-github-releases.spec.ts
+++ b/extensions/compose/src/compose-github-releases.spec.ts
@@ -22,6 +22,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { Octokit } from '@octokit/rest';
+import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ComposeGitHubReleases } from './compose-github-releases';
@@ -38,13 +39,7 @@ vi.mock(import('@octokit/rest'), () => {
   return { Octokit } as any;
 });
 
-vi.mock(import('@podman-desktop/api'), () => {
-  return {
-    authentication: {
-      getSession: vi.fn().mockResolvedValue({ accessToken: 'test-token' }),
-    },
-  } as any;
-});
+vi.mock(import('@podman-desktop/api'));
 
 let composeGitHubReleases: ComposeGitHubReleases;
 
@@ -56,6 +51,28 @@ beforeEach(() => {
 afterEach(() => {
   vi.resetAllMocks();
   vi.restoreAllMocks();
+});
+
+test.each([
+  {
+    id: 'session1',
+    accessToken: '12345ABC',
+    account: {
+      id: 'account1',
+      label: 'Account 1',
+    },
+    scopes: [],
+  },
+  undefined,
+])('Auth token is passed to Octokit instance from github-authentication if there is one', async authToken => {
+  vi.mocked(extensionApi.authentication.getSession).mockResolvedValue(authToken);
+
+  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: [] });
+
+  await composeGitHubReleases.grabLatestsReleasesMetadata();
+
+  expect(extensionApi.authentication.getSession).toHaveBeenCalledWith('github-authentication', []);
+  expect(Octokit).toHaveBeenCalledWith({ auth: authToken?.accessToken });
 });
 
 test('expect grab 5 releases', async () => {

--- a/extensions/compose/src/compose-github-releases.ts
+++ b/extensions/compose/src/compose-github-releases.ts
@@ -19,8 +19,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import type { Octokit } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import type { QuickPickItem } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
 
 export interface ComposeGithubReleaseArtifactMetadata extends QuickPickItem {
   tag: string;
@@ -31,15 +32,22 @@ export interface ComposeGithubReleaseArtifactMetadata extends QuickPickItem {
 export class ComposeGitHubReleases {
   private static readonly COMPOSE_GITHUB_OWNER = 'docker';
   private static readonly COMPOSE_GITHUB_REPOSITORY = 'compose';
+  private octokit?: Octokit;
 
-  constructor(private readonly octokit: Octokit) {}
+  private async ensureOctokit(): Promise<void> {
+    if (!this.octokit) {
+      const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
+      this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
+    }
+  }
 
   // Provides last 5 majors releases from GitHub using the GitHub API
   // return name, tag and id of the release
   async grabLatestsReleasesMetadata(): Promise<ComposeGithubReleaseArtifactMetadata[]> {
     // Grab last 5 majors releases from GitHub using the GitHub API
+    await this.ensureOctokit();
 
-    const lastReleases = await this.octokit.repos.listReleases({
+    const lastReleases = await this.octokit!.repos.listReleases({
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
     });
@@ -63,6 +71,8 @@ export class ComposeGitHubReleases {
   // operatingSystem: win32, darwin, linux (see os.platform())
   // arch: x64, arm64 (see os.arch())
   async getReleaseAssetId(releaseId: number, operatingSystem: string, arch: string): Promise<number> {
+    await this.ensureOctokit();
+
     let extension = '';
     if (operatingSystem === 'win32') {
       operatingSystem = 'windows';
@@ -75,7 +85,7 @@ export class ComposeGitHubReleases {
       arch = 'aarch64';
     }
 
-    const listOfAssets = await this.octokit.paginate(this.octokit.repos.listReleaseAssets, {
+    const listOfAssets = await this.octokit!.paginate(this.octokit!.repos.listReleaseAssets, {
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
       release_id: releaseId,
@@ -94,7 +104,9 @@ export class ComposeGitHubReleases {
 
   // download the given asset id
   async downloadReleaseAsset(assetId: number, destination: string): Promise<void> {
-    const asset = await this.octokit.repos.getReleaseAsset({
+    await this.ensureOctokit();
+
+    const asset = await this.octokit!.repos.getReleaseAsset({
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
       asset_id: assetId,

--- a/extensions/compose/src/compose-github-releases.ts
+++ b/extensions/compose/src/compose-github-releases.ts
@@ -19,9 +19,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
+import type { Octokit } from '@octokit/rest';
 import type { QuickPickItem } from '@podman-desktop/api';
-import * as extensionApi from '@podman-desktop/api';
 
 export interface ComposeGithubReleaseArtifactMetadata extends QuickPickItem {
   tag: string;
@@ -32,13 +31,15 @@ export interface ComposeGithubReleaseArtifactMetadata extends QuickPickItem {
 export class ComposeGitHubReleases {
   private static readonly COMPOSE_GITHUB_OWNER = 'docker';
   private static readonly COMPOSE_GITHUB_REPOSITORY = 'compose';
+  private octokitFactory: () => Promise<Octokit>;
   private octokit?: Octokit;
 
+  constructor(octokitFactory: () => Promise<Octokit>) {
+    this.octokitFactory = octokitFactory;
+  }
+
   private async ensureOctokit(): Promise<Octokit> {
-    if (!this.octokit) {
-      const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
-      this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
-    }
+    this.octokit ??= await this.octokitFactory();
     return this.octokit;
   }
 

--- a/extensions/compose/src/compose-github-releases.ts
+++ b/extensions/compose/src/compose-github-releases.ts
@@ -47,7 +47,11 @@ export class ComposeGitHubReleases {
     // Grab last 5 majors releases from GitHub using the GitHub API
     await this.ensureOctokit();
 
-    const lastReleases = await this.octokit!.repos.listReleases({
+    if (!this.octokit) {
+      throw new Error('Octokit instance not initialized');
+    }
+
+    const lastReleases = await this.octokit.repos.listReleases({
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
     });
@@ -73,6 +77,10 @@ export class ComposeGitHubReleases {
   async getReleaseAssetId(releaseId: number, operatingSystem: string, arch: string): Promise<number> {
     await this.ensureOctokit();
 
+    if (!this.octokit) {
+      throw new Error('Octokit instance not initialized');
+    }
+
     let extension = '';
     if (operatingSystem === 'win32') {
       operatingSystem = 'windows';
@@ -85,7 +93,7 @@ export class ComposeGitHubReleases {
       arch = 'aarch64';
     }
 
-    const listOfAssets = await this.octokit!.paginate(this.octokit!.repos.listReleaseAssets, {
+    const listOfAssets = await this.octokit.paginate(this.octokit.repos.listReleaseAssets, {
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
       release_id: releaseId,
@@ -106,7 +114,11 @@ export class ComposeGitHubReleases {
   async downloadReleaseAsset(assetId: number, destination: string): Promise<void> {
     await this.ensureOctokit();
 
-    const asset = await this.octokit!.repos.getReleaseAsset({
+    if (!this.octokit) {
+      throw new Error('Octokit instance not initialized');
+    }
+
+    const asset = await this.octokit.repos.getReleaseAsset({
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
       asset_id: assetId,

--- a/extensions/compose/src/compose-github-releases.ts
+++ b/extensions/compose/src/compose-github-releases.ts
@@ -34,24 +34,21 @@ export class ComposeGitHubReleases {
   private static readonly COMPOSE_GITHUB_REPOSITORY = 'compose';
   private octokit?: Octokit;
 
-  private async ensureOctokit(): Promise<void> {
+  private async ensureOctokit(): Promise<Octokit> {
     if (!this.octokit) {
       const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
       this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
     }
+    return this.octokit;
   }
 
   // Provides last 5 majors releases from GitHub using the GitHub API
   // return name, tag and id of the release
   async grabLatestsReleasesMetadata(): Promise<ComposeGithubReleaseArtifactMetadata[]> {
     // Grab last 5 majors releases from GitHub using the GitHub API
-    await this.ensureOctokit();
+    const octokit = await this.ensureOctokit();
 
-    if (!this.octokit) {
-      throw new Error('Octokit instance not initialized');
-    }
-
-    const lastReleases = await this.octokit.repos.listReleases({
+    const lastReleases = await octokit.repos.listReleases({
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
     });
@@ -75,11 +72,7 @@ export class ComposeGitHubReleases {
   // operatingSystem: win32, darwin, linux (see os.platform())
   // arch: x64, arm64 (see os.arch())
   async getReleaseAssetId(releaseId: number, operatingSystem: string, arch: string): Promise<number> {
-    await this.ensureOctokit();
-
-    if (!this.octokit) {
-      throw new Error('Octokit instance not initialized');
-    }
+    const octokit = await this.ensureOctokit();
 
     let extension = '';
     if (operatingSystem === 'win32') {
@@ -93,7 +86,7 @@ export class ComposeGitHubReleases {
       arch = 'aarch64';
     }
 
-    const listOfAssets = await this.octokit.paginate(this.octokit.repos.listReleaseAssets, {
+    const listOfAssets = await octokit.paginate(octokit.repos.listReleaseAssets, {
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
       release_id: releaseId,
@@ -112,13 +105,9 @@ export class ComposeGitHubReleases {
 
   // download the given asset id
   async downloadReleaseAsset(assetId: number, destination: string): Promise<void> {
-    await this.ensureOctokit();
+    const octokit = await this.ensureOctokit();
 
-    if (!this.octokit) {
-      throw new Error('Octokit instance not initialized');
-    }
-
-    const asset = await this.octokit.repos.getReleaseAsset({
+    const asset = await octokit.repos.getReleaseAsset({
       owner: ComposeGitHubReleases.COMPOSE_GITHUB_OWNER,
       repo: ComposeGitHubReleases.COMPOSE_GITHUB_REPOSITORY,
       asset_id: assetId,

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { Octokit } from '@octokit/rest';
 import type { Logger, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 
@@ -68,7 +69,13 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Create new classes to handle the onboarding sequence
   const detect = new Detect(os, extensionContext.storagePath);
 
-  const composeGitHubReleases = new ComposeGitHubReleases();
+  // Create the Octokit factory for GitHub authentication
+  const octokitFactory = async (): Promise<Octokit> => {
+    const auth = await extensionApi.authentication.getSession('github-authentication', []);
+    return new Octokit({ auth: auth?.accessToken });
+  };
+
+  const composeGitHubReleases = new ComposeGitHubReleases(octokitFactory);
   const composeDownload = new ComposeDownload(extensionContext, composeGitHubReleases, os);
 
   // Need to "ADD" a provider so we can actually press the button!

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -19,7 +19,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
 import type { Logger, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 
@@ -67,10 +66,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   handler.handleConfigurationChanges(extensionContext);
 
   // Create new classes to handle the onboarding sequence
-  const octokit = new Octokit();
   const detect = new Detect(os, extensionContext.storagePath);
 
-  const composeGitHubReleases = new ComposeGitHubReleases(octokit);
+  const composeGitHubReleases = new ComposeGitHubReleases();
   const composeDownload = new ComposeDownload(extensionContext, composeGitHubReleases, os);
 
   // Need to "ADD" a provider so we can actually press the button!

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { Octokit } from '@octokit/rest';
 import type { AuditRequestItems, CancellationToken, CliTool, Logger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { window } from '@podman-desktop/api';
@@ -457,7 +458,13 @@ async function registerCliTool(
   extensionContext: extensionApi.ExtensionContext,
   telemetryLogger: extensionApi.TelemetryLogger,
 ): Promise<void> {
-  installer = new KindInstaller(extensionContext.storagePath, telemetryLogger);
+  // Create the Octokit factory for GitHub authentication
+  const octokitFactory = async (): Promise<Octokit> => {
+    const auth = await extensionApi.authentication.getSession('github-authentication', []);
+    return new Octokit({ auth: auth?.accessToken });
+  };
+
+  installer = new KindInstaller(extensionContext.storagePath, telemetryLogger, octokitFactory);
 
   let binary: { path: string; version: string } | undefined = undefined;
   let installationSource: extensionApi.CliToolInstallationSource | undefined;

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -19,7 +19,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
 import type { AuditRequestItems, CancellationToken, CliTool, Logger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import { window } from '@podman-desktop/api';
@@ -458,8 +457,7 @@ async function registerCliTool(
   extensionContext: extensionApi.ExtensionContext,
   telemetryLogger: extensionApi.TelemetryLogger,
 ): Promise<void> {
-  const octokit = new Octokit();
-  installer = new KindInstaller(extensionContext.storagePath, telemetryLogger, octokit);
+  installer = new KindInstaller(extensionContext.storagePath, telemetryLogger);
 
   let binary: { path: string; version: string } | undefined = undefined;
   let installationSource: extensionApi.CliToolInstallationSource | undefined;

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -68,6 +68,28 @@ beforeEach(async () => {
   (extensionApi.env.isMac as unknown as boolean) = false;
 });
 
+test.each([
+  {
+    id: 'session1',
+    accessToken: '12345ABC',
+    account: {
+      id: 'account1',
+      label: 'Account 1',
+    },
+    scopes: [],
+  },
+  undefined,
+])('Auth token is passed to Octokit instance from github-authentication if there is one', async authToken => {
+  vi.mocked(extensionApi.authentication.getSession).mockResolvedValue(authToken);
+
+  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: [] });
+
+  await installer.grabLatestsReleasesMetadata();
+
+  expect(extensionApi.authentication.getSession).toHaveBeenCalledWith('github-authentication', []);
+  expect(Octokit).toHaveBeenCalledWith({ auth: authToken?.accessToken });
+});
+
 test.skip('expect installBinaryToSystem to succesfully pass with a binary', async () => {
   (extensionApi.env.isLinux as unknown as boolean) = true;
 

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -22,7 +22,6 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -40,16 +39,16 @@ vi.mock(import('node:os'), async () => {
   };
 });
 vi.mock(import('node:fs'));
-vi.mock(import('@octokit/rest'), () => {
-  const Octokit = vi.fn();
-  Octokit.prototype.repos = {
+
+const mockOctokit = {
+  repos: {
     listReleases: vi.fn(),
     listReleaseAssets: vi.fn(),
     getReleaseAsset: vi.fn(),
-  };
-  Octokit.prototype.paginate = vi.fn();
-  return { Octokit } as any;
-});
+  },
+};
+
+const mockOctokitFactory = vi.fn();
 
 const telemetryLogUsageMock = vi.fn();
 const telemetryLogErrorMock = vi.fn();
@@ -59,35 +58,21 @@ const telemetryLoggerMock = {
 } as unknown as extensionApi.TelemetryLogger;
 
 beforeEach(async () => {
-  vi.clearAllMocks();
-  installer = new KindInstaller('.', telemetryLoggerMock);
   vi.resetAllMocks();
+  mockOctokitFactory.mockResolvedValue(mockOctokit);
+  installer = new KindInstaller('.', telemetryLoggerMock, mockOctokitFactory);
 
   (extensionApi.env.isLinux as unknown as boolean) = false;
   (extensionApi.env.isWindows as unknown as boolean) = false;
   (extensionApi.env.isMac as unknown as boolean) = false;
 });
 
-test.each([
-  {
-    id: 'session1',
-    accessToken: '12345ABC',
-    account: {
-      id: 'account1',
-      label: 'Account 1',
-    },
-    scopes: [],
-  },
-  undefined,
-])('Auth token is passed to Octokit instance from github-authentication if there is one', async authToken => {
-  vi.mocked(extensionApi.authentication.getSession).mockResolvedValue(authToken);
-
-  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: [] });
+test('Auth token is passed to Octokit factory', async () => {
+  mockOctokit.repos.listReleases.mockResolvedValue({ data: [] });
 
   await installer.grabLatestsReleasesMetadata();
 
-  expect(extensionApi.authentication.getSession).toHaveBeenCalledWith('github-authentication', []);
-  expect(Octokit).toHaveBeenCalledWith({ auth: authToken?.accessToken });
+  expect(mockOctokitFactory).toHaveBeenCalled();
 });
 
 test.skip('expect installBinaryToSystem to succesfully pass with a binary', async () => {
@@ -117,7 +102,7 @@ describe('grabLatestsReleasesMetadata', () => {
     const resultREST = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
+    mockOctokit.repos.listReleases.mockResolvedValue({ data: resultREST });
     const releases = await installer.grabLatestsReleasesMetadata();
     expect(releases).toBeDefined();
     expect(releases.length).toBe(5);
@@ -133,7 +118,7 @@ describe('promptUserForVersion', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
+    mockOctokit.repos.listReleases.mockResolvedValue({ data: resultREST });
     const showQuickPickMock = vi.spyOn(extensionApi.window, 'showQuickPick').mockResolvedValue(resultREST[0]);
     const release = await installer.promptUserForVersion();
 
@@ -151,7 +136,7 @@ describe('promptUserForVersion', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
+    mockOctokit.repos.listReleases.mockResolvedValue({ data: resultREST });
     vi.spyOn(extensionApi.window, 'showQuickPick').mockResolvedValue(undefined);
     await expect(() => installer.promptUserForVersion()).rejects.toThrowError('No version selected');
   });
@@ -162,12 +147,12 @@ describe('getReleaseAssetId', () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     const fsActual = await vi.importActual<typeof import('node:fs')>('node:fs');
 
-    // mock the result of vi.mocked((Octokit.prototype as any).repos.listReleaseAssets) REST API
+    // mock the result of mockOctokit.repos.listReleaseAssets REST API
     const resultREST = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-assets.json'), 'utf8'),
     );
 
-    vi.mocked((Octokit.prototype as any).repos.listReleaseAssets).mockReturnValue({ data: resultREST });
+    mockOctokit.repos.listReleaseAssets.mockResolvedValue({ data: resultREST });
   });
 
   test('macOS x86_64', async () => {
@@ -232,12 +217,12 @@ describe('install', () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     const fsActual = await vi.importActual<typeof import('node:fs')>('node:fs');
 
-    // mock the result of vi.mocked((Octokit.prototype as any).repos.listReleaseAssets) REST API
+    // mock the result of mockOctokit.repos.listReleaseAssets REST API
     const resultREST = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-assets.json'), 'utf8'),
     );
 
-    vi.mocked((Octokit.prototype as any).repos.listReleaseAssets).mockReturnValue({ data: resultREST });
+    mockOctokit.repos.listReleaseAssets.mockResolvedValue({ data: resultREST });
   });
   test('should download file on win system', async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -247,7 +232,7 @@ describe('install', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
+    mockOctokit.repos.listReleases.mockResolvedValue({ data: resultREST });
     vi.mocked(os.platform).mockReturnValue('win32');
     vi.mocked(os.arch).mockReturnValue('x64');
 
@@ -268,7 +253,7 @@ describe('install', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
+    mockOctokit.repos.listReleases.mockResolvedValue({ data: resultREST });
     vi.mocked(os.platform).mockReturnValue('darwin');
     vi.mocked(os.arch).mockReturnValue('x64');
     vi.mocked(fs.existsSync).mockReturnValue(true);
@@ -282,7 +267,7 @@ describe('install', () => {
 
 describe('downloadReleaseAsset', () => {
   test('should download the file if parent folder does exist', async () => {
-    vi.mocked((Octokit.prototype as any).repos.getReleaseAsset).mockReturnValue({ data: 'foo' });
+    mockOctokit.repos.getReleaseAsset.mockResolvedValue({ data: 'foo' });
 
     // mock fs
     const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -300,7 +285,7 @@ describe('downloadReleaseAsset', () => {
   });
 
   test('should download the file if parent folder does not exist', async () => {
-    vi.mocked((Octokit.prototype as any).repos.getReleaseAsset).mockReturnValue({ data: 'foo' });
+    mockOctokit.repos.getReleaseAsset.mockResolvedValue({ data: 'foo' });
 
     // mock fs
     const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import type { Octokit } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -38,18 +38,16 @@ vi.mock(import('node:os'), async () => {
   };
 });
 vi.mock(import('node:fs'));
-
-const listReleasesMock = vi.fn();
-const listReleaseAssetsMock = vi.fn();
-const getReleaseAssetMock = vi.fn();
-
-const octokitMock: Octokit = {
-  repos: {
-    listReleases: listReleasesMock,
-    listReleaseAssets: listReleaseAssetsMock,
-    getReleaseAsset: getReleaseAssetMock,
-  },
-} as unknown as Octokit;
+vi.mock(import('@octokit/rest'), () => {
+  const Octokit = vi.fn();
+  Octokit.prototype.repos = {
+    listReleases: vi.fn(),
+    listReleaseAssets: vi.fn(),
+    getReleaseAsset: vi.fn(),
+  };
+  Octokit.prototype.paginate = vi.fn();
+  return { Octokit } as any;
+});
 
 const telemetryLogUsageMock = vi.fn();
 const telemetryLogErrorMock = vi.fn();
@@ -58,8 +56,9 @@ const telemetryLoggerMock = {
   logError: telemetryLogErrorMock,
 } as unknown as extensionApi.TelemetryLogger;
 
-beforeEach(() => {
-  installer = new KindInstaller('.', telemetryLoggerMock, octokitMock);
+beforeEach(async () => {
+  vi.clearAllMocks();
+  installer = new KindInstaller('.', telemetryLoggerMock);
   vi.resetAllMocks();
 
   (extensionApi.env.isLinux as unknown as boolean) = false;
@@ -94,7 +93,7 @@ describe('grabLatestsReleasesMetadata', () => {
     const resultREST = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockReturnValue({ data: resultREST });
+    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
     const releases = await installer.grabLatestsReleasesMetadata();
     expect(releases).toBeDefined();
     expect(releases.length).toBe(5);
@@ -110,7 +109,7 @@ describe('promptUserForVersion', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockReturnValue({ data: resultREST });
+    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
     const showQuickPickMock = vi.spyOn(extensionApi.window, 'showQuickPick').mockResolvedValue(resultREST[0]);
     const release = await installer.promptUserForVersion();
 
@@ -128,7 +127,7 @@ describe('promptUserForVersion', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockReturnValue({ data: resultREST });
+    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
     vi.spyOn(extensionApi.window, 'showQuickPick').mockResolvedValue(undefined);
     await expect(() => installer.promptUserForVersion()).rejects.toThrowError('No version selected');
   });
@@ -139,12 +138,12 @@ describe('getReleaseAssetId', () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     const fsActual = await vi.importActual<typeof import('node:fs')>('node:fs');
 
-    // mock the result of listReleaseAssetsMock REST API
+    // mock the result of vi.mocked((Octokit.prototype as any).repos.listReleaseAssets) REST API
     const resultREST = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-assets.json'), 'utf8'),
     );
 
-    listReleaseAssetsMock.mockReturnValue({ data: resultREST });
+    vi.mocked((Octokit.prototype as any).repos.listReleaseAssets).mockReturnValue({ data: resultREST });
   });
 
   test('macOS x86_64', async () => {
@@ -209,12 +208,12 @@ describe('install', () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     const fsActual = await vi.importActual<typeof import('node:fs')>('node:fs');
 
-    // mock the result of listReleaseAssetsMock REST API
+    // mock the result of vi.mocked((Octokit.prototype as any).repos.listReleaseAssets) REST API
     const resultREST = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-assets.json'), 'utf8'),
     );
 
-    listReleaseAssetsMock.mockReturnValue({ data: resultREST });
+    vi.mocked((Octokit.prototype as any).repos.listReleaseAssets).mockReturnValue({ data: resultREST });
   });
   test('should download file on win system', async () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -224,7 +223,7 @@ describe('install', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockReturnValue({ data: resultREST });
+    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
     vi.mocked(os.platform).mockReturnValue('win32');
     vi.mocked(os.arch).mockReturnValue('x64');
 
@@ -245,7 +244,7 @@ describe('install', () => {
     const resultREST: KindGithubReleaseArtifactMetadata[] = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kind-github-release-all.json'), 'utf8'),
     );
-    listReleasesMock.mockReturnValue({ data: resultREST });
+    vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
     vi.mocked(os.platform).mockReturnValue('darwin');
     vi.mocked(os.arch).mockReturnValue('x64');
     vi.mocked(fs.existsSync).mockReturnValue(true);
@@ -259,7 +258,7 @@ describe('install', () => {
 
 describe('downloadReleaseAsset', () => {
   test('should download the file if parent folder does exist', async () => {
-    getReleaseAssetMock.mockReturnValue({ data: 'foo' });
+    vi.mocked((Octokit.prototype as any).repos.getReleaseAsset).mockReturnValue({ data: 'foo' });
 
     // mock fs
     const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -277,7 +276,7 @@ describe('downloadReleaseAsset', () => {
   });
 
   test('should download the file if parent folder does not exist', async () => {
-    getReleaseAssetMock.mockReturnValue({ data: 'foo' });
+    vi.mocked((Octokit.prototype as any).repos.getReleaseAsset).mockReturnValue({ data: 'foo' });
 
     // mock fs
     const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -19,7 +19,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import type { Octokit } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
 
 export interface AssetInfo {
@@ -56,17 +56,24 @@ export class KindInstaller {
   private readonly KIND_GITHUB_OWNER = 'kubernetes-sigs';
   private readonly KIND_GITHUB_REPOSITORY = 'kind';
   private assetNames = new Map<string, string>();
+  private octokit?: Octokit;
 
   constructor(
     private readonly storagePath: string,
     private telemetryLogger: extensionApi.TelemetryLogger,
-    private readonly octokit: Octokit,
   ) {
     this.assetNames.set(WINDOWS_X64_PLATFORM, WINDOWS_X64_ASSET_NAME);
     this.assetNames.set(LINUX_X64_PLATFORM, LINUX_X64_ASSET_NAME);
     this.assetNames.set(LINUX_ARM64_PLATFORM, LINUX_ARM64_ASSET_NAME);
     this.assetNames.set(MACOS_X64_PLATFORM, MACOS_X64_ASSET_NAME);
     this.assetNames.set(MACOS_ARM64_PLATFORM, MACOS_ARM64_ASSET_NAME);
+  }
+
+  private async ensureOctokit(): Promise<void> {
+    if (!this.octokit) {
+      const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
+      this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
+    }
   }
 
   // Get the latest version of kubectl from GitHub Releases
@@ -81,8 +88,9 @@ export class KindInstaller {
   // return name, tag and id of the release
   async grabLatestsReleasesMetadata(): Promise<KindGithubReleaseArtifactMetadata[]> {
     // Grab last 5 majors releases from GitHub using the GitHub API
+    await this.ensureOctokit();
 
-    const lastReleases = await this.octokit.repos.listReleases({
+    const lastReleases = await this.octokit!.repos.listReleases({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
     });
@@ -126,6 +134,8 @@ export class KindInstaller {
   // operatingSystem: win32, darwin, linux (see os.platform())
   // arch: x64, arm64 (see os.arch())
   async getReleaseAssetId(releaseId: number, operatingSystem: string, arch: string): Promise<number> {
+    await this.ensureOctokit();
+
     if (operatingSystem === 'win32') {
       operatingSystem = 'windows';
     }
@@ -133,7 +143,7 @@ export class KindInstaller {
       arch = 'amd64';
     }
 
-    const listOfAssets = await this.octokit.repos.listReleaseAssets({
+    const listOfAssets = await this.octokit!.repos.listReleaseAssets({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
       release_id: releaseId,
@@ -183,7 +193,9 @@ export class KindInstaller {
   }
 
   async downloadReleaseAsset(assetId: number, destination: string): Promise<void> {
-    const asset = await this.octokit.repos.getReleaseAsset({
+    await this.ensureOctokit();
+
+    const asset = await this.octokit!.repos.getReleaseAsset({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
       asset_id: assetId,

--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -69,11 +69,12 @@ export class KindInstaller {
     this.assetNames.set(MACOS_ARM64_PLATFORM, MACOS_ARM64_ASSET_NAME);
   }
 
-  private async ensureOctokit(): Promise<void> {
+  private async ensureOctokit(): Promise<Octokit> {
     if (!this.octokit) {
       const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
       this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
     }
+    return this.octokit;
   }
 
   // Get the latest version of kubectl from GitHub Releases
@@ -88,13 +89,9 @@ export class KindInstaller {
   // return name, tag and id of the release
   async grabLatestsReleasesMetadata(): Promise<KindGithubReleaseArtifactMetadata[]> {
     // Grab last 5 majors releases from GitHub using the GitHub API
-    await this.ensureOctokit();
+    const octokit = await this.ensureOctokit();
 
-    if (!this.octokit) {
-      throw new Error('Octokit instance not initialized');
-    }
-
-    const lastReleases = await this.octokit.repos.listReleases({
+    const lastReleases = await octokit.repos.listReleases({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
     });
@@ -138,11 +135,7 @@ export class KindInstaller {
   // operatingSystem: win32, darwin, linux (see os.platform())
   // arch: x64, arm64 (see os.arch())
   async getReleaseAssetId(releaseId: number, operatingSystem: string, arch: string): Promise<number> {
-    await this.ensureOctokit();
-
-    if (!this.octokit) {
-      throw new Error('Octokit instance not initialized');
-    }
+    const octokit = await this.ensureOctokit();
 
     if (operatingSystem === 'win32') {
       operatingSystem = 'windows';
@@ -151,7 +144,7 @@ export class KindInstaller {
       arch = 'amd64';
     }
 
-    const listOfAssets = await this.octokit.repos.listReleaseAssets({
+    const listOfAssets = await octokit.repos.listReleaseAssets({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
       release_id: releaseId,
@@ -201,13 +194,9 @@ export class KindInstaller {
   }
 
   async downloadReleaseAsset(assetId: number, destination: string): Promise<void> {
-    await this.ensureOctokit();
+    const octokit = await this.ensureOctokit();
 
-    if (!this.octokit) {
-      throw new Error('Octokit instance not initialized');
-    }
-
-    const asset = await this.octokit.repos.getReleaseAsset({
+    const asset = await octokit.repos.getReleaseAsset({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
       asset_id: assetId,

--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -19,7 +19,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
+import type { Octokit } from '@octokit/rest';
 import * as extensionApi from '@podman-desktop/api';
 
 export interface AssetInfo {
@@ -56,24 +56,24 @@ export class KindInstaller {
   private readonly KIND_GITHUB_OWNER = 'kubernetes-sigs';
   private readonly KIND_GITHUB_REPOSITORY = 'kind';
   private assetNames = new Map<string, string>();
+  private octokitFactory: () => Promise<Octokit>;
   private octokit?: Octokit;
 
   constructor(
     private readonly storagePath: string,
     private telemetryLogger: extensionApi.TelemetryLogger,
+    octokitFactory: () => Promise<Octokit>,
   ) {
     this.assetNames.set(WINDOWS_X64_PLATFORM, WINDOWS_X64_ASSET_NAME);
     this.assetNames.set(LINUX_X64_PLATFORM, LINUX_X64_ASSET_NAME);
     this.assetNames.set(LINUX_ARM64_PLATFORM, LINUX_ARM64_ASSET_NAME);
     this.assetNames.set(MACOS_X64_PLATFORM, MACOS_X64_ASSET_NAME);
     this.assetNames.set(MACOS_ARM64_PLATFORM, MACOS_ARM64_ASSET_NAME);
+    this.octokitFactory = octokitFactory;
   }
 
   private async ensureOctokit(): Promise<Octokit> {
-    if (!this.octokit) {
-      const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
-      this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
-    }
+    this.octokit ??= await this.octokitFactory();
     return this.octokit;
   }
 

--- a/extensions/kind/src/kind-installer.ts
+++ b/extensions/kind/src/kind-installer.ts
@@ -90,7 +90,11 @@ export class KindInstaller {
     // Grab last 5 majors releases from GitHub using the GitHub API
     await this.ensureOctokit();
 
-    const lastReleases = await this.octokit!.repos.listReleases({
+    if (!this.octokit) {
+      throw new Error('Octokit instance not initialized');
+    }
+
+    const lastReleases = await this.octokit.repos.listReleases({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
     });
@@ -136,6 +140,10 @@ export class KindInstaller {
   async getReleaseAssetId(releaseId: number, operatingSystem: string, arch: string): Promise<number> {
     await this.ensureOctokit();
 
+    if (!this.octokit) {
+      throw new Error('Octokit instance not initialized');
+    }
+
     if (operatingSystem === 'win32') {
       operatingSystem = 'windows';
     }
@@ -143,7 +151,7 @@ export class KindInstaller {
       arch = 'amd64';
     }
 
-    const listOfAssets = await this.octokit!.repos.listReleaseAssets({
+    const listOfAssets = await this.octokit.repos.listReleaseAssets({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
       release_id: releaseId,
@@ -195,7 +203,11 @@ export class KindInstaller {
   async downloadReleaseAsset(assetId: number, destination: string): Promise<void> {
     await this.ensureOctokit();
 
-    const asset = await this.octokit!.repos.getReleaseAsset({
+    if (!this.octokit) {
+      throw new Error('Octokit instance not initialized');
+    }
+
+    const asset = await this.octokit.repos.getReleaseAsset({
       owner: this.KIND_GITHUB_OWNER,
       repo: this.KIND_GITHUB_REPOSITORY,
       asset_id: assetId,

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -19,7 +19,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
 import type { CliTool, Logger, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 
@@ -83,10 +82,9 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   handler.handleConfigurationChanges(extensionContext);
 
   // Create new classes to handle the onboarding sequence
-  const octokit = new Octokit();
   const detect = new Detect(os, extensionContext.storagePath);
 
-  const kubectlGitHubReleases = new KubectlGitHubReleases(octokit);
+  const kubectlGitHubReleases = new KubectlGitHubReleases();
   const kubectlDownload = new KubectlDownload(extensionContext, kubectlGitHubReleases, os);
 
   // ONBOARDING: Command to check kubectl is downloaded

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -19,6 +19,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { Octokit } from '@octokit/rest';
 import type { CliTool, Logger, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 
@@ -84,7 +85,13 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   // Create new classes to handle the onboarding sequence
   const detect = new Detect(os, extensionContext.storagePath);
 
-  const kubectlGitHubReleases = new KubectlGitHubReleases();
+  // Create the Octokit factory for GitHub authentication
+  const octokitFactory = async (): Promise<Octokit> => {
+    const auth = await extensionApi.authentication.getSession('github-authentication', []);
+    return new Octokit({ auth: auth?.accessToken });
+  };
+
+  const kubectlGitHubReleases = new KubectlGitHubReleases(octokitFactory);
   const kubectlDownload = new KubectlDownload(extensionContext, kubectlGitHubReleases, os);
 
   // ONBOARDING: Command to check kubectl is downloaded

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -22,6 +22,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { Octokit } from '@octokit/rest';
+import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { KubectlGitHubReleases } from './kubectl-github-releases';
@@ -37,13 +38,7 @@ vi.mock(import('@octokit/rest'), () => {
   return { Octokit } as any;
 });
 
-vi.mock(import('@podman-desktop/api'), () => {
-  return {
-    authentication: {
-      getSession: vi.fn().mockResolvedValue({ accessToken: 'test-token' }),
-    },
-  } as any;
-});
+vi.mock(import('@podman-desktop/api'));
 
 let kubectlGitHubReleases: KubectlGitHubReleases;
 
@@ -55,6 +50,28 @@ beforeEach(() => {
 afterEach(() => {
   vi.resetAllMocks();
   vi.restoreAllMocks();
+});
+
+test.each([
+  {
+    id: 'session1',
+    accessToken: '12345ABC',
+    account: {
+      id: 'account1',
+      label: 'Account 1',
+    },
+    scopes: [],
+  },
+  undefined,
+])('Auth token is passed to Octokit instance from github-authentication if there is one', async authToken => {
+  vi.mocked(extensionApi.authentication.getSession).mockResolvedValue(authToken);
+
+  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: [] });
+
+  await kubectlGitHubReleases.grabLatestsReleasesMetadata();
+
+  expect(extensionApi.authentication.getSession).toHaveBeenCalledWith('github-authentication', []);
+  expect(Octokit).toHaveBeenCalledWith({ auth: authToken?.accessToken });
 });
 
 test('expect grab 5 releases', async () => {

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -16,13 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { Octokit } from '@octokit/rest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { KubectlGitHubReleases } from './kubectl-github-releases';
-import { Octokit } from '@octokit/rest';
 
 vi.mock(import('node:fs'));
 
@@ -71,16 +73,6 @@ test('expect grab 5 releases', async () => {
 });
 
 describe('Grab asset id for a given release id', async () => {
-  beforeEach(async () => {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-    const fsActual = await vi.importActual<typeof import('node:fs')>('node:fs');
-
-    // mock the result of listReleaseAssetsMock REST API
-    const resultREST = JSON.parse(
-      fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kubectl-github-release-all.json'), 'utf8'),
-    );
-  });
-
   test('macOS x86_64', async () => {
     const result = await kubectlGitHubReleases.getReleaseAssetURL('v1.2.1', 'darwin', 'x64');
     expect(result).toBeDefined();
@@ -119,7 +111,6 @@ describe('Grab asset id for a given release id', async () => {
 });
 
 test('should download the file if parent folder does exist', async () => {
-
   // mock fs
   const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
 

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -21,30 +21,26 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
-import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { KubectlGitHubReleases } from './kubectl-github-releases';
 
 vi.mock(import('node:fs'));
 
-vi.mock(import('@octokit/rest'), () => {
-  const Octokit = vi.fn();
-  Octokit.prototype.repos = {
+const mockOctokit = {
+  repos: {
     listReleases: vi.fn(),
-  };
-  Octokit.prototype.paginate = vi.fn();
-  return { Octokit } as any;
-});
+  },
+};
 
-vi.mock(import('@podman-desktop/api'));
+const mockOctokitFactory = vi.fn();
 
 let kubectlGitHubReleases: KubectlGitHubReleases;
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  kubectlGitHubReleases = new KubectlGitHubReleases();
+  vi.resetAllMocks();
+  mockOctokitFactory.mockResolvedValue(mockOctokit);
+  kubectlGitHubReleases = new KubectlGitHubReleases(mockOctokitFactory);
 });
 
 afterEach(() => {
@@ -52,26 +48,12 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test.each([
-  {
-    id: 'session1',
-    accessToken: '12345ABC',
-    account: {
-      id: 'account1',
-      label: 'Account 1',
-    },
-    scopes: [],
-  },
-  undefined,
-])('Auth token is passed to Octokit instance from github-authentication if there is one', async authToken => {
-  vi.mocked(extensionApi.authentication.getSession).mockResolvedValue(authToken);
-
-  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: [] });
+test('Auth token is passed to Octokit factory', async () => {
+  mockOctokit.repos.listReleases.mockResolvedValue({ data: [] });
 
   await kubectlGitHubReleases.grabLatestsReleasesMetadata();
 
-  expect(extensionApi.authentication.getSession).toHaveBeenCalledWith('github-authentication', []);
-  expect(Octokit).toHaveBeenCalledWith({ auth: authToken?.accessToken });
+  expect(mockOctokitFactory).toHaveBeenCalled();
 });
 
 test('expect grab 5 releases', async () => {
@@ -82,7 +64,7 @@ test('expect grab 5 releases', async () => {
   const resultREST = JSON.parse(
     fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kubectl-github-release-all.json'), 'utf8'),
   );
-  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
+  mockOctokit.repos.listReleases.mockResolvedValue({ data: resultREST });
 
   const result = await kubectlGitHubReleases.grabLatestsReleasesMetadata();
   expect(result).toBeDefined();

--- a/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.spec.ts
@@ -19,28 +19,35 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import type { Octokit } from '@octokit/rest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { KubectlGitHubReleases } from './kubectl-github-releases';
+import { Octokit } from '@octokit/rest';
 
 vi.mock(import('node:fs'));
 
+vi.mock(import('@octokit/rest'), () => {
+  const Octokit = vi.fn();
+  Octokit.prototype.repos = {
+    listReleases: vi.fn(),
+  };
+  Octokit.prototype.paginate = vi.fn();
+  return { Octokit } as any;
+});
+
+vi.mock(import('@podman-desktop/api'), () => {
+  return {
+    authentication: {
+      getSession: vi.fn().mockResolvedValue({ accessToken: 'test-token' }),
+    },
+  } as any;
+});
+
 let kubectlGitHubReleases: KubectlGitHubReleases;
 
-const listReleaseAssetsMock = vi.fn();
-const listReleasesMock = vi.fn();
-const getReleaseAssetMock = vi.fn();
-const octokitMock: Octokit = {
-  repos: {
-    listReleases: listReleasesMock,
-    listReleaseAssets: listReleaseAssetsMock,
-    getReleaseAsset: getReleaseAssetMock,
-  },
-} as unknown as Octokit;
-
 beforeEach(() => {
-  kubectlGitHubReleases = new KubectlGitHubReleases(octokitMock);
+  vi.clearAllMocks();
+  kubectlGitHubReleases = new KubectlGitHubReleases();
 });
 
 afterEach(() => {
@@ -56,7 +63,7 @@ test('expect grab 5 releases', async () => {
   const resultREST = JSON.parse(
     fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kubectl-github-release-all.json'), 'utf8'),
   );
-  listReleasesMock.mockReturnValue({ data: resultREST });
+  vi.mocked((Octokit.prototype as any).repos.listReleases).mockReturnValue({ data: resultREST });
 
   const result = await kubectlGitHubReleases.grabLatestsReleasesMetadata();
   expect(result).toBeDefined();
@@ -72,8 +79,6 @@ describe('Grab asset id for a given release id', async () => {
     const resultREST = JSON.parse(
       fsActual.readFileSync(path.resolve(__dirname, '../tests/resources/kubectl-github-release-all.json'), 'utf8'),
     );
-
-    listReleaseAssetsMock.mockReturnValue({ data: resultREST });
   });
 
   test('macOS x86_64', async () => {
@@ -114,7 +119,6 @@ describe('Grab asset id for a given release id', async () => {
 });
 
 test('should download the file if parent folder does exist', async () => {
-  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
 
   // mock fs
   const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -132,8 +136,6 @@ test('should download the file if parent folder does exist', async () => {
 });
 
 test('should download the file if parent folder does not exist', async () => {
-  getReleaseAssetMock.mockReturnValue({ data: 'foo' });
-
   // mock fs
   const existSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
   const mkdirSpy = vi.spyOn(fs.promises, 'mkdir').mockResolvedValue('');

--- a/extensions/kubectl-cli/src/kubectl-github-releases.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.ts
@@ -20,8 +20,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { Octokit } from '@octokit/rest';
-import * as extensionApi from '@podman-desktop/api';
 import type { QuickPickItem } from '@podman-desktop/api';
+import * as extensionApi from '@podman-desktop/api';
 
 export interface KubectlGithubReleaseArtifactMetadata extends QuickPickItem {
   tag: string;

--- a/extensions/kubectl-cli/src/kubectl-github-releases.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.ts
@@ -19,7 +19,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import type { Octokit } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
+import * as extensionApi from '@podman-desktop/api';
 import type { QuickPickItem } from '@podman-desktop/api';
 
 export interface KubectlGithubReleaseArtifactMetadata extends QuickPickItem {
@@ -32,15 +33,22 @@ export class KubectlGitHubReleases {
   private static readonly KUBECTL_GITHUB_OWNER = 'kubernetes';
   private static readonly KUBECTL_GITHUB_REPOSITORY = 'kubernetes';
   private static readonly DOWNLOAD_URL_PREFIX = 'https://dl.k8s.io/release';
+  private octokit?: Octokit;
 
-  constructor(private readonly octokit: Octokit) {}
+  private async ensureOctokit(): Promise<void> {
+    if (!this.octokit) {
+      const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
+      this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
+    }
+  }
 
   // Provides last 5 majors releases from GitHub using the GitHub API
   // return name, tag and id of the release
   async grabLatestsReleasesMetadata(): Promise<KubectlGithubReleaseArtifactMetadata[]> {
     // Grab last 5 majors releases from GitHub using the GitHub API
+    await this.ensureOctokit();
 
-    const lastReleases = await this.octokit.repos.listReleases({
+    const lastReleases = await this.octokit!.repos.listReleases({
       owner: KubectlGitHubReleases.KUBECTL_GITHUB_OWNER,
       repo: KubectlGitHubReleases.KUBECTL_GITHUB_REPOSITORY,
       per_page: 10, // limit to last 5 releases

--- a/extensions/kubectl-cli/src/kubectl-github-releases.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.ts
@@ -48,7 +48,11 @@ export class KubectlGitHubReleases {
     // Grab last 5 majors releases from GitHub using the GitHub API
     await this.ensureOctokit();
 
-    const lastReleases = await this.octokit!.repos.listReleases({
+    if (!this.octokit) {
+      throw new Error('Octokit instance not initialized');
+    }
+
+    const lastReleases = await this.octokit.repos.listReleases({
       owner: KubectlGitHubReleases.KUBECTL_GITHUB_OWNER,
       repo: KubectlGitHubReleases.KUBECTL_GITHUB_REPOSITORY,
       per_page: 10, // limit to last 5 releases

--- a/extensions/kubectl-cli/src/kubectl-github-releases.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.ts
@@ -19,9 +19,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { Octokit } from '@octokit/rest';
+import type { Octokit } from '@octokit/rest';
 import type { QuickPickItem } from '@podman-desktop/api';
-import * as extensionApi from '@podman-desktop/api';
 
 export interface KubectlGithubReleaseArtifactMetadata extends QuickPickItem {
   tag: string;
@@ -33,13 +32,15 @@ export class KubectlGitHubReleases {
   private static readonly KUBECTL_GITHUB_OWNER = 'kubernetes';
   private static readonly KUBECTL_GITHUB_REPOSITORY = 'kubernetes';
   private static readonly DOWNLOAD_URL_PREFIX = 'https://dl.k8s.io/release';
+  private octokitFactory: () => Promise<Octokit>;
   private octokit?: Octokit;
 
+  constructor(octokitFactory: () => Promise<Octokit>) {
+    this.octokitFactory = octokitFactory;
+  }
+
   private async ensureOctokit(): Promise<Octokit> {
-    if (!this.octokit) {
-      const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
-      this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
-    }
+    this.octokit ??= await this.octokitFactory();
     return this.octokit;
   }
 

--- a/extensions/kubectl-cli/src/kubectl-github-releases.ts
+++ b/extensions/kubectl-cli/src/kubectl-github-releases.ts
@@ -35,24 +35,21 @@ export class KubectlGitHubReleases {
   private static readonly DOWNLOAD_URL_PREFIX = 'https://dl.k8s.io/release';
   private octokit?: Octokit;
 
-  private async ensureOctokit(): Promise<void> {
+  private async ensureOctokit(): Promise<Octokit> {
     if (!this.octokit) {
       const OcktokitAuth = await extensionApi.authentication.getSession('github-authentication', []);
       this.octokit = new Octokit({ auth: OcktokitAuth?.accessToken });
     }
+    return this.octokit;
   }
 
   // Provides last 5 majors releases from GitHub using the GitHub API
   // return name, tag and id of the release
   async grabLatestsReleasesMetadata(): Promise<KubectlGithubReleaseArtifactMetadata[]> {
     // Grab last 5 majors releases from GitHub using the GitHub API
-    await this.ensureOctokit();
+    const octokit = await this.ensureOctokit();
 
-    if (!this.octokit) {
-      throw new Error('Octokit instance not initialized');
-    }
-
-    const lastReleases = await this.octokit.repos.listReleases({
+    const lastReleases = await octokit.repos.listReleases({
       owner: KubectlGitHubReleases.KUBECTL_GITHUB_OWNER,
       repo: KubectlGitHubReleases.KUBECTL_GITHUB_REPOSITORY,
       per_page: 10, // limit to last 5 releases


### PR DESCRIPTION
### What does this PR do?
Refactor Octokit initialization to use lazy loading with GitHub authentication. 
Instead of initializing Octokit in extension activate methods, move initialization to the classes that use it. This way ensures that if there is authentication available from the GitHub authentication extension, it is available by the time Octokit is initialized.
With this change, API rate limit should increase to at least 15000 requests per hour for authenticated users

- Add private ensureOctokit() method to each class that initializes
  Octokit with GitHub authentication only when needed
- Remove Octokit initialization from extension activate methods
- Classes: ComposeGitHubReleases, KubectlGitHubReleases, KindInstaller

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/16251
Closes https://github.com/podman-desktop/podman-desktop/issues/6653 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
