### PR TITLE
feat(secret): add MenuContext entry

### DIFF
--- a/packages/api/src/menu-context.ts
+++ b/packages/api/src/menu-context.ts
@@ -23,4 +23,5 @@ export enum MenuContext {
   DASHBOARD_VOLUME = 'dashboard/volume',
   DASHBOARD_COMPOSE = 'dashboard/compose',
   DASHBOARD_CONTAINER_CONNECTION = 'dashboard/container-connection',
+  DASHBOARD_SECRET = 'dashboard/secret',
 }

--- a/packages/renderer/src/lib/secrets/SecretDetails.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretDetails.spec.ts
@@ -42,6 +42,8 @@ const secret: SecretInfo = {
 beforeEach(() => {
   vi.resetAllMocks();
   secretsInfo.set([]);
+
+  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
 });
 
 test('expect secret details page to render when secret exists', async () => {

--- a/packages/renderer/src/lib/secrets/SecretsList.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretsList.spec.ts
@@ -84,6 +84,7 @@ beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(window.listSecrets).mockResolvedValue([]);
   vi.mocked(window.getProviderInfos).mockResolvedValue([]);
+  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
   providerInfos.set([]);
   secretsInfo.set([]);
   searchPattern.set('');

--- a/packages/renderer/src/lib/secrets/components/SecretActions.spec.ts
+++ b/packages/renderer/src/lib/secrets/components/SecretActions.spec.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { SecretInfo } from '@podman-desktop/core-api';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import SecretActions from './SecretActions.svelte';
+
+const secret: SecretInfo = {
+  engineId: 'engine1',
+  engineName: 'Engine 1',
+  engineType: 'podman',
+  Id: 'secret123',
+  Name: 'my-secret',
+  CreatedAt: '2026-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
+});
+
+test('Expect delete button to be visible and trigger confirmation', async () => {
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
+
+  const { getByTitle } = render(SecretActions, { object: secret });
+
+  const deleteButton = getByTitle('Delete Secret');
+  expect(deleteButton).toBeInTheDocument();
+
+  await fireEvent.click(deleteButton);
+
+  await waitFor(() => {
+    expect(window.showMessageBox).toHaveBeenCalledOnce();
+  });
+
+  expect(window.removeSecret).toHaveBeenCalledWith(secret.engineId, secret.Id);
+});
+
+describe('contributions', () => {
+  test('Expect contributed menus to be fetched on mount', async () => {
+    render(SecretActions, { object: secret });
+
+    await waitFor(() => {
+      expect(window.getContributedMenus).toHaveBeenCalledWith('dashboard/secret');
+    });
+  });
+
+  test('Expect contributed menus to be visible', async () => {
+    vi.mocked(window.getContributedMenus).mockResolvedValue([
+      {
+        command: 'foo',
+        title: 'Open foo',
+      },
+    ]);
+
+    const { getByRole, getByTitle } = render(SecretActions, { object: secret });
+
+    const kebabMenu = await waitFor(() => {
+      return getByRole('button', { name: 'kebab menu' });
+    });
+
+    expect(kebabMenu).toBeInTheDocument();
+    await fireEvent.click(kebabMenu);
+
+    const openFoo = await vi.waitFor(() => {
+      return getByTitle('Open foo');
+    });
+    await fireEvent.click(openFoo);
+
+    await vi.waitFor(() => {
+      expect(window.executeCommand).toHaveBeenCalledOnce();
+      expect(window.executeCommand).toHaveBeenCalledWith('foo', secret);
+    });
+  });
+});

--- a/packages/renderer/src/lib/secrets/components/SecretActions.svelte
+++ b/packages/renderer/src/lib/secrets/components/SecretActions.svelte
@@ -1,18 +1,26 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import type { SecretInfo } from '@podman-desktop/core-api';
+import type { Menu, SecretInfo } from '@podman-desktop/core-api';
+import { MenuContext } from '@podman-desktop/core-api';
+import { DropdownMenu } from '@podman-desktop/ui-svelte';
 
+import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
+import FlatMenu from '/@/lib/ui/FlatMenu.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 
 interface Props {
   object: SecretInfo;
+  dropdownMenu?: boolean;
   detailed?: boolean;
 }
 
-let { object, detailed = false }: Props = $props();
+let { object, dropdownMenu = true, detailed = false }: Props = $props();
 
 let loading: boolean = $state(false);
+let contributions: Promise<Menu[]> = $derived(window.getContributedMenus(MenuContext.DASHBOARD_SECRET));
+
+const MenuComponent = $derived(dropdownMenu ? DropdownMenu : FlatMenu);
 
 function onDeleteSecret(): void {
   withConfirmation(
@@ -37,3 +45,17 @@ function onDeleteSecret(): void {
   inProgress={loading}
   detailed={detailed}
   enabled={true} />
+
+{#await contributions then menus}
+  {#if menus.length > 0}
+    <MenuComponent>
+      <ContributionActions
+        args={[object]}
+        contextPrefix="secretItem"
+        dropdownMenu={dropdownMenu}
+        contributions={menus}
+        detailed={detailed}
+        onError={(errorMessage: string): void => console.error(errorMessage)} />
+    </MenuComponent>
+  {/if}
+{/await}

--- a/website/docs/extensions/developing/menu.md
+++ b/website/docs/extensions/developing/menu.md
@@ -57,6 +57,7 @@ This example shows how to integrate a menu into the Podman Desktop extension thr
 - 'dashboard/pod': Item menu on pod actions
 - 'dashboard/volume': Item menu on volume actions
 - 'dashboard/compose': Item menu on compose actions
+- 'dashboard/secret': Item menu on secret actions
 
 ### Verification
 


### PR DESCRIPTION
### What does this PR do?

Allowing extensions to specify contribution menu for the secrets

### Screenshot / video of UI

<img width="1072" height="386" alt="image" src="https://github.com/user-attachments/assets/c5031214-8a88-41d9-a5d1-ec14b43e7b01" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17853

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

If you are motivated, you can try to clone the Quadlet extension, and add the following code in the `packages/backend/package.json` in the section `contributes#menus`

```json
      "dashboard/secret": [
        {
          "command": "podlet.generate.container",
          "title": "Generate Quadlet"
        }
      ],
```

You should get the result visible in the screenshot.