### PR TITLE
test(e2e): update serial declaration - part 3

### DIFF
--- a/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
+++ b/tests/playwright/src/specs/docker-compatibility-smoke.spec.ts
@@ -60,55 +60,55 @@ test.afterAll(async ({ runner, page }) => {
 test.skip(!isWindows, 'Testing only on Windows');
 test.skip(!!isCI && isRHEL, 'Docker Engine is not officially supported on RHEL');
 
-test.describe
-  .serial('Verify docker compatibility feature', { tag: '@smoke' }, () => {
-    test('Enable the docker compatibility experimental feature', async ({ navigationBar, page }) => {
-      //Verify Settings
-      await navigationBar.openSettings();
-      const settingsBar = new SettingsBar(page);
+test.describe('Verify docker compatibility feature', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Enable the docker compatibility experimental feature', async ({ navigationBar, page }) => {
+    //Verify Settings
+    await navigationBar.openSettings();
+    const settingsBar = new SettingsBar(page);
 
-      const DCLink = settingsBar.getLinkLocatorByHref('/preferences/docker-compatibility');
-      await playExpect(DCLink).not.toBeVisible();
+    const DCLink = settingsBar.getLinkLocatorByHref('/preferences/docker-compatibility');
+    await playExpect(DCLink).not.toBeVisible();
 
-      //Enable the feature
-      await setDockerCompatibilityFeature(page, true);
+    //Enable the feature
+    await setDockerCompatibilityFeature(page, true);
+  });
+  test('Verify Docker Compatibility page', async ({ page }) => {
+    const settingsBar = new SettingsBar(page);
+    // Navigate to Resources and back to ensure Docker Compatibility page state is fresh
+    await settingsBar.openTabPage(ResourcesPage);
+    const dockerCompatibilityPage = await settingsBar.openTabPage(DockerCompatibilityPage);
+    await playExpect(dockerCompatibilityPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => await dockerCompatibilityPage.socketIsReachable(), { timeout: 60_000 })
+      .toBeTruthy();
+    await playExpect(dockerCompatibilityPage.serverInformationBox).toBeVisible();
+  });
+  test('Verify socket reachability is responding to podman machine status', async ({ page }) => {
+    test.setTimeout(180_000);
+    const settingsBar = new SettingsBar(page);
+    await settingsBar.openTabPage(ResourcesPage);
+    const podmanMachineDetails = new PodmanMachineDetails(page, defaultMachine);
+    await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
+    await podmanMachineDetails.podmanMachineStopButton.click();
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
+      timeout: 60_000,
     });
-    test('Verify Docker Compatibility page', async ({ page }) => {
-      const settingsBar = new SettingsBar(page);
-      // Navigate to Resources and back to ensure Docker Compatibility page state is fresh
-      await settingsBar.openTabPage(ResourcesPage);
-      const dockerCompatibilityPage = await settingsBar.openTabPage(DockerCompatibilityPage);
-      await playExpect(dockerCompatibilityPage.heading).toBeVisible();
-      await playExpect
-        .poll(async () => await dockerCompatibilityPage.socketIsReachable(), { timeout: 60_000 })
-        .toBeTruthy();
-      await playExpect(dockerCompatibilityPage.serverInformationBox).toBeVisible();
-    });
-    test('Verify socket reachability is responding to podman machine status', async ({ page }) => {
-      test.setTimeout(180_000);
-      const settingsBar = new SettingsBar(page);
-      await settingsBar.openTabPage(ResourcesPage);
-      const podmanMachineDetails = new PodmanMachineDetails(page, defaultMachine);
-      await playExpect(podmanMachineDetails.podmanMachineStopButton).toBeEnabled();
-      await podmanMachineDetails.podmanMachineStopButton.click();
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Off, {
-        timeout: 60_000,
-      });
 
-      const dockerCompatibilityPage = await settingsBar.openTabPage(DockerCompatibilityPage);
-      await playExpect
-        .poll(async () => await dockerCompatibilityPage.socketIsReachable(), { timeout: 60_000 })
-        .toBeFalsy();
-      await playExpect(dockerCompatibilityPage.serverInformationBox).not.toBeVisible();
+    const dockerCompatibilityPage = await settingsBar.openTabPage(DockerCompatibilityPage);
+    await playExpect
+      .poll(async () => await dockerCompatibilityPage.socketIsReachable(), { timeout: 60_000 })
+      .toBeFalsy();
+    await playExpect(dockerCompatibilityPage.serverInformationBox).not.toBeVisible();
 
-      await settingsBar.openTabPage(ResourcesPage);
-      await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
-      await podmanMachineDetails.podmanMachineStartButton.click();
-      await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
-        timeout: 120_000,
-      });
-    });
-    test('Disable docker compatibility', async ({ page }) => {
-      await setDockerCompatibilityFeature(page, false);
+    await settingsBar.openTabPage(ResourcesPage);
+    await playExpect(podmanMachineDetails.podmanMachineStartButton).toBeEnabled();
+    await podmanMachineDetails.podmanMachineStartButton.click();
+    await playExpect(podmanMachineDetails.podmanMachineStatus).toHaveText(ResourceElementState.Running, {
+      timeout: 120_000,
     });
   });
+  test('Disable docker compatibility', async ({ page }) => {
+    await setDockerCompatibilityFeature(page, false);
+  });
+});

