### PR TITLE
chore: remove override

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,6 @@
       "electron-builder-squirrel-windows": "^26.8.2",
       "svelte>devalue": "^5.6.4",
       "protobufjs": "^7.6.4",
-      "smol-toml": "^1.6.1",
       "follow-redirects": "^1.16.0",
       "uuid": "^14.0.0",
       "ip-address": ">=10.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,6 @@ overrides:
   electron-builder-squirrel-windows: ^26.8.2
   svelte>devalue: ^5.6.4
   protobufjs: ^7.6.4
-  smol-toml: ^1.6.1
   follow-redirects: ^1.16.0
   uuid: ^14.0.0
   ip-address: '>=10.1.1'
@@ -457,7 +456,7 @@ importers:
         specifier: ^7.8.5
         version: 7.8.5
       smol-toml:
-        specifier: ^1.6.1
+        specifier: 1.6.1
         version: 1.6.1
       ssh2:
         specifier: ^1.17.0


### PR DESCRIPTION
### What does this PR do?
markdownlint-cli2 package has updated its dependency to smol-toml can remove the global override

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/pull/18083

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
