### PR TITLE
chore(test): ensuring wait for podman method works with new dashboard

### DIFF
--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -63,14 +63,21 @@ test.describe
 async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
   dashboardPage = await navigationBar.openDashboard();
 
-  if (enabled) {
-    await playExpect(dashboardPage.getPodmanStatusLocator()).toBeVisible({
-      timeout: 15_000,
-    });
+  const isEnhancedDashboard = await dashboardPage.systemOverviewButton.isVisible({ timeout: 5_000 }).catch(() => false);
+
+  if (isEnhancedDashboard) {
+    if (enabled) {
+      await dashboardPage.expandSystemOverview(true);
+      await playExpect(dashboardPage.statusButton).toBeVisible({ timeout: 15_000 });
+    } else {
+      await playExpect(dashboardPage.setUpPodmanButton).not.toBeVisible({ timeout: 15_000 });
+    }
   } else {
-    await playExpect(dashboardPage.getPodmanStatusLocator()).not.toBeVisible({
-      timeout: 15_000,
-    });
+    if (enabled) {
+      await playExpect(dashboardPage.getPodmanStatusLocator()).toBeVisible({ timeout: 15_000 });
+    } else {
+      await playExpect(dashboardPage.getPodmanStatusLocator()).not.toBeVisible({ timeout: 15_000 });
+    }
   }
   // always present and visible
   // go to the details of the extension

--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -66,8 +66,8 @@ async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
   const isEnhancedDashboard = await dashboardPage.systemOverviewButton.isVisible({ timeout: 5_000 }).catch(() => false);
 
   if (isEnhancedDashboard) {
+    await dashboardPage.expandSystemOverview(true);
     if (enabled) {
-      await dashboardPage.expandSystemOverview(true);
       await playExpect(dashboardPage.statusButton).toBeVisible({ timeout: 15_000 });
     } else {
       await playExpect(dashboardPage.setUpPodmanButton).not.toBeVisible({ timeout: 15_000 });

--- a/tests/playwright/src/utility/wait.ts
+++ b/tests/playwright/src/utility/wait.ts
@@ -19,6 +19,7 @@
 import type { Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
+import { SystemOverviewState } from '/@/model/core/states';
 import { NavigationBar } from '/@/model/workbench/navigation';
 import { createPodmanMachineFromCLI, resetPodmanMachinesFromCLI } from '/@/utility/operations';
 
@@ -119,17 +120,35 @@ export async function waitForPodmanMachineStartup(page: Page, timeout = 30_000):
 
     const dashboardPage = await new NavigationBar(page).openDashboard();
     await playExpect(dashboardPage.heading).toBeVisible();
-    await playExpect(dashboardPage.podmanStatusLabel).toBeVisible({ timeout });
 
-    try {
-      // sometimes the podman machine is stuck in STARTING state, so we try to reset it once
-      await playExpect(dashboardPage.podmanStatusLabel).not.toHaveText('STARTING', { timeout });
-    } catch (error) {
-      console.error('Podman machine stuck in STARTING state, trying to restart it', error);
-      await resetPodmanMachinesFromCLI();
-      await createPodmanMachineFromCLI();
+    const isEnhancedDashboard = await dashboardPage.systemOverviewButton
+      .isVisible({ timeout: 5_000 })
+      .catch(() => false);
+
+    if (isEnhancedDashboard) {
+      await dashboardPage.expandSystemOverview(true);
+
+      try {
+        await playExpect(dashboardPage.statusButton).not.toHaveText(SystemOverviewState.Starting, { timeout });
+      } catch (error) {
+        console.error('Podman machine stuck in STARTING state, trying to restart it', error);
+        await resetPodmanMachinesFromCLI();
+        await createPodmanMachineFromCLI();
+      }
+
+      await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Operational, { timeout });
+    } else {
+      await playExpect(dashboardPage.podmanStatusLabel).toBeVisible({ timeout });
+
+      try {
+        await playExpect(dashboardPage.podmanStatusLabel).not.toHaveText('STARTING', { timeout });
+      } catch (error) {
+        console.error('Podman machine stuck in STARTING state, trying to restart it', error);
+        await resetPodmanMachinesFromCLI();
+        await createPodmanMachineFromCLI();
+      }
+
+      await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', { timeout });
     }
-
-    await playExpect(dashboardPage.podmanStatusLabel).toHaveText('RUNNING', { timeout });
   });
 }


### PR DESCRIPTION
### What does this PR do?
Updates some methods in the test framework to work with both version of the dashboard.

### What issues does this PR fix or reference?

