### PR TITLE
fix(renderer): replace native title tooltips with Tooltip component in utility components

### DIFF
--- a/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { StatusBarEntry } from '@podman-desktop/core-api';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 
 import { iconClass } from './StatusBarItem';
 
@@ -38,21 +39,22 @@ async function executeCommand(entry: StatusBarEntry): Promise<void> {
 }
 </script>
 
-<button
-  onclick={async (): Promise<void> => {
-    await executeCommand(entry);
-  }}
-  class="{opacity(entry)} px-1 py-px flex h-full items-center {hoverBackground(entry)} {hoverCursor(
-    entry,
-  )} relative inline-block"
-  title={tooltipText(entry)}>
-  {#if iconClass(entry)}
-    <span class={iconClass(entry)} aria-hidden="true" data-task-button="{tooltipText(entry)}"></span>
-  {/if}
-  {#if entry.text}
-    <span class="ml-1">{entry.text}</span>
-  {/if}
-  {#if entry.highlight}
-    <span role="status" class="absolute bg-[var(--pd-notification-dot)] rounded-full p-1 top-[1px] right-[-1px]"></span>
-  {/if}
-</button>
+<Tooltip tip={tooltipText(entry)} top>
+  <button
+    onclick={async (): Promise<void> => {
+      await executeCommand(entry);
+    }}
+    class="{opacity(entry)} px-1 py-px flex h-full items-center {hoverBackground(entry)} {hoverCursor(
+      entry,
+    )} relative inline-block">
+    {#if iconClass(entry)}
+      <span class={iconClass(entry)} aria-hidden="true" data-task-button="{tooltipText(entry)}"></span>
+    {/if}
+    {#if entry.text}
+      <span class="ml-1">{entry.text}</span>
+    {/if}
+    {#if entry.highlight}
+      <span role="status" class="absolute bg-[var(--pd-notification-dot)] rounded-full p-1 top-[1px] right-[-1px]"></span>
+    {/if}
+  </button>
+</Tooltip>

--- a/packages/renderer/src/lib/task-manager/TaskManagerWindowEvents.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManagerWindowEvents.svelte
@@ -14,7 +14,7 @@ function toggle(val: boolean): void {
 function onWindowClick({ clientX, clientY, target }: MouseEvent): void {
   // grab the task manager button from the status bar
   const statusBarElement = document.querySelector('div[aria-label="Status Bar"]');
-  const taskManagerButton = statusBarElement?.querySelector('button[title="Tasks"]');
+  const taskManagerButton = statusBarElement?.querySelector('[data-task-button="Tasks"]')?.closest('button');
 
   // if the task manager is not open, do not check anything
   if (!showTaskManager) {

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.spec.ts
@@ -42,10 +42,11 @@ test('Expect the dropDownMenuItem to have classes that display a disabled object
     contextUI: contextUI,
   });
 
-  const listItemSpan = screen.getByTitle(title);
+  const listItemSpan = screen.getByText(title);
   expect(listItemSpan).toBeInTheDocument();
+  const menuItem = listItemSpan.closest('[role="none"]');
   expect(
-    listItemSpan.parentElement!.outerHTML.indexOf(
+    menuItem!.outerHTML.indexOf(
       'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--pd-dropdown-disabled-item-bg)]',
     ) > 0,
   ).toBeTruthy();
@@ -61,10 +62,11 @@ test('Expect the dropDownMenuItem to have classes that display a disabled object
     menu: true,
   });
 
-  const listItemSpan = screen.getByTitle(title);
+  const listItemSpan = screen.getByText(title);
   expect(listItemSpan).toBeInTheDocument();
+  const menuItem = listItemSpan.closest('[role="none"]');
   expect(
-    listItemSpan.parentElement!.outerHTML.indexOf(
+    menuItem!.outerHTML.indexOf(
       'text-[var(--pd-dropdown-disabled-item-text)] bg-[var(--pd-dropdown-disabled-item-bg)]',
     ) > 0,
   ).toBeTruthy();
@@ -85,9 +87,10 @@ test('Expect the dropDownMenuItem NOT to have classes that display a disabled ob
     contextUI: contextUI,
   });
 
-  const listItemSpan = screen.getByTitle(title);
+  const listItemSpan = screen.getByText(title);
   expect(listItemSpan).toBeInTheDocument();
-  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
+  const menuItem = listItemSpan.closest('[role="none"]');
+  expect(menuItem!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
 });
 
 test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is false', async () => {
@@ -100,9 +103,10 @@ test('Expect the dropDownMenuItem NOT to have classes that display a disabled ob
     menu: true,
   });
 
-  const listItemSpan = screen.getByTitle(title);
+  const listItemSpan = screen.getByText(title);
   expect(listItemSpan).toBeInTheDocument();
-  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
+  const menuItem = listItemSpan.closest('[role="none"]');
+  expect(menuItem!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
 });
 
 test('Expect the dropDownMenuItem NOT to have classes that display a disabled object if the disabled when clause is empty', async () => {
@@ -115,9 +119,10 @@ test('Expect the dropDownMenuItem NOT to have classes that display a disabled ob
     menu: true,
   });
 
-  const listItemSpan = screen.getByTitle(title);
+  const listItemSpan = screen.getByText(title);
   expect(listItemSpan).toBeInTheDocument();
-  expect(listItemSpan.parentElement!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
+  const menuItem = listItemSpan.closest('[role="none"]');
+  expect(menuItem!.outerHTML.indexOf('text-gray-900 bg-charcoal-800') === -1).toBeTruthy();
 });
 
 test('With custom font icon', async () => {
@@ -166,7 +171,7 @@ test('expect button to not have inline-flex when hidden is true', async () => {
     menu: false,
   });
 
-  const listItemSpan = screen.getByTitle(title);
+  const listItemSpan = screen.getByRole('button', { name: title });
   expect(listItemSpan).toBeInTheDocument();
   expect(listItemSpan).toHaveClass('hidden');
   expect(listItemSpan).not.toHaveClass('inline-flex');
@@ -182,7 +187,7 @@ test('expect button to have inline-flex when hidden is false', async () => {
     menu: false,
   });
 
-  const listItemSpan = screen.getByTitle(title);
+  const listItemSpan = screen.getByRole('button', { name: title });
   expect(listItemSpan).toBeInTheDocument();
   expect(listItemSpan).not.toHaveClass('hidden');
   expect(listItemSpan).toHaveClass('inline-flex');

--- a/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
+++ b/packages/renderer/src/lib/ui/ListItemButtonIcon.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
-import { DropdownMenu } from '@podman-desktop/ui-svelte';
+import { DropdownMenu, Tooltip } from '@podman-desktop/ui-svelte';
 import { onDestroy } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 
@@ -111,18 +111,19 @@ const styleClass = $derived(
     onClick={handleClick} />
 {:else}
   <!-- enabled button -->
-  <button
-    title={title}
-    aria-label={title}
-    onclick={handleClick}
-    class="{styleClass} relative"
-    class:disabled={inProgress}
-    class:hidden={hidden}
-    class:inline-flex={!hidden}
-    disabled={!enabled}>
-    <LoadingIcon
-      icon={icon}
-      loading={inProgress}
-    />
-  </button>
+  <Tooltip tip={title}>
+    <button
+      aria-label={title}
+      onclick={handleClick}
+      class="{styleClass} relative"
+      class:disabled={inProgress}
+      class:hidden={hidden}
+      class:inline-flex={!hidden}
+      disabled={!enabled}>
+      <LoadingIcon
+        icon={icon}
+        loading={inProgress}
+      />
+    </button>
+  </Tooltip>
 {/if}

--- a/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
+++ b/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
@@ -48,19 +48,19 @@ afterEach(() => {
 
 describe('button states', () => {
   test('back button should be disabled when no history', async () => {
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const backButton = await findByTitle('Back (hold for history)');
+      const backButton = await findByRole('button', { name: 'Back (hold for history)' });
       expect(backButton).toBeDisabled();
     });
   });
 
   test('forward button should be disabled when no history', async () => {
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const forwardButton = await findByTitle('Forward (hold for history)');
+      const forwardButton = await findByRole('button', { name: 'Forward (hold for history)' });
       expect(forwardButton).toBeDisabled();
     });
   });
@@ -69,10 +69,10 @@ describe('button states', () => {
     navigationHistory.stack = ['/containers', '/images'];
     navigationHistory.index = 1;
 
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const backButton = await findByTitle('Back (hold for history)');
+      const backButton = await findByRole('button', { name: 'Back (hold for history)' });
       expect(backButton).toBeEnabled();
     });
   });
@@ -81,10 +81,10 @@ describe('button states', () => {
     navigationHistory.stack = ['/containers', '/images'];
     navigationHistory.index = 0;
 
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const forwardButton = await findByTitle('Forward (hold for history)');
+      const forwardButton = await findByRole('button', { name: 'Forward (hold for history)' });
       expect(forwardButton).toBeEnabled();
     });
   });
@@ -95,10 +95,10 @@ describe('click navigation', () => {
     navigationHistory.stack = ['/containers', '/images'];
     navigationHistory.index = 1;
 
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const backButton = await findByTitle('Back (hold for history)');
+      const backButton = await findByRole('button', { name: 'Back (hold for history)' });
       await fireEvent.click(backButton);
       expect(goBack).toHaveBeenCalled();
     });
@@ -108,10 +108,10 @@ describe('click navigation', () => {
     navigationHistory.stack = ['/containers', '/images'];
     navigationHistory.index = 0;
 
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const forwardButton = await findByTitle('Forward (hold for history)');
+      const forwardButton = await findByRole('button', { name: 'Forward (hold for history)' });
       await fireEvent.click(forwardButton);
       expect(goForward).toHaveBeenCalled();
     });
@@ -306,10 +306,10 @@ describe('long press dropdown', () => {
       { index: 0, name: 'Containers' },
     ]);
 
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const backButton = await findByTitle('Back (hold for history)');
+      const backButton = await findByRole('button', { name: 'Back (hold for history)' });
 
       // Start long press
       await fireEvent.mouseDown(backButton, { button: 0 });
@@ -318,8 +318,8 @@ describe('long press dropdown', () => {
       vi.advanceTimersByTime(600);
 
       // Dropdown should be visible
-      expect(await findByTitle('Images')).toBeInTheDocument();
-      expect(await findByTitle('Containers')).toBeInTheDocument();
+      expect(await findByRole('button', { name: 'Images' })).toBeInTheDocument();
+      expect(await findByRole('button', { name: 'Containers' })).toBeInTheDocument();
     });
   });
 
