### PR TITLE
chore(renderer): migrate CreateVolume component to Svelte 5 runes

### DIFF
--- a/packages/renderer/src/lib/volume/CreateVolume.spec.ts
+++ b/packages/renderer/src/lib/volume/CreateVolume.spec.ts
@@ -21,7 +21,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderInfo, VolumeListInfo } from '@podman-desktop/core-api';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
@@ -261,11 +261,12 @@ test('Expect error and disabled button when volume name already exists', async (
   const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
   await userEvent.type(nameInput, 'existing-volume');
 
-  const errorMessage = screen.getByText('The name "existing-volume" already exists. Please choose a different name.');
-  expect(errorMessage).toBeInTheDocument();
-
-  const createButton = screen.getByRole('button', { name: createButtonTitle });
-  expect(createButton).toBeDisabled();
+  await waitFor(() => {
+    expect(
+      screen.getByText('The name "existing-volume" already exists. Please choose a different name.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+  });
 });
 
 test('Expect no error when volume name is unique', async () => {
@@ -298,11 +299,10 @@ test('Expect no error when volume name is unique', async () => {
   const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
   await userEvent.type(nameInput, 'new-volume');
 
-  const errorMessage = screen.queryByText(/already exists/);
-  expect(errorMessage).not.toBeInTheDocument();
-
-  const createButton = screen.getByRole('button', { name: createButtonTitle });
-  expect(createButton).toBeEnabled();
+  await waitFor(() => {
+    expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+  });
 });
 
 test('Expect no error when volume name is empty', async () => {
@@ -335,14 +335,16 @@ test('Expect no error when volume name is empty', async () => {
   const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
   await userEvent.type(nameInput, 'existing-volume');
 
-  expect(screen.getByText(/already exists/)).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByText(/already exists/)).toBeInTheDocument();
+  });
 
   await userEvent.clear(nameInput);
 
-  expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
-
-  const createButton = screen.getByRole('button', { name: createButtonTitle });
-  expect(createButton).toBeEnabled();
+  await waitFor(() => {
+    expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+  });
 });
 
 test('Expect revalidation when provider changes', async () => {
@@ -393,14 +395,18 @@ test('Expect revalidation when provider changes', async () => {
   const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
   await userEvent.type(nameInput, 'shared-name');
 
-  expect(screen.getByText(/already exists/)).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+  await waitFor(() => {
+    expect(screen.getByText(/already exists/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+  });
 
   const providerSelect = screen.getByRole('combobox', { name: 'Provider Choice' });
   await userEvent.selectOptions(providerSelect, 'docker');
 
-  expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
-  expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+  await waitFor(() => {
+    expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+  });
 });
 
 test('Expect no false positive when providers share connection name', async () => {
@@ -452,16 +458,20 @@ test('Expect no false positive when providers share connection name', async () =
   await userEvent.type(nameInput, 'my-vol');
 
   // podman.Docker is selected first — no volume named 'my-vol' there
-  expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
-  expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+  await waitFor(() => {
+    expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+  });
 
   // switch to docker.Docker — 'my-vol' exists there
   const providerSelect = screen.getByRole('combobox', { name: 'Provider Choice' });
   const options = providerSelect.querySelectorAll('option');
   await userEvent.selectOptions(providerSelect, options[1] as HTMLOptionElement);
 
-  expect(screen.getByText(/already exists/)).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+  await waitFor(() => {
+    expect(screen.getByText(/already exists/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+  });
 });
 
 test('Expect error clears when name is corrected', async () => {
@@ -494,12 +504,16 @@ test('Expect error clears when name is corrected', async () => {
   const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
   await userEvent.type(nameInput, 'my-volume');
 
-  expect(screen.getByText(/already exists/)).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+  await waitFor(() => {
+    expect(screen.getByText(/already exists/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeDisabled();
+  });
 
   await userEvent.clear(nameInput);
   await userEvent.type(nameInput, 'my-volume-2');
 
-  expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
-  expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+  await waitFor(() => {
+    expect(screen.queryByText(/already exists/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: createButtonTitle })).toBeEnabled();
+  });
 });

--- a/packages/renderer/src/lib/volume/CreateVolume.svelte
+++ b/packages/renderer/src/lib/volume/CreateVolume.svelte
@@ -3,10 +3,8 @@
 // https://github.com/import-js/eslint-plugin-import/issues/1479
 import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 /* eslint-enable import/no-duplicates */
-import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
+import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
-import { onDestroy, onMount } from 'svelte';
-import { get } from 'svelte/store';
 import { router } from 'tinro';
 
 import VolumeIcon from '/@/lib/images/VolumeIcon.svelte';
@@ -14,60 +12,56 @@ import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import { providerInfos } from '/@/stores/providers';
 import { volumeListInfos } from '/@/stores/volumes';
 
-let providers: ProviderInfo[] = [];
-let providerConnections: ProviderContainerConnectionInfo[] = [];
-let selectedProvider: ProviderContainerConnectionInfo | undefined = undefined;
-let selectedProviderConnection: ProviderContainerConnectionInfo | undefined = undefined;
+interface Props {
+  volumeName?: string;
+}
+const { volumeName: initialVolumeName = '' }: Props = $props();
 
-onMount(async () => {
-  providers = get(providerInfos);
-  providerConnections = providers
-    .map(provider => provider.containerConnections)
-    .flat()
-    .filter(providerContainerConnection => providerContainerConnection.status === 'started');
-
-  selectedProviderConnection = providerConnections.length > 0 ? providerConnections[0] : undefined;
-  selectedProvider = !selectedProvider && selectedProviderConnection ? selectedProviderConnection : selectedProvider;
-});
-
-let createVolumeInProgress = false;
-let createError: string | undefined = undefined;
-let volumeNameError: string | undefined = undefined;
-let invalidName = false;
-onDestroy(() => {});
-
-function checkVolumeName(nameValue: string, provider: ProviderContainerConnectionInfo | undefined): void {
-  if (!nameValue || !provider) {
-    volumeNameError = undefined;
-    invalidName = false;
-    return;
-  }
-
-  const parentProvider = providers.find(p => p.containerConnections.includes(provider));
-  const engineId = parentProvider ? `${parentProvider.id}.${provider.name}` : undefined;
-
-  const volumeAlreadyExists = engineId
-    ? $volumeListInfos
-        .filter(vli => vli.engineId === engineId)
-        .flatMap(vli => vli.Volumes)
-        .some(volume => volume.Name === nameValue)
-    : false;
-
-  if (volumeAlreadyExists) {
-    volumeNameError = `The name "${nameValue}" already exists. Please choose a different name.`;
-    invalidName = true;
-  } else {
-    volumeNameError = undefined;
-    invalidName = false;
-  }
+interface ConnectionWithEngine {
+  connection: ProviderContainerConnectionInfo;
+  engineId: string;
 }
 
-$: checkVolumeName(volumeName, selectedProvider);
+let volumeName = $state(initialVolumeName);
+let selectedIndex = $state(-1);
+let createVolumeInProgress = $state(false);
+let createError: string | undefined = $state(undefined);
+let createVolumeFinished = $state(false);
+
+let connectionsWithEngine: ConnectionWithEngine[] = $derived(
+  $providerInfos.flatMap(provider =>
+    provider.containerConnections
+      .filter(c => c.status === 'started')
+      .map(c => ({ connection: c, engineId: `${provider.id}.${c.name}` })),
+  ),
+);
+
+let providerConnections = $derived(connectionsWithEngine.map(x => x.connection));
+let selectedProvider = $derived(providerConnections[selectedIndex]);
+let selectedEngineId = $derived(connectionsWithEngine[selectedIndex]?.engineId);
+
+$effect(() => {
+  if (connectionsWithEngine.length === 0) {
+    selectedIndex = -1;
+  } else if (selectedIndex < 0 || selectedIndex >= connectionsWithEngine.length) {
+    selectedIndex = 0;
+  }
+});
+
+let invalidName = $derived.by(() => {
+  if (!volumeName || !selectedEngineId) return false;
+  return $volumeListInfos
+    .filter(vli => vli.engineId === selectedEngineId)
+    .flatMap(vli => vli.Volumes)
+    .some(volume => volume.Name === volumeName);
+});
+
+let volumeNameError: string | undefined = $derived(
+  invalidName ? `The name "${volumeName}" already exists. Please choose a different name.` : undefined,
+);
 
 async function createVolume(providerConnectionInfo: ProviderContainerConnectionInfo): Promise<void> {
   createError = undefined;
-  volumeNameError = undefined;
-  invalidName = false;
   createVolumeInProgress = true;
   try {
     await window.createVolume(providerConnectionInfo, { Name: volumeName });
@@ -83,10 +77,6 @@ function end(): void {
   // redirect to the volumes page
   router.goto('/volumes');
 }
-
-let createVolumeFinished = false;
-
-export let volumeName = '';
 </script>
 
 <EngineFormPage
@@ -111,23 +101,23 @@ export let volumeName = '';
             class="w-full p-2 outline-hidden bg-[var(--pd-select-bg)] rounded-xs text-[var(--pd-content-card-text)]"
             aria-label="Provider Choice"
             disabled={createVolumeFinished}
-            bind:value={selectedProvider}>
+            bind:value={selectedIndex}>
             {#each providerConnections as providerConnection, index (index)}
-              <option value={providerConnection}>{providerConnection.name}</option>
+              <option value={index}>{providerConnection.name}</option>
             {/each}
           </select>
         </label>
       {/if}
     </div>
-    {#if providerConnections.length === 1 && selectedProviderConnection}
-      <input type="hidden" aria-label="Provider Choice" readonly bind:value={selectedProvider} />
+    {#if providerConnections.length === 1 && providerConnections[0]}
+      <input type="hidden" aria-label="Provider Choice" readonly value={selectedIndex} />
     {/if}
 
     <div class="w-full flex flex-row space-x-4">
       {#if !createVolumeFinished && selectedProvider}
         {@const connection = selectedProvider}
         <Button
-          on:click={(): Promise<void> => createVolume(connection)}
+          onclick={(): Promise<void> => createVolume(connection)}
           disabled={createVolumeInProgress || invalidName}
           class="w-full"
           inProgress={createVolumeInProgress}
@@ -137,7 +127,7 @@ export let volumeName = '';
       {/if}
 
       {#if createVolumeFinished}
-        <Button on:click={end} class="w-full">Done</Button>
+        <Button onclick={end} class="w-full">Done</Button>
       {/if}
     </div>
 


### PR DESCRIPTION
### What does this PR do?

Migrates `CreateVolume.svelte` from Svelte 4 syntax to Svelte 5

### Screenshot / video of UI

No visual changes — this is a pure syntax migration.

### What issues does this PR fix or reference?

Closes #17817

### How to test this PR?

Run unit tests: `pnpm exec vitest run packages/renderer/src/lib/volume/CreateVolume.spec.ts` — all 11 tests pass

- [x] Tests are covering the bug fix or the new feature

Signed-off-by: Anton Misskii <a.misskii@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>