### PR TITLE
feat(ui): persist table expanded/collapsed state across remounts

### DIFF
--- a/packages/ui/src/lib/table/Table.spec.ts
+++ b/packages/ui/src/lib/table/Table.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,12 @@ import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Table, TableColumn, tablePersistence } from '/@/lib';
 import SimpleColumn from '/@/lib/table/SimpleColumn.svelte';
 import { Column, Row } from '/@/lib/table/table';
+import { collapsedStateMap } from '/@/lib/table/table-persistence-store.svelte';
 
 import TestTable from './TestTable.svelte';
 
@@ -648,5 +649,151 @@ describe('Table#collapsed', () => {
     // Should not have layout management button
     const layoutButton = screen.queryByTitle('Configure Columns');
     expect(layoutButton).not.toBeInTheDocument();
+  });
+});
+
+describe('Table collapse state persistence across remounts', () => {
+  interface Item {
+    id: string;
+    name?: string;
+  }
+
+  const ROW = new Row<Item>({
+    children: (item): Item[] => [{ id: `${item.id}-child`, name: `${item.name} child` }],
+  });
+
+  const COLUMN = new Column<Item, string>('Name', {
+    width: '3fr',
+    renderMapping: (obj): string => obj.name ?? 'unknown',
+    renderer: SimpleColumn,
+  });
+
+  beforeEach(() => {
+    collapsedStateMap.clear();
+  });
+
+  test('collapsed state is restored when Table with same kind is remounted', async () => {
+    const data: Item[] = [{ id: 'group1', name: 'Group 1' }];
+
+    const { unmount, getByRole } = render(Table<Item>, {
+      kind: 'remount-test',
+      data,
+      columns: [COLUMN],
+      row: ROW,
+      key: (item: Item): string => item.id,
+    });
+
+    const collapseBtn = getByRole('button', { name: 'Collapse Row' });
+    expect(collapseBtn).toHaveAttribute('aria-expanded', 'true');
+
+    await fireEvent.click(collapseBtn);
+
+    const expandBtn = getByRole('button', { name: 'Expand Row' });
+    expect(expandBtn).toHaveAttribute('aria-expanded', 'false');
+
+    unmount();
+
+    const { getByRole: getByRole2 } = render(Table<Item>, {
+      kind: 'remount-test',
+      data,
+      columns: [COLUMN],
+      row: ROW,
+      key: (item: Item): string => item.id,
+    });
+
+    const expandBtn2 = getByRole2('button', { name: 'Expand Row' });
+    expect(expandBtn2).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('different kind values maintain independent collapsed state', async () => {
+    const data: Item[] = [{ id: 'group1', name: 'Group 1' }];
+
+    const { unmount, getByRole } = render(Table<Item>, {
+      kind: 'kind-a',
+      data,
+      columns: [COLUMN],
+      row: ROW,
+      key: (item: Item): string => item.id,
+    });
+
+    await fireEvent.click(getByRole('button', { name: 'Collapse Row' }));
+    unmount();
+
+    const { getByRole: getByRole2 } = render(Table<Item>, {
+      kind: 'kind-b',
+      data,
+      columns: [COLUMN],
+      row: ROW,
+      key: (item: Item): string => item.id,
+    });
+
+    const collapseBtn = getByRole2('button', { name: 'Collapse Row' });
+    expect(collapseBtn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('expanding a previously collapsed row updates the persisted state', async () => {
+    const data: Item[] = [{ id: 'group1', name: 'Group 1' }];
+
+    const { unmount, getByRole } = render(Table<Item>, {
+      kind: 'toggle-back-test',
+      data,
+      columns: [COLUMN],
+      row: ROW,
+      key: (item: Item): string => item.id,
+    });
+
+    await fireEvent.click(getByRole('button', { name: 'Collapse Row' }));
+    await fireEvent.click(getByRole('button', { name: 'Expand Row' }));
+
+    unmount();
+
+    const { getByRole: getByRole2 } = render(Table<Item>, {
+      kind: 'toggle-back-test',
+      data,
+      columns: [COLUMN],
+      row: ROW,
+      key: (item: Item): string => item.id,
+    });
+
+    const collapseBtn = getByRole2('button', { name: 'Collapse Row' });
+    expect(collapseBtn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('multiple rows persist their individual collapsed state', async () => {
+    const data: Item[] = [
+      { id: 'g1', name: 'Group 1' },
+      { id: 'g2', name: 'Group 2' },
+    ];
+
+    const { unmount, getAllByRole } = render(Table<Item>, {
+      kind: 'multi-row-test',
+      data,
+      columns: [COLUMN],
+      row: ROW,
+      key: (item: Item): string => item.id,
+    });
+
+    const collapseButtons = getAllByRole('button', { name: 'Collapse Row' });
+    expect(collapseButtons).toHaveLength(2);
+
+    await fireEvent.click(collapseButtons[0]);
+
+    unmount();
+
+    const { getByRole: getByRole2 } = render(Table<Item>, {
+      kind: 'multi-row-test',
+      data,
+      columns: [COLUMN],
+      row: ROW,
+      key: (item: Item): string => item.id,
+    });
+
+    const g1Row = getByRole2('row', { name: 'Group 1' });
+    const g1Btn = within(g1Row).getByRole('button', { name: 'Expand Row' });
+    expect(g1Btn).toHaveAttribute('aria-expanded', 'false');
+
+    const g2Row = getByRole2('row', { name: 'Group 2' });
+    const g2Btn = within(g2Row).getByRole('button', { name: 'Collapse Row' });
+    expect(g2Btn).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/packages/ui/src/lib/table/Table.svelte
+++ b/packages/ui/src/lib/table/Table.svelte
@@ -17,7 +17,7 @@ import type { ListOrganizerItem } from '../layouts/ListOrganizer';
 import ListOrganizer from '../layouts/ListOrganizer.svelte';
 /* eslint-enable import/no-duplicates */
 import type { Column, Row } from './table';
-import { tablePersistence } from './table-persistence-store.svelte';
+import { collapsedStateMap, tablePersistence } from './table-persistence-store.svelte';
 
 export let kind: string;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -25,7 +25,7 @@ export let columns: Column<T, any>[];
 export let row: Row<T>;
 export let data: T[];
 export let defaultSortColumn: string | undefined = undefined;
-export let collapsed: string[] = [];
+export let collapsed: string[] = collapsedStateMap.get(kind) ?? [];
 /**
  * To better distinct individual row, you can provide a dedicated key method
  *
@@ -332,6 +332,7 @@ function toggleChildren(name: string | undefined): void {
   }
   // trigger Svelte update
   collapsed = collapsed;
+  collapsedStateMap.set(kind, [...collapsed]);
 }
 
 // Handle column order changes from ListOrganizer

--- a/packages/ui/src/lib/table/table-persistence-store.svelte.ts
+++ b/packages/ui/src/lib/table/table-persistence-store.svelte.ts
@@ -19,3 +19,11 @@
 import type { TablePersistence } from './table';
 
 export const tablePersistence = $state<{ storage: TablePersistence | undefined }>({ storage: undefined });
+
+/**
+ * Module-level map that preserves which table rows are collapsed across
+ * component remounts (e.g. when navigating away and back). Keyed by the
+ * Table's `kind` prop so each list maintains independent state.
+ * Cleared on app restart (in-memory only).
+ */
+export const collapsedStateMap = new Map<string, string[]>();


### PR DESCRIPTION
### What does this PR do?
Use a module-level Map keyed by the table's `kind` prop to store collapsed row identifiers. When a Table component remounts with the same kind, it restores the previously persisted collapse state instead of resetting to the default.

### Screenshot / video of UI


https://github.com/user-attachments/assets/2de37caa-0b48-4c73-a71c-f46de8d6cb18


### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/13699

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
