### PR TITLE
docs: align kubectl set-cluster placeholders with upstream

### DIFF
--- a/website/docs/kubernetes/existing-kubernetes/index.md
+++ b/website/docs/kubernetes/existing-kubernetes/index.md
@@ -23,10 +23,10 @@ You can also use the Kubernetes CLI to configure access to your Kubernetes clust
 #### Procedure
 
 1. (Optionally) Go to **<Icon icon="fa-solid fa-cog" size="lg" /> Settings > Preferences > Kubernetes** to adapt your kubeconfig file location, when different from the default `$HOME/.kube/config`.
-1. Register your _`<my_kubernetes>`_ Kubernetes cluster:
+1. Register your Kubernetes cluster:
 
-   ```shell-session
-   $ kubectl config set-cluster <my_kubernetes> --server=<my_kubernetes_url>
+   ```bash
+   kubectl config set-cluster <cluster-name> --server=<server-url>
    ```
 
 #### Verification


### PR DESCRIPTION
### What does this PR do?
This PR updates the existing Kubernetes documentation to improve technical clarity and developer experience:
- Aligns command placeholders with official `kubectl config set-cluster` terminology (`NAME` and `server` mapping to `<cluster-name>` and `<server-url>`).
   ```shell-session
   ❯ kubectl config set-cluster --help | egrep -A1 "Usage:"
   Usage:
      kubectl config set-cluster NAME [--server=server] [--certificate-authority=path/to/certificate/authority] [--insecure-skip-tls-verify=true] [--tls-server-name=example.com] [options]
   ```
- Optimises the code snippet for direct copy-paste usability by changing the language indicator from `shell-session` to `bash` and removing the `$` prompt symbol.
- Cleans up inline markdown formatting by removing unnecessary italics tags.

### Screenshot / video of UI
N/A (Documentation change only).

### What issues does this PR fix or reference?
None. This is a self-initiated documentation polish to prevent configuration confusion for new users.

### How to test this PR?
The code will show the fix in index.md of the page being referenced.
- [x] Tests are covering the but fix or the new feature
