### PR TITLE
chore(lint): activate unicorn/no-array-sort eslint rule

### DIFF
--- a/CODE-GUIDELINES.md
+++ b/CODE-GUIDELINES.md
@@ -19,6 +19,32 @@ import { WinPlatform } from './win-platform';
 import type { WSL2Check } from '../checks/windows/wsl2-check';
 ```
 
+### Array sorting (`toSorted` vs `sort`)
+
+Prefer `toSorted()` over `sort()` when deriving a sorted view from an existing array.
+This includes cases where the sorted value is assigned later in the function.
+
+🚫 **Avoid this pattern:**
+
+```ts
+let providers = getProviders();
+
+providers.sort((a, b) => a.name.localeCompare(b.name));
+
+// ... some logic
+
+const sortedProviders = providers;
+```
+
+✅ **Use this instead:**
+
+```ts
+let providers = getProviders();
+const sortedProviders = providers.toSorted((a, b) => a.name.localeCompare(b.name));
+```
+
+Use `sort()` only when you explicitly need in-place mutation semantics.
+
 ### Svelte
 
 On templates of Svelte components, avoid using inline code and arrow functions. Instead, call a function defined in the script part of the component.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -290,6 +290,7 @@ export default [
       'sonarjs/no-nested-assignment': 'off',
       'sonarjs/no-alphabetical-sort': 'off',
       'svelte/no-reactive-literals': 'error',
+      'unicorn/no-array-sort': 'error',
     },
   },
 

--- a/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.svelte
+++ b/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.svelte
@@ -18,7 +18,7 @@ let notificationsUnsubscribe: Unsubscriber;
 onMount(() => {
   // if there is a new provider we display the dot
   providersUnsubscribe = providerInfos.subscribe(updatedProviders => {
-    const updatedProvidersId = updatedProviders.map(prov => prov.internalId).sort();
+    const updatedProvidersId = updatedProviders.map(prov => prov.internalId).toSorted();
     if (!hasNewProviders) {
       // if the user is in the dashboard page we do not check for new providers
       hasNewProviders = hasNewProvider(providersId, updatedProvidersId);

--- a/packages/renderer/src/lib/dashboard/SystemOverviewResourceUsage.svelte
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewResourceUsage.svelte
@@ -26,7 +26,7 @@ type ResourceData = {
 let configurationKeys: IConfigurationPropertyRecordedSchema[] = $derived(
   $configurationProperties
     .filter(property => property.scope === 'ContainerConnection')
-    .sort((a, b) => (a?.id ?? '').localeCompare(b?.id ?? '')),
+    .toSorted((a, b) => (a?.id ?? '').localeCompare(b?.id ?? '')),
 );
 
 let resourceConfig = $state<IProviderConnectionConfigurationPropertyRecorded[]>([]);

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.svelte
@@ -90,7 +90,7 @@ onMount(async () => {
   }
 
   // sort the default cards using current arch as first
-  DEFAULT_CARDS.sort((a, b) => {
+  sortedCards = DEFAULT_CARDS.toSorted((a, b) => {
     if (a.value.includes(arch)) {
       return -1;
     }
@@ -99,7 +99,6 @@ onMount(async () => {
     }
     return 0;
   });
-  sortedCards = DEFAULT_CARDS;
 
   advancedCards = ADVANCED_CARDS;
   sortedCards[0].isDefault = true;

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.svelte
@@ -48,7 +48,7 @@ async function callProviders(_providers: readonly ImageCheckerInfo[]): Promise<v
     info: p,
     state: 'running',
   }));
-  const sortedProvidersIds = providers.map(p => p.info.id).sort();
+  const sortedProvidersIds = providers.map(p => p.info.id).toSorted();
   cancellableTokenId = await window.getCancellableTokenSource();
   remainingProviders = providers.length;
 
@@ -75,7 +75,7 @@ async function callProviders(_providers: readonly ImageCheckerInfo[]): Promise<v
             check,
           });
         });
-        results.sort((a, b) => {
+        results = results.toSorted((a, b) => {
           const statusA = orderStatus.indexOf(a.check.status);
           const statusB = orderStatus.indexOf(b.check.status);
           if (statusA !== statusB) {
@@ -95,7 +95,6 @@ async function callProviders(_providers: readonly ImageCheckerInfo[]): Promise<v
           }
           return 0;
         });
-        results = [...results];
       })
       .catch((error: unknown) => {
         if (error instanceof Error) {

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -87,22 +87,21 @@ function updateImages(globalContext: ContextUI): void {
       image.selected = matchingImage.selected;
     }
   });
-  computedImages.sort((first, second) => second.createdAt - first.createdAt);
+  images = computedImages.toSorted((first, second) => second.createdAt - first.createdAt);
 
-  // Go through each image and if it has a children, remove the "children" from computedImages so they do not show up
+  // Go through each image and if it has a children, remove the "children" from images so they do not show up
   // in the table
-  computedImages.forEach(image => {
+  images.forEach(image => {
     if (image.children) {
       image.children.forEach(child => {
-        const index = computedImages.findIndex(computedImage => computedImage.id === child.id);
+        const index = images.findIndex(computedImage => computedImage.id === child.id);
         if (index !== -1) {
-          computedImages.splice(index, 1);
+          images.splice(index, 1);
         }
       });
     }
   });
 
-  images = computedImages;
   if (imageEngineId) {
     images = images.filter(image => image.engineId === imageEngineId);
   }

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -179,7 +179,7 @@ onMount(async () => {
     // sort from newest to oldest
     const runningContainers = engineContainers
       .filter(container => container.state === 'RUNNING')
-      .sort((a, b) => b.created - a.created);
+      .toSorted((a, b) => b.created - a.created);
     if (runningContainers.length > 0) {
       // use the first running container
       networkingModeUserContainer = runningContainers[0].id;

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.svelte
@@ -41,7 +41,7 @@ let loggerHandlerKey: symbol | undefined;
 let configurationKeys: IConfigurationPropertyRecordedSchema[];
 $: configurationKeys = properties
   .filter(property => property.scope === 'ContainerConnection')
-  .sort((a, b) => (a.id ?? '').localeCompare(b.id ?? ''));
+  .toSorted((a, b) => (a.id ?? '').localeCompare(b.id ?? ''));
 
 let providersUnsubscribe: Unsubscriber;
 onMount(async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -39,7 +39,7 @@ let loggerHandlerKey: symbol | undefined;
 let configurationKeys: IConfigurationPropertyRecordedSchema[];
 $: configurationKeys = properties
   .filter(property => property.scope === 'KubernetesConnection')
-  .sort((a, b) => (a?.id ?? '').localeCompare(b?.id ?? ''));
+  .toSorted((a, b) => (a?.id ?? '').localeCompare(b?.id ?? ''));
 
 let providersUnsubscribe: Unsubscriber;
 onMount(async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.svelte
@@ -80,7 +80,7 @@ function updateSearchValue(event: any): void {
       {#if matchingRecords.size === 0}
         <div>No Settings Found</div>
       {:else}
-        {#each [...matchingRecords.keys()].sort((a, b) => a.localeCompare(b)) as configSection, index (index)}
+        {#each [...matchingRecords.keys()].toSorted((a, b) => a.localeCompare(b)) as configSection, index (index)}
           {@const records = matchingRecords.get(configSection)}
           {#if records}
             <div>

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.svelte
@@ -408,7 +408,7 @@ function handleError(errorMessage: string): void {
 let configurationKeys: IConfigurationPropertyRecordedSchema[] = $derived(
   properties
     .filter(property => property.scope === 'ContainerConnection')
-    .sort((a, b) => (a?.id ?? '').localeCompare(b?.id ?? '')),
+    .toSorted((a, b) => (a?.id ?? '').localeCompare(b?.id ?? '')),
 );
 
 let tmpProviderContainerConfiguration = $state<IProviderConnectionConfigurationPropertyRecorded[]>([]);

--- a/packages/renderer/src/lib/statusbar/StatusBar.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBar.svelte
@@ -35,7 +35,7 @@ onMount(async () => {
       .filter(descriptor => {
         return descriptor.alignLeft === true;
       })
-      .sort((d1, d2) => {
+      .toSorted((d1, d2) => {
         if (d1.priority > d2.priority) {
           return 1;
         } else if (d1.priority < d2.priority) {
@@ -52,7 +52,7 @@ onMount(async () => {
       .filter(descriptor => {
         return descriptor.alignLeft === false;
       })
-      .sort((d1, d2) => {
+      .toSorted((d1, d2) => {
         if (d1.priority > d2.priority) {
           return 1;
         } else if (d1.priority < d2.priority) {

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStores.svelte
@@ -16,8 +16,7 @@ let allEventsUnsubscriber: Unsubscriber;
 onMount(() => {
   allEventsUnsubscriber = allEventStoresInfo.subscribe(value => {
     // sort the store
-    value.sort((a, b) => a.name.localeCompare(b.name));
-    allEventstores = value;
+    allEventstores = value.toSorted((a, b) => a.name.localeCompare(b.name));
   });
 });
 

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -48,7 +48,7 @@ $: onboardingProviders = $onboardingList
       containerEngine: hasContainerConnection,
     };
   })
-  .sort((a, b) => Number(b.containerEngine) - Number(a.containerEngine)); // Sort by containerEngine (true first)
+  .toSorted((a, b) => Number(b.containerEngine) - Number(a.containerEngine)); // Sort by containerEngine (true first)
 
 onMount(async () => {
   const ver = await welcomeUtils.getVersion();

--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -302,7 +302,7 @@ function getEntryInfo(url: string): { name: string; icon?: HistoryEntryIcon } {
   }
 
   // Check settings navigation entries (sorted by specificity)
-  const sortedEntries = [...settingsNavigationEntries].sort((a, b) => b.href.length - a.href.length);
+  const sortedEntries = settingsNavigationEntries.toSorted((a, b) => b.href.length - a.href.length);
   for (const route of sortedEntries) {
     if (matchesRoute(path, route.href)) {
       return {

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -131,9 +131,9 @@ async function saveColumnConfiguration(): Promise<void> {
 // Get ordered columns based on current ordering
 function getOrderedColumns(): ListOrganizerItem[] {
   if (columnOrdering.size === 0) {
-    return [...columnItems].sort((a, b) => a.originalOrder - b.originalOrder);
+    return columnItems.toSorted((a, b) => a.originalOrder - b.originalOrder);
   }
-  return [...columnItems].sort((a, b) => {
+  return columnItems.toSorted((a, b) => {
     const aOrder = columnOrdering.get(a.id) ?? a.originalOrder;
     const bOrder = columnOrdering.get(b.id) ?? b.originalOrder;
     return aOrder - bOrder;
@@ -159,8 +159,8 @@ $: visibleColumns = ((): Column<T, any>[] => {
   // Get ordered columns inline to ensure reactivity
   const orderedColumns =
     columnOrdering.size === 0
-      ? [...columnItems].sort((a, b) => a.originalOrder - b.originalOrder)
-      : [...columnItems].sort((a, b) => {
+      ? columnItems.toSorted((a, b) => a.originalOrder - b.originalOrder)
+      : columnItems.toSorted((a, b) => {
           const aOrder = columnOrdering.get(a.id) ?? a.originalOrder;
           const bOrder = columnOrdering.get(b.id) ?? b.originalOrder;
           return aOrder - bOrder;
@@ -270,8 +270,7 @@ function sortImpl(): void {
     comparator = (a, b): number => -comparatorTemp(a, b);
   }
 
-  // eslint-disable-next-line etc/no-assign-mutated-array
-  data = data.sort(comparator);
+  data = data.toSorted(comparator);
 }
 
 onMount(async () => {


### PR DESCRIPTION
### What does this PR do?

Activate the `unicorn/no-array-sort` eslint rule and change all array `sort` (around 20) and use `toSorted` instead.

With that change, we will be able to remove the `etc/no-assign-mutated-array` rule because the package is deprecated.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17957

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
