### PR TITLE
feat(certificate-sync): sync local CA certs when creating podman vm

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -140,6 +140,14 @@
           "when": "podman.podmanMachineEditRootfulSupported",
           "hidden": true
         },
+        "podman.machine.importNativeCA": {
+          "type": "boolean",
+          "default": false,
+          "scope": "ContainerConnection",
+          "markdownDescription": "Import host trusted CA certificates into the machine during startup. See [documentation](https://docs.podman.io/en/latest/markdown/podman-machine-init.1.html#import-native-ca).",
+          "when": "podman.podmanMachineEditImportNativeCASupported",
+          "hidden": true
+        },
         "podman.factory.machine.name": {
           "type": "string",
           "default": "podman-machine-default",
@@ -232,6 +240,21 @@
           "scope": "ContainerProviderConnectionFactory",
           "description": "Start the machine now",
           "when": "podman.isStartNowAtMachineInitSupported"
+        },
+        "podman.factory.machine.import-native-ca": {
+          "type": "boolean",
+          "default": true,
+          "scope": "ContainerProviderConnectionFactory",
+          "markdownDescription": "Import host trusted CA certificates into the machine during startup. See [documentation](https://docs.podman.io/en/latest/markdown/podman-machine-init.1.html#import-native-ca).",
+          "when": "podman.isImportNativeCASupported == true"
+        },
+        "podman.factory.machine.import-native-ca-lt-6": {
+          "type": "boolean",
+          "default": false,
+          "scope": "ContainerProviderConnectionFactory",
+          "markdownDescription": "Import host trusted CA certificates into the machine during startup.<br/>This option is supported only for podman 6 and above. Use manual sync of CA certificates instead.",
+          "when": "podman.isImportNativeCASupported == false",
+          "readonly": true
         },
         "podman.setting.rosetta": {
           "type": "boolean",

--- a/extensions/podman/packages/extension/src/constants.ts
+++ b/extensions/podman/packages/extension/src/constants.ts
@@ -32,6 +32,8 @@ export const PODMAN_MACHINE_EDIT_MEMORY = 'podman.podmanMachineEditMemorySupport
 export const PODMAN_MACHINE_EDIT_DISK_SIZE = 'podman.podmanMachineEditDiskSizeSupported';
 export const PODMAN_MACHINE_EDIT_ROOTFUL = 'podman.podmanMachineEditRootfulSupported';
 export const PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY = 'podman.isImportNativeCASupported';
+export const PODMAN_EDIT_IMPORT_NATIVE_CA = 'podman.podmanMachineEditImportNativeCASupported';
+
 /**
  * Command ID to uninstall a version of podman installed with non-msi installer
  */

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -20,7 +20,9 @@
 import type * as proc from 'node:child_process';
 import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { arch } from 'node:os';
+import path from 'node:path';
 
 import type { Configuration, ContainerEngineInfo, ContainerProviderConnection } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
@@ -33,6 +35,7 @@ import * as compatibilityModeLib from '/@/compatibility-mode/compatibility-mode'
 import {
   CLEANUP_REQUIRED_MACHINE_KEY,
   CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
+  PODMAN_EDIT_IMPORT_NATIVE_CA,
   PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY,
   PODMAN_MACHINE_CPU_SUPPORTED_KEY,
   PODMAN_MACHINE_DISK_SUPPORTED_KEY,
@@ -56,6 +59,7 @@ import { PodmanBinary } from '/@/utils/podman-binary';
 
 import * as extension from './extension';
 import {
+  getImportNativeCAFromConfig,
   initCheckAndRegisterUpdate,
   registerOnboardingMachineExistsCommand,
   registerOnboardingUnsupportedPodmanMachineCommand,
@@ -298,6 +302,13 @@ const originalConsoleTrace = console.trace;
 const consoleTraceMock = vi.fn();
 
 vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    readFile: vi.fn(),
+  };
+});
 vi.mock(import('node:child_process'), async importOriginal => {
   const childProcessActual = await importOriginal();
   return {
@@ -714,6 +725,72 @@ describe.each([
     expect(telemetryLogger.logUsage).toBeCalledWith(
       'podman.machine.init',
       expect.objectContaining({ cpus: '2', defaultName: true, diskSize: '250000000000', imagePath: 'custom' }),
+    );
+  });
+
+  test('createMachine passes --import-native-ca when param is true and Podman >= 6', async () => {
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '6.0.0' });
+
+    await extension.createMachine(
+      {
+        'podman.factory.machine.cpus': '2',
+        'podman.factory.machine.image': 'path',
+        'podman.factory.machine.memory': '1048000000',
+        'podman.factory.machine.diskSize': '250000000000',
+        'podman.factory.machine.import-native-ca': true,
+        'podman.factory.machine.provider': provider,
+      },
+      podmanConfiguration,
+    );
+
+    expect(vi.mocked(extensionApi.process.exec)).toBeCalledWith(
+      podmanCli.getPodmanCli(),
+      expect.arrayContaining(['--import-native-ca']),
+      expect.any(Object),
+    );
+  });
+
+  test('createMachine does not pass --import-native-ca when param is true but Podman < 6', async () => {
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '5.8.0' });
+
+    await extension.createMachine(
+      {
+        'podman.factory.machine.cpus': '2',
+        'podman.factory.machine.image': 'path',
+        'podman.factory.machine.memory': '1048000000',
+        'podman.factory.machine.diskSize': '250000000000',
+        'podman.factory.machine.import-native-ca': true,
+        'podman.factory.machine.provider': provider,
+      },
+      podmanConfiguration,
+    );
+
+    expect(vi.mocked(extensionApi.process.exec)).not.toBeCalledWith(
+      podmanCli.getPodmanCli(),
+      expect.arrayContaining(['--import-native-ca']),
+      expect.any(Object),
+    );
+  });
+
+  test('createMachine does not pass --import-native-ca when param is false and Podman >= 6', async () => {
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '6.0.0' });
+
+    await extension.createMachine(
+      {
+        'podman.factory.machine.cpus': '2',
+        'podman.factory.machine.image': 'path',
+        'podman.factory.machine.memory': '1048000000',
+        'podman.factory.machine.diskSize': '250000000000',
+        'podman.factory.machine.import-native-ca': false,
+        'podman.factory.machine.provider': provider,
+      },
+      podmanConfiguration,
+    );
+
+    expect(vi.mocked(extensionApi.process.exec)).not.toBeCalledWith(
+      podmanCli.getPodmanCli(),
+      expect.arrayContaining(['--import-native-ca']),
+      expect.any(Object),
     );
   });
 });
