### PR TITLE
chore(extension/kind): remove `tsx` dependency

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -109,7 +109,7 @@
     ]
   },
   "scripts": {
-    "install:contour": "tsx ./scripts/download.ts",
+    "install:contour": "node ./scripts/download.ts",
     "build": "vite build && node ./scripts/build.js",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
@@ -125,7 +125,6 @@
   "devDependencies": {
     "adm-zip": "^0.6.0",
     "mkdirp": "^3.0.1",
-    "tsx": "^4.23.1",
     "vite": "^8.1.4",
     "vitest": "^4.1.10"
   }

--- a/extensions/kind/scripts/download.ts
+++ b/extensions/kind/scripts/download.ts
@@ -19,7 +19,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
+import type { RestEndpointMethodTypes } from '@octokit/rest';
 import type { OctokitResponse } from '@octokit/types';
 import type { OctokitOptions } from '@octokit/core/types';
 type ReposGetContentResponseData = RestEndpointMethodTypes['repos']['getContent']['response']['data'] & {
@@ -43,7 +44,7 @@ const octokit = new Octokit(octokitOptions);
 export {};
 
 async function download(tagVersion: string, repoPath: string, fileName: string): Promise<void> {
-  const destDir = path.resolve(__dirname, '..', 'src', 'resources');
+  const destDir = path.resolve(import.meta.dirname, '..', 'src', 'resources');
   if (!fs.existsSync(destDir)) {
     fs.mkdirSync(destDir);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,9 +301,6 @@ importers:
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
-      tsx:
-        specifier: ^4.23.1
-        version: 4.23.1
       vite:
         specifier: ^8.1.4
         version: 8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.36.0)(tsx@4.23.1)(yaml@2.9.0)


### PR DESCRIPTION
### What does this PR do?

Removes the `tsx` dependency from the `kind` extension. Recent Node.js versions strip TypeScript types natively, so `scripts/download.ts` no longer needs `tsx` to run — `install:contour` now invokes it directly with `node`.

Two small changes were required for the script to work under Node's native type-stripping (which, unlike `tsx`, does not infer type-only imports):
- `RestEndpointMethodTypes` is now imported with `import type` instead  of as a mixed value/type import.
- `__dirname` is replaced with `import.meta.dirname`, since the script  runs as an ES module.

### Screenshot / video of UI

N/A — no UI changes.

### What issues does this PR fix or reference?

Fixes #17815

### How to test this PR?

1. `cd extensions/kind`
2. `pnpm run install:contour`
3. Confirm it downloads `contour.yaml` into `src/resources/` without requiring `tsx`, using Node's built-in TypeScript support.

- [x] Tests are covering the bug fix or the new feature
