### PR TITLE
chore(deps): override gray-matter with @11ty/gray-matter to fix CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,7 @@
       "concurrently>shell-quote": ">=1.8.4",
       "dockerode>@grpc/grpc-js": ">=1.14.4",
       "form-data": ">=4.0.6",
+      "@docusaurus/utils@3>gray-matter": "npm:@11ty/gray-matter@^2.1.0",
       "@docusaurus/types>joi": "^17.13.4",
       "markdown-it": ">=14.2.0",
       "launch-editor": ">=2.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,7 @@ overrides:
   concurrently>shell-quote: '>=1.8.4'
   dockerode>@grpc/grpc-js: '>=1.14.4'
   form-data: '>=4.0.6'
+  '@docusaurus/utils@3>gray-matter': npm:@11ty/gray-matter@^2.1.0
   '@docusaurus/types>joi': ^17.13.4
   markdown-it: '>=14.2.0'
   launch-editor: '>=2.14.1'
@@ -1243,6 +1244,10 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@11ty/gray-matter@2.1.0':
+    resolution: {integrity: sha512-fNdBOb3MgDz/1UCIoeY4wDuGbp+/3s5y6UrsyfMabECbh/CVycj7Er33JXqSxRwxrRKXcGE1Jipuq/1mODInsQ==}
+    engines: {node: '>=11'}
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
@@ -8084,10 +8089,6 @@ packages:
     resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  gray-matter@4.0.3:
-    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
-    engines: {node: '>=6.0'}
-
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
@@ -8816,10 +8817,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -11569,10 +11566,6 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
-  strip-bom-string@1.0.0:
-    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
-    engines: {node: '>=0.10.0'}
-
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
@@ -12744,6 +12737,11 @@ packages:
 snapshots:
 
   7zip-bin@5.2.0: {}
+
+  '@11ty/gray-matter@2.1.0':
+    dependencies:
+      js-yaml: 4.2.0
+      section-matter: 1.0.0
 
   '@adobe/css-tools@4.4.4': {}
 
@@ -15107,7 +15105,7 @@ snapshots:
       fs-extra: 11.3.5
       github-slugger: 1.5.0
       globby: 11.1.0
-      gray-matter: 4.0.3
+      gray-matter: '@11ty/gray-matter@2.1.0'
       jiti: 1.21.7
       js-yaml: 4.2.0
       lodash: 4.18.1
@@ -18367,6 +18365,7 @@ snapshots:
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+    optional: true
 
   argparse@2.0.1: {}
 
@@ -21214,13 +21213,6 @@ snapshots:
 
   graphql@16.14.0: {}
 
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.14.2
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
-
   gzip-size@6.0.0:
     dependencies:
       duplexer: 0.1.2
@@ -21976,11 +21968,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -25297,7 +25284,8 @@ snapshots:
 
   spotify-audio-element@1.0.3: {}
 
-  sprintf-js@1.0.3: {}
+  sprintf-js@1.0.3:
+    optional: true
 
   sprintf-js@1.1.3:
     optional: true
@@ -25482,8 +25470,6 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
-
-  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 


### PR DESCRIPTION
### What does this PR do?

Override `gray-matter@4.0.3` (transitive dependency of `@docusaurus/utils@3.10.1`) with `@11ty/gray-matter@^2.1.0` to resolve CVE caused by the vulnerable `js-yaml` dependency.

The override is scoped to `@docusaurus/utils@3` so it will not apply once Docusaurus ships the fix natively in 4.x.

Upstream fix: https://github.com/facebook/docusaurus/issues/12174

### Screenshot / video of UI

N/A — no UI changes.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18057

### How to test this PR?

1. Run `pnpm install` — should succeed
2. Check `pnpm-lock.yaml` confirms `@11ty/gray-matter@2.1.0` is resolved for `@docusaurus/utils`
3. Run `cd website && pnpm build` — website builds successfully

- [ ] Tests are covering the bug fix or the new feature
