### PR TITLE
feat(dockerode): add removeSecret method

### DIFF
--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -547,3 +547,29 @@ describe('kube play', () => {
     expect(second.headers.get('Content-Type')).toBe('application/yaml');
   });
 });
+
+describe('secrets', () => {
+  test('removeSecret should call DELETE on libpod secrets endpoint', async () => {
+    const deleteHandler = vi.fn().mockReturnValue(HttpResponse.text('', { status: 204 }));
+
+    server = setupServer(http.delete('http://localhost/v4.2.0/libpod/secrets/secret123', deleteHandler));
+    server.listen({ onUnhandledRequest: 'error' });
+
+    const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+    await (api as unknown as LibPod).removeSecret('secret123');
+
+    expect(deleteHandler).toHaveBeenCalledOnce();
+  });
+
+  test('removeSecret should reject when server returns an error', async () => {
+    server = setupServer(
+      http.delete('http://localhost/v4.2.0/libpod/secrets/secret123', () =>
+        HttpResponse.json({ message: 'no such secret' }, { status: 404 }),
+      ),
+    );
+    server.listen({ onUnhandledRequest: 'error' });
+
+    const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+    await expect((api as unknown as LibPod).removeSecret('secret123')).rejects.toThrow();
+  });
+});

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -256,6 +256,15 @@ export interface LibPod {
   podmanPushManifest(manifestOptions: ManifestPushOptions, authInfo?: Dockerode.AuthConfig): Promise<void>;
   podmanRemoveManifest(manifestName: string): Promise<void>;
   updateNetwork(networkId: string, addDNSServer: string[], removeDNSServer: string[]): Promise<void>;
+  /**
+   * The compatibility endpoint to delete a secret on the podman service has an issue where the path is not recognised;
+   * Therefore, we need to use the official libpod api to be able to remove a secret
+   *
+   * Ref https://github.com/containers/podman/issues/27548
+   * This has been fixed in podman >=5.7
+   * @param secretId
+   */
+  removeSecret(secretId: string): Promise<void>;
 }
 
 // change the method from private to public as we're overriding it
@@ -940,6 +949,27 @@ export class LibpodDockerode {
         path: `/v4.2.0/libpod/networks/${networkId}/update`,
         method: 'POST',
         options: options,
+        statusCodes: {
+          200: true,
+          204: true,
+          400: 'bad parameter',
+          500: 'server error',
+        },
+      };
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(wrapAs<void>(data));
+        });
+      });
+    };
+
+    prototypeOfDockerode.removeSecret = function (secretId: string): Promise<void> {
+      const optsf = {
+        path: `/v4.2.0/libpod/secrets/${secretId}`,
+        method: 'DELETE',
         statusCodes: {
           200: true,
           204: true,


### PR DESCRIPTION
### What does this PR do?

The podman compatibility remove secret endpoint has an issue for version 5.6<= , to allow user with podman version bellow the fix, we can use the podman libpod endpoint for removing secret, which act the same.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/17841

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

Full feature can be tested in https://github.com/podman-desktop/podman-desktop/pull/18152