### PR TITLE
feat: disable manual cert sync when podman 6 is installed

### DIFF
--- a/extensions/podman/packages/extension/package.json
+++ b/extensions/podman/packages/extension/package.json
@@ -58,7 +58,8 @@
       },
       {
         "command": "podman.synchronizeCertificates",
-        "title": "Podman: Synchronize certificates to all VMs"
+        "title": "Podman: Synchronize certificates to all VMs",
+        "enablement": "!podman.isImportNativeCASupported"
       }
     ],
     "configuration": {

--- a/extensions/podman/packages/extension/src/constants.ts
+++ b/extensions/podman/packages/extension/src/constants.ts
@@ -31,6 +31,7 @@ export const PODMAN_MACHINE_EDIT_CPU = 'podman.podmanMachineEditCPUSupported';
 export const PODMAN_MACHINE_EDIT_MEMORY = 'podman.podmanMachineEditMemorySupported';
 export const PODMAN_MACHINE_EDIT_DISK_SIZE = 'podman.podmanMachineEditDiskSizeSupported';
 export const PODMAN_MACHINE_EDIT_ROOTFUL = 'podman.podmanMachineEditRootfulSupported';
+export const PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY = 'podman.isImportNativeCASupported';
 /**
  * Command ID to uninstall a version of podman installed with non-msi installer
  */

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -56,6 +56,7 @@ import { PodmanBinary } from '/@/utils/podman-binary';
 import * as extension from './extension';
 import {
   initCheckAndRegisterUpdate,
+  isPodman6OrLater,
   registerOnboardingMachineExistsCommand,
   registerOnboardingUnsupportedPodmanMachineCommand,
   setWSLEnabled,
@@ -3826,6 +3827,21 @@ describe('monitorProvider', () => {
 
     await vi.runAllTimersAsync();
     expect(mockDoMonitorProvider).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('isPodman6OrLater', () => {
+  test.for(['5.0.0', '5.4.2', '5.9.9'])('should return false for Podman %s (cert sync command enabled)', version => {
+    expect(isPodman6OrLater(version)).toBe(false);
+  });
+
+  test.for([
+    '6.0.0',
+    '6.1.0',
+    '6.3.2',
+    '7.0.0',
+  ])('should return true for Podman %s (cert sync command disabled)', version => {
+    expect(isPodman6OrLater(version)).toBe(true);
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -33,6 +33,7 @@ import * as compatibilityModeLib from '/@/compatibility-mode/compatibility-mode'
 import {
   CLEANUP_REQUIRED_MACHINE_KEY,
   CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
+  PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY,
   PODMAN_MACHINE_CPU_SUPPORTED_KEY,
   PODMAN_MACHINE_DISK_SUPPORTED_KEY,
   PODMAN_MACHINE_EDIT_CPU,
@@ -56,7 +57,6 @@ import { PodmanBinary } from '/@/utils/podman-binary';
 import * as extension from './extension';
 import {
   initCheckAndRegisterUpdate,
-  isPodman6OrLater,
   registerOnboardingMachineExistsCommand,
   registerOnboardingUnsupportedPodmanMachineCommand,
   setWSLEnabled,
@@ -3830,18 +3830,26 @@ describe('monitorProvider', () => {
   });
 });
 
-describe('isPodman6OrLater', () => {
-  test.for(['5.0.0', '5.4.2', '5.9.9'])('should return false for Podman %s (cert sync command enabled)', version => {
-    expect(isPodman6OrLater(version)).toBe(false);
-  });
+describe('activate sets PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY', () => {
+  const cases = (
+    [
+      ['5.0.0', false],
+      ['5.4.2', false],
+      ['5.9.9', false],
+      ['6.0.0', true],
+      ['6.1.0', true],
+      ['6.3.2', true],
+      ['7.0.0', true],
+    ] as const
+  ).map(([version, supported]) => ({ version, supported }));
 
-  test.for([
-    '6.0.0',
-    '6.1.0',
-    '6.3.2',
-    '7.0.0',
-  ])('should return true for Podman %s (cert sync command disabled)', version => {
-    expect(isPodman6OrLater(version)).toBe(true);
+  test.for(cases)('Podman $version sets native CA import supported to $supported', async ({ version, supported }) => {
+    vi.mocked(PODMAN_BINARY_MOCK.getBinaryInfo).mockResolvedValue({ version } as InstalledPodman);
+    vi.spyOn(PodmanInstall.prototype, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: false,
+    } as unknown as UpdateCheck);
+    await extension.activate(getContextMock());
+    expect(extensionApi.context.setValue).toHaveBeenCalledWith(PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY, supported);
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -33,6 +33,7 @@ import {
   CLEANUP_REQUIRED_MACHINE_KEY,
   CREATE_WSL_MACHINE_OPTION_SELECTED_KEY,
   PODMAN_DOCKER_COMPAT_ENABLE_KEY,
+  PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY,
   PODMAN_MACHINE_CPU_SUPPORTED_KEY,
   PODMAN_MACHINE_DISK_SUPPORTED_KEY,
   PODMAN_MACHINE_EDIT_CPU,
@@ -1342,6 +1343,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     extensionApi.context.setValue(START_NOW_MACHINE_INIT_SUPPORTED_KEY, isStartNowAtMachineInitSupported(version));
     extensionApi.context.setValue(USER_MODE_NETWORKING_SUPPORTED_KEY, isUserModeNetworkingSupported(version));
     extensionApi.context.setValue(PODMAN_PROVIDER_LIBKRUN_SUPPORTED_KEY, isLibkrunSupported(version));
+    extensionApi.context.setValue(PODMAN_IMPORT_NATIVE_CA_SUPPORTED_KEY, isPodman6OrLater(version));
     isMovedPodmanSocket = isPodmanSocketLocationMoved(version);
   }
 
@@ -1936,6 +1938,10 @@ export function setWSLEnabled(enabled: boolean): void {
 
 export function isPodman5OrLater(podmanVersion: string): boolean {
   return compare(podmanVersion, '5.0.0') >= 0;
+}
+
+export function isPodman6OrLater(podmanVersion: string): boolean {
+  return compare(podmanVersion, '6.0.0') >= 0;
 }
 
 export function sendTelemetryRecords(


### PR DESCRIPTION
### What does this PR do?

Disables manual CA certificates synchronization when podman 6 detected.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Related to #17146.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature (covers v6 detection)
- [x] commands enablement is tested [here](https://github.com/podman-desktop/podman-desktop/blob/main/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts#L357)
