### PR TITLE
feat(main): rotate learning center guides hourly

### DIFF
--- a/packages/main/src/plugin/learning-center/learning-center.spec.ts
+++ b/packages/main/src/plugin/learning-center/learning-center.spec.ts
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { Guide } from '@podman-desktop/core-api/learning-center';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import productJSONFile from '/@product.json' with { type: 'json' };
+
+import { downloadGuideList } from './learning-center.js';
+
+vi.mock(import('/@product.json'));
+
+function createGuide(id: string): Guide {
+  return { id, url: `https://example.com/${id}`, title: id, description: id, categories: [], icon: '' };
+}
+
+const threeGuides: Guide[] = [createGuide('a'), createGuide('b'), createGuide('c')];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.mocked(productJSONFile).learningCenter = { guides: threeGuides };
+});
+
+describe('downloadGuideList', () => {
+  test('returns all guides without dropping any', () => {
+    const result = downloadGuideList();
+    expect(result).toHaveLength(threeGuides.length);
+    for (const guide of threeGuides) {
+      expect(result).toContainEqual(guide);
+    }
+  });
+
+  test('same hour produces the same order (deterministic)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 1, 10, 0, 0));
+
+    const first = downloadGuideList();
+    const second = downloadGuideList();
+    expect(first).toEqual(second);
+  });
+
+  test('different hours produce different starting positions', () => {
+    vi.useFakeTimers();
+
+    vi.setSystemTime(new Date(2026, 0, 1, 0, 0, 0));
+    const atHour0 = downloadGuideList();
+
+    vi.setSystemTime(new Date(2026, 0, 1, 1, 0, 0));
+    const atHour1 = downloadGuideList();
+
+    expect(atHour0).not.toEqual(atHour1);
+  });
+
+  test('rotation uses startingIndex = hours % length', () => {
+    vi.useFakeTimers();
+
+    for (let hour = 0; hour < 24; hour++) {
+      vi.setSystemTime(new Date(2026, 0, 1, hour, 0, 0));
+      const result = downloadGuideList();
+      const expectedStartIndex = hour % threeGuides.length;
+      expect(result[0]).toEqual(threeGuides[expectedStartIndex]);
+    }
+  });
+
+  test('returns empty array as-is', () => {
+    vi.mocked(productJSONFile).learningCenter = { guides: [] } as typeof productJSONFile.learningCenter;
+    expect(downloadGuideList()).toEqual([]);
+  });
+
+  test('returns single-element array as-is without rotation', () => {
+    const single = [createGuide('only')];
+    vi.mocked(productJSONFile).learningCenter = { guides: single } as typeof productJSONFile.learningCenter;
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 1, 5, 0, 0));
+    expect(downloadGuideList()).toEqual(single);
+
+    vi.setSystemTime(new Date(2026, 0, 1, 17, 0, 0));
+    expect(downloadGuideList()).toEqual(single);
+  });
+});

--- a/packages/main/src/plugin/learning-center/learning-center.ts
+++ b/packages/main/src/plugin/learning-center/learning-center.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2025 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,5 +21,11 @@ import type { Guide } from '@podman-desktop/core-api/learning-center';
 import product from '/@product.json' with { type: 'json' };
 
 export function downloadGuideList(): Guide[] {
-  return product.learningCenter.guides;
+  const guides = product.learningCenter.guides;
+  if (guides.length <= 1) {
+    return guides;
+  }
+
+  const startingIndex = new Date().getHours() % guides.length;
+  return Array.from({ length: guides.length }, (_, i) => guides[(startingIndex + i) % guides.length]);
 }

