### PR TITLE
refactor(RunImage): simple & derive containers and networks management

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -18,17 +18,22 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { ImageInspectInfo } from '@podman-desktop/core-api';
+import type { ContainerInfo, ImageInspectInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
+import { get } from 'svelte/store';
 import { router } from 'tinro';
 import { afterEach, beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
 import RunImage from '/@/lib/image/RunImage.svelte';
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
 import { mockBreadcrumb } from '/@/stores/breadcrumb.spec';
+import { containersInfos } from '/@/stores/containers';
+import { networksListInfo } from '/@/stores/networks';
 import { runImageInfo } from '/@/stores/run-image-store';
+
+const ENGINE_ID = 'engine-id-abc123';
 
 const originalConsoleDebug = console.debug;
 
@@ -66,7 +71,7 @@ async function createRunImage(entrypoint?: string | string[], cmd?: string[]): P
     age: '',
     base64RepoTag: '',
     createdAt: 0,
-    engineId: '',
+    engineId: ENGINE_ID,
     engineName: '',
     size: 0,
     humanSize: '',
@@ -139,7 +144,7 @@ async function createRunImage(entrypoint?: string | string[], cmd?: string[]): P
     },
     Size: 0,
     VirtualSize: 0,
-    engineId: 'engineid',
+    engineId: ENGINE_ID,
     engineName: 'engineName',
   };
   (window.getImageInspect as Mock).mockResolvedValue(imageInfo);
@@ -215,7 +220,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Entrypoint: ['entrypoint'] }),
     );
   });
@@ -228,7 +233,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Entrypoint: ['entrypoint'] }),
     );
   });
@@ -241,7 +246,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Entrypoint: ['entrypoint with space'] }),
     );
   });
@@ -254,7 +259,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Entrypoint: ['entrypoint1', 'entrypoint2'] }),
     );
   });
@@ -267,7 +272,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Entrypoint: ['entrypoint1', 'entrypoint2'] }),
     );
   });
@@ -280,7 +285,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Cmd: ['command'] }),
     );
   });
@@ -293,7 +298,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Cmd: ['command with space'] }),
     );
   });
@@ -305,7 +310,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Cmd: ['command1', 'command2'] }),
     );
   });
@@ -318,7 +323,7 @@ describe('RunImage', () => {
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ Cmd: ['command1', 'command2'] }),
     );
   });
@@ -455,7 +460,7 @@ describe('RunImage', () => {
 
     // should have item 1 and item 3 as we deleted item 2
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({ EnvFiles: [customEnvFile, 'foo3'] }),
     );
   });
@@ -531,7 +536,7 @@ describe('RunImage', () => {
 
     // should have item 1 and item 3 as we deleted item 2
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
-      'engineid',
+      ENGINE_ID,
       expect.objectContaining({
         HostConfig: expect.objectContaining({
           Devices: [
@@ -549,5 +554,118 @@ describe('RunImage', () => {
         }),
       }),
     );
+  });
+
+  describe('NetworkingTab', () => {
+    const CONTAINER_ID = 'container-abc123';
+    const NETWORK_ID = 'network-xyz789';
+
+    beforeEach(async () => {
+      router.goto('/basic');
+      vi.mocked(window.listContainers).mockResolvedValue([
+        {
+          Id: CONTAINER_ID,
+          Names: ['/my-container'],
+          Image: 'my-image',
+          State: 'Running',
+          Status: 'Running',
+          engineId: ENGINE_ID,
+          engineName: 'engineName',
+          ImageID: 'dummy-image-id',
+        } as unknown as ContainerInfo,
+      ]);
+      vi.mocked(window.listNetworks).mockResolvedValue([
+        {
+          engineId: ENGINE_ID,
+          engineName: 'engineName',
+          engineType: 'podman',
+          Name: 'my-network',
+          Id: NETWORK_ID,
+          Created: '',
+          Scope: '',
+          Driver: '',
+          EnableIPv6: false,
+          Internal: false,
+          Attachable: false,
+          Ingress: false,
+          ConfigOnly: false,
+        },
+      ]);
+
+      window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+      // wait store are populated
+      await vi.waitFor(() => {
+        expect(get(containersInfos)).toHaveLength(1);
+        expect(get(containersInfos)[0].Id).toBe(CONTAINER_ID);
+
+        expect(get(networksListInfo)).toHaveLength(1);
+        expect(get(networksListInfo)[0].Id).toBe(NETWORK_ID);
+      });
+    });
+
+    test('Expect networkingModeUserContainer is defined when selecting choice-container mode', async () => {
+      await createRunImage('entrypoint', []);
+
+      const networkTab = screen.getByRole('link', {
+        name: 'Networking',
+      });
+      await fireEvent.click(networkTab);
+
+      const modeButton = await vi.waitFor(() => {
+        return screen.getByRole('button', {
+          name: 'Creates a network stack on the default bridge (default)',
+        });
+      });
+      await fireEvent.click(modeButton);
+
+      const containerOption = screen.getByRole('button', {
+        name: 'Use another container networking stack',
+      });
+      await fireEvent.click(containerOption);
+
+      const button = screen.getByRole('button', { name: 'Start Container' });
+      await fireEvent.click(button);
+
+      expect(window.createAndStartContainer).toHaveBeenCalledWith(
+        ENGINE_ID,
+        expect.objectContaining({
+          HostConfig: expect.objectContaining({
+            NetworkMode: `container:${CONTAINER_ID}`,
+          }),
+        }),
+      );
+    });
+
+    test('Expect networkingModeUserNetwork is defined when selecting choice-network mode', async () => {
+      await createRunImage('entrypoint', []);
+
+      const networkTab = screen.getByRole('link', {
+        name: 'Networking',
+      });
+      await fireEvent.click(networkTab);
+
+      const modeButton = await vi.waitFor(() => {
+        return screen.getByRole('button', {
+          name: 'Creates a network stack on the default bridge (default)',
+        });
+      });
+      await fireEvent.click(modeButton);
+
+      const networkOption = screen.getByRole('button', { name: 'User-defined network' });
+      await fireEvent.click(networkOption);
+
+      const button = screen.getByRole('button', { name: 'Start Container' });
+      await fireEvent.click(button);
+
+      expect(window.createAndStartContainer).toHaveBeenCalledWith(
+        ENGINE_ID,
+        expect.objectContaining({
+          HostConfig: expect.objectContaining({
+            NetworkMode: NETWORK_ID,
+          }),
+        }),
+      );
+    });
   });
 });

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -34,7 +34,19 @@ interface PortInfo {
 let imageInspectInfo: ImageInspectInfo;
 
 let containerName = $state('');
-let containerNameError = $state('');
+let containerNameError: string | undefined = $derived.by(() => {
+  // ok, now check if we already have a matching container: same name and same engine ID
+  const containerAlreadyExists = $containersInfos.find(
+    container =>
+      container.engineId === imageInspectInfo.engineId &&
+      container.Names.some(iteratingContainerName => iteratingContainerName === `/${containerName}`),
+  );
+  if (containerAlreadyExists) {
+    return `The name ${containerName} already exists. Please choose another name or leave blank to generate a name.`;
+  } else {
+    return undefined;
+  }
+});
 
 let command = $state('');
 
@@ -56,9 +68,12 @@ let devices = $state<{ host: string; container: string; read: boolean; write: bo
   { host: '', container: '', read: false, write: false, mknod: false },
 ]);
 
-let invalidName = $state(false);
-let invalidPorts = $state(false);
-let invalidFields = $derived(invalidName || invalidPorts);
+let invalidPorts = $derived.by(() => {
+  const invalidHostPorts = hostContainerPortMappings.filter(pair => pair.hostPort.error);
+  const invalidContainerPortMapping = containerPortMapping?.filter(port => port.error) ?? [];
+  return invalidHostPorts.length > 0 || invalidContainerPortMapping.length > 0;
+});
+let invalidFields = $derived(!!containerNameError || invalidPorts);
 
 // auto remove the container on exit
 let autoRemove = $state(false);
@@ -518,7 +533,6 @@ function addHostContainerPorts(): void {
 
 async function deleteHostContainerPorts(index: number): Promise<void> {
   hostContainerPortMappings = hostContainerPortMappings.filter((_, i) => i !== index);
-  await assertAllPortAreValid();
 }
 
 function addVolumeMount(): void {
@@ -576,36 +590,15 @@ function deleteDevice(index: number): void {
   devices = devices.filter((_, i) => i !== index);
 }
 
-// called when user change the container's name
-function checkContainerName(event: Event): void {
-  const containerValue = event.target instanceof Input ? event.target.value : '';
-
-  // ok, now check if we already have a matching container: same name and same engine ID
-  const containerAlreadyExists = $containersInfos.find(
-    container =>
-      container.engineId === imageInspectInfo.engineId &&
-      container.Names.some(iteratingContainerName => iteratingContainerName === `/${containerValue}`),
-  );
-  if (containerAlreadyExists) {
-    containerNameError = `The name ${containerValue} already exists. Please choose another name or leave blank to generate a name.`;
-    invalidName = true;
-  } else {
-    containerNameError = '';
-    invalidName = false;
-  }
-}
-
 function onContainerPortMappingInput(event: Event, index: number): void {
   onPortInput(event, containerPortMapping[index], () => {
     containerPortMapping = containerPortMapping;
-    assertAllPortAreValid().catch((err: unknown) => console.error('Error checking all ports valid', err));
   });
 }
 
 function onHostContainerPortMappingInput(event: Event, index: number): void {
   onPortInput(event, hostContainerPortMappings[index].hostPort, () => {
     hostContainerPortMappings = hostContainerPortMappings;
-    assertAllPortAreValid().catch((err: unknown) => console.error('Error checking all ports valid', err));
   });
 }
 
@@ -629,12 +622,6 @@ function onPortInput(event: Event, portInfo: PortInfo, updateUI: () => void): vo
         updateUI();
       });
   }, 500);
