### PR TITLE
feat(renderer): add onboarding skip confirmation dialog 

### DIFF
--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingSkipConfirmDialog.spec.ts
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingSkipConfirmDialog.spec.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, test, vi } from 'vitest';
+
+import OnboardingSkipConfirmDialog from './OnboardingSkipConfirmDialog.svelte';
+
+describe('OnboardingSkipConfirmDialog', () => {
+  test('renders dialog title and body text', () => {
+    render(OnboardingSkipConfirmDialog, { onskip: vi.fn(), onclose: vi.fn() });
+
+    expect(screen.getByRole('dialog', { name: 'Skip setup confirmation' })).toBeInTheDocument();
+    expect(screen.getByText('Skip setup?')).toBeInTheDocument();
+    expect(screen.getByText(/Taking a moment to configure these settings/)).toBeInTheDocument();
+  });
+
+  test('renders Skip anyway and Continue setup buttons', () => {
+    render(OnboardingSkipConfirmDialog, { onskip: vi.fn(), onclose: vi.fn() });
+
+    expect(screen.getByRole('button', { name: 'Skip anyway' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Continue setup' })).toBeInTheDocument();
+  });
+
+  test('calls onskip when Skip anyway is clicked', async () => {
+    const onskip = vi.fn();
+    render(OnboardingSkipConfirmDialog, { onskip, onclose: vi.fn() });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Skip anyway' }));
+    expect(onskip).toHaveBeenCalledOnce();
+  });
+
+  test('calls onclose when Continue setup is clicked', async () => {
+    const onclose = vi.fn();
+    render(OnboardingSkipConfirmDialog, { onskip: vi.fn(), onclose });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Continue setup' }));
+    expect(onclose).toHaveBeenCalledOnce();
+  });
+
+  test('calls onclose when close button (X) is clicked', async () => {
+    const onclose = vi.fn();
+    render(OnboardingSkipConfirmDialog, { onskip: vi.fn(), onclose });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onclose).toHaveBeenCalledOnce();
+  });
+
+  test('calls onclose when Escape key is pressed', async () => {
+    const onclose = vi.fn();
+    render(OnboardingSkipConfirmDialog, { onskip: vi.fn(), onclose });
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onclose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingSkipConfirmDialog.svelte
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingSkipConfirmDialog.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { faCirclePlay } from '@fortawesome/free-solid-svg-icons';
+import { Button, CloseButton, Modal } from '@podman-desktop/ui-svelte';
+
+interface Props {
+  onskip: () => void;
+  onclose: () => void;
+}
+
+let { onskip, onclose }: Props = $props();
+</script>
+
+<Modal name="Skip setup confirmation" onclose={onclose}>
+  <div class="flex flex-col gap-4 p-6">
+    <div class="flex items-start justify-between">
+      <span class="text-xl font-semibold text-(--pd-content-header)">Skip setup?</span>
+      <CloseButton onclick={onclose} />
+    </div>
+
+    <p class="text-sm text-(--pd-content-card-text)">
+      Taking a moment to configure these settings now ensures a smooth experience. Without them, your environment won't
+      be ready to run containers. You can also configure these later in Settings.
+    </p>
+
+    <div class="flex items-center gap-4 pt-2">
+      <Button type="link" onclick={onskip}>Skip anyway</Button>
+      <Button icon={faCirclePlay} onclick={onclose}>Continue setup</Button>
+    </div>
+  </div>
+</Modal>


### PR DESCRIPTION
### What does this PR do?

Implements the skip confirmation modal dialog for the onboarding wizard, as specified in #17466.

The dialog will be shown when a user attempts to skip the onboarding setup, warning them that their environment won't be ready to run containers without completing the configuration. It provides two actions:
- **Skip anyway** — proceeds to skip the setup
- **Continue setup** — closes the dialog and returns to the wizard

The component uses the existing `Modal` from `@podman-desktop/ui-svelte` and includes a close (X) button and Escape key dismissal.

### Screenshot / video of UI
<img width="1385" height="859" alt="Screenshot 2026-07-06 at 15 16 32" src="https://github.com/user-attachments/assets/56022692-6eda-4548-a9e2-6512c5f710ce" />
<img width="1385" height="859" alt="Screenshot 2026-07-06 at 15 18 00" src="https://github.com/user-attachments/assets/6bd20805-d0a6-41bb-b265-d7cdf2fdcfd3" />


<!-- Will add screenshot showing the dialog integrated in the onboarding wizard -->

### What issues does this PR fix or reference?

Required for #17466
Part of #17316

### How to test this PR?

You can go to the branch https://github.com/simonrey1/podman-desktop/tree/feat/onboarding-skip-dialog-17466-demo and click "Skip entire setup".

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)