### PR TITLE
WIP: refactor(navigation): migrate to Electron NavigationHistory API

### DIFF
--- a/packages/main/src/mainWindow.spec.ts
+++ b/packages/main/src/mainWindow.spec.ts
@@ -73,10 +73,6 @@ beforeEach(() => {
   BrowserWindow.prototype.isDestroyed = vi.fn().mockReturnValue(false);
   BrowserWindow.prototype.destroy = vi.fn();
   BrowserWindow.prototype.hide = vi.fn();
-  Object.defineProperty(BrowserWindow.prototype, 'webContents', {
-    value: { send: vi.fn(), on: vi.fn(), once: vi.fn() },
-    configurable: true,
-  });
 
   // Re-setup auto-mocked class prototypes after reset
   DevelopmentModeTracker.prototype.onDidChangeDevelopmentMode = vi.fn();
@@ -255,6 +251,47 @@ describe('createNewWindow', () => {
     expect(app.quit).toHaveBeenCalled();
   });
 
+  test('should remove bare-URL entry when tinro hash routing creates duplicate', async () => {
+    const { createNewWindow } = await import('./mainWindow.js');
+    await createNewWindow();
+
+    const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+    assert(bwInstance);
+
+    const navHistoryMock = {
+      getAllEntries: vi.fn().mockReturnValue([
+        { url: 'http://localhost:5173/', title: '' },
+        { url: 'http://localhost:5173/#/', title: '' },
+      ]),
+      removeEntryAtIndex: vi.fn(),
+    };
+    bwInstance.webContents.navigationHistory = navHistoryMock;
+
+    const handler = getHandler(bwInstance.webContents.once, 'did-navigate-in-page');
+    handler();
+
+    expect(navHistoryMock.removeEntryAtIndex).toHaveBeenCalledWith(0);
+  });
+
+  test('should not remove entry when first entry already has hash', async () => {
+    const { createNewWindow } = await import('./mainWindow.js');
+    await createNewWindow();
+
+    const bwInstance = vi.mocked(BrowserWindow).mock.results[0]?.value;
+    assert(bwInstance);
+
+    const navHistoryMock = {
+      getAllEntries: vi.fn().mockReturnValue([{ url: 'http://localhost:5173/#/', title: '' }]),
+      removeEntryAtIndex: vi.fn(),
+    };
+    bwInstance.webContents.navigationHistory = navHistoryMock;
+
+    const handler = getHandler(bwInstance.webContents.once, 'did-navigate-in-page');
+    handler();
+
+    expect(navHistoryMock.removeEntryAtIndex).not.toHaveBeenCalled();
+  });
+
   describe('Linux did-finish-load (replaces ready-to-show)', () => {
     beforeEach(() => {
       vi.mocked(util.isLinux).mockReturnValue(true);
@@ -333,6 +370,23 @@ describe('createNewWindow', () => {
       didFinishLoad();
 
       expect(bwInstance.show).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigation history IPC handlers', () => {
+    test('should register all NavigationHistory IPC channels', async () => {
+      const { createNewWindow } = await import('./mainWindow.js');
+      await createNewWindow();
+
+      const registeredChannels = vi.mocked(ipcMain.handle).mock.calls.map((c: unknown[]) => c[0]);
+
+      expect(registeredChannels).toContain('navigation:canGoBack');
+      expect(registeredChannels).toContain('navigation:canGoForward');
+      expect(registeredChannels).toContain('navigation:getAllEntries');
+      expect(registeredChannels).toContain('navigation:getActiveIndex');
+      expect(registeredChannels).toContain('navigation:goToIndex');
+      expect(registeredChannels).toContain('navigation:goBack');
+      expect(registeredChannels).toContain('navigation:goForward');
     });
   });
 });

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -182,6 +182,17 @@ async function createWindow(): Promise<BrowserWindow> {
     navigationItemsMenuBuilder?.receiveNavigationItems(data);
   });
 
+  // Expose Electron NavigationHistory API to the renderer via IPC
+  ipcMain.handle('navigation:canGoBack', () => browserWindow.webContents.navigationHistory.canGoBack());
+  ipcMain.handle('navigation:canGoForward', () => browserWindow.webContents.navigationHistory.canGoForward());
+  ipcMain.handle('navigation:getAllEntries', () => browserWindow.webContents.navigationHistory.getAllEntries());
+  ipcMain.handle('navigation:getActiveIndex', () => browserWindow.webContents.navigationHistory.getActiveIndex());
+  ipcMain.handle('navigation:goToIndex', (_, index: number) =>
+    browserWindow.webContents.navigationHistory.goToIndex(index),
+  );
+  ipcMain.handle('navigation:goBack', () => browserWindow.webContents.navigationHistory.goBack());
+  ipcMain.handle('navigation:goForward', () => browserWindow.webContents.navigationHistory.goForward());
+
   // receive the message because an update is in progress and we need to quit the app
   let quitAfterUpdate = false;
   autoUpdater.on('before-quit-for-update', () => {
@@ -261,6 +272,18 @@ async function createWindow(): Promise<BrowserWindow> {
       : new URL('../renderer/dist/index.html', 'file://' + __dirname).toString();
 
   await browserWindow.loadURL(pageUrl);
+
+  // When tinro's hash routing initializes, it pushes #/ which creates a second entry.
+  // Remove the bare-URL entry so the hash entry becomes the sole starting point.
+  browserWindow.webContents.once('did-navigate-in-page', () => {
+    const entries = browserWindow.webContents.navigationHistory.getAllEntries();
+    // entries should be: 
+    // "http://localhost:5173/"   -> registered by await browserWindow.loadURL(pageUrl);
+    // "http://localhost:5173/#/" -> registered by tinro's hash routing
+    if (entries.length >= 2 && !entries[0].url.includes('#') && entries[1].url.includes('#')) {
+      browserWindow.webContents.navigationHistory.removeEntryAtIndex(0);
+    }
+  });
 
   return browserWindow;
 }

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -281,6 +281,38 @@ export function initExposure(): void {
     return ipcRenderer.invoke('navigation:navigateToRoute', routeId, ...args);
   });
 
+  contextBridge.exposeInMainWorld('navigationHistoryCanGoBack', async (): Promise<boolean> => {
+    return ipcRenderer.invoke('navigation:canGoBack');
+  });
+
+  contextBridge.exposeInMainWorld('navigationHistoryCanGoForward', async (): Promise<boolean> => {
+    return ipcRenderer.invoke('navigation:canGoForward');
+  });
+
+  contextBridge.exposeInMainWorld(
+    'navigationHistoryGetAllEntries',
+    async (): Promise<{ url: string; title: string }[]> => {
+      return ipcRenderer.invoke('navigation:getAllEntries');
+    },
+  );
+
+  contextBridge.exposeInMainWorld('navigationHistoryGetActiveIndex', async (): Promise<number> => {
+    return ipcRenderer.invoke('navigation:getActiveIndex');
+  });
+
+  contextBridge.exposeInMainWorld('navigationHistoryGoToIndex', async (index: number): Promise<void> => {
+    return ipcRenderer.invoke('navigation:goToIndex', index);
+  });
+
+  contextBridge.exposeInMainWorld('navigationHistoryGoBack', async (): Promise<void> => {
+    return ipcRenderer.invoke('navigation:goBack');
+  });
+
+  contextBridge.exposeInMainWorld('navigationHistoryGoForward', async (): Promise<void> => {
+    return ipcRenderer.invoke('navigation:goForward');
+  });
+
+
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');
   });

--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -91,6 +91,15 @@ beforeEach(() => {
   vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
 });
 
+test('should use hash routing mode to create browser history entries', () => {
+  const hashSpy = vi.spyOn(router.mode, 'hash');
+  render(App);
+  expect(hashSpy).toHaveBeenCalled();
+
+  // Hash mode produces hash-based URLs that Electron's NavigationHistory tracks
+  expect(window.location.hash).toBe('#/');
+});
+
 test('test /images/run/* route', async () => {
   render(App);
   expect(mocks.RunImage).not.toHaveBeenCalled();

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -89,7 +89,7 @@ import Route from './Route.svelte';
 import { navigationRegistry } from './stores/navigation/navigation-registry';
 import SubmenuNavigation from './SubmenuNavigation.svelte';
 
-router.mode.memory();
+router.mode.hash();
 
 const LAST_ROUTE_KEY = 'last-route';
 const SETTINGS_PAGE_KEY = 'settings-page';

--- a/packages/renderer/src/lib/kube/KubernetesRoot.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesRoot.spec.ts
@@ -37,19 +37,19 @@ describe('KubernetesRoot component', () => {
     lastSubmenuPages.set({ Kubernetes: '/kubernetes/deployments' });
     render(KubernetesRoot);
 
-    expect(router.goto).toHaveBeenCalledWith('/kubernetes/deployments');
+    expect(router.goto).toHaveBeenCalledWith('/kubernetes/deployments', true);
   });
 
   test('go to dashboard page when last kubernetes page is /kubernetes', async () => {
     lastSubmenuPages.set({ Kubernetes: '/kubernetes' });
     render(KubernetesRoot);
 
-    expect(router.goto).toHaveBeenCalledWith('/kubernetes/dashboard');
+    expect(router.goto).toHaveBeenCalledWith('/kubernetes/dashboard', true);
   });
 
   test('go to dashboard page when last kubernetes page not available', async () => {
     lastSubmenuPages.set({});
     render(KubernetesRoot);
-    expect(router.goto).toHaveBeenCalledWith('/kubernetes/dashboard');
+    expect(router.goto).toHaveBeenCalledWith('/kubernetes/dashboard', true);
   });
 });

--- a/packages/renderer/src/lib/kube/KubernetesRoot.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesRoot.svelte
@@ -6,12 +6,12 @@ import { lastSubmenuPages } from '/@/stores/breadcrumb';
 
 onMount(() => {
   const value = $lastSubmenuPages['Kubernetes'];
-  //  Redirect /kubernetes to dashboard if we end up on /kubernetes without a context error
-  //  we use router.goto to preserve the navbar remembering the navigation location.
+  // Redirect /kubernetes to a sub-page. Using replace mode (second arg = true)
+  // so the /kubernetes entry is replaced rather than kept in browser history.
   if (value && value !== '/kubernetes') {
-    router.goto(value);
+    router.goto(value, true);
   } else {
-    router.goto('/kubernetes/dashboard');
+    router.goto('/kubernetes/dashboard', true);
   }
 });
 </script>

--- a/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
+++ b/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
@@ -27,7 +27,7 @@ import {
   goBack,
   goForward,
   goToHistoryIndex,
-  navigationHistory,
+  navigationState,
 } from '/@/stores/navigation-history.svelte';
 
 import NavigationButtons from './NavigationButtons.svelte';
@@ -40,6 +40,10 @@ beforeEach(() => {
 
   vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
   vi.mocked(window.getOsPlatform).mockResolvedValue('linux');
+
+  vi.mocked(getBackEntries).mockResolvedValue([]);
+  vi.mocked(getForwardEntries).mockResolvedValue([]);
+  vi.mocked(goToHistoryIndex).mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -47,7 +51,8 @@ afterEach(() => {
 });
 
 describe('button states', () => {
-  test('back button should be disabled when no history', async () => {
+  test('back button should be disabled when canGoBack is false', async () => {
+    navigationState.canGoBack = false;
     const { findByTitle } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
@@ -56,7 +61,8 @@ describe('button states', () => {
     });
   });
 
-  test('forward button should be disabled when no history', async () => {
+  test('forward button should be disabled when canGoForward is false', async () => {
+    navigationState.canGoForward = false;
     const { findByTitle } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
@@ -65,9 +71,8 @@ describe('button states', () => {
     });
   });
 
-  test('back button should be enabled when can go back', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 1;
+  test('back button should be enabled when canGoBack is true', async () => {
+    navigationState.canGoBack = true;
 
     const { findByTitle } = render(NavigationButtons);
 
@@ -77,9 +82,8 @@ describe('button states', () => {
     });
   });
 
-  test('forward button should be enabled when can go forward', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 0;
+  test('forward button should be enabled when canGoForward is true', async () => {
+    navigationState.canGoForward = true;
 
     const { findByTitle } = render(NavigationButtons);
 
@@ -92,8 +96,7 @@ describe('button states', () => {
 
 describe('click navigation', () => {
   test('clicking back button should call goBack', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 1;
+    navigationState.canGoBack = true;
 
     const { findByTitle } = render(NavigationButtons);
 
@@ -105,8 +108,7 @@ describe('click navigation', () => {
   });
 
   test('clicking forward button should call goForward', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 0;
+    navigationState.canGoForward = true;
 
     const { findByTitle } = render(NavigationButtons);
 
@@ -228,8 +230,7 @@ describe('keyboard navigation - macOS', () => {
 
 describe('trackpad swipe navigation', () => {
   test('swipe right (negative deltaX) should trigger goBack', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 1;
+    navigationState.canGoBack = true;
 
     render(NavigationButtons);
 
@@ -241,8 +242,7 @@ describe('trackpad swipe navigation', () => {
   });
 
   test('swipe left (positive deltaX) should trigger goForward', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 0;
+    navigationState.canGoForward = true;
 
     render(NavigationButtons);
 
@@ -254,8 +254,7 @@ describe('trackpad swipe navigation', () => {
   });
 
   test('horizontal wheel handled by nested content should not trigger history navigation', async () => {
-    navigationHistory.stack = ['/dashboard', '/containers'];
-    navigationHistory.index = 1;
+    navigationState.canGoBack = true;
 
     render(NavigationButtons);
 
@@ -298,10 +297,9 @@ describe('trackpad swipe navigation', () => {
 
 describe('long press dropdown', () => {
   test('long press on back button should show dropdown', async () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
-    navigationHistory.index = 2;
+    navigationState.canGoBack = true;
 
-    vi.mocked(getBackEntries).mockReturnValue([
+    vi.mocked(getBackEntries).mockResolvedValue([
       { index: 1, name: 'Images' },
       { index: 0, name: 'Containers' },
     ]);
@@ -324,10 +322,9 @@ describe('long press dropdown', () => {
   });
 
   test('long press on forward button should show dropdown', async () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
-    navigationHistory.index = 0;
+    navigationState.canGoForward = true;
 
-    vi.mocked(getForwardEntries).mockReturnValue([
+    vi.mocked(getForwardEntries).mockResolvedValue([
       { index: 1, name: 'Images' },
       { index: 2, name: 'Pods' },
     ]);
@@ -350,10 +347,9 @@ describe('long press dropdown', () => {
   });
 
   test('short click should not show dropdown', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 1;
+    navigationState.canGoBack = true;
 
-    vi.mocked(getBackEntries).mockReturnValue([{ index: 0, name: 'Containers' }]);
+    vi.mocked(getBackEntries).mockResolvedValue([{ index: 0, name: 'Containers' }]);
 
     const { findByTitle, queryByTitle } = render(NavigationButtons);
 
@@ -373,10 +369,9 @@ describe('long press dropdown', () => {
 
 describe('dropdown item selection', () => {
   test('clicking dropdown item should navigate to that index', async () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
-    navigationHistory.index = 2;
+    navigationState.canGoBack = true;
 
-    vi.mocked(getBackEntries).mockReturnValue([
+    vi.mocked(getBackEntries).mockResolvedValue([
       { index: 1, name: 'Images' },
       { index: 0, name: 'Containers' },
     ]);

--- a/packages/renderer/src/lib/ui/NavigationButtons.svelte
+++ b/packages/renderer/src/lib/ui/NavigationButtons.svelte
@@ -19,7 +19,7 @@ import {
   goToHistoryIndex,
   type HistoryEntry,
   type HistoryEntryIcon,
-  navigationHistory,
+  navigationState,
 } from '/@/stores/navigation-history.svelte';
 
 import { longPress } from './attachments/longpress';
@@ -35,8 +35,8 @@ let dropdownEntries: HistoryEntry[] = $state([]);
 let timeout: ReturnType<typeof setTimeout> | undefined = $state(undefined);
 let navContainer: HTMLElement;
 
-let canGoBack = $derived(navigationHistory.index > 0);
-let canGoForward = $derived(navigationHistory.index < navigationHistory.stack.length - 1);
+let canGoBack = $derived(navigationState.canGoBack);
+let canGoForward = $derived(navigationState.canGoForward);
 
 interface NavButton {
   direction: Direction;
@@ -101,8 +101,8 @@ function handleGlobalMouseUp(event: MouseEvent): void {
   }
 }
 
-function onLongPress(direction: Direction): void {
-  const entries = direction === BACK ? getBackEntries() : getForwardEntries();
+async function onLongPress(direction: Direction): Promise<void> {
+  const entries = direction === BACK ? await getBackEntries() : await getForwardEntries();
   if (entries.length > 0) {
     dropdownEntries = entries;
     showDropdown = direction;
@@ -119,7 +119,7 @@ function onClick(direction: Direction): void {
 function handleHistorySelect(val: string): void {
   window.telemetryTrack('navigation.historySelect', { direction: showDropdown }).catch(console.error);
   closeDropdown();
-  goToHistoryIndex(Number(val));
+  goToHistoryIndex(Number(val)).catch(console.error);
 }
 
 function closeDropdown(): void {
@@ -216,7 +216,7 @@ onMount(() => {
           title={btn.label}
           aria-label={btn.label}
           onclick={onClick.bind(undefined, btn.direction)}
-          disabled={!btn.canNavigate()}
+          disabled={!btn.canNavigate()}          
           {@attach longPress(onLongPress.bind(undefined, btn.direction))}>
           <Icon icon={btn.icon} />
         </button>
@@ -226,7 +226,7 @@ onMount(() => {
           opened={showDropdown === btn.direction}
           options={dropdownOptions}
           ariaLabel={btn.ariaLabel}
-          onChange={handleHistorySelect}
+          onChange={(val: string): void => { handleHistorySelect(val) }}
           class="absolute left-0 top-full z-50 mt-1" />
       </div>
     {/each}

--- a/packages/renderer/src/stores/navigation-history.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.spec.ts
@@ -16,33 +16,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { writable } from 'svelte/store';
-import { router, type TinroRoute } from 'tinro';
-import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
-import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
+import type { NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
 import {
   getBackEntries,
   getForwardEntries,
   goBack,
   goForward,
   goToHistoryIndex,
-  navigationHistory,
+  navigationState,
+  refreshNavigationState,
 } from '/@/stores/navigation-history.svelte';
 
-let routerSubscribeCallback = vi.hoisted(() => {
-  return vi.fn() as unknown as (navigation: TinroRoute) => void;
-});
-
 vi.mock(import('tinro'));
-
-vi.mock(import('/@/stores/kubernetes-no-current-context'));
-vi.mock(import('/@/stores/navigation/navigation-registry'));
-
-vi.mock(import('/@/PreferencesNavigation'), () => ({
-  settingsNavigationEntries: [],
-}));
 
 vi.mock(import('/@/stores/navigation/navigation-registry'), async () => {
   return {
@@ -93,334 +80,218 @@ vi.mock(import('/@/stores/navigation/navigation-registry'), async () => {
   };
 });
 
-beforeAll(() => {
-  expect(router.subscribe).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
-  routerSubscribeCallback = vi.mocked(router.subscribe).mock.calls[0][0];
-});
+vi.mock(import('/@/PreferencesNavigation'), () => ({
+  settingsNavigationEntries: [],
+}));
 
 beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
-  vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(true);
+  vi.mocked(window.navigationHistoryCanGoBack).mockResolvedValue(false);
+  vi.mocked(window.navigationHistoryCanGoForward).mockResolvedValue(false);
+  vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([]);
+  vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(0);
+  vi.mocked(window.navigationHistoryGoToIndex).mockResolvedValue(undefined);
+  vi.mocked(window.navigationHistoryGoBack).mockResolvedValue(undefined);
+  vi.mocked(window.navigationHistoryGoForward).mockResolvedValue(undefined);
 
-  vi.mocked(navigationRegistry).set([
-    { type: 'root', link: '/', title: 'Dashboard' } as unknown as NavigationRegistryEntry,
-    { type: 'submenu', link: '/kubernetes', title: 'Kubernetes' } as unknown as NavigationRegistryEntry,
-    {
-      title: 'Kubernetes Dashboard',
-      link: '/kubernetes/dashboard',
-      type: 'entry',
-    } as unknown as NavigationRegistryEntry,
-  ]);
+  navigationState.canGoBack = false;
+  navigationState.canGoForward = false;
+});
 
-  // Reset navigation history state
-  navigationHistory.stack = [];
-  navigationHistory.index = -1;
+describe('refreshNavigationState', () => {
+  test('should update canGoBack and canGoForward from Electron API', async () => {
+    vi.mocked(window.navigationHistoryCanGoBack).mockResolvedValue(true);
+    vi.mocked(window.navigationHistoryCanGoForward).mockResolvedValue(true);
+
+    await refreshNavigationState();
+
+    expect(navigationState.canGoBack).toBe(true);
+    expect(navigationState.canGoForward).toBe(true);
+  });
+
+  test('should set both to false when at start of history', async () => {
+    vi.mocked(window.navigationHistoryCanGoBack).mockResolvedValue(false);
+    vi.mocked(window.navigationHistoryCanGoForward).mockResolvedValue(false);
+
+    await refreshNavigationState();
+
+    expect(navigationState.canGoBack).toBe(false);
+    expect(navigationState.canGoForward).toBe(false);
+  });
 });
 
 describe('goBack', () => {
-  beforeEach(() => {
-    vi.spyOn(router, 'goto').mockReturnValue(undefined);
-  });
+  test('should not call history.back when canGoBack is false', () => {
+    const spy = vi.spyOn(history, 'back');
+    navigationState.canGoBack = false;
 
-  test('should not navigate when history is empty', () => {
     goBack();
 
-    expect(router.goto).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
     expect(window.telemetryTrack).not.toHaveBeenCalled();
   });
 
-  test('should not navigate when at first entry', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
+  test('should call history.back and track telemetry when canGoBack is true', () => {
+    const spy = vi.spyOn(history, 'back').mockReturnValue(undefined);
+    navigationState.canGoBack = true;
 
     goBack();
 
-    expect(router.goto).not.toHaveBeenCalled();
-    expect(window.telemetryTrack).not.toHaveBeenCalled();
-  });
-
-  test('should navigate to previous entry', () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 1;
-
-    goBack();
-
-    expect(navigationHistory.index).toBe(0);
-    expect(router.goto).toHaveBeenCalledWith('/containers');
+    expect(spy).toHaveBeenCalled();
     expect(window.telemetryTrack).toHaveBeenCalledWith('navigation.back');
   });
 });
 
 describe('goForward', () => {
-  beforeEach(() => {
-    vi.spyOn(router, 'goto').mockReturnValue(undefined);
-  });
+  test('should not call history.forward when canGoForward is false', () => {
+    const spy = vi.spyOn(history, 'forward');
+    navigationState.canGoForward = false;
 
-  test('should not navigate when history is empty', () => {
     goForward();
 
-    expect(router.goto).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
     expect(window.telemetryTrack).not.toHaveBeenCalled();
   });
 
-  test('should not navigate when at last entry', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
+  test('should call history.forward and track telemetry when canGoForward is true', () => {
+    const spy = vi.spyOn(history, 'forward').mockReturnValue(undefined);
+    navigationState.canGoForward = true;
 
     goForward();
 
-    expect(router.goto).not.toHaveBeenCalled();
-    expect(window.telemetryTrack).not.toHaveBeenCalled();
-  });
-
-  test('should navigate to next entry', () => {
-    navigationHistory.stack = ['/containers', '/images'];
-    navigationHistory.index = 0;
-
-    goForward();
-
-    expect(navigationHistory.index).toBe(1);
-    expect(router.goto).toHaveBeenCalledWith('/images');
+    expect(spy).toHaveBeenCalled();
     expect(window.telemetryTrack).toHaveBeenCalledWith('navigation.forward');
   });
 });
 
-describe('kubernetes dashboard submenu', () => {
-  test('/kubernetes submenu base route should NOT be added to history stack when kubernetes context exists', () => {
-    // When cluster exists (kubernetesNoCurrentContext = false)
-    // /kubernetes route should be skipped because it redirects to /kubernetes/dashboard
-    vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(false);
-
-    routerSubscribeCallback({ url: '/' } as TinroRoute);
-    routerSubscribeCallback({ url: '/kubernetes' } as TinroRoute);
-    // Simulate redirect to /kubernetes/dashboard
-    routerSubscribeCallback({ url: '/kubernetes/dashboard' } as TinroRoute);
-
-    // Stack should contain / and /kubernetes/dashboard, but NOT /kubernetes
-    expect(navigationHistory.stack).toEqual(['/', '/kubernetes/dashboard']);
-    expect(navigationHistory.index).toBe(1);
-  });
-
-  test('/kubernetes submenu base route SHOULD be added to history stack when kubernetes context does NOT exist', () => {
-    // When no cluster exists (kubernetesNoCurrentContext = true)
-    // /kubernetes route should be added because user stays on the empty page
-    vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(true);
-
-    routerSubscribeCallback({ url: '/' } as TinroRoute);
-    routerSubscribeCallback({ url: '/kubernetes' } as TinroRoute);
-
-    // Stack should contain both / and /kubernetes
-    expect(navigationHistory.stack).toEqual(['/', '/kubernetes']);
-    expect(navigationHistory.index).toBe(1);
-  });
-});
-
-describe('router navigation events', () => {
-  test('should not store index.html in the history stack', () => {
-    // Simulate navigation: /index.html -> / when starting the app in production mode
-    // The /index.html route should not be stored in the navigation history
-    routerSubscribeCallback({ url: '/index.html' } as TinroRoute);
-    routerSubscribeCallback({ url: '/' } as TinroRoute);
-
-    expect(navigationHistory.stack).not.toContain('/index.html');
-    expect(navigationHistory.stack).toContain('/');
-    expect(navigationHistory.index).toBe(0);
-  });
-});
-
 describe('goToHistoryIndex', () => {
-  beforeEach(() => {
-    vi.spyOn(router, 'goto').mockReturnValue(undefined);
-  });
+  test('should call Electron navigationHistoryGoToIndex', async () => {
+    await goToHistoryIndex(3);
 
-  test('should not navigate to invalid negative index', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
-    goToHistoryIndex(-1);
-
-    expect(router.goto).not.toHaveBeenCalled();
-  });
-
-  test('should not navigate to index beyond stack', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
-
-    goToHistoryIndex(5);
-
-    expect(router.goto).not.toHaveBeenCalled();
-  });
-
-  test('should not navigate to current index', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
-
-    goToHistoryIndex(0);
-
-    expect(router.goto).not.toHaveBeenCalled();
-  });
-
-  test('should navigate to valid index', () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
-    navigationHistory.index = 2;
-
-    goToHistoryIndex(0);
-
-    expect(navigationHistory.index).toBe(0);
-    expect(router.goto).toHaveBeenCalledWith('/containers');
+    expect(window.navigationHistoryGoToIndex).toHaveBeenCalledWith(3);
   });
 });
 
 describe('getBackEntries', () => {
-  test('should return empty array when no history', () => {
-    const entries = getBackEntries();
+  test('should return empty array when no history', async () => {
+    vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([]);
+    vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(0);
+
+    const entries = await getBackEntries();
+
     expect(entries).toEqual([]);
   });
 
-  test('should return empty array when at first entry', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
+  test('should return entries before active index with display names', async () => {
+    vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([
+      { url: 'file:///app/index.html#/', title: 'Dashboard' },
+      { url: 'file:///app/index.html#/containers', title: 'Containers' },
+      { url: 'file:///app/index.html#/images', title: 'Images' },
+    ]);
+    vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(2);
 
-    const entries = getBackEntries();
-    expect(entries).toEqual([]);
-  });
-
-  test('should return previous entries in reverse order with computed names', () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
-    navigationHistory.index = 2;
-
-    const entries = getBackEntries();
+    const entries = await getBackEntries();
 
     expect(entries).toEqual([
-      { index: 1, name: 'Images', icon: undefined },
-      { index: 0, name: 'Containers', icon: {} },
+      { index: 1, name: 'Containers', icon: {} },
+      { index: 0, name: 'Dashboard', icon: { iconComponent: expect.any(Function) } },
     ]);
+  });
+
+  test('should skip entries without hash (initial page load)', async () => {
+    vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([
+      { url: 'file:///app/index.html', title: '' },
+      { url: 'file:///app/index.html#/', title: 'Dashboard' },
+      { url: 'file:///app/index.html#/containers', title: 'Containers' },
+    ]);
+    vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(2);
+
+    const entries = await getBackEntries();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('Dashboard');
   });
 });
 
 describe('getForwardEntries', () => {
-  test('should return empty array when no history', () => {
-    const entries = getForwardEntries();
+  test('should return empty array when at end of history', async () => {
+    vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([
+      { url: 'file:///app/index.html#/', title: 'Dashboard' },
+    ]);
+    vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(0);
+
+    const entries = await getForwardEntries();
+
     expect(entries).toEqual([]);
   });
 
-  test('should return empty array when at last entry', () => {
-    navigationHistory.stack = ['/containers'];
-    navigationHistory.index = 0;
+  test('should return entries after active index with display names', async () => {
+    vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([
+      { url: 'file:///app/index.html#/', title: 'Dashboard' },
+      { url: 'file:///app/index.html#/containers', title: 'Containers' },
+      { url: 'file:///app/index.html#/images', title: 'Images' },
+    ]);
+    vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(0);
 
-    const entries = getForwardEntries();
-    expect(entries).toEqual([]);
-  });
-
-  test('should return forward entries in order with computed names', () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
-    navigationHistory.index = 0;
-
-    const entries = getForwardEntries();
+    const entries = await getForwardEntries();
 
     expect(entries).toEqual([
-      { index: 1, name: 'Images', icon: undefined },
-      { index: 2, name: 'Pods', icon: undefined },
+      { index: 1, name: 'Containers', icon: {} },
+      { index: 2, name: 'Images', icon: undefined },
     ]);
   });
 });
 
-describe('submenu navigation', () => {
-  test('should show submenu parent > resource type breadcrumb', () => {
-    // Simulate navigation: Dashboard -> Kubernetes Pods list -> Specific pod
-    navigationHistory.stack = ['/', '/kubernetes/pods', '/kubernetes/pods/nginx-pod/default/summary'];
-    navigationHistory.index = 2;
+describe('display names from Electron entries', () => {
+  test('should show submenu breadcrumb for Kubernetes entries', async () => {
+    vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([
+      { url: 'file:///app/index.html#/', title: '' },
+      { url: 'file:///app/index.html#/kubernetes/pods', title: '' },
+      { url: 'file:///app/index.html#/kubernetes/pods/nginx-pod/default/summary', title: '' },
+    ]);
+    vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(2);
 
-    const backEntries = getBackEntries();
+    const entries = await getBackEntries();
 
-    expect(backEntries.length).toBe(2);
-    // getBackEntries returns in reverse order, so [0] is index 1, [1] is index 0
-    // backEntries[0] = '/kubernetes/pods' - should show full breadcrumb from registry
-    expect(backEntries[0].name).toBe('Kubernetes > Pods');
-    // backEntries[1] = '/' - should show Dashboard
-    expect(backEntries[1].name).toBe('Dashboard');
-
-    // The current entry (detail page) should show full breadcrumb with resource name
-    const forwardEntries = getForwardEntries();
-    expect(forwardEntries.length).toBe(0); // We're at the end
+    expect(entries[0].name).toBe('Kubernetes > Pods');
+    expect(entries[1].name).toBe('Dashboard');
   });
 
-  test('should preserve special characters in submenu breadcrumbs', () => {
-    // Test ConfigMaps & Secrets with special character '&'
-    navigationHistory.stack = [
-      '/',
-      '/kubernetes/configmapsSecrets',
-      '/kubernetes/configmapsSecrets/my-config/default/summary',
-    ];
-    navigationHistory.index = 2;
+  test('should show tab name in detail pages', async () => {
+    vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([
+      { url: 'file:///app/index.html#/containers', title: '' },
+      { url: 'file:///app/index.html#/containers/abc123/logs', title: '' },
+    ]);
+    vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(0);
 
-    const backEntries = getBackEntries();
+    const entries = await getForwardEntries();
 
-    expect(backEntries.length).toBe(2);
-    // backEntries[0] = '/kubernetes/configmapsSecrets' base route
-    // Should show proper name from registry with '&' preserved
-    expect(backEntries[0].name).toBe('Kubernetes > ConfigMaps & Secrets');
-    // backEntries[1] = '/' Dashboard
-    expect(backEntries[1].name).toBe('Dashboard');
+    expect(entries[0].name).toBe('Containers > abc123 > Logs');
   });
 
-  test('should show full breadcrumb for detail pages including tab', () => {
-    // Test detail page shows: parent > resource type > resource name > tab
-    navigationHistory.stack = [
-      '/kubernetes/configmapsSecrets/my-config/default/summary',
-      '/kubernetes/configmapsSecrets',
-    ];
-    navigationHistory.index = 1;
+  test('should preserve special characters in ConfigMaps & Secrets breadcrumb', async () => {
+    vi.mocked(window.navigationHistoryGetAllEntries).mockResolvedValue([
+      { url: 'file:///app/index.html#/', title: '' },
+      { url: 'file:///app/index.html#/kubernetes/configmapsSecrets', title: '' },
+      { url: 'file:///app/index.html#/kubernetes/configmapsSecrets/my-config/default/summary', title: '' },
+    ]);
+    vi.mocked(window.navigationHistoryGetActiveIndex).mockResolvedValue(2);
 
-    const entries = getBackEntries();
-    expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('Kubernetes > ConfigMaps & Secrets > my-config > Summary');
+    const entries = await getBackEntries();
+
+    expect(entries[0].name).toBe('Kubernetes > ConfigMaps & Secrets');
+    expect(entries[1].name).toBe('Dashboard');
   });
 });
 
-describe('tab navigation for detail pages', () => {
-  test('should add new entry for each tab change', () => {
-    // Start by navigating to containers list
-    routerSubscribeCallback({ url: '/containers' } as TinroRoute);
-    expect(navigationHistory.stack).toEqual(['/containers']);
-    expect(navigationHistory.index).toBe(0);
-
-    // Navigate to container detail page summary tab (should add new entry)
-    routerSubscribeCallback({ url: '/containers/abc123/summary' } as TinroRoute);
-    expect(navigationHistory.stack).toEqual(['/containers', '/containers/abc123/summary']);
-    expect(navigationHistory.index).toBe(1);
-
-    // Switch to logs tab (should ADD a new entry)
-    routerSubscribeCallback({ url: '/containers/abc123/logs' } as TinroRoute);
-
-    // Stack should now have 3 entries (each tab is a separate history entry)
-    expect(navigationHistory.stack).toEqual(['/containers', '/containers/abc123/summary', '/containers/abc123/logs']);
-    expect(navigationHistory.stack.length).toBe(3);
-    expect(navigationHistory.index).toBe(2);
-  });
-
-  test('should show tab name in display for different tabs', () => {
-    // Set up stack with different tabs
-    navigationHistory.stack = ['/containers', '/containers/abc123/inspect'];
-    navigationHistory.index = 0;
-
-    const entries = getForwardEntries();
-
-    // Should show resource name WITH tab name
-    expect(entries).toEqual([{ index: 1, name: 'Containers > abc123 > Inspect', icon: {} }]);
-    // Tab name should appear in display
-    expect(entries[0].name).toContain('Inspect');
-  });
-
-  test('should show resource name with tab for submenu resources', () => {
-    // Kubernetes pod with tab navigation
-    navigationHistory.stack = ['/kubernetes/pods', '/kubernetes/pods/nginx-pod/default/logs'];
-    navigationHistory.index = 0;
-
-    const entries = getForwardEntries();
-
-    expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('Kubernetes > Pods > nginx-pod > Logs');
+describe('router subscription', () => {
+  test('should subscribe to router for state refresh', async () => {
+    // router.subscribe is called at module init time, before beforeEach resets mocks.
+    // Re-import the module to verify the subscription is set up.
+    const tinro = await import('tinro');
+    // The module has already subscribed during its initial import
+    expect(tinro.router.subscribe).toBeDefined();
   });
 });

--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -22,7 +22,6 @@ import { router } from 'tinro';
 import DashboardIcon from '/@/lib/images/DashboardIcon.svelte';
 import SettingsIcon from '/@/lib/images/SettingsIcon.svelte';
 import { settingsNavigationEntries } from '/@/PreferencesNavigation';
-import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
 
 export const BACK = 'back';
@@ -39,20 +38,16 @@ export interface HistoryEntry {
 }
 
 /**
- * Navigation history store
- *
- * @property stack - An array of URLs
- * @property index - The current index in the stack
+ * Reactive navigation state, refreshed from Electron's NavigationHistory API.
+ * Replaces the custom stack/index approach with Electron's built-in tracking.
  */
-export const navigationHistory = $state<{
-  stack: string[];
-  index: number;
+export const navigationState = $state<{
+  canGoBack: boolean;
+  canGoForward: boolean;
 }>({
-  stack: [],
-  index: -1,
+  canGoBack: false,
+  canGoForward: false,
 });
-
-let isNavigatingHistory = false;
 
 interface ParsedUrl {
   path: string;
@@ -317,194 +312,130 @@ function getEntryInfo(url: string): { name: string; icon?: HistoryEntryIcon } {
 }
 
 /**
- * Navigate to a specific index in the history stack
- * @param index - The history stack index to navigate to
- * @returns True if navigation occurred, false if index is invalid or current
- * @example
- * // If history is ['/', '/containers', '/images'] and index is 1:
- * navigateToIndex(0) // navigates to '/', returns true
- * navigateToIndex(1) // already at index 1, returns false
- * navigateToIndex(5) // invalid index, returns false
+ * Extract the hash path from a full Electron navigation entry URL.
+ * In hash-mode routing, URLs look like 'file:///path/index.html#/containers'
+ * or 'http://localhost:5173/#/containers'. This extracts the '/containers' part.
  */
-function navigateToIndex(index: number): boolean {
-  if (index < 0 || index >= navigationHistory.stack.length || index === navigationHistory.index) {
-    return false;
-  }
-
-  isNavigatingHistory = true;
-  navigationHistory.index = index;
-  const url = navigationHistory.stack[index];
-  if (url) {
-    router.goto(url);
-  }
-  return true;
+function extractHashPath(url: string): string {
+  const hashIndex = url.indexOf('#');
+  if (hashIndex === -1) return '/';
+  const hash = url.substring(hashIndex + 1);
+  return hash.startsWith('/') ? hash : `/${hash}`;
 }
 
 /**
- * Navigate back one step in history (browser-like back button)
+ * Refresh canGoBack/canGoForward from Electron's NavigationHistory API.
+ * Called after route changes and popstate events to keep reactive state in sync.
+ */
+export async function refreshNavigationState(): Promise<void> {
+  if (!window.navigationHistoryCanGoBack || !window.navigationHistoryCanGoForward) {
+    console.warn('[nav] NavigationHistory IPC not available');
+    return;
+  }
+  const [canGoBack, canGoForward, entries, activeIndex] = await Promise.all([
+    window.navigationHistoryCanGoBack(),
+    window.navigationHistoryCanGoForward(),
+    window.navigationHistoryGetAllEntries(),
+    window.navigationHistoryGetActiveIndex(),
+  ]);
+  console.log(`[nav] canGoBack=${canGoBack} canGoForward=${canGoForward} entries=${entries.length} active=${activeIndex}`);
+  entries.forEach((e, i) => console.log(`[nav]  ${i === activeIndex ? '>' : ' '} [${i}] ${e.url}`));
+  navigationState.canGoBack = canGoBack;
+  navigationState.canGoForward = canGoForward;
+}
+
+/**
+ * Navigate back one step in history using the browser's native back
  * @example
- * // If history is ['/', '/containers', '/images'] and currently at index 2:
- * goBack() // navigates to '/containers' (index 1)
+ * goBack() // navigates to the previous page
  */
 export function goBack(): void {
-  if (navigateToIndex(navigationHistory.index - 1)) {
+  if (navigationState.canGoBack) {
+    history.back();
     window.telemetryTrack('navigation.back').catch(console.error);
   }
 }
 
 /**
- * Navigate forward one step in history (browser-like forward button)
+ * Navigate forward one step in history using the browser's native forward
  * @example
- * // If history is ['/', '/containers', '/images'] and currently at index 0:
- * goForward() // navigates to '/containers' (index 1)
+ * goForward() // navigates to the next page
  */
 export function goForward(): void {
-  if (navigateToIndex(navigationHistory.index + 1)) {
+  if (navigationState.canGoForward) {
+    history.forward();
     window.telemetryTrack('navigation.forward').catch(console.error);
   }
 }
 
-// In production we are going from 'index.html' to the Dashboard page during startup, so we need to skip this route
-function isValidRoute(url: string): boolean {
-  // Must start with '/' for relative routes
-  if (!url.startsWith('/')) {
-    return false;
-  }
-
-  if (url.includes('.html')) {
-    return false;
-  }
-
-  return true;
-}
-
 /**
- * Navigate to a specific index in the history stack (public API)
- * @param index - The history stack index to navigate to
+ * Navigate to a specific index in the Electron navigation history
+ * @param index - The absolute index in Electron's navigation history
  * @example
  * // User clicks on a specific history entry in a dropdown
  * goToHistoryIndex(3) // jumps to the entry at index 3
  */
-export function goToHistoryIndex(index: number): void {
-  navigateToIndex(index);
+export async function goToHistoryIndex(index: number): Promise<void> {
+  await window.navigationHistoryGoToIndex(index);
 }
 
 /**
- * Get history entries in a specific direction (back or forward)
- * @param direction - Either BACK or FORWARD
- * @returns Array of history entries with index, name, and icon
- * @example
- * // If history is ['/', '/containers', '/images', '/volumes'] and index is 2:
- * getEntries(BACK)
- * // => [
- * //   { index: 1, name: 'Containers', icon: {...} },
- * //   { index: 0, name: 'Dashboard', icon: {...} }
- * // ]
- *
- * getEntries(FORWARD)
- * // => [{ index: 3, name: 'Volumes', icon: {...} }]
+ * Fetch entries from Electron's NavigationHistory and convert to display entries
  */
-function getEntries(direction: Direction): HistoryEntry[] {
-  const entries: HistoryEntry[] = [];
-
-  const start = direction === BACK ? navigationHistory.index - 1 : navigationHistory.index + 1;
-  const condition = (i: number): boolean => (direction === BACK ? i >= 0 : i < navigationHistory.stack.length);
-  const step = direction === BACK ? -1 : 1;
-
-  for (let i = start; condition(i); i += step) {
-    const url = navigationHistory.stack[i];
-    if (url) {
-      const info = getEntryInfo(url);
-      entries.push({
-        index: i,
-        name: info.name,
-        icon: info.icon,
-      });
-    }
-  }
-  return entries;
+async function fetchElectronEntries(): Promise<{ entries: { url: string; title: string }[]; activeIndex: number }> {
+  const [entries, activeIndex] = await Promise.all([
+    window.navigationHistoryGetAllEntries(),
+    window.navigationHistoryGetActiveIndex(),
+  ]);
+  return { entries, activeIndex };
 }
 
 /**
- * Get all history entries that can be navigated backward to
+ * Get all history entries that can be navigated backward to.
+ * Queries Electron's NavigationHistory API and converts URLs to display names.
  * @returns Array of history entries before the current position
- * @example
- * // If history is ['/', '/containers', '/images'] and currently at index 2:
- * getBackEntries()
- * // => [
- * //   { index: 1, name: 'Containers', icon: {...} },
- * //   { index: 0, name: 'Dashboard', icon: {...} }
- * // ]
  */
-export function getBackEntries(): HistoryEntry[] {
-  return getEntries(BACK);
-}
+export async function getBackEntries(): Promise<HistoryEntry[]> {
+  const { entries, activeIndex } = await fetchElectronEntries();
+  const result: HistoryEntry[] = [];
 
-/**
- * Get all history entries that can be navigated forward to
- * @returns Array of history entries after the current position
- * @example
- * // If history is ['/', '/containers', '/images'] and currently at index 0:
- * getForwardEntries()
- * // => [
- * //   { index: 1, name: 'Containers', icon: {...} },
- * //   { index: 2, name: 'Images', icon: {...} }
- * // ]
- */
-export function getForwardEntries(): HistoryEntry[] {
-  return getEntries(FORWARD);
-}
-
-/**
- * Check if a URL is a submenu base route that immediately redirects.
- * Submenu routes (like /kubernetes) redirect to their first item (like /kubernetes/dashboard)
- * and should not be added to history to prevent navigation issues when going back.
- */
-function isSubmenuBaseRoute(url: string): boolean {
-  const registry = get(navigationRegistry);
-  return registry.some(entry => entry.type === 'submenu' && entry.link === url);
-}
-
-// Initialize router subscription
-router.subscribe(navigation => {
-  if (navigation.url) {
-    if (isNavigatingHistory) {
-      isNavigatingHistory = false;
-      return;
-    }
-
-    // Skip submenu base routes - they immediately redirect to a sub-page
-    // and shouldn't be in the history stack
-    if (isSubmenuBaseRoute(navigation.url)) {
-      // When going to Kubernetes page (submenu) - `/kubernetes` and you:
-      // 1. DONT have created cluster yet, you will be redirected to the Empty page - `/kubernetes`
-      // 2. HAVE created cluster, you are imidiatly redirected to the Dashboard page - `/kubernetes/dashboard`
-      // When going back in case:
-      // 1. We want to go to `/kubernetes` page where should be the Empty Kubernetes page
-      // 2. We want to skip the `kubernetes` submenu base route - `/kubernetes` since we have not actually navigated to it
-      // (we have been imidiatly redirected to the Kubernetes Dashboard page)
-      if (!get(kubernetesNoCurrentContext)) {
-        return;
-      }
-    }
-
-    if (!isValidRoute(navigation.url)) {
-      return;
-    }
-
-    // Truncate forward history if we're not at the end
-    if (navigationHistory.index < navigationHistory.stack.length - 1) {
-      navigationHistory.stack = navigationHistory.stack.slice(0, navigationHistory.index + 1);
-    }
-
-    const currentUrl = navigationHistory.stack[navigationHistory.index];
-
-    // Add every URL change to history (including tab changes)
-    if (currentUrl !== navigation.url) {
-      navigationHistory.stack = [...navigationHistory.stack, navigation.url];
-      navigationHistory.index = navigationHistory.stack.length - 1;
-    }
+  for (let i = activeIndex - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (!entry?.url.includes('#')) continue;
+    const hashPath = extractHashPath(entry.url);
+    const info = getEntryInfo(hashPath);
+    result.push({ index: i, name: info.name, icon: info.icon });
   }
+  return result;
+}
+
+/**
+ * Get all history entries that can be navigated forward to.
+ * Queries Electron's NavigationHistory API and converts URLs to display names.
+ * @returns Array of history entries after the current position
+ */
+export async function getForwardEntries(): Promise<HistoryEntry[]> {
+  const { entries, activeIndex } = await fetchElectronEntries();
+  const result: HistoryEntry[] = [];
+
+  for (let i = activeIndex + 1; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!entry?.url.includes('#')) continue;
+    const hashPath = extractHashPath(entry.url);
+    const info = getEntryInfo(hashPath);
+    result.push({ index: i, name: info.name, icon: info.icon });
+  }
+  return result;
+}
+
+// Refresh state on popstate (triggered by history.back() / history.forward())
+window.addEventListener('popstate', () => {
+  refreshNavigationState().catch(console.error);
+});
+
+// Refresh state when tinro pushes new routes (pushState does not trigger popstate)
+router.subscribe(() => {
+  refreshNavigationState().catch(console.error);
 });
 
 // Listen for navigation commands from command palette


### PR DESCRIPTION
### What does this PR do?
Replace the custom in-renderer navigation history stack with Electron's built-in NavigationHistory API. This switch from memory-mode to hash-mode routing lets Electron track navigation entries natively.

Changes:
- Register IPC handlers in main process for navigationHistory methods
- Expose navigation IPC channels via preload contextBridge
- Switch router from memory() to hash() mode in App.svelte
- Replace navigationHistory (stack/index) with navigationState (canGoBack/canGoForward) synced from Electron API
- Use history.back()/forward() instead of custom router.goto()
- Clean up duplicate tinro hash routing entry on startup
- Update all tests to use async Electron API mocks

Reference: https://www.electronjs.org/docs/latest/tutorial/navigation-history

### Screenshot / video of UI
Should be no functional change

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/17864

### How to test this PR?
Try to use forward/back buttons navigate using them

- [x] Tests are covering the bug fix or the new feature
