### PR TITLE
chore: add e2e test to disable in-app updates

### DIFF
--- a/tests/playwright/src/runner/chrome-dev-tools-protocol-runner.ts
+++ b/tests/playwright/src/runner/chrome-dev-tools-protocol-runner.ts
@@ -121,8 +121,11 @@ export class ChromeDevToolsProtocolRunner extends Runner {
       throw Error(`Podman Desktop could not be started correctly with error: ${err}`);
     }
 
-    // Direct Electron console to Node terminal.
-    this.getPage().on('console', console.log);
+    // Direct Electron console to Node terminal and collect in buffer.
+    this.getPage().on('console', msg => {
+      this.pushConsoleMessage(msg.text());
+      console.log(msg);
+    });
 
     // Start playwright tracing
     await this.startTracing();

--- a/tests/playwright/src/runner/electron-runner.ts
+++ b/tests/playwright/src/runner/electron-runner.ts
@@ -86,8 +86,11 @@ export class ElectronRunner extends Runner {
       throw new Error(`Podman Desktop could not be started correctly with error: ${err}`);
     }
 
-    // Direct Electron console to Node terminal.
-    this.getPage().on('console', console.log);
+    // Direct Electron console to Node terminal and collect in buffer.
+    this.getPage().on('console', msg => {
+      this.pushConsoleMessage(msg.text());
+      console.log(msg);
+    });
 
     // Start playwright tracing
     await this.startTracing();

--- a/tests/playwright/src/runner/podman-desktop-runner.ts
+++ b/tests/playwright/src/runner/podman-desktop-runner.ts
@@ -24,6 +24,8 @@ import { test } from '@playwright/test';
 import { RunnerOptions } from '/@/runner/runner-options';
 import { isLinux } from '/@/utility/platform';
 
