### PR TITLE
fix(renderer): show disabled update button while provider is starting

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderStarting.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStarting.spec.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { beforeAll, test } from 'vitest';
+
+import ProviderStarting from '/@/lib/dashboard/ProviderStarting.svelte';
+
+import { verifyStatus } from './ProviderStatusTestHelper.spec';
+
+beforeAll(() => {
+  (window.events as unknown) = {
+    receive: (_channel: string, func: unknown): void => {
+      (func as () => void)();
+    },
+  };
+});
+
+test('Expect starting provider shows disabled update button', async () => {
+  await verifyStatus(ProviderStarting, 'starting', false, true);
+});
+
+test('Expect starting provider does not show update button if version same', async () => {
+  await verifyStatus(ProviderStarting, 'starting', true);
+});

--- a/packages/renderer/src/lib/dashboard/ProviderStarting.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderStarting.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-import type { ProviderInfo } from '@podman-desktop/core-api';
+import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 
 import ProviderCard from './ProviderCard.svelte';
+import ProviderUpdateButton from './ProviderUpdateButton.svelte';
 
 export let provider: ProviderInfo;
 </script>
@@ -14,6 +15,11 @@ export let provider: ProviderInfo;
           {provider.containerConnections.map(c => c.name).join(', ')}
         </p>
       </div>
+    {/if}
+  </svelte:fragment>
+  <svelte:fragment slot="update">
+    {#if provider.updateInfo?.version && provider.version !== provider.updateInfo?.version}
+      <ProviderUpdateButton onPreflightChecks={(): CheckStatus[] => []} provider={provider} />
     {/if}
   </svelte:fragment>
 </ProviderCard>

--- a/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderStatusTestHelper.spec.ts
@@ -26,7 +26,7 @@ import { type InitializationContext, InitializeAndStartMode } from '/@/lib/dashb
 
 export async function verifyStatus<
   C extends Component<{ provider: ProviderInfo; initializationContext: InitializationContext }>,
->(component: C, status: ProviderStatus, sameVersions: boolean): Promise<void> {
+>(component: C, status: ProviderStatus, sameVersions: boolean, expectedDisabled?: boolean): Promise<void> {
   const provider: ProviderInfo = {
     containerConnections: [],
     containerProviderConnectionCreation: false,
@@ -68,6 +68,13 @@ export async function verifyStatus<
       expect(updateButton).not.toBeInTheDocument();
     } else {
       expect(updateButton).toBeInTheDocument();
+      if (expectedDisabled !== undefined) {
+        if (expectedDisabled) {
+          expect(updateButton).toBeDisabled();
+        } else {
+          expect(updateButton).toBeEnabled();
+        }
+      }
     }
   });
 }

--- a/packages/renderer/src/lib/dashboard/ProviderUpdateButton.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderUpdateButton.svelte
@@ -52,7 +52,7 @@ async function performUpdate(provider: ProviderInfo): Promise<void> {
 {#if provider?.version && provider?.updateInfo?.version && provider.version !== provider.updateInfo.version}
   <Button
     inProgress={updateInProgress}
-    disabled={preflightChecksFailed}
+    disabled={preflightChecksFailed || provider.status === 'starting'}
     icon={faBoxOpen}
     padding="px-3 py-0.5"
     on:click={(): Promise<void> => performUpdate(provider)}>


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Shows the Podman update button in a disabled state while the provider is in the `starting` status, instead of hiding it completely. Previously, the button would disappear during startup and reappear once the provider finished starting, causing a confusing flickering effect.

### Screenshot / video of UI



### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17337

### How to test this PR?

1. Have a Podman update available
2. Restart the Podman provider
3. While the provider status is `starting`, verify the update button is visible but disabled (grayed out)
4. Once the provider finishes starting, verify the button becomes enabled

- [x] Tests are covering the bug fix or the new featur
