### PR TITLE
feat(images): add image update action

### DIFF
--- a/packages/main/src/plugin/cancellation-token-registry.spec.ts
+++ b/packages/main/src/plugin/cancellation-token-registry.spec.ts
@@ -54,3 +54,12 @@ test('Return CancellationToken if id valid', async () => {
   expect(token).toBeDefined();
   expect(token instanceof CancellationTokenSource).toBeTruthy();
 });
+
+test('Remove CancellationToken if id valid', () => {
+  const tokenSourceId = cancellationTokenRegistry.createCancellationTokenSource();
+
+  cancellationTokenRegistry.removeCancellationTokenSource(tokenSourceId);
+
+  expect(cancellationTokenRegistry.hasCancellationTokenSource(tokenSourceId)).toBe(false);
+  expect(cancellationTokenRegistry.getCancellationTokenSource(tokenSourceId)).toBeUndefined();
+});

--- a/packages/main/src/plugin/cancellation-token-registry.ts
+++ b/packages/main/src/plugin/cancellation-token-registry.ts
@@ -48,4 +48,9 @@ export class CancellationTokenRegistry {
   hasCancellationTokenSource(id: number): boolean {
     return this.callbacksCancellableToken.has(id);
   }
+
+  removeCancellationTokenSource(id: number): void {
+    this.callbacksCancellableToken.get(id)?.dispose();
+    this.callbacksCancellableToken.delete(id);
+  }
 }

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -29,6 +29,7 @@ import type {
   ContainerInspectInfo,
   HostConfig,
   ImageInspectInfo,
+  ImageUpdateStatus,
   ProviderContainerConnectionInfo,
 } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
