### PR TITLE
chore(test): switch using testing images ghcr.io

### DIFF
--- a/tests/playwright/resources/compose.yaml
+++ b/tests/playwright/resources/compose.yaml
@@ -1,10 +1,10 @@
 services:
   backend:
-    image: quay.io/podman-desktop-demo/podify-demo-backend:v1
+    image: ghcr.io/podmandesktop-ci/podify-demo-backend:v1
     ports:
       - '6379:6379'
   frontend:
-    image: quay.io/podman-desktop-demo/podify-demo-frontend:v1
+    image: ghcr.io/podmandesktop-ci/podify-demo-frontend:v1
     ports:
       - '5001:5001'
     depends_on:

--- a/tests/playwright/resources/images/long-task-example.containerfile
+++ b/tests/playwright/resources/images/long-task-example.containerfile
@@ -1,0 +1,5 @@
+FROM quay.io/fbenoit/long-task-example:v1.0
+LABEL org.opencontainers.image.title="Long task sample"
+LABEL io.podman-desktop.api.version=">= 1.14.0"
+LABEL org.opencontainers.image.licenses="Apache-2.0 license"
+LABEL org.opencontainers.image.description="Rebuild of https://github.com/benoitf/tstcncl-tsk - Long Task Sample"

--- a/tests/playwright/resources/images/podify-demo/podify-demo-backend.containerfile
+++ b/tests/playwright/resources/images/podify-demo/podify-demo-backend.containerfile
@@ -1,0 +1,5 @@
+FROM quay.io/podman-desktop-demo/podify-demo-backend:v1
+LABEL org.opencontainers.image.title="Podman Desktop Podify demo backend"
+LABEL io.podman-desktop.api.version=">= 1.14.0"
+LABEL org.opencontainers.image.licenses="Apache-2.0 license"
+LABEL org.opencontainers.image.description="Rebuild of backend app from https://github.com/redhat-developer/podman-desktop-demo"

--- a/tests/playwright/resources/images/podify-demo/podify-demo-frontend.containerfile
+++ b/tests/playwright/resources/images/podify-demo/podify-demo-frontend.containerfile
@@ -1,0 +1,5 @@
+FROM quay.io/podman-desktop-demo/podify-demo-frontend:v1
+LABEL org.opencontainers.image.title="Podman Desktop Podify demo frontend"
+LABEL io.podman-desktop.api.version=">= 1.14.0"
+LABEL org.opencontainers.image.licenses="Apache-2.0 license"
+LABEL org.opencontainers.image.description="Rebuild of frontend app from https://github.com/redhat-developer/podman-desktop-demo"

--- a/tests/playwright/resources/kubernetes/test-pod-configmaps-secrets.yaml
+++ b/tests/playwright/resources/kubernetes/test-pod-configmaps-secrets.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-app-configmap-secret
-      image: quay.io/podman-desktop-demo/podify-demo-backend:v1
+      image: ghcr.io/podmandesktop-ci/podify-demo-backend:v1
       envFrom:
         - configMapRef:
             name: test-configmap-resource

--- a/tests/playwright/resources/kubernetes/test-pod-pvcs.yaml
+++ b/tests/playwright/resources/kubernetes/test-pod-pvcs.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-app-pvc
-    image: quay.io/podman-desktop-demo/podify-demo-backend:v1
+    image: ghcr.io/podmandesktop-ci/podify-demo-backend:v1
     volumeMounts:
     - name: config-volume
       mountPath: /etc/config

--- a/tests/playwright/resources/primary-podify-demo.yaml
+++ b/tests/playwright/resources/primary-podify-demo.yaml
@@ -18,7 +18,7 @@ spec:
       value: xterm
     - name: HOME
       value: /home/redis
-    image: quay.io/podman-desktop-demo/podify-demo-backend:v1
+    image: ghcr.io/podmandesktop-ci/podify-demo-backend:v1
     resources:
         limits:
           cpu: 1
@@ -37,7 +37,7 @@ spec:
       value: /home/frontend
     - name: HOSTNAME
       value: 4daf7345fc17
-    image: quay.io/podman-desktop-demo/podify-demo-frontend:v1
+    image: ghcr.io/podmandesktop-ci/podify-demo-frontend:v1
     resources:
         limits:
           cpu: 1

--- a/tests/playwright/src/specs/cancelable-task-smoke.spec.ts
+++ b/tests/playwright/src/specs/cancelable-task-smoke.spec.ts
@@ -23,7 +23,7 @@ import { TasksPage } from '/@/model/pages/tasks-page';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
-const longRunningTaskName = 'quay.io/fbenoit/long-task-example:v1.0';
+const longRunningTaskName = 'ghcr.io/podmandesktop-ci/long-task-example:v1.0';
 const taskName = 'Dummy Long Task';
 const taskDisplayName = 'Doing something';
 

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -28,8 +28,8 @@ import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '/@/utility/wa
 let backendPort: string;
 let frontendPort: string;
 