@@ -332,10 +332,10 @@ describe('long press dropdown', () => {
       { index: 2, name: 'Pods' },
     ]);
 
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const forwardButton = await findByTitle('Forward (hold for history)');
+      const forwardButton = await findByRole('button', { name: 'Forward (hold for history)' });
 
       // Start long press
       await fireEvent.mouseDown(forwardButton, { button: 0 });
@@ -344,8 +344,8 @@ describe('long press dropdown', () => {
       vi.advanceTimersByTime(600);
 
       // Dropdown should be visible
-      expect(await findByTitle('Images')).toBeInTheDocument();
-      expect(await findByTitle('Pods')).toBeInTheDocument();
+      expect(await findByRole('button', { name: 'Images' })).toBeInTheDocument();
+      expect(await findByRole('button', { name: 'Pods' })).toBeInTheDocument();
     });
   });
 
@@ -355,10 +355,10 @@ describe('long press dropdown', () => {
 
     vi.mocked(getBackEntries).mockReturnValue([{ index: 0, name: 'Containers' }]);
 
-    const { findByTitle, queryByTitle } = render(NavigationButtons);
+    const { findByRole, queryByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const backButton = await findByTitle('Back (hold for history)');
+      const backButton = await findByRole('button', { name: 'Back (hold for history)' });
 
       // Short click (mousedown then mouseup before timer)
       await fireEvent.mouseDown(backButton, { button: 0 });
@@ -366,7 +366,7 @@ describe('long press dropdown', () => {
       await fireEvent.mouseUp(backButton);
 
       // Dropdown should not be visible
-      expect(queryByTitle('Containers')).not.toBeInTheDocument();
+      expect(queryByRole('button', { name: 'Containers' })).not.toBeInTheDocument();
     });
   });
 });
