### PR TITLE
feat(updating): add support for supplying a generic update server

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -286,10 +286,16 @@ const config = {
     schemes: [product.urlProtocol],
     role: 'Editor',
   },
-  publish: {
-    provider: 'github',
-    timeout: 10000,
-  },
+  publish: product.update?.url
+    ? {
+        provider: 'generic',
+        url: product.update.url,
+        timeout: 10000,
+      }
+    : {
+        provider: 'github',
+        timeout: 10000,
+      },
   /*extraMetadata: {
     version: process.env.VITE_APP_VERSION,
   },*/
@@ -299,7 +305,8 @@ const config = {
 if (process.env.AIRGAP_DOWNLOAD) {
   config.publish = {
     publishAutoUpdate: false,
-    provider: 'github',
+    provider: product.update?.url ? 'generic' : 'github',
+    ...(product.update?.url ? { url: product.update.url } : {}),
   };
 }
 

--- a/CUSTOM_UPDATE_SERVER.md
+++ b/CUSTOM_UPDATE_SERVER.md
@@ -1,0 +1,272 @@
+# Custom Update Server Support
+
+## Overview
+
+Downstream forks can point the auto-updater at any HTTPS server by setting `update.url` in `product.json`. 
+When empty (default), the existing GitHub Releases behavior is preserved.
+
+```json
+"update": {
+  "url": "https://updates.myserver.com/this/dir"
+}
+```
+
+The fork then hosts the electron-builder metadata files (`latest-mac.yml`, `latest.yml`) and SIGNED binaries on that server.
+
+---
+
+## Testing with a Local Update Server
+
+Test the full update flow locally using nginx in a Podman container. Build 2 versions, a high version (v99.0.0) served as the update, and a low version (v1.0.0) that you run locally.
+
+### macOS
+
+#### Step 1: Clean assets directory
+
+
+For testing locally remove old `.pkg` files and `.zst` machine images in `extensions/podman/packages/extension/assets/` before building. These inflate the ZIP from ~200MB to 1.5GB+, causing Squirrel.Mac to crash (it buffers the entire download in memory).
+
+```bash
+rm extensions/podman/packages/extension/assets/*
+```
+
+#### Step 2: Create a self-signed code signing certificate
+
+Squirrel.Mac (how it downloads) requires both the running app and the update to share the same code signing identity. 
+Ad-hoc signatures (`--sign -`) produce a unique identity per signing, so you need to generate a named certificate.
+
+```bash
+cat > /tmp/cert.cfg <<'EOF'
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+
+[ dn ]
+CN = Podman Desktop Test
+O = Test
+C = US
+
+[ v3_code_signing ]
+keyUsage = digitalSignature
+extendedKeyUsage = codeSigning
+EOF
+
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/test-key.pem -out /tmp/test-cert.pem \
+  -days 365 -nodes -config /tmp/cert.cfg -extensions v3_code_signing
+
+# Export to p12 (-legacy flag required for macOS compatibility)
+openssl pkcs12 -export -out /tmp/test-cert.p12 -inkey /tmp/test-key.pem \
+  -in /tmp/test-cert.pem -passout pass:test123 -legacy
+
+# Import into keychain
+security import /tmp/test-cert.p12 -k ~/Library/Keychains/login.keychain-db \
+  -P test123 -T /usr/bin/codesign -T /usr/bin/security
+
+# Trust for code signing
+security add-trusted-cert -d -r trustRoot -p codeSign \
+  -k ~/Library/Keychains/login.keychain-db /tmp/test-cert.pem
+
+# Verify — should show "Podman Desktop Test" with 1 valid identity
+security find-identity -v -p codesigning
+```
+
+#### Step 3: Configure `product.json`
+
+Get your local IP and set it in `product.json`, this will be used for our "update server":
+
+```bash
+ipconfig getifaddr en0
+```
+
+```json
+"update": {
+  "url": "http://<YOUR_LOCAL_IP>:8080"
+}
+```
+
+#### Step 4: Build the update binary (v99.0.0)
+
+```bash
+
+# pre-build
+pnpm install && pnpm build
+
+# replace the version with 99.0.0
+sed -i '' 's/"version": ".*"/"version": "99.0.0"/' package.json
+
+# build the compiled binary
+CSC_NAME="Podman Desktop Test" pnpm compile:current
+```
+
+#### Step 5: Re-sign, repackage, and host the update
+
+electron-builder signs the main executable, but the Electron Framework inside the bundle may retains a different Team ID. You must re-sign with `--deep`, repackage the ZIP, and update the checksum.
+
+```bash
+# Re-sign with --deep
+codesign --force --deep --sign "Podman Desktop Test" "dist/mac-arm64/Podman Desktop.app"
+codesign --verify --deep --strict "dist/mac-arm64/Podman Desktop.app"
+
+# Repackage ZIP (ditto matches electron-builder's format)
+mkdir -p /tmp/update-repack
+cd dist/mac-arm64
+ditto -c -k --sequesterRsrc --keepParent "Podman Desktop.app" /tmp/update-repack/podman-desktop-99.0.0-arm64.zip
+cd -
+
+# Get new checksum and size to check..
+NEW_SHA512=$(shasum -a 512 /tmp/update-repack/podman-desktop-99.0.0-arm64.zip | awk '{print $1}' | xxd -r -p | base64)
+NEW_SIZE=$(stat -f%z /tmp/update-repack/podman-desktop-99.0.0-arm64.zip)
+echo "sha512: $NEW_SHA512"
+echo "size: $NEW_SIZE"
+
+# Copy to to a server directory (we will use ~/update-server dir, or use whatever you'd like)
+mkdir -p ~/update-server
+cp dist/latest-mac.yml ~/update-server/
+cp /tmp/update-repack/podman-desktop-99.0.0-arm64.zip ~/update-server/
+cp dist/podman-desktop-99.0.0-arm64.zip.blockmap ~/update-server/
+```
+
+**IMPORTANT!:**
+
+Edit `~/update-server/latest-mac.yml` and replace the `sha512` and `size` for the `arm64.zip` entry with the values printed above, or this will NOT work.
+
+#### Step 6: Build the current binary (v1.0.0)
+
+Now we will build the current binary that we will test updating to.
+
+```bash
+sed -i '' 's/"version": ".*"/"version": "1.0.0"/' package.json
+
+CSC_NAME="Podman Desktop Test" pnpm compile:current
+```
+
+#### Step 7: Start the update server
+
+We'll use nginx in order to host the files.
+
+```bash
+podman run --rm -d \
+  --name update-server \
+  -p 8080:80 \
+  -v "$HOME/update-server:/usr/share/nginx/html:ro,Z" \
+  docker.io/library/nginx:alpine
+
+# Verify
+curl http://<YOUR_LOCAL_IP>:8080/latest-mac.yml | head -2
+```
+
+#### Step 8: Install and run
+
+Install your `1.0.0` binary locally (the .app):
+
+```bash
+cp -R "dist/mac-arm64/Podman Desktop.app" "/Applications/Podman Desktop.app"
+codesign --force --deep --sign "Podman Desktop Test" "/Applications/Podman Desktop.app"
+open "/Applications/Podman Desktop.app"
+```
+
+The app should show v1.0.0 and detect v99.0.0.
+
+Test downloading the update, and after restarting it will show v99.0.0.
+
+#### Step 9: Clean up
+
+Stop the update server, and clean up / remove your test keys!
+
+```bash
+podman stop update-server
+rm -rf ~/update-server /tmp/update-repack
+rm -f /tmp/test-key.pem /tmp/test-cert.pem /tmp/test-cert.p12 /tmp/cert.cfg
+security delete-identity -c "Podman Desktop Test"
+git checkout product.json package.json
+```
+
+### Windows
+
+Windows uses NSIS (not Squirrel) for updating, so no need for signing at all.
+
+#### Step 1: Configure `product.json`
+
+Get your local IP and set it:
+
+```powershell
+(Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias "Wi-Fi").IPAddress
+```
+
+```json
+"update": {
+  "url": "http://<YOUR_LOCAL_IP>:8080"
+}
+```
+
+#### Step 2: Build the update binary (v99.0.0)
+
+```powershell
+pnpm install
+pnpm build
+
+# Edit package.json to set version to "99.0.0"
+(Get-Content package.json -Raw) -replace '"version":\s*".*?"', '"version": "99.0.0"' | Set-Content package.json
+
+pnpm compile:current
+```
+
+#### Step 3: Host the update
+
+```powershell
+mkdir $HOME\update-server
+
+copy dist\latest.yml $HOME\update-server\
+copy dist\podman-desktop-99.0.0-setup-x64.exe $HOME\update-server\
+copy dist\podman-desktop-99.0.0-setup-x64.exe.blockmap $HOME\update-server\
+```
+
+#### Step 4: Build the current binary (v1.0.0)
+
+```powershell
+# Edit package.json to set version to "1.0.0"
+(Get-Content package.json -Raw) -replace '"version":\s*".*?"', '"version": "1.0.0"' | Set-Content package.json
+
+pnpm compile:current
+```
+
+#### Step 5: Start the update server
+
+```powershell
+podman run --rm -d --name update-server -p 8080:80 -v "$HOME/update-server:/usr/share/nginx/html:ro" docker.io/library/nginx:alpine
+
+# Verify
+curl http://<YOUR_LOCAL_IP>:8080/latest.yml
+```
+
+#### Step 6: Install and run
+
+Install the v1.0.0 setup exe from `dist/`, then launch the app. It should detect v99.0.0 and offer to update. Test that it downloads / updates.
+
+#### Step 7: Clean up
+
+Clean up by stopping podman + removing the gen files.
+
+```powershell
+podman stop update-server
+Remove-Item -Recurse $HOME\update-server
+git checkout product.json package.json
+```
+
+---
+
+### HTTPS
+
+The above example uses http, however, electron-updater WILL reject self-signed TLS certs by default on the server.
+
+If you want to test with an https server, you could use:
+
+- GitHub pages
+- Let's Encrypt via a reverse proxy with a real domain
+- [ngrok](https://ngrok.com/) — tunnels with a valid HTTPS certificate:
+  ```bash
+  ngrok http 8080
+  # Use the ngrok HTTPS URL in product.json
+  ```

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -63,6 +63,7 @@ vi.mock(import('electron-updater'), () => ({
     quitAndInstall: vi.fn(),
     checkForUpdates: vi.fn(),
     on: vi.fn(),
+    setFeedURL: vi.fn(),
     autoDownload: true,
     disableDifferentialDownload: false,
   } as unknown as AppUpdater,
@@ -167,6 +168,10 @@ beforeEach(() => {
     image: '',
   };
 
+  vi.mocked(product).update = {
+    url: '',
+  };
+
   vi.mocked(commandRegistryMock.executeCommand).mockResolvedValue(undefined);
   vi.mocked(util.isLinux).mockReturnValue(false);
 
@@ -242,6 +247,64 @@ test('expect configuration description to use product name', () => {
   expect(configurationNode?.properties?.['preferences.update.reminder']?.description).toBe(
     'Configure whether you receive update reminders when starting Custom Product Name',
   );
+});
+
+test('expect setFeedURL not to be called when product.update.url is empty', () => {
+  vi.mocked(product).update = { url: '' };
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  expect(autoUpdater.setFeedURL).not.toHaveBeenCalled();
+});
+
+test('expect setFeedURL to be called with generic provider when product.update.url is set', () => {
+  vi.mocked(product).update = { url: 'https://updates.example.com/releases' };
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  expect(autoUpdater.setFeedURL).toHaveBeenCalledWith({
+    provider: 'generic',
+    url: 'https://updates.example.com/releases',
+  });
+});
+
+test('expect setFeedURL to be called before checkForUpdates', () => {
+  vi.mocked(product).update = { url: 'https://updates.example.com/releases' };
+
+  const callOrder: string[] = [];
+  vi.mocked(autoUpdater.setFeedURL).mockImplementation(() => {
+    callOrder.push('setFeedURL');
+  });
+  vi.mocked(autoUpdater.checkForUpdates).mockImplementation(() => {
+    callOrder.push('checkForUpdates');
+    // eslint-disable-next-line no-null/no-null
+    return Promise.resolve(null);
+  });
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  expect(callOrder).toStrictEqual(['setFeedURL', 'checkForUpdates']);
 });
 
 describe('differential download', () => {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -471,6 +471,16 @@ export class Updater {
   public init(): Disposable {
     // disable auto download
     autoUpdater.autoDownload = false;
+
+    // If a custom update server URL is configured in product.json, use it
+    // instead of the default GitHub provider.
+    if (product.update?.url) {
+      autoUpdater.setFeedURL({
+        provider: 'generic',
+        url: product.update.url,
+      });
+    }
+
     /**
      * Differential updates take **a lot** of memory
      * and have lead to constant JavaScript heap out of memory on windows

--- a/product.json
+++ b/product.json
@@ -77,6 +77,9 @@
       }
     ]
   },
+  "update": {
+    "url": ""
+  },
   "releaseNotes": {
     "url": "",
     "blog": "",


### PR DESCRIPTION
feat(updating): add support for supplying a generic update server

### What does this PR do?

Allow downstream forks to point the auto-updater at any HTTPS server
by setting `update.url` in `product.json`.

When the field is empty (the default), the existing GitHub Releases provider is used.

When set, electron-builder's `generic` provider is configured at both build time and run time.

This allows you to host metadata files (ex. `latest-mac.yml` and
`latest.yml`) on an https server for you to download (given both files
use the same signed signature).

### Screenshot / video of UI

N/A, no UI changes in this PR.

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/16824

### How to test this PR?

A more thorough guide is located in `CUSTOM_UPDATE_SERVER.md` which is
in the root dir.

But TLDR is:

1. Set `update.url` in `product.json` to a valid HTTPS server hosting
   electron-builder metadata files (`latest-mac.yml` / `latest.yml`),
   with VALID signed binaries (both the "previous" version and "new"
   version must have the same signature).
2. Build the "previous" version (version `0.0.1`)
3. Build the "next" version (version `0.0.2`) and host it on the https
   server.
4. Run a HTTP server with the "next" version binary.
5. Open the "previous" version and you should get prompted to update.

- [x] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
