### PR TITLE
fix(renderer): fix command palette navigation to untagged images

### DIFF
--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -272,7 +272,7 @@ async function executeAction(index: number): Promise<void> {
   } else if (isGoToItem(item)) {
     // Go to item
     if (item.type === 'Image') {
-      const repoTag = item.RepoTags?.[0] ?? item.Id;
+      const repoTag = item.RepoTags?.[0] ?? '<none>';
       handleNavigation({
         page: NavigationPage.IMAGE,
         parameters: {


### PR DESCRIPTION
### What does this PR do?

Fixes navigation from the command palette to images that have no `RepoTags`. Previously, `image.Id` was used as the fallback tag parameter, but `ImageDetails` resolves images using `base64('<none>')` for untagged images. The mismatch caused the detail page to render empty.

Uses `'<none>'` as the fallback tag to match the expected lookup value in `getImageInfoUI()`.

### Screenshot / video of UI


https://github.com/user-attachments/assets/d43c345c-a69d-4bb6-ba96-3e493b6bbbc5


### What issues does this PR fix or reference?

Fixes #18244

### How to test this PR?

1. Have an image without repo tags (pull one and remove tags, or build without tagging)
2. Open the command palette (Ctrl+Shift+P / Cmd+Shift+P)
3. Switch to the "Go to" tab
4. Click on the untagged image entry (e.g. `Image: sha256:abc123...`)
5. Verify: image details page loads correctly

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)