### PR TITLE
fix(main): correct status definition in libpod-dockerode.ts

### DIFF
--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -530,7 +530,7 @@ export class LibpodDockerode {
         statusCodes: {
           200: true,
           204: true,
-          304: 'pod already stopped',
+          304: 'pod already started',
           404: 'no such pod',
           409: 'unexpected error',
           500: 'server error',


### PR DESCRIPTION
### What does this PR do?
The method startPod in [libpod-dockerode.ts](https://github.com/podman-desktop/podman-desktop/blob/main/packages/main/src/plugin/dockerode/libpod-dockerode.ts#L533) has wrong status code definition: pod already stopped.
This PR changes it to `pod already started`.

### Screenshot / video of UI
none
<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes #18088 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
