### PR TITLE
fix(cli): include path in convertToCliToolInfo

### DIFF
--- a/packages/main/src/plugin/cli-tool-registry.spec.ts
+++ b/packages/main/src/plugin/cli-tool-registry.spec.ts
@@ -534,6 +534,7 @@ suite('cli module', () => {
       displayName: 'tool-display-name',
       markdownDescription: 'markdown description',
       images: {},
+      path: '/usr/bin/tool-name',
     };
     const newCliTool = cliToolRegistry.createCliTool(extensionInfo, options);
     const cliToolInfo = cliToolRegistry['convertToCliToolInfo'](newCliTool);
@@ -543,5 +544,6 @@ suite('cli module', () => {
     expect(cliToolInfo.displayName).equals(newCliTool.displayName);
     expect(cliToolInfo.markdownDescription).equals(newCliTool.markdownDescription);
     expect(cliToolInfo.version).equals(newCliTool.version);
+    expect(cliToolInfo.path).equals(newCliTool.path);
   });
 });

--- a/packages/main/src/plugin/cli-tool-registry.ts
+++ b/packages/main/src/plugin/cli-tool-registry.ts
@@ -182,6 +182,7 @@ export class CliToolRegistry {
       markdownDescription: cliTool.markdownDescription,
       images: cliTool.images,
       version: cliTool.version,
+      path: cliTool.path,
       extensionInfo: {
         id: cliTool.extensionInfo.id,
         label: cliTool.extensionInfo.label,


### PR DESCRIPTION
## Summary
- Add missing `path` field to `convertToCliToolInfo()` so that `getCliTools()` and `getCliTool(id)` return the tool's path
- Add unit test coverage for the `path` field in the conversion test

Fixes #18040

Signed-off-by: Jeff MAURY <jmaury@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>