--- a/tests/playwright/src/specs/enhanced-dashboard.spec.ts
+++ b/tests/playwright/src/specs/enhanced-dashboard.spec.ts
@@ -73,97 +73,97 @@ test.afterAll(async ({ runner, page }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Enhanced dashboard experimental feature', { tag: ['@experimental'] }, () => {
-    test('Enable/disable experimental feature', async ({ navigationBar, page }) => {
-      await test.step('Verify feature is disabled by default', async () => {
-        await setEnhancedDashboardFeature(page, navigationBar, false);
-        const dashboardPage = await waitForDashboardState(navigationBar, false);
-        await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
-        await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: TIMEOUT_SHORT });
-        await dashboardPage.podmanProvider.scrollIntoViewIfNeeded();
-      });
-
-      await test.step('Enable feature and verify system overview appears', async () => {
-        await setEnhancedDashboardFeature(page, navigationBar, true);
-        const dashboardPage = await waitForDashboardState(navigationBar, true);
-        await playExpect(dashboardPage.systemOverviewButton).toBeEnabled();
-        await dashboardPage.expandSystemOverview(true);
-        await playExpect(dashboardPage.systemOverview).toBeVisible({ timeout: TIMEOUT_SHORT });
-        await playExpect(dashboardPage.podmanProvider).not.toBeVisible();
-        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Stopped);
-        await playExpect(dashboardPage.noContainerEngineLabel).toBeVisible();
-        await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled();
-      });
-
-      await test.step('Disable feature and verify dashboard reverts', async () => {
-        await setEnhancedDashboardFeature(page, navigationBar, false);
-        const dashboardPage = await waitForDashboardState(navigationBar, false);
-        await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
-        await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: TIMEOUT_SHORT });
-      });
+test.describe('Enhanced dashboard experimental feature', { tag: ['@experimental'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Enable/disable experimental feature', async ({ navigationBar, page }) => {
+    await test.step('Verify feature is disabled by default', async () => {
+      await setEnhancedDashboardFeature(page, navigationBar, false);
+      const dashboardPage = await waitForDashboardState(navigationBar, false);
+      await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
+      await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: TIMEOUT_SHORT });
+      await dashboardPage.podmanProvider.scrollIntoViewIfNeeded();
     });
 
-    test('Create Podman machine from Dashboard', async ({ page, navigationBar }) => {
-      test.setTimeout(TIMEOUT_CREATE_MACHINE_TEST);
+    await test.step('Enable feature and verify system overview appears', async () => {
+      await setEnhancedDashboardFeature(page, navigationBar, true);
+      const dashboardPage = await waitForDashboardState(navigationBar, true);
+      await playExpect(dashboardPage.systemOverviewButton).toBeEnabled();
+      await dashboardPage.expandSystemOverview(true);
+      await playExpect(dashboardPage.systemOverview).toBeVisible({ timeout: TIMEOUT_SHORT });
+      await playExpect(dashboardPage.podmanProvider).not.toBeVisible();
+      await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Stopped);
+      await playExpect(dashboardPage.noContainerEngineLabel).toBeVisible();
+      await playExpect(dashboardPage.setUpPodmanButton).toBeEnabled();
+    });
 
-      await test.step('Create machine from system overview', async () => {
-        await setEnhancedDashboardFeature(page, navigationBar, true);
-        const dashboardPage = await waitForDashboardState(navigationBar, true);
-        await dashboardPage.createPodmanMachineFromSystemOverview(PODMAN_MACHINE_NAME, {
-          isRootful: false,
-          enableUserNet: false,
-          startNow: true,
-          virtualizationProvider: getVirtualizationProvider(),
-        });
-      });
-
-      await test.step('Wait for machine to reach operational state', async () => {
-        const dashboardPage = await navigationBar.openDashboard();
-        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
-        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Starting, {
-          timeout: PODMAN_MACHINE_STARTUP_TIMEOUT,
-        });
-        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Operational, {
-          timeout: PODMAN_MACHINE_STARTUP_TIMEOUT,
-        });
-      });
-
-      await test.step('Navigate to resources via status button', async () => {
-        const dashboardPage = await navigationBar.openDashboard();
-        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
-        await playExpect(dashboardPage.statusButton).toBeEnabled();
-        await dashboardPage.statusButton.click();
-        const resourcesPage = new ResourcesPage(page);
-        await playExpect
-          .poll(async () => resourcesPage.resourceCardIsVisible('podman'), { timeout: TIMEOUT_STANDARD })
-          .toBeTruthy();
-        const resourcesPodmanConnections = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME);
-        await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: TIMEOUT_SHORT });
-      });
-
-      await test.step('Stop machine and verify dashboard reflects stopped state', async () => {
-        const resourcesPodmanConnections = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME);
-        await resourcesPodmanConnections.performConnectionAction(ResourceElementActions.Stop);
-        const dashboardPage = await navigationBar.openDashboard();
-        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
-        await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Stopped, {
-          timeout: TIMEOUT_SHORT,
-        });
-      });
-
-      await test.step('Verify resource details navigation', async () => {
-        const dashboardPage = await navigationBar.openDashboard();
-        await dashboardPage.checkSystemOverviewResourceDetails(PODMAN_MACHINE_VISIBLE_NAME);
-      });
-
-      await test.step('Verify status button navigates to resources page', async () => {
-        const dashboardPage = await navigationBar.openDashboard();
-        await dashboardPage.statusButton.scrollIntoViewIfNeeded();
-        await playExpect(dashboardPage.statusButton).toBeEnabled();
-        await dashboardPage.statusButton.click();
-        const resourcesPage = new ResourcesPage(page);
-        await playExpect(resourcesPage.header).toBeVisible();
-      });
+    await test.step('Disable feature and verify dashboard reverts', async () => {
+      await setEnhancedDashboardFeature(page, navigationBar, false);
+      const dashboardPage = await waitForDashboardState(navigationBar, false);
+      await playExpect(dashboardPage.systemOverviewButton).not.toBeVisible();
+      await playExpect(dashboardPage.podmanProvider).toBeVisible({ timeout: TIMEOUT_SHORT });
     });
   });
