### PR TITLE
chore(test): add e2e test for update tools from resource page

### DIFF
--- a/tests/playwright/src/model/pages/resources-page.ts
+++ b/tests/playwright/src/model/pages/resources-page.ts
@@ -16,7 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { Locator, Page } from 'playwright';
+import type { Locator, Page } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
 
 import { SettingsPage } from './settings-page';
 
@@ -43,6 +44,24 @@ export class ResourcesPage extends SettingsPage {
     await this.resourceCardLocatorGenerator(resourceCardAriaLabel)
       .getByRole('button', { name: `Create new ${buttonName}` })
       .click();
+  }
+
+  public getProviderUpdateButton(providerCardLabel: string): Locator {
+    return this.resourceCardLocatorGenerator(providerCardLabel).getByRole('button', { name: /Update to/ });
+  }
+
+  public async updateProvider(providerCardLabel: string, timeout = 60_000): Promise<this> {
+    return test.step(`Update provider ${providerCardLabel} from Resources page`, async () => {
+      const providerCard = this.resourceCardLocatorGenerator(providerCardLabel);
+      await playExpect(providerCard).toBeVisible({ timeout: 10_000 });
+
+      const updateButton = this.getProviderUpdateButton(providerCardLabel);
+      await playExpect(updateButton).toBeVisible({ timeout: 10_000 });
+      await playExpect(updateButton).toBeEnabled();
+      await updateButton.click();
+      await playExpect(updateButton).toBeHidden({ timeout });
+      return this;
+    });
   }
 
   private resourceCardLocatorGenerator(resourceCardAriaLabel: string): Locator {

--- a/tests/playwright/src/specs/cli-tools-smoke.spec.ts
+++ b/tests/playwright/src/specs/cli-tools-smoke.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { CLIToolsPage } from '/@/model/pages/cli-tools-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
 import type { SettingsBar } from '/@/model/pages/settings-bar';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { isLinux, isMac } from '/@/utility/platform';
@@ -27,6 +28,11 @@ let cliToolsPage: CLIToolsPage;
 const tools = process.env.CLI_TOOLS;
 const allTools = ['Kind', 'Compose', 'kubectl'];
 const toolsToTest = tools === 'all' ? allTools : tools ? tools.split(',') : ['Kind'];
+
+const toolToProviderCard: Record<string, string> = {
+  Kind: 'kind',
+  Compose: 'Compose',
+};
 
 test.skip(!!isLinux || !!isMac, 'Tests suite should not run on Linux or Mac platform');
 
@@ -69,6 +75,39 @@ toolsToTest.forEach(tool => {
         await cliToolsPage.installTool(tool);
         await cliToolsPage.downgradeTool(tool);
         await cliToolsPage.updateTool(tool);
+        await cliToolsPage.uninstallTool(tool);
+        await playExpect
+          .poll(async () => await cliToolsPage.getCurrentToolVersion(tool), { timeout: 90_000 })
+          .toBeFalsy();
+      });
+
+      test(`Install ${tool} -> downgrade -> upgrade from Resources page -> uninstall`, async ({ page }) => {
+        test.setTimeout(180_000);
+
+        const providerCardLabel = toolToProviderCard[tool];
+        if (!providerCardLabel) {
+          test.skip(true, `${tool} does not have a provider card on the Resources page`);
+          return;
+        }
+
+        await cliToolsPage.installTool(tool);
+        await cliToolsPage.downgradeTool(tool);
+
+        const currentVersion = await cliToolsPage.getCurrentToolVersion(tool);
+
+        await settingsBar.resourcesTab.click();
+        const resourcesPage = new ResourcesPage(page);
+        await playExpect(resourcesPage.heading).toBeVisible({ timeout: 10_000 });
+
+        await resourcesPage.updateProvider(providerCardLabel);
+
+        await settingsBar.cliToolsTab.click();
+        await playExpect(cliToolsPage.toolsTable).toBeVisible({ timeout: 10_000 });
+
+        await playExpect
+          .poll(async () => await cliToolsPage.getCurrentToolVersion(tool), { timeout: 60_000 })
+          .not.toContain(currentVersion);
+
         await cliToolsPage.uninstallTool(tool);
         await playExpect
           .poll(async () => await cliToolsPage.getCurrentToolVersion(tool), { timeout: 90_000 })


### PR DESCRIPTION
### What does this PR do?
Adds e2e test to validate cli tool update from resources page.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/17823
