### PR TITLE
fix(ui): replace native tooltips in packages/ui shared components

### DIFF
--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -5,6 +5,7 @@ import { createEventDispatcher, untrack } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
 import Spinner from '../progress/Spinner.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 import type { ButtonType } from './Button';
 
 interface Props {
@@ -88,34 +89,35 @@ let classes = $derived.by(() => {
 });
 </script>
 
-<button
-  type="button"
-  class="relative {actualPadding} motion-reduce:transition-none min-h-[28px] min-w-[28px] leading-[15px] select-none {classes} {classNames}"
-  class:border-[var(--pd-button-tab-border-selected)]={type === 'tab' && selected && !disabled && !inProgress}
-  class:hover:border-[var(--pd-button-tab-hover-border)]={type === 'tab' && !selected && !disabled && !inProgress}
-  class:text-[var(--pd-button-tab-text-selected)]={type === 'tab' && selected && !disabled && !inProgress}
-  class:text-[var(--pd-button-tab-text)]={type === 'tab' && !selected && !disabled && !inProgress}
-  hidden={hidden}
-  title={title}
-  aria-label={ariaLabel}
-  onclick={onclick}
-  disabled={disabled || inProgress}
-  aria-disabled={disabled || inProgress}
-  aria-busy={inProgress}>
-  {#if icon ?? inProgress}
-    <div
-      class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]"
-      class:py-[3px]={!children}>
-      {#if inProgress}
-        <Spinner size="1em" />
-      {:else if icon}
-        <Icon icon={icon}/>
-      {/if}
-      {#if children}
-        <span>{@render children()}</span>
-      {/if}
-    </div>
-  {:else}
-    {@render children?.()}
-  {/if}
-</button>
+<Tooltip tip={title} containerClass="contents">
+  <button
+    type="button"
+    class="relative {actualPadding} motion-reduce:transition-none min-h-[28px] min-w-[28px] leading-[15px] select-none {classes} {classNames}"
+    class:border-[var(--pd-button-tab-border-selected)]={type === 'tab' && selected && !disabled && !inProgress}
+    class:hover:border-[var(--pd-button-tab-hover-border)]={type === 'tab' && !selected && !disabled && !inProgress}
+    class:text-[var(--pd-button-tab-text-selected)]={type === 'tab' && selected && !disabled && !inProgress}
+    class:text-[var(--pd-button-tab-text)]={type === 'tab' && !selected && !disabled && !inProgress}
+    hidden={hidden}
+    aria-label={ariaLabel ?? (!children ? title : undefined)}
+    onclick={onclick}
+    disabled={disabled || inProgress}
+    aria-disabled={disabled || inProgress}
+    aria-busy={inProgress}>
+    {#if icon ?? inProgress}
+      <div
+        class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]"
+        class:py-[3px]={!children}>
+        {#if inProgress}
+          <Spinner size="1em" />
+        {:else if icon}
+          <Icon icon={icon}/>
+        {/if}
+        {#if children}
+          <span>{@render children()}</span>
+        {/if}
+      </div>
+    {:else}
+      {@render children?.()}
+    {/if}
+  </button>
+</Tooltip>

--- a/packages/ui/src/lib/button/CloseButton.svelte
+++ b/packages/ui/src/lib/button/CloseButton.svelte
@@ -3,6 +3,7 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { createEventDispatcher } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 
 interface Props {
   onclick?: () => void;
@@ -19,11 +20,12 @@ let {
 const dispatch = createEventDispatcher<{ click: undefined }>();
 </script>
 
-<button
-  type="button"
-  class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-focus-ring)] {className}"
-  onclick={onclick}
-  title="Close"
-  aria-label="Close">
-  <Icon icon={faTimes} />
-</button>
+<Tooltip tip="Close">
+  <button
+    type="button"
+    class="hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px] p-1 no-underline cursor-pointer outline-transparent focus:outline-[var(--pd-button-focus-ring)] {className}"
+    onclick={onclick}
+    aria-label="Close">
+    <Icon icon={faTimes} />
+  </button>
+</Tooltip>

--- a/packages/ui/src/lib/checkbox/Checkbox.spec.ts
+++ b/packages/ui/src/lib/checkbox/Checkbox.spec.ts
@@ -44,9 +44,9 @@ test('Basic check', async () => {
   expect(parent).toBeInTheDocument();
   expect(parent).toHaveClass('relative p-2 self-start');
 
-  const grandParent = parent?.parentElement;
-  expect(grandParent).toBeInTheDocument();
-  expect(grandParent).toHaveClass('flex flex-row items-center');
+  const label = checkbox.closest('label');
+  expect(label).toBeInTheDocument();
+  expect(label).toHaveClass('flex flex-row items-center');
 
   const peer = getPeer(checkbox);
   expect(peer).toBeInTheDocument();
@@ -120,14 +120,12 @@ test('Check tooltips', async () => {
   const title = 'My title';
   render(Checkbox, { title: title });
 
-  // check for one element of the styling
   const checkbox = screen.getByRole('checkbox');
   expect(checkbox).toBeInTheDocument();
+  expect(checkbox).toHaveAttribute('aria-label', title);
 
-  // check the peer, since we do our own styling
-  const peer = getPeer(checkbox);
-  expect(peer).toBeInTheDocument();
-  expect(peer).toHaveAttribute('title', title);
+  const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+  expect(tooltipTrigger).toBeInTheDocument();
 });
 
 test('Check disabled tooltips', async () => {
@@ -137,8 +135,6 @@ test('Check disabled tooltips', async () => {
   const checkbox = screen.getByRole('checkbox');
   expect(checkbox).toBeInTheDocument();
 
-  // check the peer, since we do our own styling
-  const peer = getPeer(checkbox);
-  expect(peer).toBeInTheDocument();
-  expect(peer).toHaveAttribute('title', title);
+  const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+  expect(tooltipTrigger).toBeInTheDocument();
 });

--- a/packages/ui/src/lib/checkbox/Checkbox.svelte
+++ b/packages/ui/src/lib/checkbox/Checkbox.svelte
@@ -4,6 +4,7 @@ import { faCheckSquare, faMinusSquare, faSquare } from '@fortawesome/free-solid-
 import { createEventDispatcher, type Snippet } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 
 const dispatch = createEventDispatcher<{ click: boolean }>();
 
@@ -48,12 +49,12 @@ function handleClick(event: MouseEvent & { currentTarget: EventTarget & HTMLInpu
 </script>
 
 <label class="flex flex-row items-center {className}">
-  <div class="relative p-2 self-start" class:mt-0.5={!!children} class:mr-1={!!children}>
-    <div
-      class="grid absolute left-0 top-0"
-      title={disabled ? disabledTooltip : title}
-      class:cursor-pointer={!disabled}
-      class:cursor-not-allowed={disabled}>
+  <Tooltip tip={disabled ? disabledTooltip : title}>
+    <div class="relative p-2 self-start" class:mt-0.5={!!children} class:mr-1={!!children}>
+      <div
+        class="grid absolute left-0 top-0"
+        class:cursor-pointer={!disabled}
+        class:cursor-not-allowed={disabled}>
       {#if disabled}
         <Icon size={faSize} icon={faSquare} class="text-[var(--pd-input-checkbox-disabled)]"/>
       {:else if indeterminate}
@@ -69,19 +70,20 @@ function handleClick(event: MouseEvent & { currentTarget: EventTarget & HTMLInpu
           icon={faOutlineSquare}
           class="text-[var(--pd-input-checkbox-unchecked)] hover:text-[var(--pd-input-checkbox-focused-unchecked)]"/>
       {/if}
+      </div>
+      <input
+        aria-label={title}
+        type="checkbox"
+        id={id}
+        name={name}
+        bind:checked={checked}
+        disabled={disabled}
+        required={required}
+        class:cursor-pointer={!disabled}
+        class:cursor-not-allowed={disabled}
+        class="opacity-0 absolute top-0 left-0 w-px h-px text-xl"
+        onclick={handleClick} />
     </div>
-    <input
-      aria-label={title}
-      type="checkbox"
-      id={id}
-      name={name}
-      bind:checked={checked}
-      disabled={disabled}
-      required={required}
-      class:cursor-pointer={!disabled}
-      class:cursor-not-allowed={disabled}
-      class="opacity-0 absolute top-0 left-0 w-px h-px text-xl"
-      onclick={handleClick} />
-  </div>
+  </Tooltip>
   {@render children?.()}
 </label>

--- a/packages/ui/src/lib/dropdown/Dropdown.svelte
+++ b/packages/ui/src/lib/dropdown/Dropdown.svelte
@@ -4,6 +4,7 @@ import { faCaretDown, faCheck } from '@fortawesome/free-solid-svg-icons';
 import { type Component, onMount, type Snippet } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 
 interface Option {
   value: string;
@@ -202,14 +203,14 @@ function onWindowClick(e: Event): void {
           class="flex w-full p-2.5 hover:bg-[var(--pd-dropdown-item-hover-bg)] hover:text-[var(--pd-dropdown-item-hover-text)] hover:rounded-md text-[var(--pd-dropdown-item-text)] hover:cursor-pointer text-start"
           class:bg-[var(--pd-dropdown-item-hover-bg)]={highlightIndex === i}
           class:text-[var(--pd-dropdown-item-hover-text)]={highlightIndex === i}>
-          <span
-            title={option.label}
-            class="group flex items-center no-underline whitespace-nowrap h-4">
-            {#if option.icon}
-              <Icon class="w-4 text-md" icon={option.icon} />
-            {/if}
-            <span class={option.icon ? 'ml-2' : ''}>{option.label}</span>
-          </span>
+          <Tooltip tip={option.label}>
+            <span class="group flex items-center no-underline whitespace-nowrap h-4">
+              {#if option.icon}
+                <Icon class="w-4 text-md" icon={option.icon} />
+              {/if}
+              <span class={option.icon ? 'ml-2' : ''}>{option.label}</span>
+            </span>
+          </Tooltip>
         </button>
       {/each}
     </div>

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.spec.ts
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.spec.ts
@@ -58,9 +58,8 @@ test('Expect tooltip is used if not empty', async () => {
     icon: faCircleUp,
   });
 
-  // grab the svg element
-  const span = screen.getByTitle('tooltip');
-  expect(span).toBeInTheDocument();
+  const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+  expect(tooltipTrigger).toBeInTheDocument();
 });
 
 test('Expect font awesome icon to have class w-4 text-md', async () => {

--- a/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropDownMenuItem.svelte
@@ -3,6 +3,7 @@ import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
 import type { Component } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 
 interface Props {
   title: string;
@@ -21,14 +22,13 @@ const disabledClasses = 'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--
 </script>
 
 {#if !hidden}
-  <!-- Use a div + onclick so there's no "blind spots" for when clicking-->
-  <div class={`p-2.5 ${enabled ? enabledClasses : disabledClasses}`} role="none" onclick={onClick}>
-    <span
-      title={tooltip !== '' ? tooltip : title}
-      class="group flex items-center no-underline whitespace-nowrap h-4"
-      tabindex="-1">
-      <Icon class="w-4 text-md" icon={icon} />
-      {#if title}<span class="ml-2">{title}</span>{/if}
-    </span>
-  </div>
+  <Tooltip tip={tooltip || title}>
+    <!-- Use a div + onclick so there's no "blind spots" for when clicking-->
+    <div class={`p-2.5 ${enabled ? enabledClasses : disabledClasses}`} role="none" onclick={onClick}>
+      <span class="group flex items-center no-underline whitespace-nowrap h-4" tabindex="-1">
+        <Icon class="w-4 text-md" icon={icon} />
+        {#if title}<span class="ml-2">{title}</span>{/if}
+      </span>
+    </div>
+  </Tooltip>
 {/if}

--- a/packages/ui/src/lib/dropdownMenu/DropdownMenu.svelte
+++ b/packages/ui/src/lib/dropdownMenu/DropdownMenu.svelte
@@ -4,6 +4,7 @@ import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 import type { Component, Snippet } from 'svelte';
 
 import Icon from '../icons/Icon.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 import DropDownMenuItems from './DropDownMenuItems.svelte';
 
 interface Props {
@@ -67,16 +68,17 @@ function onButtonClick(e: MouseEvent): void {
   <!-- Create a "kebab" menu for additional actions. -->
   <div class="relative inline-block text-left">
     <!-- Button for the dropdown menu -->
-    <button
-      aria-label={title.length > 0 ? title : 'kebab menu'}
-      onclick={onButtonClick}
-      title={title}
-      bind:this={outsideWindow}
-      class="text-[var(--pd-action-button-text)] {shownAsMenuActionItem
-        ? 'bg-[var(--pd-action-button-details-bg)] px-3'
-        : 'hover:bg-[var(--pd-action-button-details-bg)]'} hover:text-[var(--pd-action-button-hover-text)] font-medium rounded-md inline-flex items-center px-2 py-2 text-center">
-        <Icon class="h-4 w-4" icon={icon}/>
-      </button>
+    <Tooltip tip={title}>
+      <button
+        aria-label={title.length > 0 ? title : 'kebab menu'}
+        onclick={onButtonClick}
+        bind:this={outsideWindow}
+        class="text-[var(--pd-action-button-text)] {shownAsMenuActionItem
+          ? 'bg-[var(--pd-action-button-details-bg)] px-3'
+          : 'hover:bg-[var(--pd-action-button-details-bg)]'} hover:text-[var(--pd-action-button-hover-text)] font-medium rounded-md inline-flex items-center px-2 py-2 text-center">
+          <Icon class="h-4 w-4" icon={icon}/>
+        </button>
+    </Tooltip>
 
     <!-- Dropdown menu for all other actions -->
     {#if showMenu}

--- a/packages/ui/src/lib/layouts/DetailsPage.spec.ts
+++ b/packages/ui/src/lib/layouts/DetailsPage.spec.ts
@@ -77,7 +77,7 @@ test('Expect close link is defined', async () => {
     onclose: closeClickMock,
   });
 
-  const closeElement = screen.getByTitle('Close');
+  const closeElement = screen.getByRole('button', { name: 'Close' });
   expect(closeElement).toBeInTheDocument();
   await fireEvent.click(closeElement);
 

--- a/packages/ui/src/lib/layouts/FormPage.spec.ts
+++ b/packages/ui/src/lib/layouts/FormPage.spec.ts
@@ -47,7 +47,7 @@ test('Expect no backlink or close is defined', async () => {
   const backElement = screen.queryByLabelText('Back');
   expect(backElement).not.toBeInTheDocument();
 
-  const closeElement = screen.queryByTitle('Close');
+  const closeElement = screen.queryByRole('button', { name: 'Close' });
   expect(closeElement).toBeInTheDocument();
 });
 

--- a/packages/ui/src/lib/layouts/ListOrganizer.spec.ts
+++ b/packages/ui/src/lib/layouts/ListOrganizer.spec.ts
@@ -37,14 +37,14 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('Expect trigger button is visible and has correct title', async () => {
+test('Expect trigger button is visible and has correct label', async () => {
   const title = 'Manage Layout';
   render(ListOrganizer, {
     items: mockItems,
     title,
   });
 
-  const triggerButton = screen.getByTitle(title);
+  const triggerButton = screen.getByRole('button', { name: title });
   expect(triggerButton).toBeInTheDocument();
   expect(triggerButton).toHaveAttribute('tabindex', '0');
 });
@@ -55,7 +55,7 @@ test('Expect dropdown opens when trigger button is clicked', async () => {
     title: 'Manage Layout',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
 
   // Initially, dropdown should not be visible
   expect(screen.queryByText('First Item')).not.toBeInTheDocument();
@@ -76,7 +76,7 @@ test.skip('Expect dropdown closes when clicking outside', async () => {
     title: 'Manage Layout',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
 
   // Open dropdown
   await fireEvent.click(triggerButton);
@@ -96,7 +96,7 @@ test('Expect enabled items show check icon', async () => {
     enableToggle: true,
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Check that enabled items have check icons
@@ -123,7 +123,7 @@ test('Expect item toggle functionality works when enableToggle is true', async (
     enableToggle: true,
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Click on third item to enable it
@@ -145,7 +145,7 @@ test('Expect grip icons are visible when enableReorder is true', async () => {
     enableReorder: true,
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Check for grip icons - just verify they exist
@@ -163,7 +163,7 @@ test('Expect reset button is visible when onReset is provided', async () => {
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   const resetButton = screen.getByText('Reset to default');
@@ -180,7 +180,7 @@ test('Expect reset button calls onReset when clicked', async () => {
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   const resetButton = screen.getByText('Reset to default');
@@ -202,7 +202,7 @@ test('Expect reset button is disabled when items are in default state', async ()
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   const resetButton = screen.getByText('Reset to default').closest('button');
@@ -222,7 +222,7 @@ test('Expect reset button is enabled when items are modified', async () => {
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   const resetButton = screen.getByText('Reset to default').closest('button');
@@ -264,7 +264,7 @@ test('Expect reset button is enabled when items are reordered', async () => {
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   const resetButton = screen.getByText('Reset to default').closest('button');
@@ -278,7 +278,7 @@ test('Expect drag handles are draggable when enableReorder is true', async () =>
     enableReorder: true,
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Find drag handle
@@ -294,7 +294,7 @@ test('Expect mouse events work on drag handles', async () => {
     enableReorder: true,
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Find drag handle
@@ -314,7 +314,7 @@ test('Expect grip handle accepts click events', async () => {
     enableReorder: true,
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Find grip handle
@@ -333,7 +333,7 @@ test('Expect custom title is used', async () => {
     title: customTitle,
   });
 
-  const triggerButton = screen.getByTitle(customTitle);
+  const triggerButton = screen.getByRole('button', { name: customTitle });
   expect(triggerButton).toBeInTheDocument();
 });
 
@@ -348,7 +348,7 @@ test('Expect custom reset button label is used', async () => {
     resetButtonLabel: customLabel,
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   const resetButton = screen.getByText(customLabel);
@@ -361,7 +361,7 @@ test('Expect no reset button when onReset is not provided', async () => {
     title: 'Manage Layout',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Should not find any reset button
@@ -377,7 +377,7 @@ test('Expect reset button has proper styling', async () => {
     onReset: onResetMock,
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Just check that reset button exists
@@ -404,7 +404,7 @@ test('Expect reset button disabled in default state (all enabled, original order
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   const resetButton = screen.getByText('Reset to default').closest('button');
@@ -430,7 +430,7 @@ test('Expect reset button enabled after toggling item', async () => {
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Update with toggled item
@@ -471,7 +471,7 @@ test('Expect reset button enabled after reordering items', async () => {
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Create an ordering Map that represents reordered state
@@ -517,7 +517,7 @@ test('Expect clicking reset button resets state and disables button', async () =
     resetButtonLabel: 'Reset to default',
   });
 
-  const triggerButton = screen.getByTitle('Manage Layout');
+  const triggerButton = screen.getByRole('button', { name: 'Manage Layout' });
   await fireEvent.click(triggerButton);
 
   // Initially disabled (default state)

--- a/packages/ui/src/lib/layouts/ListOrganizer.svelte
+++ b/packages/ui/src/lib/layouts/ListOrganizer.svelte
@@ -3,6 +3,7 @@ import { faCheck, faGripVertical, faPen, faUndo } from '@fortawesome/free-solid-
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
 import { Icon } from '../icons';
+import Tooltip from '../tooltip/Tooltip.svelte';
 import type { ListOrganizerItem } from './ListOrganizer';
 
 /**
@@ -245,15 +246,17 @@ function handleReset(): void {
 <svelte:body class:cursor-grabbing={isDraggingActive} />
 
 <div class="relative inline-block {className}" bind:this={containerElement}>
-  <button
-    class="cursor-pointer text-[var(--pd-action-button-text)] hover:text-[var(--pd-action-button-hover-text)] transition-all duration-150 hover:scale-110 active:scale-95 flex items-center justify-center p-1"
-    class:text-[var(--pd-action-button-hover-text)]={isOpen}
-    onclick={toggleDropdown}
-    title={title}
-    tabindex="0"
-  >
-    <Icon icon={faPen} />
-  </button>
+  <Tooltip tip={title}>
+    <button
+      class="cursor-pointer text-[var(--pd-action-button-text)] hover:text-[var(--pd-action-button-hover-text)] transition-all duration-150 hover:scale-110 active:scale-95 flex items-center justify-center p-1"
+      class:text-[var(--pd-action-button-hover-text)]={isOpen}
+      onclick={toggleDropdown}
+      aria-label={title}
+      tabindex="0"
+    >
+      <Icon icon={faPen} />
+    </button>
+  </Tooltip>
 
   {#if isOpen}
     <div
@@ -285,23 +288,24 @@ function handleReset(): void {
               </div>
 
               {#if enableReorder}
-              <div
-                class="text-[var(--pd-dropdown-item-text)] flex-shrink-0 rounded-sm p-1"
-                class:cursor-grab={!isDraggingActive}
-                class:cursor-grabbing={isDraggingActive}
-                draggable={true}
-                role="button"
-                tabindex="0"
-                data-grip-index={originalIndex}
-                onmousedown={(e): void => startDrag(e, originalIndex)}
-                onclick={(e): void => e.stopPropagation()}
-                onkeydown={(e): void => handleGripKeydown(e, originalIndex)}
-                onmouseenter={(): void => {isGripHovered = true;}}
-                onmouseleave={(): void => {isGripHovered = false;}}
-                title="Use arrow keys to reorder, or drag with mouse"
-              >
-                <Icon icon={faGripVertical} class="text-[var(--pd-dropdown-item-text)]"/>
-              </div>
+              <Tooltip tip="Use arrow keys to reorder, or drag with mouse" right>
+                <div
+                  class="text-[var(--pd-dropdown-item-text)] flex-shrink-0 rounded-sm p-1"
+                  class:cursor-grab={!isDraggingActive}
+                  class:cursor-grabbing={isDraggingActive}
+                  draggable={true}
+                  role="button"
+                  tabindex="0"
+                  data-grip-index={originalIndex}
+                  onmousedown={(e): void => startDrag(e, originalIndex)}
+                  onclick={(e): void => e.stopPropagation()}
+                  onkeydown={(e): void => handleGripKeydown(e, originalIndex)}
+                  onmouseenter={(): void => {isGripHovered = true;}}
+                  onmouseleave={(): void => {isGripHovered = false;}}
+                >
+                  <Icon icon={faGripVertical} class="text-[var(--pd-dropdown-item-text)]"/>
+                </div>
+              </Tooltip>
             {/if}
           </button>
         {/each}

--- a/packages/ui/src/lib/layouts/Page.spec.ts
+++ b/packages/ui/src/lib/layouts/Page.spec.ts
@@ -47,7 +47,7 @@ test('Expect no backlink or close is defined', async () => {
   const backElement = screen.queryByLabelText('Back');
   expect(backElement).not.toBeInTheDocument();
 
-  const closeElement = screen.queryByTitle('Close');
+  const closeElement = screen.queryByRole('button', { name: 'Close' });
   expect(closeElement).toBeInTheDocument();
 });
 

--- a/packages/ui/src/lib/screen/EmptyScreen.svelte
+++ b/packages/ui/src/lib/screen/EmptyScreen.svelte
@@ -90,7 +90,7 @@ let copyTextDivElement = $state<HTMLDivElement>();
           data-testid="copyTextDivElement">
           {commandline}
         </div>
-        <Button title="Copy To Clipboard" class="ml-5" on:click={handleClick} type="link">
+        <Button title="Copy To Clipboard" aria-label="Copy To Clipboard" class="ml-5" on:click={handleClick} type="link">
           <Icon class="h-5 w-5 cursor-pointer text-xl text-(--pd-action-button-primary-text)" icon={faPaste}/>
         </Button>
       </div>

--- a/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
+++ b/packages/ui/src/lib/settingsNavItem/SettingsNavItem.svelte
@@ -4,6 +4,7 @@ import type { Component } from 'svelte';
 
 import ChevronExpander from '../icons/ChevronExpander.svelte';
 import Icon from '../icons/Icon.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 
 interface Props {
   title: string;
@@ -31,47 +32,58 @@ let {
   onClick = (): void => {},
 }: Props = $props();
 
+let labelEl: HTMLElement | undefined = $state(undefined);
+let isTruncated = $state(false);
+
+$effect(() => {
+  if (labelEl) {
+    isTruncated = labelEl.scrollWidth > labelEl.clientWidth;
+  }
+});
+
 function click(): void {
   expanded = !expanded;
   onClick();
 }
 </script>
 
-<a class="no-underline" href={href} aria-label={title} onclick={click}>
-  <div
-    class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px]"
-    class:pl-3={!child}
-    class:pl-[34px]={child}
-    class:leading-none={child}
-    class:text-md={!child}
-    class:font-medium={!child}
-    class:bg-[var(--pd-secondary-nav-selected-bg)]={selected}
-    class:border-[var(--pd-secondary-nav-bg)]={!selected}
-    class:border-[var(--pd-secondary-nav-selected-highlight)]={selected}
-    class:text-[color:var(--pd-secondary-nav-text-selected)]={selected}
-    class:text-[color:var(--pd-secondary-nav-text)]={!selected}
-    class:hover:text-[color:var(--pd-secondary-nav-text-hover)]={!selected}
-    class:hover:bg-[var(--pd-secondary-nav-text-hover-bg)]={!selected}
-    class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]={!selected}>
-    <span
-      class="group-hover:block flex flex-row gap-x-2 items-center"
-      class:capitalize={!child}>
-      {#if icon}
+<Tooltip tip={isTruncated ? title : undefined} right containerClass="block w-full">
+  <a class="no-underline" href={href} aria-label={title} onclick={click}>
+    <div
+      class="flex w-full pr-1 py-2 justify-between items-center cursor-pointer border-l-[4px]"
+      class:pl-3={!child}
+      class:pl-[34px]={child}
+      class:leading-none={child}
+      class:text-md={!child}
+      class:font-medium={!child}
+      class:bg-[var(--pd-secondary-nav-selected-bg)]={selected}
+      class:border-[var(--pd-secondary-nav-bg)]={!selected}
+      class:border-[var(--pd-secondary-nav-selected-highlight)]={selected}
+      class:text-[color:var(--pd-secondary-nav-text-selected)]={selected}
+      class:text-[color:var(--pd-secondary-nav-text)]={!selected}
+      class:hover:text-[color:var(--pd-secondary-nav-text-hover)]={!selected}
+      class:hover:bg-[var(--pd-secondary-nav-text-hover-bg)]={!selected}
+      class:hover:border-[var(--pd-secondary-nav-text-hover-bg)]={!selected}>
+      <span
+        class="group-hover:block flex flex-row gap-x-2 items-center min-w-0"
+        class:capitalize={!child}>
+        {#if icon}
           <Icon icon={icon}/>
+        {/if}
+        <span bind:this={labelEl} class="truncate">{title}</span>
+        {#if iconRight && iconRightAlign === 'inline'}
+          <Icon icon={iconRight}/>
+        {/if}
+      </span>
+      {#if section}
+        <div class="px-2 text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
+          <ChevronExpander expanded={expanded} />
+        </div>
+      {:else if iconRight && iconRightAlign === 'end'}
+        <div class="px-2 flex items-center">
+          <Icon icon={iconRight}/>
+        </div>
       {/if}
-      <span>{title}</span>
-      {#if iconRight && iconRightAlign === 'inline'}
-        <Icon icon={iconRight}/>
-      {/if}
-    </span>
-    {#if section}
-      <div class="px-2 text-[color:var(--pd-secondary-nav-expander)] pointer-events-none">
-        <ChevronExpander expanded={expanded} />
-      </div>
-    {:else if iconRight && iconRightAlign === 'end'}
-      <div class="px-2 flex items-center">
-        <Icon icon={iconRight}/>
-      </div>
-    {/if}
-  </div>
-</a>
+    </div>
+  </a>
+</Tooltip>

--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -28,7 +28,7 @@ test('Expect starting styling', async () => {
   render(StatusIcon, { status });
   const icon = screen.getByRole('status');
   expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('title', status);
+  expect(icon).toHaveAttribute('aria-label', status);
 
   expect(icon).toHaveClass('bg-[var(--pd-status-starting)]');
   expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
@@ -39,7 +39,7 @@ test('Expect running styling', async () => {
   render(StatusIcon, { status });
   const icon = screen.getByRole('status');
   expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('title', status);
+  expect(icon).toHaveAttribute('aria-label', status);
 
   expect(icon).toHaveClass('bg-[var(--pd-status-running)]');
   expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
@@ -50,7 +50,7 @@ test('Expect degraded styling', async () => {
   render(StatusIcon, { status });
   const icon = screen.getByRole('status');
   expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('title', status);
+  expect(icon).toHaveAttribute('aria-label', status);
 
   expect(icon).toHaveClass('bg-[var(--pd-status-degraded)]');
   expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
@@ -61,7 +61,7 @@ test('Expect deleting styling', async () => {
   render(StatusIcon, { status });
   const icon = screen.getByRole('status', { name: status });
   expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('title', status);
+  expect(icon).toHaveAttribute('aria-label', status);
   expect(icon).not.toHaveAttribute('border');
 
   const spinner = screen.getByRole('status', { name: 'Loading' }).firstChild;
@@ -74,7 +74,7 @@ test('Expect updating styling', async () => {
   render(StatusIcon, { status });
   const icon = screen.getByRole('status', { name: status });
   expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('title', status);
+  expect(icon).toHaveAttribute('aria-label', status);
   expect(icon).not.toHaveAttribute('border');
 
   const spinner = screen.getByRole('status', { name: 'Loading' }).firstChild;

--- a/packages/ui/src/lib/statusIcon/StatusIcon.svelte
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.svelte
@@ -5,6 +5,7 @@ import type { Component } from 'svelte';
 import Icon from '../icons/Icon.svelte';
 import StarIcon from '../icons/StarIcon.svelte';
 import Spinner from '../progress/Spinner.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 
 interface Props {
   // status: one of RUNNING, STARTING, USED, CREATED, DELETING, UPDATING, or DEGRADED
@@ -19,25 +20,27 @@ let solid = $derived(status === 'RUNNING' || status === 'STARTING' || status ===
 </script>
 
 <div class="grid place-content-center" style="position:relative">
-  <div
-    class="grid place-content-center rounded-sm aspect-square"
-    class:bg-[var(--pd-status-running)]={status === 'RUNNING' || status === 'USED'}
-    class:bg-[var(--pd-status-starting)]={status === 'STARTING'}
-    class:bg-[var(--pd-status-degraded)]={status === 'DEGRADED'}
-    class:border-2={!solid && status !== 'DELETING' && status !== 'UPDATING'}
-    class:p-0.5={!solid}
-    class:p-1={solid}
-    class:border-[var(--pd-status-not-running)]={!solid}
-    class:text-[var(--pd-status-not-running)]={!solid}
-    class:text-[var(--pd-status-contrast)]={solid}
-    role="status"
-    title={status}>
-    {#if status === 'DELETING' || status === 'UPDATING'}
-      <Spinner size="1.4em" />
-    {:else if icon}
-      <Icon icon={icon} size={size} />
-    {/if}
-  </div>
+  <Tooltip tip={status} containerClass="grid place-content-center">
+    <div
+      class="grid place-content-center rounded-sm aspect-square"
+      class:bg-[var(--pd-status-running)]={status === 'RUNNING' || status === 'USED'}
+      class:bg-[var(--pd-status-starting)]={status === 'STARTING'}
+      class:bg-[var(--pd-status-degraded)]={status === 'DEGRADED'}
+      class:border-2={!solid && status !== 'DELETING' && status !== 'UPDATING'}
+      class:p-0.5={!solid}
+      class:p-1={solid}
+      class:border-[var(--pd-status-not-running)]={!solid}
+      class:text-[var(--pd-status-not-running)]={!solid}
+      class:text-[var(--pd-status-contrast)]={solid}
+      role="status"
+      aria-label={status}>
+      {#if status === 'DELETING' || status === 'UPDATING'}
+        <Spinner size="1.4em" />
+      {:else if icon}
+        <Icon icon={icon} size={size} />
+      {/if}
+    </div>
+  </Tooltip>
   {#if status === 'CREATED'}
     <StarIcon size="8" style="position:absolute;top:0;right:0" />
   {/if}

--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -622,7 +622,7 @@ describe('Table#collapsed', () => {
     expect(headers.length).toBe(5);
 
     // Should have layout management button
-    const layoutButton = screen.getByTitle('Configure Columns');
+    const layoutButton = screen.getByRole('button', { name: 'Configure Columns' });
     expect(layoutButton).toBeInTheDocument();
   });
 
@@ -646,7 +646,7 @@ describe('Table#collapsed', () => {
     expect(headers.length).toBe(4);
 
     // Should not have layout management button
-    const layoutButton = screen.queryByTitle('Configure Columns');
+    const layoutButton = screen.queryByRole('button', { name: 'Configure Columns' });
     expect(layoutButton).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -15,6 +15,7 @@ import Checkbox from '../checkbox/Checkbox.svelte';
 import ChevronExpander from '../icons/ChevronExpander.svelte';
 import type { ListOrganizerItem } from '../layouts/ListOrganizer';
 import ListOrganizer from '../layouts/ListOrganizer.svelte';
+import Tooltip from '../tooltip/Tooltip.svelte';
 /* eslint-enable import/no-duplicates */
 import type { Column, Row } from './table';
 import { tablePersistence } from './table-persistence-store.svelte';
@@ -455,16 +456,18 @@ async function resetColumns(): Promise<void> {
           aria-label={label(object)}>
           <div class="whitespace-nowrap place-self-center" role="cell">
             {#if children.length > 0}
-              <button
-                title={collapsed.includes(itemKey) ? 'Expand Row' : 'Collapse Row'}
-                aria-expanded={!collapsed.includes(itemKey)}
-                on:click={toggleChildren.bind(undefined, itemKey)}
-              >
-                <ChevronExpander
-                  expanded={!collapsed.includes(itemKey)}
-                  size="0.8x"
-                  class="text-[var(--pd-table-body-text)] cursor-pointer" />
-              </button>
+              <Tooltip tip={collapsed.includes(itemKey) ? 'Expand Row' : 'Collapse Row'}>
+                <button
+                  aria-label={collapsed.includes(itemKey) ? 'Expand Row' : 'Collapse Row'}
+                  aria-expanded={!collapsed.includes(itemKey)}
+                  on:click={toggleChildren.bind(undefined, itemKey)}
+                >
+                  <ChevronExpander
+                    expanded={!collapsed.includes(itemKey)}
+                    size="0.8x"
+                    class="text-[var(--pd-table-body-text)] cursor-pointer" />
+                </button>
+              </Tooltip>
             {/if}
           </div>
           {#if row.info.selectable}


### PR DESCRIPTION
### What does this PR do?

Replaces all native HTML `title` attribute tooltips with the custom `Tooltip` component across the shared `packages/ui` library. Because these components are consumed throughout the renderer, fixing them here propagates correct, consistent tooltip behavior to every consumer automatically.

Components updated:

- **Button** - wrapped with `<Tooltip tip={title}>`, `title` attribute removed; icon-only   buttons preserve their accessible name via `aria-label`
- **CloseButton** - `title="Close"` replaced with `<Tooltip tip="Close">`
- **Checkbox** - `<Tooltip>` wraps the checkbox control; `title` removed from inner div
- **StatusIcon** - `title={status}` replaced with `<Tooltip tip={status}>` and `aria-label={status}` added to the status div
- **Table** - expand/collapse button uses `<Tooltip>` and `aria-label` instead of `title`
- **ListOrganizer** - trigger button and drag-grip handle both wrapped with `<Tooltip>`;  `aria-label` added to trigger button
- **DropDownMenuItem** - `<Tooltip tip={tooltip || title}>` wraps the item div
- **Dropdown** - option label `title` replaced with `<Tooltip tip={option.label}>`
- **DropdownMenu** - kebab button `title` replaced with `<Tooltip tip={title}>`
- **SettingsNavItem** - truncation-aware tooltip: uses `$effect` to compare `scrollWidth > clientWidth` and only shows the tooltip when the label is actually clipped; label span gains `truncate min-w-0` classes

Tests updated to use role-based or `aria-label`-based queries instead of `getByTitle` /
`toHaveAttribute('title', ...)`.

### What issues does this PR fix or reference?

- Resolves: #18025

### How to test this PR?

1. Run the unit tests: `pnpm test:unit`
2. Launch the app (`pnpm watch`) and hover over:
   - Any button with a `title` prop (e.g. action buttons in container/image lists)
   - The close button on detail pages
   - A checkbox with a `title` prop
   - A status icon in any list
   - The table expand/collapse chevron
   - The list organizer trigger and drag-grip handles
   - A settings nav item whose label is long enough to be truncated
3. Verify the custom Tooltip renders instead of the native browser tooltip
4. Verify the `SettingsNavItem` tooltip only appears when the label is actually truncated

- [x] Tests are covering the bug fix or the new feature
