### PR TITLE
fix: resolve CVE-2026-53550 in js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
       "node-forge": "^1.4.0",
       "config-file-ts>glob": "^10.5.0",
       "compression>on-headers": "^1.1.0",
-      "@kubernetes/client-node>js-yaml": "^4.1.1",
+      "js-yaml": "^4.2.0",
       "tmp-promise>tmp": "^0.2.7",
       "tar": "^7.5.3",
       "cheerio>undici": "^7.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ overrides:
   node-forge: ^1.4.0
   config-file-ts>glob: ^10.5.0
   compression>on-headers: ^1.1.0
-  '@kubernetes/client-node>js-yaml': ^4.1.1
+  js-yaml: ^4.2.0
   tmp-promise>tmp: ^0.2.7
   tar: ^7.5.3
   cheerio>undici: ^7.18.2
@@ -8818,10 +8818,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -15800,7 +15796,7 @@ snapshots:
       form-data: 4.0.6
       hpagent: 1.2.0
       isomorphic-ws: 5.0.0(ws@8.21.0)
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       jsonpath-plus: 10.3.0
       node-fetch: 2.7.0(encoding@0.1.13)
       openid-client: 6.5.0
@@ -21969,10 +21965,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -22348,7 +22340,7 @@ snapshots:
   markdownlint-cli2@0.22.1:
     dependencies:
       globby: 16.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
       markdown-it: 14.2.0


### PR DESCRIPTION
### What does this PR do?

we get rid of packages depending on js-yaml v3
now we can handle v4 update

Fix moderate severity vulnerability CVE-2026-53550 in `js-yaml`.

**Advisory**: JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases
**Vulnerable versions**: <=4.1.1
**Patched versions**: >=4.2.0
**Advisory URL**: https://github.com/advisories/GHSA-h67p-54hq-rp68

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-53550: _JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-53550 is no longer reported