### PR TITLE
chore: use lowercase for 'Podman Kube Play'

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -211,7 +211,7 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
           </Route>
         </Route>
 
-        <Route path="/kube/play" breadcrumb="Podman Kube Play">
+        <Route path="/kube/play" breadcrumb="Podman kube play">
           <KubePlayYAML />
         </Route>
 

--- a/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
+++ b/packages/renderer/src/lib/kube/PodmanKubePlay.spec.ts
@@ -34,16 +34,16 @@ beforeEach(() => {
 test('Expect button to be visible with correct text and title', () => {
   const { getByRole } = render(PodmanKubePlay);
 
-  const button = getByRole('button', { name: 'Podman Kube Play' });
+  const button = getByRole('button', { name: 'Podman kube play' });
   expect(button).toBeInTheDocument();
-  expect(button).toHaveTextContent('Podman Kube Play');
+  expect(button).toHaveTextContent('Podman kube play');
   expect(button).toHaveAttribute('title', 'Create containers, pods and volumes based on Kubernetes YAML');
 });
 
 test('Expect click on button to navigate to kube play page', async () => {
   const { getByRole } = render(PodmanKubePlay);
 
-  const button = getByRole('button', { name: 'Podman Kube Play' });
+  const button = getByRole('button', { name: 'Podman kube play' });
   expect(button).toBeInTheDocument();
 
   // Verify router.goto hasn't been called yet

--- a/packages/renderer/src/lib/kube/PodmanKubePlay.svelte
+++ b/packages/renderer/src/lib/kube/PodmanKubePlay.svelte
@@ -10,5 +10,5 @@ function runContainerYaml(): void {
 </script>
 
 <Button onclick={runContainerYaml} title="Create containers, pods and volumes based on Kubernetes YAML" icon={KubePlayIcon}>
-  Podman Kube Play
+  Podman kube play
 </Button>

--- a/tests/playwright/src/model/pages/pods-page.ts
+++ b/tests/playwright/src/model/pages/pods-page.ts
@@ -33,7 +33,7 @@ export class PodsPage extends MainPage {
   constructor(page: Page) {
     super(page, 'pods');
     this.podmanKubePlayButton = this.page.getByRole('button', {
-      name: 'Podman Kube Play',
+      name: 'Podman kube play',
     });
     this.prunePodsButton = this.page.getByRole('button', { name: 'Prune' });
     this.pruneConfirmationButton = this.page.getByRole('button', {


### PR DESCRIPTION
### What does this PR do?
The button present in pods page named "Podman Kube Play" should have only the first word capitalized. So this PR replaces it with "Podman kube play".

### Screenshot / video of UI
BEFORE:

<img width="291" height="97" alt="image" src="https://github.com/user-attachments/assets/163969ba-4cce-4c4e-98ca-413f48215ef3" />

AFTER:

<img width="421" height="75" alt="fix-btn" src="https://github.com/user-attachments/assets/279b6cb7-b68b-4c88-8f49-e889e70b85d0" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes #17999 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
