### PR TITLE
fix(renderer): load UI state before Keychain authentication

### DIFF
--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -24,7 +24,7 @@ import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 import { render, screen } from '@testing-library/svelte';
 import { readable } from 'svelte/store';
 import type { TinroRouteMeta } from 'tinro';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
 
@@ -46,6 +46,10 @@ beforeAll(() => {
   onDidChangeConfiguration.addEventListener = vi.fn().mockImplementation((message: string, callback: () => void) => {
     callbacks.set(message, callback);
   });
+});
+
+beforeEach(() => {
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(160);
 });
 
 test('Test rendering of the navigation bar with empty items', async (_arg: unknown) => {
@@ -75,7 +79,6 @@ test('Test rendering of the navigation bar with empty items', async (_arg: unkno
     meta,
     exitSettingsCallback: () => {},
   });
-
   const navigationBar = screen.getByRole('navigation', { name: 'AppNavigation' });
   expect(navigationBar).toBeInTheDocument();
 

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -6,14 +6,22 @@ import App from './App.svelte';
 import SealRocket from './lib/images/SealRocket.svelte';
 import ColorsStyle from './lib/style/ColorsStyle.svelte';
 import { lastPage } from './stores/breadcrumb';
+import { colorsInfos } from './stores/colors';
 
 let systemReady = false;
+let colorsLoaded = false;
 
 let toggle = false;
 
 let loadingSequence: NodeJS.Timeout;
 
 let extensionsStarterChecker: NodeJS.Timeout;
+
+const unsubscribeColors = colorsInfos.subscribe(colors => {
+  if (colors && colors.length > 0) {
+    colorsLoaded = true;
+  }
+});
 
 onMount(async () => {
   loadingSequence = setInterval(() => {
@@ -49,6 +57,7 @@ onDestroy(() => {
   if (loadingSequence) {
     clearInterval(loadingSequence);
   }
+  unsubscribeColors();
 
   if (extensionsStarterChecker) {
     clearInterval(extensionsStarterChecker);
@@ -66,7 +75,7 @@ window.events?.receive('install-extension:from-id', (extensionId: unknown) => {
     lastPage.set({ name: 'Extensions', path: '/extensions' });
   };
 
-  if (!systemReady) {
+  if (!systemReady || !colorsLoaded) {
     // need to wait for the system to be ready, so we delay the install
     window.addEventListener('system-ready', () => {
       action().catch((err: unknown) => console.log('Error while redirecting to extensions', err));


### PR DESCRIPTION
On macOS initial startup from DMG, UI was not properly initialized until after Keychain authentication completed. Window showed with black background and missing navigation labels while waiting for user to authenticate.

Fix consists in keep showing the splash screen until colors are loaded from the
main process, preventing a flash of unstyled content. Guard
AppNavigation rendering until iconWithTitle config is resolved.


This is a backport of https://github.com/openkaiden/kaiden/pull/2104
I did not manage to reproduce Kaiden's issue in PD, but Kaiden needs this change done in PD first.
