### PR TITLE
fix(ci): replace deprecated publish-release action with gh CLI

### DIFF
--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -178,13 +178,11 @@ jobs:
 
       - name: Publish release
         if: ${{ needs.build.result == 'success' }}
-        uses: StuYarrow/publish-release@01f2a1365bacd77bad861873a7fdf274ab49eefd # v1.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
-        with:
-          id: ${{ needs.tag.outputs.releaseId }}
-          repo: testing-prereleases
-          owner: podman-desktop
+        run: |
+          gh api --method PATCH /repos/podman-desktop/testing-prereleases/releases/${{ needs.tag.outputs.releaseId }} \
+            -F draft=false
       
       - name: Delete release
         if: ${{ needs.build.result != 'success' }}

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -169,10 +169,8 @@ jobs:
         run: echo the release id is ${{ needs.tag.outputs.releaseId}}
 
       - name: Publish release
-        uses: StuYarrow/publish-release@01f2a1365bacd77bad861873a7fdf274ab49eefd # v1.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.PODMAN_DESKTOP_BOT_TOKEN }}
-        with:
-          id: ${{ needs.tag.outputs.releaseId}}
-          repo: prereleases
-          owner: podman-desktop
+        run: |
+          gh api --method PATCH /repos/podman-desktop/prereleases/releases/${{ needs.tag.outputs.releaseId }} \
+            -F draft=false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -219,11 +219,11 @@ jobs:
         run: echo the release id is ${{ needs.tag.outputs.releaseId}}
 
       - name: Publish release
-        uses: StuYarrow/publish-release@01f2a1365bacd77bad861873a7fdf274ab49eefd # v1.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          id: ${{ needs.tag.outputs.releaseId}}
+        run: |
+          gh api --method PATCH /repos/${{ github.repository }}/releases/${{ needs.tag.outputs.releaseId }} \
+            -F draft=false
 
   # publish the pnpm store for flathub builds
   pnpm-store:


### PR DESCRIPTION
Signed-off-by: JustMell0 <original.justmello1337@gmail.com>

### What does this PR do?

Replaces the deprecated `StuYarrow/publish-release` action with a `gh api` call in all three workflows that use it. The archived action runs on Node.js 20, which GitHub will force to Node.js 24 on June 16, 2026 and remove entirely on September 16, 2026.

The action only flips a GitHub release from `draft: true` to `draft: false` — a single `gh api PATCH` call does the same thing with no external dependencies.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes #17802 

### How to test this PR?

1. Verify the three modified workflow files parse correctly (`gh workflow view release`, `gh workflow view next-build`, `gh workflow view daily-testing-build`)
2. Confirm no references to `StuYarrow/publish-release` remain: `grep -r "StuYarrow" .github/`
3. On a test run, confirm the release step successfully un-drafts the release

- [x] Tests are covering the bug fix or the new feature
