### PR TITLE
feat(container-registry): create, inspect, remove and list secrets

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -78,6 +78,7 @@ export * from './proxy.js';
 export * from './pull-event.js';
 export * from './release-notes-info.js';
 export * from './search-option.js';
+export * from './secret-info.js';
 export * from './status-bar.js';
 export * from './system-overview-info.js';
 export * from './taskInfo.js';

--- a/packages/api/src/secret-info.ts
+++ b/packages/api/src/secret-info.ts
@@ -1,0 +1,41 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { ProviderContainerConnectionInfo } from '/@/provider-info.js';
+
+export interface SecretInfo {
+  engineId: string;
+  engineName: string;
+  engineType: 'podman' | 'docker';
+  Id: string;
+  Name: string;
+  CreatedAt?: string; // datetime
+  UpdatedAt?: string; // datetime
+  Labels?: Record<string, string>;
+}
+
+export interface SecretCreateOptions {
+  name: string;
+  selectedProvider: ProviderContainerConnectionInfo | undefined;
+  data: string;
+  labels?: Record<string, string>;
+}
+
+export interface SecretCreateResult {
+  id: string;
+  engineId: string;
+}

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -7168,34 +7168,6 @@ describe('listSecrets', () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.Id).toBe('secret1');
   });
-
-  test('should not include SecretData in listing', async () => {
-    const listSecretsMock = vi.fn().mockResolvedValue([
-      {
-        ID: 'secret1',
-        Spec: { Name: 'my-secret', Data: 'should-not-appear' },
-        CreatedAt: '2024-01-01T00:00:00Z',
-        UpdatedAt: '2024-01-01T00:00:00Z',
-      },
-    ]);
-
-    containerRegistry.addInternalProvider('podman1', {
-      name: 'podman',
-      id: 'podman1',
-      api: { listSecrets: listSecretsMock } as unknown as Dockerode,
-      connection: {
-        type: 'podman',
-        name: 'podman',
-        displayName: 'podman',
-        endpoint: { socketPath: '/endpoint1.sock' },
-        status: () => 'started',
-      },
-    });
-
-    const result = await containerRegistry.listSecrets();
-
-    expect(result[0]?.SecretData).toBeUndefined();
-  });
 });
 
 describe('inspectSecret', () => {

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6652,3 +6652,599 @@ describe('ContainerRegistrySettings', () => {
     expect(registeredConfig?.properties?.['container-registry.providerTimeout']?.maximum).toBe(120);
   });
 });
