### PR TITLE
fix(renderer): replace native title tooltips with Tooltip component in feature components

### DIFF
--- a/packages/renderer/src/lib/container/ContainerColumnImage.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnImage.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Tooltip } from '@podman-desktop/ui-svelte';
+
 import { ContainerUtils } from './container-utils';
 import type { ContainerGroupInfoUI, ContainerInfoUI } from './ContainerInfoUI';
 
@@ -8,7 +10,9 @@ const containerUtils = new ContainerUtils();
 </script>
 
 {#if containerUtils.isContainerInfoUI(object)}
-  <div class="text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis" title={object.image}>
-    {object.shortImage}
-  </div>
+  <Tooltip tip={object.image}>
+    <div class="text-[var(--pd-table-body-text)] overflow-hidden text-ellipsis">
+      {object.shortImage}
+    </div>
+  </Tooltip>
 {/if}

--- a/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnNameContainer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { NavigationPage } from '@podman-desktop/core-api';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 
 import { handleNavigation } from '/@/navigation';
 
@@ -21,11 +22,12 @@ function openContainerDetails(container: ContainerInfoUI): void {
   <div class="flex items-center max-w-full">
     <div class="max-w-full">
       <div class="flex flex-nowrap max-w-full">
-        <div
-          class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis group-hover:text-[var(--pd-link)]"
-          title={object.name}>
-          {object.name}
-        </div>
+        <Tooltip tip={object.name}>
+          <div
+            class="text-[var(--pd-table-body-text-highlight)] overflow-hidden text-ellipsis group-hover:text-[var(--pd-link)]">
+            {object.name}
+          </div>
+        </Tooltip>
       </div>
       <div class="flex flex-nowrap text-xs font-extra-light text-[var(--pd-table-body-text)] items-center max-w-full">
         <div>{object.state}</div>

--- a/packages/renderer/src/lib/container/ContainerColumnNameGroup.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnNameGroup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { router } from 'tinro';
 
 import type { ContainerGroupInfoUI } from './ContainerInfoUI';
@@ -26,14 +27,15 @@ function openGroupDetails(containerGroup: ContainerGroupInfoUI): void {
 }
 </script>
 
-<button
-  class="flex flex-col text-[var(--pd-table-body-text-highlight)] max-w-full text-left"
-  title={object.type}
-  on:click={(): void => openGroupDetails(object)}>
-  <div class="max-w-full overflow-hidden text-ellipsis">
-    {object.name} ({object.type})
-  </div>
-  <div class="text-sm font-extra-light text-[var(--pd-table-body-text)]">
-    {displayContainersCount(object)}
-  </div>
-</button>
+<Tooltip tip={object.type}>
+  <button
+    class="flex flex-col text-[var(--pd-table-body-text-highlight)] max-w-full text-left"
+    on:click={(): void => openGroupDetails(object)}>
+    <div class="max-w-full overflow-hidden text-ellipsis">
+      {object.name} ({object.type})
+    </div>
+    <div class="text-sm font-extra-light text-[var(--pd-table-body-text)]">
+      {displayContainersCount(object)}
+    </div>
+  </button>
+</Tooltip>

--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faEraser } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import type { Terminal } from '@xterm/xterm';
 import { SvelteDate } from 'svelte/reactivity';
@@ -54,10 +55,12 @@ async function clear(): Promise<void> {
 </script>
 
 <div class="absolute top-0 right-2 px-1 z-50 m-1 opacity-50 space-x-1">
-  <button title="Clear logs" onclick={clear} class="">
-    <Icon
-      class="cursor-pointer rounded-full bg-[var(--pd-button-disabled)] min-h-8 w-8 p-1.5 hover:bg-[var(--pd-button-close-hover-bg)]"
-      icon={faEraser}
-    />
-  </button>
+  <Tooltip tip="Clear logs">
+    <button onclick={clear} class="" aria-label="Clear logs">
+      <Icon
+        class="cursor-pointer rounded-full bg-[var(--pd-button-disabled)] min-h-8 w-8 p-1.5 hover:bg-[var(--pd-button-close-hover-bg)]"
+        icon={faEraser}
+      />
+    </button>
+  </Tooltip>
 </div>

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -1211,7 +1211,7 @@ test('Expect create container dialog opens when Create button is clicked', async
 
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 
-  const createButton = screen.getByTitle('Create a container');
+  const createButton = screen.getByRole('button', { name: 'Create' });
   await fireEvent.click(createButton);
 
   await waitFor(() => {
@@ -1227,7 +1227,7 @@ test('Expect create container dialog has secondary button before primary button'
   await waitFor(() => expect(get(providerInfos)).not.toHaveLength(0));
   await waitRender({});
 
-  const createButton = screen.getByTitle('Create a container');
+  const createButton = screen.getByRole('button', { name: 'Create' });
   await fireEvent.click(createButton);
 
   const dialog = await waitFor(() => screen.getByRole('dialog', { name: 'Create a new container' }));
@@ -1248,7 +1248,7 @@ test('Expect clicking Containerfile button navigates to build image page', async
   await waitFor(() => expect(get(providerInfos)).not.toHaveLength(0));
   await waitRender({});
 
-  const createButton = screen.getByTitle('Create a container');
+  const createButton = screen.getByRole('button', { name: 'Create' });
   await fireEvent.click(createButton);
 
   const dialog = await waitFor(() => screen.getByRole('dialog', { name: 'Create a new container' }));
@@ -1267,7 +1267,7 @@ test('Expect clicking Existing image button closes dialog', async () => {
   await waitFor(() => expect(get(providerInfos)).not.toHaveLength(0));
   await waitRender({});
 
-  const createButton = screen.getByTitle('Create a container');
+  const createButton = screen.getByRole('button', { name: 'Create' });
   await fireEvent.click(createButton);
 
   const dialog = await waitFor(() => screen.getByRole('dialog', { name: 'Create a new container' }));

--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.spec.ts
@@ -50,7 +50,7 @@ test('Expect notification card to show notification title, description and close
 
   const deleteButton = screen.getByRole('button', { name: 'Delete notification 1' });
   expect(deleteButton).toBeInTheDocument();
-  expect(deleteButton).toHaveAttribute('title', 'Delete notification');
+  expect(deleteButton).toHaveAttribute('aria-label', 'Delete notification 1');
 
   await fireEvent.click(deleteButton);
 

--- a/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
+++ b/packages/renderer/src/lib/dashboard/NotificationCardItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import type { NotificationCard } from '@podman-desktop/core-api';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import Markdown from '/@/lib/markdown/Markdown.svelte';
@@ -58,13 +59,14 @@ const notificationStyle = notificationStyleMap[notification.type];
       </div>
     {/if}
     <div class="text-[var(--pd-content-card-carousel-card-header-text)]">
-      <button
-        class="p-1 hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px]"
-        on:click={(): Promise<void> => window.removeNotification(notification.id)}
-        aria-label={`Delete notification ${notification.id}`}
-        title="Delete notification">
-        <Icon icon={faXmark}/>
-      </button>
+      <Tooltip tip="Delete notification">
+        <button
+          class="p-1 hover:bg-[var(--pd-button-close-hover-bg)] hover:bg-opacity-10 transition-all rounded-[4px]"
+          on:click={(): Promise<void> => window.removeNotification(notification.id)}
+          aria-label={`Delete notification ${notification.id}`}>
+          <Icon icon={faXmark}/>
+        </button>
+      </Tooltip>
     </div>
   </div>
 </div>

--- a/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardCompact.svelte
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewProviderCardCompact.svelte
@@ -5,7 +5,7 @@ import {
   type ProviderInfo,
   type SystemOverviewStatus,
 } from '@podman-desktop/core-api';
-import { Button } from '@podman-desktop/ui-svelte';
+import { Button, Tooltip } from '@podman-desktop/ui-svelte';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
 import { handleNavigation } from '/@/navigation';
@@ -86,14 +86,15 @@ function navigateToConnection(): void {
       </div>
     </Button>
   {:else}
-    <button
-      class="w-9 h-9 rounded-full flex items-center justify-center cursor-pointer bg-[var(--pd-content-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] transition-colors"
-      onclick={navigateToConnection}
-      aria-label="Navigate to {connectionName}"
-      title="Navigate to {connectionName}">
-      <div class="flex-shrink-0 w-7 h-7 flex items-center justify-center">
-        <IconImage image={provider.images?.icon} alt={provider.name} class="max-w-7 max-h-7 object-contain" />
-      </div>
-    </button>
+    <Tooltip tip="Navigate to {connectionName}">
+      <button
+        class="w-9 h-9 rounded-full flex items-center justify-center cursor-pointer bg-[var(--pd-content-card-bg)] hover:bg-[var(--pd-content-card-carousel-card-hover-bg)] transition-colors"
+        onclick={navigateToConnection}
+        aria-label="Navigate to {connectionName}">
+        <div class="flex-shrink-0 w-7 h-7 flex items-center justify-center">
+          <IconImage image={provider.images?.icon} alt={provider.name} class="max-w-7 max-h-7 object-contain" />
+        </div>
+      </button>
+    </Tooltip>
   {/if}
 </div>

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.spec.ts
@@ -413,9 +413,9 @@ describe('QuickPickInput', () => {
       }
     });
 
-    const { getByTitle } = render(QuickPickInput, {});
+    const { getByRole } = render(QuickPickInput, {});
 
-    const item1 = getByTitle('Select item1');
+    const item1 = getByRole('button', { name: 'Select item1' });
     expect(item1).toBeDefined();
   });
 
@@ -455,7 +455,7 @@ describe('QuickPickInput', () => {
     });
 
     // render the first quickpick
-    const { getByTitle } = render(QuickPickInput, {});
+    const { getByRole } = render(QuickPickInput, {});
 
     // wait that the event callback is set
     await vi.waitFor(() => eventCallback !== undefined);
@@ -465,7 +465,7 @@ describe('QuickPickInput', () => {
     eventCallback?.(quickPickOptions);
 
     // check the first quick pick options is displayed
-    const item1 = await vi.waitFor(() => getByTitle('Select item1'));
+    const item1 = await vi.waitFor(() => getByRole('button', { name: 'Select item1' }));
     expect(item1).toBeDefined();
 
     // now, press the ESC key
@@ -475,7 +475,7 @@ describe('QuickPickInput', () => {
     expect(window.sendShowQuickPickValues).toBeCalledWith(idRequest);
 
     // and the next quickpick should be displayed
-    const itemFoo = getByTitle('Select foo');
+    const itemFoo = getByRole('button', { name: 'Select foo' });
     expect(itemFoo).toBeDefined();
   });
 });

--- a/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
+++ b/packages/renderer/src/lib/dialogs/QuickPickInput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Button, Checkbox, Modal } from '@podman-desktop/ui-svelte';
+import { Button, Checkbox, Modal, Tooltip } from '@podman-desktop/ui-svelte';
 import { onDestroy, onMount, tick } from 'svelte';
 
 import Markdown from '/@/lib/markdown/Markdown.svelte';
@@ -370,26 +370,28 @@ async function handleKeydown(e: KeyboardEvent): Promise<void> {
               {#if quickPickCanPickMany}
                 <Checkbox class="mx-1 my-auto" bind:checked={item.checkbox} />
               {/if}
-              <button
-                title="Select {item.value}"
-                on:click={async (): Promise<void> => await clickQuickPickItem(item, i)}
-                class="text-[var(--pd-modal-dropdown-text)] text-left relative my-1 w-full px-1">
-                <div class="flex flex-col w-full">
-                  <!-- first row is Value + optional description-->
-                  <div class="flex flex-row w-full max-w-[700px] truncate">
-                    <div class="font-bold overflow-hidden text-ellipsis">{item.value}</div>
-                    {#if item.description}
-                      <div class="text-[var(--pd-modal-dropdown-text)] text-xs ml-2">{item.description}</div>
+              <Tooltip tip="Select {item.value}">
+                <button
+                  on:click={async (): Promise<void> => await clickQuickPickItem(item, i)}
+                  aria-label="Select {item.value}"
+                  class="text-[var(--pd-modal-dropdown-text)] text-left relative my-1 w-full px-1">
+                  <div class="flex flex-col w-full">
+                    <!-- first row is Value + optional description-->
+                    <div class="flex flex-row w-full max-w-[700px] truncate">
+                      <div class="font-bold overflow-hidden text-ellipsis">{item.value}</div>
+                      {#if item.description}
+                        <div class="text-[var(--pd-modal-dropdown-text)] text-xs ml-2">{item.description}</div>
+                      {/if}
+                    </div>
+                    <!-- second row is optional detail -->
+                    {#if item.detail}
+                      <div class="w-full max-w-[700px] truncate text-[var(--pd-modal-dropdown-text)] text-xs">
+                        {item.detail}
+                      </div>
                     {/if}
                   </div>
-                  <!-- second row is optional detail -->
-                  {#if item.detail}
-                    <div class="w-full max-w-[700px] truncate text-[var(--pd-modal-dropdown-text)] text-xs">
-                      {item.detail}
-                    </div>
-                  {/if}
-                </div>
-              </button>
+                </button>
+              </Tooltip>
             </div>
           {/each}
         {/if}

--- a/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.spec.ts
@@ -132,8 +132,8 @@ test('Expect featured extension to show install button', () => {
     featuredExtension: fetchableFeaturedExtension,
   });
 
-  // get by title
-  const description = screen.getByTitle('This is FooBar description');
+  // get by aria-label (displayName)
+  const description = screen.getByLabelText('FooBar');
   expect(description).toBeInTheDocument();
 
   const image = screen.getByRole('img', { name: 'FooBar logo' });
@@ -153,8 +153,8 @@ test('Expect featured extension to show installed info', () => {
     featuredExtension: installedFeaturedExtension,
   });
 
-  // get by title
-  const description = screen.getByTitle('Foobaz description');
+  // get by aria-label (displayName)
+  const description = screen.getByLabelText('FooBaz');
   expect(description).toBeInTheDocument();
   // contains the text installed
   expect(description).toHaveTextContent(/.*installed/);
@@ -171,8 +171,8 @@ test('Expect featured extension to show NAN when not fetchable', () => {
     featuredExtension: notFetchableFeaturedExtension,
   });
 
-  // get by title
-  const description = screen.getByTitle('FooBar not fetchable description');
+  // get by aria-label (displayName)
+  const description = screen.getByLabelText('Bar');
   expect(description).toBeInTheDocument();
   // contains the text installed
   expect(description).toHaveTextContent(/.*N\/A/);

--- a/packages/renderer/src/lib/featured/FeaturedExtension.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtension.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faCheckCircle, faCircleXmark } from '@fortawesome/free-solid-svg-icons';
 import type { FeaturedExtension } from '@podman-desktop/core-api/featured';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import FeaturedExtensionDownload from './FeaturedExtensionDownload.svelte';
@@ -10,8 +11,8 @@ export let variant: 'primary' | 'secondary' = 'primary';
 export let displayTitle: boolean = false;
 </script>
 
+<Tooltip tip={featuredExtension.description} containerClass="contents">
 <div
-  title={featuredExtension.description}
   class:bg-[var(--pd-card-bg)]={variant === 'primary'}
   class:border-[var(--pd-card-bg)]={variant === 'primary'}
   class:bg-[var(--pd-invert-content-card-bg)]={variant === 'secondary'}
@@ -47,3 +48,4 @@ export let displayTitle: boolean = false;
     </div>
   </div>
 </div>
+</Tooltip>

--- a/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
+++ b/packages/renderer/src/lib/featured/FeaturedExtensionDownload.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
-import { ErrorMessage } from '@podman-desktop/ui-svelte';
+import { ErrorMessage, Tooltip } from '@podman-desktop/ui-svelte';
 
 import LoadingIcon from '/@/lib/ui/LoadingIcon.svelte';
 
@@ -72,18 +72,19 @@ async function installExtension(): Promise<void> {
 </script>
 
 <ErrorMessage icon wrapMessage class="-top-[15px] right-0 absolute" error={errorInstall}/>
-<button
-  aria-label="Install {extension.id} Extension"
-  on:click={installExtension}
-  hidden={!extension.fetchable}
-  title="Install {extension.displayName} v{extension.fetchVersion} Extension"
-  class="border-2 relative rounded-sm border-[var(--pd-button-secondary-border)] text-[var(--pd-button-secondary-text)] hover:bg-[var(--pd-button-secondary-hover-bg)] w-10 p-2 text-center cursor-pointer flex flex-row justify-center">
-  <LoadingIcon
-    icon={faDownload}
-    iconSize="1x"
-    loading={installInProgress} />
-  <span
-    class:hidden={!installInProgress}
-    class="absolute -top-[15px] right-0 text-[var(--pd-action-button-spinner)]"
-    style="font-size: 8px">{percentage}</span>
-</button>
+<Tooltip tip="Install {extension.displayName} v{extension.fetchVersion} Extension">
+  <button
+    aria-label="Install {extension.id} Extension"
+    on:click={installExtension}
+    hidden={!extension.fetchable}
+    class="border-2 relative rounded-sm border-[var(--pd-button-secondary-border)] text-[var(--pd-button-secondary-text)] hover:bg-[var(--pd-button-secondary-hover-bg)] w-10 p-2 text-center cursor-pointer flex flex-row justify-center">
+    <LoadingIcon
+      icon={faDownload}
+      iconSize="1x"
+      loading={installInProgress} />
+    <span
+      class:hidden={!installInProgress}
+      class="absolute -top-[15px] right-0 text-[var(--pd-action-button-spinner)]"
+      style="font-size: 8px">{percentage}</span>
+  </button>
+</Tooltip>

--- a/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
+++ b/packages/renderer/src/lib/featured/FeaturedExtensions.spec.ts
@@ -88,8 +88,8 @@ test('Expect that featured extensions are displayed', async () => {
 
   render(FeaturedExtensions);
 
-  // get by title
-  const firstExtension = screen.getByTitle('This is FooBar description');
+  // get by aria-label (displayName)
+  const firstExtension = screen.getByLabelText('FooBar');
   expect(firstExtension).toBeInTheDocument();
 
   // Not installed so it should have a button to install
@@ -97,7 +97,7 @@ test('Expect that featured extensions are displayed', async () => {
   // expect the button to be there
   expect(installButton).toBeInTheDocument();
 
-  // get by title
-  const thirdExtension = screen.getByTitle('FooBar not fetchable description');
+  // get by aria-label (displayName)
+  const thirdExtension = screen.getByLabelText('Bar');
   expect(thirdExtension).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -64,7 +64,7 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
   includeSystemInfo?: HTMLElement;
   includeExtensionInfo?: HTMLElement;
 } & RenderResult<Component<ComponentProps<typeof GitHubIssueFeedback>>> {
-  const { getByRole, queryByTitle, ...restResult } = render(GitHubIssueFeedback, props);
+  const { getByRole, queryByRole, ...restResult } = render(GitHubIssueFeedback, props);
 
   // text inputs
   const title = getByRole('textbox', { name: 'Issue Title' });
@@ -82,9 +82,9 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
   expect(cancel).toBeInstanceOf(HTMLButtonElement);
 
   // checkbox
-  const includeSystemInfo = queryByTitle('Include system information') ?? undefined;
+  const includeSystemInfo = queryByRole('checkbox', { name: 'Include system information' }) ?? undefined;
 
-  const includeExtensionInfo = queryByTitle('Include enabled extensions') ?? undefined;
+  const includeExtensionInfo = queryByRole('checkbox', { name: 'Include enabled extensions' }) ?? undefined;
 
   return {
     title: title as HTMLInputElement,
@@ -94,7 +94,7 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
     includeSystemInfo,
     includeExtensionInfo,
     getByRole,
-    queryByTitle,
+    queryByRole,
     ...restResult,
   };
 }
@@ -257,7 +257,7 @@ describe('includeSystemInfo', () => {
     expect(includeSystemInfo).toBeInTheDocument();
 
     // enabled by default
-    expect(includeSystemInfo?.children?.[0]).toHaveClass('text-[var(--pd-input-checkbox-checked)]');
+    expect(includeSystemInfo).toBeChecked();
   });
 
   test('uncheck the Include system information should set includeSystemInfo to false', async () => {
@@ -318,7 +318,7 @@ describe('includeExtensionInfo', () => {
     expect(includeExtensionInfo).toBeInTheDocument();
 
     // enabled by default
-    expect(includeExtensionInfo?.children?.[0]).toHaveClass('text-[var(--pd-input-checkbox-checked)]');
+    expect(includeExtensionInfo).toBeChecked();
   });
 
   test('uncheck the Include system information should set includeSystemInfo to false', async () => {

--- a/packages/renderer/src/lib/help/HelpActions.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActions.spec.ts
@@ -47,9 +47,9 @@ describe('HelpActions component', () => {
     vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
     const title = 'Title 1';
     vi.mocked(window.helpMenuGetItems).mockResolvedValue([{ enabled: true, title, icon: 'fas fa-lightbulb' }]);
-    const { getByTitle } = render(HelpActions);
+    const { getByText } = render(HelpActions);
     await vi.waitUntil(() => !!toggleMenuCallback);
     toggleMenuCallback?.();
-    await vi.waitFor(() => expect(getByTitle(title)).toBeVisible());
+    await vi.waitFor(() => expect(getByText(title)).toBeVisible());
   });
 });

--- a/packages/renderer/src/lib/help/HelpActionsItems.spec.ts
+++ b/packages/renderer/src/lib/help/HelpActionsItems.spec.ts
@@ -57,7 +57,7 @@ describe('HelpActionsItems component', () => {
 
   test('by default is not visible', () => {
     const ha = render(HelpActionsItems, { items: Items });
-    const items = ha.queryAllByTitle(Items[0].title);
+    const items = ha.queryAllByText(Items[0].title);
     expect(items).toHaveLength(0);
   });
 
@@ -106,7 +106,7 @@ describe('HelpActionsItems component', () => {
     const ha = render(HelpActionsItems, { items: Items });
     toggleMenuCallback();
     await vi.waitFor(async () => {
-      const item = await ha.findByTitle(tooltip ?? title);
+      const item = await ha.findByText(tooltip ?? title);
       expect(item).toBeVisible();
     });
   });

--- a/packages/renderer/src/lib/help/HelpMenu.svelte
+++ b/packages/renderer/src/lib/help/HelpMenu.svelte
@@ -35,7 +35,7 @@ onDestroy(() => window.removeEventListener('resize', updateMenuLocation));
   class="absolute z-30"
   data-testid="help-menu">
   <div
-    title="Help Menu Items"
+    aria-label="Help Menu Items"
     class="z-10 m-1 rounded-md shadow-lg bg-[var(--pd-dropdown-bg)] ring-2 ring-[var(--pd-dropdown-ring)] hover:ring-[var(--pd-dropdown-hover-ring)] divide-y divide-[var(--pd-dropdown-divider)] focus:outline-hidden">
     {@render children?.()}
   </div>

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCard.spec.ts
@@ -79,7 +79,8 @@ test('Expect default tooltip', async () => {
     icon: undefined,
   });
 
-  const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+  const tooltipTriggers = screen.getAllByTestId('tooltip-trigger');
+  const tooltipTrigger = tooltipTriggers[tooltipTriggers.length - 1];
   expect(tooltipTrigger).toBeInTheDocument();
   await fireEvent.mouseEnter(tooltipTrigger);
 

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.spec.ts
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfileCards.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeAll, expect, test, vi } from 'vitest';
 
@@ -46,7 +46,9 @@ test('check default on arm64', async () => {
   const button = screen.getByRole('button', { name: 'linux/arm64' });
   expect(button).toBeInTheDocument();
 
-  const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+  // The "Default platform" tooltip trigger is inside the default card button
+  const tooltipTriggers = within(button).getAllByTestId('tooltip-trigger');
+  const tooltipTrigger = tooltipTriggers[tooltipTriggers.length - 1];
   expect(tooltipTrigger).toBeInTheDocument();
   await fireEvent.mouseEnter(tooltipTrigger);
 
@@ -67,7 +69,9 @@ test('check default on amd64', async () => {
   const button = screen.getByRole('button', { name: 'linux/amd64' });
   expect(button).toBeInTheDocument();
 
-  const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+  // The "Default platform" tooltip trigger is inside the default card button
+  const tooltipTriggers = within(button).getAllByTestId('tooltip-trigger');
+  const tooltipTrigger = tooltipTriggers[tooltipTriggers.length - 1];
   expect(tooltipTrigger).toBeInTheDocument();
   await fireEvent.mouseEnter(tooltipTrigger);
 

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -91,7 +91,7 @@ test('Expect error dialog with correct message when image deletion fails', async
     onRenameImage: vi.fn(),
     image,
   });
-  const button = screen.getByTitle('Delete Image');
+  const button = screen.getByRole('button', { name: 'Delete Image' });
   expect(button).toBeDefined();
   await fireEvent.click(button);
 
@@ -128,9 +128,10 @@ test('Expect no dropdown when one contribution and dropdownMenu off', async () =
   expect(getContributedMenusMock).toHaveBeenCalled();
 
   await waitFor(() => {
-    const div = screen.getByTitle('dummy-contrib').parentElement;
-    expect(div).toBeDefined();
-    expect(div?.classList).toHaveLength(0);
+    const button = screen.getByRole('button', { name: 'dummy-contrib' });
+    expect(button).toBeDefined();
+    // With one contribution and no grouping, the button is directly visible (not behind a kebab menu)
+    expect(screen.queryByLabelText('kebab menu')).toBeNull();
   });
 });
 
@@ -185,15 +186,17 @@ test('Expect no dropdown when several contributions and dropdownMenu mode on', a
   await fireEvent.click(screen.getByLabelText('kebab menu'));
 
   await waitFor(async () => {
-    const button = screen.getByTitle('dummy-contrib');
-    expect(button).toBeDefined();
-    const img = within(button).getByRole('img', { hidden: true });
+    const textSpan = screen.getByText('dummy-contrib');
+    const itemSpan = textSpan.parentElement;
+    expect(itemSpan).toBeDefined();
+    const img = within(itemSpan!).getByRole('img', { hidden: true });
     expect(img).toBeDefined();
     expect(img.nodeName.toLowerCase()).toBe('svg');
 
-    const button2 = screen.getByTitle('dummy-contrib-2');
-    expect(button2).toBeDefined();
-    const img2 = within(button2).getByRole('img', { hidden: true });
+    const textSpan2 = screen.getByText('dummy-contrib-2');
+    const itemSpan2 = textSpan2.parentElement;
+    expect(itemSpan2).toBeDefined();
+    const img2 = within(itemSpan2!).getByRole('img', { hidden: true });
     expect(img2).toBeDefined();
     expect(img2.nodeName.toLowerCase()).toBe('svg');
   });
@@ -213,7 +216,7 @@ test('Expect Push image to be there', async () => {
     image,
   });
 
-  const button = screen.getByTitle('Push Image');
+  const button = screen.getByRole('button', { name: 'Push Image' });
   expect(button).toBeDefined();
 });
 
@@ -232,7 +235,7 @@ test('Expect Save image to be there', async () => {
     image,
   });
 
-  const button = screen.getByTitle('Save Image');
+  const button = screen.getByRole('button', { name: 'Save Image' });
   expect(button).toBeDefined();
 
   await userEvent.click(button);
@@ -254,7 +257,7 @@ test('Expect withConfirmation to indicate image name and tag', async () => {
     onRenameImage: vi.fn(),
     image,
   });
-  const button = screen.getByTitle('Delete Image');
+  const button = screen.getByRole('button', { name: 'Delete Image' });
   expect(button).toBeDefined();
   await fireEvent.click(button);
 

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -505,7 +505,7 @@ test('expect redirect to saveImage page when at least one image is selected and 
 
   await waitRender({});
 
-  const toggleAll = screen.getByTitle('Toggle all');
+  const toggleAll = screen.getByRole('checkbox', { name: 'Toggle all' });
   await fireEvent.click(toggleAll);
 
   const saveImages = screen.getByRole('button', { name: 'Save images' });

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -10,7 +10,7 @@ import type {
   NetworkInspectInfo,
 } from '@podman-desktop/core-api';
 import { NavigationPage } from '@podman-desktop/core-api';
-import { Button, Checkbox, Dropdown, ErrorMessage, Input, NumberInput, Tab } from '@podman-desktop/ui-svelte';
+import { Button, Checkbox, Dropdown, ErrorMessage, Input, NumberInput, Tab, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
@@ -878,9 +878,10 @@ const envDialogOptions: OpenDialogOptions = {
                 class="flex flex-row justify-center items-center w-full py-1 {restartPolicyName === 'on-failure'
                   ? 'opacity-100'
                   : 'opacity-20'}">
-                <span
-                  class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
-                  title="Number of times to retry before giving up.">Retries:</span>
+                <Tooltip tip="Number of times to retry before giving up.">
+                  <span
+                    class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]">Retries:</span>
+                </Tooltip>
                 <NumberInput
                   minimum={0}
                   bind:value={restartPolicyMaxRetryCount}

--- a/packages/renderer/src/lib/kube/KubeActions.spec.ts
+++ b/packages/renderer/src/lib/kube/KubeActions.spec.ts
@@ -51,9 +51,9 @@ beforeEach(() => {
 });
 
 test('KubeApplyYAMLButton should redirect to', async () => {
-  const { getByTitle } = render(KubeActions);
+  const { getByRole } = render(KubeActions);
 
-  const applyYAMLBtn = getByTitle('Apply YAML');
+  const applyYAMLBtn = getByRole('button', { name: 'Apply YAML' });
   expect(applyYAMLBtn).toBeInTheDocument();
 
   await userEvent.click(applyYAMLBtn);

--- a/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
+++ b/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
@@ -37,7 +37,6 @@ test('Expect button to be visible with correct text and title', () => {
   const button = getByRole('button', { name: 'Podman Kube Play' });
   expect(button).toBeInTheDocument();
   expect(button).toHaveTextContent('Podman Kube Play');
-  expect(button).toHaveAttribute('title', 'Create containers, pods and volumes based on Kubernetes YAML');
 });
 
 test('Expect click on button to navigate to kube play page', async () => {

--- a/packages/renderer/src/lib/kube/details/KubePort.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePort.spec.ts
@@ -46,7 +46,7 @@ const DUMMY_FORWARD_CONFIG: ForwardConfig = {
 
 describe('port forwarding', () => {
   test('forward button should be visible and unique for each container port', async () => {
-    const { getByTitle } = render(KubePort, {
+    const { getByRole } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/TCP',
@@ -58,12 +58,12 @@ describe('port forwarding', () => {
       kind: WorkloadKind.POD,
     });
 
-    const port80 = getByTitle('Forward port 80');
+    const port80 = getByRole('button', { name: 'Forward...' });
     expect(port80).toBeDefined();
   });
 
   test('forward button should call ', async () => {
-    const { getByTitle } = render(KubePort, {
+    const { getByRole } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/TCP',
@@ -75,7 +75,7 @@ describe('port forwarding', () => {
       kind: WorkloadKind.POD,
     });
 
-    const forwardBtn = getByTitle('Forward port 80');
+    const forwardBtn = getByRole('button', { name: 'Forward...' });
     await fireEvent.click(forwardBtn);
 
     await vi.waitFor(() => {
@@ -93,7 +93,7 @@ describe('port forwarding', () => {
   });
 
   test('existing forward should display actions', async () => {
-    const { getByTitle } = render(KubePort, {
+    const { getByRole } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/TCP',
@@ -105,15 +105,15 @@ describe('port forwarding', () => {
       kind: WorkloadKind.POD,
     });
 
-    const openBtn = getByTitle('Open in browser');
+    const openBtn = getByRole('button', { name: 'Open' });
     expect(openBtn).toBeDefined();
 
-    const removeBtn = getByTitle('Remove port forward');
+    const removeBtn = getByRole('button', { name: 'Remove' });
     expect(removeBtn).toBeDefined();
   });
 
   test('open button should use window.openExternal with proper local port', async () => {
-    const { getByTitle } = render(KubePort, {
+    const { getByRole } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/TCP',
@@ -125,7 +125,7 @@ describe('port forwarding', () => {
       kind: WorkloadKind.POD,
     });
 
-    const openBtn = getByTitle('Open in browser');
+    const openBtn = getByRole('button', { name: 'Open' });
     await fireEvent.click(openBtn);
 
     await vi.waitFor(() => {
@@ -134,7 +134,7 @@ describe('port forwarding', () => {
   });
 
   test('remove button should use window.deleteKubernetesPortForward with proper local port', async () => {
-    const { getByTitle } = render(KubePort, {
+    const { getByRole } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/TCP',
@@ -146,7 +146,7 @@ describe('port forwarding', () => {
       kind: WorkloadKind.POD,
     });
 
-    const removeBtn = getByTitle('Remove port forward');
+    const removeBtn = getByRole('button', { name: 'Remove' });
     await fireEvent.click(removeBtn);
 
     await vi.waitFor(() => {
@@ -157,7 +157,7 @@ describe('port forwarding', () => {
   test('error from createKubernetesPortForward should be displayed', async () => {
     vi.mocked(window.createKubernetesPortForward).mockRejectedValue('Dummy error');
 
-    const { getByTitle, getByRole } = render(KubePort, {
+    const { getByRole } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/TCP',
@@ -169,7 +169,7 @@ describe('port forwarding', () => {
       kind: WorkloadKind.POD,
     });
 
-    const port80 = getByTitle('Forward port 80');
+    const port80 = getByRole('button', { name: 'Forward...' });
     await fireEvent.click(port80);
 
     await vi.waitFor(() => {
@@ -179,7 +179,7 @@ describe('port forwarding', () => {
   });
 
   test('non-TCP port should not display the forward action', async () => {
-    const { queryByTitle, getByText } = render(KubePort, {
+    const { queryByRole, getByText } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/UDP',
@@ -191,7 +191,7 @@ describe('port forwarding', () => {
       kind: WorkloadKind.POD,
     });
 
-    const port80 = queryByTitle('Forward port 80');
+    const port80 = queryByRole('button', { name: 'Forward...' });
     expect(port80).toBeNull();
 
     const tooltipTrigger = screen.getByTestId('tooltip-trigger');
@@ -203,7 +203,7 @@ describe('port forwarding', () => {
 
   // kubernetes default to TCP
   test('undefined protocol should display the forward action', async () => {
-    const { getByTitle } = render(KubePort, {
+    const { getByRole } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80',
@@ -215,7 +215,7 @@ describe('port forwarding', () => {
       kind: WorkloadKind.POD,
     });
 
-    const port80 = getByTitle('Forward port 80');
+    const port80 = getByRole('button', { name: 'Forward...' });
     expect(port80).not.toBeNull();
   });
 
@@ -223,7 +223,7 @@ describe('port forwarding', () => {
     // only reject ONCE
     vi.mocked(window.deleteKubernetesPortForward).mockRejectedValueOnce('Dummy error');
 
-    const { getByTitle, getByRole, queryByRole } = render(KubePort, {
+    const { getByRole, queryByRole } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/TCP',
@@ -236,7 +236,7 @@ describe('port forwarding', () => {
     });
 
     // first click will raise an error
-    const removeBtn = getByTitle('Remove port forward');
+    const removeBtn = getByRole('button', { name: 'Remove' });
     await fireEvent.click(removeBtn);
 
     await vi.waitFor(() => {
@@ -256,7 +256,7 @@ describe('port forwarding', () => {
   test('existing forward should display localhost port and copy', async () => {
     const clipboardWriteTextMock = vi.fn().mockImplementation(() => {});
     Object.defineProperty(window, 'clipboardWriteText', { value: clipboardWriteTextMock });
-    const { getByTitle, getByRole } = render(KubePort, {
+    const { getByRole, getByText } = render(KubePort, {
       namespace: 'dummy-ns',
       port: {
         displayValue: '80/TCP',
@@ -269,7 +269,7 @@ describe('port forwarding', () => {
     });
 
     const expected = 'http://localhost:55076';
-    const copySpan = getByTitle(expected);
+    const copySpan = getByText(expected);
     expect(copySpan).toBeDefined();
 
     const button = getByRole('button', { name: 'Copy To Clipboard' });

--- a/packages/renderer/src/lib/kube/details/KubePortsList.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubePortsList.spec.ts
@@ -121,11 +121,11 @@ test('expect only target remote port have open button', async () => {
 
   const div80 = getByLabelText('port 80');
   expect(div80).toBeDefined();
-  const open80 = within(div80).getByTitle('Open in browser');
+  const open80 = within(div80).getByRole('button', { name: 'Open' });
   expect(open80).toBeDefined();
 
   const div100 = getByLabelText('port 100');
   expect(div100).toBeDefined();
-  const open100 = within(div100).queryByTitle('Open in browser');
+  const open100 = within(div100).queryByRole('button', { name: 'Open' });
   expect(open100).toBeNull();
 });

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardActions.spec.ts
@@ -54,34 +54,34 @@ beforeEach(() => {
 });
 
 test('actions should be defined', () => {
-  const { getByTitle } = render(PortForwardActions, {
+  const { getByRole } = render(PortForwardActions, {
     object: MOCKED_USER_FORWARD_CONFIG,
   });
 
-  const openBtn = getByTitle('Open forwarded port');
+  const openBtn = getByRole('button', { name: 'Open forwarded port' });
   expect(openBtn).toBeDefined();
 
-  const deleteBtn = getByTitle('Delete forwarded port');
+  const deleteBtn = getByRole('button', { name: 'Delete forwarded port' });
   expect(deleteBtn).toBeDefined();
 });
 
 test('open should call openExternal', async () => {
-  const { getByTitle } = render(PortForwardActions, {
+  const { getByRole } = render(PortForwardActions, {
     object: MOCKED_USER_FORWARD_CONFIG,
   });
 
-  const openBtn = getByTitle('Open forwarded port');
+  const openBtn = getByRole('button', { name: 'Open forwarded port' });
   await fireEvent.click(openBtn);
 
   expect(window.openExternal).toHaveBeenCalledWith('http://localhost:55087');
 });
 
 test('remove should call deleteKubernetesPortForward', async () => {
-  const { getByTitle } = render(PortForwardActions, {
+  const { getByRole } = render(PortForwardActions, {
     object: MOCKED_USER_FORWARD_CONFIG,
   });
 
-  const deleteBtn = getByTitle('Delete forwarded port');
+  const deleteBtn = getByRole('button', { name: 'Delete forwarded port' });
   await fireEvent.click(deleteBtn);
 
   expect(window.deleteKubernetesPortForward).toHaveBeenCalledWith(MOCKED_USER_FORWARD_CONFIG);

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.spec.ts
@@ -73,7 +73,7 @@ test('click on name should redirect to pod page', async () => {
     },
   ]);
 
-  const { getByTitle } = render(PodNameColumn, {
+  const { getByRole } = render(PodNameColumn, {
     object: {
       name: 'dummy-pod-name',
       namespace: 'dummy-ns',
@@ -83,7 +83,7 @@ test('click on name should redirect to pod page', async () => {
     },
   });
 
-  const openBtn = getByTitle('Open pod details');
+  const openBtn = getByRole('button', { name: 'Open pod details' });
   expect(openBtn).toBeDefined();
 
   await fireEvent.click(openBtn);

--- a/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.svelte
+++ b/packages/renderer/src/lib/kubernetes-port-forward/PortForwardNameColumn.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { KubernetesObject } from '@kubernetes/client-node';
 import { type ForwardConfig, WorkloadKind } from '@podman-desktop/core-api';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { get } from 'svelte/store';
 
 import { kubernetesCurrentContextPods } from '/@/stores/kubernetes-contexts-state';
@@ -36,7 +37,8 @@ async function openResourceDetails(): Promise<void> {
 }
 </script>
 
-<button title="Open pod details" class="hover:cursor-pointer flex flex-col max-w-full" disabled={object.kind !== WorkloadKind.POD} onclick={openResourceDetails}>
+<Tooltip tip="Open pod details">
+<button class="hover:cursor-pointer flex flex-col max-w-full" disabled={object.kind !== WorkloadKind.POD} onclick={openResourceDetails} aria-label="Open pod details">
   <div class="text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis">
     {object.name}
   </div>
@@ -46,3 +48,4 @@ async function openResourceDetails(): Promise<void> {
     {/if}
   </div>
 </button>
+</Tooltip>

--- a/packages/renderer/src/lib/network/CreateNetwork.spec.ts
+++ b/packages/renderer/src/lib/network/CreateNetwork.spec.ts
@@ -363,7 +363,7 @@ test('Expect createNetwork to be called with IPv6 enabled', async () => {
   await fireEvent.click(advancedTab);
 
   // Enable IPv6
-  const ipv6Checkbox = screen.getByTitle('Enable IPv6');
+  const ipv6Checkbox = screen.getByRole('checkbox', { name: 'Enable IPv6' });
   await userEvent.click(ipv6Checkbox);
 
   const createButton = screen.getByRole('button', { name: 'Create' });
@@ -390,7 +390,7 @@ test('Expect createNetwork to be called with Internal network enabled', async ()
   await fireEvent.click(advancedTab);
 
   // Enable Internal network
-  const internalCheckbox = screen.getByTitle('Internal network');
+  const internalCheckbox = screen.getByRole('checkbox', { name: 'Internal network' });
   await userEvent.click(internalCheckbox);
 
   const createButton = screen.getByRole('button', { name: 'Create' });
@@ -575,10 +575,10 @@ test('Expect createNetwork to be called with all advanced options combined', asy
   await userEvent.type(ipRange, '10.50.0.128/25');
 
   // Enable IPv6 and Internal
-  const ipv6Checkbox = screen.getByTitle('Enable IPv6');
+  const ipv6Checkbox = screen.getByRole('checkbox', { name: 'Enable IPv6' });
   await userEvent.click(ipv6Checkbox);
 
-  const internalCheckbox = screen.getByTitle('Internal network');
+  const internalCheckbox = screen.getByRole('checkbox', { name: 'Internal network' });
   await userEvent.click(internalCheckbox);
 
   // Enter DNS server
@@ -664,10 +664,10 @@ test('Expect DNS checkbox to disable DNS servers input when unchecked', async ()
   await fireEvent.click(advancedTab);
 
   // DNS should be enabled by default for Podman bridge
-  expect(screen.getByTitle('Enable DNS')).toBeInTheDocument();
+  expect(screen.getByRole('checkbox', { name: 'Enable DNS' })).toBeInTheDocument();
 
   // Disable DNS
-  const dnsCheckbox = screen.getByTitle('Enable DNS');
+  const dnsCheckbox = screen.getByRole('checkbox', { name: 'Enable DNS' });
   await userEvent.click(dnsCheckbox);
 
   // DNS server inputs should no longer be visible

--- a/packages/renderer/src/lib/network/NetworkActions.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkActions.spec.ts
@@ -64,11 +64,11 @@ test('Expect non-podman unused network to have delete option and disabled edit',
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 0 });
   render(NetworkActions, { object: network1 });
 
-  expect(screen.queryByTitle('Delete Network')).toBeInTheDocument();
-  expect(screen.queryByTitle('Update Network')).toBeInTheDocument();
-  expect(screen.queryByTitle('Update Network')).toBeDisabled();
+  expect(screen.queryByRole('button', { name: 'Delete Network' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Update Network' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Update Network' })).toBeDisabled();
 
-  const deleteButton = screen.getByTitle('Delete Network');
+  const deleteButton = screen.getByRole('button', { name: 'Delete Network' });
   await fireEvent.click(deleteButton);
   expect(window.removeNetwork).toHaveBeenCalledWith(network1.engineId, network1.id);
 });
@@ -81,7 +81,7 @@ test('Expect error dialog when network deletion fails', async () => {
   const network: NetworkInfoUI = { ...network1, status: 'UNUSED' };
   render(NetworkActions, { object: network });
 
-  const deleteButton = screen.getByTitle('Delete Network');
+  const deleteButton = screen.getByRole('button', { name: 'Delete Network' });
   await fireEvent.click(deleteButton);
 
   await waitFor(() => {
@@ -98,11 +98,11 @@ test('Expect error dialog when network deletion fails', async () => {
 test('Expect podman used network to have edit option and disabled delete', async () => {
   render(NetworkActions, { object: network2 });
 
-  expect(screen.queryByTitle('Delete Network')).toBeInTheDocument();
-  expect(screen.queryByTitle('Delete Network')).toBeDisabled();
-  expect(screen.queryByTitle('Update Network')).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Delete Network' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Delete Network' })).toBeDisabled();
+  expect(screen.queryByRole('button', { name: 'Update Network' })).toBeInTheDocument();
 
-  const updateButton = screen.getByTitle('Update Network');
+  const updateButton = screen.getByRole('button', { name: 'Update Network' });
   await fireEvent.click(updateButton);
 
   await tick();

--- a/packages/renderer/src/lib/network/NetworkEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkEmptyScreen.spec.ts
@@ -29,7 +29,7 @@ test('Expect to have CLI command that can be copied', async () => {
   expect(screen.getByText('No networks')).toBeInTheDocument();
   expect(screen.getByText('Create your first network using the following command line:')).toBeInTheDocument();
 
-  const copyButton = screen.getByTitle('Copy To Clipboard');
+  const copyButton = screen.getByRole('button', { name: 'Copy To Clipboard' });
   expect(copyButton).toBeDefined();
 
   await fireEvent.click(copyButton);

--- a/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodColumnActions.spec.ts
@@ -83,7 +83,8 @@ test('Expect error message', async () => {
 
   render(PodColumnActions, { object: pod });
 
-  const tooltipTrigger = screen.getByTestId('tooltip-trigger');
+  const tooltipTriggers = screen.getAllByTestId('tooltip-trigger');
+  const tooltipTrigger = tooltipTriggers[0];
   await fireEvent.mouseEnter(tooltipTrigger);
 
   const error = await screen.findByText('Pod failed');

--- a/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/pod/PodEmptyScreen.spec.ts
@@ -137,6 +137,6 @@ test('button click shows error message if there is no active provider connection
 });
 
 testComponent(`${copyToClipboard} button click puts starting pod command to clipboard`, async () => {
-  await fireEvent.click(screen.getByTitle(copyToClipboard));
+  await fireEvent.click(screen.getByRole('button', { name: copyToClipboard }));
   expect(window.clipboardWriteText).toBeCalledWith(podCreateCommand);
 });

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -3,7 +3,7 @@ import { faPlusCircle, faTrash, faUser, faUserPen } from '@fortawesome/free-soli
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import { PreferredRegistriesSettings } from '@podman-desktop/core-api';
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
-import { Button, DropdownMenu, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { Button, DropdownMenu, ErrorMessage, Input, Tooltip } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
@@ -345,29 +345,31 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
                 <!-- Show/hide password start -->
                 {#if registry.username && registry.secret}
                   {#if showPasswordForServerUrls.some(r => r === registry.serverUrl)}
-                    <button
-                      type="button"
-                      class="justify-center"
-                      id="hide-password"
-                      title="Hide password"
-                      aria-label="Hide password"
-                      aria-expanded="true"
-                      aria-haspopup="true"
-                      onclick={(): void => setPasswordForRegistryVisible(registry, false)}>
-                      <i class="fa fa-eye-slash"></i>
-                    </button>
+                    <Tooltip tip="Hide password">
+                      <button
+                        type="button"
+                        class="justify-center"
+                        id="hide-password"
+                        aria-label="Hide password"
+                        aria-expanded="true"
+                        aria-haspopup="true"
+                        onclick={(): void => setPasswordForRegistryVisible(registry, false)}>
+                        <i class="fa fa-eye-slash"></i>
+                      </button>
+                    </Tooltip>
                   {:else}
-                    <button
-                      type="button"
-                      class="justify-center"
-                      id="show-password"
-                      title="Show password"
-                      aria-label="Show password"
-                      aria-expanded="true"
-                      aria-haspopup="true"
-                      onclick={(): void => setPasswordForRegistryVisible(registry, true)}>
-                      <i class="fa fa-eye"></i>
-                    </button>
+                    <Tooltip tip="Show password">
+                      <button
+                        type="button"
+                        class="justify-center"
+                        id="show-password"
+                        aria-label="Show password"
+                        aria-expanded="true"
+                        aria-haspopup="true"
+                        onclick={(): void => setPasswordForRegistryVisible(registry, true)}>
+                        <i class="fa fa-eye"></i>
+                      </button>
+                    </Tooltip>
                   {/if}
                 {/if}
 

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -798,7 +798,7 @@ describe('container provider connections', () => {
 
     const typeDiv = within(region).getByLabelText(`${defaultContainerConnectionName} type`);
     expect(typeDiv.textContent).toBe('Podman endpoint');
-    const endpointSpan = await vi.waitFor(() => within(region).getByTitle('unix://socket'));
+    const endpointSpan = await vi.waitFor(() => within(region).getByLabelText('unix://socket copy to clipboard'));
     expect(endpointSpan.textContent).toBe('unix://socket');
     const connectionType = within(region).getByLabelText('Connection Type');
     expect(connectionType.textContent).equal('Libkrun');
@@ -815,7 +815,7 @@ describe('container provider connections', () => {
 
     const typeDiv = within(region).getByLabelText(`${defaultContainerConnectionName} type`);
     expect(typeDiv.textContent).toBe('Docker endpoint');
-    const endpointSpan = await vi.waitFor(() => within(region).getByTitle('unix://socket'));
+    const endpointSpan = await vi.waitFor(() => within(region).getByLabelText('unix://socket copy to clipboard'));
     expect(endpointSpan.textContent).toBe('unix://socket');
   });
 

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
@@ -78,14 +78,14 @@ function onCancelClick(e: Event): void {
   {/if}
 
   {#if !editingInProgress}
-    <Button on:click={onSwitchToInProgress} title="Edit" class="ml-1" padding="p-2" type="link">
+    <Button on:click={onSwitchToInProgress} title="Edit" aria-label="Edit" class="ml-1" padding="p-2" type="link">
       <Icon size="0.8x" icon={faPencil} />
     </Button>
   {:else}
-    <Button on:click={onCancelClick} title="Cancel" class="ml-3" padding="p-2" type="link">
+    <Button on:click={onCancelClick} title="Cancel" aria-label="Cancel" class="ml-3" padding="p-2" type="link">
       <Icon size="0.9x" class="text-[var(--pd-state-error)]" icon={faXmark} />
     </Button>
-    <Button on:click={onSaveClick} title="Save" padding="p-2" disabled={disableSaveButton} type="link">
+    <Button on:click={onSaveClick} title="Save" aria-label="Save" padding="p-2" disabled={disableSaveButton} type="link">
       <Icon size="0.9x" class={`${disableSaveButton ? 'text-[var(--pd-button-disabled-text)]' : 'text-[var(--pd-state-success)]'}`} icon={faCheck} />
     </Button>
   {/if}

--- a/packages/renderer/src/lib/statusbar/PinActions.spec.ts
+++ b/packages/renderer/src/lib/statusbar/PinActions.spec.ts
@@ -92,7 +92,7 @@ test('should register windows#events#receive', async () => {
  * utility function to directly get the render result with the menu opened (default is hidden/closed)
  */
 async function getOpenedPinActions(): Promise<RenderResult<Component<ComponentProps<typeof PinActions>>>> {
-  const { getByTitle, ...result } = render(PinActions);
+  const { getByLabelText, ...result } = render(PinActions);
 
   // call toggle listener (will open the menu)
   const listener = getListener();
@@ -100,12 +100,12 @@ async function getOpenedPinActions(): Promise<RenderResult<Component<ComponentPr
 
   // wait for the menu to be open
   await vi.waitFor(() => {
-    const element = getByTitle('Pin Menu');
+    const element = getByLabelText('Pin Menu');
     expect(element).toBeInTheDocument();
   });
 
   return {
-    getByTitle,
+    getByLabelText,
     ...result,
   };
 }
@@ -123,12 +123,12 @@ test('opened menu should render provider based on pin options', async () => {
 
 test('escape should hide the menu', async () => {
   // render
-  const { queryByTitle } = await getOpenedPinActions();
+  const { queryByLabelText } = await getOpenedPinActions();
 
   await userEvent.keyboard('{Escape}');
 
   await vi.waitFor(() => {
-    expect(queryByTitle('Pin Menu')).toBeNull();
+    expect(queryByLabelText('Pin Menu')).toBeNull();
   });
 });
 

--- a/packages/renderer/src/lib/statusbar/PinMenu.svelte
+++ b/packages/renderer/src/lib/statusbar/PinMenu.svelte
@@ -2,7 +2,7 @@
   class="fixed z-10 bottom-[26px] left-px"
   data-testid="pin-menu">
   <div
-    title="Pin Menu"
+    aria-label="Pin Menu"
     class="z-10 m-1 rounded-md shadow-lg bg-[var(--pd-dropdown-bg)] ring-2 ring-[var(--pd-dropdown-ring)] hover:ring-[var(--pd-dropdown-hover-ring)] divide-y divide-[var(--pd-dropdown-divider)] focus:outline-hidden">
     <slot />
   </div>

--- a/packages/renderer/src/lib/statusbar/Providers.svelte
+++ b/packages/renderer/src/lib/statusbar/Providers.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { ProviderInfo } from '@podman-desktop/core-api';
 import { STATUS_BAR_PIN_CONSTANTS } from '@podman-desktop/core-api/status-bar';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 
 import ProviderWidget from '/@/lib/statusbar/ProviderWidget.svelte';
 import { providerInfos } from '/@/stores/providers';
@@ -19,13 +20,14 @@ function onclick(): void {
 
 {#if $statusBarPinned.length > 0}
   <!-- We cannot use <Fa> object here, as we detect click on this button and outside to toggle the menu -->
-  <button
-    data-task-button="Pin"
-    onclick={onclick}
-    class="px-1 py-px flex h-full items-center relative hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer z-1 fa-solid fa-thumbtack"
-    title="Pin"
-    aria-label="Pin">
-  </button>
+  <Tooltip tip="Pin" bottom>
+    <button
+      data-task-button="Pin"
+      onclick={onclick}
+      class="px-1 py-px flex h-full items-center relative hover:bg-[var(--pd-statusbar-hover-bg)] hover:cursor-pointer z-1 fa-solid fa-thumbtack"
+      aria-label="Pin">
+    </button>
+  </Tooltip>
 {/if}
 
 {#each providers as entry, i (entry.id)}

--- a/packages/renderer/src/lib/task-manager/table/TaskManagerTableProgressColumnCompleted.svelte
+++ b/packages/renderer/src/lib/task-manager/table/TaskManagerTableProgressColumnCompleted.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { faCircleCheck, faCircleXmark } from '@fortawesome/free-regular-svg-icons';
 import { faCancel, faSquareCheck, type IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import type { TaskInfoUI } from '/@/stores/tasks';
@@ -43,8 +44,10 @@ const { icon, iconColor } = $derived.by(() => {
   <div class="ml-1 text-[var(--pd-table-body-text)]">{task.status}</div>
 
   {#if task.status === 'failure' && task.error}
-    <div class="cursor-default ml-1 text-[var(--pd-state-error)] overflow-hidden text-ellipsis" title={task.error}>
-      ({task.error})
-    </div>
+    <Tooltip tip={task.error}>
+      <div class="cursor-default ml-1 text-[var(--pd-state-error)] overflow-hidden text-ellipsis">
+        ({task.error})
+      </div>
+    </Tooltip>
   {/if}
 </div>

--- a/packages/renderer/src/lib/toast/ToastCustomUi.svelte
+++ b/packages/renderer/src/lib/toast/ToastCustomUi.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { faCheckCircle, faCircleExclamation, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import type { TaskInfo } from '@podman-desktop/core-api';
-import { CloseButton, Spinner } from '@podman-desktop/ui-svelte';
+import { CloseButton, Spinner, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { toast } from '@zerodevx/svelte-toast';
 
@@ -28,9 +28,9 @@ const closeAction = (): void => {
 };
 </script>
 
+<Tooltip tip={taskInfo.name}>
 <div
   class="flex flex-nowrap min-h-10 select-none pointer-events-auto cursor-default max-h-50 max-w-[var(--toastWidth)] flex-row p-2 border-[var(--pd-content-divider)] border rounded bg-[var(--pd-modal-bg)] gap-2 justify-between text-base"
-  title={taskInfo.name}
 >
   <div class="flex flex-row gap-1 items-start">
     <div
@@ -62,3 +62,4 @@ const closeAction = (): void => {
   </div>
 
 </div>
+</Tooltip>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.svelte
@@ -46,9 +46,9 @@ async function copyLogsToClipboard(): Promise<void> {
     <Icon size="1.875x" class="pr-3" icon={faFileLines} />
     <div class="text-xl">Logs</div>
     <div class="flex flex-1 justify-end items-center gap-1">
-      <Button title="Toggle Timestamps" on:click={async (): Promise<void> => { showTimestamps = !showTimestamps; await window.updateConfigurationValue(TIMESTAMPS_CONFIG_KEY, showTimestamps); }} type="link"
+      <Button title="Toggle Timestamps" aria-label="Toggle Timestamps" on:click={async (): Promise<void> => { showTimestamps = !showTimestamps; await window.updateConfigurationValue(TIMESTAMPS_CONFIG_KEY, showTimestamps); }} type="link"
         ><Icon class="h-5 w-5 cursor-pointer text-xl {showTimestamps ? 'text-(--pd-action-button-primary-text)' : 'text-(--pd-content-text)'}" icon={faClock} /></Button>
-      <Button title="Copy To Clipboard" on:click={async (): Promise<void> => await copyLogsToClipboard()} type="link"
+      <Button title="Copy To Clipboard" aria-label="Copy To Clipboard" on:click={async (): Promise<void> => await copyLogsToClipboard()} type="link"
         ><Icon class="h-5 w-5 cursor-pointer text-xl text-(--pd-action-button-primary-text)" icon={faPaste} /></Button>
     </div>
   </div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPageStore.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
-import { Button } from '@podman-desktop/ui-svelte';
+import { Button, Tooltip } from '@podman-desktop/ui-svelte';
 
 import type { EventStoreInfo } from '/@/stores/event-store';
 
@@ -28,14 +28,15 @@ let openDetails = $state(false);
 <div class="flex flex-col bg-[var(--pd-invert-content-card-bg)] p-2 items-center rounded-sm w-full" role="listitem" aria-label={eventStoreInfo.name}>
   <div><eventStoreInfo.iconComponent size="20" /></div>
   <div class="text-xl">
-    <button
-      disabled={fetchInProgress}
-      class="underline outline-hidden"
-      title="Open Details"
-      aria-label="Open Details"
-      onclick={(): boolean => (openDetails = true)}>
-      {eventStoreInfo.name}
-    </button>
+    <Tooltip tip="Open Details">
+      <button
+        disabled={fetchInProgress}
+        class="underline outline-hidden"
+        aria-label="Open Details"
+        onclick={(): boolean => (openDetails = true)}>
+        {eventStoreInfo.name}
+      </button>
+    </Tooltip>
   </div>
   <div class="text-sm">({eventStoreInfo.size} items)</div>
   <div class="">
@@ -51,7 +52,9 @@ let openDetails = $state(false);
   {#if eventStoreInfo.bufferEvents.length > 0}
     {@const lastUpdate = eventStoreInfo.bufferEvents[eventStoreInfo.bufferEvents.length - 1]}
     {#if lastUpdate.humanDuration}
-      <div class="text-xs italic" title="Time to update">{lastUpdate.humanDuration}</div>
+      <Tooltip tip="Time to update">
+        <div class="text-xs italic">{lastUpdate.humanDuration}</div>
+      </Tooltip>
     {/if}
   {/if}
 

--- a/packages/renderer/src/lib/ui/CopyToClipboard.spec.ts
+++ b/packages/renderer/src/lib/ui/CopyToClipboard.spec.ts
@@ -32,7 +32,7 @@ test('Expect text to be copied to clipboard', async () => {
 
   render(CopyToClipboard, { clipboardData: textToCopy, title });
 
-  const componentText = screen.getByTitle(title);
+  const componentText = screen.getByText(title);
   expect(componentText).toBeInTheDocument();
 
   const button = screen.getByRole('button', { name: 'Copy To Clipboard' });

--- a/packages/renderer/src/lib/ui/CopyToClipboard.svelte
+++ b/packages/renderer/src/lib/ui/CopyToClipboard.svelte
@@ -19,7 +19,6 @@ async function copyTextToClipboard(): Promise<void> {
 <div class="float-right">
   <Tooltip bottom tip="Copy to Clipboard">
     <button
-      title="Copy To Clipboard"
       class="ml-5 {className}"
       aria-label="Copy To Clipboard"
       onclick={copyTextToClipboard}>
@@ -27,6 +26,8 @@ async function copyTextToClipboard(): Promise<void> {
     </button>
   </Tooltip>
 </div>
-<div class="mt-1 my-auto text-xs truncate {className}" aria-label="{title} copy to clipboard" title={title}>
-  {title}
-</div>
+<Tooltip tip={title}>
+  <div class="mt-1 my-auto text-xs truncate {className}" aria-label="{title} copy to clipboard">
+    {title}
+  </div>
+</Tooltip>

--- a/packages/renderer/src/lib/ui/DetailsPage.spec.ts
+++ b/packages/renderer/src/lib/ui/DetailsPage.spec.ts
@@ -83,7 +83,7 @@ test('Expect close link is defined', async () => {
     title: 'No Title',
   });
 
-  const closeElement = screen.getByTitle('Close');
+  const closeElement = screen.getByRole('button', { name: 'Close' });
   expect(closeElement).toBeInTheDocument();
   await fireEvent.click(closeElement);
 

--- a/packages/renderer/src/lib/ui/EngineFormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/EngineFormPage.spec.ts
@@ -83,7 +83,7 @@ test('Expect close link is defined', async () => {
     title: 'No Title',
   });
 
-  const closeElement = screen.getByTitle('Close');
+  const closeElement = screen.getByRole('button', { name: 'Close' });
   expect(closeElement).toBeInTheDocument();
   await fireEvent.click(closeElement);
 

--- a/packages/renderer/src/lib/ui/FormPage.spec.ts
+++ b/packages/renderer/src/lib/ui/FormPage.spec.ts
@@ -82,7 +82,7 @@ test('Expect close link is defined', async () => {
     title: 'No Title',
   });
 
-  const closeElement = screen.getByTitle('Close');
+  const closeElement = screen.getByRole('button', { name: 'Close' });
   expect(closeElement).toBeInTheDocument();
   await fireEvent.click(closeElement);
 

--- a/packages/renderer/src/lib/ui/SearchButton.spec.ts
+++ b/packages/renderer/src/lib/ui/SearchButton.spec.ts
@@ -31,7 +31,7 @@ test('Expect basic styling', async () => {
   // get button
   const button = screen.getByRole('button', { name: label });
   expect(button).toBeInTheDocument();
-  expect(button).toHaveAttribute('title', label);
+  expect(button).not.toHaveAttribute('title');
   expect(button).toHaveClass('text-[color:var(--pd-global-nav-icon)]');
 });
 

--- a/packages/renderer/src/lib/ui/SearchButton.svelte
+++ b/packages/renderer/src/lib/ui/SearchButton.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 interface Props {
@@ -9,6 +10,8 @@ interface Props {
 let { onclick = (): void => {} }: Props = $props();
 </script>
 
-<button id="Search button" title="Search" class="text-[color:var(--pd-global-nav-icon)] flex justify-center items-center gap-1" style="-webkit-app-region: none;" {onclick}>
+<Tooltip tip="Search">
+  <button id="Search button" class="text-[color:var(--pd-global-nav-icon)] flex justify-center items-center gap-1" style="-webkit-app-region: none;" {onclick}>
     <Icon icon={faMagnifyingGlass} />Search
-</button>
+  </button>
+</Tooltip>

--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -57,7 +57,7 @@ test('Expect prompt dialog and deletion', async () => {
   render(VolumeActions, {
     volume,
   });
-  const button = screen.getByTitle('Delete Volume');
+  const button = screen.getByRole('button', { name: 'Delete Volume' });
   expect(button).toBeDefined();
   await fireEvent.click(button);
 


### PR DESCRIPTION
### What does this PR do?

Replaces native HTML `title` attributes on buttons and other elements with the `<Tooltip>`
component from `@podman-desktop/ui-svelte` across the renderer's feature-area components.
This is the third part of the tooltip migration, following the utility-component and
statusbar/navigation work in the previous PRs.

Components updated:

**Containers**
- `ContainerColumnImage.svelte` - wraps image name div with `<Tooltip tip={object.image}>`
- `ContainerColumnNameContainer.svelte` - wraps container name with `<Tooltip>`
- `ContainerColumnNameGroup.svelte` - wraps group type button with `<Tooltip>`
- `ContainerDetailsLogsClear.svelte` - wraps clear logs button with `<Tooltip>`

**Dashboard**
- `NotificationCardItem.svelte` - wraps delete button with `<Tooltip>`
- `SystemOverviewProviderCardCompact.svelte` - wraps navigate button with `<Tooltip>`

**Dialogs**
- `QuickPickInput.svelte` - wraps item selection buttons with `<Tooltip>`

**Extensions**
- `FeaturedExtension.svelte` - wraps description div with `<Tooltip>`
- `FeaturedExtensionDownload.svelte` - wraps install button with `<Tooltip>`

**Help**
- `HelpMenu.svelte` - converts `title` on container div to `aria-label`

**Images**
- `RunImage.svelte` - wraps retry count span with `<Tooltip>`

**Kubernetes / port forwarding**
- `PortForwardNameColumn.svelte` - wraps open details button with `<Tooltip>`

**Preferences**
- `PreferencesRegistriesEditing.svelte` - wraps hide/show password and login buttons with `<Tooltip>`
- `EditableItem.svelte` - adds `aria-label` to icon-only edit/cancel/save buttons

**Status bar**
- `PinMenu.svelte` - converts `title` on container div to `aria-label`
- `Providers.svelte` - wraps pin button with `<Tooltip>`

**Task manager**
- `TaskManagerTableProgressColumnCompleted.svelte` - wraps error div with `<Tooltip>`

**Toast**
- `ToastCustomUi.svelte` - wraps task name div with `<Tooltip>`

**Troubleshooting**
- `TroubleshootingPageStore.svelte` - wraps open details and update buttons with `<Tooltip>`
- `TroubleshootingDevToolsConsoleLogs.svelte` - removes redundant `title` inside existing `<Tooltip>`

**UI utilities**
- `CopyToClipboard.svelte` - removes redundant `title` inside existing `<Tooltip>`
- `SearchButton.svelte` - wraps search button with `<Tooltip>`

Tests updated to use `getByRole`/`getByText`/`aria-label` queries instead of `getByTitle`
across 25+ spec files.

### What issues does this PR fix or reference?

- Resolves: #18029

### How to test this PR?

1. Hover over container name and image columns in the containers list - verify styled
   app tooltips appear instead of native OS tooltips
2. Hover over notification dismiss buttons in the dashboard - verify styled tooltips
3. Hover over items in QuickPick dialogs - verify styled tooltips
4. Hover over featured extension cards and install buttons - verify styled tooltips
5. Hover over preferences registry edit/login buttons - verify styled tooltips
6. Hover over the search button in list views - verify styled tooltip
7. Run unit tests: `pnpm run test:unit`

- [x] Tests are covering the bug fix or the new feature