### PR TITLE
chore(tsconfig): remove baseUrl deprecated in Typescript 6 

### DIFF
--- a/extensions/docker/packages/api/tsconfig.json
+++ b/extensions/docker/packages/api/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "node16",
-    "baseUrl": ".",
     "types": ["node"],
     "strict": true,
     "esModuleInterop": true,

--- a/extensions/podman/packages/api/tsconfig.json
+++ b/extensions/podman/packages/api/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "node16",
-    "baseUrl": ".",
     "types": ["node"],
     "strict": true,
     "esModuleInterop": true,

--- a/packages/api-mocks-vitest/tsconfig.json
+++ b/packages/api-mocks-vitest/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "esnext",
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "baseUrl": ".",
     "types": ["node"],
     "strict": true,
     "esModuleInterop": true,

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -16,7 +16,6 @@
 
     "types": ["node"],
 
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"]
     }

--- a/packages/extension-api/tsconfig.json
+++ b/packages/extension-api/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "node16",
-    "baseUrl": ".",
     "types": ["node"],
     "strict": true,
     "esModuleInterop": true,

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -15,7 +15,6 @@
     "emitDecoratorMetadata": true,
     "types": ["node"],
 
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"],
       "/@tests/*": ["./tests/*"],

--- a/packages/preload-docker-extension/tsconfig.json
+++ b/packages/preload-docker-extension/tsconfig.json
@@ -14,7 +14,6 @@
 
     "types": ["node"],
 
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"]
     }

--- a/packages/preload-webview/tsconfig.json
+++ b/packages/preload-webview/tsconfig.json
@@ -13,7 +13,6 @@
     "resolveJsonModule": true,
     "types": ["node"],
 
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"]
     }

--- a/packages/preload/tsconfig.json
+++ b/packages/preload/tsconfig.json
@@ -13,7 +13,6 @@
     "emitDecoratorMetadata": true,
     "types": ["node"],
 
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"]
     }

--- a/packages/renderer/src/stores/run-image-store.ts
+++ b/packages/renderer/src/stores/run-image-store.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ImageInfoUI } from 'src/lib/image/ImageInfoUI';
 import type { Writable } from 'svelte/store';
 import { writable } from 'svelte/store';
+
+import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
 
 /**
  * Defines the store used to define the image to run when starting a container.

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -8,7 +8,6 @@
     "preserveValueImports": false,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"]
     },

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -6,7 +6,6 @@
     "strict": true,
     "resolveJsonModule": true,
     "preserveValueImports": false,
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"]
     },

--- a/packages/webview-api/tsconfig.json
+++ b/packages/webview-api/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "node16",
-    "baseUrl": ".",
     "types": [],
     "strict": true,
     "esModuleInterop": true,

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -6,7 +6,6 @@
     "strict": true,
     "resolveJsonModule": true,
     "preserveValueImports": false,
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["./src/*"]
     },

--- a/tests/playwright/tsconfig.json
+++ b/tests/playwright/tsconfig.json
@@ -16,7 +16,7 @@
     "types": ["node"],
 
     "paths": {
-      "/@/*": ["src/*"]
+      "/@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*.ts", "../types/**/*.d.ts", "../../playwright.config.ts", "scripts/*"],

--- a/tests/playwright/tsconfig.json
+++ b/tests/playwright/tsconfig.json
@@ -15,7 +15,6 @@
 
     "types": ["node"],
 
-    "baseUrl": ".",
     "paths": {
       "/@/*": ["src/*"]
     }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -2,7 +2,6 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "strict": true,
-    "baseUrl": "."
+    "strict": true
   }
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes `baseUrl` from `tsconfig.json` files since it was deprecated in Typescript 6 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#deprecated---baseurl).
This is needed to allow the update from Typescript 5 to 6.
There is one import affected in one file : `packages/renderer/src/stores/run-image-store.ts` where it was used, I changed it to use path alias.
I checked that `pnpm typecheck` is passing.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/17248

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
