### PR TITLE
fix(renderer): mark retagged images as in-use by matching on ImageID

### DIFF
--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -155,7 +155,7 @@ describe('inUse', () => {
     ImageID: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
   } as unknown as ContainerInfo;
 
-  test('should expect inUsed with an untagged image', async () => {
+  test('should expect inUse with an untagged image', async () => {
     const containerInfo = {
       Id: 'container1',
       Image: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
@@ -163,13 +163,11 @@ describe('inUse', () => {
     } as unknown as ContainerInfo;
 
     const isUsed = imageUtils.getInUse(untaggedImageInfo, undefined, [containerInfo]);
-    // image should be used
     expect(isUsed).toBeTruthy();
   });
 
-  test('should not expect inUsed without a containerInfo', async () => {
+  test('should not expect inUse without a containerInfo', async () => {
     const isUsed = imageUtils.getInUse(imageInfoHello);
-    // image should not be used
     expect(isUsed).toBeFalsy();
   });
 
@@ -177,9 +175,8 @@ describe('inUse', () => {
     ['quay.io/podman/hello:latest', true],
     ['quay.io/podman/hello2:latest', false],
     ['quay.io/podman/hello3:latest', false],
-  ])('should expect different inUsed based on repoTag %s', async (repoTag: string, expected: boolean) => {
+  ])('should expect different inUse based on repoTag %s', async (repoTag: string, expected: boolean) => {
     const isUsed = imageUtils.getInUse(imageInfoHello, repoTag, [containerInfo]);
-    // image should be used
     expect(isUsed).toBe(expected);
   });
 
@@ -192,6 +189,32 @@ describe('inUse', () => {
 
     const isUsed = imageUtils.getInUse(untaggedImageInfo, undefined, [containerWithTag]);
     expect(isUsed).toBeTruthy();
+  });
+
+  test('should expect inUse for retagged image when container still references old tag', async () => {
+    const retaggedImage = {
+      Id: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
+      RepoTags: ['quay.io/podman/hello:custom-tag'],
+    } as unknown as ImageInfo;
+
+    const isUsed = imageUtils.getInUse(retaggedImage, 'quay.io/podman/hello:custom-tag', [containerInfo]);
+    expect(isUsed).toBeTruthy();
+  });
+
+  test('should not expect inUse when no container matches the ImageID', async () => {
+    const differentContainer = {
+      Id: 'container2',
+      Image: 'quay.io/podman/hello:latest',
+      ImageID: 'sha256:different_image_id',
+    } as unknown as ContainerInfo;
+
+    const isUsed = imageUtils.getInUse(imageInfoHello, 'quay.io/podman/hello:latest', [differentContainer]);
+    expect(isUsed).toBeFalsy();
+  });
+
+  test('should not expect inUse with empty containers list', async () => {
+    const isUsed = imageUtils.getInUse(imageInfoHello, 'quay.io/podman/hello:latest', []);
+    expect(isUsed).toBeFalsy();
   });
 });
 

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -92,8 +92,6 @@ export class ImageUtils {
     return Buffer.from(name, 'binary').toString('base64');
   }
 
-  // is that this image is used by a container or not
-  // search if there is a container matching this image
   getInUse(imageInfo: ImageInfo, repositoryTag?: string, containersInfo?: ContainerInfo[]): boolean {
     if (!containersInfo) {
       return false;
@@ -104,7 +102,13 @@ export class ImageUtils {
         return false;
       }
       if (repositoryTag) {
-        return container.Image === repositoryTag;
+        if (container.Image === repositoryTag) {
+          return true;
+        }
+        // The container's original tag no longer exists on the image (e.g. image was retagged).
+        // All remaining tags should be considered in-use since the underlying image data is referenced.
+        const repoTags = imageInfo.RepoTags ?? [];
+        return !repoTags.includes(container.Image);
       }
       return (imageInfo.RepoTags ?? []).length === 0;
     });


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Fixes the `getInUse()` method in `image-utils.ts` to correctly detect retagged images as in-use while preserving per-tag granularity for aliases.

Previously, when an image was retagged (e.g., `alpine:latest` → `myimage:x`), the container still stored the old tag name (`alpine:latest`) in its `Image` field. The code compared `container.Image === repositoryTag`, which failed because the tag name had changed — causing the image to be incorrectly marked as UNUSED.

The fix adds a fallback: if a container references the image by `ImageID` but its original tag no longer exists in the image's current `RepoTags`, all remaining tags are marked as USED. Unused aliases on multi-tagged images can still be deleted independently.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/8418

### How to test this PR?

1. `podman pull docker.io/library/alpine:latest`
2. `podman run --name test-8418 -d alpine:latest sleep 3600`
3. `podman tag alpine:latest myimage:x`
4. `podman rmi docker.io/library/alpine:latest`
5. Open Podman Desktop → Images page
6. Verify `myimage:x` shows status **USED** (green icon) and the delete button is **disabled**
7. Cleanup: `podman stop test-8418 && podman rm test-8418`

- [x] Tests are covering the bug fix or the new feature