+
+  test('Create Podman machine from Dashboard', async ({ page, navigationBar }) => {
+    test.setTimeout(TIMEOUT_CREATE_MACHINE_TEST);
+
+    await test.step('Create machine from system overview', async () => {
+      await setEnhancedDashboardFeature(page, navigationBar, true);
+      const dashboardPage = await waitForDashboardState(navigationBar, true);
+      await dashboardPage.createPodmanMachineFromSystemOverview(PODMAN_MACHINE_NAME, {
+        isRootful: false,
+        enableUserNet: false,
+        startNow: true,
+        virtualizationProvider: getVirtualizationProvider(),
+      });
+    });
+
+    await test.step('Wait for machine to reach operational state', async () => {
+      const dashboardPage = await navigationBar.openDashboard();
+      await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+      await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Starting, {
+        timeout: PODMAN_MACHINE_STARTUP_TIMEOUT,
+      });
+      await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Operational, {
+        timeout: PODMAN_MACHINE_STARTUP_TIMEOUT,
+      });
+    });
+
+    await test.step('Navigate to resources via status button', async () => {
+      const dashboardPage = await navigationBar.openDashboard();
+      await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+      await playExpect(dashboardPage.statusButton).toBeEnabled();
+      await dashboardPage.statusButton.click();
+      const resourcesPage = new ResourcesPage(page);
+      await playExpect
+        .poll(async () => resourcesPage.resourceCardIsVisible('podman'), { timeout: TIMEOUT_STANDARD })
+        .toBeTruthy();
+      const resourcesPodmanConnections = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME);
+      await playExpect(resourcesPodmanConnections.providerConnections).toBeVisible({ timeout: TIMEOUT_SHORT });
+    });
+
+    await test.step('Stop machine and verify dashboard reflects stopped state', async () => {
+      const resourcesPodmanConnections = new ResourceConnectionCardPage(page, 'podman', PODMAN_MACHINE_NAME);
+      await resourcesPodmanConnections.performConnectionAction(ResourceElementActions.Stop);
+      const dashboardPage = await navigationBar.openDashboard();
+      await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+      await playExpect(dashboardPage.statusButton).toHaveText(SystemOverviewState.Stopped, {
+        timeout: TIMEOUT_SHORT,
+      });
+    });
+
+    await test.step('Verify resource details navigation', async () => {
+      const dashboardPage = await navigationBar.openDashboard();
+      await dashboardPage.checkSystemOverviewResourceDetails(PODMAN_MACHINE_VISIBLE_NAME);
+    });
+
+    await test.step('Verify status button navigates to resources page', async () => {
+      const dashboardPage = await navigationBar.openDashboard();
+      await dashboardPage.statusButton.scrollIntoViewIfNeeded();
+      await playExpect(dashboardPage.statusButton).toBeEnabled();
+      await dashboardPage.statusButton.click();
+      const resourcesPage = new ResourcesPage(page);
+      await playExpect(resourcesPage.header).toBeVisible();
+    });
+  });
+});

