### PR TITLE
refactor(renderer): replace `bg-black/4 dark:bg-white/4` with color-registry token in `TroubleshootingDevToolsConsoleLogs`

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -118,6 +118,10 @@ class TestColorRegistry extends ColorRegistry {
   override initActionButton(): void {
     super.initActionButton();
   }
+
+  override initInvertContent(): void {
+    super.initInvertContent();
+  }
 }
 
 const _onDidChangeConfiguration = new Emitter<IConfigurationChangeEvent>();
@@ -1822,5 +1826,44 @@ describe('initActionButton', () => {
       hcDark: tailwindColorPalette.accent1[500],
       hcLight: tailwindColorPalette.accent1[700],
     });
+  });
+});
+
+describe('initInvertContent', () => {
+  let spyOnRegisterColor: MockInstance<(colorId: string, definition: ColorDefinition) => void>;
+  let spyOnRegisterColorDefinition: MockInstance<(definition: ColorDefinitionWithId) => void>;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    spyOnRegisterColor = vi.spyOn(colorRegistry, 'registerColor');
+    spyOnRegisterColor.mockReturnValue(undefined);
+    spyOnRegisterColorDefinition = vi.spyOn(colorRegistry, 'registerColorDefinition');
+    spyOnRegisterColorDefinition.mockReturnValue(undefined);
+    colorRegistry.initInvertContent();
+  });
+
+  test('registers invert-content-table-row-stripe with alpha transparency', () => {
+    const stripeCall = spyOnRegisterColorDefinition.mock.calls.find(
+      call => call?.[0]?.id === 'invert-content-table-row-stripe',
+    );
+    expect(stripeCall).toBeDefined();
+
+    const definition = stripeCall?.[0];
+    expect(definition?.id).toBe('invert-content-table-row-stripe');
+    expect(definition?.dark).toBeDefined();
+    expect(definition?.light).toBeDefined();
+    expect(definition?.hcDark).toBeDefined();
+    expect(definition?.hcLight).toBeDefined();
+
+    // verify 4% opacity applied across all themes
+    expect(definition?.dark).toContain('0.04');
+    expect(definition?.light).toContain('0.04');
+    expect(definition?.hcDark).toContain('0.04');
+    expect(definition?.hcLight).toContain('0.04');
+  });
+
+  test('registers solid invert-content colors via registerColor', () => {
+    expect(spyOnRegisterColor).toHaveBeenCalledWith('invert-content-bg', expect.any(Object));
+    expect(spyOnRegisterColor).toHaveBeenCalledWith('invert-content-divider', expect.any(Object));
   });
 });

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -671,6 +671,15 @@ export class ColorRegistry {
       hcDark: white,
       hcLight: black,
     });
+
+    this.registerColorDefinition(
+      this.color(`${invCt}table-row-stripe`)
+        .withLight(colorPaletteHelper(black).withAlpha(0.04))
+        .withDark(colorPaletteHelper(white).withAlpha(0.04))
+        .withHcLight(colorPaletteHelper(black).withAlpha(0.04))
+        .withHcDark(colorPaletteHelper(white).withAlpha(0.04))
+        .build(),
+    );
   }
 
   protected initContent(): void {

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -56,7 +56,7 @@ async function copyLogsToClipboard(): Promise<void> {
     <div class="h-full overflow-auto p-2 bg-[var(--pd-invert-content-card-bg)]">
       <ul aria-label="logs">
         {#each logs as log, index (index)}
-          <li class="py-[3px] px-1 rounded-sm {index % 2 === 0 ? 'bg-black/4 dark:bg-white/4' : ''}">
+          <li class="py-[3px] px-1 rounded-sm {index % 2 === 0 ? 'bg-(--pd-invert-content-table-row-stripe)' : ''}">
             <div class="flex flex-row items-start gap-2">
               {#if showTimestamps}
                 <span


### PR DESCRIPTION
### What does this PR do?

Registers a new `invert-content-table-row-stripe` color token in the color registry and uses it in `TroubleshootingDevToolsConsoleLogs` in place of the hardcoded `bg-black/4 dark:bg-white/4` zebra-stripe classes.

The old classes manually replicate what the color registry handles automatically (the `dark:` variant) and use direct palette colors instead of semantic tokens. The new token is defined via `registerColorDefinition` with 4% opacity black on light/hc-light themes and 4% opacity white on dark/hc-dark themes, preserving the original visual appearance while keeping theme handling consistent with the rest of the codebase.

### Screenshot / video of UI

No visible change — the stripe color and opacity are identical to before.

### What issues does this PR fix or reference?

- Closes #17395

### How to test this PR?

1. Run the app (`pnpm watch`) and open **Troubleshooting → Dev Tools Console Logs**.
2. Trigger a few console log entries (open dev tools in any page and run `console.log('test')`).
3. Verify even-indexed rows show a subtle alternating background stripe in both light and dark themes.
4. Switch between light, dark, hc-light, and hc-dark themes and confirm the stripe is visible in all four.

- [x] Tests are covering the bug fix or the new feature