### PR TITLE
fix(e2e): investigate and fix windows update e2e test flake (preload/renderer race)

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -243,6 +243,9 @@ jobs:
         exclude:
         - installation: ${{ (github.event.inputs.update_with_extensions && github.event.inputs.update_with_extensions == 'true') && 'N/A' || 'custom-extensions' }}
     steps:
+      - name: Exclude workspace from Windows Defender scanning
+        run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+
       - name: Set the default env. variables
         env:
           DEFAULT_UPDATE_TARGET_OWNER: 'podman-desktop'

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -15,6 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+// (delete-me) cold-start trace — write to file since Playwright consumes both stdout and stderr
+import { appendFileSync } from 'node:fs';
+
 import type { Event } from '@podman-desktop/core-api';
 import { app, ipcMain, Menu, Tray } from 'electron';
 
@@ -36,10 +39,25 @@ import { isMac, isWindows, stoppedExtensions } from './util.js';
 
 let extensionLoader: ExtensionLoader | undefined;
 let animatedTray: AnimatedTray | undefined;
+const T0 = Date.now();
+const traceFile = process.env['PD_COLD_TRACE_FILE'];
+const trace = (msg: string): void => {
+  const line = `[TRACE] +${Date.now() - T0}ms ${msg}\n`;
+  if (traceFile)
+    try {
+      appendFileSync(traceFile, line);
+    } catch (_e) {
+      /* ignore */
+    }
+  process.stderr.write(line);
+};
+trace('index.ts module loaded');
 
 // Main startup
 const podmanDesktopMain = new Main(app);
+trace('Main constructed');
 podmanDesktopMain.main(process.argv);
+trace('Main.main() returned');
 
 // TODO: remove when index.spec.ts tests are migrated in podmanDesktopMain-main.spec
 export const mainWindowDeferred = podmanDesktopMain.mainWindowDeferred;
