### PR TITLE
test(e2e): detect podman machine from system overview exp feature

### DIFF
--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -105,7 +105,7 @@ test.describe('Enhanced dashboard experimental feature', { tag: ['@experimental'
   });
 
     test('Detect Podman machine created from CLI in System Overview', async ({ page, navigationBar }) => {
-      test.setTimeout(320_000);
+      test.setTimeout(620_000);
 
       await setEnhancedDashboardFeature(page, navigationBar, true);
       let dashboardPage = await waitForDashboardState(navigationBar, true);

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -104,6 +104,35 @@ test.describe('Enhanced dashboard experimental feature', { tag: ['@experimental'
     });
   });
 
+    test('Detect Podman machine created from CLI in System Overview', async ({ page, navigationBar }) => {
+      test.setTimeout(320_000);
+
+      await setEnhancedDashboardFeature(page, navigationBar, true);
+      let dashboardPage = await waitForDashboardState(navigationBar, true);
+      await dashboardPage.expandSystemOverview(true);
+
+      await createPodmanMachineFromCLI();
+
+      await test.step('Open dashboard and wait for CLI-created Podman machine', async () => {
+        dashboardPage = await navigationBar.openDashboard();
+        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Starting, { timeout: 300_000 });
+        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Operational, {
+          timeout: 300_000,
+        });
+        await playExpect(dashboardPage.statusButton).toBeEnabled();
+        await dashboardPage.statusButton.click();
+        const resourcesPage = new ResourcesPage(page);
+        await playExpect
+          .poll(async () => resourcesPage.resourceCardIsVisible('podman'), { timeout: 30_000 })
+          .toBeTruthy();
+        const resourcesPodmanConnections = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME);
+        await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: 10_000 });
+      });
+
+      await deletePodmanMachine(page, PODMAN_MACHINE_NAME);
+    });
+
   test('Create Podman machine from Dashboard', async ({ page, navigationBar }) => {
     test.setTimeout(TIMEOUT_CREATE_MACHINE_TEST);
 

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -104,34 +104,36 @@ test.describe('Enhanced dashboard experimental feature', { tag: ['@experimental'
     });
   });
 
-    test('Detect Podman machine created from CLI in System Overview', async ({ page, navigationBar }) => {
-      test.setTimeout(620_000);
+  test('Detect Podman machine created from CLI in System Overview', async ({ page, navigationBar }) => {
+    test.setTimeout(620_000);
 
-      await setEnhancedDashboardFeature(page, navigationBar, true);
-      let dashboardPage = await waitForDashboardState(navigationBar, true);
-      await dashboardPage.expandSystemOverview(true);
+    await setEnhancedDashboardFeature(page, navigationBar, true);
+    let dashboardPage = await waitForDashboardState(navigationBar, true);
+    await dashboardPage.expandSystemOverview(true);
 
-      await createPodmanMachineFromCLI();
+    await createPodmanMachineFromCLI();
 
-      await test.step('Open dashboard and wait for CLI-created Podman machine', async () => {
-        dashboardPage = await navigationBar.openDashboard();
-        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
-        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Starting, { timeout: 300_000 });
-        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Operational, {
-          timeout: 300_000,
-        });
-        await playExpect(dashboardPage.statusButton).toBeEnabled();
-        await dashboardPage.statusButton.click();
-        const resourcesPage = new ResourcesPage(page);
-        await playExpect
-          .poll(async () => resourcesPage.resourceCardIsVisible('podman'), { timeout: 30_000 })
-          .toBeTruthy();
-        const resourcesPodmanConnections = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME);
-        await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: 10_000 });
+    await test.step('Open dashboard and wait for CLI-created Podman machine', async () => {
+      dashboardPage = await navigationBar.openDashboard();
+      await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+      await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Starting, {
+        timeout: PODMAN_MACHINE_STARTUP_TIMEOUT,
       });
-
-      await deletePodmanMachine(page, PODMAN_MACHINE_NAME);
+      await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Operational, {
+        timeout: PODMAN_MACHINE_STARTUP_TIMEOUT,
+      });
+      await playExpect(dashboardPage.statusButton).toBeEnabled();
+      await dashboardPage.statusButton.click();
+      const resourcesPage = new ResourcesPage(page);
+      await playExpect
+        .poll(async () => resourcesPage.resourceCardIsVisible('podman'), { timeout: TIMEOUT_STANDARD })
+        .toBeTruthy();
+      const resourcesPodmanConnections = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME);
+      await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: TIMEOUT_SHORT });
     });
+
+    await deletePodmanMachine(page, PODMAN_MACHINE_NAME);
+  });
 
   test('Create Podman machine from Dashboard', async ({ page, navigationBar }) => {
     test.setTimeout(TIMEOUT_CREATE_MACHINE_TEST);


### PR DESCRIPTION
### What does this PR do?
Adds an e2e test case that checks if a podman machine created from cli is detected through the enhanced dashboard / system overview experimental feature
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #17926 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run `pnpm test:e2e:experimental`
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
