### PR TITLE
fix(renderer): use stable keys for command palette GoTo items

### DIFF
--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -455,7 +455,7 @@ function getIcon(item: CommandInfo | DocumentationInfo | GoToInfo): IconDefiniti
           {/each}
         </div>
         <ul class="max-h-[50vh] overflow-y-auto flex flex-col mt-1">
-          {#each filteredItems as item, i (i)}
+          {#each filteredItems as item, i (getTextToHighlight(item))}
             {@const goToItem = isGoToItem(item)}
             {@const docItem = isDocItem(item)}
             {@const itemIcon = getIcon(item)}


### PR DESCRIPTION
### What does this PR do?

Replaces the index-based `{#each}` key `(i)` with a stable identity key `(getTextToHighlight(item))` in the command palette's item list. This prevents Svelte from reusing DOM nodes by position when the list changes, which caused icons from one item to bleed into another.

### Screenshot / video of UI

<img width="1408" height="842" alt="Screenshot 2026-07-10 at 15 27 40" src="https://github.com/user-attachments/assets/786ad464-6119-44cb-a319-2ba7c445766a" />

### What issues does this PR fix or reference?

Fixes #18243

### How to test this PR?

1. Open the command palette (Ctrl+Shift+P / Cmd+Shift+P)
2. Switch to the "Go to" tab
3. Verify each item displays the correct icon (containers, images, pods, volumes, etc.)
4. Type a filter, then clear it — icons should remain correct

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)