### PR TITLE
fix(renderer): fix registries table column misalignment 

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.spec.ts
@@ -18,19 +18,21 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { Registry } from '@podman-desktop/api';
+import type { Registry, RegistrySuggestedProvider } from '@podman-desktop/api';
 import { waitFor } from '@testing-library/dom';
 import { render, screen } from '@testing-library/svelte';
 import { default as userEvent } from '@testing-library/user-event';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { registriesInfos } from '/@/stores/registries';
+import { registriesInfos, registriesSuggestedInfos } from '/@/stores/registries';
 
 import PreferencesRegistriesEditing from './PreferencesRegistriesEditing.svelte';
 
 describe('PreferencesRegistriesEditing', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    registriesInfos.set([]);
+    registriesSuggestedInfos.set([]);
   });
 
   test('Expect that add registry button is visible and enabled', async () => {
@@ -60,6 +62,213 @@ describe('PreferencesRegistriesEditing', () => {
     const button = screen.getByRole('button', { name: 'Add registry' });
     expect(button).toBeInTheDocument();
     expect(button).toBeEnabled();
+  });
+
+  test('Expect registry without name shows serverUrl', async () => {
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://myregistry.example.com',
+      username: 'user',
+      secret: 'secret',
+    };
+    registriesInfos.set([registry]);
+    render(PreferencesRegistriesEditing, {});
+
+    const entry = screen.getByText('myregistry.example.com');
+    expect(entry).toBeInTheDocument();
+  });
+
+  test('Expect registry with alias shows alias instead of username', async () => {
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://test.com',
+      name: 'Test Registry',
+      username: 'user',
+      secret: 'secret',
+      alias: 'myAlias',
+    };
+    registriesInfos.set([registry]);
+    render(PreferencesRegistriesEditing, {});
+
+    expect(screen.getByText('myAlias')).toBeInTheDocument();
+    expect(screen.queryByText('user')).not.toBeInTheDocument();
+  });
+
+  test('Expect registry without credentials shows Login now button', async () => {
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://test.com',
+      name: 'Test Registry',
+      username: '',
+      secret: '',
+    };
+    registriesInfos.set([registry]);
+    render(PreferencesRegistriesEditing, {});
+
+    const loginButton = screen.getByRole('button', { name: 'Login now' });
+    expect(loginButton).toBeInTheDocument();
+  });
+
+  test('Expect edit mode shows Login and Cancel buttons after clicking Edit password', async () => {
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://test.com',
+      name: 'Test Registry',
+      username: 'user',
+      secret: 'secret',
+    };
+    registriesInfos.set([registry]);
+    render(PreferencesRegistriesEditing, {});
+
+    const kebabMenu = screen.getByRole('button', { name: 'kebab menu' });
+    await userEvent.click(kebabMenu);
+
+    const editButton = screen.getByTitle('Edit password');
+    await userEvent.click(editButton);
+
+    const loginButton = screen.getByRole('button', { name: 'Login' });
+    expect(loginButton).toBeInTheDocument();
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    expect(cancelButton).toBeInTheDocument();
+
+    const usernameInput = screen.getByPlaceholderText('Username');
+    expect(usernameInput).toBeInTheDocument();
+  });
+
+  test('Expect cancel in edit mode restores original values', async () => {
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://test.com',
+      name: 'Test Registry',
+      username: 'originalUser',
+      secret: 'originalSecret',
+    };
+    registriesInfos.set([registry]);
+    render(PreferencesRegistriesEditing, {});
+
+    const kebabMenu = screen.getByRole('button', { name: 'kebab menu' });
+    await userEvent.click(kebabMenu);
+
+    const editButton = screen.getByTitle('Edit password');
+    await userEvent.click(editButton);
+
+    const usernameInput = screen.getByPlaceholderText('Username');
+    await userEvent.clear(usernameInput);
+    await userEvent.type(usernameInput, 'newUser');
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancelButton);
+
+    expect(screen.getByText('originalUser')).toBeInTheDocument();
+  });
+
+  test('Expect show/hide password buttons work for existing registry', async () => {
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://test.com',
+      name: 'Test Registry',
+      username: 'user',
+      secret: 'mySecretPassword',
+    };
+    registriesInfos.set([registry]);
+    render(PreferencesRegistriesEditing, {});
+
+    const showButton = screen.getByTitle('Show password');
+    expect(showButton).toBeInTheDocument();
+
+    await userEvent.click(showButton);
+
+    expect(screen.getByText('mySecretPassword')).toBeInTheDocument();
+
+    const hideButton = screen.getByTitle('Hide password');
+    expect(hideButton).toBeInTheDocument();
+
+    await userEvent.click(hideButton);
+
+    expect(screen.queryByText('mySecretPassword')).not.toBeInTheDocument();
+  });
+
+  test('Expect suggested registries are visible with Configure button', async () => {
+    const suggested: RegistrySuggestedProvider = {
+      name: 'Docker Hub',
+      url: 'docker.io',
+    };
+    registriesSuggestedInfos.set([suggested]);
+    render(PreferencesRegistriesEditing, {});
+
+    expect(screen.getByText('Docker Hub')).toBeInTheDocument();
+    const configureButton = screen.getByRole('button', { name: 'Configure' });
+    expect(configureButton).toBeInTheDocument();
+  });
+
+  test('Expect Configure on suggested registry shows login form', async () => {
+    const suggested: RegistrySuggestedProvider = {
+      name: 'Docker Hub',
+      url: 'docker.io',
+    };
+    registriesSuggestedInfos.set([suggested]);
+    render(PreferencesRegistriesEditing, {});
+
+    const configureButton = screen.getByRole('button', { name: 'Configure' });
+    await userEvent.click(configureButton);
+
+    expect(screen.getByText('https://docker.io')).toBeInTheDocument();
+
+    const usernameInput = screen.getByPlaceholderText('Username');
+    expect(usernameInput).toBeInTheDocument();
+
+    const loginButton = screen.getByRole('button', { name: 'Login' });
+    expect(loginButton).toBeInTheDocument();
+    expect(loginButton).toBeDisabled();
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    expect(cancelButton).toBeInTheDocument();
+  });
+
+  test('Expect login in edit mode calls updateImageRegistry', async () => {
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://test.com',
+      name: 'Test Registry',
+      username: 'user',
+      secret: 'secret',
+    };
+    registriesInfos.set([registry]);
+    vi.mocked(window.checkImageCredentials).mockResolvedValue(undefined);
+    vi.mocked(window.updateImageRegistry).mockResolvedValue(undefined);
+    render(PreferencesRegistriesEditing, {});
+
+    const kebabMenu = screen.getByRole('button', { name: 'kebab menu' });
+    await userEvent.click(kebabMenu);
+
+    const editButton = screen.getByTitle('Edit password');
+    await userEvent.click(editButton);
+
+    const loginButton = screen.getByRole('button', { name: 'Login' });
+    await userEvent.click(loginButton);
+
+    await waitFor(() => expect(window.updateImageRegistry).toHaveBeenCalledOnce());
+  });
+
+  test('Expect removing registry calls unregisterImageRegistry', async () => {
+    const registry: Registry = {
+      source: 'test',
+      serverUrl: 'https://test.com',
+      name: 'Test Registry',
+      username: 'user',
+      secret: 'secret',
+    };
+    registriesInfos.set([registry]);
+    render(PreferencesRegistriesEditing, {});
+
+    const kebabMenu = screen.getByRole('button', { name: 'kebab menu' });
+    await userEvent.click(kebabMenu);
+
+    const removeButton = screen.getByTitle('Remove');
+    await userEvent.click(removeButton);
+
+    expect(window.unregisterImageRegistry).toHaveBeenCalledOnce();
   });
 
   test('Expect that adding a registry enables a form, and Add button is initially disabled', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRegistriesEditing.svelte
@@ -267,10 +267,10 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
         class="flex w-full space-x-2 text-sm font-semibold text-[var(--pd-table-header-text)]"
         role="rowgroup"
         aria-label="header">
-        <div class="text-left py-4 uppercase w-2/5 pl-5" role="columnheader">Registry Location</div>
-        <div class="text-left py-4 uppercase w-1/5" role="columnheader">Username</div>
-        <div class="text-left py-4 uppercase w-1/5" role="columnheader">Password</div>
-        <div class="text-left py-4 uppercase w-1/5" role="columnheader"></div>
+        <div class="text-left py-4 uppercase w-2/5 min-w-0 pl-5" role="columnheader">Registry Location</div>
+        <div class="text-left py-4 uppercase w-1/5 min-w-0" role="columnheader">Username</div>
+        <div class="text-left py-4 uppercase w-1/5 min-w-0" role="columnheader">Password</div>
+        <div class="text-left py-4 uppercase w-1/5 min-w-0" role="columnheader"></div>
       </div>
 
       {#each $registriesInfos as registry, index (index)}
@@ -280,19 +280,19 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
           role="row"
           aria-label={registry.name ?? registry.serverUrl}>
           <div class="flex flex-row items-center pt-4 pb-3 space-x-2">
-            <div class="pl-5 w-2/5" role="cell">
+            <div class="pl-5 w-2/5 min-w-0" role="cell">
               <div class="flex w-full h-full">
-                <div class="flex items-center">
+                <div class="flex items-center min-w-0">
                   <!-- Only show if a "suggested" registry icon has been added -->
                   {#if registry.icon}
-                    <IconImage image={registry.icon} class="w-6 h-6" alt={registry.name}></IconImage>
+                    <IconImage image={registry.icon} class="w-6 h-6 shrink-0" alt={registry.name}></IconImage>
                   {/if}
                   {#if registry.name}
-                    <span class="ml-2">
+                    <span class="ml-2 truncate">
                       {registry.name}
                     </span>
                   {:else}
-                    <span class="ml-2">
+                    <span class="ml-2 truncate">
                       {registry.serverUrl.replace('https://', '')}
                     </span>
                   {/if}
@@ -301,7 +301,7 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
             </div>
 
             <!-- Username -->
-            <div class="w-1/5 text-ellipsis overflow-hidden" role="cell">
+            <div class="w-1/5 min-w-0 truncate" role="cell">
               {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
                 <Input placeholder="Username" aria-label="Username" bind:value={registry.username} />
               {:else if !registry.username && !registry.secret}
@@ -313,7 +313,7 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
 
             <!-- Password -->
             {#if originRegistries.some(r => r.serverUrl === registry.serverUrl)}
-              <div class="w-1/5" role="cell">
+              <div class="w-1/5 min-w-0" role="cell">
                 <PasswordInput
                   id="r.serverUrl"
                   bind:password={registry.secret}
@@ -323,25 +323,25 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
                       !showPasswordForServerUrls.some(r => r === registry.serverUrl),
                     )} />
               </div>
-              <div class="w-1/5" role="cell">
+              <div class="w-1/5 min-w-0 flex flex-row items-center justify-end space-x-1" role="cell">
                 <Button onclick={(): Promise<void>=> loginToRegistry(registry)} inProgress={loggingIn}>Login</Button>
                 <Button onclick={(): void => markRegistryAsClean(registry)} type="link">Cancel</Button>
               </div>
             {:else}
-              <div class="w-1/5" role="cell">
+              <div class="w-1/5 min-w-0" role="cell">
                 <!-- Password field start -->
-                <div class="container mx-auto w-full self-center items-center truncate">
+                <div class="w-full self-center items-center truncate">
                   {#if !registry.username && !registry.secret}
                     <span class="no-user-select">&nbsp;</span>
                   {:else if showPasswordForServerUrls.some(r => r === registry.serverUrl)}
-                    {registry.secret}
+                    <span class="truncate block">{registry.secret}</span>
                   {:else}
                     ····················
                   {/if}
                 </div>
                 <!-- Password field end -->
               </div>
-              <div class="w-1/5 flex flex-row space-x-2 justify-end" role="cell">
+              <div class="w-1/5 min-w-0 flex flex-row space-x-2 justify-end" role="cell">
                 <!-- Show/hide password start -->
                 {#if registry.username && registry.secret}
                   {#if showPasswordForServerUrls.some(r => r === registry.serverUrl)}
@@ -407,14 +407,14 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
           role="row"
           aria-label={registry.name ? registry.name : registry.url}>
           <div class="flex flex-row items-center pt-4 pb-3 space-x-2">
-            <div class="pl-5 w-2/5" role="cell">
+            <div class="pl-5 w-2/5 min-w-0" role="cell">
               <div class="flex w-full h-full">
-                <div class="flex items-center">
+                <div class="flex items-center min-w-0">
                   {#if registry.icon}
-                    <IconImage image={registry.icon} class="w-6 h-6" alt={registry.name}></IconImage>
+                    <IconImage image={registry.icon} class="w-6 h-6 shrink-0" alt={registry.name}></IconImage>
                   {/if}
                   <!-- By default, just show the name, but if we go to add it, show the full URL including https -->
-                  <span class="ml-2">
+                  <span class="ml-2 truncate">
                     {#if listedSuggestedRegistries[i]}
                       https://{registry.url}
                     {:else}
@@ -424,12 +424,12 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
                 </div>
               </div>
             </div>
-            <div class="w-1/5" role="cell">
+            <div class="w-1/5 min-w-0" role="cell">
               {#if listedSuggestedRegistries[i]}
                 <Input placeholder="Username" aria-label="Username" bind:value={newRegistryRequest.username} />
               {/if}
             </div>
-            <div class="w-1/5" role="cell">
+            <div class="w-1/5 min-w-0" role="cell">
               {#if listedSuggestedRegistries[i]}
                 <PasswordInput
                   id="r.serverUrl"
@@ -441,7 +441,7 @@ async function removeExistingRegistry(registry: containerDesktopAPI.Registry): P
                     )} />
               {/if}
             </div>
-            <div class="w-1/5 flex space-x-2 justify-end" role="cell">
+            <div class="w-1/5 min-w-0 flex items-center justify-end space-x-1" role="cell">
               {#if listedSuggestedRegistries[i]}
                 <Button
                   onclick={(): Promise<void> => loginToRegistry(newRegistryRequest)}


### PR DESCRIPTION
Signed-off-by: Dias Tursynbayev <original.justmello1337@gmail.com>

### What does this PR do?

Fixes the registries table layout in Settings -> Registries so that columns maintain stable width regardless of content length or view/edit mode. Adds `min-w-0` to all flex column cells to enforce width constraints, applies `truncate` to prevent long passwords/usernames/registry names from pushing the layout, and aligns Login/Cancel buttons to the right to match the Configure button placement

### Screenshot / video of UI

Before:
<img width="1231" height="638" alt="image" src="https://github.com/user-attachments/assets/3d33d6a0-2a08-438d-a169-1a61fb968836" />


After: 
<img width="1320" height="638" alt="image" src="https://github.com/user-attachments/assets/61b8f4f2-50f4-47fb-91ee-e45770309918" />


### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15779

### How to test this PR?

1. Open Settings -> Registries
2. Configure a registry with a long username and password
3. Toggle show/hide password, then columns should remain stable
4. Click "Edit password" and Login/Cancel buttons should align to the right, matching the Configure button
5. Configure a registry (e.g. Docker Hub) at the same time and Login/Cancel buttons should align with the ones above

- [x] Tests are covering the bug fix or the new feature
