### PR TITLE
chore: add product.json file to Compose extension

### DIFF
--- a/extensions/compose/product.json
+++ b/extensions/compose/product.json
@@ -1,0 +1,3 @@
+{
+  "composeMarkdown": "The Compose extension provides optional command line support for [Compose files](https://compose-spec.io/) with Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/tags/compose)"
+}

--- a/extensions/compose/product.json
+++ b/extensions/compose/product.json
@@ -1,3 +1,3 @@
 {
-  "composeMarkdown": "The Compose extension provides optional command line support for [Compose files](https://compose-spec.io/) with Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/tags/compose)"
+  "composeDescription": "The Compose extension provides optional command line support for [Compose files](https://compose-spec.io/) with Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/tags/compose)"
 }

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -47,7 +47,7 @@ export function initTelemetryLogger(): void {
 
 const composeCliName = 'docker-compose';
 const composeDisplayName = 'Compose';
-const composeDescription = product.composeMarkdown ?? '';
+const composeDescription = product.composeDescription ?? '';
 const imageLocation = './icon.png';
 
 let binaryVersion: string | undefined;

--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -23,6 +23,7 @@ import { Octokit } from '@octokit/rest';
 import type { Logger, ProviderUpdate } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 
+import product from '../product.json' with { type: 'json' };
 import { getSystemBinaryPath, installBinaryToSystem } from './cli-run';
 import type { ComposeGithubReleaseArtifactMetadata } from './compose-github-releases';
 import { ComposeGitHubReleases } from './compose-github-releases';
@@ -46,7 +47,7 @@ export function initTelemetryLogger(): void {
 
 const composeCliName = 'docker-compose';
 const composeDisplayName = 'Compose';
-const composeDescription = `The Compose extension provides optional command line support for [Compose files](https://compose-spec.io/) with Podman.\n\nMore information: [Podman Desktop Documentation](https://podman-desktop.io/docs/tags/compose)`;
+const composeDescription = product.composeMarkdown ?? '';
 const imageLocation = './icon.png';
 
 let binaryVersion: string | undefined;


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds a `product.json` file for the Compose extension and updates the CLI tool provider to use the description value from `product.json`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/18096

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
