### PR TITLE
feat(RunImage): support mounting secret 

### DIFF
--- a/packages/api/src/container-info.ts
+++ b/packages/api/src/container-info.ts
@@ -273,6 +273,11 @@ export interface ContainerCreateOptions {
   Shell?: string[];
   NetworkConfig?: NetworkingConfig;
   pod?: string;
+  Secrets?: Array<{
+    Source: string;
+    Target: string;
+  }>;
+  SecretEnv?: Record<string, string>;
 }
 
 export type NetworkCreateOptions = Dockerode.NetworkCreateOptions;

--- a/packages/api/src/libpod/libpod.ts
+++ b/packages/api/src/libpod/libpod.ts
@@ -117,4 +117,9 @@ export interface ContainerCreateOptions {
   volumes?: Array<ContainerCreateNamedVolume>;
   selinux_opts?: string[];
   devices?: PodmanDevice[];
+  secrets?: Array<{
+    Source: string;
+    Target: string;
+  }>;
+  secret_env?: Record<string, string>;
 }

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4736,34 +4736,73 @@ describe('createContainerLibPod', () => {
     expect(createPodmanContainerMock).toBeCalledWith(expectedOptions);
   });
 
-  test('check that secrets and secret_env are passed to createPodmanContainer', async () => {
-    const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
+  test('expect createContainer to use compat api for non-podman options', async () => {
+    vi.spyOn(containerRegistry, 'attachToContainer').mockResolvedValue();
 
-    const libpod = new LibpodDockerode();
-    libpod.enhancePrototypeWithLibPod();
+    const dockerAPI = {
+      createContainer: vi.fn(),
+    } as unknown as Dockerode;
+    const libpodAPI = {
+      createPodmanContainer: vi.fn(),
+    } as unknown as LibPod;
+
+    vi.mocked(dockerAPI.createContainer).mockResolvedValue({
+      start: () => {},
+      inspect: () => {},
+    } as unknown as Dockerode.Container);
+
     containerRegistry.addInternalProvider('podman1', {
       name: 'podman',
       id: 'podman1',
       api: dockerAPI,
-      libpodApi: dockerAPI,
+      libpodApi: libpodAPI,
       connection: {
         type: 'podman',
       },
     } as unknown as InternalContainerProvider);
 
-    const createPodmanContainerMock = vi
-      .spyOn(dockerAPI as unknown as LibPod, 'createPodmanContainer')
-      .mockImplementation(_options =>
-        Promise.resolve({
-          Id: 'id',
-          Warnings: [],
-        }),
-      );
-    vi.spyOn(dockerAPI as unknown as Dockerode, 'getContainer').mockImplementation((_id: string) => {
-      return {
-        start: () => {},
-      } as unknown as Dockerode.Container;
+    await containerRegistry.createContainer('podman1', {
+      Image: 'image',
+      name: 'name',
     });
+
+    expect(dockerAPI.createContainer).toHaveBeenCalledExactlyOnceWith({
+      Image: 'image',
+      name: 'name',
+    });
+    expect(libpodAPI.createPodmanContainer).not.toHaveBeenCalled();
+  });
+
+  test('check that secrets and secret_env are passed to createPodmanContainer', async () => {
+    vi.spyOn(containerRegistry, 'attachToContainer').mockResolvedValue();
+
+    const dockerAPI = {
+      createContainer: vi.fn(),
+      getContainer: vi.fn(),
+    } as unknown as Dockerode;
+    const libpodAPI = {
+      createPodmanContainer: vi.fn(),
+    } as unknown as LibPod;
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman',
+      id: 'podman1',
+      api: dockerAPI,
+      libpodApi: libpodAPI,
+      connection: {
+        type: 'podman',
+      },
+    } as unknown as InternalContainerProvider);
+
+    vi.mocked(dockerAPI.getContainer).mockResolvedValue({
+      start: vi.fn(),
+    } as unknown as Dockerode.Container);
+
+    vi.mocked(libpodAPI.createPodmanContainer).mockResolvedValue({
+      Id: 'id',
+      Warnings: [],
+    });
+
     vi.spyOn(containerRegistry, 'attachToContainer').mockResolvedValue();
 
     const options: ContainerCreateOptions = {
@@ -4775,7 +4814,8 @@ describe('createContainerLibPod', () => {
 
     await containerRegistry.createContainer('podman1', options);
 
-    expect(createPodmanContainerMock).toBeCalledWith(
+    expect(dockerAPI.createContainer).not.toHaveBeenCalled();
+    expect(libpodAPI.createPodmanContainer).toBeCalledWith(
       expect.objectContaining({
         secrets: [{ Source: 'my-secret', Target: '/run/secrets/my-secret' }],
         secret_env: { FOO_DATA: 'foo-data' },

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4735,6 +4735,53 @@ describe('createContainerLibPod', () => {
     await containerRegistry.createContainer('podman1', options);
     expect(createPodmanContainerMock).toBeCalledWith(expectedOptions);
   });
+
+  test('check that secrets and secret_env are passed to createPodmanContainer', async () => {
+    const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+    const libpod = new LibpodDockerode();
+    libpod.enhancePrototypeWithLibPod();
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman',
+      id: 'podman1',
+      api: dockerAPI,
+      libpodApi: dockerAPI,
+      connection: {
+        type: 'podman',
+      },
+    } as unknown as InternalContainerProvider);
+
+    const createPodmanContainerMock = vi
+      .spyOn(dockerAPI as unknown as LibPod, 'createPodmanContainer')
+      .mockImplementation(_options =>
+        Promise.resolve({
+          Id: 'id',
+          Warnings: [],
+        }),
+      );
+    vi.spyOn(dockerAPI as unknown as Dockerode, 'getContainer').mockImplementation((_id: string) => {
+      return {
+        start: () => {},
+      } as unknown as Dockerode.Container;
+    });
+    vi.spyOn(containerRegistry, 'attachToContainer').mockResolvedValue();
+
+    const options: ContainerCreateOptions = {
+      Image: 'image',
+      name: 'name',
+      Secrets: [{ Source: 'my-secret', Target: '/run/secrets/my-secret' }],
+      SecretEnv: { FOO_DATA: 'foo-data' },
+    };
+
+    await containerRegistry.createContainer('podman1', options);
+
+    expect(createPodmanContainerMock).toBeCalledWith(
+      expect.objectContaining({
+        secrets: [{ Source: 'my-secret', Target: '/run/secrets/my-secret' }],
+        secret_env: { FOO_DATA: 'foo-data' },
+      }),
+    );
+  });
 });
 
 describe('getContainerCreateMountOptionFromBind', () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2251,7 +2251,7 @@ export class ContainerProviderRegistry {
     let telemetryOptions = {};
     try {
       let container: Dockerode.Container;
-      let forceLibPod = false;
+      let forceLibPod = !!options.Secrets || !!options.SecretEnv;
 
       // the device option requesting an nvidia gpu on linux only works
       // if the LibPod API is used. Check if such a device is requested
@@ -2440,6 +2440,8 @@ export class ContainerProviderRegistry {
       hostadd: options.HostConfig?.ExtraHosts,
       userns: options.HostConfig?.UsernsMode,
       devices: updatedDevices,
+      secrets: options.Secrets,
+      secret_env: options.SecretEnv,
     };
 
     const container = await engine.libpodApi.createPodmanContainer(podmanOptions);

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2251,7 +2251,7 @@ export class ContainerProviderRegistry {
     let telemetryOptions = {};
     try {
       let container: Dockerode.Container;
-      let forceLibPod = !!options.Secrets || !!options.SecretEnv;
+      let forceLibPod = (options.Secrets?.length ?? 0) > 0 || Object.entries(options.SecretEnv ?? {}).length > 0;
 
       // the device option requesting an nvidia gpu on linux only works
       // if the LibPod API is used. Check if such a device is requested

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ImageInfo } from '@podman-desktop/api';
-import type { ImageInspectInfo } from '@podman-desktop/core-api';
+import type { ImageInspectInfo, SecretInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -29,11 +29,13 @@ import { afterEach, beforeAll, beforeEach, describe, expect, type Mock, test, vi
 import RunImage from '/@/lib/image/RunImage.svelte';
 import { mockBreadcrumb } from '/@/stores/breadcrumb.spec';
 import { imagesInfos } from '/@/stores/images';
+import { secretsInfo } from '/@/stores/secrets';
 
 const originalConsoleDebug = console.debug;
 
 const MY_IMAGE = {
   engineId: 'podman',
+  engineType: 'podman',
   Id: 'sha256:5555',
   Size: 0,
 } as unknown as ImageInfo;
@@ -55,6 +57,7 @@ beforeAll(() => {
 beforeEach(() => {
   console.error = vi.fn();
   vi.clearAllMocks();
+  secretsInfo.set([]);
 });
 
 afterEach(() => {
@@ -319,7 +322,6 @@ describe('RunImage', () => {
 
   test('Expect to see an error if the container/host ranges have different size', async () => {
     (window.isFreePort as Mock).mockResolvedValue(true);
-    router.goto('/basic');
 
     await createRunImage(undefined, ['command1', 'command2']);
 
@@ -515,6 +517,121 @@ describe('RunImage', () => {
     const button = screen.getByRole('button', { name: 'Start Container' });
     await tick();
     expect((button as HTMLButtonElement).disabled).toBeTruthy();
+  });
+
+  test('Expect "Add secret mapping" button to be disabled when no secrets available', async () => {
+    secretsInfo.set([]);
+    await createRunImage('', []);
+
+    const link = screen.getByRole('link', { name: 'Basic' });
+    await fireEvent.click(link);
+
+    const addButton = screen.getByRole('button', { name: 'Add secret mapping' });
+    expect(addButton).toBeDisabled();
+  });
+
+  test('Expect "Add secret mapping" button to be enabled when secrets are available', async () => {
+    secretsInfo.set([
+      { engineId: 'engineid', engineName: 'podman', engineType: 'podman', Id: 's1', Name: 'my-secret' } as SecretInfo,
+    ]);
+    await createRunImage('', []);
+
+    const link = screen.getByRole('link', { name: 'Basic' });
+    await fireEvent.click(link);
+
+    const addButton = screen.getByRole('button', { name: 'Add secret mapping' });
+    expect(addButton).toBeEnabled();
+  });
+
+  test('Expect mount secret mapping to be sent to API as Secrets', async () => {
+    secretsInfo.set([
+      { engineId: 'engineid', engineName: 'podman', engineType: 'podman', Id: 's1', Name: 'my-secret' } as SecretInfo,
+    ]);
+    await createRunImage('', []);
+
+    const link = screen.getByRole('link', { name: 'Basic' });
+    await fireEvent.click(link);
+
+    const addButton = screen.getByRole('button', { name: 'Add secret mapping' });
+    await fireEvent.click(addButton);
+
+    const targetInputs = screen.getAllByPlaceholderText('Path inside the container');
+    const targetInput = targetInputs[targetInputs.length - 1]!;
+    await userEvent.clear(targetInput);
+    await userEvent.type(targetInput, '/run/secrets/my-secret');
+
+    const button = screen.getByRole('button', { name: 'Start Container' });
+    await fireEvent.click(button);
+
+    expect(window.createAndStartContainer).toHaveBeenCalledWith(
+      'engineid',
+      expect.objectContaining({
+        Secrets: [{ Source: 'my-secret', Target: '/run/secrets/my-secret' }],
+        SecretEnv: {},
+      }),
+    );
+  });
+
+  test('Expect env secret mapping to be sent to API as SecretEnv', async () => {
+    secretsInfo.set([
+      { engineId: 'engineid', engineName: 'podman', engineType: 'podman', Id: 's1', Name: 'foo-data' } as SecretInfo,
+    ]);
+    await createRunImage('', []);
+
+    const link = screen.getByRole('link', { name: 'Basic' });
+    await fireEvent.click(link);
+
+    const addButton = screen.getByRole('button', { name: 'Add secret mapping' });
+    await fireEvent.click(addButton);
+
+    // change type to env via keyboard navigation
+    const typeDropdown = screen.getByRole('button', { name: 'Mount' });
+    typeDropdown.focus();
+    await userEvent.keyboard('[ArrowDown]');
+    await userEvent.keyboard('[ArrowDown]');
+    await userEvent.keyboard('[Enter]');
+
+    const targetInput = screen.getByPlaceholderText('Name of the environment variable');
+    await userEvent.clear(targetInput);
+    await userEvent.type(targetInput, 'FOO_SECRET');
+
+    const button = screen.getByRole('button', { name: 'Start Container' });
+    await fireEvent.click(button);
+
+    expect(window.createAndStartContainer).toHaveBeenCalledWith(
+      'engineid',
+      expect.objectContaining({
+        Secrets: [],
+        SecretEnv: { FOO_SECRET: 'foo-data' },
+      }),
+    );
+  });
+
+  test('Expect secret mapping to be removed when clicking remove button', async () => {
+    secretsInfo.set([
+      { engineId: 'engineid', engineName: 'podman', engineType: 'podman', Id: 's1', Name: 'my-secret' } as SecretInfo,
+    ]);
+    await createRunImage('', []);
+
+    const link = screen.getByRole('link', { name: 'Basic' });
+    await fireEvent.click(link);
+
+    const addButton = screen.getByRole('button', { name: 'Add secret mapping' });
+    await fireEvent.click(addButton);
+
+    const removeButton = screen.getByRole('button', { name: 'Remove secret' });
+    await fireEvent.click(removeButton);
+
+    const button = screen.getByRole('button', { name: 'Start Container' });
+    await fireEvent.click(button);
+
+    expect(window.createAndStartContainer).toHaveBeenCalledWith(
+      'engineid',
+      expect.objectContaining({
+        Secrets: [],
+        SecretEnv: {},
+      }),
+    );
   });
 
   test('Expect able to play with devices', async () => {

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -58,6 +58,7 @@ beforeEach(() => {
   console.error = vi.fn();
   vi.clearAllMocks();
   secretsInfo.set([]);
+  router.goto('/basic');
 });
 
 afterEach(() => {

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -828,7 +828,7 @@ const envDialogOptions: OpenDialogOptions = {
                 </div>
               {/each}
 
-              {#if imageInspectInfo?.engineName === 'Podman'}
+              {#if imageInspectInfo?.engineType === 'podman'}
                 <label
                   for="secrets"
                   class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -8,6 +8,7 @@ import type {
   HostConfigPortBinding,
   ImageInspectInfo,
   NetworkInspectInfo,
+  SecretInfo,
 } from '@podman-desktop/core-api';
 import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, Checkbox, Dropdown, ErrorMessage, Input, NumberInput, Tab } from '@podman-desktop/ui-svelte';
@@ -28,6 +29,7 @@ import { handleNavigation } from '/@/navigation';
 import Route from '/@/Route.svelte';
 import { containersInfos } from '/@/stores/containers';
 import { imagesInfos } from '/@/stores/images';
+import { secretsInfo } from '/@/stores/secrets';
 
 interface Props {
   imageID: string;
@@ -54,6 +56,7 @@ let options: RunOptions = $state({
     environmentFiles: [''],
     hostContainerPortMappings: [],
     containerPortMapping: [],
+    secretMappings: [],
   },
   networking: {
     hostname: undefined,
@@ -83,6 +86,8 @@ let options: RunOptions = $state({
 });
 
 let imageInspectInfo: ImageInspectInfo;
+
+let secrets: Array<SecretInfo> = $derived($secretsInfo.filter(secret => secret.engineId === imageInspectInfo.engineId));
 
 let containerNameError: string | undefined = $derived.by(() => {
   // ok, now check if we already have a matching container: same name and same engine ID
@@ -393,6 +398,15 @@ async function startContainer(): Promise<void> {
     ExposedPorts,
     Tty,
     OpenStdin,
+    Secrets: options.basic.secretMappings
+      .filter(({ type }) => type === 'mount')
+      .map(({ name, target }) => ({
+        Source: name,
+        Target: target,
+      })),
+    SecretEnv: Object.fromEntries(
+      options.basic.secretMappings.filter(({ type }) => type === 'env').map(({ name, target }) => [target, name]),
+    ),
   };
   if (options.basic.command.trim().length > 0) {
     createOptions.Cmd = splitSpacesHandlingDoubleQuotes(options.basic.command);
@@ -614,6 +628,22 @@ function onPortInput(event: Event, portInfo: PortInfo): void {
   }, 500);
 }
 
+function addSecretMapping(): void {
+  if (secrets.length === 0) {
+    return;
+  }
+
+  options.basic.secretMappings.push({
+    name: secrets[0].Name,
+    target: '',
+    type: 'mount',
+  });
+}
+
+function removeSecretMapping(index: number): void {
+  options.basic.secretMappings.splice(index, 1);
+}
+
 const volumeDialogOptions: OpenDialogOptions = {
   title: 'Select a directory to mount in the container',
   selectors: ['openDirectory'],
@@ -797,6 +827,51 @@ const envDialogOptions: OpenDialogOptions = {
                     icon={faPlusCircle} />
                 </div>
               {/each}
+
+              {#if imageInspectInfo?.engineName === 'Podman'}
+                <label
+                  for="secrets"
+                  class="pt-4 block mb-2 text-sm font-medium text-[var(--pd-content-card-header-text)]"
+                >Secrets:</label>
+                {#each options.basic.secretMappings as _, index (index)}
+                  <div class="flex gap-x-2 flex-row justify-center items-center w-full py-1">
+                    <Dropdown class="w-full" name="type" bind:value={options.basic.secretMappings[index].name}>
+                      {#each secrets as secret (secret.Id)}
+                        <option value={secret.Name}>{secret.Name}</option>
+                      {/each}
+                    </Dropdown>
+
+                    <Dropdown class="w-fit" name="type" bind:value={options.basic.secretMappings[index].type}>
+                      <option value="mount">Mount</option>
+                      <option value="env">Env</option>
+                    </Dropdown>
+
+                    <div class="w-full">
+                      <Input
+                        bind:value={options.basic.secretMappings[index].target}
+                        placeholder={options.basic.secretMappings[index].type === 'mount' ? 'Path inside the container' : 'Name of the environment variable'} />
+                    </div>
+
+                    <div class="w-fit">
+                      <Button
+                        type="link"
+                        aria-label="Remove secret"
+                        onclick={removeSecretMapping.bind(undefined, index)}
+                        icon={faMinusCircle} />
+                    </div>
+                  </div>
+                {/each}
+
+                <Button
+                  onclick={addSecretMapping}
+                  icon={faPlusCircle}
+                  disabled={secrets.length === 0}
+                  type="link"
+                  title={secrets.length === 0 ? 'No secrets available' : ''}
+                  aria-label="Add secret mapping">
+                  Add secret mapping
+                </Button>
+              {/if}
             </div>
           </Route>
           <Route path="/advanced" breadcrumb="Advanced" navigationHint="tab">

--- a/packages/renderer/src/lib/image/run/run-options.ts
+++ b/packages/renderer/src/lib/image/run/run-options.ts
@@ -21,6 +21,12 @@ export interface PortInfo {
   error: string;
 }
 
+export interface SecretMapping {
+  name: string;
+  type: 'mount' | 'env';
+  target: string;
+}
+
 export interface RunOptions {
   basic: {
     containerName: string;
@@ -31,6 +37,7 @@ export interface RunOptions {
     environmentFiles: string[];
     hostContainerPortMappings: { hostPort: PortInfo; containerPort: string }[];
     containerPortMapping: Array<PortInfo>;
+    secretMappings: Array<SecretMapping>;
   };
   networking: {
     hostname?: string;


### PR DESCRIPTION
### What does this PR do?

Adding the support to mount a secret as file or as env in the container.

:warning: this only works with Podman engine.  Thanks to https://github.com/podman-desktop/podman-desktop/pull/18302 we have the `engineType`, and we hide the secret mounting option if `engineType !== 'podman'`

### Screenshot / video of UI

<img width="944" height="210" alt="image" src="https://github.com/user-attachments/assets/1ef02f63-d8f5-499d-a11d-4601634172d5" />

https://github.com/user-attachments/assets/80a68615-a552-48d2-b394-779582579c38

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17845

Require rebase after
- https://github.com/podman-desktop/podman-desktop/pull/18270
- https://github.com/podman-desktop/podman-desktop/pull/18302

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Create two secrets
```
$ printf "foodata" | podman secret create foo-secret -
$ printf "bardata" | podman secret create bar-secret -
```
2. Select any image, and click on `Run`
3. In the bottom of the `Basic` tab assert you see `Add Secret Mapping` button
4. Click on it
5. Mount the `foo-secret` to any path on the container
6. MOunt the `bar-secret ` as an env
7. CLick on run
8. Open a terminal in the container
9. Assert secrets are located at the expected place