### PR TITLE
chore(argos-website): update concurrency group

### DIFF
--- a/.github/workflows/argos-website.yaml
+++ b/.github/workflows/argos-website.yaml
@@ -18,7 +18,7 @@
 name: Visual Testing
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow_ref }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
### What does this PR do?

After https://github.com/podman-desktop/podman-desktop/pull/17905 I configured the concurrency to use `github.workflow`, but sad part, this is not the workflow filename, but the workflow name; since https://github.com/podman-desktop/podman-desktop/pull/17903 will introduce a workflow with the same name for consistency, we should use the `github.workflow_ref` to avoid possible conflict.

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/pull/17903

### How to test this PR?

- CI should be :green_circle: 
