### PR TITLE
chore: remove ssh2 & cpu-features from built dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,13 +12,11 @@ onlyBuiltDependencies:
   - '@biomejs/biome'
   - core-js
   - core-js-pure
-  - cpu-features
   - electron
   - esbuild
   - msw
   - protobufjs
   - sharp
-  - ssh2
   - svelte-preprocess
   - win-ca
 


### PR DESCRIPTION
### What does this PR do?

We have `ssh2` & `cpu-features` in the built dependency, but I'm not sure we need to build them? Reading the ssh2 repository description, we can see

> SSH2 client and server modules written in pure JavaScript for node.js

Not sure why they have a `binding.gyp` in `lib/protocol/crypto` 

### What issues does this PR fix or reference?

Require rebase after
- https://github.com/podman-desktop/podman-desktop/pull/18115

### How to test this PR?

Production build should be tested 

Do not merge until all platforms have been tested

| Platform | Tested |
| --- | --- |
| linux | :red_circle:  |
| windows | :red_circle: |
| mac | :red_circle: |

Workflow that should be tested with prod binary

1. Start a container
2. Stop a container
3. Pull an image