### PR TITLE
fix(images): include digests when listing images

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -5051,6 +5051,7 @@ test('pass options to compat api when using podmanListImages', async () => {
 
   expect(vi.mocked(listImagesSpy)).toHaveBeenCalledWith({
     all: true,
+    digests: true,
     filters: '{"dangling":["false"]}',
   });
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -772,7 +772,7 @@ export class ContainerProviderRegistry {
           if (!provider.api) {
             return [];
           }
-          const images = await provider.api.listImages({ all: false });
+          const images = await provider.api.listImages({ all: false, digests: true });
           return images.map(image => {
             const imageInfo: ImageInfo = {
               ...image,
@@ -824,6 +824,7 @@ export class ContainerProviderRegistry {
           // Create list options with explicit defaults
           const listOptions = {
             all: options?.all ?? false,
+            digests: true,
             filters: options?.filters,
           };
 


### PR DESCRIPTION
### What does this PR do?

Requests image digests when listing images through both the generic provider API and the Podman-compatible image list path.

This keeps repository digests available to callers consistently.

### Screenshot / video of UI

N/A, backend image metadata change only.

### What issues does this PR fix or reference?

Relates to https://github.com/podman-desktop/podman-desktop/issues/923.

### How to test this PR?

- Run `npx vitest run packages/main/src/plugin/container-registry.spec.ts`

- [x] Tests are covering the bug fix or the new feature

This pr is the first of 7 that will add the update image feature. This pr was needed to get the proper digests to cleanly check if an image needs updating

Please refer to https://github.com/podman-desktop/podman-desktop/pull/18003 for the full implementation if you want to test it