### PR TITLE
feat(docker): register a container connection per docker context

### DIFF
--- a/extensions/docker/packages/extension/src/docker-api.ts
+++ b/extensions/docker/packages/extension/src/docker-api.ts
@@ -16,5 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+export const UNIX_SCHEME = 'unix://';
+export const NPIPE_SCHEME = 'npipe://';
 export const WINDOWS_NPIPE = '//./pipe/docker_engine';
 export const UNIX_SOCKET_PATH = '/var/run/docker.sock';

--- a/extensions/docker/packages/extension/src/docker-context-handler.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-context-handler.spec.ts
@@ -326,3 +326,21 @@ describe('removeContext', () => {
     expect(rmSpy).toBeCalled();
   });
 });
+
+describe('parseEndpoint', () => {
+  test('resolves a unix:// endpoint to its socket path', () => {
+    expect(dockerContextHandler.parseEndpoint('unix:///var/run/docker.sock')).toBe('/var/run/docker.sock');
+  });
+
+  test('resolves a npipe:// endpoint to its pipe path', () => {
+    expect(dockerContextHandler.parseEndpoint('npipe:////./pipe/docker_engine')).toBe('//./pipe/docker_engine');
+  });
+
+  test('returns undefined for a tcp:// endpoint', () => {
+    expect(dockerContextHandler.parseEndpoint('tcp://1.2.3.4:2376')).toBeUndefined();
+  });
+
+  test('returns undefined for a ssh:// endpoint', () => {
+    expect(dockerContextHandler.parseEndpoint('ssh://user@host/run/podman/podman.sock')).toBeUndefined();
+  });
+});

--- a/extensions/docker/packages/extension/src/docker-context-handler.ts
+++ b/extensions/docker/packages/extension/src/docker-context-handler.ts
@@ -23,7 +23,7 @@ import { join } from 'node:path';
 import { env } from '@podman-desktop/api';
 import type { DockerContextInfo, DockerContextParsingInfo } from '@podman-desktop/docker-extension-api';
 