--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -86,195 +86,195 @@ async function _startup(extensionLabel: string): Promise<void> {
 }
 
 for (const { extensionLabel, extensionFullLabel, extensionName, extensionFullName } of extensionsToTest) {
-  test.describe
-    .serial(`Extension installation for ${extensionName}`, { tag: '@smoke' }, () => {
-      test.skip(extensionName === openshiftDockerExtension.extensionName && !!isWindows); // Currently timing out in azure cicd https://github.com/podman-desktop/e2e/issues/396
+  test.describe(`Extension installation for ${extensionName}`, { tag: '@smoke' }, () => {
+    test.describe.configure({ mode: 'serial' });
+    test.skip(extensionName === openshiftDockerExtension.extensionName && !!isWindows); // Currently timing out in azure cicd https://github.com/podman-desktop/e2e/issues/396
 
-      test.beforeAll(async () => {
-        await _startup(extensionLabel);
-      });
-      test.afterAll(async () => {
-        await pdRunner.close();
-      });
+    test.beforeAll(async () => {
+      await _startup(extensionLabel);
+    });
+    test.afterAll(async () => {
+      await pdRunner.close();
+    });
 
-      test('Initialize extension type', async () => {
-        initializeLocators(extensionName);
-        await navigationBar.openExtensions();
-      });
+    test('Initialize extension type', async () => {
+      initializeLocators(extensionName);
+      await navigationBar.openExtensions();
+    });
 
-      test('Install extension through Extensions Catalog', async () => {
-        test.skip(!!ociImageUrl, 'Extension has OCI image configured, skipping catalog install');
-        test.setTimeout(200_000);
+    test('Install extension through Extensions Catalog', async () => {
+      test.skip(!!ociImageUrl, 'Extension has OCI image configured, skipping catalog install');
+      test.setTimeout(200_000);
 
-        const extensionsPage = new ExtensionsPage(page);
-        await playExpect(extensionsPage.heading).toBeVisible();
+      const extensionsPage = new ExtensionsPage(page);
+      await playExpect(extensionsPage.heading).toBeVisible();
 
+      await extensionsPage.openCatalogTab();
+      const extensionCatalog = new ExtensionCatalogCardPage(page, extensionName);
+      await playExpect(extensionCatalog.parent).toBeVisible();
+
+      await playExpect.poll(async () => await extensionCatalog.isInstalled()).toBeFalsy();
+      await extensionCatalog.install(180_000);
+
+      await extensionsPage.openInstalledTab();
+      await playExpect.poll(async () => await extensionsPage.extensionIsInstalled(extensionFullLabel)).toBeTruthy();
+    });
+
+    test('Install extension from OCI Image', async () => {
+      test.skip(!ociImageUrl, 'No OCI image configured, skipping OCI install');
+      test.setTimeout(200_000);
+
+      const extensionsPage = new ExtensionsPage(page);
+
+      if (!ociImageUrl) throw new Error('ociImageUrl is required for OCI install');
+      await extensionsPage.installExtensionFromOCIImage(ociImageUrl, 180_000);
+      if (extensionName !== openshiftDockerExtension.extensionName) {
         await extensionsPage.openCatalogTab();
         const extensionCatalog = new ExtensionCatalogCardPage(page, extensionName);
         await playExpect(extensionCatalog.parent).toBeVisible();
+        await playExpect.poll(async () => await extensionCatalog.isInstalled()).toBeTruthy();
+      }
 
-        await playExpect.poll(async () => await extensionCatalog.isInstalled()).toBeFalsy();
-        await extensionCatalog.install(180_000);
+      await extensionsPage.openInstalledTab();
+      await playExpect
+        .poll(async () => await extensionsPage.extensionIsInstalled(extensionFullLabel), { timeout: 15_000 })
+        .toBeTruthy();
+    });
 
-        await extensionsPage.openInstalledTab();
-        await playExpect.poll(async () => await extensionsPage.extensionIsInstalled(extensionFullLabel)).toBeTruthy();
+    test.describe('Extension verification after installation', () => {
+      test.describe.configure({ mode: 'serial' });
+      test('Extension details can be opened', async () => {
+        const extensionsPage = await navigationBar.openExtensions();
+
+        const extensionDetailsPage = await extensionsPage.openExtensionDetails(
+          extensionLabel,
+          extensionFullLabel,
+          extensionFullName,
+        );
+        await playExpect(extensionDetailsPage.status).toBeVisible({ timeout: 15_000 });
       });
 
-      test('Install extension from OCI Image', async () => {
-        test.skip(!ociImageUrl, 'No OCI image configured, skipping OCI install');
-        test.setTimeout(200_000);
+      test('Extension is active and there are not errors', async () => {
+        const extensionsPage = await navigationBar.openExtensions();
+        const extensionPage = await extensionsPage.openExtensionDetails(
+          extensionLabel,
+          extensionFullLabel,
+          extensionFullName,
+        );
+        await playExpect(extensionPage.heading).toBeVisible();
+        await playExpect(extensionPage.status).toHaveText(ExtensionState.Active, { timeout: 15_000 });
+        // tabs are empty in case there is no error. If there is error, there are two tabs' buttons present
+        const errorTab = extensionPage.tabs.getByRole('button', { name: 'Error' });
+        // we would like to propagate the error's stack trace into test failure message
+        let stackTrace = '';
+        if ((await errorTab.count()) > 0) {
+          stackTrace = await errorTab.innerText();
+        }
+        await playExpect(errorTab, `Error Tab was present with stackTrace: ${stackTrace}`).not.toBeVisible();
+      });
 
-        const extensionsPage = new ExtensionsPage(page);
+      test.describe('Extension can be disabled and reenabled', () => {
+        test.describe.configure({ mode: 'serial' });
+        test.skip(
+          extensionName === openshiftDockerExtension.extensionName,
+          'OpenShift Docker extension cannot be disabled',
+        );
 
-        if (!ociImageUrl) throw new Error('ociImageUrl is required for OCI install');
-        await extensionsPage.installExtensionFromOCIImage(ociImageUrl, 180_000);
+        test('Disable extension and verify Navbar and Resources components if present', async () => {
+          const extensionsPage = await navigationBar.openExtensions();
+          const extensionPage = await extensionsPage.openExtensionDetails(
+            extensionLabel,
+            extensionFullLabel,
+            extensionFullName,
+          );
+
+          await extensionPage.disableExtension();
+          await playExpect(extensionPage.status).toHaveText(ExtensionState.Disabled);
+
+          // check that extension navbar icon is hidden/shown
+          if (extensionNavigationBarIcon) {
+            await playExpect(extensionNavigationBarIcon).toBeHidden();
+          }
+
+          // check that the provider card is on Resources Page -> bootc require binary installation, docker doesn't have
+          if (
+            resourceLabel &&
+            extensionName !== openshiftDockerExtension.extensionName &&
+            extensionName !== bootcExtension.extensionName
+          ) {
+            const settingsBar = await goToSettings();
+            const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
+            const extensionResourceBox = resourcesPage.featuredProviderResources.getByRole('region', {
+              name: resourceLabel,
+            });
+            await playExpect(extensionResourceBox).toBeHidden();
+          }
+        });
+
+        test('Enable extension and verify Navbar and Resources components', async () => {
+          const extensionsPage = await navigationBar.openExtensions();
+          const extensionPage = await extensionsPage.openExtensionDetails(
+            extensionLabel,
+            extensionFullLabel,
+            extensionFullName,
+          );
+
+          await extensionPage.enableExtension();
+          await playExpect(extensionPage.status).toHaveText(ExtensionState.Active, { timeout: 10_000 });
+
+          // check that extension navbar icon is hidden/shown
+          if (extensionNavigationBarIcon) {
+            await playExpect(extensionNavigationBarIcon).toBeVisible();
+          }
+
+          // check that the provider card is on Resources Page -> bootc requires binary installation
+          if (
+            resourceLabel &&
+            extensionName !== openshiftDockerExtension.extensionName &&
+            extensionName !== bootcExtension.extensionName
+          ) {
+            const settingsBar = await goToSettings();
+            const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
+            const extensionResourceBox = resourcesPage.featuredProviderResources.getByRole('region', {
+              name: resourceLabel,
+            });
+            await playExpect(extensionResourceBox).toBeVisible();
+          }
+        });
+      });
+    });
+
+    test.describe('Remove extension and verify UI', () => {
+      test.describe.configure({ mode: 'serial' });
+      test('Remove extension and verify components', async () => {
+        let extensionsPage = await navigationBar.openExtensions();
+
+        const extensionDetails = await extensionsPage.openExtensionDetails(
+          extensionLabel,
+          extensionFullLabel,
+          extensionFullName,
+        );
         if (extensionName !== openshiftDockerExtension.extensionName) {
-          await extensionsPage.openCatalogTab();
-          const extensionCatalog = new ExtensionCatalogCardPage(page, extensionName);
-          await playExpect(extensionCatalog.parent).toBeVisible();
-          await playExpect.poll(async () => await extensionCatalog.isInstalled()).toBeTruthy();
+          await extensionDetails.disableExtension();
+        }
+        await extensionDetails.removeExtension(false);
+
+        if (extensionName !== openshiftDockerExtension.extensionName) {
+          // now if deleted from extension details, the page details are still there, just different
+          await playExpect(extensionDetails.status).toHaveText(ExtensionState.Downloadable);
+          await playExpect(
+            extensionDetails.page.getByRole('button', { name: `Install ${extensionFullLabel} Extension` }),
+          ).toBeVisible();
         }
 
-        await extensionsPage.openInstalledTab();
+        await goToDashboard();
+        extensionsPage = await navigationBar.openExtensions();
         await playExpect
-          .poll(async () => await extensionsPage.extensionIsInstalled(extensionFullLabel), { timeout: 15_000 })
-          .toBeTruthy();
+          .poll(async () => extensionsPage.extensionIsInstalled(extensionFullLabel), { timeout: 15_000 })
+          .toBeFalsy();
       });
-
-      test.describe
-        .serial('Extension verification after installation', () => {
-          test('Extension details can be opened', async () => {
-            const extensionsPage = await navigationBar.openExtensions();
-
-            const extensionDetailsPage = await extensionsPage.openExtensionDetails(
-              extensionLabel,
-              extensionFullLabel,
-              extensionFullName,
-            );
-            await playExpect(extensionDetailsPage.status).toBeVisible({ timeout: 15_000 });
-          });
-
-          test('Extension is active and there are not errors', async () => {
-            const extensionsPage = await navigationBar.openExtensions();
-            const extensionPage = await extensionsPage.openExtensionDetails(
-              extensionLabel,
-              extensionFullLabel,
-              extensionFullName,
-            );
-            await playExpect(extensionPage.heading).toBeVisible();
-            await playExpect(extensionPage.status).toHaveText(ExtensionState.Active, { timeout: 15_000 });
-            // tabs are empty in case there is no error. If there is error, there are two tabs' buttons present
-            const errorTab = extensionPage.tabs.getByRole('button', { name: 'Error' });
-            // we would like to propagate the error's stack trace into test failure message
-            let stackTrace = '';
-            if ((await errorTab.count()) > 0) {
-              stackTrace = await errorTab.innerText();
-            }
-            await playExpect(errorTab, `Error Tab was present with stackTrace: ${stackTrace}`).not.toBeVisible();
-          });
-
-          test.describe
-            .serial('Extension can be disabled and reenabled', () => {
-              test.skip(
-                extensionName === openshiftDockerExtension.extensionName,
-                'OpenShift Docker extension cannot be disabled',
-              );
-
-              test('Disable extension and verify Navbar and Resources components if present', async () => {
-                const extensionsPage = await navigationBar.openExtensions();
-                const extensionPage = await extensionsPage.openExtensionDetails(
-                  extensionLabel,
-                  extensionFullLabel,
-                  extensionFullName,
-                );
-
-                await extensionPage.disableExtension();
-                await playExpect(extensionPage.status).toHaveText(ExtensionState.Disabled);
-
-                // check that extension navbar icon is hidden/shown
-                if (extensionNavigationBarIcon) {
-                  await playExpect(extensionNavigationBarIcon).toBeHidden();
-                }
-
-                // check that the provider card is on Resources Page -> bootc require binary installation, docker doesn't have
-                if (
-                  resourceLabel &&
-                  extensionName !== openshiftDockerExtension.extensionName &&
-                  extensionName !== bootcExtension.extensionName
-                ) {
-                  const settingsBar = await goToSettings();
-                  const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
-                  const extensionResourceBox = resourcesPage.featuredProviderResources.getByRole('region', {
-                    name: resourceLabel,
-                  });
-                  await playExpect(extensionResourceBox).toBeHidden();
-                }
-              });
-
-              test('Enable extension and verify Navbar and Resources components', async () => {
-                const extensionsPage = await navigationBar.openExtensions();
-                const extensionPage = await extensionsPage.openExtensionDetails(
-                  extensionLabel,
-                  extensionFullLabel,
-                  extensionFullName,
-                );
-
-                await extensionPage.enableExtension();
-                await playExpect(extensionPage.status).toHaveText(ExtensionState.Active, { timeout: 10_000 });
-
-                // check that extension navbar icon is hidden/shown
-                if (extensionNavigationBarIcon) {
-                  await playExpect(extensionNavigationBarIcon).toBeVisible();
-                }
-
-                // check that the provider card is on Resources Page -> bootc requires binary installation
-                if (
-                  resourceLabel &&
-                  extensionName !== openshiftDockerExtension.extensionName &&
-                  extensionName !== bootcExtension.extensionName
-                ) {
-                  const settingsBar = await goToSettings();
-                  const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
-                  const extensionResourceBox = resourcesPage.featuredProviderResources.getByRole('region', {
-                    name: resourceLabel,
-                  });
-                  await playExpect(extensionResourceBox).toBeVisible();
-                }
-              });
-            });
-        });
-
-      test.describe
-        .serial('Remove extension and verify UI', () => {
-          test('Remove extension and verify components', async () => {
-            let extensionsPage = await navigationBar.openExtensions();
-
-            const extensionDetails = await extensionsPage.openExtensionDetails(
-              extensionLabel,
-              extensionFullLabel,
-              extensionFullName,
-            );
-            if (extensionName !== openshiftDockerExtension.extensionName) {
-              await extensionDetails.disableExtension();
-            }
-            await extensionDetails.removeExtension(false);
-
-            if (extensionName !== openshiftDockerExtension.extensionName) {
-              // now if deleted from extension details, the page details are still there, just different
-              await playExpect(extensionDetails.status).toHaveText(ExtensionState.Downloadable);
-              await playExpect(
-                extensionDetails.page.getByRole('button', { name: `Install ${extensionFullLabel} Extension` }),
-              ).toBeVisible();
-            }
-
-            await goToDashboard();
-            extensionsPage = await navigationBar.openExtensions();
-            await playExpect
-              .poll(async () => extensionsPage.extensionIsInstalled(extensionFullLabel), { timeout: 15_000 })
-              .toBeFalsy();
-          });
-        });
     });
+  });
 }
 
 function initializeLocators(extensionName: string): void {


### PR DESCRIPTION
### What does this PR do?
Updates the old, to be deprecated, serial declaration of the e2e tests to the current standard. Only 3 test cases at a time to make it feasible to review. Most of the changes are white spaces. Unfortunately the GH UI does not show very clearly the differences, but I can see them using Cursor diff.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Partially https://github.com/podman-desktop/podman-desktop/issues/15697
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
