### PR TITLE
fix(renderer): change alignment and button type in PullImage.svelte

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -496,7 +496,7 @@ async function searchFunction(value: string): Promise<void> {
     <footer>
       <div class="w-full flex flex-col justify-end">
         {#if !pullFinished}
-          <div class="space-x-2 flex flex-nowrap text-[var(--pd-content-text)]">
+          <div class="space-x-2 flex flex-nowrap justify-end text-[var(--pd-content-text)]">
             <Button
               icon={faArrowCircleDown}
               disabled={imageNameIsInvalid || pullInProgress}
@@ -509,9 +509,9 @@ async function searchFunction(value: string): Promise<void> {
             {/if}
           </div>
         {:else}
-        <div class="space-x-2 flex flex-nowrap text-[var(--pd-content-text)]">
-          <Button type='secondary' on:click={pullImageFinished}>Close</Button>
-          <Button type='link' on:click={gotoImageDetails}>View details</Button>
+        <div class="space-x-2 flex flex-nowrap justify-end text-[var(--pd-content-text)]">
+          <Button type='link' on:click={pullImageFinished}>Close</Button>
+          <Button type='secondary' on:click={gotoImageDetails}>View details</Button>
           <Button type='primary' on:click={gotoImageRun}>Run</Button>
         </div>
         {/if}


### PR DESCRIPTION
### What does this PR do?
Buttons in PullImage.svelte are aligned towards left. 
Also, buttons like `cancel` and `view details` have swapped variant types.

This PR aligns buttons towards right and corrects the button types according to standards.

### Screenshot / video of UI
Before:
<img width="1065" height="710" alt="image" src="https://github.com/user-attachments/assets/8d0cc3da-3192-45d8-adc8-0cdf84a62e5d" />

After:
<img width="1707" height="282" alt="fix-img-btn" src="https://github.com/user-attachments/assets/8810baba-4c25-40a9-8465-e6fbbd988b10" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes #18047 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
