### PR TITLE
feat(api): add skipFlatpakSpawn option to RunOptions

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -4593,6 +4593,13 @@ declare module '@podman-desktop/api' {
      * if Podman Desktop exits. Stdout/stderr will not be captured.
      */
     detached?: boolean;
+
+    /**
+     * If true, skip wrapping the command with `flatpak-spawn --host` even when
+     * running inside a Flatpak environment. Use this for binaries that are
+     * shipped inside the Flatpak bundle and should run inside the sandbox.
+     */
+    skipFlatpakSpawn?: boolean;
   }
 
   /**

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -420,6 +420,72 @@ describe('exec', () => {
     expect(stdout).toContain('Hello, World!');
   });
 
+  test('should skip flatpak-spawn wrapping when skipFlatpakSpawn is true', async () => {
+    const command = 'echo';
+    const args = ['Hello, World!'];
+
+    vi.mocked(isLinux).mockReturnValue(true);
+
+    const on = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
+      if (event === 'data') {
+        cb('Hello, World!');
+      }
+    }) as unknown as Readable;
+    const spawnMock = vi.mocked(spawn).mockReturnValue({
+      stdout: { on, setEncoding: vi.fn() },
+      stderr: { on, setEncoding: vi.fn() },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'close') {
+          cb(0);
+        }
+      }),
+    } as unknown as ChildProcess);
+
+    const { stdout } = await exec.exec(command, args, {
+      env: { FLATPAK_ID: 'io.podman_desktop.PodmanDesktop' },
+      skipFlatpakSpawn: true,
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(command, args, expect.anything());
+    expect(stdout).toBeDefined();
+    expect(stdout).toContain('Hello, World!');
+  });
+
+  test('should still wrap with flatpak-spawn when skipFlatpakSpawn is false', async () => {
+    const command = 'echo';
+    const args = ['Hello, World!'];
+
+    vi.mocked(isLinux).mockReturnValue(true);
+
+    const on = vi.fn().mockImplementationOnce((event: string, cb: (arg0: string) => string) => {
+      if (event === 'data') {
+        cb('Hello, World!');
+      }
+    }) as unknown as Readable;
+    const spawnMock = vi.mocked(spawn).mockReturnValue({
+      stdout: { on, setEncoding: vi.fn() },
+      stderr: { on, setEncoding: vi.fn() },
+      on: vi.fn().mockImplementation((event: string, cb: (arg0: number) => void) => {
+        if (event === 'close') {
+          cb(0);
+        }
+      }),
+    } as unknown as ChildProcess);
+
+    const { stdout } = await exec.exec(command, args, {
+      env: { FLATPAK_ID: 'io.podman_desktop.PodmanDesktop' },
+      skipFlatpakSpawn: false,
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'flatpak-spawn',
+      expect.arrayContaining(['--host', command, 'Hello, World!']),
+      expect.anything(),
+    );
+    expect(stdout).toBeDefined();
+    expect(stdout).toContain('Hello, World!');
+  });
+
   test('should run the command with privileges using exec on Windows', async () => {
     const command = 'echo';
     const args = ['Hello, World!'];

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -141,7 +141,7 @@ export class Exec {
       }
     }
 
-    if (env['FLATPAK_ID']) {
+    if (env['FLATPAK_ID'] && !options?.skipFlatpakSpawn) {
       const customEnvVariables: string[] = [];
       for (const envVar in options?.env) {
         customEnvVariables.push(`--env=${envVar}=${options.env[envVar]}`);


### PR DESCRIPTION
## Summary

- Add `skipFlatpakSpawn?: boolean` to the `RunOptions` interface in the extension API
- Guard the `flatpak-spawn --host` wrapping in `Exec.exec()` so it is skipped when `skipFlatpakSpawn` is `true`
- Add unit tests for both `skipFlatpakSpawn: true` (bypasses wrapping) and `skipFlatpakSpawn: false` (preserves wrapping)

Fixes #18250

## Test plan

- [x] `npx vitest run packages/main/src/plugin/util/exec.spec.ts` — all 25 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)