### PR TITLE
chore: make the extension development documentation link configurable

### DIFF
--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -75,6 +75,7 @@ beforeEach(() => {
   vi.mocked(tmpdir).mockReturnValue(TMP_DIR);
   vi.mocked(product).extensions = {
     remote: [],
+    developmentDocumentation: '',
   };
 
   vi.mocked(ImageRegistry.prototype.getManifestFromImageName).mockResolvedValue(MANIFEST_MOCK);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3393,9 +3393,12 @@ export class PluginSystem {
       },
     );
 
-    this.ipcHandle('extension-development:getExtensionDevelopmentDocsLink', async (_listener): Promise<string> => {
-      return product.extensions.developmentDocumentation;
-    });
+    this.ipcHandle(
+      'extension-development:getExtensionDevelopmentDocsLink',
+      async (_listener): Promise<string | undefined> => {
+        return product.extensions.developmentDocumentation;
+      },
+    );
 
     this.ipcHandle(
       'kubernetes:getTroubleshootingInformation',

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3393,6 +3393,10 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('extension-development:getExtensionDevelopmentDocsLink', async (_listener): Promise<string> => {
+      return product.extensions.developmentDocumentation;
+    });
+
     this.ipcHandle(
       'kubernetes:getTroubleshootingInformation',
       async (_listener: unknown): Promise<KubernetesTroubleshootingInformation> => {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2724,7 +2724,7 @@ export function initExposure(): void {
     return ipcInvoke('extension-development-folders:addDevelopmentFolder', path);
   });
 
-  contextBridge.exposeInMainWorld('getExtensionDevelopmentDocsLink', async (): Promise<string> => {
+  contextBridge.exposeInMainWorld('getExtensionDevelopmentDocsLink', async (): Promise<string | undefined> => {
     return ipcInvoke('extension-development:getExtensionDevelopmentDocsLink');
   });
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2724,6 +2724,10 @@ export function initExposure(): void {
     return ipcInvoke('extension-development-folders:addDevelopmentFolder', path);
   });
 
+  contextBridge.exposeInMainWorld('getExtensionDevelopmentDocsLink', async (): Promise<string> => {
+    return ipcInvoke('extension-development:getExtensionDevelopmentDocsLink');
+  });
+
   contextBridge.exposeInMainWorld(
     'kubernetesGetTroubleshootingInformation',
     async (): Promise<KubernetesTroubleshootingInformation> => {

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.spec.ts
@@ -18,13 +18,39 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import DevelopmentExtensionEmptyScreen from './DevelopmentExtensionEmptyScreen.svelte';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.getExtensionDevelopmentDocsLink).mockResolvedValue(undefined);
+});
 
 test('Expect we see the text of the empty screen', async () => {
   render(DevelopmentExtensionEmptyScreen);
   const emptyText = screen.getByText('Enable Preferences > Extensions > Development Mode to test local extensions');
   expect(emptyText).toBeInTheDocument();
+});
+
+test('Should not show button when extension development link is not configured', async () => {
+  render(DevelopmentExtensionEmptyScreen);
+
+  await waitFor(() => {
+    expect(window.getExtensionDevelopmentDocsLink).toHaveBeenCalled();
+  });
+
+  const button = screen.queryByRole('button', { name: 'How to write your first extension' });
+  expect(button).not.toBeInTheDocument();
+});
+
+test('Should show button when extension development link is configured', async () => {
+  vi.mocked(window.getExtensionDevelopmentDocsLink).mockResolvedValue('https://example.com/docs');
+  render(DevelopmentExtensionEmptyScreen);
+
+  await waitFor(() => {
+    const button = screen.getByRole('button', { name: 'How to write your first extension' });
+    expect(button).toBeInTheDocument();
+  });
 });

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.spec.ts
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.spec.ts
@@ -19,6 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import DevelopmentExtensionEmptyScreen from './DevelopmentExtensionEmptyScreen.svelte';
@@ -30,7 +31,9 @@ beforeEach(() => {
 
 test('Expect we see the text of the empty screen', async () => {
   render(DevelopmentExtensionEmptyScreen);
-  const emptyText = screen.getByText('Enable Preferences > Extensions > Development Mode to test local extensions');
+  const emptyText = await waitFor(() =>
+    screen.getByText('Enable Preferences > Extensions > Development Mode to test local extensions'),
+  );
   expect(emptyText).toBeInTheDocument();
 });
 
@@ -45,12 +48,14 @@ test('Should not show button when extension development link is not configured',
   expect(button).not.toBeInTheDocument();
 });
 
-test('Should show button when extension development link is configured', async () => {
-  vi.mocked(window.getExtensionDevelopmentDocsLink).mockResolvedValue('https://example.com/docs');
+test('Should show button when extension development link is configured and open correct link when clicked', async () => {
+  const testLink = 'https://example.com/docs';
+  vi.mocked(window.getExtensionDevelopmentDocsLink).mockResolvedValue(testLink);
   render(DevelopmentExtensionEmptyScreen);
 
-  await waitFor(() => {
-    const button = screen.getByRole('button', { name: 'How to write your first extension' });
-    expect(button).toBeInTheDocument();
-  });
+  const button = await waitFor(() => screen.getByRole('button', { name: 'How to write your first extension' }));
+  expect(button).toBeInTheDocument();
+
+  await userEvent.click(button);
+  expect(window.openExternal).toHaveBeenCalledWith(testLink);
 });

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.svelte
@@ -1,13 +1,8 @@
 <script lang="ts">
 import { faCog } from '@fortawesome/free-solid-svg-icons';
 import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
-import { onMount } from 'svelte';
 
-let extDevelopementLink: string | undefined;
-
-onMount(async () => {
-  extDevelopementLink = await window.getExtensionDevelopmentDocsLink();
-});
+let extDevelopementLink = $derived(await window.getExtensionDevelopmentDocsLink());
 
 async function openExtensionDocumentation(): Promise<void> {
   await window.openExternal('https://podman-desktop.io/docs/extensions/developing');

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.svelte
@@ -5,7 +5,9 @@ import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
 let extDevelopementLink = $derived(await window.getExtensionDevelopmentDocsLink());
 
 async function openExtensionDocumentation(): Promise<void> {
-  await window.openExternal('https://podman-desktop.io/docs/extensions/developing');
+  if (extDevelopementLink) {
+    await window.openExternal(extDevelopementLink);
+  }
 }
 </script>
 

--- a/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/DevelopmentExtensionEmptyScreen.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 import { faCog } from '@fortawesome/free-solid-svg-icons';
 import { Button, EmptyScreen } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+
+let extDevelopementLink: string | undefined;
+
+onMount(async () => {
+  extDevelopementLink = await window.getExtensionDevelopmentDocsLink();
+});
 
 async function openExtensionDocumentation(): Promise<void> {
   await window.openExternal('https://podman-desktop.io/docs/extensions/developing');
@@ -11,7 +18,9 @@ async function openExtensionDocumentation(): Promise<void> {
   icon={faCog}
   title="Local extensions (developer mode)"
   message="Enable Preferences > Extensions > Development Mode to test local extensions">
-  <div class="flex gap-2 justify-center">
-    <Button type="link" on:click={openExtensionDocumentation}>How to write your first extension</Button>
-  </div>
+  {#if extDevelopementLink}
+    <div class="flex gap-2 justify-center">
+      <Button type="link" on:click={openExtensionDocumentation}>How to write your first extension</Button>
+    </div>
+  {/if}
 </EmptyScreen>

--- a/product.json
+++ b/product.json
@@ -29,7 +29,8 @@
     "default": "https://registry.podman-desktop.io/api/extensions.json"
   },
   "extensions": {
-    "remote": []
+    "remote": [],
+    "developmentDocumentation": "https://podman-desktop.io/docs/extensions/developing"
   },
   "helpMenu": {
     "items": [


### PR DESCRIPTION
### What does this PR do?
Adds the `extensions.developmentDocumentation` property in the main `product.json` file to make the extension development documentation link configurable. If such value does not exist, the `How to write your first extension` text won't be shown in the local extension development page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/18097

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
