### PR TITLE
feat(extension-api): adding method for secrets

### DIFF
--- a/packages/api/src/secret-info.ts
+++ b/packages/api/src/secret-info.ts
@@ -15,6 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+import type { ContainerProviderConnection } from '@podman-desktop/api';
+
 import type { ProviderContainerConnectionInfo } from '/@/provider-info.js';
 
 export interface SecretInfo {
@@ -30,7 +32,7 @@ export interface SecretInfo {
 
 export interface SecretCreateOptions {
   name: string;
-  selectedProvider: ProviderContainerConnectionInfo | undefined;
+  provider?: ProviderContainerConnectionInfo | ContainerProviderConnection;
   data: string;
   labels?: Record<string, string>;
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2717,8 +2717,6 @@ declare module '@podman-desktop/api' {
   }
 
   interface SecretCreateOptions {
-    name: string;
-    data: string;
     labels?: Record<string, string>;
     // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
     provider?: ContainerProviderConnection;
@@ -4243,7 +4241,11 @@ declare module '@podman-desktop/api' {
     export function listSecrets(): Promise<SecretInfo[]>;
     export function removeSecret(engineId: string, secretId: string): Promise<void>;
     export function inspectSecret(engineId: string, id: string): Promise<SecretInspectInfo>;
-    export function createSecret(options: SecretCreateOptions): Promise<SecretCreateResult>;
+    export function createSecret(
+      name: string,
+      data: string,
+      options?: SecretCreateOptions,
+    ): Promise<SecretCreateResult>;
   }
 
   /**

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2716,6 +2716,32 @@ declare module '@podman-desktop/api' {
     Status: string;
   }
 
+  interface SecretCreateOptions {
+    name: string;
+    data: string;
+    labels?: Record<string, string>;
+    // Set the provider to use, if not we will try select the first one available (sorted in favor of Podman).
+    provider?: ContainerProviderConnection;
+  }
+
+  interface SecretCreateResult {
+    id: string;
+    engineId: string;
+  }
+
+  interface SecretInfo {
+    engineId: string;
+    engineName: string;
+    engineType: 'podman' | 'docker';
+    Id: string;
+    Name: string;
+    CreatedAt?: string; // datetime
+    UpdatedAt?: string; // datetime
+    Labels?: Record<string, string>;
+  }
+
+  type SecretInspectInfo = SecretInfo;
+
   interface PodInfo {
     engineId: string;
     engineName: string;
@@ -4212,6 +4238,12 @@ declare module '@podman-desktop/api' {
     export function inspectManifest(engineId: string, id: string): Promise<ManifestInspectInfo>;
     export function pushManifest(options: ManifestPushOptions): Promise<void>;
     export function removeManifest(engineId: string, id: string): Promise<void>;
+
+    // Secret related methods
+    export function listSecrets(): Promise<SecretInfo[]>;
+    export function removeSecret(engineId: string, secretId: string): Promise<void>;
+    export function inspectSecret(engineId: string, id: string): Promise<SecretInspectInfo>;
+    export function createSecret(options: SecretCreateOptions): Promise<SecretCreateResult>;
   }
 
   /**

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6700,7 +6700,7 @@ describe('createSecret', () => {
       containerRegistry.createSecret({
         name: 'my-secret',
         data: 'secret-value',
-        selectedProvider: undefined,
+        provider: undefined,
       }),
     ).rejects.toThrow('cannot create secret without selected provider');
   });
@@ -6727,7 +6727,7 @@ describe('createSecret', () => {
       containerRegistry.createSecret({
         name: 'my-secret',
         data: 'secret-value',
-        selectedProvider: {
+        provider: {
           name: 'podman',
           endpoint: { socketPath: '/endpoint1.sock' },
         } as ProviderContainerConnectionInfo,
@@ -6760,7 +6760,7 @@ describe('createSecret', () => {
     const result = await containerRegistry.createSecret({
       name: 'my-secret',
       data: 'secret-value',
-      selectedProvider: {
+      provider: {
         name: 'podman',
         endpoint: { socketPath: '/endpoint1.sock' },
       } as ProviderContainerConnectionInfo,
@@ -6800,7 +6800,7 @@ describe('createSecret', () => {
       name: 'my-secret',
       data: 'secret-value',
       labels: { env: 'prod' },
-      selectedProvider: {
+      provider: {
         name: 'podman',
         endpoint: { socketPath: '/endpoint1.sock' },
       } as ProviderContainerConnectionInfo,
@@ -6840,7 +6840,7 @@ describe('createSecret', () => {
     await containerRegistry.createSecret({
       name: 'my-secret',
       data: 'secret-value',
-      selectedProvider: {
+      provider: {
         name: 'podman',
         endpoint: { socketPath: '/endpoint1.sock' },
       } as ProviderContainerConnectionInfo,
@@ -6877,7 +6877,7 @@ describe('createSecret', () => {
       containerRegistry.createSecret({
         name: 'my-secret',
         data: 'secret-value',
-        selectedProvider: {
+        provider: {
           name: 'podman',
           endpoint: { socketPath: '/endpoint1.sock' },
         } as ProviderContainerConnectionInfo,

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -448,11 +448,11 @@ export class ContainerProviderRegistry {
   }
 
   async createSecret(options: SecretCreateOptions): Promise<SecretCreateResult> {
-    if (!options.selectedProvider) throw new Error('cannot create secret without selected provider');
+    if (!options.provider) throw new Error('cannot create secret without selected provider');
 
     const telemetryOptions: Record<string, unknown> = {};
     try {
-      const provider = this.getMatchingContainerProvider(options.selectedProvider);
+      const provider = this.getMatchingContainerProvider(options.provider);
       if (!provider.api) throw new Error(`provider ${provider.name} has no api`);
       const { id } = await provider.api.createSecret({
         // The data need to be encoded in base64 url safe

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1235,6 +1235,18 @@ export class ExtensionLoader implements IAsyncDisposable {
 
     const containerProviderRegistry = this.containerProviderRegistry;
     const containerEngine: typeof containerDesktopAPI.containerEngine = {
+      createSecret(options: containerDesktopAPI.SecretCreateOptions): Promise<containerDesktopAPI.SecretCreateResult> {
+        return containerProviderRegistry.createSecret(options);
+      },
+      inspectSecret(engineId: string, id: string): Promise<containerDesktopAPI.SecretInspectInfo> {
+        return containerProviderRegistry.inspectSecret(engineId, id);
+      },
+      listSecrets(): Promise<containerDesktopAPI.SecretInfo[]> {
+        return containerProviderRegistry.listSecrets();
+      },
+      removeSecret(engineId: string, secretId: string): Promise<void> {
+        return containerProviderRegistry.removeSecret(engineId, secretId);
+      },
       listContainers(): Promise<containerDesktopAPI.ContainerInfo[]> {
         return containerProviderRegistry.listSimpleContainers();
       },

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1235,8 +1235,16 @@ export class ExtensionLoader implements IAsyncDisposable {
 
     const containerProviderRegistry = this.containerProviderRegistry;
     const containerEngine: typeof containerDesktopAPI.containerEngine = {
-      createSecret(options: containerDesktopAPI.SecretCreateOptions): Promise<containerDesktopAPI.SecretCreateResult> {
-        return containerProviderRegistry.createSecret(options);
+      createSecret(
+        name: string,
+        data: string,
+        options?: containerDesktopAPI.SecretCreateOptions,
+      ): Promise<containerDesktopAPI.SecretCreateResult> {
+        return containerProviderRegistry.createSecret({
+          name,
+          data,
+          ...options,
+        });
       },
       inspectSecret(engineId: string, id: string): Promise<containerDesktopAPI.SecretInspectInfo> {
         return containerProviderRegistry.inspectSecret(engineId, id);

--- a/packages/renderer/src/lib/secrets/SecretCreate.svelte
+++ b/packages/renderer/src/lib/secrets/SecretCreate.svelte
@@ -16,8 +16,8 @@ import { providerInfos } from '/@/stores/providers';
 let createError: string | undefined = $state(undefined);
 let loading = $state(false);
 
-let secretCreateOptions: SecretCreateOptions = $state({
-  selectedProvider: undefined,
+let secretCreateOptions: SecretCreateOptions & { provider?: ProviderContainerConnectionInfo } = $state({
+  provider: undefined,
   name: '',
   data: '',
 });
@@ -30,19 +30,19 @@ let providerConnections = $derived(
 );
 
 $effect(() => {
-  if (providerConnections.length > 0 && secretCreateOptions.selectedProvider === undefined) {
-    secretCreateOptions.selectedProvider = providerConnections[0];
+  if (providerConnections.length > 0 && secretCreateOptions.provider === undefined) {
+    secretCreateOptions.provider = providerConnections[0];
   }
 });
 
 let valid = $derived(
-  secretCreateOptions.selectedProvider !== undefined &&
+  secretCreateOptions.provider !== undefined &&
     secretCreateOptions.name.trim().length > 0 &&
     secretCreateOptions.data.length > 0,
 );
 
 async function createSecret(): Promise<void> {
-  if (!secretCreateOptions.selectedProvider) return;
+  if (!secretCreateOptions.provider) return;
 
   try {
     loading = true;
@@ -74,7 +74,7 @@ function close(): void {
           <ContainerConnectionDropdown
             id="providerChoice"
             name="providerChoice"
-            bind:value={secretCreateOptions.selectedProvider}
+            bind:value={secretCreateOptions.provider}
             connections={providerConnections} />
         </div>
       {/if}


### PR DESCRIPTION
### What does this PR do?

Adding the listSecrets, removeSecret, inspectSecret and createSecret method to the extension api. This will allow extensions to interact with the secrets.

To be consistent with the pod, volume api, I renamed the `selectedProvider` property to `provider`.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17846

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
