### PR TITLE
refactor: move containerPortMapping to basic options

### DIFF
--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -53,6 +53,7 @@ beforeEach(() => {
 
 afterEach(() => {
   console.error = originalConsoleDebug;
+  vi.useRealTimers();
 });
 
 async function waitRender(): Promise<void> {
@@ -458,6 +459,38 @@ describe('RunImage', () => {
       'engineid',
       expect.objectContaining({ EnvFiles: [customEnvFile, 'foo3'] }),
     );
+  });
+
+  test('Expect error to be visible if isFreePort is not free', async () => {
+    vi.useFakeTimers({
+      shouldAdvanceTime: true,
+    });
+
+    vi.mocked(window.isFreePort).mockRejectedValue(new Error('Port 8080 is already in use.'));
+    router.goto('/basic');
+
+    await createRunImage(undefined, ['command1', 'command2']);
+
+    const customMappingButton = screen.getByRole('button', { name: 'Add custom port mapping' });
+    await fireEvent.click(customMappingButton);
+
+    const hostInput = screen.getByLabelText('host port');
+    await userEvent.click(hostInput);
+    await userEvent.clear(hostInput);
+    await userEvent.keyboard('8080');
+
+    const containerInput = screen.getByLabelText('container port');
+    await userEvent.click(containerInput);
+    await userEvent.clear(containerInput);
+    await userEvent.keyboard('8080');
+
+    // wait for debounce
+    await vi.advanceTimersByTimeAsync(800);
+
+    const error = await vi.waitFor(() => {
+      return screen.getByText('Port 8080 is already in use.');
+    });
+    expect(error).toBeInTheDocument();
   });
 
   test('Expect "start container" button to be disabled when port is not free', async () => {

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -36,6 +36,7 @@ let options: RunOptions = $state({
     environmentVariables: [{ key: '', value: '' }],
     environmentFiles: [''],
     hostContainerPortMappings: [],
+    containerPortMapping: [],
   },
   networking: {
     hostname: undefined,
@@ -80,14 +81,13 @@ let containerNameError: string | undefined = $derived.by(() => {
   }
 });
 
-let containerPortMapping = $state<PortInfo[]>([]);
 let exposedPorts = $state<string[]>([]);
 let createError = $state<string>();
 let onPortInputTimeout: NodeJS.Timeout;
 
 let invalidPorts = $derived.by(() => {
   const invalidHostPorts = options.basic.hostContainerPortMappings.filter(pair => pair.hostPort.error);
-  const invalidContainerPortMapping = containerPortMapping?.filter(port => port.error) ?? [];
+  const invalidContainerPortMapping = options.basic.containerPortMapping?.filter(port => port.error) ?? [];
   return invalidHostPorts.length > 0 || invalidContainerPortMapping.length > 0;
 });
 let invalidFields = $derived(!!containerNameError || invalidPorts);
@@ -108,8 +108,6 @@ onMount(async () => {
     return;
   }
 
-  containerPortMapping = [];
-
   imageInspectInfo = await window.getImageInspect(image.engineId, image.id);
   exposedPorts = Array.from(Object.keys(imageInspectInfo?.Config?.ExposedPorts ?? {}));
 
@@ -125,13 +123,12 @@ onMount(async () => {
     options.basic.entrypoint = '';
   }
 
-  // auto-assign ports from available free port
-  containerPortMapping = new Array<PortInfo>(exposedPorts.length);
+  options.basic.containerPortMapping = new Array<PortInfo>(exposedPorts.length);
   await Promise.all(
     exposedPorts.map(async (port, index) => {
       const localPorts = await getPortsInfo(port);
       if (localPorts) {
-        containerPortMapping[index] = { port: localPorts, error: '' };
+        options.basic.containerPortMapping[index] = { port: localPorts, error: '' };
       }
     }),
   );
@@ -244,11 +241,11 @@ async function startContainer(): Promise<void> {
   const PortBindings: HostConfigPortBinding = {};
   try {
     exposedPorts.forEach((port, index) => {
-      if (port.includes('-') || containerPortMapping[index]?.port.includes('-')) {
-        addPortsFromRange(ExposedPorts, PortBindings, port, containerPortMapping[index].port);
+      if (port.includes('-') || options.basic.containerPortMapping[index]?.port.includes('-')) {
+        addPortsFromRange(ExposedPorts, PortBindings, port, options.basic.containerPortMapping[index].port);
       } else {
-        if (containerPortMapping[index]?.port) {
-          PortBindings[port] = [{ HostPort: containerPortMapping[index].port }];
+        if (options.basic.containerPortMapping[index]?.port) {
+          PortBindings[port] = [{ HostPort: options.basic.containerPortMapping[index].port }];
         }
         ExposedPorts[port] = {};
       }
@@ -573,18 +570,14 @@ function deleteDevice(index: number): void {
 }
 
 function onContainerPortMappingInput(event: Event, index: number): void {
-  onPortInput(event, containerPortMapping[index], () => {
-    containerPortMapping = containerPortMapping;
-  });
+  onPortInput(event, options.basic.containerPortMapping[index]);
 }
 
 function onHostContainerPortMappingInput(event: Event, index: number): void {
-  onPortInput(event, options.basic.hostContainerPortMappings[index].hostPort, () => {
-    options.basic.hostContainerPortMappings = options.basic.hostContainerPortMappings;
-  });
+  onPortInput(event, options.basic.hostContainerPortMappings[index].hostPort);
 }
 
-function onPortInput(event: Event, portInfo: PortInfo, updateUI: () => void): void {
+function onPortInput(event: Event, portInfo: PortInfo): void {
   // clear the timeout so if there was an old call to areAllPortsFree pending is deleted. We will create a new one soon
   clearTimeout(onPortInputTimeout);
   const target = event.currentTarget as HTMLInputElement;
@@ -595,13 +588,11 @@ function onPortInput(event: Event, portInfo: PortInfo, updateUI: () => void): vo
       .isFreePort(_value)
       .then(_ => {
         portInfo.error = '';
-        updateUI();
       })
       .catch((error: unknown) => {
         if (error && typeof error === 'object' && 'message' in error) {
           portInfo.error = (error as { message: string }).message;
         }
-        updateUI();
       });
   }, 500);
 }
@@ -700,12 +691,12 @@ const envDialogOptions: OpenDialogOptions = {
                     class="text-sm flex-1 inline-block align-middle whitespace-nowrap text-[var(--pd-content-card-text)]"
                     >Local port for {port}:</span>
                   <Input
-                    bind:value={containerPortMapping[index].port}
+                    bind:value={options.basic.containerPortMapping[index].port}
                     on:input={(event): void => onContainerPortMappingInput(event, index)}
                     placeholder="Enter value for port {port}"
-                    error={containerPortMapping[index].error}
+                    error={options.basic.containerPortMapping[index].error}
                     class="ml-2 w-full"
-                    title={containerPortMapping[index].error} />
+                    title={options.basic.containerPortMapping[index].error} />
                 </div>
               {/each}
 

--- a/packages/renderer/src/lib/image/run/run-options.ts
+++ b/packages/renderer/src/lib/image/run/run-options.ts
@@ -30,6 +30,7 @@ export interface RunOptions {
     environmentVariables: { key: string; value: string }[];
     environmentFiles: string[];
     hostContainerPortMappings: { hostPort: PortInfo; containerPort: string }[];
+    containerPortMapping: Array<PortInfo>;
   };
   networking: {
     hostname?: string;


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/18208, the `containerPortMapping` option was missing because it was a bit complex. 

I added a unit test to ensure we don't lose any reactivity.

### Screenshot / video of UI

<img width="837" height="177" alt="image" src="https://github.com/user-attachments/assets/6da8d688-dd76-4934-a69c-de1b83cdb35e" />

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/18200

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Run a container with a port mapping (E.g. `podman run -it -p 8080:80 nginx`)
2. Go to `Run image` and try to bind to `8080` port
3. Assert the error