### PR TITLE
fix(extensions): keep summary card in horizontal layout at all times

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -94,7 +94,7 @@ $: extension = derived(
     {/snippet}
 
     {#snippet contentSnippet()}
-      <div class="flex w-full h-full overflow-y-auto p-5 flex-col lg:flex-row">
+      <div class="flex w-full h-full overflow-y-auto p-5 flex-col">
         {#if screen === 'README'}
           <ExtensionDetailsSummaryCard extensionDetails={$extension} />
           <ExtensionDetailsReadme readme={$extension.readme} />

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
@@ -9,9 +9,8 @@ interface Props {
 let { extensionDetails }: Props = $props();
 </script>
 
-<div class="order-first lg:order-last w-full lg:w-48 flex flex-row grow justify-end pb-4 lg:pb-0">
-  <div
-    class="bg-[var(--pd-details-card-bg)] lg:w-40 h-fit lg:ml-4 p-4 rounded-md flex flex-row lg:flex-col w-full space-x-4 lg:space-x-0">
+<div class="w-full pb-4">
+  <div class="bg-[var(--pd-details-card-bg)] h-fit p-4 rounded-md flex flex-row w-full space-x-4">
     <ExtensionDetailsSummaryCardEntry label="version" value={extensionDetails.version} />
 
     <ExtensionDetailsSummaryCardEntry label="released" value={extensionDetails.releaseDate} />

--- a/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.svelte
@@ -7,7 +7,7 @@ interface Props {
 let { label, value }: Props = $props();
 </script>
 
-<div class="flex flex-col lg:mb-4 items-start">
+<div class="flex flex-col items-start">
   <div class="uppercase text-sm text-[var(--pd-details-card-header)]">{label}</div>
   <div class="text-left font-thin text-sm text-[var(--pd-details-card-text)]">{value}</div>
 </div>


### PR DESCRIPTION
### What does this PR do?

Removes the `lg:` responsive variants from `ExtensionDetailsSummaryCard` that switched the summary card into a narrow 160px vertical sidebar at the 1024pt breakpoint. At that width, long values — particularly repository and homepage URLs — fragmented across five or more short line-fragments and were barely readable. The `font-thin` weight on card values compounded the legibility problem in the narrow layout.

Changes:
- `ExtensionDetailsSummaryCard.svelte`: removed `lg:order-last`, `lg:w-48`, `lg:w-40`, `lg:flex-col`, `lg:space-x-0`, `lg:pb-0`, and `lg:ml-4`; the card now always renders as a horizontal row
- `ExtensionDetails.svelte`: removed `lg:flex-row` from the content wrapper so the card is always a full-width top bar and the readme always renders below it
- `InstalledExtensionDetailsSummaryCardEntry.svelte`: removed `lg:mb-4` which was only needed to space entries in the vertical sidebar layout

### Screenshot / video of UI
<img width="1993" height="1112" alt="Screenshot 2026-06-19 at 15 48 30" src="https://github.com/user-attachments/assets/de5e7e12-7598-4ccc-b5d6-2865b6803cb9" />
<img width="752" height="712" alt="Screenshot 2026-06-19 at 15 48 24" src="https://github.com/user-attachments/assets/d263d1d9-a7f8-4324-bd59-4285dc42c71e" />
<img width="1233" height="922" alt="Screenshot 2026-06-19 at 15 48 14" src="https://github.com/user-attachments/assets/1d952610-8521-4690-bf8a-0e359c3cbd01" />



<!-- Before/after screenshots to be added by reviewer -->

### What issues does this PR fix or reference?

Fixes #17873
Required for #17299 (add repository and homepage links to extension details)

### How to test this PR?

1. Open Podman Desktop and navigate to **Extensions → Compose → Details** (or any extension)
2. Resize the window to a width above 1024px — the summary card should **stay as a horizontal strip** above the readme, not collapse into a vertical sidebar
3. Resize below 1024px — layout should be unchanged (still horizontal)

- [ ] Tests are covering the bug fix or the new feature

🤖 Generated with AI assistance ([Cursor](https://cursor.com))

Made with [Cursor](https://cursor.com)