@@ -7273,5 +7274,115 @@ describe('imageExist', () => {
 
     const exists = await containerRegistry.imageExist('foo', 'bar', 'localhost/foo:latest');
     expect(exists).toBeTruthy();
+  });
+});
+
+describe('updateImages', () => {
+  const pullMock = vi.fn();
+  const followProgressMock = vi.fn();
+  const fakeDockerode = {
+    pull: pullMock,
+    modem: { followProgress: followProgressMock },
+  } as unknown as Dockerode;
+
+  beforeEach(() => {
+    pullMock.mockReset();
+    followProgressMock.mockReset();
+    telemetryTrackMock.mockReset();
+    followProgressMock.mockImplementation((_s: unknown, f: (err: Error | null) => void) => f(null));
+    containerRegistry.addInternalProvider('testEngine', {
+      name: 'testEngine',
+      id: 'testEngine',
+      connection: { type: 'podman', endpoint: { socketPath: '/test.socket' } },
+      api: fakeDockerode,
+    } as unknown as InternalContainerProvider);
+  });
+
+  test.each<ImageUpdateStatus>([
+    { status: 'normal', updateAvailable: false, message: 'Up to date' },
+    { status: 'skipped', updateAvailable: false, message: 'Skipped' },
+  ])('does not pull when status=$status', async mockStatus => {
+    vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus').mockResolvedValue(mockStatus);
+
+    const [result] = await containerRegistry.updateImages([
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+    ]);
+
+    expect(result!.updated).toBe(false);
+    expect(result!.status).toBe(mockStatus.status);
+    expect(pullMock).not.toHaveBeenCalled();
+    expect(telemetryTrackMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('checks update status with repository digests when available', async () => {
+    const checkImageUpdateStatusMock = vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus').mockResolvedValue({
+      status: 'normal',
+      updateAvailable: false,
+      message: 'Up to date',
+    });
+
+    await containerRegistry.updateImages([
+      {
+        engineId: 'testEngine',
+        image: 'nginx:latest',
+        tag: 'latest',
+        digest: 'sha256:configdigest',
+        repoDigests: ['nginx@sha256:manifestdigest'],
+      } as Parameters<ContainerProviderRegistry['updateImages']>[0][number],
+    ]);
+
+    expect(checkImageUpdateStatusMock).toHaveBeenCalledWith('nginx:latest', 'latest', ['nginx@sha256:manifestdigest']);
+    expect(pullMock).not.toHaveBeenCalled();
+  });
+
+  test('returns error when engine not found', async () => {
+    const checkImageUpdateStatusMock = vi
+      .spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus')
+      .mockRejectedValue(new Error('registry should not be checked when engine is missing'));
+    checkImageUpdateStatusMock.mockClear();
+
+    const [result] = await containerRegistry.updateImages([
+      { engineId: 'nonexistent', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+    ]);
+
+    expect(result!.updated).toBe(false);
+    expect(result!.status).toBe('error');
+    expect(result!.message).toContain('no engine matching this engine');
+    expect(checkImageUpdateStatusMock).not.toHaveBeenCalled();
+    expect(telemetryTrackMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('pulls updated images, skips failures, and tracks telemetry per image', async () => {
+    vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus')
+      .mockResolvedValueOnce({
+        status: 'normal',
+        updateAvailable: true,
+        remoteDigest: 'sha256:new',
+        message: '',
+      })
+      .mockResolvedValueOnce({
+        status: 'error',
+        updateAvailable: false,
+        message: 'Registry unavailable',
+      });
+    vi.spyOn(ImageRegistry.prototype, 'getAuthconfigForImage').mockReturnValue(undefined);
+    pullMock.mockResolvedValue({});
+
+    const results = await containerRegistry.updateImages([
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+      { engineId: 'testEngine', image: 'redis:latest', tag: 'latest', digest: 'sha256:old2' },
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual(expect.objectContaining({ updated: true, status: 'updated', imageRef: 'nginx:latest' }));
+    expect(results[1]?.updated).toBe(false);
+    expect(results[1]?.status).toBe('error');
+    expect(pullMock).toHaveBeenCalledTimes(1);
+    expect(pullMock).toHaveBeenCalledWith('nginx:latest', { authconfig: undefined });
+    expect(telemetryTrackMock).toHaveBeenCalledTimes(2);
+    expect(telemetryTrackMock).toHaveBeenCalledWith(
+      'updateImage',
+      expect.objectContaining({ imageName: expect.any(String) }),
+    );
   });
 });

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -49,6 +49,8 @@ import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
 import { ImageRegistry } from '/@/plugin/image-registry.js';
 import { KubePlayContext } from '/@/plugin/podman/kube.js';
 import type { Proxy } from '/@/plugin/proxy.js';
+import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
+import type { Task } from '/@/plugin/tasks/tasks.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 import * as util from '/@/util.js';
 
@@ -402,6 +404,11 @@ class DockerodeTestStatusError extends Error {
 }
 
 let containerRegistry: TestContainerProviderRegistry;
+let cancellationTokenRegistry: CancellationTokenRegistry;
+let task: Task;
+
+const createTaskMock = vi.fn();
+const taskManager = { createTask: createTaskMock } as unknown as TaskManager;
 
 const telemetryTrackMock = vi.fn().mockResolvedValue({});
 const telemetry: Telemetry = { track: telemetryTrackMock } as unknown as Telemetry;
@@ -448,7 +455,18 @@ beforeEach(() => {
   } as unknown as Proxy;
 
   const imageRegistry = new ImageRegistry({} as ApiSenderType, telemetry, certificates, proxy);
-  containerRegistry = new TestContainerProviderRegistry(apiSender, configurationRegistry, imageRegistry, telemetry);
+  cancellationTokenRegistry = new CancellationTokenRegistry();
+  task = { status: 'in-progress' } as Task;
+  createTaskMock.mockReset();
+  createTaskMock.mockReturnValue(task);
+  containerRegistry = new TestContainerProviderRegistry(
+    apiSender,
+    configurationRegistry,
+    imageRegistry,
+    telemetry,
+    taskManager,
+    cancellationTokenRegistry,
+  );
 });
 
 afterEach(() => {
@@ -6627,9 +6645,14 @@ describe('ContainerRegistrySettings', () => {
       receive: vi.fn(),
     };
 
-    const containerProviderRegistry = new TestContainerProviderRegistry(apiSender, configRegistry, imageRegistry, {
-      track: vi.fn(),
-    } as unknown as Telemetry);
+    const containerProviderRegistry = new TestContainerProviderRegistry(
+      apiSender,
+      configRegistry,
+      imageRegistry,
+      { track: vi.fn() } as unknown as Telemetry,
+      taskManager,
+      cancellationTokenRegistry,
+    );
 
     containerProviderRegistry.init();
 
@@ -7298,6 +7321,58 @@ describe('updateImages', () => {
     } as unknown as InternalContainerProvider);
   });
 
+  test('creates a cancellable task and completes it after updating images', async () => {
+    vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus').mockResolvedValue({
+      status: 'normal',
+      updateAvailable: false,
+      message: 'Up to date',
+    });
+
+    await containerRegistry.updateImages([
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+    ]);
+
+    expect(createTaskMock).toHaveBeenCalledExactlyOnceWith({
+      title: 'Updating image',
+      cancellable: true,
+      cancellationTokenSourceId: expect.any(Number),
+    });
+    expect(task.status).toBe('success');
+  });
+
+  test('cancels in-progress image pulls from the task', async () => {
+    vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus').mockResolvedValue({
+      status: 'normal',
+      updateAvailable: true,
+      remoteDigest: 'sha256:new',
+      message: '',
+    });
+    vi.spyOn(ImageRegistry.prototype, 'getAuthconfigForImage').mockReturnValue(undefined);
+    pullMock.mockImplementation(
+      (_image: string, options: { abortSignal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          options.abortSignal?.addEventListener('abort', () => reject(new Error('Update canceled')));
+        }),
+    );
+
+    const updatePromise = containerRegistry.updateImages([
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+    ]);
+    await vi.waitFor(() => expect(pullMock).toHaveBeenCalledOnce());
+
+    const cancellationTokenSourceId = createTaskMock.mock.calls[0]?.[0]?.cancellationTokenSourceId as number;
+    cancellationTokenRegistry.getCancellationTokenSource(cancellationTokenSourceId)?.cancel();
+
+    await expect(updatePromise).resolves.toEqual([
+      { imageRef: 'nginx:latest', updated: false, status: 'error', message: 'Update canceled' },
+    ]);
+    expect(pullMock).toHaveBeenCalledWith('nginx:latest', {
+      authconfig: undefined,
+      abortSignal: expect.objectContaining({ aborted: true }),
+    });
+    expect(task.status).toBe('canceled');
+  });
+
   test.each<ImageUpdateStatus>([
     { status: 'normal', updateAvailable: false, message: 'Up to date' },
     { status: 'skipped', updateAvailable: false, message: 'Skipped' },
@@ -7352,6 +7427,25 @@ describe('updateImages', () => {
     expect(telemetryTrackMock).toHaveBeenCalledTimes(1);
   });
 
+  test('returns every result when one image update rejects', async () => {
+    vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus').mockResolvedValue({
+      status: 'normal',
+      updateAvailable: false,
+      message: 'Up to date',
+    });
+
+    const results = await containerRegistry.updateImages([
+      { engineId: 'nonexistent', image: 'missing:latest', tag: 'latest', digest: 'sha256:missing' },
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+    ]);
+
+    expect(results).toEqual([
+      expect.objectContaining({ imageRef: 'missing:latest', updated: false, status: 'error' }),
+      { imageRef: 'nginx:latest', updated: false, status: 'normal', message: 'Up to date' },
+    ]);
+    expect(telemetryTrackMock).toHaveBeenCalledTimes(2);
+  });
+
   test('pulls updated images, skips failures, and tracks telemetry per image', async () => {
     vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus')
       .mockResolvedValueOnce({
@@ -7378,7 +7472,10 @@ describe('updateImages', () => {
     expect(results[1]?.updated).toBe(false);
     expect(results[1]?.status).toBe('error');
     expect(pullMock).toHaveBeenCalledTimes(1);
-    expect(pullMock).toHaveBeenCalledWith('nginx:latest', { authconfig: undefined });
+    expect(pullMock).toHaveBeenCalledWith('nginx:latest', {
+      authconfig: undefined,
+      abortSignal: expect.any(AbortSignal),
+    });
     expect(telemetryTrackMock).toHaveBeenCalledTimes(2);
     expect(telemetryTrackMock).toHaveBeenCalledWith(
       'updateImage',

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -7337,6 +7337,7 @@ describe('updateImages', () => {
       cancellable: true,
       cancellationTokenSourceId: expect.any(Number),
     });
+    expect(task.name).toBe('Update nginx:latest: Up to date');
     expect(task.status).toBe('success');
   });
 
@@ -7443,6 +7444,9 @@ describe('updateImages', () => {
       expect.objectContaining({ imageRef: 'missing:latest', updated: false, status: 'error' }),
       { imageRef: 'nginx:latest', updated: false, status: 'normal', message: 'Up to date' },
     ]);
+    expect(task.name).toBe('Image update results: 1 already up to date, 1 failed');
+    expect(task.error).toContain('missing:latest:');
+    expect(task.status).toBe('failure');
     expect(telemetryTrackMock).toHaveBeenCalledTimes(2);
   });
 
@@ -7471,6 +7475,9 @@ describe('updateImages', () => {
     expect(results[0]).toEqual(expect.objectContaining({ updated: true, status: 'updated', imageRef: 'nginx:latest' }));
     expect(results[1]?.updated).toBe(false);
     expect(results[1]?.status).toBe('error');
+    expect(task.name).toBe('Image update results: 1 updated, 1 failed');
+    expect(task.error).toBe('redis:latest: Registry unavailable');
+    expect(task.status).toBe('failure');
     expect(pullMock).toHaveBeenCalledTimes(1);
     expect(pullMock).toHaveBeenCalledWith('nginx:latest', {
       authconfig: undefined,

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -7337,6 +7337,8 @@ describe('updateImages', () => {
       cancellable: true,
       cancellationTokenSourceId: expect.any(Number),
     });
+    const cancellationTokenSourceId = createTaskMock.mock.calls[0]?.[0]?.cancellationTokenSourceId as number;
+    expect(cancellationTokenRegistry.hasCancellationTokenSource(cancellationTokenSourceId)).toBe(false);
     expect(task.name).toBe('Update nginx:latest: Up to date');
     expect(task.status).toBe('success');
   });
@@ -7388,6 +7390,10 @@ describe('updateImages', () => {
     expect(result!.status).toBe(mockStatus.status);
     expect(pullMock).not.toHaveBeenCalled();
     expect(telemetryTrackMock).toHaveBeenCalledTimes(1);
+    expect(telemetryTrackMock).toHaveBeenCalledWith(
+      'updateImage',
+      expect.objectContaining({ outcome: mockStatus.status === 'skipped' ? 'skipped' : 'up-to-date' }),
+    );
   });
 
   test('checks update status with repository digests when available', async () => {
@@ -7486,7 +7492,11 @@ describe('updateImages', () => {
     expect(telemetryTrackMock).toHaveBeenCalledTimes(2);
     expect(telemetryTrackMock).toHaveBeenCalledWith(
       'updateImage',
-      expect.objectContaining({ imageName: expect.any(String) }),
+      expect.objectContaining({ imageName: expect.any(String), outcome: 'updated' }),
+    );
+    expect(telemetryTrackMock).toHaveBeenCalledWith(
+      'updateImage',
+      expect.objectContaining({ imageName: expect.any(String), outcome: 'error', error: 'Registry unavailable' }),
     );
   });
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -87,8 +87,10 @@ import type { Headers, Pack, PackOptions } from 'tar-fs';
 
 import { KubePlayContext } from '/@/plugin/podman/kube.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
+import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { isWindows } from '/@/util.js';
 
+import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 import { ConfigurationRegistry } from './configuration-registry.js';
 import type { LibPod } from './dockerode/libpod-dockerode.js';
 import { LibpodDockerode } from './dockerode/libpod-dockerode.js';
@@ -145,6 +147,10 @@ export class ContainerProviderRegistry {
     private imageRegistry: ImageRegistry,
     @inject(Telemetry)
     private telemetryService: Telemetry,
+    @inject(TaskManager)
+    private taskManager: TaskManager,
+    @inject(CancellationTokenRegistry)
+    private cancellationTokenRegistry: CancellationTokenRegistry,
   ) {
     const libPodDockerode = new LibpodDockerode();
     libPodDockerode.enhancePrototypeWithLibPod();
@@ -1416,43 +1422,80 @@ export class ContainerProviderRegistry {
   }
 
   async updateImages(images: ImageUpdateInfo[]): Promise<ImageUpdateResult[]> {
-    return Promise.all(
-      images.map(async (info): Promise<ImageUpdateResult> => {
-        let telemetryOptions: Record<string, unknown> = {};
-        try {
-          const matchingEngine = this.getMatchingEngine(info.engineId);
-          const localDigests = info.repoDigests?.length ? info.repoDigests : [info.digest];
-          const status = await this.imageRegistry.checkImageUpdateStatus(info.image, info.tag, localDigests);
+    const cancellationTokenSourceId = this.cancellationTokenRegistry.createCancellationTokenSource();
+    const cancellationTokenSource =
+      this.cancellationTokenRegistry.getCancellationTokenSource(cancellationTokenSourceId);
+    if (!cancellationTokenSource) {
+      throw new Error('Failed to create CancellationTokenSource');
+    }
 
-          if (status.status === 'skipped' || status.status === 'error' || !status.updateAvailable) {
-            telemetryOptions = { skipped: true, reason: status.status };
-            return { imageRef: info.image, updated: false, status: status.status, message: status.message };
-          }
+    const task = this.taskManager.createTask({
+      title: `Updating image${images.length === 1 ? '' : 's'}`,
+      cancellable: true,
+      cancellationTokenSourceId,
+    });
+    const abortController = new AbortController();
+    const cancellationListener = cancellationTokenSource.token.onCancellationRequested(() => abortController.abort());
 
-          const authconfig = this.imageRegistry.getAuthconfigForImage(info.image);
-          const pullStream = await matchingEngine.pull(info.image, { authconfig });
+    try {
+      const settledResults = await Promise.allSettled(
+        images.map(async (info): Promise<ImageUpdateResult> => {
+          let telemetryOptions: Record<string, unknown> = {};
+          try {
+            const matchingEngine = this.getMatchingEngine(info.engineId);
+            const localDigests = info.repoDigests?.length ? info.repoDigests : [info.digest];
+            const status = await this.imageRegistry.checkImageUpdateStatus(info.image, info.tag, localDigests);
 
-          await new Promise<void>((resolve, reject) => {
+            if (status.status === 'skipped' || status.status === 'error' || !status.updateAvailable) {
+              telemetryOptions = { skipped: true, reason: status.status };
+              return { imageRef: info.image, updated: false, status: status.status, message: status.message };
+            }
+
+            const authconfig = this.imageRegistry.getAuthconfigForImage(info.image);
+            const pullStream = await matchingEngine.pull(info.image, {
+              authconfig,
+              abortSignal: abortController.signal,
+            });
+
+            const { resolve, reject, promise } = Promise.withResolvers<void>();
             matchingEngine.modem.followProgress(
               pullStream,
               (err: Error | null) => (err ? reject(err) : resolve()),
               () => {},
             );
-          });
+            await promise;
 
-          return { imageRef: info.image, updated: true, status: 'updated', message: 'Image updated successfully' };
-        } catch (error: unknown) {
-          telemetryOptions = { error: error };
-          const message = error instanceof Error ? error.message : String(error);
-          return { imageRef: info.image, updated: false, status: 'error', message };
-        } finally {
-          this.telemetryService.track('updateImage', {
-            imageName: this.getImageHash(info.image),
-            ...telemetryOptions,
-          });
+            return { imageRef: info.image, updated: true, status: 'updated', message: 'Image updated successfully' };
+          } catch (error: unknown) {
+            telemetryOptions = { error: error };
+            throw error;
+          } finally {
+            this.telemetryService.track('updateImage', {
+              imageName: this.getImageHash(info.image),
+              ...telemetryOptions,
+            });
+          }
+        }),
+      );
+      const results = settledResults.map((result, index): ImageUpdateResult => {
+        if (result.status === 'fulfilled') {
+          return result.value;
         }
-      }),
-    );
+        const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+        return { imageRef: images[index]!.image, updated: false, status: 'error', message };
+      });
+      task.status = cancellationTokenSource.token.isCancellationRequested ? 'canceled' : 'success';
+      return results;
+    } catch (error: unknown) {
+      if (cancellationTokenSource.token.isCancellationRequested) {
+        task.status = 'canceled';
+      } else {
+        task.error = String(error);
+      }
+      throw error;
+    } finally {
+      cancellationListener.dispose();
+    }
   }
 
   async pingContainerEngine(providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<unknown> {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -40,6 +40,8 @@ import type {
   ImageInspectInfo,
   ImageLoadOptions,
   ImagesSaveOptions,
+  ImageUpdateInfo,
+  ImageUpdateResult,
   LibPodPodInfo,
   ManifestCreateOptions,
   ManifestInspectInfo,
@@ -1411,6 +1413,46 @@ export class ContainerProviderRegistry {
 
   getImageHash(imageName: string): string {
     return crypto.createHash('sha512').update(imageName).digest('hex');
+  }
+
+  async updateImages(images: ImageUpdateInfo[]): Promise<ImageUpdateResult[]> {
+    return Promise.all(
+      images.map(async (info): Promise<ImageUpdateResult> => {
+        let telemetryOptions: Record<string, unknown> = {};
+        try {
+          const matchingEngine = this.getMatchingEngine(info.engineId);
+          const localDigests = info.repoDigests?.length ? info.repoDigests : [info.digest];
+          const status = await this.imageRegistry.checkImageUpdateStatus(info.image, info.tag, localDigests);
+
+          if (status.status === 'skipped' || status.status === 'error' || !status.updateAvailable) {
+            telemetryOptions = { skipped: true, reason: status.status };
+            return { imageRef: info.image, updated: false, status: status.status, message: status.message };
+          }
+
+          const authconfig = this.imageRegistry.getAuthconfigForImage(info.image);
+          const pullStream = await matchingEngine.pull(info.image, { authconfig });
+
+          await new Promise<void>((resolve, reject) => {
+            matchingEngine.modem.followProgress(
+              pullStream,
+              (err: Error | null) => (err ? reject(err) : resolve()),
+              () => {},
+            );
+          });
+
+          return { imageRef: info.image, updated: true, status: 'updated', message: 'Image updated successfully' };
+        } catch (error: unknown) {
+          telemetryOptions = { error: error };
+          const message = error instanceof Error ? error.message : String(error);
+          return { imageRef: info.image, updated: false, status: 'error', message };
+        } finally {
+          this.telemetryService.track('updateImage', {
+            imageName: this.getImageHash(info.image),
+            ...telemetryOptions,
+          });
+        }
+      }),
+    );
   }
 
   async pingContainerEngine(providerContainerConnectionInfo: ProviderContainerConnectionInfo): Promise<unknown> {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -88,6 +88,7 @@ import type { Headers, Pack, PackOptions } from 'tar-fs';
 import { KubePlayContext } from '/@/plugin/podman/kube.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
+import type { Task } from '/@/plugin/tasks/tasks.js';
 import { isWindows } from '/@/util.js';
 
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
@@ -1421,6 +1422,49 @@ export class ContainerProviderRegistry {
     return crypto.createHash('sha512').update(imageName).digest('hex');
   }
 
+  private completeUpdateImagesTask(task: Task, results: ImageUpdateResult[]): void {
+    if (results.length === 1) {
+      const result = results[0];
+      if (!result) {
+        task.status = 'success';
+        return;
+      }
+      task.name = `Update ${result.imageRef}: ${result.message}`;
+      if (result.status === 'error') {
+        task.error = result.message;
+        task.status = 'failure';
+      } else {
+        task.status = 'success';
+      }
+      return;
+    }
+
+    const updatedCount = results.filter(result => result.updated).length;
+    const upToDateCount = results.filter(result => result.status === 'normal' && !result.updated).length;
+    const skippedCount = results.filter(result => result.status === 'skipped').length;
+    const failedResults = results.filter(result => result.status === 'error');
+    const parts = [
+      this.formatUpdateImagesTaskPart(updatedCount, 'updated'),
+      this.formatUpdateImagesTaskPart(upToDateCount, 'already up to date'),
+      this.formatUpdateImagesTaskPart(skippedCount, 'skipped'),
+      this.formatUpdateImagesTaskPart(failedResults.length, 'failed'),
+    ].filter(part => part.length > 0);
+
+    if (parts.length > 0) {
+      task.name = `Image update results: ${parts.join(', ')}`;
+    }
+    if (failedResults.length > 0) {
+      task.error = failedResults.map(result => `${result.imageRef}: ${result.message}`).join('\n');
+      task.status = 'failure';
+    } else {
+      task.status = 'success';
+    }
+  }
+
+  private formatUpdateImagesTaskPart(count: number, label: string): string {
+    return count > 0 ? `${count} ${label}` : '';
+  }
+
   async updateImages(images: ImageUpdateInfo[]): Promise<ImageUpdateResult[]> {
     const cancellationTokenSourceId = this.cancellationTokenRegistry.createCancellationTokenSource();
     const cancellationTokenSource =
@@ -1484,7 +1528,11 @@ export class ContainerProviderRegistry {
         const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
         return { imageRef: images[index]!.image, updated: false, status: 'error', message };
       });
-      task.status = cancellationTokenSource.token.isCancellationRequested ? 'canceled' : 'success';
+      if (cancellationTokenSource.token.isCancellationRequested) {
+        task.status = 'canceled';
+      } else {
+        this.completeUpdateImagesTask(task, results);
+      }
       return results;
     } catch (error: unknown) {
       if (cancellationTokenSource.token.isCancellationRequested) {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1482,7 +1482,7 @@ export class ContainerProviderRegistry {
     const cancellationListener = cancellationTokenSource.token.onCancellationRequested(() => abortController.abort());
 
     try {
-      const settledResults = await Promise.allSettled(
+      const results = await Promise.all(
         images.map(async (info): Promise<ImageUpdateResult> => {
           let telemetryOptions: Record<string, unknown> = {};
           try {
@@ -1512,7 +1512,8 @@ export class ContainerProviderRegistry {
             return { imageRef: info.image, updated: true, status: 'updated', message: 'Image updated successfully' };
           } catch (error: unknown) {
             telemetryOptions = { error: error };
-            throw error;
+            const message = error instanceof Error ? error.message : String(error);
+            return { imageRef: info.image, updated: false, status: 'error', message };
           } finally {
             this.telemetryService.track('updateImage', {
               imageName: this.getImageHash(info.image),
@@ -1521,13 +1522,6 @@ export class ContainerProviderRegistry {
           }
         }),
       );
-      const results = settledResults.map((result, index): ImageUpdateResult => {
-        if (result.status === 'fulfilled') {
-          return result.value;
-        }
-        const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
-        return { imageRef: images[index]!.image, updated: false, status: 'error', message };
-      });
       if (cancellationTokenSource.token.isCancellationRequested) {
         task.status = 'canceled';
       } else {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1424,17 +1424,14 @@ export class ContainerProviderRegistry {
 
   private completeUpdateImagesTask(task: Task, results: ImageUpdateResult[]): void {
     if (results.length === 1) {
-      const result = results[0];
-      if (!result) {
-        task.status = 'success';
-        return;
-      }
-      task.name = `Update ${result.imageRef}: ${result.message}`;
-      if (result.status === 'error') {
-        task.error = result.message;
-        task.status = 'failure';
-      } else {
-        task.status = 'success';
+      for (const result of results) {
+        task.name = `Update ${result.imageRef}: ${result.message}`;
+        if (result.status === 'error') {
+          task.error = result.message;
+          task.status = 'failure';
+        } else {
+          task.status = 'success';
+        }
       }
       return;
     }
@@ -1490,8 +1487,13 @@ export class ContainerProviderRegistry {
             const localDigests = info.repoDigests?.length ? info.repoDigests : [info.digest];
             const status = await this.imageRegistry.checkImageUpdateStatus(info.image, info.tag, localDigests);
 
-            if (status.status === 'skipped' || status.status === 'error' || !status.updateAvailable) {
-              telemetryOptions = { skipped: true, reason: status.status };
+            if (status.status === 'error') {
+              telemetryOptions = { outcome: 'error', error: status.message };
+              return { imageRef: info.image, updated: false, status: status.status, message: status.message };
+            }
+
+            if (status.status === 'skipped' || !status.updateAvailable) {
+              telemetryOptions = { outcome: status.status === 'skipped' ? 'skipped' : 'up-to-date' };
               return { imageRef: info.image, updated: false, status: status.status, message: status.message };
             }
 
@@ -1509,9 +1511,10 @@ export class ContainerProviderRegistry {
             );
             await promise;
 
+            telemetryOptions = { outcome: 'updated' };
             return { imageRef: info.image, updated: true, status: 'updated', message: 'Image updated successfully' };
           } catch (error: unknown) {
-            telemetryOptions = { error: error };
+            telemetryOptions = { outcome: 'error', error: error };
             const message = error instanceof Error ? error.message : String(error);
             return { imageRef: info.image, updated: false, status: 'error', message };
           } finally {
@@ -1537,6 +1540,7 @@ export class ContainerProviderRegistry {
       throw error;
     } finally {
       cancellationListener.dispose();
+      this.cancellationTokenRegistry.removeCancellationTokenSource(cancellationTokenSourceId);
     }
   }
 

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -1144,6 +1144,32 @@ describe('checkImageUpdateStatus handler', () => {
   });
 });
 
+describe('updateImages handler', () => {
+  test('should delegate image updates to the container provider registry', async () => {
+    const handle = getHandler<
+      (
+        _event: unknown,
+        images: Array<{ engineId: string; image: string; tag: string; digest: string }>,
+      ) => Promise<{ result: Awaited<ReturnType<ContainerProviderRegistry['updateImages']>> }>
+    >('container-provider-registry:updateImages');
+
+    const images = [
+      { engineId: 'podman', image: 'nginx:latest', tag: 'latest', digest: 'sha256:abc123' },
+      { engineId: 'podman', image: 'redis:7', tag: '7', digest: 'sha256:def456' },
+    ];
+    const expectedResults = [
+      { imageRef: 'nginx:latest', updated: true, status: 'updated', message: 'Image updated successfully' },
+      { imageRef: 'redis:7', updated: false, status: 'normal', message: 'Already up to date' },
+    ] as const;
+    vi.mocked(ContainerProviderRegistry.prototype.updateImages).mockResolvedValue([...expectedResults]);
+
+    const result = await handle(undefined, images);
+
+    expect(ContainerProviderRegistry.prototype.updateImages).toHaveBeenCalledExactlyOnceWith(images);
+    expect(result.result).toEqual(expectedResults);
+  });
+});
+
 describe('container-provider-registry:playKube', () => {
   type PlayKubeHandler = (
     _listener: undefined,

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -79,6 +79,8 @@ import type {
   ImageSearchResult,
   ImagesSaveOptions,
   ImageTagsListOptions,
+  ImageUpdateInfo,
+  ImageUpdateResult,
   ImageUpdateStatus,
   KubeContext,
   KubernetesContextResources,
@@ -1387,6 +1389,13 @@ export class PluginSystem {
         localDigests: string[],
       ): Promise<ImageUpdateStatus> => {
         return imageRegistry.checkImageUpdateStatus(imageReference, imageTag, localDigests);
+      },
+    );
+
+    this.ipcHandle(
+      'container-provider-registry:updateImages',
+      async (_listener, images: ImageUpdateInfo[]): Promise<ImageUpdateResult[]> => {
+        return containerProviderRegistry.updateImages(images);
       },
     );
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -80,6 +80,8 @@ import type {
   ImageSearchResult,
   ImagesSaveOptions,
   ImageTagsListOptions,
+  ImageUpdateInfo,
+  ImageUpdateResult,
   ImageUpdateStatus,
   ItemInfo,
   KubeContext,
@@ -632,6 +634,10 @@ export function initExposure(): void {
       return ipcInvoke('image-registry:checkImageUpdateStatus', imageReference, imageTag, localDigests);
     },
   );
+
+  contextBridge.exposeInMainWorld('updateImages', async (images: ImageUpdateInfo[]): Promise<ImageUpdateResult[]> => {
+    return ipcInvoke('container-provider-registry:updateImages', images);
+  });
 
   contextBridge.exposeInMainWorld('loadImages', async (options: ImageLoadOptions): Promise<void> => {
     return ipcInvoke('container-provider-registry:loadImages', options);

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -80,6 +80,9 @@ beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(ImageUtils.prototype.deleteImage).mockRejectedValue(new Error('Cannot delete image in test'));
+  vi.mocked(ImageUtils.prototype.updateImages).mockResolvedValue([
+    { imageRef: 'dummy:latest', updated: true, status: 'updated', message: 'Image updated successfully' },
+  ]);
 });
 
 test('Expect error dialog with correct message when image deletion fails', async () => {
@@ -316,4 +319,59 @@ describe('run', () => {
       });
     });
   });
+});
+
+test.each([
+  { name: '<none>', status: 'UNUSED' as const, tag: '', digest: 'sha256:digest', expectEnabled: false },
+  { name: 'image-name', status: 'USED' as const, tag: '1.0', digest: 'sha256:digest', expectEnabled: false },
+  { name: 'image-name', status: 'UNUSED' as const, tag: '1.0', digest: undefined, expectEnabled: false },
+  { name: 'image-name', status: 'UNUSED' as const, tag: '1.0', digest: 'sha256:digest', expectEnabled: true },
+])('Expect Update Image button enabled=$expectEnabled for name=$name status=$status', async ({
+  name,
+  status,
+  tag,
+  digest,
+  expectEnabled,
+}) => {
+  getContributedMenusMock.mockResolvedValue([]);
+
+  render(ImageActions, {
+    onPushImage: vi.fn(),
+    onRenameImage: vi.fn(),
+    image: { name, status, tag, digest } as ImageInfoUI,
+  });
+
+  const button = screen.getByTitle('Update Image');
+  if (expectEnabled) {
+    expect(button).toBeEnabled();
+  } else {
+    expect(button).toBeDisabled();
+  }
+});
+
+test('Expect Update Image action to bail out when image status changes before confirmation callback', async () => {
+  getContributedMenusMock.mockResolvedValue([]);
+
+  const image: ImageInfoUI = {
+    name: 'image-name',
+    status: 'UNUSED',
+    tag: '1.0',
+    digest: 'sha256:digest',
+  } as ImageInfoUI;
+
+  vi.mocked(withConfirmation).mockImplementation(callback => {
+    image.status = 'DELETING';
+    callback();
+  });
+
+  render(ImageActions, {
+    onPushImage: vi.fn(),
+    onRenameImage: vi.fn(),
+    image,
+  });
+
+  await fireEvent.click(screen.getByTitle('Update Image'));
+
+  expect(ImageUtils.prototype.updateImages).not.toHaveBeenCalled();
+  expect(image.status).toBe('DELETING');
 });

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-import { faArrowUp, faDownload, faEdit, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowUp,
+  faDownload,
+  faEdit,
+  faLayerGroup,
+  faPlay,
+  faSync,
+  faTrash,
+} from '@fortawesome/free-solid-svg-icons';
 import type { Menu } from '@podman-desktop/core-api';
 import { MenuContext, NavigationPage } from '@podman-desktop/core-api';
 import { createEventDispatcher, onMount } from 'svelte';
@@ -108,6 +116,42 @@ function saveImage(): void {
   saveImagesInfo.set([image]);
   router.goto('/images/save');
 }
+
+async function updateImage(): Promise<void> {
+  if (!isUpdateCandidate(image)) {
+    return;
+  }
+
+  const previousStatus = image.status;
+  image.status = 'UPDATING';
+  dispatch('update', image);
+
+  try {
+    const results = await imageUtils.updateImages([image]);
+    const result = results[0];
+    if (result && !result.updated) {
+      console.info(`${image.name}:${image.tag}: ${result.message}`);
+    }
+    image.status = previousStatus;
+  } catch (error) {
+    image.status = previousStatus;
+    await onError(`Error while updating image: ${String(error)}`);
+  } finally {
+    image.selected = false;
+    dispatch('update', image);
+  }
+}
+
+function confirmUpdateImage(): void {
+  withConfirmation(updateImage, `update image ${image.name}:${image.tag} to latest build`, {
+    title: 'Update Image?',
+    buttonLabel: 'Update',
+  });
+}
+
+function isUpdateCandidate(imageInfo: ImageInfoUI): boolean {
+  return imageInfo.name !== '<none>' && imageInfo.status === 'UNUSED' && Boolean(imageInfo.digest);
+}
 </script>
 
 <ListItemButtonIcon title="Run Image" onClick={runImage} detailed={detailed} icon={faPlay} />
@@ -154,6 +198,15 @@ function saveImage(): void {
     menu={dropdownMenu}
     detailed={detailed}
     icon={faDownload} />
+
+  <ListItemButtonIcon
+    title="Update Image"
+    tooltip="Update image to the latest build"
+    onClick={confirmUpdateImage}
+    menu={dropdownMenu}
+    detailed={detailed}
+    icon={faSync}
+    enabled={isUpdateCandidate(image)} />
 
   <ActionsWrapper dropdownMenu={groupingContributions} dropdownMenuAsMenuActionItem={groupingContributions}>
     <ContributionActions

--- a/packages/renderer/src/lib/image/ImageInfoUI.ts
+++ b/packages/renderer/src/lib/image/ImageInfoUI.ts
@@ -36,11 +36,12 @@ export interface ImageInfoUI {
   // no tag, we encode <none>
   base64RepoTag: string;
   selected: boolean;
-  status: 'USED' | 'UNUSED' | 'DELETING';
+  status: 'USED' | 'UNUSED' | 'DELETING' | 'UPDATING';
   icon?: string | IconDefinition | Component;
   labels?: { [label: string]: string };
   badges: ViewContributionBadgeValue[];
   children?: ImageInfoUI[];
   isManifest?: boolean;
   digest?: string;
+  repoDigests?: string[];
 }

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -38,6 +38,7 @@ import ImagesList from './ImagesList.svelte';
 
 // fake the window.events object
 beforeEach(() => {
+  vi.clearAllMocks();
   providerInfos.set([]);
   imagesInfos.set([]);
   viewsContributions.set([]);
@@ -57,6 +58,32 @@ beforeEach(() => {
 async function waitRender(customProperties: object): Promise<void> {
   render(ImagesList, { ...customProperties });
   await tick();
+}
+
+async function renderWithImages(imageList: ImageInfo[]): Promise<void> {
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+  vi.mocked(window.listImages).mockResolvedValue(imageList);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('image-build'));
+
+  await vi.waitUntil(() => get(imagesInfos).length > 0);
+  await vi.waitUntil(() => get(providerInfos).length > 0);
+
+  await waitRender({});
 }
 
 test('Expect no container engines being displayed', async () => {
@@ -512,6 +539,178 @@ test('expect redirect to saveImage page when at least one image is selected and 
   await fireEvent.click(saveImages);
 
   expect(goToMock).toBeCalledWith('/images/save');
+});
+
+test('Expect Update images button appears when images are selected', async () => {
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
+    {
+      name: 'podman',
+      status: 'started',
+      internalId: 'podman-internal-id',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          status: 'started',
+        } as unknown as ProviderContainerConnectionInfo,
+      ],
+    } as unknown as ProviderInfo,
+  ]);
+
+  vi.mocked(window.listImages).mockResolvedValue([
+    {
+      Id: 'sha256:1234567890123',
+      RepoTags: ['fedora:latest'],
+      Digest: 'sha256:digest',
+      Created: 1644009612,
+      Size: 123,
+      Status: 'Running',
+      engineId: 'podman',
+      engineName: 'podman',
+    },
+  ] as unknown as ImageInfo[]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('image-build'));
+
+  await vi.waitUntil(() => get(imagesInfos).length > 0);
+  await vi.waitUntil(() => get(providerInfos).length > 0);
+
+  await waitRender({});
+
+  const toggleAll = screen.getByTitle('Toggle all');
+  await fireEvent.click(toggleAll);
+
+  const updateButton = screen.getByRole('button', { name: 'Update images' });
+  expect(updateButton).toBeInTheDocument();
+});
+
+test('Expect Update images confirmation to count only selected update candidates', async () => {
+  await renderWithImages([
+    {
+      Id: 'sha256:1234567890123',
+      RepoTags: ['fedora:latest'],
+      Digest: 'sha256:digest',
+      Created: 1644009612,
+      Size: 123,
+      Status: 'Running',
+      engineId: 'podman',
+      engineName: 'podman',
+    },
+    {
+      Id: 'sha256:456456456456456',
+      Created: 1,
+      Size: 1234,
+      Status: 'Running',
+      engineId: 'podman',
+      engineName: 'podman',
+    },
+    {
+      Id: 'sha256:789789789789789',
+      RepoTags: ['alpine:latest'],
+      Created: 2,
+      Size: 123,
+      Status: 'Running',
+      engineId: 'podman',
+      engineName: 'podman',
+    },
+  ] as unknown as ImageInfo[]);
+
+  await fireEvent.click(screen.getByTitle('Toggle all'));
+
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Update' });
+  vi.mocked(window.updateImages).mockResolvedValue([
+    { imageRef: 'fedora:latest', updated: true, status: 'updated', message: 'Image updated successfully' },
+  ]);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Update images' }));
+
+  await waitFor(() => expect(window.showMessageBox).toHaveBeenCalledOnce());
+  expect(window.showMessageBox).toHaveBeenCalledWith(
+    expect.objectContaining({
+      message: 'Are you sure you want to update 1 image?',
+    }),
+  );
+});
+
+test('Expect Update images button not to be actionable while selected images are deleting', async () => {
+  await renderWithImages([
+    {
+      Id: 'sha256:1234567890123',
+      RepoTags: ['fedora:latest'],
+      Digest: 'sha256:digest',
+      Created: 1644009612,
+      Size: 123,
+      Status: 'Running',
+      engineId: 'podman',
+      engineName: 'podman',
+    },
+  ] as unknown as ImageInfo[]);
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Toggle image' }));
+
+  let resolveDelete: () => void = () => {};
+  vi.mocked(window.deleteImage).mockReturnValue(
+    new Promise<void>(resolve => {
+      resolveDelete = resolve;
+    }),
+  );
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Delete 1 selected items' }));
+
+  await waitFor(() => {
+    const updateButton = screen.queryByRole('button', { name: 'Update images' });
+    if (updateButton) {
+      expect(updateButton).toBeDisabled();
+    } else {
+      expect(updateButton).not.toBeInTheDocument();
+    }
+  });
+
+  resolveDelete();
+});
+
+test('Expect Delete images button not to be actionable while selected images are updating', async () => {
+  await renderWithImages([
+    {
+      Id: 'sha256:1234567890123',
+      RepoTags: ['fedora:latest'],
+      Digest: 'sha256:digest',
+      Created: 1644009612,
+      Size: 123,
+      Status: 'Running',
+      engineId: 'podman',
+      engineName: 'podman',
+    },
+  ] as unknown as ImageInfo[]);
+
+  await fireEvent.click(screen.getByRole('checkbox', { name: 'Toggle image' }));
+
+  let resolveUpdate: (results: Awaited<ReturnType<typeof window.updateImages>>) => void = () => {};
+  vi.mocked(window.updateImages).mockReturnValue(
+    new Promise(resolve => {
+      resolveUpdate = resolve;
+    }),
+  );
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+
+  await fireEvent.click(screen.getByRole('button', { name: 'Update images' }));
+  await waitFor(() => expect(window.updateImages).toHaveBeenCalledOnce());
+
+  await waitFor(() => {
+    const deleteButton = screen.queryByTitle('Delete 1 selected items');
+    if (deleteButton) {
+      expect(deleteButton).toBeDisabled();
+    } else {
+      expect(deleteButton).not.toBeInTheDocument();
+    }
+  });
+
+  resolveUpdate([
+    { imageRef: 'fedora:latest', updated: true, status: 'updated', message: 'Image updated successfully' },
+  ]);
 });
 
 test('Expect load images button redirects to images load page', async () => {

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowCircleDown, faCube, faDownload, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
+import { faArrowCircleDown, faCube, faDownload, faSync, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
 import type { ContainerInfo, ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
 import {
   Button,
@@ -195,7 +195,12 @@ function loadImages(): void {
 
 // delete the items selected in the list
 let bulkDeleteInProgress = $state(false);
+let bulkUpdateInProgress = $state(false);
 async function deleteSelectedImages(): Promise<void> {
+  if (bulkDeleteInProgress || bulkUpdateInProgress) {
+    return;
+  }
+
   const selectedImages = filteredImages.filter(image => image.selected);
   if (selectedImages.length === 0) {
     return;
@@ -223,6 +228,78 @@ async function saveSelectedImages(): Promise<void> {
 
   saveImagesInfo.set(selectedImages);
   router.goto('/images/save');
+}
+
+let selectedUpdateCandidates = $derived(filteredImages.filter(isUpdateCandidate));
+let selectedUpdateCandidatesNumber = $derived(selectedUpdateCandidates.length);
+
+function isUpdateCandidate(image: ImageInfoUI): boolean {
+  return (
+    image.selected && image.status === 'UNUSED' && !image.isManifest && image.name !== '<none>' && Boolean(image.digest)
+  );
+}
+
+function confirmDeleteSelectedImages(): void {
+  if (selectedItemsNumber) {
+    withBulkConfirmation(
+      deleteSelectedImages,
+      `delete ${selectedItemsNumber} image${selectedItemsNumber > 1 ? 's' : ''}`,
+      {
+        title: 'Delete Images?',
+        variant: 'delete',
+      },
+    );
+  }
+}
+
+function confirmUpdateSelectedImages(): void {
+  if (selectedUpdateCandidatesNumber > 0) {
+    withBulkConfirmation(
+      updateSelectedImages,
+      `update ${selectedUpdateCandidatesNumber} image${selectedUpdateCandidatesNumber > 1 ? 's' : ''}`,
+      { title: 'Update Images?', buttonLabel: 'Update' },
+    );
+  }
+}
+
+async function updateSelectedImages(): Promise<void> {
+  if (bulkDeleteInProgress || bulkUpdateInProgress) {
+    return;
+  }
+
+  const selectedImages = selectedUpdateCandidates;
+  if (selectedImages.length === 0) {
+    return;
+  }
+
+  bulkUpdateInProgress = true;
+  // Capture each image's status before overwriting to 'UPDATING'.
+  const prevStatuses = selectedImages.map(img => img.status);
+  for (const image of selectedImages) {
+    image.status = 'UPDATING';
+  }
+  images = [...images];
+
+  try {
+    const results = await imageUtils.updateImages(selectedImages);
+    for (const result of results) {
+      if (!result.updated) {
+        console.info(`${result.imageRef}: ${result.message}`);
+      }
+    }
+  } catch (err: unknown) {
+    console.error('Failed to update images:', err);
+  }
+
+  // Restore previous statuses and deselect.
+  for (let i = 0; i < selectedImages.length; i++) {
+    selectedImages[i].status = prevStatuses[i];
+    selectedImages[i].selected = false;
+  }
+  bulkUpdateInProgress = false;
+  // Shallow-copy so the Table component detects the reference change
+  // and recalculates the "Toggle all" checkbox state.
+  images = [...images];
 }
 
 let selectedItemsNumber: number | undefined = $state();
@@ -332,20 +409,23 @@ function label(item: ImageInfoUI): string {
     <EnvironmentDropdown bind:selectedEnvironment={selectedEnvironment} />
     {#if selectedItemsNumber && selectedItemsNumber > 0}
       <Button
-        on:click={(): void => {
-          if (selectedItemsNumber) {withBulkConfirmation(
-            deleteSelectedImages,
-            `delete ${selectedItemsNumber} image${selectedItemsNumber > 1 ? 's' : ''}`,
-            { title: 'Delete Images?', variant:'delete' }
-          );}}}
+        on:click={confirmDeleteSelectedImages}
         title="Delete {selectedItemsNumber} selected items"
         inProgress={bulkDeleteInProgress}
+        disabled={bulkUpdateInProgress}
         icon={faTrash} />
       <Button
         on:click={saveSelectedImages}
         title="Save {selectedItemsNumber} selected items"
         aria-label="Save images"
         icon={faDownload} />
+      <Button
+        on:click={confirmUpdateSelectedImages}
+        title="Update {selectedUpdateCandidatesNumber} selected items"
+        inProgress={bulkUpdateInProgress || bulkDeleteInProgress}
+        disabled={selectedUpdateCandidatesNumber === 0}
+        aria-label="Update images"
+        icon={faSync} />
       <span>On {selectedItemsNumber} selected items.</span>
     {/if}
   {/snippet}

--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -22,6 +22,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ContextUI } from '/@/lib/context/context';
 
 import { ImageUtils } from './image-utils';
+import type { ImageInfoUI } from './ImageInfoUI';
 
 let imageUtils: ImageUtils;
 
@@ -255,5 +256,136 @@ describe('getImagesFromManifest and construct ImageInfoUI', () => {
     );
     expect(imageInfoUIs.length).toBe(1);
     expect(imageInfoUIs[0].id).toBe('manifest1');
+  });
+
+  test('should preserve repository digests on image info UI objects', () => {
+    const imageInfo = {
+      Id: 'image1',
+      Digest: 'sha256:configdigest',
+      RepoTags: ['quay.io/podman/hello:latest'],
+      RepoDigests: ['quay.io/podman/hello@sha256:manifestdigest'],
+      Created: 1599888000,
+      Size: 1024,
+    } as unknown as ImageInfo;
+
+    const [imageInfoUI] = imageUtils.getImagesInfoUI(imageInfo, containerInfoList, contextUI, viewContributions);
+
+    expect((imageInfoUI as ImageInfoUI & { repoDigests?: string[] })?.repoDigests).toEqual([
+      'quay.io/podman/hello@sha256:manifestdigest',
+    ]);
+  });
+});
+
+describe('updateImages', () => {
+  beforeEach(() => {
+    (window as unknown as Record<string, unknown>).updateImages = vi.fn();
+  });
+
+  test('skips images without digest', async () => {
+    const results = await imageUtils.updateImages([
+      { name: 'nginx', tag: 'latest', engineId: 'podman' } as ImageInfoUI,
+    ]);
+
+    expect(results[0]?.updated).toBe(false);
+    expect(results[0]?.message).toContain('digest');
+    expect(window.updateImages).not.toHaveBeenCalled();
+  });
+
+  test('sends batch payload in a single IPC call', async () => {
+    vi.mocked(window.updateImages).mockResolvedValue([
+      { imageRef: 'nginx:latest', updated: true, status: 'updated', message: 'Updated' },
+      { imageRef: 'redis:7', updated: false, status: 'normal', message: 'Up to date' },
+    ]);
+
+    const results = await imageUtils.updateImages([
+      { name: 'nginx', tag: 'latest', engineId: 'podman', digest: 'sha256:abc' },
+      { name: 'redis', tag: '7', engineId: 'podman', digest: 'sha256:def' },
+    ] as ImageInfoUI[]);
+
+    expect(window.updateImages).toHaveBeenCalledOnce();
+    expect(results).toHaveLength(2);
+    expect(results[0]?.updated).toBe(true);
+    expect(results[1]?.updated).toBe(false);
+  });
+
+  test('preserves original result positions when only some images have digests', async () => {
+    vi.mocked(window.updateImages).mockResolvedValue([
+      { imageRef: 'nginx:latest', updated: true, status: 'updated', message: 'Updated' },
+      { imageRef: 'redis:7', updated: false, status: 'normal', message: 'Up to date' },
+    ]);
+
+    const results = await imageUtils.updateImages([
+      { name: 'missing', tag: 'latest', engineId: 'podman' },
+      { name: 'nginx', tag: 'latest', engineId: 'podman', digest: 'sha256:abc' },
+      { name: 'redis', tag: '7', engineId: 'docker', digest: 'sha256:def' },
+      { name: 'also-missing', tag: 'dev', engineId: 'podman' },
+    ] as ImageInfoUI[]);
+
+    expect(window.updateImages).toHaveBeenCalledOnce();
+    expect(window.updateImages).toHaveBeenCalledWith([
+      { engineId: 'podman', image: 'nginx:latest', tag: 'latest', digest: 'sha256:abc', repoDigests: undefined },
+      { engineId: 'docker', image: 'redis:7', tag: '7', digest: 'sha256:def', repoDigests: undefined },
+    ]);
+    expect(results).toEqual([
+      expect.objectContaining({
+        imageRef: 'missing:latest',
+        updated: false,
+        message: expect.stringContaining('digest'),
+      }),
+      { imageRef: 'nginx:latest', updated: true, status: 'updated', message: 'Updated' },
+      { imageRef: 'redis:7', updated: false, status: 'normal', message: 'Up to date' },
+      expect.objectContaining({
+        imageRef: 'also-missing:dev',
+        updated: false,
+        message: expect.stringContaining('digest'),
+      }),
+    ]);
+  });
+
+  test('sends repository digests in update payload', async () => {
+    vi.mocked(window.updateImages).mockResolvedValue([
+      { imageRef: 'nginx:latest', updated: false, status: 'normal', message: 'Up to date' },
+    ]);
+
+    await imageUtils.updateImages([
+      {
+        name: 'nginx',
+        tag: 'latest',
+        engineId: 'podman',
+        digest: 'sha256:configdigest',
+        repoDigests: ['nginx@sha256:manifestdigest'],
+      },
+    ] as ImageInfoUI[]);
+
+    expect(window.updateImages).toHaveBeenCalledWith([
+      {
+        engineId: 'podman',
+        image: 'nginx:latest',
+        tag: 'latest',
+        digest: 'sha256:configdigest',
+        repoDigests: ['nginx@sha256:manifestdigest'],
+      },
+    ]);
+  });
+
+  test('sends a cloneable repository digests payload', async () => {
+    vi.mocked(window.updateImages).mockImplementation(async images => {
+      structuredClone(images);
+      return [{ imageRef: 'nginx:latest', updated: false, status: 'normal', message: 'Up to date' }];
+    });
+
+    const repoDigests = new Proxy(['nginx@sha256:manifestdigest'], {});
+
+    await expect(
+      imageUtils.updateImages([
+        {
+          name: 'nginx',
+          tag: 'latest',
+          engineId: 'podman',
+          digest: 'sha256:configdigest',
+          repoDigests,
+        },
+      ] as ImageInfoUI[]),
+    ).resolves.toEqual([{ imageRef: 'nginx:latest', updated: false, status: 'normal', message: 'Up to date' }]);
   });
 });

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -19,6 +19,7 @@
 import {
   type ContainerInfo,
   type ImageInfo,
+  type ImageUpdateResult,
   isViewContributionBadge,
   isViewContributionIcon,
   type ViewContributionBadgeValue,
@@ -208,6 +209,7 @@ export class ImageUtils {
           labels: imageInfo.Labels,
           isManifest: imageInfo.isManifest,
           digest: imageInfo.Digest,
+          repoDigests: imageInfo.RepoDigests,
           children,
         },
       ];
@@ -233,6 +235,7 @@ export class ImageUtils {
           labels: imageInfo.Labels,
           isManifest: imageInfo.isManifest,
           digest: imageInfo.Digest,
+          repoDigests: imageInfo.RepoDigests,
           children,
         };
       });
@@ -246,6 +249,46 @@ export class ImageUtils {
   deleteImage(image: ImageInfoUI): Promise<void> {
     const imageId = image.name === '<none>' ? image.id : `${image.name}:${image.tag}`;
     return window.deleteImage(image.engineId, imageId);
+  }
+
+  async updateImages(images: ImageInfoUI[]): Promise<ImageUpdateResult[]> {
+    const results: ImageUpdateResult[] = new Array(images.length);
+    const validEntries: { index: number; image: ImageInfoUI; digest: string }[] = [];
+
+    for (let i = 0; i < images.length; i++) {
+      const image = images[i];
+      if (!image.digest) {
+        results[i] = {
+          imageRef: `${image.name}:${image.tag}`,
+          updated: false,
+          status: 'skipped',
+          message: 'Image digest is unavailable for this image.',
+        };
+      } else {
+        validEntries.push({ index: i, image, digest: image.digest });
+      }
+    }
+
+    if (validEntries.length > 0) {
+      const backendResults = await window.updateImages(
+        validEntries.map(({ image, digest }) => {
+          const repoDigests = image.repoDigests ? Array.from(image.repoDigests) : undefined;
+          return {
+            engineId: image.engineId,
+            image: `${image.name}:${image.tag}`,
+            tag: image.tag,
+            digest,
+            repoDigests,
+          };
+        }),
+      );
+
+      for (let j = 0; j < validEntries.length; j++) {
+        results[validEntries[j].index] = backendResults[j];
+      }
+    }
+
+    return results;
   }
 
   getImageInfoUI(


### PR DESCRIPTION
## Summary

- add image update actions for single images and bulk-selected images
- compare local and remote image digests using repository digests when available
- show task feedback immediately while image updates are in progress, then summarize results

Refreshes the image update work from #16590.

Fixes #15731

https://github.com/user-attachments/assets/15b39aa8-d110-48e2-98b0-839bd2094fa1


## Testing

- `pnpm exec vitest run packages/main/src/plugin/container-registry.spec.ts packages/renderer/src/lib/image/image-utils.spec.ts packages/renderer/src/lib/image/ImageActions.spec.ts packages/renderer/src/lib/image/ImagesList.spec.ts packages/main/src/plugin/index.spec.ts`
- `pnpm run typecheck:main`
- `pnpm exec eslint packages/main/src/plugin/index.ts packages/main/src/plugin/index.spec.ts`
- `git diff --check`
