### PR TITLE
fix: update pods page on unpause/pause events

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4281,6 +4281,42 @@ test('check createPod uses running podman connection if ProviderContainerConnect
   expect(result.engineId).equal('podman1');
 });
 
+describe('unpausePod', () => {
+  test('test unpause Pod', async () => {
+    const unpauseMock = vi.fn().mockResolvedValue({});
+
+    const fakeLibPod = {
+      unpausePod: unpauseMock,
+    } as unknown as LibPod;
+
+    vi.spyOn(containerRegistry, 'getMatchingPodmanEngineLibPod').mockReturnValue(fakeLibPod);
+
+    await containerRegistry.unpausePod('podman1', '1234');
+    expect(unpauseMock).toHaveBeenCalled();
+  });
+
+  test('test unpause Pod for error handling', async () => {
+    const unpauseError = new Error('unpause failed');
+    const unpauseMock = vi.fn().mockRejectedValue(unpauseError);
+
+    const fakeLibPod = {
+      unpausePod: unpauseMock,
+    } as unknown as LibPod;
+
+    vi.spyOn(containerRegistry, 'getMatchingPodmanEngineLibPod').mockReturnValue(fakeLibPod);
+
+    await expect(containerRegistry.unpausePod('podman1', '1234')).rejects.toThrow(unpauseError);
+
+    expect(telemetry.track).toHaveBeenCalledWith(
+      'unpausePod',
+      expect.objectContaining({
+        error: unpauseError,
+      }),
+    );
+    expect(unpauseMock).toHaveBeenCalled();
+  });
+});
+
 test('check that fails if there is no podman provider running', async () => {
   const internalProvider = {
     name: 'podman1',

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1548,6 +1548,18 @@ export class ContainerProviderRegistry {
     }
   }
 
+  async unpausePod(engineId: string, podId: string): Promise<void> {
+    let telemetryOptions = {};
+    try {
+      return await this.getMatchingPodmanEngineLibPod(engineId).unpausePod(podId);
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('unpausePod', telemetryOptions);
+    }
+  }
+
   async createPod(podOptions: PodCreateOptions): Promise<{ engineId: string; Id: string }> {
     let telemetryOptions = {};
     try {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -102,6 +102,33 @@ test('Check list of images using Podman API', async () => {
   expect(firstImage?.Id).toBe('sha256:1234567890');
 });
 
+test('Check unpause Pod using Podman API', async () => {
+  const handler = vi.fn(() => HttpResponse.json({}, { status: 200 }));
+
+  server = setupServer(http.post('http://localhost/v4.2.0/libpod/pods/dummy/unpause', handler));
+
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+  await (api as unknown as LibPod).unpausePod('dummy');
+  expect(handler).toHaveBeenCalledOnce();
+});
+
+test('Check unpause Pod for error handling using Podman API', async () => {
+  server = setupServer(
+    http.post('http://localhost/v4.2.0/libpod/pods/dummy/unpause', () =>
+      HttpResponse.text('no such pod', { status: 404 }),
+    ),
+  );
+
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+  await expect((api as unknown as LibPod).unpausePod('dummy')).rejects.toThrow();
+});
+
 test('Check list of containers using Podman API', async () => {
   const jsonContainers = [
     {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -238,6 +238,7 @@ export interface LibPod {
   podmanAttach(containerId: string): Promise<NodeJS.ReadWriteStream>;
   getPodInspect(podId: string): Promise<LibPodPodInspectInfo>;
   startPod(podId: string): Promise<void>;
+  unpausePod(podId: string): Promise<void>;
   stopPod(podId: string): Promise<void>;
   removePod(podId: string, options?: PodRemoveOptions): Promise<void>;
   resolveShortnameImage(shortname: string): Promise<{ Names: string[] }>;
@@ -565,6 +566,29 @@ export class LibpodDockerode {
               return reject(err.json.Errs.join(' '));
             }
 
+            return reject(err);
+          }
+          resolve(wrapAs<void>(data));
+        });
+      });
+    };
+
+    // add unpausePod
+    prototypeOfDockerode.unpausePod = function (podId: string): Promise<void> {
+      const optsf = {
+        path: `/v4.2.0/libpod/pods/${podId}/unpause`,
+        method: 'POST',
+        statusCodes: {
+          200: true,
+          404: 'no such pod',
+          409: 'unexpected error',
+          500: 'server error',
+        },
+      };
+
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
             return reject(err);
           }
           resolve(wrapAs<void>(data));

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1041,6 +1041,12 @@ export class PluginSystem {
       },
     );
     this.ipcHandle(
+      'container-provider-registry:unpausePod',
+      async (_listener, engine: string, podId: string): Promise<void> => {
+        return containerProviderRegistry.unpausePod(engine, podId);
+      },
+    );
+    this.ipcHandle(
       'container-provider-registry:restartPod',
       async (_listener, engine: string, podId: string): Promise<void> => {
         return containerProviderRegistry.restartPod(engine, podId);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -394,6 +394,9 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('startPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:startPod', engine, podId);
   });
+  contextBridge.exposeInMainWorld('unpausePod', async (engine: string, podId: string): Promise<void> => {
+    return ipcInvoke('container-provider-registry:unpausePod', engine, podId);
+  });
   contextBridge.exposeInMainWorld('restartPod', async (engine: string, podId: string): Promise<void> => {
     return ipcInvoke('container-provider-registry:restartPod', engine, podId);
   });

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -30,7 +30,7 @@ class Pod {
   #actionError: string;
   constructor(
     public id: string,
-    public containers: { Id: string }[],
+    public containers: { Id: string; Status?: string }[],
     initialStatus: string,
     public kind: string,
     actionError: string,
@@ -69,6 +69,7 @@ beforeAll(() => {
   Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver });
   Object.defineProperty(window, 'listContainers', { value: listContainersMock });
   Object.defineProperty(window, 'startPod', { value: vi.fn() });
+  Object.defineProperty(window, 'unpausePod', { value: vi.fn() });
   Object.defineProperty(window, 'stopPod', { value: vi.fn() });
   Object.defineProperty(window, 'restartPod', { value: vi.fn() });
   Object.defineProperty(window, 'removePod', { value: vi.fn() });
@@ -97,6 +98,24 @@ test('Expect no error and status starting pod', async () => {
 
   expect(podmanPod.status).toEqual('STARTING');
   expect(podmanPod.actionError).toEqual('');
+  expect(updateMock).toHaveBeenCalled();
+});
+
+test('Expect no error and status starting for unpausing pod', async () => {
+  listContainersMock.mockResolvedValue([]);
+
+  // set status to paused
+  podmanPod.containers[0].Status = 'paused';
+  render(PodActions, { pod: podmanPod, onUpdate: updateMock });
+
+  // click on start button
+  const startButton = screen.getByRole('button', { name: 'Start Pod' });
+  await fireEvent.click(startButton);
+
+  expect(podmanPod.status).toEqual('STARTING');
+  expect(podmanPod.actionError).toEqual('');
+  expect(window.unpausePod).toHaveBeenCalledWith(podmanPod.engineId, podmanPod.id);
+  expect(window.startPod).not.toHaveBeenCalled();
   expect(updateMock).toHaveBeenCalled();
 });
 

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -89,8 +89,17 @@ function handleError(errorMessage: string): void {
 
 async function startPod(): Promise<void> {
   inProgress(true, 'STARTING');
+
+  const hasPaused = pod.containers.some(c => c.Status === 'paused');
+  const hasExited = pod.containers.some(c => c.Status === 'exited');
+
   try {
-    await window.startPod(pod.engineId, pod.id);
+    if (hasPaused) {
+      await window.unpausePod(pod.engineId, pod.id);
+    }
+    if (hasExited) {
+      await window.startPod(pod.engineId, pod.id);
+    }
   } catch (error) {
     handleError(String(error));
   } finally {

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -34,6 +34,8 @@ const windowEvents = [
   'container-removed-event',
   'container-created-event',
   'container-started-event',
+  'container-paused-event',
+  'container-unpaused-event',
   'provider-change',
   'provider-container-connection-update-status',
   'pod-event',


### PR DESCRIPTION
### What does this PR do?
When we `unpause/pause` a container that is part of a pod, the pods page is not updated.

This PR adds :
- Adds listener for container `pause/unpause` event, so UI updates on those events.
- Adds unpause feature for pods, when pod has `paused/stopped/mixed states`, clicking on start action starts the pod without any error.

### Screenshot / video of UI
Before:
<img width="2014" height="1828" alt="image" src="https://github.com/user-attachments/assets/362a84a0-6563-4cfd-9c1f-c40637a345c3" />

After:

https://github.com/user-attachments/assets/4c4ec723-2e48-4a6e-a35b-bf3d8af8171f


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes #18015 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
PR #17866 needs to be added/merged with current PR because this contains event generation updates.
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
