### PR TITLE
fix(podman): surface WSL errors instead of showing misleading notification

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -263,6 +263,7 @@ beforeEach(async () => {
   extension.initTelemetryLogger();
   extension.initExtensionNotification();
   extension.resetShouldNotifySetup();
+  extension.resetWSLWarningFlag();
   extension.initPodmanRemoteConnections(undefined as unknown as PodmanRemoteConnections);
 
   // mock PodmanInstall class methods
@@ -1818,14 +1819,14 @@ test('ensure showNotification is not called during update', async () => {
   // run the updater (it will sleep for 500ms before returning and resetting the shouldNotifySetup flag
   // run the updateMachine which should not call the showNotification func because shouldNotifySetup is false
   updater?.update({} as extensionApi.Logger).catch(() => {});
-  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('error');
+  await extension.updateMachines(provider, podmanConfiguration);
 
   expect(showNotificationMock).not.toBeCalled();
 
   // wait 500ms so that the updater is complete and shouldNotifySetup reset. Call again the updateMachines func, this time the showNotification is called
   // as there is no update in progress
   await new Promise(resolve => setTimeout(resolve, 500));
-  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('error');
+  await extension.updateMachines(provider, podmanConfiguration);
 
   expect(showNotificationMock).toBeCalled();
 });
@@ -2422,7 +2423,7 @@ test('Even with getJSONMachineList erroring, do not show setup notification on L
     message: 'description',
     stderr: 'error',
   });
-  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('description');
+  await extension.updateMachines(provider, podmanConfiguration);
   expect(extensionApi.window.showNotification).not.toBeCalled();
 });
 
@@ -2448,7 +2449,7 @@ test('Should notify clean machine if getJSONMachineList is erroring due to an in
     message: 'description',
     stderr: 'cannot unmarshal string',
   });
-  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('description');
+  await extension.updateMachines(provider, podmanConfiguration);
   expect(extensionApi.window.showNotification).toBeCalled();
   expect(extensionApi.context.setValue).toBeCalledWith(CLEANUP_REQUIRED_MACHINE_KEY, true);
 });
