### PR TITLE
feat(ui): add `ariaHidden` prop to Icon component

### DIFF
--- a/packages/ui/src/lib/icons/Icon.spec.ts
+++ b/packages/ui/src/lib/icons/Icon.spec.ts
@@ -33,6 +33,14 @@ describe('font awesome', () => {
     expect(img).not.toHaveAttribute('style');
   });
 
+  test('icon with ariaHidden should be hidden from screen readers', () => {
+    render(Icon, { icon: faGithub, ariaHidden: true });
+
+    const svg = screen.getByRole('img', { hidden: true });
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
   test('icon should reflect prefered {number}x size', () => {
     render(Icon, { icon: faGithub, size: '2x' });
 
@@ -84,6 +92,15 @@ describe('class icon', () => {
     expect(img.nodeName).toBe('SPAN');
   });
 
+  test('icon with ariaHidden should not have role img', () => {
+    const { container } = render(Icon, { icon: 'fas fa-icon', ariaHidden: true });
+
+    const span = container.querySelector('span');
+    expect(span).toBeInTheDocument();
+    expect(span).not.toHaveAttribute('role');
+    expect(span).toHaveAttribute('aria-hidden', 'true');
+  });
+
   test('icon should reflect prefered fa-{number}x size', () => {
     render(Icon, { icon: 'fas fa-icon', size: 'fa-2x' });
 
@@ -126,6 +143,15 @@ describe('component icon', () => {
     expect(img).toBeInTheDocument();
   });
 
+  test('icon with ariaHidden should not have role img', () => {
+    const { container } = render(Icon, { icon: ContainerIcon, ariaHidden: true });
+
+    const span = container.querySelector('span');
+    expect(span).toBeInTheDocument();
+    expect(span).not.toHaveAttribute('role');
+    expect(span).toHaveAttribute('aria-hidden', 'true');
+  });
+
   test('icon should reflect prefered {number} size', () => {
     render(Icon, { icon: ContainerIcon, size: '42' });
 
@@ -161,6 +187,17 @@ describe('string icon', () => {
     const img = screen.getByRole('img', { hidden: true });
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute('src', icon);
+  });
+
+  test('icon with ariaHidden should not have role img', () => {
+    const icon = 'data:image/png;base64,fooBar';
+    const { container } = render(Icon, { icon: icon, ariaHidden: true });
+
+    const img = container.querySelector('img');
+    expect(img).toBeInTheDocument();
+    expect(img).not.toHaveAttribute('role');
+    expect(img).toHaveAttribute('aria-hidden', 'true');
+    expect(img).toHaveAttribute('alt', '');
   });
 
   test('icon should reflect prefered {number} size', () => {

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -10,29 +10,31 @@ interface Props {
   size?: IconSize | number | string;
   class?: string;
   title?: string;
+  ariaHidden?: boolean;
 }
 
-let { icon, size, class: className, title }: Props = $props();
+let { icon, size, class: className, title, ariaHidden }: Props = $props();
 
-const role = 'img';
+const role = $derived(ariaHidden ? undefined : 'img');
+const ariaHiddenAttr = $derived(ariaHidden ? 'true' : undefined);
 const IconComponent = icon;
 </script>
 
 
 {#if isFontAwesomeIcon(icon)}
     {#if typeof size === 'undefined' || isFontAwesomeSize(size)}
-        <Fa {icon} {size} class={className} {title}/>
+        <Fa {icon} {size} class={className} title={ariaHidden ? undefined : title}/>
     {/if}
 {:else if typeof icon === 'string'}
     <!-- fas fa- and far fa- and fab fa- for Font awesome icons -->
     <!-- -icon for extension icons e.g. 'kind-icon' -->
     {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.startsWith('fab fa-') || icon.endsWith('-icon')}
-        <span class={`${icon} ${size} ${className}`} {role} {title}></span>
+        <span class={`${icon} ${size} ${className}`} role={role} aria-hidden={ariaHiddenAttr} {title}></span>
     {:else if icon.startsWith('data:image/')}
-        <img src={icon} alt={title ?? ''} {title} {role} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
+        <img src={icon} alt={ariaHidden ? '' : (title ?? '')} {title} role={role} aria-hidden={ariaHiddenAttr} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
     {/if}
 {:else}
     {#if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
-        <span {role} {title}><IconComponent class={className} {size}/></span>
+        <span role={role} aria-hidden={ariaHiddenAttr} {title}><IconComponent class={className} {size}/></span>
     {/if}
 {/if}


### PR DESCRIPTION
### What does this PR do?

Adds an optional `ariaHidden` prop to the `Icon` component so callers can mark decorative icons as hidden from screen readers.

When `ariaHidden={true}` is passed:
- The `role="img"` attribute is omitted from the rendered element
- `aria-hidden="true"` is set instead
- For FontAwesome icons, the `title` is suppressed to trigger svelte-fa's built-in `aria-hidden` behavior
- For `data:image/` icons, the `alt` attribute is forced to an empty string

This is fully backward compatible: `ariaHidden` defaults to unset, so existing callers render exactly as before.

This is a follow-up split of this PR per review feedback – it now only touches the `Icon` component itself. A separate PR will update the two decorative-lock-icon callers (`PreferencesManagedInput` and `PreferencesManagedLabel`) to actually use this new prop, once this one is merged.

### Screenshot / video of UI

No visual change – this PR only changes the `Icon` component API and isn't wired up to any caller yet.

### What issues does this PR fix or reference?

- Resolves: #17630

### How to test this PR?

1. Run unit tests: `npx vitest run packages/ui/src/lib/icons/Icon.spec.ts` (23 tests, including 4 new cases covering `ariaHidden` across all icon variants: FontAwesome, class-based, component, and `data:image`)
2. No manual/UI verification needed – this PR has no consumers yet and no behavior change for existing callers

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>