### PR TITLE
chore: remove duplicate autoprefixer entry from lock file

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18628,15 +18628,6 @@ snapshots:
       postcss: 8.5.16
       postcss-value-parser: 4.2.0
 
-  autoprefixer@10.5.0(postcss@8.5.16):
-    dependencies:
-      browserslist: 4.28.2
-      caniuse-lite: 1.0.30001788
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.16
-      postcss-value-parser: 4.2.0
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0


### PR DESCRIPTION
### What does this PR do?

Remove duplicate `autoprefixer@10.5.0(postcss@8.5.16)` snapshot entry from `pnpm-lock.yaml`.

### Screenshot / video of UI

N/A - no UI changes.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Run `pnpm install` and verify it resolves without errors.

- [x] Tests are covering the bug fix or the new feature