+const MAX_CONSOLE_MESSAGES = 1_000;
+
 export abstract class Runner {
   protected _options: object;
   protected _running: boolean;
@@ -35,9 +37,11 @@ export abstract class Runner {
   protected _runnerOptions: RunnerOptions;
   protected _saveTracesOnPass: boolean;
   protected _saveVideosOnPass: boolean;
+  protected _consoleMessages: string[];
 
   protected constructor(options?: { runnerOptions?: RunnerOptions }) {
     this._running = false;
+    this._consoleMessages = [];
     this._runnerOptions = options?.runnerOptions ?? new RunnerOptions();
     this._profile = this._runnerOptions._profile;
     this._saveTracesOnPass = this._runnerOptions._saveTracesOnPass;
@@ -66,6 +70,17 @@ export abstract class Runner {
     }
 
     throw Error('Application was not started yet');
+  }
+
+  public getConsoleMessages(): string[] {
+    return this._consoleMessages;
+  }
+
+  protected pushConsoleMessage(text: string): void {
+    if (this._consoleMessages.length >= MAX_CONSOLE_MESSAGES) {
+      this._consoleMessages.shift();
+    }
+    this._consoleMessages.push(text);
   }
 
   public get options(): object {

--- a/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
+++ b/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
@@ -49,10 +49,7 @@ test.afterAll(async ({ runner }) => {
 test.describe
   .serial('Podman installer integration in Podman Desktop', { tag: '@update-install' }, () => {
     test('Dashboard Podman provider card assets check', async ({ page }) => {
-      test.skip(
-        !isCI || process.env.GITHUB_ACTIONS !== 'true' || isLinux,
-        'Only run on macOS and Windows in GitHub Actions',
-      );
+      test.skip(!isCI || process.env.GITHUB_ACTIONS !== 'true', 'Only run on macOS and Windows in GitHub Actions');
       const dashboardPage = await new NavigationBar(page).openDashboard();
       await playExpect(dashboardPage.heading).toBeVisible();
       await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: 25_000 });

--- a/tests/playwright/src/special-specs/installation/update-install-disabled.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install-disabled.spec.ts
@@ -17,12 +17,13 @@
  ***********************************************************************/
 
 import { RunnerOptions } from '/@/runner/runner-options';
-import { filterConsoleForEvent } from '/@/utility/auth-utils';
 import { expect as playExpect, test } from '/@/utility/fixtures';
-import { isCI, isLinux } from '/@/utility/platform';
+import { isLinux } from '/@/utility/platform';
 
-const consoleLogRegexp = new RegExp('Application update is disabled');
-const expectedSettingsValue = 'preferences.update.appUpdate';
+const pluginsInitializtionRegexp = new RegExp('PluginSystem: initialization done');
+const applicationDisabledRegexp = new RegExp(
+  'Application update is disabled with preferences.update.appUpdate settings',
+);
 
 test.skip(isLinux, 'Applicaton update is not supported on Linux');
 
@@ -48,6 +49,12 @@ test.use({
 
 test.beforeAll(async ({ runner }) => {
   runner.setVideoAndTraceName('disabled-update-e2e');
+  await playExpect
+    .poll(() => runner.getConsoleMessages().some((msg: string) => pluginsInitializtionRegexp.test(msg)), {
+      timeout: 30_000,
+      intervals: [500],
+    })
+    .toBeTruthy();
 });
 
 test.afterAll(async ({ runner }) => {
@@ -57,19 +64,19 @@ test.afterAll(async ({ runner }) => {
 
 test.describe
   .serial('Application update can be disabled', { tag: '@update-install' }, () => {
-    test('No update on startup', async ({ page, welcomePage }) => {
-      test.skip(
-        !isCI || process.env.GITHUB_ACTIONS !== 'true' || isLinux,
-        'Only run on macOS and Windows in GitHub Actions',
-      );
-      const updateAvailableDialog = page.getByRole('dialog', { name: 'Update Podman Desktop?' });
-      await playExpect(updateAvailableDialog).not.toBeVisible({ timeout: 20_000 });
-      await welcomePage.handleWelcomePage(true);
+    test('Application update disabled message appears in console log', async ({ runner }) => {
+      await playExpect
+        .poll(() => runner.getConsoleMessages().some((msg: string) => applicationDisabledRegexp.test(msg)), {
+          timeout: 10_000,
+          intervals: [500],
+        })
+        .toBeTruthy();
     });
 
-    test('Application update disabled appears in console log', async ({ page }) => {
-      const consoleLine = await filterConsoleForEvent(page, 'log', consoleLogRegexp);
-      playExpect(consoleLine.text()).toContain(expectedSettingsValue);
+    test('No update on startup', async ({ page, welcomePage }) => {
+      const updateAvailableDialog = page.getByRole('dialog', { name: 'Update Podman Desktop?' });
+      await playExpect(updateAvailableDialog).not.toBeVisible({ timeout: 5_000 });
+      await welcomePage.handleWelcomePage(true);
     });
 
     test('Version button is visible', async ({ statusBar }) => {

--- a/tests/playwright/src/special-specs/installation/update-install-disabled.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install-disabled.spec.ts
@@ -1,0 +1,83 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { RunnerOptions } from '/@/runner/runner-options';
+import { filterConsoleForEvent } from '/@/utility/auth-utils';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { isCI, isLinux } from '/@/utility/platform';
+
+const consoleLogRegexp = new RegExp('Application update is disabled');
+const expectedSettingsValue = 'preferences.update.appUpdate';
+
+test.skip(isLinux, 'Applicaton update is not supported on Linux');
+
+test.use({
+  runnerOptions: new RunnerOptions({
+    /**
+     * For performance reasons, disable extensions which are not necessary for the e2e
+     */
+    customSettings: {
+      'preferences.update.appUpdate': false,
+      'extensions.disabled': [
+        'podman-desktop.compose',
+        'podman-desktop.docker',
+        'podman-desktop.kind',
+        'podman-desktop.kube-context',
+        'podman-desktop.kubectl-cli',
+        'podman-desktop.lima',
+        'podman-desktop.registries',
+      ],
+    },
+  }),
+});
+
+test.beforeAll(async ({ runner }) => {
+  runner.setVideoAndTraceName('disabled-update-e2e');
+});
+
+test.afterAll(async ({ runner }) => {
+  test.setTimeout(120_000);
+  await runner.close(45_000);
+});
+
+test.describe
+  .serial('Application update can be disabled', { tag: '@update-install' }, () => {
+    test('No update on startup', async ({ page, welcomePage }) => {
+      test.skip(
+        !isCI || process.env.GITHUB_ACTIONS !== 'true' || isLinux,
+        'Only run on macOS and Windows in GitHub Actions',
+      );
+      const updateAvailableDialog = page.getByRole('dialog', { name: 'Update Podman Desktop?' });
+      await playExpect(updateAvailableDialog).not.toBeVisible({ timeout: 20_000 });
+      await welcomePage.handleWelcomePage(true);
+    });
+
+    test('Application update disabled appears in console log', async ({ page }) => {
+      const consoleLine = await filterConsoleForEvent(page, 'log', consoleLogRegexp);
+      playExpect(consoleLine.text()).toContain(expectedSettingsValue);
+    });
+
+    test('Version button is visible', async ({ statusBar }) => {
+      await playExpect(statusBar.content).toBeVisible();
+      await playExpect(statusBar.versionButton).toBeVisible();
+    });
+
+    test('Update button option is not available', async ({ statusBar }) => {
+      await playExpect(statusBar.updateButtonTitle).not.toBeVisible();
+    });
+  });

--- a/tests/playwright/src/special-specs/installation/update-install-disabled.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install-disabled.spec.ts
@@ -20,7 +20,7 @@ import { RunnerOptions } from '/@/runner/runner-options';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { isLinux } from '/@/utility/platform';
 
-const pluginsInitializtionRegexp = new RegExp('PluginSystem: initialization done');
+const pluginsInitializationRegexp = new RegExp('PluginSystem: initialization done');
 const applicationDisabledRegexp = new RegExp(
   'Application update is disabled with preferences.update.appUpdate settings',
 );
@@ -50,7 +50,7 @@ test.use({
 test.beforeAll(async ({ runner }) => {
   runner.setVideoAndTraceName('disabled-update-e2e');
   await playExpect
-    .poll(() => runner.getConsoleMessages().some((msg: string) => pluginsInitializtionRegexp.test(msg)), {
+    .poll(() => runner.getConsoleMessages().some((msg: string) => pluginsInitializationRegexp.test(msg)), {
       timeout: 30_000,
       intervals: [500],
     })

--- a/tests/playwright/src/special-specs/installation/update-install-never.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install-never.spec.ts
@@ -19,7 +19,7 @@
 import { RunnerOptions } from '/@/runner/runner-options';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { handleConfirmationDialog } from '/@/utility/operations';
-import { isCI, isLinux } from '/@/utility/platform';
+import { isLinux } from '/@/utility/platform';
 
 test.skip(isLinux, 'Applicaton update is not supported on Linux');
 
@@ -56,10 +56,6 @@ test.afterAll(async ({ runner }) => {
 test.describe
   .serial('Application update reminder preferences set to Never', { tag: '@update-install' }, () => {
     test('No update on startup', async ({ page, welcomePage }) => {
-      test.skip(
-        !isCI || process.env.GITHUB_ACTIONS !== 'true' || isLinux,
-        'Only run on macOS and Windows in GitHub Actions',
-      );
       const updateAvailableDialog = page.getByRole('dialog', { name: 'Update Podman Desktop?' });
       await playExpect(updateAvailableDialog).not.toBeVisible({ timeout: 20_000 });
       await welcomePage.handleWelcomePage(true);

--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025 - 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import { extensionsExternalList, podmanExtension } from '/@/model/core/extension
 import { ExtensionCardPage } from '/@/model/pages/extension-card-page';
 import { ExtensionCatalogCardPage } from '/@/model/pages/extension-catalog-card-page';
 import type { StatusBar } from '/@/model/workbench/status-bar';
+import { RunnerOptions } from '/@/runner/runner-options';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { handleConfirmationDialog } from '/@/utility/operations';
 import { isLinux, isMac, isWindows } from '/@/utility/platform';
@@ -38,6 +39,28 @@ let updateDialog: Locator;
 let updateDownloadedDialog: Locator;
 
 test.skip(isLinux, 'Update is not supported on Linux');
+
+test.use({
+  runnerOptions: new RunnerOptions({
+    /**
+     * For performance reasons, disable extensions which are not necessary for the e2e
+     */
+    customSettings: {
+      'preferences.update.appUpdate': true,
+      'extensions.disabled': installExtensions
+        ? []
+        : [
+            'podman-desktop.compose',
+            'podman-desktop.docker',
+            'podman-desktop.kind',
+            'podman-desktop.kube-context',
+            'podman-desktop.kubectl-cli',
+            'podman-desktop.lima',
+            'podman-desktop.registries',
+          ],
+    },
+  }),
+});
 
 test.beforeAll(async ({ runner, page, statusBar }) => {
   runner.setVideoAndTraceName('update-e2e');

--- a/tests/playwright/src/utility/auth-utils.ts
+++ b/tests/playwright/src/utility/auth-utils.ts
@@ -18,7 +18,7 @@
 
 import { join } from 'node:path';
 
-import type { Browser, Locator, Page } from '@playwright/test';
+import type { Browser, ConsoleMessage, Locator, Page } from '@playwright/test';
 import { chromium, expect as playExpect } from '@playwright/test';
 
 import { waitUntil } from './wait';
@@ -124,13 +124,7 @@ export async function getEntryFromConsoleLogs(
   checkString: string,
   timeout = 10_000,
 ): Promise<string | undefined> {
-  const consoleLogPromise = page.waitForEvent('console', {
-    predicate: msg => {
-      return msg.type() === 'log' && filter.test(msg.text());
-    },
-    timeout: timeout,
-  });
-  const consoleMsg = await consoleLogPromise;
+  const consoleMsg = await filterConsoleForEvent(page, 'log', filter, timeout);
   const logLine = consoleMsg.text();
   if (checkString) {
     playExpect(logLine).toContain(checkString);
@@ -139,6 +133,21 @@ export async function getEntryFromConsoleLogs(
   const urlMatch = parsedString ? parsedString[1] : undefined;
   console.log(`Matched string: ${urlMatch}`);
   return urlMatch;
+}
+
+export async function filterConsoleForEvent(
+  page: Page,
+  eventType: string,
+  filter: RegExp,
+  timeout = 10_000,
+): Promise<ConsoleMessage> {
+  const consoleLogPromise = page.waitForEvent('console', {
+    predicate: msg => {
+      return msg.type() === eventType && filter.test(msg.text());
+    },
+    timeout: timeout,
+  });
+  return await consoleLogPromise;
 }
 
 // Accept/Refuse the cooking in the iframe element

--- a/tests/playwright/src/utility/auth-utils.ts
+++ b/tests/playwright/src/utility/auth-utils.ts
@@ -18,7 +18,7 @@
 
 import { join } from 'node:path';
 
-import type { Browser, ConsoleMessage, Locator, Page } from '@playwright/test';
+import type { Browser, Locator, Page } from '@playwright/test';
 import { chromium, expect as playExpect } from '@playwright/test';
 
 import { waitUntil } from './wait';
@@ -124,7 +124,13 @@ export async function getEntryFromConsoleLogs(
   checkString: string,
   timeout = 10_000,
 ): Promise<string | undefined> {
-  const consoleMsg = await filterConsoleForEvent(page, 'log', filter, timeout);
+  const consoleLogPromise = page.waitForEvent('console', {
+    predicate: msg => {
+      return msg.type() === 'log' && filter.test(msg.text());
+    },
+    timeout: timeout,
+  });
+  const consoleMsg = await consoleLogPromise;
   const logLine = consoleMsg.text();
   if (checkString) {
     playExpect(logLine).toContain(checkString);
@@ -133,21 +139,6 @@ export async function getEntryFromConsoleLogs(
   const urlMatch = parsedString ? parsedString[1] : undefined;
   console.log(`Matched string: ${urlMatch}`);
   return urlMatch;
-}
-
-export async function filterConsoleForEvent(
-  page: Page,
-  eventType: string,
-  filter: RegExp,
-  timeout = 10_000,
-): Promise<ConsoleMessage> {
-  const consoleLogPromise = page.waitForEvent('console', {
-    predicate: msg => {
-      return msg.type() === eventType && filter.test(msg.text());
-    },
-    timeout: timeout,
-  });
-  return await consoleLogPromise;
 }
 
 // Accept/Refuse the cooking in the iframe element


### PR DESCRIPTION
### What does this PR do?
Add update e2e test to verify that in-app update can be turned off by `preferences.update.appUpdate` settings.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#17685 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
All update e2e tests must be passing. New test was added: `Application update can be disabled`

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
