### PR TITLE
fix(main): ensure Inversify container is disposed on application quit

### DIFF
--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -125,6 +125,10 @@ class TestPluginSystem extends PluginSystem {
   setQuitting(value: boolean): void {
     this.isQuitting = value;
   }
+
+  setContainer(container?: InversifyContainer): void {
+    this.container = container;
+  }
 }
 
 let inversifyContainer: InversifyContainer;
@@ -952,6 +956,49 @@ describe.each<{
     expect(errorMock).toHaveBeenCalledWith(rejectError);
     expect(originalTask.status).toEqual('in-progress');
     expect(originalTask.error).toEqual('Something went wrong while creating container provider: Error: an error');
+  });
+});
+
+type Listener = (...args: unknown[]) => void;
+
+function getElectronAppListener(event: string): Listener {
+  const callback = vi.mocked(app.on).mock.calls.find(([mEvent]) => mEvent === event)?.[1];
+  assert(callback, `cannot find listener for event ${event}`);
+  return callback;
+}
+
+describe('before-quit container disposal', () => {
+  test('should call unbindAll on the container when before-quit is emitted', () => {
+    const beforeQuitCallback = getElectronAppListener('before-quit');
+
+    const unbindAllMock = vi.fn().mockResolvedValue(undefined);
+    pluginSystem.setContainer({ unbindAll: unbindAllMock } as unknown as InversifyContainer);
+
+    beforeQuitCallback();
+
+    expect(unbindAllMock).toHaveBeenCalled();
+  });
+
+  test('should log error if unbindAll throws', () => {
+    const beforeQuitCallback = getElectronAppListener('before-quit');
+    const error = new Error('unbind failed');
+    pluginSystem.setContainer({
+      unbindAll: vi.fn().mockImplementation(() => {
+        throw error;
+      }),
+    } as unknown as InversifyContainer);
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    beforeQuitCallback();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[PluginSystem] error during before-quit handling:', error);
+  });
+
+  test('should not throw when container is undefined', () => {
+    const beforeQuitCallback = getElectronAppListener('before-quit');
+
+    expect(() => beforeQuitCallback()).not.toThrow();
   });
 });
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -284,12 +284,19 @@ export class PluginSystem {
   private extensionLoader!: ExtensionLoader;
   private validExtList!: ExtensionInfo[];
 
+  protected container?: Container;
+
   constructor(
     private trayMenu: TrayMenu,
     private mainWindowDeferred: PromiseWithResolvers<BrowserWindow>,
   ) {
     app.on('before-quit', () => {
       this.isQuitting = true;
+      try {
+        this.container?.unbindAll();
+      } catch (err: unknown) {
+        console.error('[PluginSystem] error during before-quit handling:', err);
+      }
     });
   }
 
@@ -511,7 +518,8 @@ export class PluginSystem {
 
     // init api sender
     const apiSender = this.getApiSender(this.getWebContentsSender());
-    const container = new Container();
+    this.container = new Container();
+    const container = this.container;
     container.bind<ApiSenderType>(ApiSenderType).toConstantValue(apiSender);
     container.bind<IPCHandle>(IPCHandle).toConstantValue(this.ipcHandle);
     container.bind<IPCMainOn>(IPCMainOn).toConstantValue(this.ipcMainOn);


### PR DESCRIPTION
### What does this PR do?

When the application quits, the Inversify container is never properly disposed. This means services relying on `@preDestroy` lifecycle hooks are not called, which can leave resources (like gateways or connections) open during shutdown.

This fix stores the Inversify container as an instance field and calls `container.unbindAll()` in the `before-quit` handler, ensuring all `@preDestroy` hooks run during shutdown.

### Screenshot / video of UI

N/A — no UI changes.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18153

Flagged from https://github.com/OpenKaiden/kaiden/pull/2344

### How to test this PR?

1. Add a `@preDestroy` method with a log statement to any Inversify-managed service
2. Quit the application
3. Verify the `@preDestroy` method is called (log appears)

- [x] Tests are covering the bug fix or the new feature