### PR TITLE
chore(test): remove pw from postinstall script

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -252,6 +252,9 @@ jobs:
       - name: Execute pnpm
         run: pnpm install
 
+      - name: Install Playwright browser
+        run: npx playwright install chromium
+
       - name: Adjust/Downgrade local podman desktop version Windows
         run: node tests/playwright/scripts/version-util.cjs ./package.json --update
 
@@ -363,6 +366,9 @@ jobs:
 
       - name: Execute pnpm
         run: pnpm install
+
+      - name: Install Playwright browser
+        run: npx playwright install chromium
 
       - name: Adjust/Downgrade local podman desktop version
         run: |

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -606,6 +606,9 @@ jobs:
       - name: Execute pnpm
         run: pnpm install
 
+      - name: Install Playwright browser
+        run: npx playwright install chromium
+
       - name: Adjust/Downgrade local podman desktop version Windows
         run: node tests/playwright/scripts/version-util.cjs ./package.json --update
 
@@ -684,6 +687,8 @@ jobs:
       - name: Execute pnpm
         run: pnpm install
 
+      - name: Install Playwright browser
+        run: npx playwright install chromium
 
       - name: Adjust/Downgrade local podman desktop version
         run: |

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:unit": "pnpm run build:preload:types && pnpm run build:ui && vitest --run",
     "test:unit:coverage": "pnpm run test:unit --coverage",
     "test:e2e": "pnpm run test:e2e:build && pnpm run test:e2e:run",
-    "test:e2e:build": "cross-env NODE_ENV=development MODE=development DEBUG=pw:browser pnpm run build",
+    "test:e2e:build": "playwright install chromium && cross-env NODE_ENV=development MODE=development DEBUG=pw:browser pnpm run build",
     "test:e2e:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ --grep-invert @k8s_e2e",
     "test:e2e:all": "pnpm run test:e2e:build && pnpm run test:e2e:all:run",
     "test:e2e:all:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/",
@@ -128,7 +128,7 @@
     "storybook:dev": "pnpm run storybook:css && cd storybook && pnpm run dev",
     "storybook:build": "pnpm run build:ui && pnpm run storybook:css && cd storybook && pnpm run build",
     "prepare": "husky install",
-    "postinstall": "pnpm run build:core-api && playwright install chromium"
+    "postinstall": "pnpm run build:core-api"
   },
   "lint-staged": {
     "*.{js,ts,tsx,svelte}": [


### PR DESCRIPTION
### What does this PR do?
Removes playwright installation from postinstall script and moves it to test:e2e:build command and in some cases directly into the github workflow if those flows do not call test:e2e:build

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/17748