### PR TITLE
fix(renderer): remove grammatical error in PullImage.svelte

### DIFF
--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -422,7 +422,7 @@ async function searchFunction(value: string): Promise<void> {
 </script>
 
 <EngineFormPage
-  title="Pull image from a registry"
+  title="Pull an image from a registry"
   inProgress={pullInProgress}
   showEmptyScreen={providerConnections.length === 0}>
   {#snippet icon()}

--- a/tests/playwright/src/model/pages/pull-image-page.ts
+++ b/tests/playwright/src/model/pages/pull-image-page.ts
@@ -41,7 +41,7 @@ export class PullImagePage extends BasePage {
   constructor(page: Page) {
     super(page);
     this.heading = page.getByRole('heading', {
-      name: 'Pull Image From a Registry',
+      name: 'Pull an Image From a Registry',
     });
     this.pullImageButton = page.getByRole('button', { name: 'Pull' });
     this.closeLink = page.getByRole('link', { name: 'Close' });


### PR DESCRIPTION
### What does this PR do?
Corrects grammatical mistake, 
replaces "Pull image from a registry" with "Pull an image from a registry" in `PullImage.svelte`.

### Screenshot / video of UI

Before: 
<img width="518" height="371" alt="image" src="https://github.com/user-attachments/assets/742a5d32-15d7-41d4-8981-ce2cff481597" />

After:
<img width="477" height="107" alt="fix-grammer" src="https://github.com/user-attachments/assets/45499094-9995-4679-a6db-5d98fe507bb0" />

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
fixes #18048 

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
