### PR TITLE
fix(ui): add proper aria attributes to tooltip

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.svelte
@@ -238,7 +238,7 @@ function getLoggerHandler(_cliToolId: string): ConnectionCallback {
         {#if cliTool.version}
           <div
             class="flex flex-row justify-between align-center bg-[var(--pd-invert-content-bg)] p-2 rounded-lg min-w-[320px] w-fit">
-            <Tooltip containerClass="relative inline-block my-auto" aria-label="cli-full-path" bottomRight={true} tip="Path: {cliTool.path}">
+            <Tooltip containerClass="relative inline-block my-auto" bottomRight={true} tip="Path: {cliTool.path}">
               <div
                 class="flex text-[var(--pd-invert-content-card-text)] font-bold text-sm items-center"
                 aria-label="cli-version">

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -360,7 +360,7 @@ test('Expect tooltip text shows info when input is less than minimum', async () 
   const tooltipTrigger = screen.getByTestId('tooltip-trigger');
   await userEvent.hover(tooltipTrigger);
 
-  const tooltip = await screen.findByLabelText('tooltip');
+  const tooltip = await screen.findByRole('tooltip');
   expect(tooltip).toBeInTheDocument();
   expect(tooltip.textContent).toBe('The value cannot be less than 1');
 });
@@ -385,7 +385,7 @@ test('Expect tooltip text shows info when input is higher than maximum', async (
   const tooltipTrigger = screen.getByTestId('tooltip-trigger');
   await userEvent.hover(tooltipTrigger);
 
-  const tooltip = await screen.findByLabelText('tooltip');
+  const tooltip = await screen.findByRole('tooltip');
   expect(tooltip).toBeInTheDocument();
   expect(tooltip.textContent).toBe('The value cannot be greater than 34');
 });

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.spec.ts
@@ -47,7 +47,7 @@ test('Expect tooltip if value input is NaN', async () => {
   const tooltipTrigger = screen.getByTestId('tooltip-trigger');
   await userEvent.hover(tooltipTrigger);
 
-  const tooltip = await screen.findByLabelText('tooltip');
+  const tooltip = await screen.findByRole('tooltip');
   expect(tooltip).toBeInTheDocument();
   expect(tooltip.textContent).toContain('Expecting a number');
 });
@@ -71,7 +71,7 @@ test('Expect number with dot is valid but onChange is not called if dot is the l
   await userEvent.click(input);
   await userEvent.keyboard('.');
 
-  const tooltip = screen.queryByLabelText('tooltip');
+  const tooltip = screen.queryByRole('tooltip');
   expect(tooltip).not.toBeInTheDocument();
 
   expect(onChange).not.toBeCalled();
@@ -96,7 +96,7 @@ test('Expect onChange to be called with float number', async () => {
   await userEvent.click(input);
   await userEvent.keyboard('.2');
 
-  const tooltip = screen.queryByLabelText('tooltip');
+  const tooltip = screen.queryByRole('tooltip');
   expect(tooltip).not.toBeInTheDocument();
 
   await new Promise(resolve => setTimeout(resolve, 600));
@@ -127,7 +127,7 @@ test('Expect only one dot is added to input', async () => {
   await userEvent.keyboard('.');
   await userEvent.keyboard('2');
 
-  const tooltip = screen.queryByLabelText('tooltip');
+  const tooltip = screen.queryByRole('tooltip');
   expect(tooltip).not.toBeInTheDocument();
 
   await new Promise(resolve => setTimeout(resolve, 600));

--- a/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/NumberItem.spec.ts
@@ -51,7 +51,7 @@ test('Expect tooltip if value input is invalid', async () => {
   const tooltipTrigger = screen.getByTestId('tooltip-trigger');
   await userEvent.hover(tooltipTrigger);
 
-  const tooltip = await screen.findByLabelText('tooltip');
+  const tooltip = await screen.findByRole('tooltip');
   expect(tooltip).toBeInTheDocument();
   expect(tooltip.textContent).toContain('The value cannot be less than 10');
 });

--- a/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
+++ b/packages/renderer/src/lib/ui/KubernetesCurrentContextConnectionBadge.spec.ts
@@ -180,7 +180,7 @@ describe.each<{
     }
 
     await vi.waitFor(() => {
-      const tooltip = screen.queryByLabelText('tooltip');
+      const tooltip = screen.queryByRole('tooltip');
       expect(tooltip).toBeNull();
     });
   });
@@ -197,7 +197,7 @@ describe.each<{
     await fireEvent.mouseEnter(tooltipTrigger);
 
     await vi.waitFor(() => {
-      const tooltip = screen.getByLabelText('tooltip');
+      const tooltip = screen.getByRole('tooltip');
       expect(tooltip).toBeInTheDocument();
     });
   });
@@ -216,7 +216,7 @@ describe.each<{
     await fireEvent.mouseEnter(tooltipTrigger);
 
     await vi.waitFor(() => {
-      const tooltip = screen.getByLabelText('tooltip');
+      const tooltip = screen.getByRole('tooltip');
       expect(tooltip).toBeInTheDocument();
       expect(tooltip).toHaveTextContent('connection lost, resources may be out of sync');
     });

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -321,10 +321,10 @@ describe('Tooltip', () => {
     await fireEvent.mouseEnter(slot);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('tooltip')).toBeInTheDocument();
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
     });
 
-    return screen.getByLabelText('tooltip');
+    return screen.getByRole('tooltip');
   }
 
   function expectTooltipStyling(element: HTMLElement): void {
@@ -352,7 +352,7 @@ describe('Tooltip', () => {
     await fireEvent.mouseEnter(slot);
 
     await waitFor(() => {
-      const slotElement = screen.getByLabelText('tooltip');
+      const slotElement = screen.getByRole('tooltip');
       expect(slotElement).toHaveClass('my-[5px] mx-[10px]');
     });
   });
@@ -360,5 +360,47 @@ describe('Tooltip', () => {
   test('containerClass prop should replace the default class of the container', async () => {
     const { container } = render(TooltipTestComponent, { containerClass: 'w-full' });
     expect(container.childNodes[0]).toHaveClass('w-full');
+  });
+
+  test('tooltip has role="tooltip" when visible', async () => {
+    render(TooltipTestComponent, { tip: 'accessible tooltip' });
+
+    const slot = screen.getByTestId('tooltip-trigger');
+    await fireEvent.mouseEnter(slot);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      expect(screen.getByRole('tooltip')).toHaveTextContent('accessible tooltip');
+    });
+  });
+
+  test('trigger has aria-describedby matching tooltip id when visible', async () => {
+    render(TooltipTestComponent, { tip: 'linked tooltip' });
+
+    const slot = screen.getByTestId('tooltip-trigger');
+    await fireEvent.mouseEnter(slot);
+
+    await waitFor(() => {
+      const tooltip = screen.getByRole('tooltip');
+      expect(slot).toHaveAttribute('aria-describedby', tooltip.id);
+      expect(tooltip.id).toMatch(/^pd-tooltip-/);
+    });
+  });
+
+  test('trigger aria-describedby is removed when tooltip hides', async () => {
+    render(TooltipTestComponent, { tip: 'hide tooltip' });
+
+    const slot = screen.getByTestId('tooltip-trigger');
+    await fireEvent.mouseEnter(slot);
+
+    await waitFor(() => {
+      expect(slot).toHaveAttribute('aria-describedby');
+    });
+
+    await fireEvent.mouseLeave(slot);
+
+    await waitFor(() => {
+      expect(slot).not.toHaveAttribute('aria-describedby');
+    });
   });
 });

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -403,4 +403,18 @@ describe('Tooltip', () => {
       expect(slot).not.toHaveAttribute('aria-describedby');
     });
   });