@@ -3117,6 +3118,101 @@ test('isIncompatibleMachineOutput', () => {
 
   const applehvErrorResponse = extension.isIncompatibleMachineOutput('incompatible machine config');
   expect(applehvErrorResponse).toBeTruthy();
+});
+
+test('isWSLServiceError', () => {
+  expect(extension.isWSLServiceError(undefined)).toBeFalsy();
+  expect(extension.isWSLServiceError('')).toBeFalsy();
+  expect(extension.isWSLServiceError('unknown error')).toBeFalsy();
+  expect(extension.isWSLServiceError('Wsl/Service/E_UNEXPECTED')).toBeTruthy();
+  expect(extension.isWSLServiceError('exit status 0xffffffff')).toBeTruthy();
+  expect(extension.isWSLServiceError('WSL_E_DEFAULT_DISTRO_NOT_FOUND')).toBeTruthy();
+  expect(extension.isWSLServiceError('Error: Wsl/Service/CreateInstance')).toBeTruthy();
+});
+
+test('getJSONMachineList should handle per-provider failure and return partial results', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(WIN_PLATFORM_MOCK.isWSLEnabled).mockResolvedValue(true);
+  vi.mocked(WIN_PLATFORM_MOCK.isHyperVEnabled).mockResolvedValue(false);
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
+    return new Promise<extensionApi.RunResult>(resolve => {
+      if (command !== 'wsl' && args?.[0] === '--version') {
+        resolve({ stdout: 'podman version 5.1.1' } as extensionApi.RunResult);
+      }
+      if (command === 'wsl') {
+        resolve({
+          stdout:
+            'WSL version: 2.2.5.0\nKernel version: 5.15.90.1\nWSLg version: 1.0.51\nMSRDC version: 1.2.3770\nDirect3D version: 1.608.2-61064218\nDXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp\nWindows version: 10.0.22621.2134',
+          stderr: '',
+          command: 'command',
+        });
+      }
+      if (command === 'powershell.exe') {
+        resolve({ stdout: 'True', stderr: '', command: 'command' });
+      }
+    });
+  });
+  vi.spyOn(util, 'execPodman').mockRejectedValue({
+    message: 'WSL command failed',
+    stderr: 'Wsl/Service/E_UNEXPECTED',
+  });
+
+  const result = await extension.getJSONMachineList();
+  expect(result.list).toEqual([]);
+  expect(result.error).toContain('Wsl/Service/E_UNEXPECTED');
+});
+
+test('Should show WSL warning instead of setup notification when WSL service error occurs', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({ stdout: '[]', stderr: '' } as extensionApi.RunResult);
+  vi.spyOn(util, 'execPodman').mockRejectedValue({
+    message: 'WSL command failed',
+    stderr: 'Wsl/Service/E_UNEXPECTED',
+  });
+
+  await extension.updateMachines(provider, podmanConfiguration);
+  expect(extensionApi.window.showWarningMessage).toBeCalledWith(expect.stringContaining('wsl --shutdown'));
+});
+
+test('Should show WSL warning and not setup notification when getJSONMachineList throws with WSL error', async () => {
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockRejectedValue({
+    message: 'Wsl/Service/E_UNEXPECTED',
+    stderr: 'Wsl/Service/E_UNEXPECTED',
+  });
+
+  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow();
+  expect(extensionApi.window.showWarningMessage).toBeCalledWith(expect.stringContaining('wsl --shutdown'));
+  expect(extensionApi.window.showNotification).not.toBeCalled();
+});
+
+test('Should show WSL warning only once across multiple updateMachines calls', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({ stdout: '[]', stderr: '' } as extensionApi.RunResult);
+  vi.spyOn(util, 'execPodman').mockRejectedValue({
+    message: 'WSL command failed',
+    stderr: 'Wsl/Service/E_UNEXPECTED',
+  });
+
+  await extension.updateMachines(provider, podmanConfiguration);
+  await extension.updateMachines(provider, podmanConfiguration);
+
+  expect(extensionApi.window.showWarningMessage).toBeCalledTimes(1);
+});
+
+test('Should show setup notification when getJSONMachineList throws with non-WSL error', async () => {
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockRejectedValue({
+    message: 'some other error',
+    stderr: 'some other error',
+  });
+
+  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow();
+  expect(extensionApi.window.showNotification).toBeCalled();
+  expect(extensionApi.window.showWarningMessage).not.toBeCalled();
 });
 
 describe('calcPodmanMachineSetting', () => {
@@ -4259,7 +4355,7 @@ describe('Check notify podman setup', () => {
     } as unknown as PodmanRemoteConnections;
     extension.initPodmanRemoteConnections(mockRemoteConnections);
 
-    await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('description');
+    await extension.updateMachines(provider, podmanConfiguration);
     expect(extensionApi.window.showNotification).not.toBeCalled();
     expect(extensionApi.context.setValue).toBeCalledWith('podmanRemoteConnectionExists', true, 'onboarding');
   });

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1818,14 +1818,14 @@ test('ensure showNotification is not called during update', async () => {
   // run the updater (it will sleep for 500ms before returning and resetting the shouldNotifySetup flag
   // run the updateMachine which should not call the showNotification func because shouldNotifySetup is false
   updater?.update({} as extensionApi.Logger).catch(() => {});
-  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('error');
+  await extension.updateMachines(provider, podmanConfiguration);
 
   expect(showNotificationMock).not.toBeCalled();
 
   // wait 500ms so that the updater is complete and shouldNotifySetup reset. Call again the updateMachines func, this time the showNotification is called
   // as there is no update in progress
   await new Promise(resolve => setTimeout(resolve, 500));
-  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('error');
+  await extension.updateMachines(provider, podmanConfiguration);
 
   expect(showNotificationMock).toBeCalled();
 });
@@ -2422,7 +2422,7 @@ test('Even with getJSONMachineList erroring, do not show setup notification on L
     message: 'description',
     stderr: 'error',
   });
-  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('description');
+  await extension.updateMachines(provider, podmanConfiguration);
   expect(extensionApi.window.showNotification).not.toBeCalled();
 });
 
@@ -2448,7 +2448,7 @@ test('Should notify clean machine if getJSONMachineList is erroring due to an in
     message: 'description',
     stderr: 'cannot unmarshal string',
   });
-  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('description');
+  await extension.updateMachines(provider, podmanConfiguration);
   expect(extensionApi.window.showNotification).toBeCalled();
   expect(extensionApi.context.setValue).toBeCalledWith(CLEANUP_REQUIRED_MACHINE_KEY, true);
 });
