### PR TITLE
fix: resolve CVE-2026-48038 in joi

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,8 @@
       "ws@^8": ">=8.20.1",
       "concurrently>shell-quote": ">=1.8.4",
       "dockerode>@grpc/grpc-js": ">=1.14.4",
-      "form-data": ">=4.0.6"
+      "form-data": ">=4.0.6",
+      "@docusaurus/types>joi": "^17.13.4"
     }
   },
   "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,7 @@ overrides:
   concurrently>shell-quote: '>=1.8.4'
   dockerode>@grpc/grpc-js: '>=1.14.4'
   form-data: '>=4.0.6'
+  '@docusaurus/types>joi': ^17.13.4
 
 importers:
 
@@ -8867,8 +8868,8 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  joi@17.13.3:
-    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+  joi@17.13.4:
+    resolution: {integrity: sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==}
 
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
@@ -15159,7 +15160,7 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 18.3.12
       commander: 5.1.0
-      joi: 17.13.3
+      joi: 17.13.4
       react: 18.2.0
       react-dom: 18.3.1(react@18.2.0)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0)'
@@ -15194,7 +15195,7 @@ snapshots:
       '@docusaurus/utils': 3.10.1(acorn@8.16.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       '@docusaurus/utils-common': 3.10.1(acorn@8.16.0)(esbuild@0.28.1)(react-dom@18.3.1(react@18.2.0))(react@18.2.0)
       fs-extra: 11.3.5
-      joi: 17.13.3
+      joi: 17.13.4
       js-yaml: 4.2.0
       lodash: 4.18.1
       tslib: 2.8.1
@@ -22295,7 +22296,7 @@ snapshots:
   jju@1.4.0:
     optional: true
 
-  joi@17.13.3:
+  joi@17.13.4:
     dependencies:
       '@hapi/hoek': 9.3.0
       '@hapi/topo': 5.1.0


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-48038 in `joi`.

**Advisory**: joi has an uncaught RangeError on deeply nested input through recursive `link()` schemas
**Vulnerable versions**: <17.13.4
**Patched versions**: >=17.13.4
**Advisory URL**: https://github.com/advisories/GHSA-q7cg-457f-vx79

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-48038: _joi has an uncaught RangeError on deeply nested input through recursive `link()` schemas_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-48038 is no longer reported