### PR TITLE
fix: resolve CVE-2026-53632 in launch-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,8 @@
       "dockerode>@grpc/grpc-js": ">=1.14.4",
       "form-data": ">=4.0.6",
       "@docusaurus/types>joi": "^17.13.4",
-      "markdown-it": ">=14.2.0"
+      "markdown-it": ">=14.2.0",
+      "launch-editor": ">=2.14.1"
     }
   },
   "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,7 @@ overrides:
   form-data: '>=4.0.6'
   '@docusaurus/types>joi': ^17.13.4
   markdown-it: '>=14.2.0'
+  launch-editor: '>=2.14.1'
 
 importers:
 
@@ -9014,8 +9015,8 @@ packages:
     resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
     engines: {node: '>=18'}
 
-  launch-editor@2.9.1:
-    resolution: {integrity: sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==}
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   layout-base@1.0.2:
     resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
@@ -22435,7 +22436,7 @@ snapshots:
     dependencies:
       package-json: 10.0.1
 
-  launch-editor@2.9.1:
+  launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.4
@@ -26919,7 +26920,7 @@ snapshots:
       graceful-fs: 4.2.11
       http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ipaddr.js: 2.2.0
-      launch-editor: 2.9.1
+      launch-editor: 2.14.1
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-53632 in `launch-editor`.

**Advisory**: launch-editor: NTLMv2 hash disclosure via UNC path handling on Windows
**Vulnerable versions**: <=2.14.0
**Patched versions**: >=2.14.1
**Advisory URL**: https://github.com/advisories/GHSA-v6wh-96g9-6wx3

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-53632: _launch-editor: NTLMv2 hash disclosure via UNC path handling on Windows_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-53632 is no longer reported