### PR TITLE
fix(ui): flickering of Typeahead when selecting images

### DIFF
--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -45,6 +45,7 @@ let values: TypeaheadItem[] = $state([]);
 
 let imageToPull: string = $state('');
 let sortResults: ((a: string, b: string) => number) | undefined = $state();
+let searchRequestId = 0;
 
 let providerConnections = $derived(
   $providerInfos
@@ -315,9 +316,13 @@ async function searchFunction(value: string): Promise<void> {
   // do not search for images if no connection is selected
   if (!selectedProviderConnection) return;
 
+  const requestId = ++searchRequestId;
   value = value.trim();
   const localImagesValues = await searchLocalImages(value);
   const remoteImagesValues = await searchImages(value);
+
+  if (requestId !== searchRequestId) return;
+
   sortResults = (a: string, b: string): number => {
     const dockerIoValue = `docker.io/${value}`;
     const aStartsWithValue = a.startsWith(value) || a.startsWith(dockerIoValue);
@@ -361,7 +366,9 @@ function onContainerConnectionChange(): void {
 }
 
 // trigger search on mount to populate the typeahead with local images
-onMount(() => searchFunction(''));
+onMount(() => {
+  searchFunction('').catch(() => {});
+});
 </script>
 
 <EngineFormPage title="Select an image">

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -189,10 +189,10 @@ function validateImageName(image: string): void {
 
 // allTags is defined if last search was a query to search tags of an image
 let allTags: string[] | undefined = undefined;
-async function searchImages(value: string): Promise<string[]> {
+async function searchImages(value: string): Promise<{ images: string[]; tags: string[] | undefined }> {
   if (value.includes(':')) {
     if (allTags !== undefined) {
-      return allTags.filter(i => i.startsWith(value));
+      return { images: allTags.filter(i => i.startsWith(value)), tags: allTags };
     }
     const parts = value.split(':');
     const originalImage = parts[0];
@@ -201,12 +201,11 @@ async function searchImages(value: string): Promise<string[]> {
       image = image.slice(DOCKER_PREFIX_WITH_SLASH.length);
     }
     const tags = await window.listImageTagsInRegistry({ image });
-    allTags = tags.map(t => `${originalImage}:${t}`);
-    return allTags.filter(i => i.startsWith(value));
+    const computedTags = tags.map(t => `${originalImage}:${t}`);
+    return { images: computedTags.filter(i => i.startsWith(value)), tags: computedTags };
   }
-  allTags = undefined;
   if (value === undefined || value.trim() === '') {
-    return [];
+    return { images: [], tags: undefined };
   }
   const options: ImageSearchOptions = {
     query: '',
@@ -219,12 +218,11 @@ async function searchImages(value: string): Promise<string[]> {
     options.registry = registry;
     options.query = rest.join('/');
   }
-  let result: string[];
   const searchResult = await window.searchImageInRegistry(options);
-  result = searchResult.map(r => {
+  const result = searchResult.map(r => {
     return [options.registry, r.name].join('/');
   });
-  return result;
+  return { images: result, tags: undefined };
 }
 
 async function searchLocalImages(value: string): Promise<string[]> {
@@ -237,8 +235,7 @@ async function searchLocalImages(value: string): Promise<string[]> {
     }
     return [];
   });
-  matchingLocalImages = localImagesNames.flat().filter(image => image !== '' && image.includes(value));
-  return matchingLocalImages;
+  return localImagesNames.flat().filter(image => image !== '' && image.includes(value));
 }
 
 let latestTagMessage: string | undefined = $state();
@@ -319,9 +316,12 @@ async function searchFunction(value: string): Promise<void> {
   const requestId = ++searchRequestId;
   value = value.trim();
   const localImagesValues = await searchLocalImages(value);
-  const remoteImagesValues = await searchImages(value);
+  const remoteSearchResult = await searchImages(value);
 
   if (requestId !== searchRequestId) return;
+
+  matchingLocalImages = localImagesValues;
+  allTags = remoteSearchResult.tags;
 
   sortResults = (a: string, b: string): number => {
     const dockerIoValue = `docker.io/${value}`;
@@ -337,8 +337,8 @@ async function searchFunction(value: string): Promise<void> {
   };
 
   values = [
-    ...localImagesValues.map(value => ({ value: value, group: 'Local Images' })),
-    ...remoteImagesValues.map(value => ({ value: value, group: 'Registry Images' })),
+    ...localImagesValues.map(v => ({ value: v, group: 'Local Images' })),
+    ...remoteSearchResult.images.map(v => ({ value: v, group: 'Registry Images' })),
   ];
 }
 

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -359,6 +359,9 @@ function onContainerConnectionChange(): void {
   matchingLocalImages = [];
   imageToPull = '';
 }
+
+// trigger search on mount to populate the typeahead with local images
+onMount(() => searchFunction(''));
 </script>
 
 <EngineFormPage title="Select an image">

--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -429,6 +429,11 @@ test('list opens on focus', async () => {
 
   const input = screen.getByRole('textbox');
   await userEvent.click(input);
+  await userEvent.keyboard('text');
+
+  // click away and then select the input with tab to focus it
+  await userEvent.click(document.body);
+  await userEvent.tab();
 
   await waitFor(() => expect(searchResult.length > 0).toBeTruthy());
   await rerender({ resultItems: searchResult });

--- a/packages/renderer/src/lib/ui/Typeahead.spec.ts
+++ b/packages/renderer/src/lib/ui/Typeahead.spec.ts
@@ -415,11 +415,11 @@ test('should include heading based on given order and searchFunctions order', as
   });
 });
 
-test('list opens on focus', async () => {
+test('list opens on focus without triggering search again', async () => {
   let searchResult: TypeaheadItem[] = [];
-  const searchFunction = async (): Promise<void> => {
+  const searchFunction = vi.fn(async (): Promise<void> => {
     searchResult = ['text1', 'text2', 'text3', 'text4'].map(value => ({ value: value }));
-  };
+  });
 
   const { rerender } = render(Typeahead, {
     onInputChange: searchFunction,
@@ -431,20 +431,65 @@ test('list opens on focus', async () => {
   await userEvent.click(input);
   await userEvent.keyboard('text');
 
+  await waitFor(() => expect(searchResult.length > 0).toBeTruthy());
+  await rerender({ resultItems: searchResult });
+
+  const callCountAfterTyping = searchFunction.mock.calls.length;
+
   // click away and then select the input with tab to focus it
   await userEvent.click(document.body);
   await userEvent.tab();
-
-  await waitFor(() => expect(searchResult.length > 0).toBeTruthy());
-  await rerender({ resultItems: searchResult });
 
   await waitFor(() => {
     const list = screen.getByRole('row');
     const items = within(list).getAllByRole('button');
     expect(items.length).toBe(4);
     expect(items[0].textContent).toBe('text1');
-    expect(items[1].textContent).toBe('text2');
-    expect(items[2].textContent).toBe('text3');
-    expect(items[3].textContent).toBe('text4');
+  });
+
+  expect(searchFunction.mock.calls.length).toBe(callCountAfterTyping);
+});
+
+test('highlightIndex resets when reopening list via focus', async () => {
+  let searchResult: TypeaheadItem[] = [];
+  const searchFunction = async (s: string): Promise<void> => {
+    searchResult = s ? [{ value: s + '01' }, { value: s + '02' }, { value: s + '03' }] : [];
+  };
+  const { rerender } = render(Typeahead, {
+    onInputChange: searchFunction,
+    resultItems: searchResult,
+    delay: 10,
+  });
+
+  const input = screen.getByRole('textbox');
+  await userEvent.type(input, 'term');
+  await waitFor(() => expect(searchResult.length > 0).toBeTruthy());
+  await rerender({ resultItems: searchResult });
+
+  await waitFor(() => {
+    const items = within(screen.getByRole('row')).getAllByRole('button');
+    expect(items.length).toBe(3);
+  });
+
+  // navigate down to select an item
+  await userEvent.keyboard('[ArrowDown]');
+  await userEvent.keyboard('[ArrowDown]');
+
+  await waitFor(async () => {
+    await tick();
+    const items = within(screen.getByRole('row')).getAllByRole('button');
+    assertItemSelected(items, 1);
+  });
+
+  // close by clicking away, then reopen by focusing
+  await userEvent.click(document.body);
+  await waitFor(() => assertIsListVisible(false));
+
+  await userEvent.tab();
+
+  await waitFor(async () => {
+    await tick();
+    const items = within(screen.getByRole('row')).getAllByRole('button');
+    assertItemSelected(items, -1);
   });
 });

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -146,7 +146,6 @@ function onUpKey(e: KeyboardEvent): void {
       value = items[highlightIndex];
       makeVisible();
     } else if (highlightIndex === 0) {
-      highlightIndex = -1;
       value = userValue;
       close();
     }
@@ -231,6 +230,7 @@ function open(): void {
 }
 
 function close(): void {
+  highlightIndex = -1;
   opened = false;
 }
 

--- a/packages/renderer/src/lib/ui/Typeahead.svelte
+++ b/packages/renderer/src/lib/ui/Typeahead.svelte
@@ -277,7 +277,7 @@ function onWindowClick(e: Event): void {
     name={name}
     oninput={onInput}
     onkeydown={onKeyDown}
-    onfocus={processInput}
+    onfocus={open}
     use:requestFocus />
   {#if loading}
     <Spinner size="1em" />


### PR DESCRIPTION
### What does this PR do?
Fixes flickering of Typeahead's items when selecting images. The bug occurred when user typed something to input and then clicked on some result. 

#### Bug
Upon click of the result item, it closed the available items, but right after that its just got opened again which caused the flickering. Prop onfocus called processInput function where after search the results are shown, hence it got opened again.

#### Solution 
Typeahead's onfocus prop just opens the result items without triggering search. Search is triggered by typing into input.

#### Typeahead.spec.ts
Fixed the test to match test description scenario.

#### CreateContainerFromExistingImage.svelte
The fix of bug does not change the behaviour of CreateContainerFromExistingImage.svelte component which used the Typeahead's onfocus prop to trigger search to populate the items when user got to selecting the container's image. Added onMount to trigger the search.

### Screenshot / video of UI

https://github.com/user-attachments/assets/1ea37e09-6ffe-430d-a46e-f4935aaa0831

https://github.com/user-attachments/assets/84df9964-03e7-4dea-83e4-7dfcf7386a76

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/18046 

### How to test this PR?
Try to select image in Images -> click button Pull -> search some image name under 'Image to pull' e.g. 'nginx' -> click it and it should not flicker.

- [x] Tests are covering the bug fix or the new feature
