### PR TITLE
chore: add update e2e tests with reminder never settings

### DIFF
--- a/tests/playwright/src/special-specs/installation/update-install-never.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install-never.spec.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { RunnerOptions } from '/@/runner/runner-options';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { handleConfirmationDialog } from '/@/utility/operations';
+import { isCI, isLinux } from '/@/utility/platform';
+
+test.skip(isLinux, 'Applicaton update is not supported on Linux');
+
+test.use({
+  runnerOptions: new RunnerOptions({
+    /**
+     * For performance reasons, disable extensions which are not necessary for the e2e
+     */
+    customSettings: {
+      'preferences.update.reminder': 'never',
+      'extensions.disabled': [
+        'podman-desktop.compose',
+        'podman-desktop.docker',
+        'podman-desktop.kind',
+        'podman-desktop.kube-context',
+        'podman-desktop.kubectl-cli',
+        'podman-desktop.lima',
+        'podman-desktop.minikube',
+        'podman-desktop.registries',
+      ],
+    },
+  }),
+});
+
+test.beforeAll(async ({ runner }) => {
+  runner.setVideoAndTraceName('reminder-never-update-e2e');
+});
+
+test.afterAll(async ({ runner }) => {
+  test.setTimeout(120_000);
+  await runner.close(45_000);
+});
+
+test.describe
+  .serial('Application update reminder preferences set to Never', { tag: '@update-install' }, () => {
+    test('No update on startup', async ({ page, welcomePage }) => {
+      test.skip(
+        !isCI || process.env.GITHUB_ACTIONS !== 'true' || isLinux,
+        'Only run on macOS and Windows in GitHub Actions',
+      );
+      const updateAvailableDialog = page.getByRole('dialog', { name: 'Update Podman Desktop?' });
+      await playExpect(updateAvailableDialog).not.toBeVisible({ timeout: 20_000 });
+      await welcomePage.handleWelcomePage(true);
+    });
+    test('Version button is visible', async ({ statusBar }) => {
+      await playExpect(statusBar.content).toBeVisible();
+      await playExpect(statusBar.versionButton).toBeVisible();
+    });
+
+    test('User initiated update option is available', async ({ page, statusBar }) => {
+      await playExpect(statusBar.updateButtonTitle).toHaveText(await statusBar.versionButton.innerText());
+      await statusBar.updateButtonTitle.click();
+      await handleConfirmationDialog(page, 'Update Podman Desktop?', false, '', 'Cancel');
+    });
+  });


### PR DESCRIPTION
### What does this PR do?
It introduces a regression test for application update functionality with settings the `preferences.update.reminder` to `never`. Application update should not be offered on app. start up but it should still be possible.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#17126 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
