### PR TITLE
feat(renderer): add secret create form

### DIFF
--- a/packages/api/src/navigation-page.ts
+++ b/packages/api/src/navigation-page.ts
@@ -59,4 +59,5 @@ export enum NavigationPage {
   KUBERNETES_CONNECTION = 'kubernetes-connection',
   SECRETS = 'secrets',
   SECRET = 'secret',
+  SECRET_CREATE = 'secrets-create',
 }

--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -62,6 +62,7 @@ export interface NavigationParameters {
   [NavigationPage.VM_CONNECTION]: { provider: string; name: string };
   [NavigationPage.SECRETS]: never;
   [NavigationPage.SECRET]: { id: string; engineId: string };
+  [NavigationPage.SECRET_CREATE]: never;
 }
 
 // the parameters property is optional when the NavigationParameters say it is

--- a/packages/renderer/src/App.spec.ts
+++ b/packages/renderer/src/App.spec.ts
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
   KubernetesDashboard: vi.fn(),
   SecretsList: vi.fn(),
   SecretDetails: vi.fn(),
+  SecretCreate: vi.fn(),
 }));
 
 vi.mock(import('./lib/dashboard/DashboardPage.svelte'), () => ({
@@ -72,6 +73,9 @@ vi.mock(import('./lib/deployments/DeploymentsList.svelte'), () => ({
 
 vi.mock(import('./lib/secrets/SecretsList.svelte'), () => ({
   default: mocks.SecretsList,
+}));
+vi.mock(import('./lib/secrets/SecretCreate.svelte'), () => ({
+  default: mocks.SecretCreate,
 }));
 
 vi.mock(import('./lib/secrets/SecretDetails.svelte'), () => ({
@@ -193,6 +197,16 @@ test('test /secrets route', async () => {
 
   await vi.waitFor(() => {
     expect(mocks.SecretsList).toHaveBeenCalled();
+  });
+});
+
+test('test /secrets/create route', async () => {
+  render(App);
+  expect(mocks.SecretCreate).not.toHaveBeenCalled();
+
+  router.goto('/secrets/create');
+  await vi.waitFor(() => {
+    expect(mocks.SecretCreate).toHaveBeenCalled();
   });
 });
 

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -8,6 +8,7 @@ import { router } from 'tinro';
 
 import { parseExtensionListRequest } from '/@/lib/extensions/extension-list';
 import KubernetesRoot from '/@/lib/kube/KubernetesRoot.svelte';
+import SecretCreate from '/@/lib/secrets/SecretCreate.svelte';
 import SecretDetails from '/@/lib/secrets/SecretDetails.svelte';
 import SecretsList from '/@/lib/secrets/SecretsList.svelte';
 import PinActions from '/@/lib/statusbar/PinActions.svelte';
@@ -323,6 +324,9 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
         <Route path="/secrets/*" breadcrumb="Secrets" navigationHint="root" firstmatch>
           <Route path="/" breadcrumb="Secrets" navigationHint="root">
             <SecretsList />
+          </Route>
+          <Route path="/create" breadcrumb="Create a Secret">
+            <SecretCreate />
           </Route>
           <Route path="/:engineId/:secretId/*" breadcrumb="Secret Details" let:meta navigationHint="details">
             <SecretDetails secretId={decodeURIComponent(meta.params.secretId)} engineId={decodeURIComponent(meta.params.engineId)} />

--- a/packages/renderer/src/lib/secrets/SecretCreate.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretCreate.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { NavigationPage, type ProviderInfo } from '@podman-desktop/core-api';
+import { fireEvent, render } from '@testing-library/svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { handleNavigation } from '/@/navigation';
+import { providerInfos } from '/@/stores/providers';
+
+import SecretCreate from './SecretCreate.svelte';
+
+vi.mock(import('/@/navigation'));
+
+const providerInfoMock = {
+  id: 'podman',
+  internalId: 'podman-internal-id',
+  name: 'Podman',
+  status: 'started',
+  containerConnections: [
+    {
+      name: 'podman-machine-default',
+      status: 'started',
+      type: 'podman',
+    },
+  ],
+} as unknown as ProviderInfo;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  providerInfos.set([providerInfoMock]);
+});
+
+test('Expect create secret to call API and navigate back', async () => {
+  vi.mocked(window.createSecret).mockResolvedValue({
+    id: 'secret-id',
+    engineId: 'podman.podman-machine-default',
+  });
+
+  const { getByPlaceholderText, getByRole } = render(SecretCreate);
+
+  await fireEvent.input(getByPlaceholderText('Secret name'), { target: { value: 'my-secret' } });
+  await fireEvent.input(getByPlaceholderText('Secret data'), { target: { value: 'my-secret-data' } });
+
+  const createButton = getByRole('button', { name: 'Create' });
+  await fireEvent.click(createButton);
+
+  expect(window.createSecret).toHaveBeenCalledTimes(1);
+  expect(handleNavigation).toHaveBeenCalledWith({ page: NavigationPage.SECRETS });
+});
+
+test('Expect create secret error to be displayed', async () => {
+  vi.mocked(window.createSecret).mockRejectedValue(new Error('create failed'));
+
+  const { getByPlaceholderText, getByRole, getByText } = render(SecretCreate);
+
+  await fireEvent.input(getByPlaceholderText('Secret name'), { target: { value: 'my-secret' } });
+  await fireEvent.input(getByPlaceholderText('Secret data'), { target: { value: 'my-secret-data' } });
+  await fireEvent.click(getByRole('button', { name: 'Create' }));
+
+  expect(getByText('create failed')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/secrets/SecretCreate.svelte
+++ b/packages/renderer/src/lib/secrets/SecretCreate.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+import {
+  NavigationPage,
+  type ProviderContainerConnectionInfo,
+  type SecretCreateOptions,
+} from '@podman-desktop/core-api';
+import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import ContainerConnectionDropdown from '/@/lib/forms/ContainerConnectionDropdown.svelte';
+import SecretIcon from '/@/lib/images/SecretIcon.svelte';
+import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
+import { handleNavigation } from '/@/navigation';
+import { providerInfos } from '/@/stores/providers';
+
+let createError: string | undefined = $state(undefined);
+let loading = $state(false);
+
+let secretCreateOptions: SecretCreateOptions = $state({
+  selectedProvider: undefined,
+  name: '',
+  data: '',
+});
+
+let providerConnections = $derived(
+  $providerInfos.reduce<ProviderContainerConnectionInfo[]>((acc, provider) => {
+    const startedConnections = provider.containerConnections.filter(connection => connection.status === 'started');
+    return acc.concat(startedConnections);
+  }, []),
+);
+
+$effect(() => {
+  if (providerConnections.length > 0 && secretCreateOptions.selectedProvider === undefined) {
+    secretCreateOptions.selectedProvider = providerConnections[0];
+  }
+});
+
+let valid = $derived(
+  secretCreateOptions.selectedProvider !== undefined &&
+    secretCreateOptions.name.trim().length > 0 &&
+    secretCreateOptions.data.length > 0,
+);
+
+async function createSecret(): Promise<void> {
+  if (!secretCreateOptions.selectedProvider) return;
+
+  try {
+    loading = true;
+    createError = undefined;
+    await window.createSecret($state.snapshot(secretCreateOptions));
+    handleNavigation({ page: NavigationPage.SECRETS });
+  } catch (error: unknown) {
+    createError = error instanceof Error ? error.message : String(error);
+  } finally {
+    loading = false;
+  }
+}
+
+function close(): void {
+  handleNavigation({ page: NavigationPage.SECRETS });
+}
+</script>
+
+<EngineFormPage title="Create a Secret" showEmptyScreen={providerConnections.length === 0}>
+  {#snippet icon()}
+    <Icon icon={SecretIcon} size={27} />
+  {/snippet}
+  {#snippet content()}
+    <div class="space-y-6">
+      {#if providerConnections.length > 1}
+        <div>
+          <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+            >Container Engine <span class="text-red-500">*</span></label>
+          <ContainerConnectionDropdown
+            id="providerChoice"
+            name="providerChoice"
+            bind:value={secretCreateOptions.selectedProvider}
+            connections={providerConnections} />
+        </div>
+      {/if}
+
+      <div>
+        <label for="secretName" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Name <span class="text-red-500">*</span></label>
+        <Input
+          bind:value={secretCreateOptions.name}
+          name="secretName"
+          id="secretName"
+          placeholder="Secret name"
+          required
+          class="w-full" />
+      </div>
+
+      <div>
+        <label for="secretData" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
+          >Data <span class="text-red-500">*</span></label>
+        <Input
+          bind:value={secretCreateOptions.data}
+          name="secretData"
+          id="secretData"
+          placeholder="Secret data"
+          required
+          class="w-full" />
+      </div>
+
+      <div class="w-full flex flex-row space-x-4">
+        <Button type="secondary" class="w-full" onclick={close}>Cancel</Button>
+        <Button disabled={!valid || loading} inProgress={loading} class="w-full" onclick={createSecret}>Create</Button>
+      </div>
+
+      {#if createError}
+        <ErrorMessage class="text-sm" error={createError} />
+      {/if}
+    </div>
+  {/snippet}
+</EngineFormPage>

--- a/packages/renderer/src/lib/secrets/SecretCreate.svelte
+++ b/packages/renderer/src/lib/secrets/SecretCreate.svelte
@@ -70,7 +70,7 @@ function close(): void {
       {#if providerConnections.length > 1}
         <div>
           <label for="providerChoice" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-            >Container Engine <span class="text-red-500">*</span></label>
+            >Container Engine <span class="text-(--pd-state-error)">*</span></label>
           <ContainerConnectionDropdown
             id="providerChoice"
             name="providerChoice"
@@ -81,7 +81,7 @@ function close(): void {
 
       <div>
         <label for="secretName" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-          >Name <span class="text-red-500">*</span></label>
+          >Name <span class="text-(--pd-state-error)">*</span></label>
         <Input
           bind:value={secretCreateOptions.name}
           name="secretName"
@@ -93,11 +93,12 @@ function close(): void {
 
       <div>
         <label for="secretData" class="block mb-2 font-semibold text-[var(--pd-content-card-header-text)]"
-          >Data <span class="text-red-500">*</span></label>
+          >Data <span class="text-(--pd-state-error)">*</span></label>
         <Input
           bind:value={secretCreateOptions.data}
           name="secretData"
           id="secretData"
+          type="password"
           placeholder="Secret data"
           required
           class="w-full" />

--- a/packages/renderer/src/lib/secrets/SecretsList.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretsList.spec.ts
@@ -150,6 +150,13 @@ test('Expect secrets table to be rendered with data', async () => {
   expect(screen.getByText('my-secret-2')).toBeInTheDocument();
 });
 
+test('Expect create button to be displayed when engine is available', async () => {
+  await init();
+
+  const createButton = screen.getByRole('button', { name: 'Create' });
+  expect(createButton).toBeInTheDocument();
+});
+
 test('Expect delete action on each secret row', async () => {
   await init();
 

--- a/packages/renderer/src/lib/secrets/SecretsList.svelte
+++ b/packages/renderer/src/lib/secrets/SecretsList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { SecretInfo } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import {
   Button,
   FilteredEmptyScreen,
@@ -21,6 +22,7 @@ import SecretActions from '/@/lib/secrets/components/SecretActions.svelte';
 import SecretEmptyScreen from '/@/lib/secrets/components/SecretEmptyScreen.svelte';
 import type { SecretInfoUI } from '/@/lib/secrets/SecretInfoUI';
 import EnvironmentDropdown from '/@/lib/ui/EnvironmentDropdown.svelte';
+import { handleNavigation } from '/@/navigation';
 import { providerInfos } from '/@/stores/providers';
 import { filtered, searchPattern } from '/@/stores/secrets';
 
@@ -87,9 +89,19 @@ async function bulkDeleteSecrets(): Promise<void> {
     bulkDeleteInProgress = false;
   }
 }
+
+function gotoCreateSecret(): void {
+  handleNavigation({ page: NavigationPage.SECRET_CREATE });
+}
 </script>
 
 <NavPage bind:searchTerm={$searchPattern} title="secrets">
+  {#snippet additionalActions()}
+    {#if providerConnections.length > 0}
+      <Button onclick={gotoCreateSecret} icon={faPlusCircle} title="Create a secret" aria-label="Create">Create</Button>
+    {/if}
+  {/snippet}
+
   {#snippet bottomAdditionalActions()}
     <EnvironmentDropdown bind:selectedEnvironment={selectedEnvironment} />
     {#if selectedItemsNumber > 0}

--- a/packages/renderer/src/lib/secrets/SecretsList.svelte
+++ b/packages/renderer/src/lib/secrets/SecretsList.svelte
@@ -98,7 +98,7 @@ function gotoCreateSecret(): void {
 <NavPage bind:searchTerm={$searchPattern} title="secrets">
   {#snippet additionalActions()}
     {#if providerConnections.length > 0}
-      <Button onclick={gotoCreateSecret} icon={faPlusCircle} title="Create a secret" aria-label="Create">Create</Button>
+      <Button onclick={gotoCreateSecret} icon={faPlusCircle} title="Create a secret">Create</Button>
     {/if}
   {/snippet}
 

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -362,3 +362,9 @@ test(`Test navigationHandle for ${NavigationPage.SECRET}`, () => {
 
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/secrets/engine%20id/secret%2Fid/summary');
 });
+
+test(`Test navigationHandle for ${NavigationPage.SECRET_CREATE}`, () => {
+  handleNavigation({ page: NavigationPage.SECRET_CREATE });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/secrets/create');
+});

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -118,6 +118,8 @@ export const resolveRoute = (request: InferredNavigationRequest<NavigationPage>)
       return `/secrets`;
     case NavigationPage.SECRET:
       return `/secrets/${encodeURIComponent(request.parameters.engineId)}/${encodeURIComponent(request.parameters.id)}/summary`;
+    case NavigationPage.SECRET_CREATE:
+      return '/secrets/create';
   }
 };
 


### PR DESCRIPTION
### What does this PR do?

Adds a renderer flow to create container secrets from the Secrets page:

- Adds a **Create** button to the Secrets list
- Adds `/secrets/create` route and a dedicated `SecretCreate` page
- Adds navigation wiring via `NavigationPage.SECRET_CREATE`
- Adds test updates for navigation and Secrets list create action visibility

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

#### Light mode

<!-- TODO: add light mode screenshot(s) -->
<img width="1408" height="842" alt="Screenshot 2026-07-13 at 15 30 00" src="https://github.com/user-attachments/assets/b3c00060-1e39-4f77-9a0a-8631214cd2df" />

#### Dark mode
<img width="1408" height="842" alt="Screenshot 2026-07-13 at 15 30 07" src="https://github.com/user-attachments/assets/98bb02b4-5015-491a-b06d-556283ce0b8b" />

<!-- TODO: add dark mode screenshot(s) -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17844

### How to test this PR?

- Start Podman Desktop in dev mode.
- Ensure at least one container engine connection is started.
- Open **Secrets**.
- Verify the **Create** button is visible.
- Click **Create** and verify navigation to `/secrets/create`.
- In the form, choose engine (if multiple), enter name and data, and click **Create**.
- Verify navigation returns to **Secrets**.

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)