+
+describe('createSecret', () => {
+  test('should throw if no selectedProvider', async () => {
+    await expect(
+      containerRegistry.createSecret({
+        name: 'my-secret',
+        data: 'secret-value',
+        selectedProvider: undefined,
+      }),
+    ).rejects.toThrow('cannot create secret without selected provider');
+  });
+
+  test('should throw if provider has no api', async () => {
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: undefined,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman', internalContainerProvider);
+
+    await expect(
+      containerRegistry.createSecret({
+        name: 'my-secret',
+        data: 'secret-value',
+        selectedProvider: {
+          name: 'podman',
+          endpoint: { socketPath: '/endpoint1.sock' },
+        } as ProviderContainerConnectionInfo,
+      }),
+    ).rejects.toThrow('no running provider for the matching container');
+  });
+
+  test('should create secret with base64-encoded data', async () => {
+    const createSecretMock = vi.fn().mockResolvedValue({ id: 'secret-id-123' });
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: {
+        createSecret: createSecretMock,
+      } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman', internalContainerProvider);
+
+    const result = await containerRegistry.createSecret({
+      name: 'my-secret',
+      data: 'secret-value',
+      selectedProvider: {
+        name: 'podman',
+        endpoint: { socketPath: '/endpoint1.sock' },
+      } as ProviderContainerConnectionInfo,
+    });
+
+    expect(result).toEqual({ id: 'secret-id-123', engineId: 'podman1' });
+    expect(createSecretMock).toHaveBeenCalledWith({
+      Data: Buffer.from('secret-value').toString('base64'),
+      Name: 'my-secret',
+      Labels: undefined,
+    });
+  });
+
+  test('should pass labels when provided', async () => {
+    const createSecretMock = vi.fn().mockResolvedValue({ id: 'secret-id-456' });
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: {
+        createSecret: createSecretMock,
+      } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman', internalContainerProvider);
+
+    await containerRegistry.createSecret({
+      name: 'my-secret',
+      data: 'secret-value',
+      labels: { env: 'prod' },
+      selectedProvider: {
+        name: 'podman',
+        endpoint: { socketPath: '/endpoint1.sock' },
+      } as ProviderContainerConnectionInfo,
+    });
+
+    expect(createSecretMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Labels: { env: 'prod' },
+      }),
+    );
+  });
+
+  test('should track telemetry on success', async () => {
+    const createSecretMock = vi.fn().mockResolvedValue({ id: 'secret-id-123' });
+    const api = {
+      createSecret: createSecretMock,
+    } as unknown as Dockerode;
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman', internalContainerProvider);
+    telemetryTrackMock.mockClear();
+
+    await containerRegistry.createSecret({
+      name: 'my-secret',
+      data: 'secret-value',
+      selectedProvider: {
+        name: 'podman',
+        endpoint: { socketPath: '/endpoint1.sock' },
+      } as ProviderContainerConnectionInfo,
+    });
+
+    expect(telemetryTrackMock).toHaveBeenCalledWith('createSecret', {});
+  });
+
+  test('should track telemetry with error on failure', async () => {
+    const error = new Error('create failed');
+    const createSecretMock = vi.fn().mockRejectedValue(error);
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: {
+        createSecret: createSecretMock,
+      } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman', internalContainerProvider);
+    telemetryTrackMock.mockClear();
+
+    await expect(
+      containerRegistry.createSecret({
+        name: 'my-secret',
+        data: 'secret-value',
+        selectedProvider: {
+          name: 'podman',
+          endpoint: { socketPath: '/endpoint1.sock' },
+        } as ProviderContainerConnectionInfo,
+      }),
+    ).rejects.toThrow('create failed');
+
+    expect(telemetryTrackMock).toHaveBeenCalledWith('createSecret', { error });
+  });
+});
+
+describe('removeSecret', () => {
+  test('should throw if no matching engine', async () => {
+    await expect(containerRegistry.removeSecret('nonexistent', 'secret1')).rejects.toThrow(
+      'internal providers with engineId nonexistent has no api',
+    );
+  });
+
+  test('should use libpodApi when available', async () => {
+    const removeSecretMock = vi.fn().mockResolvedValue(undefined);
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: {} as unknown as Dockerode,
+      libpodApi: {
+        removeSecret: removeSecretMock,
+      } as unknown as LibPod,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman1', internalContainerProvider);
+
+    await containerRegistry.removeSecret('podman1', 'secret123');
+
+    expect(removeSecretMock).toHaveBeenCalledWith('secret123');
+  });
+
+  test('should fall back to dockerode api when libpodApi is not available', async () => {
+    const removeMock = vi.fn().mockResolvedValue(undefined);
+    const getSecretMock = vi.fn().mockReturnValue({ remove: removeMock });
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'docker',
+      id: 'docker1',
+      api: {
+        getSecret: getSecretMock,
+      } as unknown as Dockerode,
+      connection: {
+        type: 'docker',
+        name: 'docker',
+        displayName: 'docker',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('docker1', internalContainerProvider);
+
+    await containerRegistry.removeSecret('docker1', 'secret456');
+
+    expect(getSecretMock).toHaveBeenCalledWith('secret456');
+    expect(removeMock).toHaveBeenCalled();
+  });
+
+  test('should track telemetry on success', async () => {
+    const removeSecretMock = vi.fn().mockResolvedValue(undefined);
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: {} as unknown as Dockerode,
+      libpodApi: {
+        removeSecret: removeSecretMock,
+      } as unknown as LibPod,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman1', internalContainerProvider);
+    telemetryTrackMock.mockClear();
+
+    await containerRegistry.removeSecret('podman1', 'secret123');
+
+    expect(telemetryTrackMock).toHaveBeenCalledWith('removeSecret', {});
+  });
+
+  test('should track telemetry with error on failure', async () => {
+    const error = new Error('remove failed');
+    const removeSecretMock = vi.fn().mockRejectedValue(error);
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: {} as unknown as Dockerode,
+      libpodApi: {
+        removeSecret: removeSecretMock,
+      } as unknown as LibPod,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman1', internalContainerProvider);
+    telemetryTrackMock.mockClear();
+
+    await expect(containerRegistry.removeSecret('podman1', 'secret123')).rejects.toThrow('remove failed');
+
+    expect(telemetryTrackMock).toHaveBeenCalledWith('removeSecret', { error });
+  });
+});
+
+describe('listSecrets', () => {
+  test('should return empty array when no providers', async () => {
+    const result = await containerRegistry.listSecrets();
+    expect(result).toEqual([]);
+  });
+
+  test('should return empty array when provider has no api', async () => {
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: undefined,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman1', internalContainerProvider);
+
+    const result = await containerRegistry.listSecrets();
+    expect(result).toEqual([]);
+  });
+
+  test('should list secrets from a single provider', async () => {
+    const mockSecrets = [
+      {
+        ID: 'secret1',
+        Spec: { Name: 'my-secret', Labels: { env: 'dev' } },
+        CreatedAt: '2024-01-01T00:00:00Z',
+        UpdatedAt: '2024-01-02T00:00:00Z',
+      },
+    ];
+
+    const listSecretsMock = vi.fn().mockResolvedValue(mockSecrets);
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: {
+        listSecrets: listSecretsMock,
+      } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman1', internalContainerProvider);
+
+    const result = await containerRegistry.listSecrets();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      engineName: 'podman',
+      engineId: 'podman1',
+      engineType: 'podman',
+      Name: 'my-secret',
+      Id: 'secret1',
+      CreatedAt: '2024-01-01T00:00:00Z',
+      UpdatedAt: '2024-01-02T00:00:00Z',
+      Labels: { env: 'dev' },
+      SecretData: undefined,
+    });
+  });
+
+  test('should aggregate secrets from multiple providers', async () => {
+    const listSecretsMock1 = vi.fn().mockResolvedValue([
+      {
+        ID: 'secret1',
+        Spec: { Name: 'secret-a' },
+        CreatedAt: '2024-01-01T00:00:00Z',
+        UpdatedAt: '2024-01-01T00:00:00Z',
+      },
+    ]);
+
+    const listSecretsMock2 = vi.fn().mockResolvedValue([
+      {
+        ID: 'secret2',
+        Spec: { Name: 'secret-b' },
+        CreatedAt: '2024-02-01T00:00:00Z',
+        UpdatedAt: '2024-02-01T00:00:00Z',
+      },
+    ]);
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman',
+      id: 'podman1',
+      api: { listSecrets: listSecretsMock1 } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: { socketPath: '/endpoint1.sock' },
+        status: () => 'started',
+      },
+    });
+
+    containerRegistry.addInternalProvider('docker1', {
+      name: 'docker',
+      id: 'docker1',
+      api: { listSecrets: listSecretsMock2 } as unknown as Dockerode,
+      connection: {
+        type: 'docker',
+        name: 'docker',
+        displayName: 'docker',
+        endpoint: { socketPath: '/endpoint2.sock' },
+        status: () => 'started',
+      },
+    });
+
+    const result = await containerRegistry.listSecrets();
+
+    expect(result).toHaveLength(2);
+    expect(result.map(s => s.Id)).toEqual(['secret1', 'secret2']);
+  });
+
+  test('should use secret ID as Name when Spec.Name is missing', async () => {
+    const listSecretsMock = vi.fn().mockResolvedValue([
+      {
+        ID: 'secret-no-name',
+        Spec: {},
+        CreatedAt: '2024-01-01T00:00:00Z',
+        UpdatedAt: '2024-01-01T00:00:00Z',
+      },
+    ]);
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman',
+      id: 'podman1',
+      api: { listSecrets: listSecretsMock } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: { socketPath: '/endpoint1.sock' },
+        status: () => 'started',
+      },
+    });
+
+    const result = await containerRegistry.listSecrets();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.Name).toBe('secret-no-name');
+  });
+
+  test('should gracefully handle provider errors and return empty for that provider', async () => {
+    const listSecretsMockOk = vi.fn().mockResolvedValue([
+      {
+        ID: 'secret1',
+        Spec: { Name: 'good-secret' },
+        CreatedAt: '2024-01-01T00:00:00Z',
+        UpdatedAt: '2024-01-01T00:00:00Z',
+      },
+    ]);
+    const listSecretsMockFail = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman',
+      id: 'podman1',
+      api: { listSecrets: listSecretsMockOk } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: { socketPath: '/endpoint1.sock' },
+        status: () => 'started',
+      },
+    });
+
+    containerRegistry.addInternalProvider('docker1', {
+      name: 'docker',
+      id: 'docker1',
+      api: { listSecrets: listSecretsMockFail } as unknown as Dockerode,
+      connection: {
+        type: 'docker',
+        name: 'docker',
+        displayName: 'docker',
+        endpoint: { socketPath: '/endpoint2.sock' },
+        status: () => 'started',
+      },
+    });
+
+    const result = await containerRegistry.listSecrets();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.Id).toBe('secret1');
+  });
+
+  test('should not include SecretData in listing', async () => {
+    const listSecretsMock = vi.fn().mockResolvedValue([
+      {
+        ID: 'secret1',
+        Spec: { Name: 'my-secret', Data: 'should-not-appear' },
+        CreatedAt: '2024-01-01T00:00:00Z',
+        UpdatedAt: '2024-01-01T00:00:00Z',
+      },
+    ]);
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman',
+      id: 'podman1',
+      api: { listSecrets: listSecretsMock } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: { socketPath: '/endpoint1.sock' },
+        status: () => 'started',
+      },
+    });
+
+    const result = await containerRegistry.listSecrets();
+
+    expect(result[0]?.SecretData).toBeUndefined();
+  });
+});
+
+describe('inspectSecret', () => {
+  test('should throw if no matching engine', async () => {
+    await expect(containerRegistry.inspectSecret('nonexistent', 'secret1')).rejects.toThrow(
+      'internal providers with engineId nonexistent has no api',
+    );
+  });
+
+  test('should return secret info on success', async () => {
+    const inspectMock = vi.fn().mockResolvedValue({
+      ID: 'secret-id-123',
+      Spec: { Name: 'my-secret' },
+      CreatedAt: '2024-01-01T00:00:00Z',
+      UpdatedAt: '2024-01-02T00:00:00Z',
+    });
+    const getSecretMock = vi.fn().mockReturnValue({ inspect: inspectMock });
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      api: {
+        getSecret: getSecretMock,
+      } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+
+    containerRegistry.addInternalProvider('podman1', internalContainerProvider);
+
+    const result = await containerRegistry.inspectSecret('podman1', 'secret-id-123');
+
+    expect(getSecretMock).toHaveBeenCalledWith('secret-id-123');
+    expect(inspectMock).toHaveBeenCalled();
+    expect(result).toEqual({
+      engineName: 'podman',
+      engineId: 'podman1',
+      engineType: 'podman',
+      Name: 'my-secret',
+      Id: 'secret-id-123',
+      CreatedAt: '2024-01-01T00:00:00Z',
+      UpdatedAt: '2024-01-02T00:00:00Z',
+    });
+  });
+});

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -450,7 +450,7 @@ export class ContainerProviderRegistry {
   async createSecret(options: SecretCreateOptions): Promise<SecretCreateResult> {
     if (!options.selectedProvider) throw new Error('cannot create secret without selected provider');
 
-    let telemetryOptions = {};
+    const telemetryOptions: Record<string, unknown> = {};
     try {
       const provider = this.getMatchingContainerProvider(options.selectedProvider);
       if (!provider.api) throw new Error(`provider ${provider.name} has no api`);
@@ -466,7 +466,7 @@ export class ContainerProviderRegistry {
         engineId: provider.id,
       };
     } catch (error: unknown) {
-      telemetryOptions = { error: error };
+      telemetryOptions['error'] = error;
       throw error;
     } finally {
       this.telemetryService.track('createSecret', telemetryOptions);
@@ -474,7 +474,7 @@ export class ContainerProviderRegistry {
   }
 
   async inspectSecret(engineId: string, secretId: string): Promise<SecretInfo> {
-    let telemetryOptions = {};
+    const telemetryOptions: Record<string, unknown> = {};
     try {
       const engine = this.internalProviders.get(engineId);
       if (!engine?.api) {
@@ -493,7 +493,7 @@ export class ContainerProviderRegistry {
         Labels: secret.Spec?.Labels,
       };
     } catch (error) {
-      telemetryOptions = { error: error };
+      telemetryOptions['error'] = error;
       throw error;
     } finally {
       this.telemetryService.track('inspectSecret', telemetryOptions);
@@ -501,7 +501,7 @@ export class ContainerProviderRegistry {
   }
 
   async removeSecret(engineId: string, secretId: string): Promise<void> {
-    let telemetryOptions = {};
+    const telemetryOptions: Record<string, unknown> = {};
     try {
       const engine = this.internalProviders.get(engineId);
       if (engine?.libpodApi) {
@@ -515,7 +515,7 @@ export class ContainerProviderRegistry {
         throw new Error(`internal providers with engineId ${engineId} has no api`);
       }
     } catch (error) {
-      telemetryOptions = { error: error };
+      telemetryOptions['error'] = error;
       throw error;
     } finally {
       this.telemetryService.track('removeSecret', telemetryOptions);
@@ -523,35 +523,42 @@ export class ContainerProviderRegistry {
   }
 
   async listSecrets(): Promise<Array<SecretInfo>> {
+    const telemetryOptions: Record<string, unknown> = {};
     const providers: Array<InternalContainerProvider> = Array.from(this.internalProviders.values());
 
-    const all: SecretInfo[][] = await Promise.all(
-      Array.from(providers).map(async provider => {
-        try {
-          if (!provider.api) {
+    try {
+      const all: SecretInfo[][] = await Promise.all(
+        Array.from(providers).map(async provider => {
+          try {
+            if (!provider.api) {
+              return [];
+            }
+            const secrets = await provider.api.listSecrets();
+            return secrets.map(secret => ({
+              engineName: provider.name,
+              engineId: provider.id,
+              engineType: provider.connection.type,
+              Name: secret.Spec?.Name ?? secret.ID,
+              Id: secret.ID,
+              CreatedAt: secret.CreatedAt,
+              UpdatedAt: secret.UpdatedAt,
+              Labels: secret.Spec?.Labels,
+            }));
+          } catch (error) {
+            this.notifyConsole(`error in engine ${provider.name} ${error}`);
             return [];
           }
-          const secrets = await provider.api.listSecrets();
-          return secrets.map(secret => ({
-            engineName: provider.name,
-            engineId: provider.id,
-            engineType: provider.connection.type,
-            Name:
-              !!secret.Spec && 'Name' in secret.Spec && typeof secret.Spec['Name'] === 'string'
-                ? secret.Spec['Name']
-                : secret.ID,
-            Id: secret.ID,
-            CreatedAt: secret.CreatedAt,
-            UpdatedAt: secret.UpdatedAt,
-            Labels: secret.Spec?.Labels,
-          }));
-        } catch (error) {
-          this.notifyConsole(`error in engine ${provider.name} ${error}`);
-          return [];
-        }
-      }),
-    );
-    return all.flat();
+        }),
+      );
+      const secrets = all.flat();
+      telemetryOptions['total'] = secrets.length;
+      return secrets;
+    } catch (error) {
+      telemetryOptions['error'] = error;
+      throw error;
+    } finally {
+      this.telemetryService.track('listSecrets', telemetryOptions);
+    }
   }
 
   // do not use inspect information

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -54,6 +54,9 @@ import type {
   PodmanListImagesOptions,
   ProviderContainerConnectionInfo,
   PullEvent,
+  SecretCreateOptions,
+  SecretCreateResult,
+  SecretInfo,
   SimpleContainerInfo,
   VolumeCreateOptions,
   VolumeCreateResponseInfo,
@@ -234,6 +237,8 @@ export class ContainerProviderRegistry {
         this.apiSender.send('volume-event');
       } else if (jsonEvent?.Type === 'network') {
         this.apiSender.send('network-event');
+      } else if (jsonEvent?.Type === 'secret') {
+        this.apiSender.send('secret-event');
       } else if (status === 'remove' && jsonEvent?.Type === 'container') {
         this.apiSender.send('container-removed-event', id);
       } else if (status === 'pull' && jsonEvent?.Type === 'image') {
@@ -440,6 +445,113 @@ export class ContainerProviderRegistry {
     if (this.notify) {
       console.log(message);
     }
+  }
+
+  async createSecret(options: SecretCreateOptions): Promise<SecretCreateResult> {
+    if (!options.selectedProvider) throw new Error('cannot create secret without selected provider');
+
+    let telemetryOptions = {};
+    try {
+      const provider = this.getMatchingContainerProvider(options.selectedProvider);
+      if (!provider.api) throw new Error(`provider ${provider.name} has no api`);
+      const { id } = await provider.api.createSecret({
+        // The data need to be encoded in base64 url safe
+        // ref https://docs.podman.io/en/latest/_static/api.html?version=latest#tag/secrets-(compat)/operation/SecretCreate
+        Data: Buffer.from(options.data).toString('base64'),
+        Name: options.name,
+        Labels: options.labels,
+      });
+      return {
+        id,
+        engineId: provider.id,
+      };
+    } catch (error: unknown) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('createSecret', telemetryOptions);
+    }
+  }
+
+  async inspectSecret(engineId: string, secretId: string): Promise<SecretInfo> {
+    let telemetryOptions = {};
+    try {
+      const engine = this.internalProviders.get(engineId);
+      if (!engine?.api) {
+        throw new Error(`internal providers with engineId ${engineId} has no api`);
+      }
+      const secret = await engine.api.getSecret(secretId).inspect();
+
+      return {
+        engineName: engine.name,
+        engineId: engine.id,
+        engineType: engine.connection.type,
+        Name: secret.Spec?.Name ?? secret.ID,
+        Id: secret.ID,
+        CreatedAt: secret.CreatedAt,
+        UpdatedAt: secret.UpdatedAt,
+      };
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('inspectSecret', telemetryOptions);
+    }
+  }
+
+  async removeSecret(engineId: string, secretId: string): Promise<void> {
+    let telemetryOptions = {};
+    try {
+      const engine = this.internalProviders.get(engineId);
+      if (engine?.libpodApi) {
+        // we cannot use the /secrets (compact) api to retreive secret with podman
+        // endpoint is malformed
+        // https://github.com/containers/podman/issues/27548
+        await engine.libpodApi.removeSecret(secretId);
+      } else if (engine?.api) {
+        await engine.api.getSecret(secretId).remove();
+      } else {
+        throw new Error(`internal providers with engineId ${engineId} has no api`);
+      }
+    } catch (error) {
+      telemetryOptions = { error: error };
+      throw error;
+    } finally {
+      this.telemetryService.track('removeSecret', telemetryOptions);
+    }
+  }
+
+  async listSecrets(): Promise<Array<SecretInfo>> {
+    const providers: Array<InternalContainerProvider> = Array.from(this.internalProviders.values());
+
+    const all: SecretInfo[][] = await Promise.all(
+      Array.from(providers).map(async provider => {
+        try {
+          if (!provider.api) {
+            return [];
+          }
+          const secrets = await provider.api.listSecrets();
+          return secrets.map(secret => ({
+            engineName: provider.name,
+            engineId: provider.id,
+            engineType: provider.connection.type,
+            Name:
+              !!secret.Spec && 'Name' in secret.Spec && typeof secret.Spec['Name'] === 'string'
+                ? secret.Spec['Name']
+                : secret.ID,
+            Id: secret.ID,
+            CreatedAt: secret.CreatedAt,
+            UpdatedAt: secret.UpdatedAt,
+            Labels: secret.Spec?.Labels,
+            SecretData: undefined, // do not include secret when listing
+          }));
+        } catch (error) {
+          this.notifyConsole(`error in engine ${provider.name} ${error}`);
+          return [];
+        }
+      }),
+    );
+    return all.flat();
   }
 
   // do not use inspect information

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -490,6 +490,7 @@ export class ContainerProviderRegistry {
         Id: secret.ID,
         CreatedAt: secret.CreatedAt,
         UpdatedAt: secret.UpdatedAt,
+        Labels: secret.Spec?.Labels,
       };
     } catch (error) {
       telemetryOptions = { error: error };
@@ -543,7 +544,6 @@ export class ContainerProviderRegistry {
             CreatedAt: secret.CreatedAt,
             UpdatedAt: secret.UpdatedAt,
             Labels: secret.Spec?.Labels,
-            SecretData: undefined, // do not include secret when listing
           }));
         } catch (error) {
           this.notifyConsole(`error in engine ${provider.name} ${error}`);


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/18151 we can add the `createSecret`, `inspectSecret`, `removeSecret` and `listSecret` methods in the `container-registry`.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17841

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
