### PR TITLE
fix(renderer): reduce z-index in SystemOverviewProviderCardCompact.svelte

### DIFF
--- a/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardCompact.svelte
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardCompact.svelte
@@ -74,7 +74,7 @@ function navigateToConnection(): void {
 </script>
 
 <div class="relative flex-shrink-0 inline-flex">
-  <span class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full {STATUS_DOT_CLASS[connectionStatus.status]} z-10"></span>
+  <span class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full {STATUS_DOT_CLASS[connectionStatus.status]} z-1"></span>
 
   {#if expanded}
     <Button type="secondary" onclick={navigateToConnection} title="Navigate to {connectionName}" aria-label="Navigate to {connectionName}" padding="px-2 py-[3px]">


### PR DESCRIPTION
### What does this PR do?
The indicator in [SystemOverviewProviderCardCompact.svelte](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardCompact.svelte#L77) has `z-10` which is same as dropdowns, because of that the indicator can be seen on top of dropdown.
This PR makes the index as `z-1` which makes it below the dropdowns and above the cards.
### Screenshot / video of UI
BEFORE:

<img width="1730" height="1400" alt="image" src="https://github.com/user-attachments/assets/3ca3285d-d9fa-472c-b327-202d5b8f810b" />

AFTER:

https://github.com/user-attachments/assets/80d5045d-9397-4a83-94f8-8b021ee4ad9b
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes #17899 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