--- a/packages/main/src/plugin/recommendations/recommendations-registry.ts
+++ b/packages/main/src/plugin/recommendations/recommendations-registry.ts
@@ -29,6 +29,7 @@ import { inject, injectable } from 'inversify';
 import { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { Featured } from '/@/plugin/featured/featured.js';
+import { rotateArray } from '/@/plugin/util/array-mutation.js';
 
 // eslint-disable-next-line no-restricted-imports
 import recommendations from '../../../../../recommendations.json' with { type: 'json' };
@@ -139,13 +140,7 @@ export class RecommendationsRegistry {
     if (limit >= 0 && extensionBanners.length > limit) {
       // instead of using random generator we ensure deterministic results for a period of time (here by the hours)
       const startingIndex = new Date().getHours() % extensionBanners.length;
-
-      // Let's return the subset of banners starting at the chosen index
-      // and filter out all potential undefined items
-      return Array.from(
-        { length: limit },
-        (_, i) => extensionBanners[(startingIndex + i) % extensionBanners.length],
-      ).filter((value): value is ExtensionBanner => value !== undefined);
+      return rotateArray(extensionBanners, startingIndex).slice(0, limit);
     }
     return extensionBanners;
   }

--- a/packages/main/src/plugin/util/array-mutation.spec.ts
+++ b/packages/main/src/plugin/util/array-mutation.spec.ts
@@ -1,0 +1,66 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import { rotateArray } from './array-mutation.js';
+
+describe('rotateArray', () => {
+  test('returns empty array as-is', () => {
+    expect(rotateArray([], 0)).toEqual([]);
+    expect(rotateArray([], 5)).toEqual([]);
+  });
+
+  test('returns single-element array as-is', () => {
+    expect(rotateArray(['a'], 0)).toEqual(['a']);
+    expect(rotateArray(['a'], 3)).toEqual(['a']);
+  });
+
+  test('rotates from given start index', () => {
+    const items = ['a', 'b', 'c', 'd'];
+    expect(rotateArray(items, 0)).toEqual(['a', 'b', 'c', 'd']);
+    expect(rotateArray(items, 1)).toEqual(['b', 'c', 'd', 'a']);
+    expect(rotateArray(items, 2)).toEqual(['c', 'd', 'a', 'b']);
+    expect(rotateArray(items, 3)).toEqual(['d', 'a', 'b', 'c']);
+  });
+
+  test('wraps around when start index exceeds length', () => {
+    const items = ['a', 'b', 'c'];
+    expect(rotateArray(items, 3)).toEqual(['a', 'b', 'c']);
+    expect(rotateArray(items, 4)).toEqual(['b', 'c', 'a']);
+    expect(rotateArray(items, 7)).toEqual(['b', 'c', 'a']);
+  });
+
+  test('handles negative start index by wrapping', () => {
+    const items = ['a', 'b', 'c'];
+    expect(rotateArray(items, -1)).toEqual(['c', 'a', 'b']);
+    expect(rotateArray(items, -2)).toEqual(['b', 'c', 'a']);
+  });
+
+  test('does not mutate the original array', () => {
+    const items = ['a', 'b', 'c'];
+    rotateArray(items, 1);
+    expect(items).toEqual(['a', 'b', 'c']);
+  });
+
+  test('preserves generic typing', () => {
+    const items = [1, 2, 3];
+    const result: number[] = rotateArray(items, 1);
+    expect(result).toEqual([2, 3, 1]);
+  });
+});

--- a/packages/main/src/plugin/util/array-mutation.ts
+++ b/packages/main/src/plugin/util/array-mutation.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2026 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Guide } from '@podman-desktop/core-api/learning-center';
-
-import { rotateArray } from '/@/plugin/util/array-mutation.js';
-import product from '/@product.json' with { type: 'json' };
-
-export function downloadGuideList(): Guide[] {
-  const guides = product.learningCenter.guides;
-  if (guides.length <= 1) {
-    return guides;
+/**
+ * Rotates an array so that the element at {@link startIndex} becomes the first element.
+ * Returns a new array without mutating the original.
+ */
+export function rotateArray<T>(items: T[], startIndex: number): T[] {
+  if (items.length <= 1) {
+    return items;
   }
-
-  const startingIndex = new Date().getHours() % guides.length;
-  return rotateArray(guides, startingIndex);
+  const normalizedIndex = ((startIndex % items.length) + items.length) % items.length;
+  return [...items.slice(normalizedIndex), ...items.slice(0, normalizedIndex)];
 }


### PR DESCRIPTION
### What does this PR do?
Rotate the guides list based on the current hour so that different guides appear first throughout the day, giving each guide equal visibility over time.

### Screenshot / video of UI

Prev: 
<img width="1102" height="817" alt="image" src="https://github.com/user-attachments/assets/a7ef83ff-fd67-4b66-9a1a-878b673089a2" />


Now: 
<img width="1102" height="817" alt="image" src="https://github.com/user-attachments/assets/1748bc8a-d533-46de-ad8a-04250bf8fa74" />


### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/15741

### How to test this PR?
Open PD you should not see 'Working with kubernetes' as first one (or like you can, but after another hour it should show different item as a first one :D )

- [x] Tests are covering the bug fix or the new feature