@@ -94,6 +112,7 @@ app.on('will-finish-launching', () => {
 
 app.whenReady().then(
   async () => {
+    trace('index.ts app.whenReady() fired');
     // Setup the default tray icon + menu items (skip if user disabled tray)
     const showTrayIcon = readShowTrayIconSetting();
     if (showTrayIcon) {
@@ -101,6 +120,7 @@ app.whenReady().then(
       tray = new Tray(animatedTray.getDefaultImage());
       animatedTray.setTray(tray);
     }
+    trace('tray setup done');
     const trayMenu = new TrayMenu(tray, animatedTray);
 
     const _onDidCreatedConfigurationRegistry = new Emitter<ConfigurationRegistry>();
@@ -108,6 +128,7 @@ app.whenReady().then(
 
     // Start extensions
     const pluginSystem = new PluginSystem(trayMenu, podmanDesktopMain.mainWindowDeferred);
+    trace('PluginSystem constructed, calling initExtensions()');
 
     onDidCreatedConfigurationRegistry(async (configurationRegistry: ConfigurationRegistry) => {
       // If we've manually set the tray icon color, update the tray icon. This can only be done
@@ -155,6 +176,7 @@ app.whenReady().then(
     });
 
     extensionLoader = await pluginSystem.initExtensions(_onDidCreatedConfigurationRegistry);
+    trace('initExtensions() completed');
   },
   (e: unknown) => console.error('Failed to start app:', e),
 );

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -15,6 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
+// (delete-me) cold-start trace — write to file since Playwright consumes both stdout and stderr
+import { appendFileSync } from 'node:fs';
+
 import type { IDisposable } from '@podman-desktop/core-api';
 import type { App as ElectronApp, BrowserWindow } from 'electron';
 
@@ -26,6 +29,20 @@ import { isLinux, isMac, isWindows } from '/@/util.js';
 import product from '/@product.json' with { type: 'json' };
 
 import { ProtocolLauncher } from './protocol-launcher.js';
+
+const T0 = Date.now();
+const traceFile = process.env['PD_COLD_TRACE_FILE'];
+const trace = (msg: string): void => {
+  const line = `[TRACE] +${Date.now() - T0}ms ${msg}\n`;
+  if (traceFile)
+    try {
+      appendFileSync(traceFile, line);
+    } catch (_e) {
+      /* ignore */
+    }
+  process.stderr.write(line);
+};
+trace('main.ts module loaded');
 
 export type AdditionalData = {
   argv: string[];
@@ -54,11 +71,13 @@ export class Main implements IDisposable {
   readonly #plugins: Array<AppPlugin>;
 
   constructor(app: ElectronApp) {
+    trace('Main constructor start');
     this.app = app;
     this.app.name = product.name;
     this.mainWindowDeferred = Promise.withResolvers<BrowserWindow>();
     this.protocolLauncher = new ProtocolLauncher(this.mainWindowDeferred);
     this.#plugins = [new DefaultProtocolClient(this.app), new WindowPlugin(this.app, this.mainWindowDeferred.resolve)];
+    trace('Main constructor done');
   }
 
   main(args: string[]): void {
@@ -76,10 +95,12 @@ export class Main implements IDisposable {
   }
 
   protected init(additionalData: AdditionalData): void {
+    trace('init() start');
     /**
      * Prevent multiple instances
      */
     const isSingleInstance = this.app.requestSingleInstanceLock(additionalData);
+    trace('requestSingleInstanceLock done');
     if (!isSingleInstance) {
       console.warn(`An instance of ${product.name} is already running. Stopping`);
       this.app.quit();
@@ -91,11 +112,13 @@ export class Main implements IDisposable {
      */
     const security = new SecurityRestrictions(this.app);
     security.init();
+    trace('SecurityRestrictions.init done');
 
     /**
      * Disable Hardware Acceleration for more power-save
      */
     this.app.disableHardwareAcceleration();
+    trace('disableHardwareAcceleration done');
 
     /**
      *  @see https://www.electronjs.org/docs/latest/api/app#appsetappusermodelidid-windows
@@ -123,7 +146,9 @@ export class Main implements IDisposable {
     /**
      * Register {@link Main#whenReady} for ready event
      */
+    trace('registering app.whenReady()');
     this.app.whenReady().then(this.whenReady.bind(this)).catch(console.error);
+    trace('init() done');
   }
 
   /**
@@ -134,7 +159,10 @@ export class Main implements IDisposable {
    * @return {Promise<Array<void>>}
    */
   protected async whenReady(): Promise<Array<void>> {
-    return Promise.all(this.#plugins.map(plugin => plugin.onReady()));
+    trace('whenReady() fired — calling plugin.onReady()');
+    const result = await Promise.all(this.#plugins.map(plugin => plugin.onReady()));
+    trace('whenReady() plugins done');
+    return result;
   }
 
   /**

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+// (delete-me) cold-start trace — write to file since Playwright consumes both stdout and stderr
+import { appendFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { URL } from 'node:url';
 
@@ -33,11 +35,24 @@ import { isLinux, isMac, stoppedExtensions } from './util.js';
 
 const openDevTools = new OpenDevTools();
 let navigationItemsMenuBuilder: NavigationItemsMenuBuilder;
+const T0 = Date.now();
+const traceFile = process.env['PD_COLD_TRACE_FILE'];
+const trace = (msg: string): void => {
+  const line = `[TRACE] +${Date.now() - T0}ms ${msg}\n`;
+  if (traceFile)
+    try {
+      appendFileSync(traceFile, line);
+    } catch (_e) {
+      /* ignore */
+    }
+  process.stderr.write(line);
+};
 
 // development mode for extensions
 let isExtensionsDevelopmentModeEnabled = false;
 
 async function createWindow(): Promise<BrowserWindow> {
+  trace('createWindow() start');
   const INITIAL_APP_WIDTH = 1050;
   const INITIAL_APP_MIN_WIDTH = 640;
   const INITIAL_APP_HEIGHT = 700;
@@ -80,7 +95,9 @@ async function createWindow(): Promise<BrowserWindow> {
     browserWindowConstructorOptions.trafficLightPosition = { x: 20, y: 13 };
   }
 
+  trace('creating BrowserWindow');
   const browserWindow = new BrowserWindow(browserWindowConstructorOptions);
+  trace('BrowserWindow created');
 
   const { getCursorScreenPoint, getDisplayNearestPoint } = screen;
   const workArea = getDisplayNearestPoint(getCursorScreenPoint()).workArea;
@@ -110,6 +127,7 @@ async function createWindow(): Promise<BrowserWindow> {
 
   // Shared show logic used by both ready-to-show and the Wayland did-finish-load fallback.
   const handleWindowShow = (): void => {
+    trace('handleWindowShow() fired');
     // If started with --minimize flag (Windows login item or manual CLI), hide the window
     if (isStartedMinimize()) {
       if (isMac()) {
@@ -260,7 +278,9 @@ async function createWindow(): Promise<BrowserWindow> {
       ? import.meta.env.VITE_DEV_SERVER_URL
       : new URL('../renderer/dist/index.html', 'file://' + __dirname).toString();
 
+  trace(`loadURL start: ${pageUrl}`);
   await browserWindow.loadURL(pageUrl);
+  trace('loadURL done');
 
   return browserWindow;
 }

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -20,6 +20,8 @@
  * @module preload
  */
 import { EventEmitter } from 'node:events';
+// (delete-me) cold-start trace — write to file since Playwright consumes both stdout and stderr
+import { appendFileSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -262,6 +264,18 @@ import { WelcomeInit } from './welcome/welcome-init.js';
 const checkDiskSpace: (path: string) => Promise<{ free: number }> = checkDiskSpacePkg as unknown as (
   path: string,
 ) => Promise<{ free: number }>;
+const T0 = Date.now();
+const traceFile = process.env['PD_COLD_TRACE_FILE'];
+const trace = (msg: string): void => {
+  const line = `[TRACE] +${Date.now() - T0}ms ${msg}\n`;
+  if (traceFile)
+    try {
+      appendFileSync(traceFile, line);
+    } catch (_e) {
+      /* ignore */
+    }
+  process.stderr.write(line);
+};
 
 export const UPDATER_UPDATE_AVAILABLE_ICON = 'fa fa-exclamation-triangle';
 
@@ -497,6 +511,7 @@ export class PluginSystem {
 
   // initialize extension loader mechanism
   async initExtensions(configurationRegistryEmitter: Emitter<ConfigurationRegistry>): Promise<ExtensionLoader> {
+    trace('initExtensions() start');
     const notifications: NotificationCardOptions[] = [];
 
     this.isReady = false;
@@ -508,9 +523,11 @@ export class PluginSystem {
     this.ipcHandle('extension-system:isExtensionsStarted', async (): Promise<boolean> => {
       return this.isExtensionsStarted;
     });
+    trace('IPC handlers registered');
 
     // redirect main process logs to the extension loader
     this.redirectLogging();
+    trace('redirectLogging() done');
 
     // init api sender
     const apiSender = this.getApiSender(this.getWebContentsSender());
@@ -530,17 +547,21 @@ export class PluginSystem {
     container.bind<SafeStorageRegistry>(SafeStorageRegistry).toSelf().inSingletonScope();
 
     const safeStorageRegistry = container.get<SafeStorageRegistry>(SafeStorageRegistry);
+    trace('safeStorageRegistry.init() start');
     notifications.push(...(await safeStorageRegistry.init()));
+    trace('safeStorageRegistry.init() done');
 
     container.bind<DefaultConfiguration>(DefaultConfiguration).toSelf().inSingletonScope();
     container.bind<ConfigurationRegistry>(ConfigurationRegistry).toSelf().inSingletonScope();
     container.bind<LockedConfiguration>(LockedConfiguration).toSelf().inSingletonScope();
     container.bind<IConfigurationRegistry>(IConfigurationRegistry).toService(ConfigurationRegistry);
+    trace('initConfigurationRegistry() start');
     const configurationRegistry = await this.initConfigurationRegistry(
       container,
       notifications,
       configurationRegistryEmitter,
     );
+    trace('initConfigurationRegistry() done');
 
     container.bind<ColorRegistry>(ColorRegistry).to(InjectableColorRegistry).inSingletonScope();
     const colorRegistry = container.get<ColorRegistry>(ColorRegistry);
@@ -548,18 +569,24 @@ export class PluginSystem {
 
     container.bind<Certificates>(Certificates).toSelf().inSingletonScope();
     const certificates = container.get<Certificates>(Certificates);
+    trace('certificates.init() start');
     await certificates.init();
+    trace('certificates.init() done');
 
     container.bind<Proxy>(Proxy).toSelf().inSingletonScope();
     const proxy = container.get<Proxy>(Proxy);
+    trace('proxy.init() start');
     await proxy.init();
+    trace('proxy.init() done');
 
     const exec = new Exec(proxy);
     container.bind<Exec>(Exec).toConstantValue(exec);
 
     container.bind<Telemetry>(Telemetry).toSelf().inSingletonScope();
     const telemetry = container.get<Telemetry>(Telemetry);
+    trace('telemetry.init() start');
     await telemetry.init();
+    trace('telemetry.init() done');
 
     container.bind<ExperimentalConfigurationManager>(ExperimentalConfigurationManager).toSelf().inSingletonScope();
     const experimentalConfigurationManager = container.get<ExperimentalConfigurationManager>(
@@ -594,7 +621,9 @@ export class PluginSystem {
 
     container.bind<KubernetesClient>(KubernetesClient).toSelf().inSingletonScope();
     const kubernetesClient = container.get<KubernetesClient>(KubernetesClient);
+    trace('kubernetesClient.init() start');
     await kubernetesClient.init();
+    trace('kubernetesClient.init() done');
 
     container.bind<CloseBehavior>(CloseBehavior).toSelf().inSingletonScope();
     const closeBehaviorConfiguration = container.get<CloseBehavior>(CloseBehavior);
@@ -804,7 +833,9 @@ export class PluginSystem {
 
     container.bind<ExtensionLoader>(ExtensionLoader).toSelf().inSingletonScope();
     this.extensionLoader = container.get<ExtensionLoader>(ExtensionLoader);
+    trace('extensionLoader.init() start');
     await this.extensionLoader.init();
+    trace('extensionLoader.init() done');
 
     container.bind<FeedbackHandler>(FeedbackHandler).toSelf().inSingletonScope();
 
@@ -3473,12 +3504,15 @@ export class PluginSystem {
 
     await contributionManager.init();
 
+    trace('markAsReady()');
     this.markAsReady();
 
     apiSender.send('starting-extensions', `${this.isReady}`);
     console.log('System ready. Loading extensions...');
+    trace('extensionLoader.start() begin');
     try {
       await this.extensionLoader.start();
+      trace('extensionLoader.start() done');
       console.log('PluginSystem: initialization done.');
     } finally {
       apiSender.send('extensions-started');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -20,6 +20,7 @@
  * @module preload
  */
 
+// (delete-me) cold-start trace logging — must be before all imports
 import EventEmitter from 'node:events';
 
 import type {
@@ -153,6 +154,10 @@ import type { ExtensionBanner, RecommendedRegistry } from '@podman-desktop/core-
 import type { PinOption } from '@podman-desktop/core-api/status-bar';
 import { contextBridge, ipcRenderer } from 'electron';
 
+const _traceT0 = Date.now();
+const _trace = (msg: string): void => console.log(`[TRACE:preload] +${Date.now() - _traceT0}ms ${msg}`);
+_trace('preload module start (before imports)');
+
 export type OpenSaveDialogResultCallback = (result: string | string[] | undefined) => void;
 
 const originalConsole = console;
@@ -202,6 +207,7 @@ export function initExposure(): void {
   }
 
   contextBridge.exposeInMainWorld('events', apiSender);
+  _trace('window.events exposed');
   ipcRenderer.on('api-sender', (_, channel, data) => {
     apiSender.send(channel, data);
   });
@@ -2771,4 +2777,6 @@ export function initExposure(): void {
 }
 
 // expose methods
+_trace('imports resolved, calling initExposure()');
 initExposure();
+_trace('initExposure() done — all contextBridge APIs exposed');

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -77,7 +77,7 @@ window.events?.receive('install-extension:from-id', (extensionId: unknown) => {
 });
 
 // Wait that the server-side is ready
-window.events.receive('starting-extensions', (value: unknown) => {
+window.events?.receive('starting-extensions', (value: unknown) => {
   systemReady = value === 'true';
   if (systemReady) {
     window.dispatchEvent(new CustomEvent('system-ready', {}));

--- a/packages/renderer/src/Loader.svelte
+++ b/packages/renderer/src/Loader.svelte
@@ -7,6 +7,13 @@ import SealRocket from './lib/images/SealRocket.svelte';
 import ColorsStyle from './lib/style/ColorsStyle.svelte';
 import { lastPage } from './stores/breadcrumb';
 
+// (delete-me) cold-start trace logging
+const _t0 = Date.now();
+const _trace = (msg: string): void => console.log(`[TRACE:renderer] +${Date.now() - _t0}ms ${msg}`);
+_trace(
+  `Loader.svelte module init — window.events=${typeof window.events} window.extensionSystemIsReady=${typeof window.extensionSystemIsReady}`,
+);
+
 let systemReady = false;
 
 let toggle = false;
@@ -16,12 +23,15 @@ let loadingSequence: NodeJS.Timeout;
 let extensionsStarterChecker: NodeJS.Timeout;
 
 onMount(async () => {
+  _trace('onMount fired');
   loadingSequence = setInterval(() => {
     toggle = !toggle;
   }, 100);
   // check if the server side is ready
   try {
+    _trace('calling extensionSystemIsReady()');
     const isReady = await window.extensionSystemIsReady();
+    _trace(`extensionSystemIsReady() returned: ${isReady}`);
     systemReady = isReady;
     if (systemReady) {
       window.dispatchEvent(new CustomEvent('system-ready', {}));
@@ -78,6 +88,7 @@ window.events?.receive('install-extension:from-id', (extensionId: unknown) => {
 
 // Wait that the server-side is ready
 window.events?.receive('starting-extensions', (value: unknown) => {
+  _trace(`received 'starting-extensions' event: ${value}`);
   systemReady = value === 'true';
   if (systemReady) {
     window.dispatchEvent(new CustomEvent('system-ready', {}));

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -31,7 +31,7 @@ async function runProvider(): Promise<void> {
   try {
     await window.startProvider(provider.internalId);
     await new Promise<void>(resolve => {
-      window.events.receive('provider-change', () => {
+      window.events?.receive('provider-change', () => {
         resolve();
       });
     });

--- a/packages/renderer/src/lib/kube/active-resources-count-listen.ts
+++ b/packages/renderer/src/lib/kube/active-resources-count-listen.ts
@@ -26,7 +26,7 @@ export async function listenActiveResourcesCount(
     return;
   }
 
-  const disposable = window.events.receive('kubernetes-active-resources-count', () => {
+  const disposable = window.events?.receive('kubernetes-active-resources-count', () => {
     collectAndSendCount(callback);
   });
 
@@ -34,7 +34,7 @@ export async function listenActiveResourcesCount(
 
   return {
     dispose: (): void => {
-      disposable.dispose();
+      disposable?.dispose();
     },
   };
 }

--- a/packages/renderer/src/lib/kube/resources-listen.ts
+++ b/packages/renderer/src/lib/kube/resources-listen.ts
@@ -46,7 +46,7 @@ export async function listenResources(
   let contextName: string | undefined;
   let searchTermStoreUnsubscribe: Unsubscriber | undefined;
 
-  const disposable = window.events.receive(`kubernetes-update-${resourceName}`, () => {
+  const disposable = window.events?.receive(`kubernetes-update-${resourceName}`, () => {
     if (!contextName) {
       return;
     }
@@ -78,7 +78,7 @@ export async function listenResources(
 
   return {
     dispose: (): void => {
-      disposable.dispose();
+      disposable?.dispose();
       kubernetesContextsUnsubscribe();
       searchTermStoreUnsubscribe?.();
     },

--- a/tests/playwright/src/runner/electron-runner.ts
+++ b/tests/playwright/src/runner/electron-runner.ts
@@ -57,6 +57,7 @@ export class ElectronRunner extends Runner {
       this._app = await electron.launch({
         ...this._options,
       });
+
       // setup state
       this._page = await this.getElectronApp().firstWindow();
       this._running = true;
@@ -249,6 +250,9 @@ export class ElectronRunner extends Runner {
     }
   }
 
+  // (delete-me) cold-start trace file counter
+  private static _launchCount = 0;
+
   protected override defaultOptions(): object {
     const pdArgs = process.env.PODMAN_DESKTOP_ARGS;
     const pdBinary = process.env.PODMAN_DESKTOP_BINARY;
@@ -256,6 +260,10 @@ export class ElectronRunner extends Runner {
     const tracesDir = join(this._testOutput, 'traces', 'raw');
     console.log(`video will be written to: ${directory}`);
     const env = this.setupPodmanDesktopCustomFolder();
+    // (delete-me) pass trace file path to Electron main process
+    const traceFile = join(this._testOutput, `cold-start-trace-w${ElectronRunner._launchCount++}.log`);
+    env['PD_COLD_TRACE_FILE'] = traceFile;
+    console.log(`Cold-start trace file: ${traceFile}`);
     const recordVideo = {
       dir: directory,
       size: {


### PR DESCRIPTION
### What does this PR do?

Investigates the intermittent `windows-11-arm` and `windows-2025` update e2e test failures. Initial approach was to extend timeouts, but trace analysis revealed the actual root cause is different.

**Root cause:** A preload/renderer race condition on the first Electron cold-start. The renderer executes before the preload script finishes injecting the IPC bridge via `contextBridge.exposeInMainWorld`, causing:

```
TypeError: Cannot read properties of undefined (reading 'receive')
```

The Svelte app never mounts (`<div id="app"></div>` stays empty), and `dom-ready` never fires. On restart (2nd worker), the preload is cached and the app starts in ~2s.

**Current state (draft):** The timeout-based approach in this PR does not fix the underlying race condition. Converting to draft while we determine the correct fix — likely one of:

1. Guard renderer initialization to wait for the preload bridge before mounting
2. Detect the crash in the test runner and restart the Electron process
3. Fix the Electron preload timing at the configuration level

See #18225 for full investigation, trace analysis, and 10-run stability results.

### Screenshot / video of UI

N/A — test infrastructure investigation.

### What issues does this PR fix or reference?

Ref #18225

### How to test this PR?

Pending — current changes are insufficient. See issue for details.

- [ ] Tests are covering the bug fix or the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)