### PR TITLE
fix: add bottom spacing for main view content

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -447,7 +447,7 @@ function label(item: ContainerGroupInfoUI | ContainerInfoUI): string {
   {/snippet}
 
   {#snippet content()}
-    <div class="flex min-w-full h-full">
+    <div class="flex min-w-full grow">
       {#if providerConnections.length === 0}
         <NoContainerEngineEmptyScreen />
       {:else if containerGroups.length === 0}

--- a/packages/renderer/src/lib/dashboard/DashboardPage.svelte
+++ b/packages/renderer/src/lib/dashboard/DashboardPage.svelte
@@ -178,9 +178,9 @@ function handleDashboardToggle(itemId: string, enabled: boolean): void {
       resetButtonLabel="Reset Layout"
     />
   {/snippet}
-  
+
   {#snippet content()}
-  <div class="flex flex-col min-w-full h-full bg-[var(--pd-content-bg)] py-5">
+  <div class="flex flex-col min-w-full grow bg-[var(--pd-content-bg)] py-5">
     <div class="min-w-full flex-1">
       <NotificationsBox />
       <div class="px-5 space-y-5 h-full">

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -124,7 +124,7 @@ function changeScreen(newScreen: 'installed' | 'catalog' | 'development'): void 
  {/snippet}
 
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex min-w-full grow">
     {#if screen === 'installed'}
       {#if searchTerm && filteredInstalledExtensions.length === 0}
         <FilteredEmptyScreen

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -351,7 +351,7 @@ function label(item: ImageInfoUI): string {
   {/snippet}
 
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex min-w-full grow">
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardingList.svelte
@@ -56,7 +56,7 @@ function key(config: ForwardConfig): string {
 
 <NavPage searchEnabled={false} title="Port forwarding">
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex min-w-full grow">
     {#if $kubernetesCurrentContextPortForwards.length > 0}
       <Table
         kind="port"

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -151,7 +151,7 @@ function key(network: NetworkInfoUI): string {
   {/snippet}
 
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex min-w-full grow">
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />

--- a/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
+++ b/packages/renderer/src/lib/objects/KubernetesObjectsList.svelte
@@ -150,7 +150,7 @@ let selectedItemsNumber = $state<number>(0);
   {/snippet}
 
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex min-w-full grow">
     <Table
       kind={singular}
       bind:selectedItemsNumber={selectedItemsNumber}

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -244,7 +244,7 @@ function label(pod: PodInfoUI): string {
   {/snippet}
 
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex min-w-full grow">
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.svelte
@@ -17,7 +17,7 @@ import SettingsPage from './SettingsPage.svelte';
 </script>
 
 <SettingsPage title="Authentication">
-  <div class="container h-full" role="list">
+  <div class="container" role="list">
     <!-- Authentication Providers table start -->
     <EmptyScreen
       icon={KeyIcon}

--- a/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliToolsRendering.svelte
@@ -9,7 +9,7 @@ import SettingsPage from './SettingsPage.svelte';
 </script>
 
 <SettingsPage title="CLI Tools">
-  <div class="h-full" role="table" aria-label="cli-tools">
+  <div role="table" aria-label="cli-tools">
     <EmptyScreen
       aria-label="no-resource-panel"
       icon={EngineIcon}

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.svelte
@@ -220,7 +220,7 @@ async function connect(contextName: string): Promise<void> {
 </script>
 
 <SettingsPage title="Kubernetes Contexts">
-  <div class="h-full" role="table" aria-label="Contexts">
+  <div role="table" aria-label="Contexts">
     <!-- Use KubernetesIcon in the future / not EngineIcon -->
     <EmptyScreen
       aria-label="No Resource Panel"
@@ -363,7 +363,7 @@ async function connect(contextName: string): Promise<void> {
                     {/if}
                     {#if context.isBeingChecked}
                       <div class="ml-1"><Spinner size="12px"></Spinner></div>
-                    {/if}                    
+                    {/if}
                   </div>
                   {#if !$kubernetesContextsState.get(context.name)}
                     <div><Button on:click={(): Promise<void> => connect(context.name)}>Connect</Button></div>

--- a/packages/renderer/src/lib/preferences/SettingsPage.svelte
+++ b/packages/renderer/src/lib/preferences/SettingsPage.svelte
@@ -36,7 +36,7 @@ let { title, subtitle, actions, header, children }: Props = $props();
 
     {@render header?.()}
   </div>
-  <div class="flex flex-row w-full h-full px-5 py-4 overflow-y-auto" role="region" aria-label="Content">
+  <div class="flex flex-row min-w-full flex-1 min-h-0 px-5 py-4 overflow-y-auto" role="region" aria-label="Content">
     <div class="flex flex-col grow max-w-[905px] mx-auto">
       {@render children?.()}
     </div>

--- a/packages/renderer/src/lib/task-manager/TaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManager.svelte
@@ -65,7 +65,7 @@ const taskWordPlural = $derived(selectedItemsNumber > 1 ? 'tasks' : 'task');
       {/snippet}
 
       {#snippet content()}
-      <div class="flex min-w-full h-full">
+      <div class="flex min-w-full grow">
         <TaskManagerTable bind:selectedItemsNumber={selectedItemsNumber} tasks={$filtered} />
         {#if $filtered.length === 0}
           <TaskManagerNoFilteredTasks bind:searchTerm={searchTerm} />

--- a/packages/renderer/src/lib/volume/VolumesList.svelte
+++ b/packages/renderer/src/lib/volume/VolumesList.svelte
@@ -231,7 +231,7 @@ function label(obj: VolumeInfoUI): string {
   {/snippet}
 
   {#snippet content()}
-  <div class="flex min-w-full h-full">
+  <div class="flex min-w-full grow">
 
     {#if providerConnections.length === 0}
       <NoContainerEngineEmptyScreen />

--- a/packages/ui/src/lib/layouts/NavPage.svelte
+++ b/packages/ui/src/lib/layouts/NavPage.svelte
@@ -61,7 +61,7 @@ let {
       </div>
     {/if}
 
-    <div class="flex w-full h-full overflow-auto" role="region" aria-label="content">
+    <div class="flex flex-col w-full h-full overflow-auto" role="region" aria-label="content">
       {@render content?.()}
     </div>
   </div>


### PR DESCRIPTION
### What does this PR do?

Adds bottom spacing between page content and the StatusBar across all main views. Previously, content extended flush to the StatusBar with no breathing room.

The fix has two parts:
1. **NavPage content area** (`packages/ui`): Changed from `flex` to `flex flex-col` so children can use `grow` to fill vertical space properly.
2. **Page content divs** (`packages/renderer`): Replaced `h-full` with `grow` on 10 NavPage consumers — `grow` preserves empty screen centering while allowing proper spacing. Same `flex-1 min-h-0` pattern applied to SettingsPage.

### Screenshot / video of UI

Before: 
<img width="1079" height="748" alt="image" src="https://github.com/user-attachments/assets/477724a4-56a9-4f38-9169-e2b2163659e2" />

After: 
<img width="1065" height="735" alt="image" src="https://github.com/user-attachments/assets/454adb64-7d34-4637-bc17-29b2361e1360" />


### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17510

### How to test this PR?

1. Navigate to each page: Dashboard, Containers, Images, Pods, Volumes, Networks, Kubernetes, Port Forwarding, Extensions, Task Manager
2. Scroll to the bottom and content should have spacing above the StatusBar
3. Check Settings pages: CLI Tools, Kubernetes Contexts, Authentication — same spacing behavior
4. Verify scrolling still works correctly on all pages

- [x] Tests are covering the bug fix or the new feature
