### PR TITLE
docs(RELEASE.MD): add instruction for npmjs-publish.yaml

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -43,6 +43,15 @@ Below is what a typical release week may look like (This is just an example of t
    - Click `Run workflow`
    - You can view the PR at: https://github.com/flathub/io.podman_desktop.PodmanDesktop/pulls/podman-desktop-bot
 
+1. Approve `npmjs-publish.yaml` workflow **IMPORTANT NOTE:** We should wait for release note to be merged
+
+   The workflow will be waiting for manual approval
+   - Go to https://github.com/podman-desktop/podman-desktop/actions/workflows/npmjs-publish.yaml?query=is%3Awaiting
+   - Click on `View details` of the run corresponding to the release you wish to publish
+   - Click on `Review Deployment`
+   - Check `npmjs-publish.yaml` then click on `Approve and Deploy`
+   - Cancel any other pending run (If you did one or several re-spin, previous release tag will also wait, we should not publish them).
+
 ## Test release before it is rolling out.
 
 The release is a **pre-release**, it means it is not yet the latest version, so no clients will automatically update to this version.


### PR DESCRIPTION
### What does this PR do?

Adding instruction in the RELEASE.md corresponding to the `npmjs-publish.yaml` workflow.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17839