-}
-
-async function assertAllPortAreValid(): Promise<void> {
-  const invalidHostPorts = hostContainerPortMappings.filter(pair => pair.hostPort.error);
-  const invalidContainerPortMapping = containerPortMapping?.filter(port => port.error) ?? [];
-  invalidPorts = invalidHostPorts.length > 0 || invalidContainerPortMapping.length > 0;
 }
 
 const volumeDialogOptions: OpenDialogOptions = {
@@ -678,7 +665,6 @@ const envDialogOptions: OpenDialogOptions = {
                 for="modalContainerName"
                 class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Container name:</label>
               <Input
-                on:input={checkContainerName}
                 bind:value={containerName}
                 name="modalContainerName"
                 id="modalContainerName"

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -16,6 +16,7 @@ import { router } from 'tinro';
 
 import { ContainerUtils } from '/@/lib/container/container-utils';
 import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
+import type { PortInfo, RunOptions } from '/@/lib/image/run/run-options';
 import { splitSpacesHandlingDoubleQuotes } from '/@/lib/string/string';
 import { array2String } from '/@/lib/string/string.js';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
@@ -26,95 +27,71 @@ import Route from '/@/Route.svelte';
 import { containersInfos } from '/@/stores/containers';
 import { runImageInfo } from '/@/stores/run-image-store';
 
-interface PortInfo {
-  port: string;
-  error: string;
-}
+let options: RunOptions = $state({
+  basic: {
+    containerName: '',
+    entrypoint: '',
+    command: '',
+    volumeMounts: [{ source: '', target: '' }],
+    environmentVariables: [{ key: '', value: '' }],
+    environmentFiles: [''],
+    hostContainerPortMappings: [],
+  },
+  networking: {
+    hostname: undefined,
+    dnsServers: [''],
+    extraHosts: [{ host: '', ip: '' }],
+    networkingMode: 'bridge',
+    networkingModeUserNetwork: '',
+    networkingModeUserContainer: '',
+  },
+  advanced: {
+    useTty: true,
+    useInteractive: true,
+    runUser: undefined,
+    autoRemove: false,
+    restartPolicyName: '',
+    restartPolicyMaxRetryCount: 1,
+    devices: [{ host: '', container: '', read: false, write: false, mknod: false }],
+  },
+  security: {
+    privileged: false,
+    readOnly: false,
+    securityOpts: [''],
+    capAdds: [''],
+    capDrops: [''],
+    userNamespace: undefined,
+  },
+});
 
 let imageInspectInfo: ImageInspectInfo;
 
-let containerName = $state('');
 let containerNameError: string | undefined = $derived.by(() => {
   // ok, now check if we already have a matching container: same name and same engine ID
   const containerAlreadyExists = $containersInfos.find(
     container =>
       container.engineId === imageInspectInfo.engineId &&
-      container.Names.some(iteratingContainerName => iteratingContainerName === `/${containerName}`),
+      container.Names.some(iteratingContainerName => iteratingContainerName === `/${options.basic.containerName}`),
   );
   if (containerAlreadyExists) {
-    return `The name ${containerName} already exists. Please choose another name or leave blank to generate a name.`;
+    return `The name ${options.basic.containerName} already exists. Please choose another name or leave blank to generate a name.`;
   } else {
     return undefined;
   }
 });
 
-let command = $state('');
-
-let entrypoint = $state('');
-
 let containerPortMapping = $state<PortInfo[]>([]);
 let exposedPorts = $state<string[]>([]);
 let createError = $state<string>();
-let restartPolicyName = $state('');
-let restartPolicyMaxRetryCount = $state(1);
 let onPortInputTimeout: NodeJS.Timeout;
 
-// initialize with empty array
-let environmentVariables = $state<{ key: string; value: string }[]>([{ key: '', value: '' }]);
-let environmentFiles = $state<string[]>(['']);
-let volumeMounts = $state<{ source: string; target: string }[]>([{ source: '', target: '' }]);
-let hostContainerPortMappings = $state<{ hostPort: PortInfo; containerPort: string }[]>([]);
-let devices = $state<{ host: string; container: string; read: boolean; write: boolean; mknod: boolean }[]>([
-  { host: '', container: '', read: false, write: false, mknod: false },
-]);
-
 let invalidPorts = $derived.by(() => {
-  const invalidHostPorts = hostContainerPortMappings.filter(pair => pair.hostPort.error);
+  const invalidHostPorts = options.basic.hostContainerPortMappings.filter(pair => pair.hostPort.error);
   const invalidContainerPortMapping = containerPortMapping?.filter(port => port.error) ?? [];
   return invalidHostPorts.length > 0 || invalidContainerPortMapping.length > 0;
 });
 let invalidFields = $derived(!!containerNameError || invalidPorts);
 
-// auto remove the container on exit
-let autoRemove = $state(false);
-
-// privileged moade
-let privileged = $state(false);
-
-// read-only moade
-let readOnly = $state(false);
-
-// security options
-let securityOpts = $state<string[]>(['']);
-
-// Kernel capabilities
-let capAdds = $state<string[]>(['']);
-let capDrops = $state<string[]>(['']);
-
-// user namespace
-let userNamespace = $state<string>();
-
-// hostname;
-let hostname = $state<string>();
-
-// dns servers
-let dnsServers = $state<string[]>(['']);
-
-// extra hosts
-let extraHosts: { host: string; ip: string }[] = $state([{ host: '', ip: '' }]);
-
-// networking mode
-let networkingMode = $state('bridge');
-// user defined network if user choose a pre-defined network
-let networkingModeUserNetwork = $state('');
-// container defined network if user choose a pre-defined container
-let networkingModeUserContainer = $state('');
-
-// tty
-let useTty = $state(true);
-let useInteractive = $state(true);
-
-let runUser = $state<string>();
 let dataReady = $state(false);
 
 let imageDisplayName = $state('');
@@ -136,16 +113,16 @@ onMount(async () => {
   imageInspectInfo = await window.getImageInspect(image.engineId, image.id);
   exposedPorts = Array.from(Object.keys(imageInspectInfo?.Config?.ExposedPorts ?? {}));
 
-  command = array2String(imageInspectInfo.Config?.Cmd ?? []);
+  options.basic.command = array2String(imageInspectInfo.Config?.Cmd ?? []);
 
   if (imageInspectInfo.Config?.Entrypoint) {
     if (typeof imageInspectInfo.Config.Entrypoint === 'string') {
-      entrypoint = imageInspectInfo.Config.Entrypoint;
+      options.basic.entrypoint = imageInspectInfo.Config.Entrypoint;
     } else {
-      entrypoint = array2String(imageInspectInfo.Config.Entrypoint);
+      options.basic.entrypoint = array2String(imageInspectInfo.Config.Entrypoint);
     }
   } else {
-    entrypoint = '';
+    options.basic.entrypoint = '';
   }
 
   // auto-assign ports from available free port
@@ -174,10 +151,10 @@ onMount(async () => {
     // try to match the bridge network
     const bridgeNetwork = engineNetworks.find(network => network.Name === 'bridge');
     if (bridgeNetwork) {
-      networkingModeUserNetwork = bridgeNetwork.Id;
+      options.networking.networkingModeUserNetwork = bridgeNetwork.Id;
     } else {
       // fallback to the first network
-      networkingModeUserNetwork = engineNetworks[0].Id;
+      options.networking.networkingModeUserNetwork = engineNetworks[0].Id;
     }
   }
 
@@ -197,10 +174,10 @@ onMount(async () => {
       .toSorted((a, b) => b.created - a.created);
     if (runningContainers.length > 0) {
       // use the first running container
-      networkingModeUserContainer = runningContainers[0].id;
+      options.networking.networkingModeUserContainer = runningContainers[0].id;
     } else {
       // fallback to the first container
-      networkingModeUserContainer = engineContainers[0].id;
+      options.networking.networkingModeUserContainer = engineContainers[0].id;
     }
   }
 });
@@ -277,7 +254,7 @@ async function startContainer(): Promise<void> {
       }
     });
 
-    hostContainerPortMappings
+    options.basic.hostContainerPortMappings
       .filter(pair => pair.hostPort.port && pair.containerPort)
       .forEach(pair => {
         if (pair.containerPort.includes('-') || pair.hostPort.port.includes('-')) {
@@ -293,42 +270,44 @@ async function startContainer(): Promise<void> {
     return;
   }
 
-  const Env = environmentVariables
+  const Env = options.basic.environmentVariables
     // filter variables withouts keys
     .filter(env => env.key)
     // no value, use empty string
     .map(env => `${env.key}=${env.value ?? ''}`);
 
   // filter empty files
-  const EnvFiles = environmentFiles.filter(env => env);
+  const EnvFiles = options.basic.environmentFiles.filter(env => env);
 
   const Image = image.tag ? `${image.name}:${image.tag}` : image.id;
 
   const RestartPolicy: { Name: string; MaximumRetryCount?: number } = {
-    Name: restartPolicyName,
+    Name: options.advanced.restartPolicyName,
   };
 
   // only set MaximumRetryCount if policy is 'on-failure'
-  if (restartPolicyName === 'on-failure') {
-    RestartPolicy.MaximumRetryCount = restartPolicyMaxRetryCount;
+  if (options.advanced.restartPolicyName === 'on-failure') {
+    RestartPolicy.MaximumRetryCount = options.advanced.restartPolicyMaxRetryCount;
   }
 
   // need both source and target to be set
-  const Binds = volumeMounts
+  const Binds = options.basic.volumeMounts
     .filter(volume => volume.source && volume.target)
     .map(volume => `${volume.source}:${volume.target}`);
 
-  const SecurityOpt = securityOpts.filter(opt => opt);
+  const SecurityOpt = options.security.securityOpts.filter(opt => opt);
 
-  const CapAdd = capAdds.filter(cap => cap);
-  const CapDrop = capDrops.filter(cap => cap);
+  const CapAdd = options.security.capAdds.filter(cap => cap);
+  const CapDrop = options.security.capDrops.filter(cap => cap);
 
-  const ExtraHosts = extraHosts.filter(host => host.host && host.ip).map(host => `${host.host}:${host.ip}`);
+  const ExtraHosts = options.networking.extraHosts
+    .filter(host => host.host && host.ip)
+    .map(host => `${host.host}:${host.ip}`);
 
-  const Privileged = privileged;
+  const Privileged = options.security.privileged;
 
   let NetworkMode;
-  switch (networkingMode) {
+  switch (options.networking.networkingMode) {
     case 'bridge':
       NetworkMode = 'bridge';
       break;
@@ -339,20 +318,20 @@ async function startContainer(): Promise<void> {
       NetworkMode = 'none';
       break;
     case 'choice-network':
-      NetworkMode = networkingModeUserNetwork;
+      NetworkMode = options.networking.networkingModeUserNetwork;
       break;
     case 'choice-container':
-      NetworkMode = `container:${networkingModeUserContainer}`;
+      NetworkMode = `container:${options.networking.networkingModeUserContainer}`;
       break;
     default:
       NetworkMode = 'bridge';
   }
 
-  const ReadonlyRootfs = readOnly;
-  const Tty = useTty;
-  const OpenStdin = useInteractive;
+  const ReadonlyRootfs = options.security.readOnly;
+  const Tty = options.advanced.useTty;
+  const OpenStdin = options.advanced.useInteractive;
 
-  let Devices: DeviceMapping[] | undefined = devices
+  let Devices: DeviceMapping[] | undefined = options.advanced.devices
     .filter(d => d.host)
     .map(d => ({
       PathOnHost: d.host,
@@ -366,7 +345,7 @@ async function startContainer(): Promise<void> {
 
   const HostConfig: HostConfig = {
     Binds,
-    AutoRemove: autoRemove,
+    AutoRemove: options.advanced.autoRemove,
     RestartPolicy,
     PortBindings,
     SecurityOpt,
@@ -378,7 +357,7 @@ async function startContainer(): Promise<void> {
     Devices,
   };
 
-  const Dns = dnsServers.filter(dns => dns);
+  const Dns = options.networking.dnsServers.filter(dns => dns);
   if (Dns.length > 0) {
     HostConfig.Dns = Dns;
   }
@@ -387,37 +366,37 @@ async function startContainer(): Promise<void> {
     HostConfig.ExtraHosts = ExtraHosts;
   }
 
-  if (userNamespace) {
-    HostConfig.UsernsMode = userNamespace;
+  if (options.security.userNamespace) {
+    HostConfig.UsernsMode = options.security.userNamespace;
   }
 
-  const options: ContainerCreateOptions = {
+  const createOptions: ContainerCreateOptions = {
     Image,
     Env,
     EnvFiles,
-    name: containerName,
+    name: options.basic.containerName,
     HostConfig,
     ExposedPorts,
     Tty,
     OpenStdin,
   };
-  if (command.trim().length > 0) {
-    options.Cmd = splitSpacesHandlingDoubleQuotes(command);
+  if (options.basic.command.trim().length > 0) {
+    createOptions.Cmd = splitSpacesHandlingDoubleQuotes(options.basic.command);
   }
-  if (entrypoint.trim().length > 0) {
-    options.Entrypoint = splitSpacesHandlingDoubleQuotes(entrypoint);
-  }
-
-  if (runUser) {
-    options.User = runUser;
+  if (options.basic.entrypoint.trim().length > 0) {
+    createOptions.Entrypoint = splitSpacesHandlingDoubleQuotes(options.basic.entrypoint);
   }
 
-  if (hostname) {
-    options.Hostname = hostname;
+  if (options.advanced.runUser) {
+    createOptions.User = options.advanced.runUser;
+  }
+
+  if (options.networking.hostname) {
+    createOptions.Hostname = options.networking.hostname;
   }
 
   try {
-    const data = await window.createAndStartContainer(imageInspectInfo.engineId, options);
+    const data = await window.createAndStartContainer(imageInspectInfo.engineId, createOptions);
 
     // redirect to containers if no tty, else redirect to the container details
     if (Tty && OpenStdin) {
@@ -503,24 +482,24 @@ function getStartEndRange(range: string):
 }
 
 function addEnvVariable(): void {
-  environmentVariables = [...environmentVariables, { key: '', value: '' }];
+  options.basic.environmentVariables = [...options.basic.environmentVariables, { key: '', value: '' }];
 }
 
 function deleteEnvVariable(index: number): void {
-  environmentVariables = environmentVariables.filter((_, i) => i !== index);
+  options.basic.environmentVariables = options.basic.environmentVariables.filter((_, i) => i !== index);
 }
 
 function addEnvFile(): void {
-  environmentFiles = [...environmentFiles, ''];
+  options.basic.environmentFiles = [...options.basic.environmentFiles, ''];
 }
 
 function deleteEnvFile(index: number): void {
-  environmentFiles = environmentFiles.filter((_, i) => i !== index);
+  options.basic.environmentFiles = options.basic.environmentFiles.filter((_, i) => i !== index);
 }
 
 function addHostContainerPorts(): void {
-  hostContainerPortMappings = [
-    ...hostContainerPortMappings,
+  options.basic.hostContainerPortMappings = [
+    ...options.basic.hostContainerPortMappings,
     {
       hostPort: {
         port: '',
@@ -532,62 +511,65 @@ function addHostContainerPorts(): void {
 }
 
 async function deleteHostContainerPorts(index: number): Promise<void> {
-  hostContainerPortMappings = hostContainerPortMappings.filter((_, i) => i !== index);
+  options.basic.hostContainerPortMappings = options.basic.hostContainerPortMappings.filter((_, i) => i !== index);
 }
 
 function addVolumeMount(): void {
-  volumeMounts = [...volumeMounts, { source: '', target: '' }];
+  options.basic.volumeMounts = [...options.basic.volumeMounts, { source: '', target: '' }];
 }
 
 function deleteVolumeMount(index: number): void {
-  volumeMounts = volumeMounts.filter((_, i) => i !== index);
+  options.basic.volumeMounts = options.basic.volumeMounts.filter((_, i) => i !== index);
 }
 
 function deleteSecurityOpt(index: number): void {
-  securityOpts = securityOpts.filter((_, i) => i !== index);
+  options.security.securityOpts = options.security.securityOpts.filter((_, i) => i !== index);
 }
 
 function addSecurityOpt(): void {
-  securityOpts = [...securityOpts, ''];
+  options.security.securityOpts = [...options.security.securityOpts, ''];
 }
 
 function addCapAdd(): void {
-  capAdds = [...capAdds, ''];
+  options.security.capAdds = [...options.security.capAdds, ''];
 }
 function addCapDrop(): void {
-  capDrops = [...capDrops, ''];
+  options.security.capDrops = [...options.security.capDrops, ''];
 }
 
 function deleteCapAdd(index: number): void {
-  capAdds = capAdds.filter((_, i) => i !== index);
+  options.security.capAdds = options.security.capAdds.filter((_, i) => i !== index);
 }
 
 function deleteCappDrop(index: number): void {
-  capDrops = capDrops.filter((_, i) => i !== index);
+  options.security.capDrops = options.security.capDrops.filter((_, i) => i !== index);
 }
 
 function addDnsServer(): void {
-  dnsServers = [...dnsServers, ''];
+  options.networking.dnsServers = [...options.networking.dnsServers, ''];
 }
 
 function deleteDnsServer(index: number): void {
-  dnsServers = dnsServers.filter((_, i) => i !== index);
+  options.networking.dnsServers = options.networking.dnsServers.filter((_, i) => i !== index);
 }
 
 function addExtraHost(): void {
-  extraHosts = [...extraHosts, { host: '', ip: '' }];
+  options.networking.extraHosts = [...options.networking.extraHosts, { host: '', ip: '' }];
 }
 
 function deleteExtraHost(index: number): void {
-  extraHosts = extraHosts.filter((_, i) => i !== index);
+  options.networking.extraHosts = options.networking.extraHosts.filter((_, i) => i !== index);
 }
 
 function addDevice(): void {
-  devices = [...devices, { host: '', container: '', read: false, write: false, mknod: false }];
+  options.advanced.devices = [
+    ...options.advanced.devices,
+    { host: '', container: '', read: false, write: false, mknod: false },
+  ];
 }
 
 function deleteDevice(index: number): void {
-  devices = devices.filter((_, i) => i !== index);
+  options.advanced.devices = options.advanced.devices.filter((_, i) => i !== index);
 }
 
 function onContainerPortMappingInput(event: Event, index: number): void {
@@ -597,8 +579,8 @@ function onContainerPortMappingInput(event: Event, index: number): void {
 }
 
 function onHostContainerPortMappingInput(event: Event, index: number): void {
-  onPortInput(event, hostContainerPortMappings[index].hostPort, () => {
-    hostContainerPortMappings = hostContainerPortMappings;
+  onPortInput(event, options.basic.hostContainerPortMappings[index].hostPort, () => {
+    options.basic.hostContainerPortMappings = options.basic.hostContainerPortMappings;
   });
 }
 
@@ -665,7 +647,7 @@ const envDialogOptions: OpenDialogOptions = {
                 for="modalContainerName"
                 class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Container name:</label>
               <Input
-                bind:value={containerName}
+                bind:value={options.basic.containerName}
                 name="modalContainerName"
                 id="modalContainerName"
                 placeholder="Leave blank to generate a name"
@@ -675,15 +657,15 @@ const envDialogOptions: OpenDialogOptions = {
                 for="modalEntrypoint"
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Entrypoint:</label>
-              <Input bind:value={entrypoint} name="modalEntrypoint" id="modalEntrypoint" aria-label="Entrypoint" />
+              <Input bind:value={options.basic.entrypoint} name="modalEntrypoint" id="modalEntrypoint" aria-label="Entrypoint" />
               <label
                 for="modalCommand"
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Command:</label>
-              <Input bind:value={command} name="modalCommand" id="modalCommand" aria-label="Command" />
+              <Input bind:value={options.basic.command} name="modalCommand" id="modalCommand" aria-label="Command" />
               <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Volumes:</label>
               <!-- Display the list of volumes -->
-              {#each volumeMounts as volumeMount, index (index)}
+              {#each options.basic.volumeMounts as volumeMount, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <FileInput
                     id="volumeMount.{index}"
@@ -694,13 +676,13 @@ const envDialogOptions: OpenDialogOptions = {
                   <Input bind:value={volumeMount.target} placeholder="Path inside the container" class="ml-2" />
                   <Button
                     type="link"
-                    hidden={index === volumeMounts.length - 1}
+                    hidden={index === options.basic.volumeMounts.length - 1}
                     aria-label="Delete volume mount at index {index}"
                     on:click={(): void => deleteVolumeMount(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
-                    hidden={index < volumeMounts.length - 1}
+                    hidden={index < options.basic.volumeMounts.length - 1}
                     aria-label="Add volume mount after index {index}"
                     on:click={addVolumeMount}
                     icon={faPlusCircle} />
@@ -735,7 +717,7 @@ const envDialogOptions: OpenDialogOptions = {
                 Add custom port mapping
               </Button>
               <!-- Display the list of existing hostContainerPortMappings -->
-              {#each hostContainerPortMappings as hostContainerPortMapping, index (index)}
+              {#each options.basic.hostContainerPortMappings as hostContainerPortMapping, index (index)}
                 <div class="flex flex-row justify-center w-full py-1">
                   <Input
                     bind:value={hostContainerPortMapping.hostPort.port}
@@ -757,7 +739,7 @@ const envDialogOptions: OpenDialogOptions = {
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Environment variables:</label>
               <!-- Display the list of existing environment variables -->
-              {#each environmentVariables as environmentVariable, index (index)}
+              {#each options.basic.environmentVariables as environmentVariable, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <Input bind:value={environmentVariable.key} placeholder="Name" class="w-full" />
 
@@ -767,13 +749,13 @@ const envDialogOptions: OpenDialogOptions = {
                     class="ml-2" />
                   <Button
                     type="link"
-                    hidden={index === environmentVariables.length - 1}
+                    hidden={index === options.basic.environmentVariables.length - 1}
                     aria-label="Delete environment variable at index {index}"
                     on:click={(): void => deleteEnvVariable(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
-                    hidden={index < environmentVariables.length - 1}
+                    hidden={index < options.basic.environmentVariables.length - 1}
                     aria-label="Add environment variable after index {index}"
                     on:click={addEnvVariable}
                     icon={faPlusCircle} />
@@ -785,23 +767,23 @@ const envDialogOptions: OpenDialogOptions = {
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Environment files:</label>
               <!-- Display the list of existing environment files -->
-              {#each environmentFiles as _, index (index)}
+              {#each options.basic.environmentFiles as _, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <FileInput
                     id="filePath.{index}"
                     placeholder="Environment file containing KEY=VALUE items"
-                    bind:value={environmentFiles[index]}
+                    bind:value={options.basic.environmentFiles[index]}
                     options={envDialogOptions}
                     aria-label="environmentFile.{index}" />
                   <Button
                     type="link"
-                    hidden={index === environmentFiles.length - 1}
+                    hidden={index === options.basic.environmentFiles.length - 1}
                     aria-label="Delete env file at index {index}"
                     on:click={(): void => deleteEnvFile(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
-                    hidden={index < environmentFiles.length - 1}
+                    hidden={index < options.basic.environmentFiles.length - 1}
                     aria-label="Add env file after index {index}"
                     on:click={addEnvFile}
                     icon={faPlusCircle} />
@@ -815,8 +797,8 @@ const envDialogOptions: OpenDialogOptions = {
               <label for="containerTty" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Use TTY:</label>
               <div class="flex flex-col text-[var(--pd-content-card-text)] text-sm ml-2">
-                <Checkbox bind:checked={useTty} title="Attach a pseudo terminal">Attach a pseudo terminal</Checkbox>
-                <Checkbox bind:checked={useInteractive} title="Use interactive">
+                <Checkbox bind:checked={options.advanced.useTty} title="Attach a pseudo terminal">Attach a pseudo terminal</Checkbox>
+                <Checkbox bind:checked={options.advanced.useInteractive} title="Use interactive">
                   Interactive: Keep STDIN open even if not attached
                 </Checkbox>
               </div>
@@ -828,7 +810,7 @@ const envDialogOptions: OpenDialogOptions = {
                 >Specify user to run container as:</label>
               <div class="flex flex-row justify-center items-center w-full">
                 <Input
-                  bind:value={runUser}
+                  bind:value={options.advanced.runUser}
                   placeholder="If you specify a username, user must exist in /etc/passwd file (use user id instead)"
                   class="ml-2" />
               </div>
@@ -838,7 +820,7 @@ const envDialogOptions: OpenDialogOptions = {
                 for="containerAutoRemove"
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Auto removal of container:</label>
-              <Checkbox class="text-[var(--pd-content-card-text)] text-sm ml-2" bind:checked={autoRemove}>
+              <Checkbox class="text-[var(--pd-content-card-text)] text-sm ml-2" bind:checked={options.advanced.autoRemove}>
                 Automatically remove the container when the process exits
               </Checkbox>
 
@@ -851,7 +833,7 @@ const envDialogOptions: OpenDialogOptions = {
                 class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-card-text)]">
                 <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Policy name:</span>
 
-                <Dropdown class="w-full" name="restartPolicyName" bind:value={restartPolicyName}>
+                <Dropdown class="w-full" name="restartPolicyName" bind:value={options.advanced.restartPolicyName}>
                   <option value="">No restart</option>
                   <option value="no">Do not restart automatically</option>
                   <option value="always">Always restart</option>
@@ -861,7 +843,7 @@ const envDialogOptions: OpenDialogOptions = {
               </div>
 
               <div
-                class="flex flex-row justify-center items-center w-full py-1 {restartPolicyName === 'on-failure'
+                class="flex flex-row justify-center items-center w-full py-1 {options.advanced.restartPolicyName === 'on-failure'
                   ? 'opacity-100'
                   : 'opacity-20'}">
                 <span
@@ -869,10 +851,10 @@ const envDialogOptions: OpenDialogOptions = {
                   title="Number of times to retry before giving up.">Retries:</span>
                 <NumberInput
                   minimum={0}
-                  bind:value={restartPolicyMaxRetryCount}
+                  bind:value={options.advanced.restartPolicyMaxRetryCount}
                   type="integer"
                   class="w-24 p-2"
-                  disabled={restartPolicyName !== 'on-failure'} />
+                  disabled={options.advanced.restartPolicyName !== 'on-failure'} />
               </div>
 
               <!-- devices -->
@@ -880,7 +862,7 @@ const envDialogOptions: OpenDialogOptions = {
                 for="modalDevices"
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Devices:</label>
               <!-- Display the list of existing devices -->
-              {#each devices as device, index (index)}
+              {#each options.advanced.devices as device, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <Input
                     bind:value={device.host}
@@ -899,13 +881,13 @@ const envDialogOptions: OpenDialogOptions = {
                   </div>
                   <Button
                     type="link"
-                    hidden={index === devices.length - 1}
+                    hidden={index === options.advanced.devices.length - 1}
                     aria-label="Delete device at index {index}"
                     on:click={(): void => deleteDevice(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
-                    hidden={index < devices.length - 1}
+                    hidden={index < options.advanced.devices.length - 1}
                     aria-label="Add device after index {index}"
                     on:click={addDevice}
                     icon={faPlusCircle} />
@@ -920,7 +902,7 @@ const envDialogOptions: OpenDialogOptions = {
               <label
                 for="containerPrivileged"
                 class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Privileged:</label>
-              <Checkbox bind:checked={privileged} class="text-[var(--pd-content-card-text)] text-sm mx-2">
+              <Checkbox bind:checked={options.security.privileged} class="text-[var(--pd-content-card-text)] text-sm mx-2">
                 Turn off security<i class="pl-1 fas fa-exclamation-triangle"></i>
               </Checkbox>
 
@@ -928,7 +910,7 @@ const envDialogOptions: OpenDialogOptions = {
               <label
                 for="containerReadOnly"
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Read only:</label>
-              <Checkbox bind:checked={readOnly} class="text-[var(--pd-content-card-text)] text-sm mx-2">
+              <Checkbox bind:checked={options.security.readOnly} class="text-[var(--pd-content-card-text)] text-sm mx-2">
                 Make containers root filesystem read-only
               </Checkbox>
 
@@ -937,22 +919,22 @@ const envDialogOptions: OpenDialogOptions = {
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Security options (security-opt):</label>
               <!-- Display the list of existing security options -->
-              {#each securityOpts as _, index (index)}
+              {#each options.security.securityOpts as _, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <Input
-                    bind:value={securityOpts[index]}
+                    bind:value={options.security.securityOpts[index]}
                     placeholder="Enter a security option (Ex. seccomp=/path/to/profile.json)"
                     class="ml-2" />
 
                   <Button
                     type="link"
-                    hidden={index === securityOpts.length - 1}
+                    hidden={index === options.security.securityOpts.length - 1}
                     aria-label="Delete security option at index {index}"
                     on:click={(): void => deleteSecurityOpt(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
-                    hidden={index < securityOpts.length - 1}
+                    hidden={index < options.security.securityOpts.length - 1}
                     aria-label="Add security option after index {index}"
                     on:click={addSecurityOpt}
                     icon={faPlusCircle} />
@@ -969,17 +951,17 @@ const envDialogOptions: OpenDialogOptions = {
                 class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Add to the container (CapAdd):</label>
               <!-- Display the list of existing capAdd -->
-              {#each capAdds as _, index (index)}
+              {#each options.security.capAdds as _, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input bind:value={capAdds[index]} placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
+                  <Input bind:value={options.security.capAdds[index]} placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
 
                   <Button
                     type="link"
-                    hidden={index === capAdds.length - 1}
+                    hidden={index === options.security.capAdds.length - 1}
                     on:click={(): void => deleteCapAdd(index)}
                     icon={faMinusCircle}
                     aria-label="Remove capability" />
-                  <Button type="link" hidden={index < capAdds.length - 1} on:click={addCapAdd} icon={faPlusCircle} aria-label="Add capability" />
+                  <Button type="link" hidden={index < options.security.capAdds.length - 1} on:click={addCapAdd} icon={faPlusCircle} aria-label="Add capability" />
                 </div>
               {/each}
               <label
@@ -987,17 +969,17 @@ const envDialogOptions: OpenDialogOptions = {
                 class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Drop from the container (CapDrop):</label>
               <!-- Display the list of existing capDrop -->
-              {#each capDrops as _, index (index)}
+              {#each options.security.capDrops as _, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input bind:value={capDrops[index]} placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
+                  <Input bind:value={options.security.capDrops[index]} placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
 
                   <Button
                     type="link"
-                    hidden={index === capDrops.length - 1}
+                    hidden={index === options.security.capDrops.length - 1}
                     on:click={(): void => deleteCappDrop(index)}
                     icon={faMinusCircle}
                     aria-label="Remove capability" />
-                  <Button type="link" hidden={index < capDrops.length - 1} on:click={addCapDrop} icon={faPlusCircle} aria-label="Add capability" />
+                  <Button type="link" hidden={index < options.security.capDrops.length - 1} on:click={addCapDrop} icon={faPlusCircle} aria-label="Add capability" />
                 </div>
               {/each}
 
@@ -1007,7 +989,7 @@ const envDialogOptions: OpenDialogOptions = {
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Specify user namespace to use:</label>
               <div class="flex flex-row justify-center items-center w-full">
-                <Input bind:value={userNamespace} placeholder="Enter a user namespace" class="ml-2 w-full" />
+                <Input bind:value={options.security.userNamespace} placeholder="Enter a user namespace" class="ml-2 w-full" />
               </div>
             </div>
           </Route>
@@ -1020,7 +1002,7 @@ const envDialogOptions: OpenDialogOptions = {
                 class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Defines container hostname:</label>
               <div class="flex flex-row justify-center items-center w-full">
-                <Input bind:value={hostname} placeholder="Must be a valid RFC 1123 hostname" class="ml-2" />
+                <Input bind:value={options.networking.hostname} placeholder="Must be a valid RFC 1123 hostname" class="ml-2" />
               </div>
 
               <!-- DNS -->
@@ -1029,19 +1011,19 @@ const envDialogOptions: OpenDialogOptions = {
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Custom DNS server(s):</label>
 
-              {#each dnsServers as _, index (index)}
+              {#each options.networking.dnsServers as _, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input bind:value={dnsServers[index]} placeholder="IP Address" class="ml-2" />
+                  <Input bind:value={options.networking.dnsServers[index]} placeholder="IP Address" class="ml-2" />
 
                   <Button
                     type="link"
-                    hidden={index === dnsServers.length - 1}
+                    hidden={index === options.networking.dnsServers.length - 1}
                     aria-label="Delete DNS server at index {index}"
                     on:click={(): void => deleteDnsServer(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
-                    hidden={index < dnsServers.length - 1}
+                    hidden={index < options.networking.dnsServers.length - 1}
                     aria-label="Add DNS server after index {index}"
                     on:click={addDnsServer}
                     icon={faPlusCircle} />
@@ -1053,20 +1035,20 @@ const envDialogOptions: OpenDialogOptions = {
                 class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
                 >Add extra hosts (appends to /etc/hosts file):</label>
               <!-- Display the list of extra hosts -->
-              {#each extraHosts as extraHost, index (index)}
+              {#each options.networking.extraHosts as extraHost, index (index)}
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <Input bind:value={extraHost.host} placeholder="Hostname" class="ml-2" />
 
                   <Input bind:value={extraHost.ip} placeholder="IP Address" class="ml-2" />
                   <Button
                     type="link"
-                    hidden={index === extraHosts.length - 1}
+                    hidden={index === options.networking.extraHosts.length - 1}
                     aria-label="Delete extra host at index {index}"
                     on:click={(): void => deleteExtraHost(index)}
                     icon={faMinusCircle} />
                   <Button
                     type="link"
-                    hidden={index < extraHosts.length - 1}
+                    hidden={index < options.networking.extraHosts.length - 1}
                     aria-label="Add extra host after index {index}"
                     on:click={addExtraHost}
                     icon={faPlusCircle} />
@@ -1082,7 +1064,7 @@ const envDialogOptions: OpenDialogOptions = {
                 class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-card-text)]">
                 <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Mode:</span>
 
-                <Dropdown class="w-full" name="providerChoice" bind:value={networkingMode}>
+                <Dropdown class="w-full" name="providerChoice" bind:value={options.networking.networkingMode}>
                   <option value="bridge">Creates a network stack on the default bridge (default)</option>
                   <option value="none">No networking</option>
                   <option value="host">Use the host networking stack</option>
@@ -1092,16 +1074,16 @@ const envDialogOptions: OpenDialogOptions = {
                 </Dropdown>
               </div>
 
-              {#if networkingMode === 'choice-network'}
+              {#if options.networking.networkingMode === 'choice-network'}
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <span
                     class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
                     >Network:</span>
                   <Dropdown
                     class="w-full"
-                    disabled={networkingMode !== 'choice-network'}
+                    disabled={options.networking.networkingMode !== 'choice-network'}
                     name="networkingModeUserNetwork"
-                    bind:value={networkingModeUserNetwork}>
+                    bind:value={options.networking.networkingModeUserNetwork}>
                     {#each engineNetworks as network (network.Id)}
                       <option value={network.Id}
                         >{network.Name} (used by {Object.keys(network.Containers ?? {}).length} containers)</option>
@@ -1109,16 +1091,16 @@ const envDialogOptions: OpenDialogOptions = {
                   </Dropdown>
                 </div>
               {/if}
-              {#if networkingMode === 'choice-container'}
+              {#if options.networking.networkingMode === 'choice-container'}
                 <div class="flex flex-row justify-center items-center w-full py-1">
                   <span
                     class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
                     >Container:</span>
                   <Dropdown
                     class="w-full"
-                    disabled={networkingMode !== 'choice-container'}
+                    disabled={options.networking.networkingMode !== 'choice-container'}
                     name="networkingModeUserContainer"
-                    bind:value={networkingModeUserContainer}>
+                    bind:value={options.networking.networkingModeUserContainer}>
                     {#each engineContainers as container (container.id)}
                       <option value={container.id}>{container.name} ({container.shortId})</option>
                     {/each}

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -27,6 +27,7 @@ import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { containersInfos } from '/@/stores/containers';
+import { networksListInfo } from '/@/stores/networks';
 import { runImageInfo } from '/@/stores/run-image-store';
 
 let options: RunOptions = $state({
@@ -97,10 +98,18 @@ let dataReady = $state(false);
 
 let imageDisplayName = $state('');
 
-let engineNetworks = $state<NetworkInspectInfo[]>([]);
-let engineContainers = $state<ContainerInfoUI[]>([]);
-
 const image = $runImageInfo;
+
+const containerUtils = new ContainerUtils();
+
+let engineNetworks = $derived<NetworkInspectInfo[]>(
+  $networksListInfo.filter(network => network.engineId === image.engineId),
+);
+let engineContainers = $derived<ContainerInfoUI[]>(
+  $containersInfos
+    .filter(container => container.engineId === image.engineId)
+    .map(container => containerUtils.getContainerInfoUI(container)),
+);
 
 onMount(async () => {
   if (!image) {
@@ -139,35 +148,6 @@ onMount(async () => {
     imageDisplayName = '...' + image.name.substring(image.name.length - 60);
   } else {
     imageDisplayName = image.name;
-  }
-
-  const allNetworks = await window.listNetworks();
-  engineNetworks = allNetworks.filter(network => network.engineId === image.engineId);
-
-  if (engineNetworks.length > 0) {
-    const bridgeNetwork = engineNetworks.find(network => network.Name === 'bridge');
-    if (bridgeNetwork) {
-      options.networking.networkingModeUserNetwork = bridgeNetwork.Id;
-    } else {
-      options.networking.networkingModeUserNetwork = engineNetworks[0].Id;
-    }
-  }
-
-  const allContainers = await window.listContainers();
-  const containerUtils = new ContainerUtils();
-  engineContainers = allContainers
-    .filter(container => container.engineId === image.engineId)
-    .map(container => containerUtils.getContainerInfoUI(container));
-
-  if (engineContainers.length > 0) {
-    const runningContainers = engineContainers
-      .filter(container => container.state === 'RUNNING')
-      .toSorted((a, b) => b.created - a.created);
-    if (runningContainers.length > 0) {
-      options.networking.networkingModeUserContainer = runningContainers[0].id;
-    } else {
-      options.networking.networkingModeUserContainer = engineContainers[0].id;
-    }
   }
 });
 

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
-import type { OpenDialogOptions } from '@podman-desktop/api';
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
 import type {
   ContainerCreateOptions,
   DeviceMapping,
@@ -10,17 +9,20 @@ import type {
   NetworkInspectInfo,
 } from '@podman-desktop/core-api';
 import { NavigationPage } from '@podman-desktop/core-api';
-import { Button, Checkbox, Dropdown, ErrorMessage, Input, NumberInput, Tab } from '@podman-desktop/ui-svelte';
+import { Button, ErrorMessage, Tab } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import { ContainerUtils } from '/@/lib/container/container-utils';
 import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import type { PortInfo, RunOptions } from '/@/lib/image/run/run-options';
+import AdvancedTab from '/@/lib/image/run/tabs/AdvancedTab.svelte';
+import BasicTab from '/@/lib/image/run/tabs/BasicTab.svelte';
+import NetworkingTab from '/@/lib/image/run/tabs/NetworkingTab.svelte';
+import SecurityTab from '/@/lib/image/run/tabs/SecurityTab.svelte';
 import { splitSpacesHandlingDoubleQuotes } from '/@/lib/string/string';
 import { array2String } from '/@/lib/string/string.js';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
-import FileInput from '/@/lib/ui/FileInput.svelte';
 import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
@@ -67,7 +69,6 @@ let options: RunOptions = $state({
 let imageInspectInfo: ImageInspectInfo;
 
 let containerNameError: string | undefined = $derived.by(() => {
-  // ok, now check if we already have a matching container: same name and same engine ID
   const containerAlreadyExists = $containersInfos.find(
     container =>
       container.engineId === imageInspectInfo.engineId &&
@@ -103,7 +104,6 @@ const image = $runImageInfo;
 
 onMount(async () => {
   if (!image) {
-    // go back to image list
     router.goto('/images/');
     return;
   }
@@ -125,7 +125,6 @@ onMount(async () => {
     options.basic.entrypoint = '';
   }
 
-  // auto-assign ports from available free port
   containerPortMapping = new Array<PortInfo>(exposedPorts.length);
   await Promise.all(
     exposedPorts.map(async (port, index) => {
@@ -142,48 +141,37 @@ onMount(async () => {
     imageDisplayName = image.name;
   }
 
-  // grab all networks
   const allNetworks = await window.listNetworks();
-  // keep only the network matching our engine
   engineNetworks = allNetworks.filter(network => network.engineId === image.engineId);
 
   if (engineNetworks.length > 0) {
-    // try to match the bridge network
     const bridgeNetwork = engineNetworks.find(network => network.Name === 'bridge');
     if (bridgeNetwork) {
       options.networking.networkingModeUserNetwork = bridgeNetwork.Id;
     } else {
-      // fallback to the first network
       options.networking.networkingModeUserNetwork = engineNetworks[0].Id;
     }
   }
 
-  // grab all containers
   const allContainers = await window.listContainers();
   const containerUtils = new ContainerUtils();
-  // keep only the containers matching our engine
   engineContainers = allContainers
     .filter(container => container.engineId === image.engineId)
     .map(container => containerUtils.getContainerInfoUI(container));
 
   if (engineContainers.length > 0) {
-    // do we have a Running container ?
-    // sort from newest to oldest
     const runningContainers = engineContainers
       .filter(container => container.state === 'RUNNING')
       .toSorted((a, b) => b.created - a.created);
     if (runningContainers.length > 0) {
-      // use the first running container
       options.networking.networkingModeUserContainer = runningContainers[0].id;
     } else {
-      // fallback to the first container
       options.networking.networkingModeUserContainer = engineContainers[0].id;
     }
   }
 });
 
 async function getPortsInfo(portDescriptor: string): Promise<string | undefined> {
-  // check if portDescriptor is a range of ports
   if (portDescriptor.includes('-')) {
     return await getPortRange(portDescriptor);
   } else {
@@ -195,11 +183,6 @@ async function getPortsInfo(portDescriptor: string): Promise<string | undefined>
   }
 }
 
-/**
- * return a range of the same length as portDescriptor containing free ports
- * undefined if the portDescriptor range is not valid
- * e.g 5000:5001 -> 9000:9001
- */
 async function getPortRange(portDescriptor: string): Promise<string | undefined> {
   const rangeValues = getStartEndRange(portDescriptor);
   if (!rangeValues) {
@@ -208,7 +191,6 @@ async function getPortRange(portDescriptor: string): Promise<string | undefined>
 
   const rangeSize = rangeValues.endRange + 1 - rangeValues.startRange;
   try {
-    // if free port range fails, return undefined
     return await window.getFreePortRange(rangeSize);
   } catch (e) {
     console.error(e);
@@ -223,12 +205,10 @@ async function getPort(portDescriptor: string): Promise<number | undefined> {
   } else {
     port = parseInt(portDescriptor);
   }
-  // invalid port
   if (isNaN(port)) {
     return Promise.resolve(undefined);
   }
   try {
-    // if getFreePort fails, it returns undefined
     return await window.getFreePort(port);
   } catch (e) {
     console.error(e);
@@ -238,7 +218,6 @@ async function getPort(portDescriptor: string): Promise<number | undefined> {
 
 async function startContainer(): Promise<void> {
   createError = undefined;
-  // create ExposedPorts objects
   const ExposedPorts: { [key: string]: object } = {};
 
   const PortBindings: HostConfigPortBinding = {};
@@ -270,13 +249,8 @@ async function startContainer(): Promise<void> {
     return;
   }
 
-  const Env = options.basic.environmentVariables
-    // filter variables withouts keys
-    .filter(env => env.key)
-    // no value, use empty string
-    .map(env => `${env.key}=${env.value ?? ''}`);
+  const Env = options.basic.environmentVariables.filter(env => env.key).map(env => `${env.key}=${env.value ?? ''}`);
 
-  // filter empty files
   const EnvFiles = options.basic.environmentFiles.filter(env => env);
 
   const Image = image.tag ? `${image.name}:${image.tag}` : image.id;
@@ -285,12 +259,10 @@ async function startContainer(): Promise<void> {
     Name: options.advanced.restartPolicyName,
   };
 
-  // only set MaximumRetryCount if policy is 'on-failure'
   if (options.advanced.restartPolicyName === 'on-failure') {
     RestartPolicy.MaximumRetryCount = options.advanced.restartPolicyMaxRetryCount;
   }
 
-  // need both source and target to be set
   const Binds = options.basic.volumeMounts
     .filter(volume => volume.source && volume.target)
     .map(volume => `${volume.source}:${volume.target}`);
@@ -398,7 +370,6 @@ async function startContainer(): Promise<void> {
   try {
     const data = await window.createAndStartContainer(imageInspectInfo.engineId, createOptions);
 
-    // redirect to containers if no tty, else redirect to the container details
     if (Tty && OpenStdin) {
       handleNavigation({
         page: NavigationPage.CONTAINER_TTY,
@@ -436,7 +407,6 @@ function addPortsFromRange(
   const startHostRange = hostRangeValues.startRange;
   const endHostRange = hostRangeValues.endRange;
 
-  // if the two ranges have different size, do not proceed
   const containerRangeSize = endContainerRange + 1 - startContainerRange;
   const hostRangeSize = endHostRange + 1 - startHostRange;
   if (containerRangeSize !== hostRangeSize) {
@@ -445,10 +415,6 @@ function addPortsFromRange(
     );
   }
 
-  // we add all ports separately - if we have two ranges like 8080-8082 and 9000-9002 we'll end up with a mapping like
-  // 8080 => HostPort: 9000
-  // 8081 => HostPort: 9001
-  // 8082 => HostPort: 9002
   for (let i = 0; i < containerRangeSize; i++) {
     portBindings[`${startContainerRange + i}`] = [{ HostPort: `${startHostRange + i}` }];
     exposedPorts[`${startContainerRange + i}`] = {};
@@ -481,114 +447,15 @@ function getStartEndRange(range: string):
   };
 }
 
-function addEnvVariable(): void {
-  options.basic.environmentVariables = [...options.basic.environmentVariables, { key: '', value: '' }];
-}
-
-function deleteEnvVariable(index: number): void {
-  options.basic.environmentVariables = options.basic.environmentVariables.filter((_, i) => i !== index);
-}
-
-function addEnvFile(): void {
-  options.basic.environmentFiles = [...options.basic.environmentFiles, ''];
-}
-
-function deleteEnvFile(index: number): void {
-  options.basic.environmentFiles = options.basic.environmentFiles.filter((_, i) => i !== index);
-}
-
-function addHostContainerPorts(): void {
-  options.basic.hostContainerPortMappings = [
-    ...options.basic.hostContainerPortMappings,
-    {
-      hostPort: {
-        port: '',
-        error: '',
-      },
-      containerPort: '',
-    },
-  ];
-}
-
-async function deleteHostContainerPorts(index: number): Promise<void> {
-  options.basic.hostContainerPortMappings = options.basic.hostContainerPortMappings.filter((_, i) => i !== index);
-}
-
-function addVolumeMount(): void {
-  options.basic.volumeMounts = [...options.basic.volumeMounts, { source: '', target: '' }];
-}
-
-function deleteVolumeMount(index: number): void {
-  options.basic.volumeMounts = options.basic.volumeMounts.filter((_, i) => i !== index);
-}
-
-function deleteSecurityOpt(index: number): void {
-  options.security.securityOpts = options.security.securityOpts.filter((_, i) => i !== index);
-}
-
-function addSecurityOpt(): void {
-  options.security.securityOpts = [...options.security.securityOpts, ''];
-}
-
-function addCapAdd(): void {
-  options.security.capAdds = [...options.security.capAdds, ''];
-}
-function addCapDrop(): void {
-  options.security.capDrops = [...options.security.capDrops, ''];
-}
-
-function deleteCapAdd(index: number): void {
-  options.security.capAdds = options.security.capAdds.filter((_, i) => i !== index);
-}
-
-function deleteCappDrop(index: number): void {
-  options.security.capDrops = options.security.capDrops.filter((_, i) => i !== index);
-}
-
-function addDnsServer(): void {
-  options.networking.dnsServers = [...options.networking.dnsServers, ''];
-}
-
-function deleteDnsServer(index: number): void {
-  options.networking.dnsServers = options.networking.dnsServers.filter((_, i) => i !== index);
-}
-
-function addExtraHost(): void {
-  options.networking.extraHosts = [...options.networking.extraHosts, { host: '', ip: '' }];
-}
-
-function deleteExtraHost(index: number): void {
-  options.networking.extraHosts = options.networking.extraHosts.filter((_, i) => i !== index);
-}
-
-function addDevice(): void {
-  options.advanced.devices = [
-    ...options.advanced.devices,
-    { host: '', container: '', read: false, write: false, mknod: false },
-  ];
-}
-
-function deleteDevice(index: number): void {
-  options.advanced.devices = options.advanced.devices.filter((_, i) => i !== index);
-}
-
 function onContainerPortMappingInput(event: Event, index: number): void {
   onPortInput(event, containerPortMapping[index], () => {
     containerPortMapping = containerPortMapping;
   });
 }
 
-function onHostContainerPortMappingInput(event: Event, index: number): void {
-  onPortInput(event, options.basic.hostContainerPortMappings[index].hostPort, () => {
-    options.basic.hostContainerPortMappings = options.basic.hostContainerPortMappings;
-  });
-}
-
 function onPortInput(event: Event, portInfo: PortInfo, updateUI: () => void): void {
-  // clear the timeout so if there was an old call to areAllPortsFree pending is deleted. We will create a new one soon
   clearTimeout(onPortInputTimeout);
   const target = event.currentTarget as HTMLInputElement;
-  // convert string to number
   const _value: number = Number(target.value);
   onPortInputTimeout = setTimeout(() => {
     window
@@ -605,16 +472,6 @@ function onPortInput(event: Event, portInfo: PortInfo, updateUI: () => void): vo
       });
   }, 500);
 }
-
-const volumeDialogOptions: OpenDialogOptions = {
-  title: 'Select a directory to mount in the container',
-  selectors: ['openDirectory'],
-};
-
-const envDialogOptions: OpenDialogOptions = {
-  title: 'Select environment file',
-  selectors: ['openFile'],
-};
 </script>
 
 <Route path="/*">
@@ -642,472 +499,21 @@ const envDialogOptions: OpenDialogOptions = {
         </div>
         <div class="pt-4">
           <Route path="/basic" breadcrumb="Basic" navigationHint="tab">
-            <div class="pr-4">
-              <label
-                for="modalContainerName"
-                class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Container name:</label>
-              <Input
-                bind:value={options.basic.containerName}
-                name="modalContainerName"
-                id="modalContainerName"
-                placeholder="Leave blank to generate a name"
-                aria-label="Container Name"
-                error={containerNameError} />
-              <label
-                for="modalEntrypoint"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Entrypoint:</label>
-              <Input bind:value={options.basic.entrypoint} name="modalEntrypoint" id="modalEntrypoint" aria-label="Entrypoint" />
-              <label
-                for="modalCommand"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Command:</label>
-              <Input bind:value={options.basic.command} name="modalCommand" id="modalCommand" aria-label="Command" />
-              <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Volumes:</label>
-              <!-- Display the list of volumes -->
-              {#each options.basic.volumeMounts as volumeMount, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <FileInput
-                    id="volumeMount.{index}"
-                    placeholder="Path on the host"
-                    bind:value={volumeMount.source}
-                    options={volumeDialogOptions}
-                    aria-label="volumeMount.{index}" />
-                  <Input bind:value={volumeMount.target} placeholder="Path inside the container" class="ml-2" />
-                  <Button
-                    type="link"
-                    hidden={index === options.basic.volumeMounts.length - 1}
-                    aria-label="Delete volume mount at index {index}"
-                    on:click={(): void => deleteVolumeMount(index)}
-                    icon={faMinusCircle} />
-                  <Button
-                    type="link"
-                    hidden={index < options.basic.volumeMounts.length - 1}
-                    aria-label="Add volume mount after index {index}"
-                    on:click={addVolumeMount}
-                    icon={faPlusCircle} />
-                </div>
-              {/each}
-
-              <!-- add a label for each port-->
-              <label
-                for="modalContainerName"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Port mapping:</label>
-              {#each exposedPorts as port, index (index)}
-                <div class="flex flex-row justify-center items-center w-full">
-                  <span
-                    class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
-                    >Local port for {port}:</span>
-                  <Input
-                    bind:value={containerPortMapping[index].port}
-                    on:input={(event): void => onContainerPortMappingInput(event, index)}
-                    placeholder="Enter value for port {port}"
-                    error={containerPortMapping[index].error}
-                    class="ml-2 w-full"
-                    title={containerPortMapping[index].error} />
-                </div>
-              {/each}
-
-              <Button
-                on:click={addHostContainerPorts}
-                icon={faPlusCircle}
-                type="link"
-                aria-label="Add custom port mapping">
-                Add custom port mapping
-              </Button>
-              <!-- Display the list of existing hostContainerPortMappings -->
-              {#each options.basic.hostContainerPortMappings as hostContainerPortMapping, index (index)}
-                <div class="flex flex-row justify-center w-full py-1">
-                  <Input
-                    bind:value={hostContainerPortMapping.hostPort.port}
-                    on:input={(event): void => onHostContainerPortMappingInput(event, index)}
-                    aria-label="host port"
-                    placeholder="Host Port"
-                    error={hostContainerPortMapping.hostPort.error}
-                    title={hostContainerPortMapping.hostPort.error} />
-                  <Input
-                    bind:value={hostContainerPortMapping.containerPort}
-                    aria-label="container port"
-                    placeholder="Container Port"
-                    class="ml-2" />
-                  <Button type="link" on:click={async (): Promise<void> => await deleteHostContainerPorts(index)} icon={faMinusCircle} aria-label="Remove port mapping" />
-                </div>
-              {/each}
-              <label
-                for="modalEnvironmentVariables"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Environment variables:</label>
-              <!-- Display the list of existing environment variables -->
-              {#each options.basic.environmentVariables as environmentVariable, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input bind:value={environmentVariable.key} placeholder="Name" class="w-full" />
-
-                  <Input
-                    bind:value={environmentVariable.value}
-                    placeholder="Value (leave blank for empty)"
-                    class="ml-2" />
-                  <Button
-                    type="link"
-                    hidden={index === options.basic.environmentVariables.length - 1}
-                    aria-label="Delete environment variable at index {index}"
-                    on:click={(): void => deleteEnvVariable(index)}
-                    icon={faMinusCircle} />
-                  <Button
-                    type="link"
-                    hidden={index < options.basic.environmentVariables.length - 1}
-                    aria-label="Add environment variable after index {index}"
-                    on:click={addEnvVariable}
-                    icon={faPlusCircle} />
-                </div>
-              {/each}
-
-              <label
-                for="modalEnvironmentFiles"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Environment files:</label>
-              <!-- Display the list of existing environment files -->
-              {#each options.basic.environmentFiles as _, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <FileInput
-                    id="filePath.{index}"
-                    placeholder="Environment file containing KEY=VALUE items"
-                    bind:value={options.basic.environmentFiles[index]}
-                    options={envDialogOptions}
-                    aria-label="environmentFile.{index}" />
-                  <Button
-                    type="link"
-                    hidden={index === options.basic.environmentFiles.length - 1}
-                    aria-label="Delete env file at index {index}"
-                    on:click={(): void => deleteEnvFile(index)}
-                    icon={faMinusCircle} />
-                  <Button
-                    type="link"
-                    hidden={index < options.basic.environmentFiles.length - 1}
-                    aria-label="Add env file after index {index}"
-                    on:click={addEnvFile}
-                    icon={faPlusCircle} />
-                </div>
-              {/each}
-            </div>
+            <BasicTab
+              bind:options={options.basic}
+              {containerNameError}
+              {exposedPorts}
+              bind:containerPortMapping
+              {onContainerPortMappingInput} />
           </Route>
           <Route path="/advanced" breadcrumb="Advanced" navigationHint="tab">
-            <div class="pr-4">
-              <!-- Use tty -->
-              <label for="containerTty" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Use TTY:</label>
-              <div class="flex flex-col text-[var(--pd-content-card-text)] text-sm ml-2">
-                <Checkbox bind:checked={options.advanced.useTty} title="Attach a pseudo terminal">Attach a pseudo terminal</Checkbox>
-                <Checkbox bind:checked={options.advanced.useInteractive} title="Use interactive">
-                  Interactive: Keep STDIN open even if not attached
-                </Checkbox>
-              </div>
-
-              <!-- Specify user-->
-              <label
-                for="containerUser"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Specify user to run container as:</label>
-              <div class="flex flex-row justify-center items-center w-full">
-                <Input
-                  bind:value={options.advanced.runUser}
-                  placeholder="If you specify a username, user must exist in /etc/passwd file (use user id instead)"
-                  class="ml-2" />
-              </div>
-
-              <!-- Autoremove-->
-              <label
-                for="containerAutoRemove"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Auto removal of container:</label>
-              <Checkbox class="text-[var(--pd-content-card-text)] text-sm ml-2" bind:checked={options.advanced.autoRemove}>
-                Automatically remove the container when the process exits
-              </Checkbox>
-
-              <!-- RestartPolicy-->
-              <label
-                for="containerRestartPolicy"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Restart policy:</label>
-              <div
-                class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-card-text)]">
-                <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Policy name:</span>
-
-                <Dropdown class="w-full" name="restartPolicyName" bind:value={options.advanced.restartPolicyName}>
-                  <option value="">No restart</option>
-                  <option value="no">Do not restart automatically</option>
-                  <option value="always">Always restart</option>
-                  <option value="unless-stopped">Restart only if user has not manually stopped</option>
-                  <option value="on-failure">Restart only if exit code is non-zero</option>
-                </Dropdown>
-              </div>
-
-              <div
-                class="flex flex-row justify-center items-center w-full py-1 {options.advanced.restartPolicyName === 'on-failure'
-                  ? 'opacity-100'
-                  : 'opacity-20'}">
-                <span
-                  class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
-                  title="Number of times to retry before giving up.">Retries:</span>
-                <NumberInput
-                  minimum={0}
-                  bind:value={options.advanced.restartPolicyMaxRetryCount}
-                  type="integer"
-                  class="w-24 p-2"
-                  disabled={options.advanced.restartPolicyName !== 'on-failure'} />
-              </div>
-
-              <!-- devices -->
-              <label
-                for="modalDevices"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Devices:</label>
-              <!-- Display the list of existing devices -->
-              {#each options.advanced.devices as device, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input
-                    bind:value={device.host}
-                    placeholder="Host Device"
-                    class="w-full"
-                    aria-label="device.host.{index}" />
-                  <Input
-                    bind:value={device.container}
-                    placeholder="Container Device (leave blank for same as host device)"
-                    class="ml-2"
-                    aria-label="device.container.{index}" />
-                  <div class="flex flew-row space-x-4 ml-2 text-sm">
-                    <Checkbox bind:checked={device.read} title="Read">Read</Checkbox>
-                    <Checkbox bind:checked={device.write} title="Write">Write</Checkbox>
-                    <Checkbox bind:checked={device.mknod} title="Mknod">Mknod</Checkbox>
-                  </div>
-                  <Button
-                    type="link"
-                    hidden={index === options.advanced.devices.length - 1}
-                    aria-label="Delete device at index {index}"
-                    on:click={(): void => deleteDevice(index)}
-                    icon={faMinusCircle} />
-                  <Button
-                    type="link"
-                    hidden={index < options.advanced.devices.length - 1}
-                    aria-label="Add device after index {index}"
-                    on:click={addDevice}
-                    icon={faPlusCircle} />
-                </div>
-              {/each}
-            </div>
+            <AdvancedTab bind:options={options.advanced} />
           </Route>
-
           <Route path="/security" breadcrumb="Security" navigationHint="tab">
-            <div class="pr-4">
-              <!-- Privileged-->
-              <label
-                for="containerPrivileged"
-                class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Privileged:</label>
-              <Checkbox bind:checked={options.security.privileged} class="text-[var(--pd-content-card-text)] text-sm mx-2">
-                Turn off security<i class="pl-1 fas fa-exclamation-triangle"></i>
-              </Checkbox>
-
-              <!-- Read-Only -->
-              <label
-                for="containerReadOnly"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Read only:</label>
-              <Checkbox bind:checked={options.security.readOnly} class="text-[var(--pd-content-card-text)] text-sm mx-2">
-                Make containers root filesystem read-only
-              </Checkbox>
-
-              <label
-                for="ContainerSecurityOptions"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Security options (security-opt):</label>
-              <!-- Display the list of existing security options -->
-              {#each options.security.securityOpts as _, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input
-                    bind:value={options.security.securityOpts[index]}
-                    placeholder="Enter a security option (Ex. seccomp=/path/to/profile.json)"
-                    class="ml-2" />
-
-                  <Button
-                    type="link"
-                    hidden={index === options.security.securityOpts.length - 1}
-                    aria-label="Delete security option at index {index}"
-                    on:click={(): void => deleteSecurityOpt(index)}
-                    icon={faMinusCircle} />
-                  <Button
-                    type="link"
-                    hidden={index < options.security.securityOpts.length - 1}
-                    aria-label="Add security option after index {index}"
-                    on:click={addSecurityOpt}
-                    icon={faPlusCircle} />
-                </div>
-              {/each}
-
-              <label
-                for="ContainerSecurityCapabilitiesAdd"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Capabilities:</label>
-
-              <label
-                for="ContainerSecurityCapabilitiesAdd"
-                class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Add to the container (CapAdd):</label>
-              <!-- Display the list of existing capAdd -->
-              {#each options.security.capAdds as _, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input bind:value={options.security.capAdds[index]} placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
-
-                  <Button
-                    type="link"
-                    hidden={index === options.security.capAdds.length - 1}
-                    on:click={(): void => deleteCapAdd(index)}
-                    icon={faMinusCircle}
-                    aria-label="Remove capability" />
-                  <Button type="link" hidden={index < options.security.capAdds.length - 1} on:click={addCapAdd} icon={faPlusCircle} aria-label="Add capability" />
-                </div>
-              {/each}
-              <label
-                for="ContainerSecurityCapabilitiesDrop"
-                class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Drop from the container (CapDrop):</label>
-              <!-- Display the list of existing capDrop -->
-              {#each options.security.capDrops as _, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input bind:value={options.security.capDrops[index]} placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
-
-                  <Button
-                    type="link"
-                    hidden={index === options.security.capDrops.length - 1}
-                    on:click={(): void => deleteCappDrop(index)}
-                    icon={faMinusCircle}
-                    aria-label="Remove capability" />
-                  <Button type="link" hidden={index < options.security.capDrops.length - 1} on:click={addCapDrop} icon={faPlusCircle} aria-label="Add capability" />
-                </div>
-              {/each}
-
-              <!-- Specify user namespace-->
-              <label
-                for="containerUserNamespace"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Specify user namespace to use:</label>
-              <div class="flex flex-row justify-center items-center w-full">
-                <Input bind:value={options.security.userNamespace} placeholder="Enter a user namespace" class="ml-2 w-full" />
-              </div>
-            </div>
+            <SecurityTab bind:options={options.security} />
           </Route>
-
           <Route path="/networking" breadcrumb="Networking" navigationHint="tab">
-            <div class="pr-4">
-              <!-- hostname-->
-              <label
-                for="containerHostname"
-                class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Defines container hostname:</label>
-              <div class="flex flex-row justify-center items-center w-full">
-                <Input bind:value={options.networking.hostname} placeholder="Must be a valid RFC 1123 hostname" class="ml-2" />
-              </div>
-
-              <!-- DNS -->
-              <label
-                for="ContainerDns"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Custom DNS server(s):</label>
-
-              {#each options.networking.dnsServers as _, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input bind:value={options.networking.dnsServers[index]} placeholder="IP Address" class="ml-2" />
-
-                  <Button
-                    type="link"
-                    hidden={index === options.networking.dnsServers.length - 1}
-                    aria-label="Delete DNS server at index {index}"
-                    on:click={(): void => deleteDnsServer(index)}
-                    icon={faMinusCircle} />
-                  <Button
-                    type="link"
-                    hidden={index < options.networking.dnsServers.length - 1}
-                    aria-label="Add DNS server after index {index}"
-                    on:click={addDnsServer}
-                    icon={faPlusCircle} />
-                </div>
-              {/each}
-
-              <label
-                for="containerExtraHosts"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Add extra hosts (appends to /etc/hosts file):</label>
-              <!-- Display the list of extra hosts -->
-              {#each options.networking.extraHosts as extraHost, index (index)}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <Input bind:value={extraHost.host} placeholder="Hostname" class="ml-2" />
-
-                  <Input bind:value={extraHost.ip} placeholder="IP Address" class="ml-2" />
-                  <Button
-                    type="link"
-                    hidden={index === options.networking.extraHosts.length - 1}
-                    aria-label="Delete extra host at index {index}"
-                    on:click={(): void => deleteExtraHost(index)}
-                    icon={faMinusCircle} />
-                  <Button
-                    type="link"
-                    hidden={index < options.networking.extraHosts.length - 1}
-                    aria-label="Add extra host after index {index}"
-                    on:click={addExtraHost}
-                    icon={faPlusCircle} />
-                </div>
-              {/each}
-
-              <!-- Select network -->
-              <label
-                for="containerNetwork"
-                class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
-                >Select container networking:</label>
-              <div
-                class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-card-text)]">
-                <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Mode:</span>
-
-                <Dropdown class="w-full" name="providerChoice" bind:value={options.networking.networkingMode}>
-                  <option value="bridge">Creates a network stack on the default bridge (default)</option>
-                  <option value="none">No networking</option>
-                  <option value="host">Use the host networking stack</option>
-                  <option value="choice-container">Use another container networking stack</option>
-                  <!-- display only if there is at least one network-->
-                  <option value="choice-network">User-defined network</option>
-                </Dropdown>
-              </div>
-
-              {#if options.networking.networkingMode === 'choice-network'}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <span
-                    class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
-                    >Network:</span>
-                  <Dropdown
-                    class="w-full"
-                    disabled={options.networking.networkingMode !== 'choice-network'}
-                    name="networkingModeUserNetwork"
-                    bind:value={options.networking.networkingModeUserNetwork}>
-                    {#each engineNetworks as network (network.Id)}
-                      <option value={network.Id}
-                        >{network.Name} (used by {Object.keys(network.Containers ?? {}).length} containers)</option>
-                    {/each}
-                  </Dropdown>
-                </div>
-              {/if}
-              {#if options.networking.networkingMode === 'choice-container'}
-                <div class="flex flex-row justify-center items-center w-full py-1">
-                  <span
-                    class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
-                    >Container:</span>
-                  <Dropdown
-                    class="w-full"
-                    disabled={options.networking.networkingMode !== 'choice-container'}
-                    name="networkingModeUserContainer"
-                    bind:value={options.networking.networkingModeUserContainer}>
-                    {#each engineContainers as container (container.id)}
-                      <option value={container.id}>{container.name} ({container.shortId})</option>
-                    {/each}
-                  </Dropdown>
-                </div>
-              {/if}
-            </div>
+            <NetworkingTab bind:options={options.networking} {engineNetworks} {engineContainers} />
           </Route>
         </div>
 

--- a/packages/renderer/src/lib/image/run/run-options.ts
+++ b/packages/renderer/src/lib/image/run/run-options.ts
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface PortInfo {
+  port: string;
+  error: string;
+}
+
+export interface RunOptions {
+  basic: {
+    containerName: string;
+    entrypoint: string;
+    command: string;
+    volumeMounts: { source: string; target: string }[];
+    environmentVariables: { key: string; value: string }[];
+    environmentFiles: string[];
+    hostContainerPortMappings: { hostPort: PortInfo; containerPort: string }[];
+  };
+  networking: {
+    hostname?: string;
+    dnsServers: string[];
+    extraHosts: { host: string; ip: string }[];
+    networkingMode: string;
+    networkingModeUserNetwork: string;
+    networkingModeUserContainer: string;
+  };
+  advanced: {
+    useTty: boolean;
+    useInteractive: boolean;
+    runUser?: string;
+    autoRemove: boolean;
+    restartPolicyName: string;
+    restartPolicyMaxRetryCount: number;
+    devices: { host: string; container: string; read: boolean; write: boolean; mknod: boolean }[];
+  };
+  security: {
+    privileged: boolean;
+    readOnly: boolean;
+    securityOpts: string[];
+    capAdds: string[];
+    capDrops: string[];
+    userNamespace?: string;
+  };
+}

--- a/packages/renderer/src/lib/image/run/tabs/AdvancedTab.svelte
+++ b/packages/renderer/src/lib/image/run/tabs/AdvancedTab.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+import { faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { Button, Checkbox, Dropdown, Input, NumberInput } from '@podman-desktop/ui-svelte';
+
+import type { RunOptions } from '/@/lib/image/run/run-options';
+
+interface Props {
+  options: RunOptions['advanced'];
+}
+
+let { options = $bindable() }: Props = $props();
+
+function addDevice(): void {
+  options.devices = [...options.devices, { host: '', container: '', read: false, write: false, mknod: false }];
+}
+
+function deleteDevice(index: number): void {
+  options.devices = options.devices.filter((_, i) => i !== index);
+}
+</script>
+
+<div class="pr-4">
+  <label for="containerTty" class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Use TTY:</label>
+  <div class="flex flex-col text-[var(--pd-content-card-text)] text-sm ml-2">
+    <Checkbox bind:checked={options.useTty} title="Attach a pseudo terminal">Attach a pseudo terminal</Checkbox>
+    <Checkbox bind:checked={options.useInteractive} title="Use interactive">
+      Interactive: Keep STDIN open even if not attached
+    </Checkbox>
+  </div>
+
+  <label
+    for="containerUser"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Specify user to run container as:</label>
+  <div class="flex flex-row justify-center items-center w-full">
+    <Input
+      bind:value={options.runUser}
+      placeholder="If you specify a username, user must exist in /etc/passwd file (use user id instead)"
+      class="ml-2" />
+  </div>
+
+  <label
+    for="containerAutoRemove"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Auto removal of container:</label>
+  <Checkbox class="text-[var(--pd-content-card-text)] text-sm ml-2" bind:checked={options.autoRemove}>
+    Automatically remove the container when the process exits
+  </Checkbox>
+
+  <label
+    for="containerRestartPolicy"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Restart policy:</label>
+  <div
+    class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-card-text)]">
+    <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Policy name:</span>
+
+    <Dropdown class="w-full" name="restartPolicyName" bind:value={options.restartPolicyName}>
+      <option value="">No restart</option>
+      <option value="no">Do not restart automatically</option>
+      <option value="always">Always restart</option>
+      <option value="unless-stopped">Restart only if user has not manually stopped</option>
+      <option value="on-failure">Restart only if exit code is non-zero</option>
+    </Dropdown>
+  </div>
+
+  <div
+    class="flex flex-row justify-center items-center w-full py-1 {options.restartPolicyName === 'on-failure'
+      ? 'opacity-100'
+      : 'opacity-20'}">
+    <span
+      class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
+      title="Number of times to retry before giving up.">Retries:</span>
+    <NumberInput
+      minimum={0}
+      bind:value={options.restartPolicyMaxRetryCount}
+      type="integer"
+      class="w-24 p-2"
+      disabled={options.restartPolicyName !== 'on-failure'} />
+  </div>
+
+  <label
+    for="modalDevices"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Devices:</label>
+  {#each options.devices as device, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <Input
+        bind:value={device.host}
+        placeholder="Host Device"
+        class="w-full"
+        aria-label="device.host.{index}" />
+      <Input
+        bind:value={device.container}
+        placeholder="Container Device (leave blank for same as host device)"
+        class="ml-2"
+        aria-label="device.container.{index}" />
+      <div class="flex flew-row space-x-4 ml-2 text-sm">
+        <Checkbox bind:checked={device.read} title="Read">Read</Checkbox>
+        <Checkbox bind:checked={device.write} title="Write">Write</Checkbox>
+        <Checkbox bind:checked={device.mknod} title="Mknod">Mknod</Checkbox>
+      </div>
+      <Button
+        type="link"
+        hidden={index === options.devices.length - 1}
+        aria-label="Delete device at index {index}"
+        on:click={(): void => deleteDevice(index)}
+        icon={faMinusCircle} />
+      <Button
+        type="link"
+        hidden={index < options.devices.length - 1}
+        aria-label="Add device after index {index}"
+        on:click={addDevice}
+        icon={faPlusCircle} />
+    </div>
+  {/each}
+</div>

--- a/packages/renderer/src/lib/image/run/tabs/BasicTab.svelte
+++ b/packages/renderer/src/lib/image/run/tabs/BasicTab.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+import { faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import type { OpenDialogOptions } from '@podman-desktop/api';
+import { Button, Input } from '@podman-desktop/ui-svelte';
+
+import type { PortInfo, RunOptions } from '/@/lib/image/run/run-options';
+import FileInput from '/@/lib/ui/FileInput.svelte';
+
+interface Props {
+  options: RunOptions['basic'];
+  containerNameError?: string;
+  exposedPorts: string[];
+  containerPortMapping: PortInfo[];
+  onContainerPortMappingInput: (event: Event, index: number) => void;
+}
+
+let {
+  options = $bindable(),
+  containerNameError,
+  exposedPorts,
+  containerPortMapping = $bindable(),
+  onContainerPortMappingInput,
+}: Props = $props();
+
+function addVolumeMount(): void {
+  options.volumeMounts = [...options.volumeMounts, { source: '', target: '' }];
+}
+
+function deleteVolumeMount(index: number): void {
+  options.volumeMounts = options.volumeMounts.filter((_, i) => i !== index);
+}
+
+function addEnvVariable(): void {
+  options.environmentVariables = [...options.environmentVariables, { key: '', value: '' }];
+}
+
+function deleteEnvVariable(index: number): void {
+  options.environmentVariables = options.environmentVariables.filter((_, i) => i !== index);
+}
+
+function addEnvFile(): void {
+  options.environmentFiles = [...options.environmentFiles, ''];
+}
+
+function deleteEnvFile(index: number): void {
+  options.environmentFiles = options.environmentFiles.filter((_, i) => i !== index);
+}
+
+function addHostContainerPorts(): void {
+  options.hostContainerPortMappings = [
+    ...options.hostContainerPortMappings,
+    {
+      hostPort: {
+        port: '',
+        error: '',
+      },
+      containerPort: '',
+    },
+  ];
+}
+
+async function deleteHostContainerPorts(index: number): Promise<void> {
+  options.hostContainerPortMappings = options.hostContainerPortMappings.filter((_, i) => i !== index);
+}
+
+function onHostContainerPortMappingInput(event: Event, index: number): void {
+  onPortInput(event, options.hostContainerPortMappings[index].hostPort, () => {
+    options.hostContainerPortMappings = options.hostContainerPortMappings;
+  });
+}
+
+function onPortInput(event: Event, portInfo: PortInfo, updateUI: () => void): void {
+  clearTimeout(onPortInputTimeout);
+  const target = event.currentTarget as HTMLInputElement;
+  const _value: number = Number(target.value);
+  onPortInputTimeout = setTimeout(() => {
+    window
+      .isFreePort(_value)
+      .then(_ => {
+        portInfo.error = '';
+        updateUI();
+      })
+      .catch((error: unknown) => {
+        if (error && typeof error === 'object' && 'message' in error) {
+          portInfo.error = (error as { message: string }).message;
+        }
+        updateUI();
+      });
+  }, 500);
+}
+
+let onPortInputTimeout: NodeJS.Timeout;
+
+const volumeDialogOptions: OpenDialogOptions = {
+  title: 'Select a directory to mount in the container',
+  selectors: ['openDirectory'],
+};
+
+const envDialogOptions: OpenDialogOptions = {
+  title: 'Select environment file',
+  selectors: ['openFile'],
+};
+</script>
+
+<div class="pr-4">
+  <label
+    for="modalContainerName"
+    class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Container name:</label>
+  <Input
+    bind:value={options.containerName}
+    name="modalContainerName"
+    id="modalContainerName"
+    placeholder="Leave blank to generate a name"
+    aria-label="Container Name"
+    error={containerNameError} />
+  <label
+    for="modalEntrypoint"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Entrypoint:</label>
+  <Input bind:value={options.entrypoint} name="modalEntrypoint" id="modalEntrypoint" aria-label="Entrypoint" />
+  <label
+    for="modalCommand"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Command:</label>
+  <Input bind:value={options.command} name="modalCommand" id="modalCommand" aria-label="Command" />
+  <label for="volumes" class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Volumes:</label>
+  {#each options.volumeMounts as volumeMount, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <FileInput
+        id="volumeMount.{index}"
+        placeholder="Path on the host"
+        bind:value={volumeMount.source}
+        options={volumeDialogOptions}
+        aria-label="volumeMount.{index}" />
+      <Input bind:value={volumeMount.target} placeholder="Path inside the container" class="ml-2" />
+      <Button
+        type="link"
+        hidden={index === options.volumeMounts.length - 1}
+        aria-label="Delete volume mount at index {index}"
+        on:click={(): void => deleteVolumeMount(index)}
+        icon={faMinusCircle} />
+      <Button
+        type="link"
+        hidden={index < options.volumeMounts.length - 1}
+        aria-label="Add volume mount after index {index}"
+        on:click={addVolumeMount}
+        icon={faPlusCircle} />
+    </div>
+  {/each}
+
+  <label
+    for="modalContainerName"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Port mapping:</label>
+  {#each exposedPorts as port, index (index)}
+    <div class="flex flex-row justify-center items-center w-full">
+      <span
+        class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
+        >Local port for {port}:</span>
+      <Input
+        bind:value={containerPortMapping[index].port}
+        on:input={(event): void => onContainerPortMappingInput(event, index)}
+        placeholder="Enter value for port {port}"
+        error={containerPortMapping[index].error}
+        class="ml-2 w-full"
+        title={containerPortMapping[index].error} />
+    </div>
+  {/each}
+
+  <Button
+    on:click={addHostContainerPorts}
+    icon={faPlusCircle}
+    type="link"
+    aria-label="Add custom port mapping">
+    Add custom port mapping
+  </Button>
+  {#each options.hostContainerPortMappings as hostContainerPortMapping, index (index)}
+    <div class="flex flex-row justify-center w-full py-1">
+      <Input
+        bind:value={hostContainerPortMapping.hostPort.port}
+        on:input={(event): void => onHostContainerPortMappingInput(event, index)}
+        aria-label="host port"
+        placeholder="Host Port"
+        error={hostContainerPortMapping.hostPort.error}
+        title={hostContainerPortMapping.hostPort.error} />
+      <Input
+        bind:value={hostContainerPortMapping.containerPort}
+        aria-label="container port"
+        placeholder="Container Port"
+        class="ml-2" />
+      <Button type="link" on:click={async (): Promise<void> => await deleteHostContainerPorts(index)} icon={faMinusCircle} aria-label="Remove port mapping" />
+    </div>
+  {/each}
+  <label
+    for="modalEnvironmentVariables"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Environment variables:</label>
+  {#each options.environmentVariables as environmentVariable, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <Input bind:value={environmentVariable.key} placeholder="Name" class="w-full" />
+
+      <Input
+        bind:value={environmentVariable.value}
+        placeholder="Value (leave blank for empty)"
+        class="ml-2" />
+      <Button
+        type="link"
+        hidden={index === options.environmentVariables.length - 1}
+        aria-label="Delete environment variable at index {index}"
+        on:click={(): void => deleteEnvVariable(index)}
+        icon={faMinusCircle} />
+      <Button
+        type="link"
+        hidden={index < options.environmentVariables.length - 1}
+        aria-label="Add environment variable after index {index}"
+        on:click={addEnvVariable}
+        icon={faPlusCircle} />
+    </div>
+  {/each}
+
+  <label
+    for="modalEnvironmentFiles"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Environment files:</label>
+  {#each options.environmentFiles as _, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <FileInput
+        id="filePath.{index}"
+        placeholder="Environment file containing KEY=VALUE items"
+        bind:value={options.environmentFiles[index]}
+        options={envDialogOptions}
+        aria-label="environmentFile.{index}" />
+      <Button
+        type="link"
+        hidden={index === options.environmentFiles.length - 1}
+        aria-label="Delete env file at index {index}"
+        on:click={(): void => deleteEnvFile(index)}
+        icon={faMinusCircle} />
+      <Button
+        type="link"
+        hidden={index < options.environmentFiles.length - 1}
+        aria-label="Add env file after index {index}"
+        on:click={addEnvFile}
+        icon={faPlusCircle} />
+    </div>
+  {/each}
+</div>

--- a/packages/renderer/src/lib/image/run/tabs/NetworkingTab.svelte
+++ b/packages/renderer/src/lib/image/run/tabs/NetworkingTab.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+import { faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import type { NetworkInspectInfo } from '@podman-desktop/core-api';
+import { Button, Dropdown, Input } from '@podman-desktop/ui-svelte';
+
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
+import type { RunOptions } from '/@/lib/image/run/run-options';
+
+interface Props {
+  options: RunOptions['networking'];
+  engineNetworks: NetworkInspectInfo[];
+  engineContainers: ContainerInfoUI[];
+}
+
+let { options = $bindable(), engineNetworks, engineContainers }: Props = $props();
+
+function addDnsServer(): void {
+  options.dnsServers = [...options.dnsServers, ''];
+}
+
+function deleteDnsServer(index: number): void {
+  options.dnsServers = options.dnsServers.filter((_, i) => i !== index);
+}
+
+function addExtraHost(): void {
+  options.extraHosts = [...options.extraHosts, { host: '', ip: '' }];
+}
+
+function deleteExtraHost(index: number): void {
+  options.extraHosts = options.extraHosts.filter((_, i) => i !== index);
+}
+</script>
+
+<div class="pr-4">
+  <label
+    for="containerHostname"
+    class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Defines container hostname:</label>
+  <div class="flex flex-row justify-center items-center w-full">
+    <Input bind:value={options.hostname} placeholder="Must be a valid RFC 1123 hostname" class="ml-2" />
+  </div>
+
+  <label
+    for="ContainerDns"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Custom DNS server(s):</label>
+
+  {#each options.dnsServers as _, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <Input bind:value={options.dnsServers[index]} placeholder="IP Address" class="ml-2" />
+
+      <Button
+        type="link"
+        hidden={index === options.dnsServers.length - 1}
+        aria-label="Delete DNS server at index {index}"
+        on:click={(): void => deleteDnsServer(index)}
+        icon={faMinusCircle} />
+      <Button
+        type="link"
+        hidden={index < options.dnsServers.length - 1}
+        aria-label="Add DNS server after index {index}"
+        on:click={addDnsServer}
+        icon={faPlusCircle} />
+    </div>
+  {/each}
+
+  <label
+    for="containerExtraHosts"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Add extra hosts (appends to /etc/hosts file):</label>
+  {#each options.extraHosts as extraHost, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <Input bind:value={extraHost.host} placeholder="Hostname" class="ml-2" />
+
+      <Input bind:value={extraHost.ip} placeholder="IP Address" class="ml-2" />
+      <Button
+        type="link"
+        hidden={index === options.extraHosts.length - 1}
+        aria-label="Delete extra host at index {index}"
+        on:click={(): void => deleteExtraHost(index)}
+        icon={faMinusCircle} />
+      <Button
+        type="link"
+        hidden={index < options.extraHosts.length - 1}
+        aria-label="Add extra host after index {index}"
+        on:click={addExtraHost}
+        icon={faPlusCircle} />
+    </div>
+  {/each}
+
+  <label
+    for="containerNetwork"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Select container networking:</label>
+  <div
+    class="p-0 flex flex-row justify-start items-center align-middle w-full text-[var(--pd-content-card-text)]">
+    <span class="text-sm w-28 inline-block align-middle whitespace-nowrap">Mode:</span>
+
+    <Dropdown class="w-full" name="providerChoice" bind:value={options.networkingMode}>
+      <option value="bridge">Creates a network stack on the default bridge (default)</option>
+      <option value="none">No networking</option>
+      <option value="host">Use the host networking stack</option>
+      <option value="choice-container">Use another container networking stack</option>
+      <option value="choice-network">User-defined network</option>
+    </Dropdown>
+  </div>
+
+  {#if options.networkingMode === 'choice-network'}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <span
+        class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
+        >Network:</span>
+      <Dropdown
+        class="w-full"
+        disabled={options.networkingMode !== 'choice-network'}
+        name="networkingModeUserNetwork"
+        bind:value={options.networkingModeUserNetwork}>
+        {#each engineNetworks as network (network.Id)}
+          <option value={network.Id}
+            >{network.Name} (used by {Object.keys(network.Containers ?? {}).length} containers)</option>
+        {/each}
+      </Dropdown>
+    </div>
+  {/if}
+  {#if options.networkingMode === 'choice-container'}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <span
+        class="text-sm w-28 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
+        >Container:</span>
+      <Dropdown
+        class="w-full"
+        disabled={options.networkingMode !== 'choice-container'}
+        name="networkingModeUserContainer"
+        bind:value={options.networkingModeUserContainer}>
+        {#each engineContainers as container (container.id)}
+          <option value={container.id}>{container.name} ({container.shortId})</option>
+        {/each}
+      </Dropdown>
+    </div>
+  {/if}
+</div>

--- a/packages/renderer/src/lib/image/run/tabs/SecurityTab.svelte
+++ b/packages/renderer/src/lib/image/run/tabs/SecurityTab.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+import { faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { Button, Checkbox, Input } from '@podman-desktop/ui-svelte';
+
+import type { RunOptions } from '/@/lib/image/run/run-options';
+
+interface Props {
+  options: RunOptions['security'];
+}
+
+let { options = $bindable() }: Props = $props();
+
+function deleteSecurityOpt(index: number): void {
+  options.securityOpts = options.securityOpts.filter((_, i) => i !== index);
+}
+
+function addSecurityOpt(): void {
+  options.securityOpts = [...options.securityOpts, ''];
+}
+
+function addCapAdd(): void {
+  options.capAdds = [...options.capAdds, ''];
+}
+
+function addCapDrop(): void {
+  options.capDrops = [...options.capDrops, ''];
+}
+
+function deleteCapAdd(index: number): void {
+  options.capAdds = options.capAdds.filter((_, i) => i !== index);
+}
+
+function deleteCappDrop(index: number): void {
+  options.capDrops = options.capDrops.filter((_, i) => i !== index);
+}
+</script>
+
+<div class="pr-4">
+  <label
+    for="containerPrivileged"
+    class="block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Privileged:</label>
+  <Checkbox bind:checked={options.privileged} class="text-[var(--pd-content-card-text)] text-sm mx-2">
+    Turn off security<i class="pl-1 fas fa-exclamation-triangle"></i>
+  </Checkbox>
+
+  <label
+    for="containerReadOnly"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]">Read only:</label>
+  <Checkbox bind:checked={options.readOnly} class="text-[var(--pd-content-card-text)] text-sm mx-2">
+    Make containers root filesystem read-only
+  </Checkbox>
+
+  <label
+    for="ContainerSecurityOptions"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Security options (security-opt):</label>
+  {#each options.securityOpts as _, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <Input
+        bind:value={options.securityOpts[index]}
+        placeholder="Enter a security option (Ex. seccomp=/path/to/profile.json)"
+        class="ml-2" />
+
+      <Button
+        type="link"
+        hidden={index === options.securityOpts.length - 1}
+        aria-label="Delete security option at index {index}"
+        on:click={(): void => deleteSecurityOpt(index)}
+        icon={faMinusCircle} />
+      <Button
+        type="link"
+        hidden={index < options.securityOpts.length - 1}
+        aria-label="Add security option after index {index}"
+        on:click={addSecurityOpt}
+        icon={faPlusCircle} />
+    </div>
+  {/each}
+
+  <label
+    for="ContainerSecurityCapabilitiesAdd"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Capabilities:</label>
+
+  <label
+    for="ContainerSecurityCapabilitiesAdd"
+    class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Add to the container (CapAdd):</label>
+  {#each options.capAdds as _, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <Input bind:value={options.capAdds[index]} placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
+
+      <Button
+        type="link"
+        hidden={index === options.capAdds.length - 1}
+        on:click={(): void => deleteCapAdd(index)}
+        icon={faMinusCircle}
+        aria-label="Remove capability" />
+      <Button type="link" hidden={index < options.capAdds.length - 1} on:click={addCapAdd} icon={faPlusCircle} aria-label="Add capability" />
+    </div>
+  {/each}
+  <label
+    for="ContainerSecurityCapabilitiesDrop"
+    class="pl-4 pt-2 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Drop from the container (CapDrop):</label>
+  {#each options.capDrops as _, index (index)}
+    <div class="flex flex-row justify-center items-center w-full py-1">
+      <Input bind:value={options.capDrops[index]} placeholder="Enter a kernel capability (Ex. SYS_ADMIN)" class="ml-4" />
+
+      <Button
+        type="link"
+        hidden={index === options.capDrops.length - 1}
+        on:click={(): void => deleteCappDrop(index)}
+        icon={faMinusCircle}
+        aria-label="Remove capability" />
+      <Button type="link" hidden={index < options.capDrops.length - 1} on:click={addCapDrop} icon={faPlusCircle} aria-label="Add capability" />
+    </div>
+  {/each}
+
+  <label
+    for="containerUserNamespace"
+    class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+    >Specify user namespace to use:</label>
+  <div class="flex flex-row justify-center items-center w-full">
+    <Input bind:value={options.userNamespace} placeholder="Enter a user namespace" class="ml-2 w-full" />
+  </div>
+</div>


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/18209

We were doing some weird stuff in the `onMount` as shown bellow for the `networkingModeUserNetwork` value

https://github.com/podman-desktop/podman-desktop/blob/b91f1c5c3790b8b112247557aaac06ea84449bdf/packages/renderer/src/lib/image/RunImage.svelte#L144-L154

And same for the `networkingModeUserContainer`

https://github.com/podman-desktop/podman-desktop/blob/b91f1c5c3790b8b112247557aaac06ea84449bdf/packages/renderer/src/lib/image/RunImage.svelte#L156-L171

This is not useful for two reasons

1. The values are only used based on `networkingMode`

https://github.com/podman-desktop/podman-desktop/blob/b91f1c5c3790b8b112247557aaac06ea84449bdf/packages/renderer/src/lib/image/RunImage.svelte#L292-L297

And the default value is bridge

https://github.com/podman-desktop/podman-desktop/blob/b91f1c5c3790b8b112247557aaac06ea84449bdf/packages/renderer/src/lib/image/RunImage.svelte#L46

2. The value are binded so default value are overridden 

https://github.com/podman-desktop/podman-desktop/blob/b91f1c5c3790b8b112247557aaac06ea84449bdf/packages/renderer/src/lib/image/run/tabs/NetworkingTab.svelte#L113-L117

https://github.com/podman-desktop/podman-desktop/blob/b91f1c5c3790b8b112247557aaac06ea84449bdf/packages/renderer/src/lib/image/run/tabs/NetworkingTab.svelte#L130-L134

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Require rebase after
- https://github.com/podman-desktop/podman-desktop/pull/18209

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression

I added two tests, to ensure that when the user is using either NetworkMode `choice-container` or `choice-network` we get the correct arguments sent to `createAndStartContainer`