### PR TITLE
fix(podman): use MemAvailable instead of MemFree for accurate memory usage

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -1517,13 +1517,17 @@ test('ensure running and not starting machine reports ready provider', async () 
   expect(extension.podmanMachinesStatuses.get('podman-machine-default')).toBe('started');
 });
 
-test('ensure started machine reports configuration', async () => {
+test('ensure started machine reports configuration with SSH-based memory', async () => {
   extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
   vi.spyOn(extensionApi.process, 'exec').mockImplementation(
     (_command, args) =>
-      new Promise<extensionApi.RunResult>(resolve => {
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
         if (args?.[0] === 'machine' && args?.[1] === 'list') {
           resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
+        } else if (args?.[0] === 'machine' && args?.[1] === 'ssh') {
+          resolve({
+            stdout: 'MemTotal:        1023437 kB\nMemFree:          450000 kB\nMemAvailable:      800000 kB\n',
+          } as extensionApi.RunResult);
         } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
           resolve({
             stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Rootful: false }]),
@@ -1534,6 +1538,8 @@ test('ensure started machine reports configuration', async () => {
           } as extensionApi.RunResult);
         } else if (args?.[0] === '--version') {
           resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
+        } else {
+          reject(new Error(`unexpected exec call: ${args?.join(' ')}`));
         }
       }),
   );
@@ -1552,9 +1558,88 @@ test('ensure started machine reports configuration', async () => {
   expect(config.update).toBeCalledWith('machine.memory', Number(fakeMachineJSON[0].Memory));
   expect(config.update).toBeCalledWith('machine.diskSize', Number(fakeMachineJSON[0].DiskSize));
   expect(config.update).toBeCalledWith('machine.cpusUsage', 1);
+  // MemAvailable=800000 kB = 819200000 bytes, memory=1048000000, used=1048000000-819200000=228800000
+  // usage% = 228800000/1048000000*100 ≈ 21.83
+  expect(config.update).toBeCalledWith('machine.memoryUsage', expect.closeTo(21.83, 0));
+  expect(config.update).toBeCalledWith('machine.diskSizeUsage', 20);
+  expect(config.update).toBeCalledWith('machine.rootful', false);
+});
+
+test('ensure started machine falls back to API memoryUsed when SSH fails', async () => {
+  extension.initExtensionContext({ subscriptions: [] } as unknown as extensionApi.ExtensionContext);
+  vi.spyOn(extensionApi.process, 'exec').mockImplementation(
+    (_command, args) =>
+      new Promise<extensionApi.RunResult>((resolve, reject) => {
+        if (args?.[0] === 'machine' && args?.[1] === 'list') {
+          resolve({ stdout: JSON.stringify([fakeMachineJSON[0]]) } as extensionApi.RunResult);
+        } else if (args?.[0] === 'machine' && args?.[1] === 'ssh') {
+          reject(new Error('SSH connection refused'));
+        } else if (args?.[0] === 'machine' && args?.[1] === 'inspect') {
+          resolve({
+            stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Rootful: false }]),
+          } as unknown as extensionApi.RunResult);
+        } else if (args?.[0] === 'system' && args?.[1] === 'connection' && args?.[2] === 'list') {
+          resolve({
+            stdout: JSON.stringify([{ Name: fakeMachineJSON[0].Name, Default: true }]),
+          } as extensionApi.RunResult);
+        } else if (args?.[0] === '--version') {
+          resolve({ stdout: 'podman version 4.9.0' } as extensionApi.RunResult);
+        } else {
+          reject(new Error(`unexpected exec call: ${args?.join(' ')}`));
+        }
+      }),
+  );
+
+  await extension.updateMachines(provider, podmanConfiguration);
+  (extensionApi.containerEngine.info as Mock).mockResolvedValue({
+    cpus: 2,
+    cpuIdle: 99,
+    memory: 1048000000,
+    memoryUsed: 524000000,
+    diskSize: 250000000000,
+    diskUsed: 50000000000,
+  } as ContainerEngineInfo);
+  await extension.updateMachines(provider, podmanConfiguration);
+  expect(config.update).toBeCalledWith('machine.cpus', fakeMachineJSON[0].CPUs);
+  expect(config.update).toBeCalledWith('machine.memory', Number(fakeMachineJSON[0].Memory));
+  expect(config.update).toBeCalledWith('machine.diskSize', Number(fakeMachineJSON[0].DiskSize));
+  expect(config.update).toBeCalledWith('machine.cpusUsage', 1);
+  // Falls back to API-provided memoryUsed: 524000000/1048000000*100 = 50
   expect(config.update).toBeCalledWith('machine.memoryUsage', 50);
   expect(config.update).toBeCalledWith('machine.diskSizeUsage', 20);
   expect(config.update).toBeCalledWith('machine.rootful', false);
+});
+
+test('getMemoryUsedFromMemAvailable parses MemAvailable correctly', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({
+    stdout:
+      'MemTotal:        5603264 kB\nMemFree:         1953732 kB\nMemAvailable:    4509124 kB\nBuffers:          102400 kB\nCached:          2500000 kB\n',
+    stderr: '',
+    command: 'podman',
+  } as extensionApi.RunResult);
+
+  const result = await extension.getMemoryUsedFromMemAvailable('test-machine', 'libkrun', 5737742336);
+  // MemAvailable = 4509124 kB = 4617342976 bytes
+  // used = 5737742336 - 4617342976 = 1120399360
+  expect(result).toBe(5737742336 - 4509124 * 1024);
+});
+
+test('getMemoryUsedFromMemAvailable returns undefined on SSH failure', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockRejectedValue(new Error('connection refused'));
+
+  const result = await extension.getMemoryUsedFromMemAvailable('test-machine', 'libkrun', 5737742336);
+  expect(result).toBeUndefined();
+});
+
+test('getMemoryUsedFromMemAvailable returns undefined if MemAvailable not in output', async () => {
+  vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({
+    stdout: 'MemTotal:        5603264 kB\nMemFree:         1953732 kB\n',
+    stderr: '',
+    command: 'podman',
+  } as extensionApi.RunResult);
+
+  const result = await extension.getMemoryUsedFromMemAvailable('test-machine', 'libkrun', 5737742336);
+  expect(result).toBeUndefined();
 });
 
 test('ensure stopped machine reports configuration', async () => {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -226,6 +226,14 @@ async function doUpdateMachines(
       }
     }
 
+    let memoryUsed = machineInfo?.memoryUsed;
+    if (running && machineInfo?.memory !== undefined && memoryUsed !== undefined) {
+      const corrected = await getMemoryUsedFromMemAvailable(machine.Name, machine.VMType, machineInfo.memory);
+      if (corrected !== undefined) {
+        memoryUsed = corrected;
+      }
+    }
+
     const previousStatus = podmanMachinesStatuses.get(machine.Name);
     if (previousStatus !== status) {
       // notify status change
@@ -246,8 +254,8 @@ async function doUpdateMachines(
           ? (machineInfo?.diskUsed * 100) / machineInfo?.diskSize
           : 0,
       memoryUsage:
-        machineInfo?.memory !== undefined && machineInfo?.memoryUsed !== undefined && machineInfo?.memoryUsed > 0
-          ? (machineInfo?.memoryUsed * 100) / machineInfo?.memory
+        machineInfo?.memory !== undefined && memoryUsed !== undefined && memoryUsed > 0
+          ? (memoryUsed * 100) / machineInfo?.memory
           : 0,
       vmType: machine.VMType,
       port: machine.Port,
@@ -1775,6 +1783,30 @@ export async function calcPodmanMachineSetting(): Promise<void> {
   extensionApi.context.setValue(PODMAN_MACHINE_CPU_SUPPORTED_KEY, cpuSupported);
   extensionApi.context.setValue(PODMAN_MACHINE_MEMORY_SUPPORTED_KEY, memorySupported);
   extensionApi.context.setValue(PODMAN_MACHINE_DISK_SUPPORTED_KEY, diskSupported);
+}
+
+/**
+ * Reads MemAvailable from /proc/meminfo via SSH to compute accurate memory usage.
+ * Returns used bytes (memTotal - memAvailable) or undefined if unavailable.
+ * This works around the Podman API only exposing memFree (which excludes reclaimable buff/cache).
+ * Related issue: https://github.com/podman-desktop/podman-desktop/issues/17488
+ */
+export async function getMemoryUsedFromMemAvailable(
+  machineName: string,
+  vmType: string,
+  memTotal: number,
+): Promise<number | undefined> {
+  try {
+    const { stdout } = await execPodman(['machine', 'ssh', machineName, 'cat /proc/meminfo'], vmType);
+    const match = /MemAvailable:\s+(\d+)\s+kB/.exec(stdout);
+    if (match) {
+      const memAvailableBytes = parseInt(match[1], 10) * 1024;
+      return memTotal - memAvailableBytes;
+    }
+  } catch {
+    // SSH failed — fall back to the API-provided memoryUsed (memTotal - memFree)
+  }
+  return undefined;
 }
 
 // Function that checks to see if the default machine is running and return a string

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2825,7 +2825,10 @@ export class ContainerProviderRegistry {
         cpus: podmanInfo.host.cpus,
         cpuIdle: podmanInfo.host.cpuUtilization.idlePercent,
         memory: podmanInfo.host.memTotal,
-        memoryUsed: podmanInfo.host.memTotal - podmanInfo.host.memFree,
+        memoryUsed:
+          podmanInfo.host.memAvailable !== undefined
+            ? podmanInfo.host.memTotal - podmanInfo.host.memAvailable
+            : podmanInfo.host.memTotal - podmanInfo.host.memFree,
         diskSize: podmanInfo.store.graphRootAllocated,
         diskUsed: podmanInfo.store.graphRootUsed,
       };

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -83,6 +83,7 @@ interface Host {
   idMappings: IdMappings;
   kernel: string;
   logDriver: string;
+  memAvailable?: number;
   memFree: number;
   memTotal: number;
   networkBackend: string;


### PR DESCRIPTION
### What does this PR do?
MemFree excludes reclaimable buffer/cache memory, causing inflated memory usage reports. This change reads MemAvailable from /proc/meminfo via SSH to compute actual used memory, falling back to the API-provided memoryUsed when SSH is unavailable. Also adds memAvailable to the libpod Host interface and prefers it in the container registry info calculation.

### Screenshot / video of UI

just updated number

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/17488

### How to test this PR?
Run this PR and the production version of Podman Desktop, there should be an actual memory usage 

- [x] Tests are covering the bug fix or the new feature
