### PR TITLE
chore(container-creation): remove scrolling + update buttons.

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -651,11 +651,11 @@ const envDialogOptions: OpenDialogOptions = {
 <Route path="/*">
   {#if dataReady}
     <EngineFormPage title="Create a container from image {imageDisplayName}:{image.tag}">
-      {#snippet icon()}
-        <i class="fas fa-play fa-2x" aria-hidden="true"></i>
-      {/snippet}
-      {#snippet content()}
-      <div class="space-y-2">
+    {#snippet icon()}
+      <i class="fas fa-play fa-2x" aria-hidden="true"></i>
+    {/snippet}
+    {#snippet content()}
+    <div class="space-y-2">
         <div class="flex flex-row px-2 border-b border-[var(--pd-content-divider)]">
           <Tab title="Basic" selected={isTabSelected($router.path, 'basic')} url={getTabUrl($router.path, 'basic')} />
           <Tab
@@ -671,9 +671,9 @@ const envDialogOptions: OpenDialogOptions = {
             selected={isTabSelected($router.path, 'security')}
             url={getTabUrl($router.path, 'security')} />
         </div>
-        <div>
+        <div class="pt-4">
           <Route path="/basic" breadcrumb="Basic" navigationHint="tab">
-            <div class="h-96 overflow-y-auto pr-4">
+            <div class="pr-4">
               <label
                 for="modalContainerName"
                 class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Container name:</label>
@@ -824,7 +824,7 @@ const envDialogOptions: OpenDialogOptions = {
             </div>
           </Route>
           <Route path="/advanced" breadcrumb="Advanced" navigationHint="tab">
-            <div class="h-96 overflow-y-auto pr-4">
+            <div class="pr-4">
               <!-- Use tty -->
               <label for="containerTty" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Use TTY:</label>
@@ -929,7 +929,7 @@ const envDialogOptions: OpenDialogOptions = {
           </Route>
 
           <Route path="/security" breadcrumb="Security" navigationHint="tab">
-            <div class="h-96 overflow-y-auto pr-4">
+            <div class="pr-4">
               <!-- Privileged-->
               <label
                 for="containerPrivileged"
@@ -1027,7 +1027,7 @@ const envDialogOptions: OpenDialogOptions = {
           </Route>
 
           <Route path="/networking" breadcrumb="Networking" navigationHint="tab">
-            <div class="h-96 overflow-y-auto pr-4">
+            <div class="pr-4">
               <!-- hostname-->
               <label
                 for="containerHostname"
@@ -1143,22 +1143,30 @@ const envDialogOptions: OpenDialogOptions = {
           </Route>
         </div>
 
-        <div class="pt-2 border-[var(--pd-content-divider)] border-t-2"></div>
-        <Button
-          on:click={startContainer}
-          class="w-full"
-          icon={faPlay}
-          aria-label="Start Container"
-          disabled={invalidFields}>
-          Start Container
-        </Button>
+      <div class="pt-4 pb-2">
+        <div class="flex items-center justify-end gap-3">
+          <Button
+            type="link"
+            on:click={(): void => router.goto('/images/')}
+            aria-label="Cancel">
+            Cancel
+          </Button>
+          <Button
+            on:click={startContainer}
+            icon={faPlay}
+            aria-label="Start Container"
+            disabled={invalidFields}>
+            Start Container
+          </Button>
+        </div>
         <div aria-label="createError">
           {#if createError}
             <ErrorMessage class="py-2 text-sm" error={createError} />
           {/if}
         </div>
       </div>
-      {/snippet}
+    </div>
+    {/snippet}
     </EngineFormPage>
   {/if}
 </Route>


### PR DESCRIPTION
chore(container-creation): remove scrolling + update buttons.

### What does this PR do?

Improves the form page for creating a container following a few back and
forths on UI design.

This includes:

- Buttons now float on the right / there is a cancel button
- No more scrolling down to view all the input values
  line

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

Before:
<img width="1326" height="1099" alt="Screenshot 2026-06-23 at 10 38 48 AM" src="https://github.com/user-attachments/assets/3fd18bb7-f3f5-4c35-879e-d222d7565e2a" />

After:

<img width="1214" height="987" alt="1782225485-screenshot-dark" src="https://github.com/user-attachments/assets/0bed57aa-dc4c-4ecd-b17b-45690e745f43" />
<img width="1214" height="987" alt="1782225485-screenshot-light" src="https://github.com/user-attachments/assets/3dc64184-8508-475c-9e9b-c6760235b0eb" />
<img width="1214" height="987" alt="1782225485-screenshot-hc-dark" src="https://github.com/user-attachments/assets/e1e75580-2842-4042-a89f-e07c010d34e7" />
<img width="1214" height="987" alt="1782225485-screenshot-hc-light" src="https://github.com/user-attachments/assets/ba5ea70c-c744-4c9e-8038-af2b613ab1e6" />



### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Closes https://github.com/podman-desktop/podman-desktop/issues/16370

### How to test this PR?

1. Go to create a container
2. See the new form design.

- [X] Tests are covering the bug fix or the new feature

Signed-off-by: Charlie Drage <charlie@charliedrage.com>
