### PR TITLE
fix: dashboard provider status update on Linux

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1112,6 +1112,32 @@ describe('startMachine rosetta enable-file provisioning', () => {
   });
 });
 
+describe('on Linux, startMachine and stopMachine should not update provider status', () => {
+  beforeEach(() => {
+    vi.spyOn(provider, 'updateStatus').mockImplementation(() => {});
+    vi.mocked(extensionApi.env).isLinux = true;
+    vi.mocked(extensionApi.env).isMac = false;
+  });
+
+  test('startMachine does not call provider.updateStatus on Linux', async () => {
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '5.7.0' } as InstalledPodman);
+    vi.mocked(ROSETTA_PROVISIONER_MOCK.provisionAndRestartForRosetta).mockResolvedValue(false);
+
+    await extension.startMachine(provider, podmanConfiguration, machineInfo);
+
+    expect(provider.updateStatus).not.toHaveBeenCalled();
+  });
+
+  test('stopMachine does not call provider.updateStatus on Linux', async () => {
+    vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({} as extensionApi.RunResult);
+
+    await extension.stopMachine(provider, machineInfo);
+
+    expect(provider.updateStatus).not.toHaveBeenCalled();
+  });
+});
+
 describe('createMachine rosetta enable-file provisioning', () => {
   const createMachineBaseParams = {
     'podman.factory.machine.cpus': '2',

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -905,7 +905,9 @@ export async function registerProviderFor(
   containerProviderConnections.set(machineInfo.name, containerProviderConnection);
 
   const disposable = provider.registerContainerProviderConnection(containerProviderConnection);
-  provider.updateStatus('ready');
+  if (!extensionApi.env.isLinux) {
+    provider.updateStatus('ready');
+  }
 
   // get configuration for this connection
   const containerConfiguration = extensionApi.configuration.getConfiguration('podman', containerProviderConnection);
@@ -972,7 +974,9 @@ export async function startMachine(
       );
     }
 
-    provider.updateStatus('started');
+    if (!extensionApi.env.isLinux) {
+      provider.updateStatus('started');
+    }
   } catch (err) {
     telemetryRecords.error = err;
     if (skipHandleError) {
@@ -1003,7 +1007,9 @@ export async function stopMachine(
     await execPodman(['machine', 'stop', machineInfo.name], machineInfo.vmType, {
       logger: new LoggerDelegator(context, logger),
     });
-    provider.updateStatus('stopped');
+    if (!extensionApi.env.isLinux) {
+      provider.updateStatus('stopped');
+    }
   } catch (err: unknown) {
     telemetryRecords.error = err;
     throw err;


### PR DESCRIPTION
### What does this PR do?

On Linux, podman machines are optional — the provider status should reflect the state of the native podman installation, not machine lifecycle. However, startMachine(), stopMachine(), and registerProviderFor() unconditionally called provider.updateStatus(), overriding the native-podman-derived provider status. After stopping or removing a machine, the Dashboard Podman tile would get stuck on "Stopped" even though native podman was still running.

### Screenshot / video of UI

[<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->](https://private-user-images.githubusercontent.com/51708585/588839995-254accc3-3943-4251-96db-558a9f00ea6c.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODI3OTE1NjQsIm5iZiI6MTc4Mjc5MTI2NCwicGF0aCI6Ii81MTcwODU4NS81ODg4Mzk5OTUtMjU0YWNjYzMtMzk0My00MjUxLTk2ZGItNTU4YTlmMDBlYTZjLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA2MzAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNjMwVDAzNDc0NFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTJjOGVhYjQyNDljZmE3ZjliZDVjZDExY2Q1ZTRhZjA0Yzk3ZmE1ZDdkMTkxNjkzOGNhZTRmZmMzN2QwNzkxMmUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT12aWRlbyUyRm1wNCJ9.vsNFWIr0ezVOVC8MRTYLb72Akc88k7Ln0ih3I5AJHW8)

### What issues does this PR fix or reference?

Fix #17173.

Follow up issue #18100 to fix specific use case (pre-existing) on linux. It related to detection native linux socket liveness.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