@@ -1966,6 +2043,82 @@ test('provider is registered with limited edit capabilities on (HyperV) Windows'
     expect.arrayContaining(['machine', 'set', machineInfo.name, '--rootful=true']),
     expect.any(Object),
   );
+});
+
+describe('edit lifecycle importNativeCA', () => {
+  function mockExecForMachineEdit() {
+    const spyExecPromise = vi.spyOn(extensionApi.process, 'exec');
+    spyExecPromise.mockImplementation(
+      (_command, args) =>
+        new Promise<extensionApi.RunResult>((resolve, reject) => {
+          if (args?.[0] === 'machine' && args?.[1] === 'list') {
+            resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
+          } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
+            resolve({
+              stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Rootful: true }]),
+            } as extensionApi.RunResult);
+          } else if (args?.[0] === 'machine' && args?.[1] === 'set') {
+            resolve({ stdout: '' } as extensionApi.RunResult);
+          } else {
+            reject(new Error('unexpected command'));
+          }
+        }),
+    );
+    return spyExecPromise;
+  }
+
+  function mockRegisterConnection() {
+    let registeredConnection: ContainerProviderConnection | undefined;
+    vi.mocked(provider.registerContainerProviderConnection).mockImplementation(connection => {
+      registeredConnection = connection;
+      return Disposable.from({ dispose: () => {} });
+    });
+    return () => registeredConnection;
+  }
+
+  test.each([
+    { importNativeCA: true, expectedArg: '--import-native-ca=true' },
+    { importNativeCA: false, expectedArg: '--import-native-ca=false' },
+  ])('passes --import-native-ca=$importNativeCA when Podman >= 6', async ({ importNativeCA, expectedArg }) => {
+    vi.mocked(extensionApi.env).isMac = true;
+    extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '6.0.0' } as InstalledPodman);
+    const spyExecPromise = mockExecForMachineEdit();
+    const getConnection = mockRegisterConnection();
+
+    await extension.registerProviderFor(provider, podmanConfiguration, machineInfo, 'socket');
+    expect(getConnection()?.lifecycle?.edit).toBeDefined();
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_EDIT_IMPORT_NATIVE_CA, true);
+
+    await getConnection()?.lifecycle?.edit?.({} as unknown as extensionApi.LifecycleContext, {
+      'podman.machine.importNativeCA': importNativeCA,
+    });
+    expect(spyExecPromise).toBeCalledWith(
+      expect.any(String),
+      expect.arrayContaining(['machine', 'set', machineInfo.name, expectedArg]),
+      expect.any(Object),
+    );
+  });
+
+  test('does not pass --import-native-ca when Podman < 6', async () => {
+    vi.mocked(extensionApi.env).isMac = true;
+    extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version: '5.3.0' } as InstalledPodman);
+    const spyExecPromise = mockExecForMachineEdit();
+    const getConnection = mockRegisterConnection();
+
+    await extension.registerProviderFor(provider, podmanConfiguration, machineInfo, 'socket');
+    expect(extensionApi.context.setValue).toBeCalledWith(PODMAN_EDIT_IMPORT_NATIVE_CA, false);
+
+    await getConnection()?.lifecycle?.edit?.({} as unknown as extensionApi.LifecycleContext, {
+      'podman.machine.importNativeCA': true,
+    });
+    expect(spyExecPromise).not.toBeCalledWith(
+      expect.any(String),
+      expect.arrayContaining(['--import-native-ca=true']),
+      expect.any(Object),
+    );
+  });
 });
 
 test.each([
@@ -3850,6 +4003,62 @@ describe('activate sets PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY', () => {
     } as unknown as UpdateCheck);
     await extension.activate(getContextMock());
     expect(extensionApi.context.setValue).toHaveBeenCalledWith(PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY, supported);
+  });
+});
+
+describe('getImportNativeCAFromConfig', () => {
+  test('should return false when machineInspect is undefined', async () => {
+    const result = await getImportNativeCAFromConfig('machine1', undefined);
+    expect(result).toBe(false);
+  });
+
+  test('should return false when ConfigDir is missing', async () => {
+    const result = await getImportNativeCAFromConfig('machine1', { Rootful: true });
+    expect(result).toBe(false);
+  });
+
+  test('should return false when ConfigDir.Path is missing', async () => {
+    const result = await getImportNativeCAFromConfig('machine1', { ConfigDir: {} });
+    expect(result).toBe(false);
+  });
+
+  test('should return true when config file has ImportNativeCA set to true', async () => {
+    vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify({ ImportNativeCA: true }));
+    const configDir = path.join('some', 'config', 'dir');
+    const result = await getImportNativeCAFromConfig('machine1', { ConfigDir: { Path: configDir } });
+    expect(result).toBe(true);
+    expect(readFile).toHaveBeenCalledWith(path.join(configDir, 'machine1.json'), 'utf-8');
+  });
+
+  test('should return false when config file has ImportNativeCA set to false', async () => {
+    vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify({ ImportNativeCA: false }));
+    const result = await getImportNativeCAFromConfig('machine1', {
+      ConfigDir: { Path: path.join('some', 'config', 'dir') },
+    });
+    expect(result).toBe(false);
+  });
+
+  test('should return false when config file does not have ImportNativeCA field', async () => {
+    vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify({ Rootful: true }));
+    const result = await getImportNativeCAFromConfig('machine1', {
+      ConfigDir: { Path: path.join('some', 'config', 'dir') },
+    });
+    expect(result).toBe(false);
+  });
+
+  test('should return false when reading config file throws an error', async () => {
+    vi.mocked(readFile).mockRejectedValueOnce(new Error('ENOENT: no such file'));
+    const result = await getImportNativeCAFromConfig('machine1', {
+      ConfigDir: { Path: path.join('nonexistent', 'dir') },
+    });
+    expect(result).toBe(false);
+  });
+
+  test('should construct correct file path from configDir and machineName', async () => {
+    vi.mocked(readFile).mockResolvedValueOnce(JSON.stringify({ ImportNativeCA: true }));
+    const configDir = path.join('home', 'user', '.config', 'containers', 'podman', 'machine', 'applehv');
+    await getImportNativeCAFromConfig('my-vm', { ConfigDir: { Path: configDir } });
+    expect(readFile).toHaveBeenCalledWith(path.join(configDir, 'my-vm.json'), 'utf-8');
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -18,6 +18,7 @@
 
 import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import * as http from 'node:http';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -33,6 +34,7 @@ import {
   CLEANUP_REQUIRED_MACHINE_KEY,
   CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
   PODMAN_DOCKER_COMPAT_ENABLE_KEY,
+  PODMAN_EDIT_IMPORT_NATIVE_CA,
   PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY,
   PODMAN_MACHINE_CPU_SUPPORTED_KEY,
   PODMAN_MACHINE_DISK_SUPPORTED_KEY,
@@ -466,8 +468,9 @@ export async function checkDefaultMachine(machines: MachineJSON[]): Promise<void
   }
 }
 
-async function isRootfulMachine(machineDetails: MachineJSON | MachineInfo): Promise<boolean> {
-  let isRootful = false;
+async function getMachineInspect(
+  machineDetails: MachineJSON | MachineInfo,
+): Promise<Record<string, unknown> | undefined> {
   let vmType: string;
   let machineName: string;
   if ('name' in machineDetails) {
@@ -479,14 +482,39 @@ async function isRootfulMachine(machineDetails: MachineJSON | MachineInfo): Prom
   }
   try {
     const { stdout: machineInspectJson } = await execPodman(['machine', 'inspect', machineName], vmType);
-    const machinesInspect = JSON.parse(machineInspectJson);
-    // find the machine name in the array
-    const machineInspect = machinesInspect.find((machine: { Name: string }) => machine.Name === machineName);
-    isRootful = machineInspect?.Rootful ?? false;
+    const machinesInspect = JSON.parse(machineInspectJson) as Record<string, unknown>[];
+    return machinesInspect.find((machine: Record<string, unknown>) => machine.Name === machineName);
   } catch (error) {
-    console.error('Error when checking rootful machine: ', error);
+    console.error('Error when inspecting machine: ', error);
   }
-  return isRootful;
+  return undefined;
+}
+
+async function isRootfulMachine(machineDetails: MachineJSON | MachineInfo): Promise<boolean> {
+  const machineInspect = await getMachineInspect(machineDetails);
+  return (machineInspect?.Rootful as boolean) ?? false;
+}
+
+function isRootfulFromInspect(machineInspect: Record<string, unknown> | undefined): boolean {
+  return (machineInspect?.Rootful as boolean) ?? false;
+}
+
+export async function getImportNativeCAFromConfig(
+  machineName: string,
+  machineInspect: Record<string, unknown> | undefined,
+): Promise<boolean> {
+  const configDir = (machineInspect?.ConfigDir as { Path?: string })?.Path;
+  if (!configDir) {
+    return false;
+  }
+  try {
+    const configFile = path.join(configDir, `${machineName}.json`);
+    const content = JSON.parse(await readFile(configFile, 'utf-8'));
+    return content.ImportNativeCA ?? false;
+  } catch (error) {
+    console.error('Error reading ImportNativeCA from machine config: ', error);
+  }
+  return false;
 }
 
 async function getDefaultConnection(): Promise<ConnectionJSON | undefined> {
@@ -511,7 +539,8 @@ async function updateContainerConfiguration(
 ): Promise<void> {
   // get configuration for this connection
   const containerConfiguration = extensionApi.configuration.getConfiguration('podman', containerProviderConnection);
-  const isRootful = await isRootfulMachine(machineInfo);
+  const machineInspect = await getMachineInspect(machineInfo);
+  const isRootful = isRootfulFromInspect(machineInspect);
 
   // Set values for the machine
   await containerConfiguration.update('machine.cpus', machineInfo.cpus);
@@ -522,6 +551,9 @@ async function updateContainerConfiguration(
   await containerConfiguration.update('machine.diskSizeUsage', machineInfo.diskUsage);
 
   await containerConfiguration.update('machine.rootful', isRootful);
+
+  const importNativeCA = await getImportNativeCAFromConfig(machineInfo.name, machineInspect);
+  await containerConfiguration.update('machine.importNativeCA', importNativeCA);
 }
 
 function calcMacosSocketPath(machineName: string): string {
@@ -750,13 +782,22 @@ export async function registerProviderFor(
   const isEditDiskSizeSupported = extensionApi.env.isMac;
   const isEditRootfulSupported = extensionApi.env.isMac || extensionApi.env.isWindows;
 
+  const podmanInstallation = await podmanBinary.getBinaryInfo();
+  const podmanVersion = podmanInstallation?.version;
+  const isEditImportNativeCASupported = podmanVersion ? isPodman6OrLater(podmanVersion) : false;
+
   const isEditSupported =
-    isEditMemorySupported || isEditCPUSupported || isEditDiskSizeSupported || isEditRootfulSupported;
+    isEditMemorySupported ||
+    isEditCPUSupported ||
+    isEditDiskSizeSupported ||
+    isEditRootfulSupported ||
+    isEditImportNativeCASupported;
 
   extensionApi.context.setValue(PODMAN_MACHINE_EDIT_MEMORY, isEditMemorySupported);
   extensionApi.context.setValue(PODMAN_MACHINE_EDIT_CPU, isEditCPUSupported);
   extensionApi.context.setValue(PODMAN_MACHINE_EDIT_DISK_SIZE, isEditDiskSizeSupported);
   extensionApi.context.setValue(PODMAN_MACHINE_EDIT_ROOTFUL, isEditRootfulSupported);
+  extensionApi.context.setValue(PODMAN_EDIT_IMPORT_NATIVE_CA, isEditImportNativeCASupported);
 
   const lifecycle: extensionApi.ProviderConnectionLifecycle = {
     start: async (context, logger): Promise<void> => {
@@ -810,6 +851,9 @@ export async function registerProviderFor(
           args.push(`--rootful=${params[key]}`);
           effective = true;
           isRootful = params[key];
+        } else if (isEditImportNativeCASupported && key === 'podman.machine.importNativeCA') {
+          args.push(`--import-native-ca=${params[key]}`);
+          effective = true;
         }
       }
       if (effective) {
@@ -865,7 +909,8 @@ export async function registerProviderFor(
 
   // get configuration for this connection
   const containerConfiguration = extensionApi.configuration.getConfiguration('podman', containerProviderConnection);
-  const isRootful = await isRootfulMachine(machineInfo);
+  const machineInspect = await getMachineInspect(machineInfo);
+  const isRootful = isRootfulFromInspect(machineInspect);
 
   // Set values for the machine
   await containerConfiguration.update('machine.cpus', machineInfo.cpus);
@@ -876,6 +921,9 @@ export async function registerProviderFor(
   await containerConfiguration.update('machine.diskSizeUsage', machineInfo.diskUsage);
 
   await containerConfiguration.update('machine.rootful', isRootful);
+
+  const importNativeCA = await getImportNativeCAFromConfig(machineInfo.name, machineInspect);
+  await containerConfiguration.update('machine.importNativeCA', importNativeCA);
 
   currentConnections.set(machineInfo.name, disposable);
   storedExtensionContext?.subscriptions.push(disposable);
@@ -2178,6 +2226,14 @@ export async function createMachine(
   if (params['podman.factory.machine.user-mode-networking']) {
     parameters.push('--user-mode-networking');
     telemetryRecords.userModeNetworking = true;
+  }
+
+  const isPodmanV6OrLater = version ? isPodman6OrLater(version) : false;
+  if (params['podman.factory.machine.import-native-ca'] && isPodmanV6OrLater) {
+    parameters.push('--import-native-ca');
+    telemetryRecords.importNativeCA = true;
+  } else {
+    telemetryRecords.importNativeCA = false;
   }
 
   // name at the end

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -25,6 +25,8 @@ import { compare } from 'semver';
 
 import { getDetectionChecks } from '/@/checks/detection-checks';
 import {
+  PODMAN_EDIT_IMPORT_NATIVE_CA,
+  PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY,
   PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
   ROOTFUL_MACHINE_INIT_SUPPORTED_KEY,
   START_NOW_MACHINE_INIT_SUPPORTED_KEY,
@@ -34,6 +36,7 @@ import {
   calcPodmanMachineSetting,
   getJSONMachineList,
   isLibkrunSupported,
+  isPodman6OrLater,
   isRootfulMachineInitSupported,
   isStartNowAtMachineInitSupported,
   isUserModeNetworkingSupported,
@@ -109,6 +112,10 @@ export class PodmanInstall {
         extensionApi.context.setValue(
           PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
           isLibkrunSupported(newInstalledPodman.version),
+        );
+        extensionApi.context.setValue(
+          PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY,
+          isPodman6OrLater(newInstalledPodman.version),
         );
         await calcPodmanMachineSetting();
       }
@@ -319,6 +326,11 @@ export class PodmanInstall {
             PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY,
             isLibkrunSupported(updateInfo.bundledVersion),
           );
+          extensionApi.context.setValue(
+            PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY,
+            isPodman6OrLater(updateInfo.bundledVersion),
+          );
+          extensionApi.context.setValue(PODMAN_EDIT_IMPORT_NATIVE_CA, isPodman6OrLater(updateInfo.bundledVersion));
         } else if (answer === 'Ignore') {
           this.podmanInfo.ignoreVersionUpdate = updateInfo.bundledVersion;
         } else if (answer === 'Open release notes') {


### PR DESCRIPTION
### What does this PR do?

Integrates Podman 6's native --import-native-ca machine flag into Podman Desktop, replacing the manual SSH-based certificate synchronization for Podman >= 6.0 while keeping the manual sync available as a fallback for older versions.

### Screenshot / video of UI

https://github.com/user-attachments/assets/77fa903d-5ad4-4b68-b6be-6dd59507f16e

### What issues does this PR fix or reference?

Closes #17566.
Closes #17146.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