-import { UNIX_SOCKET_PATH, WINDOWS_NPIPE } from './docker-api.js';
+import { NPIPE_SCHEME, UNIX_SCHEME, UNIX_SOCKET_PATH, WINDOWS_NPIPE } from './docker-api.js';
 import type { DockerConfig } from './docker-config.js';
 
 /**
@@ -34,6 +34,21 @@ export class DockerContextHandler {
 
   constructor(dockerConfig: DockerConfig) {
     this.#dockerConfig = dockerConfig;
+  }
+
+  /**
+   * Resolves a Docker context endpoint host (e.g. `unix:///var/run/docker.sock`,
+   * `npipe:////./pipe/docker_engine`) to a socket path usable with `http.get({ socketPath })`.
+   * Returns undefined for schemes that are not a local socket (e.g. `tcp://`, `ssh://`).
+   */
+  parseEndpoint(host: string): string | undefined {
+    if (host.startsWith(UNIX_SCHEME)) {
+      return host.slice(UNIX_SCHEME.length);
+    }
+    if (host.startsWith(NPIPE_SCHEME)) {
+      return host.slice(NPIPE_SCHEME.length);
+    }
+    return undefined;
   }
 
   protected getDockerConfigPath(): string {

--- a/extensions/docker/packages/extension/src/docker-daemon-monitor.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-daemon-monitor.spec.ts
@@ -16,176 +16,272 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { EventEmitter } from 'node:events';
 import * as http from 'node:http';
 
 import type { ContainerProviderConnection, Disposable, ExtensionContext, Provider } from '@podman-desktop/api';
 import { provider as providerApi } from '@podman-desktop/api';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { DockerContextInfo } from '@podman-desktop/docker-extension-api';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { UNIX_SOCKET_PATH } from './docker-api';
 import { getDockerInstallation } from './docker-cli';
+import type { DockerContextHandler } from './docker-context-handler';
 import { DockerDaemonMonitor } from './docker-daemon-monitor';
 
 vi.mock(import('node:http'));
 vi.mock(import('./docker-cli'));
 
-const connectionDisposable: Disposable = { dispose: vi.fn() };
+function contextFixture(name: string, host: string): DockerContextInfo {
+  return {
+    name,
+    isCurrentContext: false,
+    metadata: { description: name },
+    endpoints: { docker: { host } },
+  };
+}
 
-const fakeProvider: Provider = {
-  registerContainerProviderConnection: vi.fn().mockReturnValue(connectionDisposable),
-  updateStatus: vi.fn(),
-  updateVersion: vi.fn(),
-  status: 'ready',
-} as unknown as Provider;
+interface EngineFixture {
+  docker?: boolean;
+  podman?: boolean;
+}
 
-let extensionContext: ExtensionContext;
-let monitor: DockerDaemonMonitor;
+const engines = new Map<string, EngineFixture>();
 
-const originalConsoleDebug = console.debug;
+function setEngine(socketPath: string, fixture: EngineFixture): void {
+  engines.set(socketPath, fixture);
+}
 
-/**
- * Mock node:http.get for socket-path pings (same EventEmitter approach as compose detect.spec).
- * Pass status codes per path; omit a path to simulate a connection error.
- */
-function mockHttpGet(statusByPath: Record<string, number>): void {
-  vi.mocked(http.get).mockImplementation(((options: unknown, callback?: (res: http.IncomingMessage) => void) => {
-    const path = (options as http.RequestOptions).path ?? '';
-    const request = new EventEmitter() as http.ClientRequest;
+function mockHttpGet(): void {
+  vi.mocked(http.get).mockImplementation(((options: unknown, callback?: (res: unknown) => void) => {
+    const { path, socketPath } = options as { path: string; socketPath: string };
+    const fixture = engines.get(socketPath);
+    const alive = path === '/_ping' ? fixture?.docker === true : fixture?.podman === true;
 
-    const statusCode = statusByPath[path];
-    if (statusCode === undefined) {
-      queueMicrotask(() => request.emit('error', new Error('connect error')));
-      return request;
+    if (alive) {
+      callback?.({
+        statusCode: 200,
+        on: (event: string, handler: () => void): void => {
+          if (event === 'end') {
+            handler();
+          }
+        },
+      });
+      return { once: vi.fn() };
     }
 
-    const response = new EventEmitter() as http.IncomingMessage;
-    response.statusCode = statusCode;
-    callback?.(response);
-    response.emit('data', '');
-    response.emit('end');
-    return request;
+    return {
+      once: (event: string, handler: (err: Error) => void): void => {
+        if (event === 'error') {
+          handler(new Error('connect error'));
+        }
+      },
+    };
   }) as unknown as typeof http.get);
 }
 
+function createFakeProvider(): Provider {
+  return {
+    registerContainerProviderConnection: vi.fn(() => ({ dispose: vi.fn() }) as unknown as Disposable),
+    updateStatus: vi.fn(),
+    updateVersion: vi.fn(),
+    status: 'ready',
+  } as unknown as Provider;
+}
+
+class TestDockerDaemonMonitor extends DockerDaemonMonitor {
+  override registerConnectionForContext(
+    dockerProvider: Provider,
+    contextInfo: DockerContextInfo,
+    contextSocketPath: string,
+  ): Disposable {
+    return super.registerConnectionForContext(dockerProvider, contextInfo, contextSocketPath);
+  }
+}
+
+let fakeProvider: Provider;
+let dockerContextHandler: DockerContextHandler;
+let extensionContext: ExtensionContext;
+let monitor: TestDockerDaemonMonitor;
+
 beforeEach(() => {
   vi.resetAllMocks();
-  console.debug = vi.fn();
+  engines.clear();
+  mockHttpGet();
 
   vi.mocked(getDockerInstallation).mockResolvedValue({ version: '24.0.0' });
-  vi.mocked(fakeProvider.registerContainerProviderConnection).mockReturnValue(connectionDisposable);
-  vi.mocked(providerApi.createProvider).mockReturnValue(fakeProvider);
-  Object.defineProperty(fakeProvider, 'status', { value: 'ready', configurable: true });
 
+  fakeProvider = createFakeProvider();
+  vi.mocked(providerApi.createProvider).mockReturnValue(fakeProvider);
+
+  dockerContextHandler = {
+    listContexts: vi.fn(),
+    parseEndpoint: (host: string): string | undefined => {
+      if (host.startsWith('unix://')) {
+        return host.slice('unix://'.length);
+      }
+      if (host.startsWith('npipe://')) {
+        return host.slice('npipe://'.length);
+      }
+      return undefined;
+    },
+  } as unknown as DockerContextHandler;
   extensionContext = { subscriptions: [] } as unknown as ExtensionContext;
-  monitor = new DockerDaemonMonitor(extensionContext, UNIX_SOCKET_PATH);
+  monitor = new TestDockerDaemonMonitor(extensionContext, dockerContextHandler);
 });
 
-afterEach(() => {
-  console.debug = originalConsoleDebug;
+describe('registerConnectionForContext', () => {
+  test('registers a docker connection using the raw context name and socket path', () => {
+    let registered: ContainerProviderConnection | undefined;
+    vi.mocked(fakeProvider.registerContainerProviderConnection).mockImplementation(connection => {
+      registered = connection;
+      return { dispose: vi.fn() } as unknown as Disposable;
+    });
+
+    monitor.registerConnectionForContext(fakeProvider, contextFixture('colima', 'unix:///colima.sock'), '/colima.sock');
+
+    expect(registered).toBeDefined();
+    expect(registered?.name).toBe('colima');
+    expect(registered?.displayName).toBe('colima');
+    expect(registered?.type).toBe('docker');
+    expect(registered?.endpoint.socketPath).toBe('/colima.sock');
+    expect(registered?.status()).toBe('started');
+  });
+
+  test('keeps displaying the default context as "Docker"', () => {
+    let registered: ContainerProviderConnection | undefined;
+    vi.mocked(fakeProvider.registerContainerProviderConnection).mockImplementation(connection => {
+      registered = connection;
+      return { dispose: vi.fn() } as unknown as Disposable;
+    });
+
+    monitor.registerConnectionForContext(
+      fakeProvider,
+      contextFixture('default', 'unix:///var/run/docker.sock'),
+      '/var/run/docker.sock',
+    );
+
+    expect(registered?.name).toBe('default');
+    expect(registered?.displayName).toBe('Docker');
+  });
 });
 
 describe('updateProvider', () => {
-  test('registers a Docker connection when the daemon is alive and not Podman', async () => {
-    mockHttpGet({ '/_ping': 200 });
+  test('registers one connection per alive, non-podman context', async () => {
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValue([
+      contextFixture('default', 'unix:///var/run/docker.sock'),
+      contextFixture('colima', 'unix:///colima.sock'),
+    ]);
+    setEngine('/var/run/docker.sock', { docker: true });
+    setEngine('/colima.sock', { docker: true });
 
-    await monitor.updateProvider();
-
-    expect(providerApi.createProvider).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'Docker',
-        id: 'docker',
-      }),
-    );
-    expect(fakeProvider.registerContainerProviderConnection).toHaveBeenCalledTimes(1);
-    const connection = vi.mocked(fakeProvider.registerContainerProviderConnection).mock
-      .calls[0][0] as ContainerProviderConnection;
-    expect(connection.name).toBe('Docker');
-    expect(connection.type).toBe('docker');
-    expect(connection.endpoint.socketPath).toBe(UNIX_SOCKET_PATH);
-    expect(connection.status()).toBe('started');
-    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('started');
-    expect(extensionContext.subscriptions).toContain(fakeProvider);
-    expect(extensionContext.subscriptions).toContain(connectionDisposable);
-
-    // install/version updates run before provider creation on the first tick;
-    // a subsequent tick reports the Docker CLI version once the provider exists
-    await monitor.updateProvider();
-    expect(fakeProvider.updateVersion).toHaveBeenCalledWith('24.0.0');
-  });
-
-  test('does not register a connection when the socket answers as Podman', async () => {
-    mockHttpGet({ '/_ping': 200, '/libpod/_ping': 200 });
-
-    await monitor.updateProvider();
-
-    expect(providerApi.createProvider).not.toHaveBeenCalled();
-    expect(fakeProvider.registerContainerProviderConnection).not.toHaveBeenCalled();
-  });
-
-  test('does not register a connection when the daemon is unreachable', async () => {
-    mockHttpGet({});
-
-    await monitor.updateProvider();
-
-    expect(providerApi.createProvider).not.toHaveBeenCalled();
-    expect(fakeProvider.registerContainerProviderConnection).not.toHaveBeenCalled();
-  });
-
-  test('disposes the connection and marks the provider stopped when the daemon dies', async () => {
-    mockHttpGet({ '/_ping': 200 });
-    await monitor.updateProvider();
-
-    mockHttpGet({});
-    await monitor.updateProvider();
-
-    expect(connectionDisposable.dispose).toHaveBeenCalled();
-    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('stopped');
-  });
-
-  test('re-registers the connection when the daemon comes back after being stopped', async () => {
-    mockHttpGet({ '/_ping': 200 });
-    await monitor.updateProvider();
-
-    mockHttpGet({});
-    await monitor.updateProvider();
-
-    const secondDisposable = { dispose: vi.fn() };
-    vi.mocked(fakeProvider.registerContainerProviderConnection).mockReturnValue(secondDisposable);
-
-    mockHttpGet({ '/_ping': 200 });
     await monitor.updateProvider();
 
     expect(fakeProvider.registerContainerProviderConnection).toHaveBeenCalledTimes(2);
-    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('started');
-    expect(extensionContext.subscriptions).toContain(secondDisposable);
+    const names = vi.mocked(fakeProvider.registerContainerProviderConnection).mock.calls.map(([c]) => c.name);
+    expect(names).toEqual(['default', 'colima']);
   });
 
-  test('marks the provider not-installed when Docker CLI is missing', async () => {
-    mockHttpGet({ '/_ping': 200 });
+  test('never registers a context whose socket answers as podman, not docker', async () => {
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValue([
+      contextFixture('podman', 'unix:///run/podman.sock'),
+    ]);
+    setEngine('/run/podman.sock', { docker: true, podman: true });
+
     await monitor.updateProvider();
 
-    vi.mocked(getDockerInstallation).mockResolvedValue(undefined);
-    await monitor.updateProvider();
-
-    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('not-installed');
+    expect(fakeProvider.registerContainerProviderConnection).not.toHaveBeenCalled();
   });
 
-  test('updates provider status to installed when Docker appears after being not-installed', async () => {
-    mockHttpGet({ '/_ping': 200 });
+  test('skips and logs a context with an unsupported endpoint scheme', async () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValue([contextFixture('remote', 'tcp://1.2.3.4:2376')]);
+
     await monitor.updateProvider();
 
-    Object.defineProperty(fakeProvider, 'status', { value: 'not-installed', configurable: true });
-    vi.mocked(getDockerInstallation).mockResolvedValue({ version: '25.0.0' });
-    await monitor.updateProvider();
-
-    expect(fakeProvider.updateVersion).toHaveBeenCalledWith('25.0.0');
-    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('installed');
+    expect(fakeProvider.registerContainerProviderConnection).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('remote'));
   });
-});
 
-describe('stop', () => {
-  test('stops the monitoring loop', () => {
-    expect(() => monitor.stop()).not.toThrow();
+  test('keeps a connection registered and flips its status when its engine stops answering, then answers again', async () => {
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValue([contextFixture('colima', 'unix:///colima.sock')]);
+    setEngine('/colima.sock', { docker: true });
+
+    await monitor.updateProvider();
+    expect(fakeProvider.registerContainerProviderConnection).toHaveBeenCalledTimes(1);
+    const registeredConnection = vi.mocked(fakeProvider.registerContainerProviderConnection).mock.calls[0][0];
+    const disposable = vi.mocked(fakeProvider.registerContainerProviderConnection).mock.results[0]?.value as Disposable;
+    expect(registeredConnection.status()).toBe('started');
+
+    setEngine('/colima.sock', { docker: false });
+    await monitor.updateProvider();
+    expect(disposable.dispose).not.toHaveBeenCalled();
+    expect(registeredConnection.status()).toBe('stopped');
+
+    setEngine('/colima.sock', { docker: true });
+    await monitor.updateProvider();
+    // still the same connection object, not re-registered
+    expect(fakeProvider.registerContainerProviderConnection).toHaveBeenCalledTimes(1);
+    expect(registeredConnection.status()).toBe('started');
+  });
+
+  test('keeps a connection registered while its context is still listed but its engine stops answering', async () => {
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValue([contextFixture('colima', 'unix:///colima.sock')]);
+    setEngine('/colima.sock', { docker: true });
+    await monitor.updateProvider();
+    const registeredConnection = vi.mocked(fakeProvider.registerContainerProviderConnection).mock.calls[0][0];
+    const disposable = vi.mocked(fakeProvider.registerContainerProviderConnection).mock.results[0]?.value as Disposable;
+
+    setEngine('/colima.sock', { docker: false });
+    await monitor.updateProvider();
+
+    expect(disposable.dispose).not.toHaveBeenCalled();
+    // registered only once, never re-registered
+    expect(fakeProvider.registerContainerProviderConnection).toHaveBeenCalledTimes(1);
+    expect(registeredConnection.status()).toBe('stopped');
+  });
+
+  test('disposes a connection once its context disappears entirely (e.g. `colima stop` removes its own context)', async () => {
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValueOnce([
+      contextFixture('colima', 'unix:///colima.sock'),
+    ]);
+    setEngine('/colima.sock', { docker: true });
+    await monitor.updateProvider();
+    const disposable = vi.mocked(fakeProvider.registerContainerProviderConnection).mock.results[0]?.value as Disposable;
+
+    // colima removes its own context and stops answering at the same time
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValueOnce([]);
+    setEngine('/colima.sock', { docker: false });
+    await monitor.updateProvider();
+
+    expect(disposable.dispose).toHaveBeenCalled();
+  });
+
+  test('still disposes a connection if its context later answers as podman, not docker', async () => {
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValue([contextFixture('shared', 'unix:///shared.sock')]);
+    setEngine('/shared.sock', { docker: true });
+    await monitor.updateProvider();
+    const disposable = vi.mocked(fakeProvider.registerContainerProviderConnection).mock.results[0]?.value as Disposable;
+
+    setEngine('/shared.sock', { docker: true, podman: true });
+    await monitor.updateProvider();
+
+    expect(disposable.dispose).toHaveBeenCalled();
+  });
+
+  test('marks the provider started while any connection is alive, without redundant updates', async () => {
+    vi.mocked(dockerContextHandler.listContexts).mockResolvedValue([
+      contextFixture('default', 'unix:///var/run/docker.sock'),
+    ]);
+    setEngine('/var/run/docker.sock', { docker: true });
+
+    await monitor.updateProvider();
+    await monitor.updateProvider();
+
+    const startedCalls = vi.mocked(fakeProvider.updateStatus).mock.calls.filter(([status]) => status === 'started');
+    expect(startedCalls).toHaveLength(1);
+
+    setEngine('/var/run/docker.sock', { docker: false });
+    await monitor.updateProvider();
+
+    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('stopped');
   });
 });

--- a/extensions/docker/packages/extension/src/docker-daemon-monitor.ts
+++ b/extensions/docker/packages/extension/src/docker-daemon-monitor.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2026 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,25 +19,30 @@
 import * as http from 'node:http';
 
 import * as extensionApi from '@podman-desktop/api';
+import type { DockerContextInfo } from '@podman-desktop/docker-extension-api';
 
 import { getDockerInstallation } from './docker-cli';
+import type { DockerContextHandler } from './docker-context-handler';
 
 /**
- * Monitors the default Docker socket and registers a single ContainerProviderConnection
- * while the daemon is reachable (and not a disguised Podman socket).
+ * Monitors Docker CLI contexts and registers one ContainerProviderConnection per local
+ * context. A connection's engine going unreachable only flips its status (kept registered,
+ * mirrors Podman's machine model) so it doesn't disappear just because the engine is
+ * temporarily off. It's only disposed once the context itself is gone from `docker context ls`.
  */
 export class DockerDaemonMonitor {
   #extensionContext: extensionApi.ExtensionContext;
-  #socketPath: string;
+  #dockerContextHandler: DockerContextHandler;
   #stopLoop = false;
   #provider: extensionApi.Provider | undefined;
-  #providerState: extensionApi.ProviderConnectionStatus = 'stopped';
-  #containerProviderConnection: extensionApi.ContainerProviderConnection | undefined;
-  #containerProviderConnectionDisposable: extensionApi.Disposable | undefined;
+  #lastProviderStatus: extensionApi.ProviderStatus | undefined;
+  // one connection per Docker CLI context, keyed by context name
+  #connectionDisposables = new Map<string, extensionApi.Disposable>();
+  #connectionStatuses = new Map<string, extensionApi.ProviderConnectionStatus>();
 
-  constructor(extensionContext: extensionApi.ExtensionContext, socketPath: string) {
+  constructor(extensionContext: extensionApi.ExtensionContext, dockerContextHandler: DockerContextHandler) {
     this.#extensionContext = extensionContext;
-    this.#socketPath = socketPath;
+    this.#dockerContextHandler = dockerContextHandler;
   }
 
   start(): void {
@@ -71,42 +76,93 @@ export class DockerDaemonMonitor {
       // ignore the update
     }
 
-    // check if the daemon is alive
-    const isAlive = await this.isDockerDaemonAlive(this.#socketPath);
+    const contexts = await this.#dockerContextHandler.listContexts();
+    const contextNames = new Set(contexts.map(contextInfo => contextInfo.name));
 
-    // alive
-    if (isAlive) {
-      // but was stopped before, needs to update the provider state
-      if (this.#providerState === 'stopped') {
-        // first we check that it's not podman behind
-        const isPodman = await this.isDisguisedPodman(this.#socketPath);
-        if (!isPodman) {
-          // if no provider, create one
-          if (!this.#provider) {
-            this.initProvider();
-          }
-          this.#providerState = 'started';
-          // register again the connection
-          if (this.#provider && this.#containerProviderConnection) {
-            this.#containerProviderConnectionDisposable = this.#provider.registerContainerProviderConnection(
-              this.#containerProviderConnection,
-            );
-            this.#extensionContext.subscriptions.push(this.#containerProviderConnectionDisposable);
-            this.#provider.updateStatus('started');
-          }
-        }
+    for (const contextInfo of contexts) {
+      const contextSocketPath = this.#dockerContextHandler.parseEndpoint(contextInfo.endpoints.docker.host);
+      if (!contextSocketPath) {
+        console.debug(
+          `Skipping docker context '${contextInfo.name}': unsupported endpoint '${contextInfo.endpoints.docker.host}'`,
+        );
+        continue;
       }
-    } else if (this.#providerState === 'started') {
-      // no longer alive but it was running before so we need to update status
-      // dispose the current connection
-      this.#containerProviderConnectionDisposable?.dispose();
-      this.#providerState = 'stopped';
-      this.#provider?.updateStatus('stopped');
+
+      const isAlive = await this.isDockerDaemonAlive(contextSocketPath);
+      // a context created by the podman-docker-context extension points at a Podman socket, not a Docker one
+      const isPodman = isAlive && (await this.isDisguisedPodman(contextSocketPath));
+      const isRegistered = this.#connectionDisposables.has(contextInfo.name);
+
+      if (isPodman) {
+        // no longer (or never was) a genuine Docker engine behind this context
+        if (isRegistered) {
+          this.disposeConnectionForContext(contextInfo.name);
+        }
+        continue;
+      }
+
+      if (isRegistered) {
+        // keep the connection registered; just reflect whether its engine currently answers
+        this.#connectionStatuses.set(contextInfo.name, isAlive ? 'started' : 'stopped');
+        continue;
+      }
+
+      if (isAlive) {
+        if (!this.#provider) {
+          this.#provider = this.initProvider();
+          this.#extensionContext.subscriptions.push(this.#provider);
+        }
+        const disposable = this.registerConnectionForContext(this.#provider, contextInfo, contextSocketPath);
+        this.#extensionContext.subscriptions.push(disposable);
+        this.#connectionDisposables.set(contextInfo.name, disposable);
+      }
+    }
+
+    // the context itself is gone (e.g. `docker context rm`, or colima removing its own context on stop)
+    for (const name of this.#connectionDisposables.keys()) {
+      if (!contextNames.has(name)) {
+        this.disposeConnectionForContext(name);
+      }
+    }
+
+    if (this.#provider) {
+      const anyStarted = [...this.#connectionStatuses.values()].some(status => status === 'started');
+      const nextStatus: extensionApi.ProviderStatus = anyStarted ? 'started' : 'stopped';
+      if (nextStatus !== this.#lastProviderStatus) {
+        this.#provider.updateStatus(nextStatus);
+        this.#lastProviderStatus = nextStatus;
+      }
     }
   }
 
-  protected initProvider(): void {
-    this.#provider = extensionApi.provider.createProvider({
+  protected registerConnectionForContext(
+    dockerProvider: extensionApi.Provider,
+    contextInfo: DockerContextInfo,
+    contextSocketPath: string,
+  ): extensionApi.Disposable {
+    this.#connectionStatuses.set(contextInfo.name, 'started');
+
+    const containerProviderConnection: extensionApi.ContainerProviderConnection = {
+      name: contextInfo.name,
+      displayName: contextInfo.name === 'default' ? 'Docker' : contextInfo.name,
+      type: 'docker',
+      status: (): extensionApi.ProviderConnectionStatus => this.#connectionStatuses.get(contextInfo.name) ?? 'stopped',
+      endpoint: {
+        socketPath: contextSocketPath,
+      },
+    };
+
+    return dockerProvider.registerContainerProviderConnection(containerProviderConnection);
+  }
+
+  protected disposeConnectionForContext(name: string): void {
+    this.#connectionDisposables.get(name)?.dispose();
+    this.#connectionDisposables.delete(name);
+    this.#connectionStatuses.delete(name);
+  }
+
+  protected initProvider(): extensionApi.Provider {
+    return extensionApi.provider.createProvider({
       name: 'Docker',
       id: 'docker',
       status: 'ready',
@@ -115,19 +171,6 @@ export class DockerDaemonMonitor {
         logo: './logo.png',
       },
     });
-
-    this.#containerProviderConnection = {
-      name: 'Docker',
-      type: 'docker',
-      status: (): extensionApi.ProviderConnectionStatus => this.#providerState,
-      endpoint: {
-        socketPath: this.#socketPath,
-      },
-    };
-
-    // provider is started
-    this.#providerState = 'started';
-    this.#extensionContext.subscriptions.push(this.#provider);
   }
 
   protected async isDockerDaemonAlive(socketPath: string): Promise<boolean> {
@@ -195,7 +238,7 @@ export class DockerDaemonMonitor {
       try {
         await this.updateProvider();
       } catch (error) {
-        // ignore the update of machines
+        // ignore the update of contexts
       }
       await this.timeout(5000);
       this.monitorDaemon().catch((err: unknown) => {

--- a/extensions/docker/packages/extension/src/extension.ts
+++ b/extensions/docker/packages/extension/src/extension.ts
@@ -16,12 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as os from 'node:os';
-
 import type { ExtensionContext } from '@podman-desktop/api';
 import type { DockerExtensionApi } from '@podman-desktop/docker-extension-api';
 
-import { UNIX_SOCKET_PATH, WINDOWS_NPIPE } from './docker-api';
 import { DockerCompatibilitySetup } from './docker-compatibility-setup';
 import { DockerConfig } from './docker-config';
 import { DockerContextHandler } from './docker-context-handler';
@@ -30,8 +27,6 @@ import { DockerDaemonMonitor } from './docker-daemon-monitor';
 let daemonMonitor: DockerDaemonMonitor | undefined;
 
 export async function activate(extensionContext: ExtensionContext): Promise<DockerExtensionApi> {
-  const socketPath = os.platform() === 'win32' ? WINDOWS_NPIPE : UNIX_SOCKET_PATH;
-
   const dockerConfig = new DockerConfig();
   const dockerContextHandler = new DockerContextHandler(dockerConfig);
   const dockerCompatibilitySetup = new DockerCompatibilitySetup(dockerContextHandler);
@@ -39,7 +34,7 @@ export async function activate(extensionContext: ExtensionContext): Promise<Dock
     console.error('Error while initializing docker compatibility setup', err);
   });
 
-  daemonMonitor = new DockerDaemonMonitor(extensionContext, socketPath);
+  daemonMonitor = new DockerDaemonMonitor(extensionContext, dockerContextHandler);
   daemonMonitor.start();
 
   return {


### PR DESCRIPTION
### What does this PR do?

Previously the extension only ever monitored the default Docker socket path. Switch to listing `docker context ls` and registering one ContainerProviderConnection per context (keyed by name), so engines behind non-default contexts (e.g. colima) show up as Resources too.

This PR is stacked on top of #18524:
1. `refactor(docker): extract DockerDaemonMonitor from extension` (same commit as #18524)
2. `feat(docker): register a container connection per docker context` (this PR's feature)

- Add `parseEndpoint()` to resolve unix:///npipe:// context endpoints to a socket path, returning undefined for schemes that aren't a local socket (tcp://, ssh://).
- A context whose engine stops answering just flips its connection's status to stopped instead of disposing it, mirroring the Podman machine model; the connection is only disposed once its context is gone from `docker context ls`.
- Continue skipping contexts that turn out to be a disguised Podman socket.

### Screenshot / video of UI

<!-- Please put an image of images or a video showing the new feature -->

### What issues does this PR fix or reference?

Closes #17594

### How to test this PR?

Start colima or rancher desktop, new connection should be registered

- [x] Tests are covering the bug fix or the new feature