-const backendImage = 'quay.io/podman-desktop-demo/podify-demo-backend';
-const frontendImage = 'quay.io/podman-desktop-demo/podify-demo-frontend';
+const backendImage = 'ghcr.io/podmandesktop-ci/podify-demo-backend';
+const frontendImage = 'ghcr.io/podmandesktop-ci/podify-demo-frontend';
 const imagesTag = 'v1';
 const backendContainer = 'backend';
 const frontendContainer = 'frontend';

--- a/tests/playwright/src/specs/podman-compose-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-compose-smoke.spec.ts
@@ -34,8 +34,8 @@ const __dirname = path.dirname(__filename);
 const backendContainerName = 'backend-1';
 const frontendContainerName = 'frontend-1';
 const composeContainer = 'resources';
-const backendImageName = 'quay.io/podman-desktop-demo/podify-demo-backend';
-const frontendImageName = 'quay.io/podman-desktop-demo/podify-demo-frontend';
+const backendImageName = 'ghcr.io/podmandesktop-ci/podify-demo-backend';
+const frontendImageName = 'ghcr.io/podmandesktop-ci/podify-demo-frontend';
 let cliToolsPage: CLIToolsPage;
 
 test.beforeAll(async ({ runner, welcomePage, page }) => {

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -23,7 +23,7 @@ import { expect as playExpect, test } from '/@/utility/fixtures';
 import { deleteContainer, deleteImage, readFileInVolumeFromCLI } from '/@/utility/operations';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
-const imageToPull = 'ghcr.io/osbuild/bootc-image-builder:latest';
+const imageToPull = 'ghcr.io/osbuild/bootc-image-builder';
 const imageTag = 'latest';
 const noVolumeImageToPull = 'ghcr.io/linuxcontainers/alpine';
 const containerName = 'alpine';
@@ -234,7 +234,7 @@ test.describe
         })
         .toBeTruthy();
 
-      //pull image from ghcr.io/podmandesktop-ci/podify-demo-backend
+      //pull image from ghcr.io/linuxcontainers/alpine
       let images = await navigationBar.openImages();
       const pullImagePage = await images.openPullImage();
       images = await pullImagePage.pullImage(noVolumeImageToPull, imageTag, 120_000);

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -23,7 +23,7 @@ import { expect as playExpect, test } from '/@/utility/fixtures';
 import { deleteContainer, deleteImage, readFileInVolumeFromCLI } from '/@/utility/operations';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
-const imageToPull = 'quay.io/centos-bootc/bootc-image-builder';
+const imageToPull = 'ghcr.io/osbuild/bootc-image-builder:latest';
 const imageTag = 'latest';
 const noVolumeImageToPull = 'ghcr.io/linuxcontainers/alpine';
 const containerName = 'alpine';
@@ -154,7 +154,7 @@ test.describe
         }
       }
 
-      //pull image from quay.io/centos-bootc/bootc-image-builder
+      //pull image from ghcr.io/osbuild/bootc-image-builder
       let images = await navigationBar.openImages();
       const pullImagePage = await images.openPullImage();
       images = await pullImagePage.pullImage(imageToPull, imageTag, 240_000);
@@ -234,7 +234,7 @@ test.describe
         })
         .toBeTruthy();
 
-      //pull image from quay.io/podman-desktop-demo/podify-demo-backend
+      //pull image from ghcr.io/podmandesktop-ci/podify-demo-backend
       let images = await navigationBar.openImages();
       const pullImagePage = await images.openPullImage();
       images = await pullImagePage.pullImage(noVolumeImageToPull, imageTag, 120_000);

--- a/tests/playwright/src/specs/yaml-smoke.spec.ts
+++ b/tests/playwright/src/specs/yaml-smoke.spec.ts
@@ -27,8 +27,8 @@ import { waitForPodmanMachineStartup } from '/@/utility/wait';
 
 const podAppName = 'primary-podify-demo';
 const podName = 'podify-demo-pod';
-const frontendImage = 'quay.io/podman-desktop-demo/podify-demo-frontend';
-const backendImage = 'quay.io/podman-desktop-demo/podify-demo-backend';
+const frontendImage = 'ghcr.io/podmandesktop-ci/podify-demo-frontend';
+const backendImage = 'ghcr.io/podmandesktop-ci/podify-demo-backend';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);


### PR DESCRIPTION
### What does this PR do?
In the e2e tests, we are using some specific images for testing. The best way to make sure the high availability is to move these images under ghcr.io as our CI uses the same infrastructure. There might be issues with quay.io sometimes or docker.io. 

I also used newer builder image which is already on ghcr.io under osbuild org.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#10678 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
all tests should be passing.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