+
+  test('aria-describedby is set on nested focusable trigger', async () => {
+    render(TooltipTestComponent, { tip: 'button tooltip', useButton: true });
+
+    const slot = screen.getByTestId('tooltip-trigger');
+    const button = screen.getByRole('button', { name: 'Hover me' });
+    await fireEvent.mouseEnter(slot);
+
+    await waitFor(() => {
+      const tooltip = screen.getByRole('tooltip');
+      expect(button).toHaveAttribute('aria-describedby', tooltip.id);
+      expect(slot).not.toHaveAttribute('aria-describedby');
+    });
+  });
 });

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -387,6 +387,21 @@ describe('Tooltip', () => {
     });
   });
 
+  test('each tooltip instance gets a unique id', async () => {
+    render(TooltipTestComponent, { tip: 'first tooltip' });
+    render(TooltipTestComponent, { tip: 'second tooltip' });
+
+    const slots = screen.getAllByTestId('tooltip-trigger');
+    await fireEvent.mouseEnter(slots[0]);
+    await fireEvent.mouseEnter(slots[1]);
+
+    await waitFor(() => {
+      const tooltips = screen.getAllByRole('tooltip');
+      expect(tooltips).toHaveLength(2);
+      expect(tooltips[0].id).not.toBe(tooltips[1].id);
+    });
+  });
+
   test('trigger aria-describedby is removed when tooltip hides', async () => {
     render(TooltipTestComponent, { tip: 'hide tooltip' });
 

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -36,7 +36,6 @@ interface Props {
   containerClass?: string;
   tipSnippet?: Snippet;
   children?: Snippet;
-  'aria-label'?: string;
 }
 
 let {
@@ -53,8 +52,9 @@ let {
   containerClass,
   tipSnippet,
   children,
-  'aria-label': ariaLabel,
 }: Props = $props();
+
+const tooltipId = `pd-tooltip-${crypto.randomUUID()}`;
 
 let referenceElement: HTMLElement | undefined = $state(undefined);
 let tooltipElement: HTMLElement | undefined = $state(undefined);
@@ -152,11 +152,11 @@ $effect((): (() => void) => {
 });
 </script>
 
-<div class={containerClass ?? 'relative inline-block'} aria-label={ariaLabel}>
+<div class={containerClass ?? 'relative inline-block'}>
   <span
-    role="none"
     data-testid="tooltip-trigger"
     class="group tooltip-slot {className}"
+    aria-describedby={isVisible ? tooltipId : undefined}
     bind:this={referenceElement}
     onmouseenter={handleMouseEnter}
     onmouseleave={handleMouseLeave}
@@ -171,12 +171,12 @@ $effect((): (() => void) => {
       class:opacity-0={!isPositioned}
       style="left: 0; top: 0;">
       {#if tip}
-        <div class="{tooltipInnerClasses} {className}" aria-label="tooltip">
+        <div class="{tooltipInnerClasses} {className}" role="tooltip" id={tooltipId}>
           {tip}
         </div>
       {/if}
       {#if tipSnippet && !tip}
-        <div class="{tooltipInnerClasses} {className}" aria-label="tooltip">
+        <div class="{tooltipInnerClasses} {className}" role="tooltip" id={tooltipId}>
           {@render tipSnippet?.()}
         </div>
       {/if}

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -65,6 +65,25 @@ let cleanupAutoUpdate: (() => void) | undefined;
 const tooltipInnerClasses =
   'pt-[4px] pb-[5px] px-[8px] rounded-[9px] bg-[var(--pd-tooltip-bg)] text-[var(--pd-tooltip-text)] border-[1px] border-[var(--pd-tooltip-inner-border)] backdrop-blur-sm';
 
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable="true"]';
+
+function getTooltipAriaTarget(root: HTMLElement | undefined): HTMLElement | undefined {
+  if (!root) return undefined;
+  return root.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ?? root;
+}
+
+function setTooltipAriaDescribedBy(root: HTMLElement | undefined, id: string | undefined): void {
+  const target = getTooltipAriaTarget(root);
+  if (!target) return;
+
+  if (id) {
+    target.setAttribute('aria-describedby', id);
+  } else {
+    target.removeAttribute('aria-describedby');
+  }
+}
+
 function getPreferredPlacement(): Placement {
   if (top) return 'top';
   if (topLeft) return 'top-start';
@@ -150,13 +169,21 @@ $effect((): (() => void) => {
     }
   };
 });
+
+$effect(() => {
+  const shouldDescribe = isVisible && !$tooltipHidden && (tip ?? tipSnippet);
+  setTooltipAriaDescribedBy(referenceElement, shouldDescribe ? tooltipId : undefined);
+
+  return (): void => {
+    setTooltipAriaDescribedBy(referenceElement, undefined);
+  };
+});
 </script>
 
 <div class={containerClass ?? 'relative inline-block'}>
   <span
     data-testid="tooltip-trigger"
     class="group tooltip-slot {className}"
-    aria-describedby={isVisible ? tooltipId : undefined}
     bind:this={referenceElement}
     onmouseenter={handleMouseEnter}
     onmouseleave={handleMouseLeave}

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -15,6 +15,15 @@
 }
 </style>
 
+<script module lang="ts">
+let tooltipIdCounter = 0;
+
+function nextTooltipId(): string {
+  tooltipIdCounter += 1;
+  return `pd-tooltip-${tooltipIdCounter}`;
+}
+</script>
+
 <script lang="ts">
 import type { Placement } from '@floating-ui/dom';
 import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
@@ -54,7 +63,7 @@ let {
   children,
 }: Props = $props();
 
-const tooltipId = `pd-tooltip-${crypto.randomUUID()}`;
+const tooltipId = nextTooltipId();
 
 let referenceElement: HTMLElement | undefined = $state(undefined);
 let tooltipElement: HTMLElement | undefined = $state(undefined);

--- a/packages/ui/src/lib/tooltip/TooltipTestComponent.svelte
+++ b/packages/ui/src/lib/tooltip/TooltipTestComponent.svelte
@@ -14,6 +14,7 @@ interface Props {
   bottomRight?: boolean;
   classStyle?: string;
   containerClass?: string;
+  useButton?: boolean;
 }
 
 let {
@@ -29,6 +30,7 @@ let {
   bottomRight,
   classStyle,
   containerClass,
+  useButton = false,
 }: Props = $props();
 </script>
 
@@ -49,5 +51,9 @@ let {
       {tipSlot}
     {/if}
   {/snippet}
-  <div>Hover me</div>
+  {#if useButton}
+    <button type="button">Hover me</button>
+  {:else}
+    <div>Hover me</div>
+  {/if}
 </Tooltip>


### PR DESCRIPTION
### What does this PR do?

Implements the WAI-ARIA Tooltip pattern on the shared `Tooltip` component so screen readers can access tooltip content:

- Adds `role="tooltip"` and a unique `id` to the tooltip popup, generated via a lightweight module-scoped counter shared across instances
- Links the trigger to the popup with `aria-describedby`, applied to the actual focusable element inside the trigger (nested button/link) rather than the wrapper, and only while the tooltip is visible
- Removes `role="none"` from the trigger and the static `aria-label="tooltip"` on the popup
- Drops the unused `aria-label` prop from the component API
- Removes the obsolete `aria-label` usage in `PreferencesCliTool.svelte`

### Screenshot / video of UI

No visual change — this is an accessibility-only update.

### What issues does this PR fix or reference?

- Resolves: #15784

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

```bash
npx vitest run packages/ui/src/lib/tooltip/Tooltip.spec.ts