@@ -381,17 +381,17 @@ describe('dropdown item selection', () => {
       { index: 0, name: 'Containers' },
     ]);
 
-    const { findByTitle } = render(NavigationButtons);
+    const { findByRole } = render(NavigationButtons);
 
     await vi.waitFor(async () => {
-      const backButton = await findByTitle('Back (hold for history)');
+      const backButton = await findByRole('button', { name: 'Back (hold for history)' });
 
       // Long press to show dropdown
       await fireEvent.mouseDown(backButton, { button: 0 });
       vi.advanceTimersByTime(600);
 
       // Release mouse on dropdown item (simulates long-press selection)
-      const containersItem = await findByTitle('Containers');
+      const containersItem = await findByRole('button', { name: 'Containers' });
       await fireEvent.mouseUp(containersItem);
 
       expect(goToHistoryIndex).toHaveBeenCalledWith(0);

--- a/packages/renderer/src/lib/ui/NavigationButtons.svelte
+++ b/packages/renderer/src/lib/ui/NavigationButtons.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { faArrowLeft, faArrowRight, faBackward, faForward } from '@fortawesome/free-solid-svg-icons';
-import { Dropdown } from '@podman-desktop/ui-svelte';
+import { Dropdown, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import type { Component } from 'svelte';
 import { onMount } from 'svelte';
@@ -211,15 +211,16 @@ onMount(() => {
     style="-webkit-app-region: none;">
     {#each navButtons as btn (btn.direction)}
       <div class="relative">
-        <button
-          class="h-[25px] w-[25px] flex place-items-center justify-center hover:rounded hover:bg-[var(--pd-titlebar-hover-bg)] disabled:opacity-30 disabled:cursor-default disabled:hover:bg-transparent"
-          title={btn.label}
-          aria-label={btn.label}
-          onclick={onClick.bind(undefined, btn.direction)}
-          disabled={!btn.canNavigate()}
-          {@attach longPress(onLongPress.bind(undefined, btn.direction))}>
-          <Icon icon={btn.icon} />
-        </button>
+        <Tooltip tip={btn.label} bottom>
+          <button
+            class="h-[25px] w-[25px] flex place-items-center justify-center hover:rounded hover:bg-[var(--pd-titlebar-hover-bg)] disabled:opacity-30 disabled:cursor-default disabled:hover:bg-transparent"
+            aria-label={btn.label}
+            onclick={onClick.bind(undefined, btn.direction)}
+            disabled={!btn.canNavigate()}
+            {@attach longPress(onLongPress.bind(undefined, btn.direction))}>
+            <Icon icon={btn.icon} />
+          </button>
+        </Tooltip>
         <Dropdown
           triggerless
           selectOnMouseUp

--- a/packages/renderer/src/lib/ui/RefreshButton.spec.ts
+++ b/packages/renderer/src/lib/ui/RefreshButton.spec.ts
@@ -31,7 +31,7 @@ test('Expect basic styling', async () => {
   // get button
   const button = screen.getByRole('button', { name: label });
   expect(button).toBeInTheDocument();
-  expect(button).toHaveAttribute('title', label);
+  expect(button).toHaveAttribute('aria-label', label);
   expect(button).toHaveClass('text-(--pd-action-button-primary-text)');
   expect(button).toHaveClass('hover:text-(--pd-action-button-primary-hover-text)');
 });

--- a/packages/renderer/src/lib/ui/RefreshButton.svelte
+++ b/packages/renderer/src/lib/ui/RefreshButton.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Tooltip } from '@podman-desktop/ui-svelte';
+
 interface Props {
   label: string;
   onclick: () => void;
@@ -6,10 +8,11 @@ interface Props {
 let { label, onclick }: Props = $props();
 </script>
 
-<button
-  onclick={onclick}
-  title={label}
-  class="text-xs text-(--pd-action-button-primary-text) hover:text-(--pd-action-button-primary-hover-text)"
-  aria-label={label}>
-  <i class="fas fa-undo" aria-hidden="true"></i>
-</button>
+<Tooltip tip={label}>
+  <button
+    onclick={onclick}
+    class="text-xs text-(--pd-action-button-primary-text) hover:text-(--pd-action-button-primary-hover-text)"
+    aria-label={label}>
+    <i class="fas fa-undo" aria-hidden="true"></i>
+  </button>
+</Tooltip>

--- a/packages/renderer/src/lib/ui/StatusDot.svelte
+++ b/packages/renderer/src/lib/ui/StatusDot.svelte
@@ -21,8 +21,8 @@ let resolvedTooltip = $derived(
 <Tooltip top tip={resolvedTooltip}>
   <div
     class="mr-0.5 {number ? 'mt-3' : ''}"
-    data-testid="status-dot"
-    title={resolvedTooltip}>
+    title={resolvedTooltip}
+    data-testid="status-dot">
     <StatusDotIcon {status} />
   </div>
   {#if number}

--- a/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.spec.ts
@@ -32,5 +32,5 @@ test('Check Minimize', async () => {
   expect(customButton).toBeInTheDocument();
 
   // check the title of the button is 'Maximize'
-  expect(customButton).toHaveAttribute('title', 'Minimize');
+  expect(customButton).toHaveAttribute('aria-label', 'Minimize');
 });

--- a/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faSquare } from '@fortawesome/free-regular-svg-icons';
 import { faMinus, faXmark, type IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
 import type { IconSize } from 'svelte-fa';
@@ -26,10 +27,11 @@ onMount(() => {
 });
 </script>
 
-<button
-  on:click={action}
-  title={titleName}
-  aria-label={name}
-  class="h-[25px] w-[25px] cursor-pointer text-[var(--pd-titlebar-text)] hover:rounded-full hover:bg-[var(--pd-titlebar-hover-bg)] flex place-items-center justify-center">
-  <Icon size={iconSize} icon={icon} />
-</button>
+<Tooltip tip={titleName} bottom>
+  <button
+    on:click={action}
+    aria-label={name}
+    class="h-[25px] w-[25px] cursor-pointer text-[var(--pd-titlebar-text)] hover:rounded-full hover:bg-[var(--pd-titlebar-hover-bg)] flex place-items-center justify-center">
+    <Icon size={iconSize} icon={icon} />
+  </button>
+</Tooltip>

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
@@ -36,20 +36,11 @@ test('Check Maximize/Restore', async () => {
   const customButton = screen.getByRole('button', { name: 'Maximize' });
   expect(customButton).toBeInTheDocument();
 
-  // check the title of the button is 'Maximize'
-  expect(customButton).toHaveAttribute('title', 'Maximize');
-
-  // click on the button
+  // click on the button to maximize
   await fireEvent.click(customButton);
 
-  // check the title of the button is 'Restore'
-  expect(customButton).toHaveAttribute('title', 'Restore');
-
-  // click on the button
+  // click on the button to restore
   await fireEvent.click(customButton);
-
-  // check the title of the button is 'Maximize'
-  expect(customButton).toHaveAttribute('title', 'Maximize');
 });
 
 test('Check Windows Maximize control button colors', async () => {

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { type Component, onMount } from 'svelte';
 
 import WindowsExitIcon from '/@/lib/images/WindowsExitIcon.svelte';
@@ -54,14 +55,15 @@ function executeAction(): void {
 }
 </script>
 
-<button
-  on:click={executeAction}
-  aria-label={name}
-  title={titleName}
-  class="h-[32px] w-[45px] cursor-pointer {name === 'Close'
-    ? 'hover:bg-(--pd-titlebar-windows-hover-exit-bg) hover:text-(--pd-titlebar-windows-hover-exit-text)'
-    : 'hover:bg-(--pd-titlebar-windows-hover-bg)'} text-(--pd-titlebar-icon) flex place-items-center justify-center">
-  {#if icon}
-    <svelte:component this={icon} size={iconSize} />
-  {/if}
-</button>
+<Tooltip tip={titleName} bottom>
+  <button
+    on:click={executeAction}
+    aria-label={name}
+    class="h-[32px] w-[45px] cursor-pointer {name === 'Close'
+      ? 'hover:bg-(--pd-titlebar-windows-hover-exit-bg) hover:text-(--pd-titlebar-windows-hover-exit-text)'
+      : 'hover:bg-(--pd-titlebar-windows-hover-bg)'} text-(--pd-titlebar-icon) flex place-items-center justify-center">
+    {#if icon}
+      <svelte:component this={icon} size={iconSize} />
+    {/if}
+  </button>
+</Tooltip>


### PR DESCRIPTION
### What does this PR do?

Replaces native HTML `title` attributes on buttons with the `<Tooltip>` component from `@podman-desktop/ui-svelte` across the renderer's shared utility components. The key change is `ListItemButtonIcon.svelte` - wrapping its button with `<Tooltip>` automatically upgrades every action button (Start, Stop, Delete, etc.) across containers, pods, images, networks, and all other resource lists without touching those individual action files.

Components updated:

- `StatusBarItem.svelte` - wraps button with `<Tooltip tip={tooltipText(entry)} top>`
- `ListItemButtonIcon.svelte` - wraps enabled button with `<Tooltip tip={title}>`
- `NavigationButtons.svelte` - wraps each nav button with `<Tooltip tip={btn.label} bottom>`
- `RefreshButton.svelte` - wraps button with `<Tooltip tip={label}>`
- `StatusDot.svelte` - removes redundant `title` attr (already wrapped by `<Tooltip>`)
- `LinuxControlButton.svelte` - wraps button with `<Tooltip tip={titleName} bottom>`
- `WindowsControlButton.svelte` - wraps button with `<Tooltip tip={titleName} bottom>`
- `TaskManagerWindowEvents.svelte` - updates DOM selector from `button[title="Tasks"]` to
  `[data-task-button="Tasks"]` then `.closest('button')` now that `title` is gone from buttons

Tests updated to use `getByRole`/`getByText` queries instead of `getByTitle`.

### What issues does this PR fix or reference?

- Resolves: #18027

### How to test this PR?

1. Hover over status bar items - verify styled app tooltip appears instead of native OS tooltip
2. Hover over action buttons (Start, Stop, Delete) on containers, images, pods, and networks - verify styled tooltips appear
3. Hover over the navigation Back and Forward buttons - verify styled tooltips appear
4. Open the task manager via the status bar; click outside it - verify it closes correctly (the `TaskManagerWindowEvents` selector update must not break this behavior)
5. Run unit tests: `pnpm run test:unit`

- [ ] Tests are covering the bug fix or the new feature