@@ -3117,6 +3117,85 @@ test('isIncompatibleMachineOutput', () => {
 
   const applehvErrorResponse = extension.isIncompatibleMachineOutput('incompatible machine config');
   expect(applehvErrorResponse).toBeTruthy();
+});
+
+test('isWSLServiceError', () => {
+  expect(extension.isWSLServiceError(undefined)).toBeFalsy();
+  expect(extension.isWSLServiceError('')).toBeFalsy();
+  expect(extension.isWSLServiceError('unknown error')).toBeFalsy();
+  expect(extension.isWSLServiceError('Wsl/Service/E_UNEXPECTED')).toBeTruthy();
+  expect(extension.isWSLServiceError('exit status 0xffffffff')).toBeTruthy();
+  expect(extension.isWSLServiceError('WSL_E_DEFAULT_DISTRO_NOT_FOUND')).toBeTruthy();
+  expect(extension.isWSLServiceError('Error: Wsl/Service/CreateInstance')).toBeTruthy();
+});
+
+test('getJSONMachineList should handle per-provider failure and return partial results', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+  vi.mocked(WIN_PLATFORM_MOCK.isWSLEnabled).mockResolvedValue(true);
+  vi.mocked(WIN_PLATFORM_MOCK.isHyperVEnabled).mockResolvedValue(false);
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation((command, args) => {
+    return new Promise<extensionApi.RunResult>(resolve => {
+      if (command !== 'wsl' && args?.[0] === '--version') {
+        resolve({ stdout: 'podman version 5.1.1' } as extensionApi.RunResult);
+      }
+      if (command === 'wsl') {
+        resolve({
+          stdout:
+            'WSL version: 2.2.5.0\nKernel version: 5.15.90.1\nWSLg version: 1.0.51\nMSRDC version: 1.2.3770\nDirect3D version: 1.608.2-61064218\nDXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp\nWindows version: 10.0.22621.2134',
+          stderr: '',
+          command: 'command',
+        });
+      }
+      if (command === 'powershell.exe') {
+        resolve({ stdout: 'True', stderr: '', command: 'command' });
+      }
+    });
+  });
+  vi.spyOn(util, 'execPodman').mockRejectedValue({
+    message: 'WSL command failed',
+    stderr: 'Wsl/Service/E_UNEXPECTED',
+  });
+
+  const result = await extension.getJSONMachineList();
+  expect(result.list).toEqual([]);
+  expect(result.error).toContain('Wsl/Service/E_UNEXPECTED');
+});
+
+test('Should show WSL warning instead of setup notification when WSL service error occurs', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({ stdout: '[]', stderr: '' } as extensionApi.RunResult);
+  vi.spyOn(util, 'execPodman').mockRejectedValue({
+    message: 'WSL command failed',
+    stderr: 'Wsl/Service/E_UNEXPECTED',
+  });
+
+  await extension.updateMachines(provider, podmanConfiguration);
+  expect(extensionApi.window.showWarningMessage).toBeCalledWith(expect.stringContaining('wsl --shutdown'));
+});
+
+test('Should show WSL warning and not setup notification when getJSONMachineList throws with WSL error', async () => {
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockRejectedValue({
+    message: 'Wsl/Service/E_UNEXPECTED',
+    stderr: 'Wsl/Service/E_UNEXPECTED',
+  });
+
+  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow();
+  expect(extensionApi.window.showWarningMessage).toBeCalledWith(expect.stringContaining('wsl --shutdown'));
+  expect(extensionApi.window.showNotification).not.toBeCalled();
+});
+
+test('Should show setup notification when getJSONMachineList throws with non-WSL error', async () => {
+  vi.mocked(extensionApi.env).isLinux = false;
+  vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockRejectedValue({
+    message: 'some other error',
+    stderr: 'some other error',
+  });
+
+  await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow();
+  expect(extensionApi.window.showNotification).toBeCalled();
+  expect(extensionApi.window.showWarningMessage).not.toBeCalled();
 });
 
 describe('calcPodmanMachineSetting', () => {
@@ -4259,7 +4338,7 @@ describe('Check notify podman setup', () => {
     } as unknown as PodmanRemoteConnections;
     extension.initPodmanRemoteConnections(mockRemoteConnections);
 
-    await expect(extension.updateMachines(provider, podmanConfiguration)).rejects.toThrow('description');
+    await extension.updateMachines(provider, podmanConfiguration);
     expect(extensionApi.window.showNotification).not.toBeCalled();
     expect(extensionApi.context.setValue).toBeCalledWith('podmanRemoteConnectionExists', true, 'onboarding');
   });

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -153,6 +153,14 @@ export function isIncompatibleMachineOutput(output: string | undefined): boolean
   }
 }
 
