### PR TITLE
fix(renderer): prevent duplicate mapped port key collisions

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
@@ -157,3 +157,21 @@ test('port link shows tooltip with full URL and external link icon', async () =>
   const tooltipTrigger = portLink.closest('[data-testid="tooltip-trigger"]');
   expect(tooltipTrigger).toBeInTheDocument();
 });
+
+test('renders duplicate public ports on different host IPs without key collision', async () => {
+  const containerWithDuplicatedPublicPorts: ContainerInfoUI = {
+    ...fakeStandaloneContainer,
+    ports: [
+      { IP: '127.0.0.1', PrivatePort: 53, PublicPort: 53, Type: 'udp' },
+      { IP: '127.0.0.1', PrivatePort: 53, PublicPort: 53, Type: 'tcp' },
+      { IP: '203.0.113.10', PrivatePort: 53, PublicPort: 53, Type: 'udp' },
+      { IP: '203.0.113.10', PrivatePort: 53, PublicPort: 53, Type: 'tcp' },
+    ],
+    portsAsString: '53',
+    hasPublicPort: true,
+  };
+
+  const { getAllByText } = render(ContainerDetailsSummary, { container: containerWithDuplicatedPublicPorts });
+
+  expect(getAllByText('53')).toHaveLength(4);
+});

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -63,7 +63,7 @@ function openPort(port: number): void {
     <DetailsCell>Ports</DetailsCell>
     {#if container.hasPublicPort}
       <DetailsCell>
-        {#each container.ports as port, i (port.PublicPort)}
+        {#each container.ports as port, i (`${port.IP ?? ''}-${port.PublicPort}-${port.Type}`)}
           {#if i > 0},&nbsp;{/if}
           <Tooltip tip={portUrl(port.PublicPort)} bottom>
             <Link on:click={(): void => openPort(port.PublicPort)}>


### PR DESCRIPTION
### What does this PR do?

Fixes a regression in `ContainerDetailsSummary` where Svelte could throw `each_key_duplicate` when the same `PublicPort` appears on multiple host IPs/protocols. The keyed `{#each}` now uses host IP + public port + protocol, and a regression unit test was added for duplicate public ports across host IPs.

### Screenshot / video of UI

N/A (no visual change)

### What issues does this PR fix or reference?

Fixes #18188

### How to test this PR?

- Run `npx vitest run packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts`
- Run `npx eslint packages/renderer/src/lib/container/ContainerDetailsSummary.svelte packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts`
- Optionally validate manually with a container exposing the same port/protocol on multiple host IPs; Container Details should render without crash

- [x] Tests are covering the bug fix or the new feature