### PR TITLE
feat(renderer): add container secret details page

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -58,4 +58,5 @@ export enum NavigationPage {
   VM_CONNECTION = 'vm-connection',
   KUBERNETES_CONNECTION = 'kubernetes-connection',
   SECRETS = 'secrets',
+  SECRET = 'secret',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -61,6 +61,7 @@ export interface NavigationParameters {
   [NavigationPage.KUBERNETES_CONNECTION]: { provider: string; apiURL: string };
   [NavigationPage.VM_CONNECTION]: { provider: string; name: string };
   [NavigationPage.SECRETS]: never;
+  [NavigationPage.SECRET]: { id: string; engineId: string };
 }
 
 // the parameters property is optional when the NavigationParameters say it is

--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -37,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   DeploymentsList: vi.fn(),
   KubernetesDashboard: vi.fn(),
   SecretsList: vi.fn(),
+  SecretDetails: vi.fn(),
 }));
 
 vi.mock(import('./lib/dashboard/DashboardPage.svelte'), () => ({
@@ -71,6 +72,10 @@ vi.mock(import('./lib/deployments/DeploymentsList.svelte'), () => ({
 
 vi.mock(import('./lib/secrets/SecretsList.svelte'), () => ({
   default: mocks.SecretsList,
+}));
+
+vi.mock(import('./lib/secrets/SecretDetails.svelte'), () => ({
+  default: mocks.SecretDetails,
 }));
 
 vi.mock(import('/@/stores/kubernetes-contexts-state'), async () => {
@@ -188,6 +193,20 @@ test('test /secrets route', async () => {
 
   await vi.waitFor(() => {
     expect(mocks.SecretsList).toHaveBeenCalled();
+  });
+});
+
+test('test /secrets/:engineId/:secretId/* route', async () => {
+  render(App);
+  expect(mocks.SecretDetails).not.toHaveBeenCalled();
+  expect(mocks.DashboardPage).toHaveBeenCalled();
+  router.goto('/secrets/engine%201/secret%2Fid/summary');
+
+  await vi.waitFor(() => {
+    expect(mocks.SecretDetails).toHaveBeenCalledWith(expect.anything(), {
+      secretId: 'secret/id',
+      engineId: 'engine 1',
+    });
   });
 });
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -8,6 +8,7 @@ import { router } from 'tinro';
 
 import { parseExtensionListRequest } from '/@/lib/extensions/extension-list';
 import KubernetesRoot from '/@/lib/kube/KubernetesRoot.svelte';
+import SecretDetails from '/@/lib/secrets/SecretDetails.svelte';
 import SecretsList from '/@/lib/secrets/SecretsList.svelte';
 import PinActions from '/@/lib/statusbar/PinActions.svelte';
 import { handleNavigation } from '/@/navigation';
@@ -322,6 +323,9 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/secrets/*" breadcrumb="Secrets" navigationHint="root" firstmatch>
           <Route path="/" breadcrumb="Secrets" navigationHint="root">
             <SecretsList />
+          </Route>
+          <Route path="/:engineId/:secretId/*" breadcrumb="Secret Details" let:meta navigationHint="details">
+            <SecretDetails secretId={decodeURIComponent(meta.params.secretId)} engineId={decodeURIComponent(meta.params.engineId)} />
           </Route>
         </Route>
         {#if $kubernetesNoCurrentContext}

--- a/packages/renderer/src/lib/secrets/SecretDetails.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretDetails.spec.ts
@@ -1,0 +1,67 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { NavigationPage, type SecretInfo } from '@podman-desktop/core-api';
+import { render, waitFor } from '@testing-library/svelte';
+import { router } from 'tinro';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { handleNavigation } from '/@/navigation';
+import { secretsInfo } from '/@/stores/secrets';
+
+import SecretDetails from './SecretDetails.svelte';
+
+vi.mock(import('/@/navigation'));
+
+const secret: SecretInfo = {
+  engineId: 'engine-id-1',
+  engineName: 'Podman 1',
+  engineType: 'podman',
+  Id: 'secret-id-1',
+  Name: 'my-secret',
+  CreatedAt: '2026-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  secretsInfo.set([]);
+});
+
+test('expect secret details page to render when secret exists', async () => {
+  secretsInfo.set([secret]);
+  router.goto('/secrets/engine-id-1/secret-id-1/summary');
+
+  const { getByText, getByRole } = render(SecretDetails, { secretId: 'secret-id-1', engineId: 'engine-id-1' });
+
+  await waitFor(() => {
+    expect(getByText('my-secret')).toBeInTheDocument();
+    expect(getByText('secret-id-1')).toBeInTheDocument();
+    expect(getByRole('link', { name: 'Summary' })).toBeInTheDocument();
+    expect(getByRole('link', { name: 'Inspect' })).toBeInTheDocument();
+  });
+});
+
+test('expect navigation back to list when secret does not exist', async () => {
+  render(SecretDetails, { secretId: 'missing-secret', engineId: 'engine-id-1' });
+
+  await waitFor(() => {
+    expect(handleNavigation).toHaveBeenCalledWith({ page: NavigationPage.SECRETS });
+  });
+});

--- a/packages/renderer/src/lib/secrets/SecretDetails.svelte
+++ b/packages/renderer/src/lib/secrets/SecretDetails.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
+import { StatusIcon, Tab } from '@podman-desktop/ui-svelte';
+import { router } from 'tinro';
+
+import SecretIcon from '/@/lib/images/SecretIcon.svelte';
+import SecretActions from '/@/lib/secrets/components/SecretActions.svelte';
+import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
+import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
+import { handleNavigation } from '/@/navigation';
+import Route from '/@/Route.svelte';
+import { secretsInfo } from '/@/stores/secrets';
+
+import SecretDetailsInspect from './tabs/SecretDetailsInspect.svelte';
+import SecretDetailsSummary from './tabs/SecretDetailsSummary.svelte';
+
+interface Props {
+  secretId: string;
+  engineId: string;
+}
+
+let { secretId, engineId }: Props = $props();
+
+let secret = $derived($secretsInfo.find(item => item.Id === secretId && item.engineId === engineId));
+
+$effect(() => {
+  if (!secret) {
+    handleNavigation({ page: NavigationPage.SECRETS });
+  }
+});
+</script>
+
+{#if secret}
+  <DetailsPage title={secret.Name} subtitle={secret.Id}>
+    {#snippet iconSnippet()}
+      <StatusIcon icon={SecretIcon} size={24} />
+    {/snippet}
+
+    {#snippet actionsSnippet()}
+      <SecretActions object={secret} detailed={true} />
+    {/snippet}
+
+    {#snippet tabsSnippet()}
+      <Tab title="Summary" selected={isTabSelected($router.path, 'summary')} url={getTabUrl($router.path, 'summary')} />
+      <Tab title="Inspect" selected={isTabSelected($router.path, 'inspect')} url={getTabUrl($router.path, 'inspect')} />
+    {/snippet}
+
+    {#snippet contentSnippet()}
+      <Route path="/summary" breadcrumb="Summary" navigationHint="tab">
+        <SecretDetailsSummary {secret} />
+      </Route>
+      <Route path="/inspect" breadcrumb="Inspect" navigationHint="tab">
+        <SecretDetailsInspect {secret} />
+      </Route>
+    {/snippet}
+  </DetailsPage>
+{/if}

--- a/packages/renderer/src/lib/secrets/SecretDetailsInspect.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretDetailsInspect.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { SecretInfo } from '@podman-desktop/core-api';
+import { render } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+
+import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
+
+import SecretDetailsInspect from './tabs/SecretDetailsInspect.svelte';
+
+vi.mock(import('/@/lib/editor/MonacoEditor.svelte'));
+
+const secret: SecretInfo = {
+  engineId: 'podman1',
+  engineName: 'Podman 1',
+  engineType: 'podman',
+  Id: 'secret-id-1',
+  Name: 'my-secret',
+  CreatedAt: '2026-01-01T00:00:00Z',
+};
+
+test('Expect monaco editor to be called with secret details output', async () => {
+  render(SecretDetailsInspect, { secret });
+
+  expect(MonacoEditor).toHaveBeenCalledWith(expect.anything(), {
+    content: JSON.stringify(secret, undefined, 2),
+    language: 'json',
+  });
+});

--- a/packages/renderer/src/lib/secrets/SecretDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretDetailsSummary.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { SecretInfo } from '@podman-desktop/core-api';
+import { render } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import SecretDetailsSummary from './tabs/SecretDetailsSummary.svelte';
+
+const secret: SecretInfo = {
+  engineId: 'podman1',
+  engineName: 'Podman 1',
+  engineType: 'podman',
+  Id: 'secret-id-1',
+  Name: 'my-secret',
+  CreatedAt: '2026-01-01T00:00:00Z',
+  UpdatedAt: '2026-01-02T00:00:00Z',
+  Labels: { app: 'demo' },
+};
+
+test('Expect secret summary details to be displayed', () => {
+  const { getByText } = render(SecretDetailsSummary, { secret });
+
+  expect(getByText('my-secret')).toBeInTheDocument();
+  expect(getByText('secret-id-1')).toBeInTheDocument();
+  expect(getByText('Podman 1')).toBeInTheDocument();
+  expect(getByText('podman')).toBeInTheDocument();
+  expect(getByText('app')).toBeInTheDocument();
+  expect(getByText('demo')).toBeInTheDocument();
+});
+
+test('Expect labels value to be N/A when there are no labels', () => {
+  const { getByText } = render(SecretDetailsSummary, { secret: { ...secret, Labels: {} } });
+
+  expect(getByText('No labels')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/secrets/columns/SecretColumnName.spec.ts
+++ b/packages/renderer/src/lib/secrets/columns/SecretColumnName.spec.ts
@@ -18,12 +18,18 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { NavigationPage } from '@podman-desktop/core-api';
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { SecretInfoUI } from '/@/lib/secrets/SecretInfoUI';
+import { handleNavigation } from '/@/navigation';
 
 import SecretColumnName from './SecretColumnName.svelte';
+
+vi.mock(import('/@/navigation'), () => ({
+  handleNavigation: vi.fn(),
+}));
 
 const secret: SecretInfoUI = {
   engineId: 'podman1',
@@ -35,9 +41,28 @@ const secret: SecretInfoUI = {
   selected: false,
 };
 
-test('Expect secret name to be displayed', async () => {
-  render(SecretColumnName, { object: secret });
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
-  const text = screen.getByText('my-secret');
+test('Expect secret name to be displayed', async () => {
+  const { getByText } = render(SecretColumnName, { object: secret });
+
+  const text = getByText('my-secret');
   expect(text).toBeInTheDocument();
+});
+
+test('Expect click to open secret details', async () => {
+  const { getByRole } = render(SecretColumnName, { object: secret });
+
+  const secretButton = getByRole('button', { name: 'my-secret' });
+  await fireEvent.click(secretButton);
+
+  expect(handleNavigation).toHaveBeenCalledWith({
+    page: NavigationPage.SECRET,
+    parameters: {
+      id: secret.Id,
+      engineId: secret.engineId,
+    },
+  });
 });

--- a/packages/renderer/src/lib/secrets/columns/SecretColumnName.spec.ts
+++ b/packages/renderer/src/lib/secrets/columns/SecretColumnName.spec.ts
@@ -27,9 +27,7 @@ import { handleNavigation } from '/@/navigation';
 
 import SecretColumnName from './SecretColumnName.svelte';
 
-vi.mock(import('/@/navigation'), () => ({
-  handleNavigation: vi.fn(),
-}));
+vi.mock(import('/@/navigation'));
 
 const secret: SecretInfoUI = {
   engineId: 'podman1',

--- a/packages/renderer/src/lib/secrets/columns/SecretColumnName.svelte
+++ b/packages/renderer/src/lib/secrets/columns/SecretColumnName.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+import { NavigationPage } from '@podman-desktop/core-api';
+
 import type { SecretInfoUI } from '/@/lib/secrets/SecretInfoUI';
+import { handleNavigation } from '/@/navigation';
 
 interface Props {
   object: SecretInfoUI;
@@ -8,4 +11,15 @@ interface Props {
 let { object }: Props = $props();
 </script>
 
-<span>{object.Name}</span>
+<button
+  class="hover:cursor-pointer flex text-[var(--pd-table-body-text-highlight)] max-w-full overflow-hidden text-ellipsis"
+  onclick={(): void =>
+    handleNavigation({
+      page: NavigationPage.SECRET,
+      parameters: {
+        id: object.Id,
+        engineId: object.engineId,
+      },
+    })}>
+  {object.Name}
+</button>

--- a/packages/renderer/src/lib/secrets/tabs/SecretDetailsInspect.svelte
+++ b/packages/renderer/src/lib/secrets/tabs/SecretDetailsInspect.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+import type { SecretInfo } from '@podman-desktop/core-api';
+
+import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
+
+interface Props {
+  secret: SecretInfo;
+}
+
+let { secret }: Props = $props();
+const inspectDetails = $derived(JSON.stringify(secret, undefined, 2));
+</script>
+
+<MonacoEditor content={inspectDetails} language="json" />

--- a/packages/renderer/src/lib/secrets/tabs/SecretDetailsSummary.svelte
+++ b/packages/renderer/src/lib/secrets/tabs/SecretDetailsSummary.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+import type { SecretInfo } from '@podman-desktop/core-api';
+
+import DetailsCell from '/@/lib/details/DetailsCell.svelte';
+import DetailsTable from '/@/lib/details/DetailsTable.svelte';
+import DetailsTitle from '/@/lib/details/DetailsTitle.svelte';
+
+interface Props {
+  secret: SecretInfo;
+}
+
+let { secret }: Props = $props();
+let labels = $derived(secret?.Labels ? Object.entries(secret.Labels) : []);
+</script>
+
+<DetailsTable>
+  <tr>
+    <DetailsTitle>Details</DetailsTitle>
+  </tr>
+  <tr>
+    <DetailsCell>Name</DetailsCell>
+    <DetailsCell>{secret.Name}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>ID</DetailsCell>
+    <DetailsCell>{secret.Id}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Created</DetailsCell>
+    <DetailsCell>{secret.CreatedAt ?? 'N/A'}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Updated</DetailsCell>
+    <DetailsCell>{secret.UpdatedAt ?? 'N/A'}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine Name</DetailsCell>
+    <DetailsCell>{secret.engineName}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine ID</DetailsCell>
+    <DetailsCell>{secret.engineId}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsCell>Engine Type</DetailsCell>
+    <DetailsCell>{secret.engineType}</DetailsCell>
+  </tr>
+  <tr>
+    <DetailsTitle>Labels</DetailsTitle>
+  </tr>
+  {#if labels.length === 0}
+    <tr>
+      <DetailsCell>No labels</DetailsCell>
+    </tr>
+  {:else}
+    {#each labels as [key, value] (key)}
+      <tr>
+        <DetailsCell>{key}</DetailsCell>
+        <DetailsCell>{value}</DetailsCell>
+      </tr>
+    {/each}
+  {/if}
+</DetailsTable>

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -344,3 +344,21 @@ test(`Test navigationHandle for ${NavigationPage.VM_CONNECTION}`, () => {
     '/preferences/vm-connection/dummyProviderId/dummyProviderName/terminal',
   );
 });
+
+test(`Test navigationHandle for ${NavigationPage.SECRETS}`, () => {
+  handleNavigation({ page: NavigationPage.SECRETS });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/secrets');
+});
+
+test(`Test navigationHandle for ${NavigationPage.SECRET}`, () => {
+  handleNavigation({
+    page: NavigationPage.SECRET,
+    parameters: {
+      id: 'secret/id',
+      engineId: 'engine id',
+    },
+  });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/secrets/engine%20id/secret%2Fid/summary');
+});

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -169,5 +169,10 @@ export const handleNavigation = (request: InferredNavigationRequest<NavigationPa
     case NavigationPage.SECRETS:
       router.goto(`/secrets`);
       break;
+    case NavigationPage.SECRET:
+      router.goto(
+        `/secrets/${encodeURIComponent(request.parameters.engineId)}/${encodeURIComponent(request.parameters.id)}/summary`,
+      );
+      break;
   }
 };


### PR DESCRIPTION
### What does this PR do?

Adds a dedicated Container Secrets details page in the renderer with Summary and Inspect tabs.

It wires navigation from the secrets list to details, introduces route handling for secret details URLs, and aligns details rendering with the `secretsInfo` store.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

#### Light mode
<img width="1207" height="722" alt="Screenshot 2026-07-08 at 10 42 37" src="https://github.com/user-attachments/assets/8ba85d83-1411-46ef-92c8-ab82aa3eaca9" />
<img width="1207" height="722" alt="Screenshot 2026-07-08 at 10 42 46" src="https://github.com/user-attachments/assets/8a297385-dce7-435f-a4a9-4b6e5a0e1001" />

<!-- TODO: add light mode screenshots -->

#### Dark mode

<img width="1207" height="722" alt="Screenshot 2026-07-08 at 10 43 16" src="https://github.com/user-attachments/assets/fac11c71-88cf-4122-adef-4e1d1a164cbc" />

<img width="1207" height="722" alt="Screenshot 2026-07-08 at 10 43 20" src="https://github.com/user-attachments/assets/be85a2fe-8039-4d49-b548-3f161983b715" />

<!-- TODO: add dark mode screenshots -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17843

### How to test this PR?

- Start Podman Desktop dev environment.
- Ensure at least one secret exists in a running container engine.
- Open **Secrets** from the left navigation.
- Verify **Summary** tab shows secret metadata and labels.
- Verify empty labels show **No labels**.
- Verify **Inspect** tab shows JSON for the selected secret.
- Delete the secret and verify details navigation returns to the secrets list.

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)