### PR TITLE
chore(test): increase podman machine start timeouts

### DIFF
--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -194,10 +194,11 @@ for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of mac
       });
 
       test('Start the machine', async ({ page }) => {
+        test.setTimeout(TIMEOUT_MACHINE_CREATION);
         const machineCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, PODMAN_MACHINE_NAME);
         await machineCard.performConnectionAction(ResourceElementActions.Start);
 
-        await playExpect(dialog).toBeVisible({ timeout: TIMEOUT_MEDIUM });
+        await playExpect(dialog).toBeVisible({ timeout: TIMEOUT_LONG });
         await handlePodmanConfirmationDialogs(page);
 
         await waitUntil(


### PR DESCRIPTION
### What does this PR do?
Increases some timeouts in e2e tests when starting podman machine in some scenario.

### What issues does this PR fix or reference?