+export function isWSLServiceError(output: string | undefined): boolean {
+  if (!output) {
+    return false;
+  }
+  const lower = output.toLowerCase();
+  return lower.includes('wsl/service/') || lower.includes('exit status 0xffffffff') || lower.includes('wsl_e_');
+}
+
 export async function updateMachines(
   provider: extensionApi.Provider,
   podmanConfiguration: PodmanConfiguration,
@@ -179,11 +187,16 @@ async function doUpdateMachines(
     if (runError.stderr) {
       shouldCleanMachine = isIncompatibleMachineOutput(runError.stderr);
     }
-    extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
 
-    if (!hasRemoteConnections) {
+    if (isWSLServiceError(runError.stderr ?? runError.message)) {
+      await extensionApi.window.showWarningMessage(
+        `Podman machines cannot be listed due to a WSL error. Try running 'wsl --shutdown' in a terminal and restarting the machine from Podman Desktop. Error: ${runError.stderr ?? runError.message}`,
+      );
+    } else if (!hasRemoteConnections) {
       extensionNotifications.notifySetupPodmanNotLinux();
     }
+
+    extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
     throw error;
   }
 
@@ -198,6 +211,13 @@ async function doUpdateMachines(
   // check if the machine needs to be cleaned for v4 --> v5 format
   if (!shouldCleanMachine) {
     shouldCleanMachine = isIncompatibleMachineOutput(machineListOutput.error);
+  }
+
+  // check if there are WSL service errors in the accumulated error output
+  if (isWSLServiceError(machineListOutput.error)) {
+    await extensionApi.window.showWarningMessage(
+      `Some Podman machines may not be visible due to a WSL error. Try running 'wsl --shutdown' in a terminal. Error: ${machineListOutput.error.trim()}`,
+    );
   }
 
   // invalid machines is not making the provider working properly so always notify
@@ -689,7 +709,7 @@ export async function monitorMachines(
     try {
       await updateMachines(provider, podmanConfiguration);
     } catch (error) {
-      // ignore the update of machines
+      console.warn('Error updating podman machines', error);
     }
 
     await timeout(5000);
@@ -1939,9 +1959,14 @@ export async function getJSONMachineList(): Promise<MachineJSONListOutput> {
   const list: MachineJSON[] = [];
   let error = '';
   for (const provider of containerMachineProviders) {
-    const machineListOutput = await getJSONMachineListByProvider(provider);
-    list.push(...(JSON.parse(machineListOutput.stdout) as MachineJSON[]));
-    error += machineListOutput.stderr + '\n';
+    try {
+      const machineListOutput = await getJSONMachineListByProvider(provider);
+      list.push(...(JSON.parse(machineListOutput.stdout) as MachineJSON[]));
+      error += machineListOutput.stderr + '\n';
+    } catch (err) {
+      const runError = err as RunError;
+      error += (runError.stderr ?? runError.message ?? String(err)) + '\n';
+    }
   }
 
   return { list, error };

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -135,6 +135,7 @@ const updateMachinesMutex = new Mutex();
 let createWSLMachineOptionSelected = false;
 let wslAndHypervEnabledContextValue = false;
 let wslEnabled = false;
+let wslWarningShown = false;
 
 let extensionNotifications: ExtensionNotifications;
 let podmanRemoteConnections: PodmanRemoteConnections | undefined;
@@ -151,6 +152,14 @@ export function isIncompatibleMachineOutput(output: string | undefined): boolean
   } else {
     return false;
   }
+}
+
+export function isWSLServiceError(output: string | undefined): boolean {
+  if (!output) {
+    return false;
+  }
+  const lower = output.toLowerCase();
+  return lower.includes('wsl/service/') || lower.includes('exit status 0xffffffff') || lower.includes('wsl_e_');
 }
 
 export async function updateMachines(
@@ -179,11 +188,19 @@ async function doUpdateMachines(
     if (runError.stderr) {
       shouldCleanMachine = isIncompatibleMachineOutput(runError.stderr);
     }
-    extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
 
-    if (!hasRemoteConnections) {
+    if (isWSLServiceError(runError.stderr ?? runError.message)) {
+      if (!wslWarningShown) {
+        wslWarningShown = true;
+        await extensionApi.window.showWarningMessage(
+          `Podman machines cannot be listed due to a WSL error. Try running 'wsl --shutdown' in a terminal and restarting the machine from Podman Desktop. Error: ${runError.stderr ?? runError.message}`,
+        );
+      }
+    } else if (!hasRemoteConnections) {
       extensionNotifications.notifySetupPodmanNotLinux();
     }
+
+    extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
     throw error;
   }
 
@@ -198,6 +215,18 @@ async function doUpdateMachines(
   // check if the machine needs to be cleaned for v4 --> v5 format
   if (!shouldCleanMachine) {
     shouldCleanMachine = isIncompatibleMachineOutput(machineListOutput.error);
+  }
+
+  // check if there are WSL service errors in the accumulated error output
+  if (isWSLServiceError(machineListOutput.error)) {
+    if (!wslWarningShown) {
+      wslWarningShown = true;
+      await extensionApi.window.showWarningMessage(
+        `Some Podman machines may not be visible due to a WSL error. Try running 'wsl --shutdown' in a terminal. Error: ${machineListOutput.error.trim()}`,
+      );
+    }
+  } else {
+    wslWarningShown = false;
   }
 
   // invalid machines is not making the provider working properly so always notify
@@ -689,7 +718,7 @@ export async function monitorMachines(
     try {
       await updateMachines(provider, podmanConfiguration);
     } catch (error) {
-      // ignore the update of machines
+      console.warn('Error updating podman machines', error);
     }
 
     await timeout(5000);
@@ -1939,9 +1968,14 @@ export async function getJSONMachineList(): Promise<MachineJSONListOutput> {
   const list: MachineJSON[] = [];
   let error = '';
   for (const provider of containerMachineProviders) {
-    const machineListOutput = await getJSONMachineListByProvider(provider);
-    list.push(...(JSON.parse(machineListOutput.stdout) as MachineJSON[]));
-    error += machineListOutput.stderr + '\n';
+    try {
+      const machineListOutput = await getJSONMachineListByProvider(provider);
+      list.push(...(JSON.parse(machineListOutput.stdout) as MachineJSON[]));
+      error += machineListOutput.stderr + '\n';
+    } catch (err) {
+      const runError = err as RunError;
+      error += (runError.stderr ?? runError.message ?? String(err)) + '\n';
+    }
   }
 
   return { list, error };
@@ -2366,6 +2400,10 @@ export async function createMachine(
 
 export function resetShouldNotifySetup(): void {
   extensionNotifications.shouldNotifySetup = true;
+}
+
+export function resetWSLWarningFlag(): void {
+  wslWarningShown = false;
 }
 
 async function switchCompatibilityMode(enabled: boolean): Promise<void> {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -375,7 +375,7 @@ async function doUpdateMachines(
   // the native podman installation / not machine.
   if (!extensionApi.env.isLinux) {
     if (machines.length === 0 && !hasRemoteConnections) {
-      if (provider.status !== 'configuring') {
+      if (provider.status !== 'configuring' && installedPodman) {
         provider.updateStatus('installed');
       }
     } else if (machines.length === 0 && hasRemoteConnections) {


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

When WSL encounters service errors (like `Wsl/Service/E_UNEXPECTED`), Podman Desktop previously showed a misleading "Podman needs to be set up" notification and an empty machine list, even though machines actually existed. Users had no way to understand the root cause or how to fix it.

This PR:
- Adds WSL-specific error detection (`isWSLServiceError`) for patterns like `wsl/service/`, `exit status 0xffffffff`, and `wsl_e_`
- Wraps the provider loop in `getJSONMachineList()` with try-catch so one provider failing doesn't prevent listing machines from other providers
- Shows an actionable warning message suggesting `wsl --shutdown` instead of the generic "needs to be set up" notification when WSL errors are detected
- Adds `console.warn` in `monitorMachines()` so errors are no longer silently swallowed

### Screenshot / video of UI

N/A. When triggered, users will now see a warning message containing:
> "Some Podman machines may not be visible due to a WSL error. Try running 'wsl --shutdown' in a terminal."

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17420

### How to test this PR?

- Break WSL (or simulate by mocking) so that `podman machine list` returns a WSL service error 
- Verify the warning message appears with the `wsl --shutdown` suggestion instead of the "needs to be set up" notification

- [x] Tests are covering the bug fix or the new feature
