### PR TITLE
fix: expanded system overview by default

### DIFF
--- a/packages/main/src/plugin/dashboard/dashboard-service.spec.ts
+++ b/packages/main/src/plugin/dashboard/dashboard-service.spec.ts
@@ -143,7 +143,7 @@ test('should register a configuration', () => {
   expect(configurationNode?.properties?.[SYSTEM_OVERVIEW_EXPANDED]).toBeDefined();
   expect(configurationNode?.properties?.[SYSTEM_OVERVIEW_EXPANDED]?.type).toBe('boolean');
   expect(configurationNode?.properties?.[SYSTEM_OVERVIEW_EXPANDED]?.hidden).toBe(true);
-  expect(configurationNode?.properties?.[SYSTEM_OVERVIEW_EXPANDED]?.default).toBe(false);
+  expect(configurationNode?.properties?.[SYSTEM_OVERVIEW_EXPANDED]?.default).toBe(true);
   expect(
     configurationNode?.properties?.[ENHANCED_DASHBOARD_CONFIGURATION_KEY]?.experimental?.githubDiscussionLink,
   ).toBe('https://github.com/podman-desktop/podman-desktop/discussions/16055');

--- a/packages/main/src/plugin/dashboard/dashboard-service.ts
+++ b/packages/main/src/plugin/dashboard/dashboard-service.ts
@@ -90,7 +90,7 @@ export class DashboardService implements IDisposable {
           type: 'boolean',
           description: 'Expand the system overview section on the dashboard',
           hidden: true,
-          default: false,
+          default: true,
         },
       },
     };


### PR DESCRIPTION
### What does this PR do?
Aligns the system overview card with the rest of the cards from the dashboard, by making it expanded by default the first time you enable the feature.

### Screenshot / video of UI
Previously:
[Screencast From 2026-06-18 12-44-45.webm](https://github.com/user-attachments/assets/5f9a3664-f911-4129-a268-e6edee754653)

Now:
[Screencast From 2026-06-18 12-46-51.webm](https://github.com/user-attachments/assets/3f7eca7a-335b-45b2-b3f1-2e555790c108)
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #17848 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
