### PR TITLE
feat(ImageInfo): adding missing engineType property

### DIFF
--- a/packages/api/src/image-info.ts
+++ b/packages/api/src/image-info.ts
@@ -24,6 +24,7 @@ import type { ProviderContainerConnectionInfo } from './provider-info.js';
 export interface ImageInfo extends Dockerode.ImageInfo {
   engineId: string;
   engineName: string;
+  engineType: 'podman' | 'docker';
   History?: string[];
   Digest: string;
   isManifest?: boolean;

--- a/packages/api/src/image-inspect-info.ts
+++ b/packages/api/src/image-inspect-info.ts
@@ -21,4 +21,5 @@ import type Dockerode from 'dockerode';
 export interface ImageInspectInfo extends Dockerode.ImageInspectInfo {
   engineId: string;
   engineName: string;
+  engineType: 'podman' | 'docker';
 }

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2545,6 +2545,7 @@ declare module '@podman-desktop/api' {
   export interface ImageInspectInfo {
     engineId: string;
     engineName: string;
+    engineType: 'podman' | 'docker';
     Id: string;
     RepoTags: string[];
     RepoDigests: string[];

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2519,6 +2519,7 @@ declare module '@podman-desktop/api' {
   export interface ImageInfo {
     engineId: string;
     engineName: string;
+    engineType: 'podman' | 'docker';
     Id: string;
     ParentId: string;
     RepoTags: string[] | undefined;

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4857,6 +4857,9 @@ describe('listImages', () => {
     const internalContainerProvider = {
       name: 'dummyName',
       id: 'dummyId',
+      connection: {
+        type: 'podman',
+      },
       api: {
         listImages: vi.fn(),
       },
@@ -4886,6 +4889,7 @@ describe('listImages', () => {
       Id: 'dummyImageId',
       engineId: 'dummyId',
       engineName: 'dummyName',
+      engineType: 'podman',
       Digest: 'sha256:dummyImageId',
     });
   });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -858,6 +858,7 @@ export class ContainerProviderRegistry {
                 ...image,
                 engineName: provider.name,
                 engineId: provider.id,
+                engineType: provider.connection.type,
                 isManifest,
                 Id: image.Digest ? `sha256:${image.Id}` : image.Id,
                 Digest: image.Digest ?? `sha256:${image.Id}`,
@@ -2525,6 +2526,7 @@ export class ContainerProviderRegistry {
       return {
         engineName: provider.name,
         engineId: provider.id,
+        engineType: provider.connection.type,
         ...imageInspect,
       };
     } catch (error) {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -778,6 +778,7 @@ export class ContainerProviderRegistry {
               ...image,
               engineName: provider.name,
               engineId: provider.id,
+              engineType: provider.connection.type,
               Digest: `sha256:${image.Id}`,
             };
             return imageInfo;

--- a/packages/main/src/plugin/image-checker.spec.ts
+++ b/packages/main/src/plugin/image-checker.spec.ts
@@ -136,6 +136,7 @@ suite('image checker module', () => {
       const imageInfo: ImageInfo = {
         engineId: 'eng-id',
         engineName: 'eng-name',
+        engineType: 'podman',
         Id: 'id',
         ParentId: 'parent-id',
         RepoTags: undefined,
@@ -162,6 +163,7 @@ suite('image checker module', () => {
       const imageInfo: ImageInfo = {
         engineId: 'eng-id',
         engineName: 'eng-name',
+        engineType: 'podman',
         Id: 'id',
         ParentId: 'parent-id',
         RepoTags: undefined,

--- a/packages/main/src/plugin/image-files-registry.spec.ts
+++ b/packages/main/src/plugin/image-files-registry.spec.ts
@@ -165,6 +165,7 @@ suite('image files module', () => {
       const imageInfo: ImageInfo = {
         engineId: 'eng-id',
         engineName: 'eng-name',
+        engineType: 'podman',
         Id: 'id',
         ParentId: 'parent-id',
         RepoTags: undefined,
@@ -195,6 +196,7 @@ suite('image files module', () => {
       const imageInfo: ImageInfo = {
         engineId: 'eng-id',
         engineName: 'eng-name',
+        engineType: 'podman',
         Id: 'id',
         ParentId: 'parent-id',
         RepoTags: undefined,

--- a/packages/main/src/plugin/util/manifest.spec.ts
+++ b/packages/main/src/plugin/util/manifest.spec.ts
@@ -28,6 +28,7 @@ describe('guessIsManifest function', () => {
       Labels: {},
       engineId: 'engine1',
       engineName: 'podman',
+      engineType: 'podman',
       ParentId: '',
       RepoTags: ['manifestTag'],
       RepoDigests: ['manifestDigest'],
@@ -48,6 +49,7 @@ describe('guessIsManifest function', () => {
       Labels: {},
       engineId: 'engine2',
       engineName: 'podman',
+      engineType: 'podman',
       ParentId: '',
       RepoTags: ['largeImageTag'],
       RepoDigests: ['largeImageDigest'],
@@ -68,6 +70,7 @@ describe('guessIsManifest function', () => {
       Labels: { key: 'value' },
       engineId: 'engine3',
       engineName: 'podman',
+      engineType: 'podman',
       ParentId: '',
       RepoTags: ['labeledImageTag'],
       RepoDigests: ['labeledImageDigest'],
@@ -88,6 +91,7 @@ describe('guessIsManifest function', () => {
       Labels: {},
       engineId: 'engine4',
       engineName: 'podman',
+      engineType: 'podman',
       ParentId: '',
       RepoTags: [],
       RepoDigests: ['noTagImageDigest'],
@@ -108,6 +112,7 @@ describe('guessIsManifest function', () => {
       Labels: {},
       engineId: 'engine5',
       engineName: 'podman',
+      engineType: 'podman',
       ParentId: '',
       RepoTags: ['noDigestImageTag'],
       RepoDigests: [],
@@ -128,6 +133,7 @@ describe('guessIsManifest function', () => {
       Labels: {},
       engineId: 'engine5', // Assuming 'engineId' and 'engineName' are part of your ImageInfo but not relevant here
       engineName: 'podman',
+      engineType: 'podman',
       ParentId: '',
       RepoTags: ['testdomain.io/library/hello:latest'],
       RepoDigests: [
@@ -169,6 +175,7 @@ describe('guessIsManifest function', () => {
       History: ['localhost/testm123:latest', 'localhost/foobar123:latest'],
       engineId: 'engine1',
       engineName: 'podman',
+      engineType: 'podman',
       Digest: 'sha256:0b4f2606b1ac40f4aca2e5ec467b1f5a943bd3f8aa0f618830716c20e9783629',
     };
 
@@ -183,6 +190,7 @@ test('expect to fail even if engine name does not equal podman', () => {
     Labels: {},
     engineId: 'engine1',
     engineName: 'podman',
+    engineType: 'podman',
     ParentId: '',
     RepoTags: ['manifestTag'],
     RepoDigests: ['manifestDigest'],

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -48,6 +48,7 @@ const myImage: ImageInfo = {
   Labels: {},
   engineId: 'engine0',
   engineName: 'podman',
+  engineType: 'podman',
   ParentId: '',
   RepoTags: ['myImageTag'],
   Created: 0,

--- a/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetailsCheck.spec.ts
@@ -61,6 +61,7 @@ test('expect to display wait message before to receive results', async () => {
     imageInfo: {
       engineId: 'podman.Podman',
       engineName: 'Podman',
+      engineType: 'podman',
       Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
       ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
       RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -95,6 +96,7 @@ test('expect to cancel when clicking the Cancel button', async () => {
     imageInfo: {
       engineId: 'podman.Podman',
       engineName: 'Podman',
+      engineType: 'podman',
       Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
       ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
       RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -135,6 +137,7 @@ test('expect to cancel when destroying the component', async () => {
     imageInfo: {
       engineId: 'podman.Podman',
       engineName: 'Podman',
+      engineType: 'podman',
       Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
       ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
       RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -172,6 +175,7 @@ test('expect to not cancel again when destroying the component after manual canc
     imageInfo: {
       engineId: 'podman.Podman',
       engineName: 'Podman',
+      engineType: 'podman',
       Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
       ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
       RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -224,6 +228,7 @@ test('expect to display results from image checker provider', async () => {
     imageInfo: {
       engineId: 'podman.Podman',
       engineName: 'Podman',
+      engineType: 'podman',
       Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
       ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
       RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -271,6 +276,7 @@ test('expect to not cancel when destroying the component after displaying result
     imageInfo: {
       engineId: 'podman.Podman',
       engineName: 'Podman',
+      engineType: 'podman',
       Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
       ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
       RepoTags: ['quay.io/user/image-name:v0.0.1'],

--- a/packages/renderer/src/lib/image/PushImageModal.spec.ts
+++ b/packages/renderer/src/lib/image/PushImageModal.spec.ts
@@ -123,6 +123,7 @@ const fakedImageInspect: ImageInspectInfo = {
   VirtualSize: 0,
   engineId: 'engineid',
   engineName: 'engineName',
+  engineType: 'podman',
 };
 
 async function waitRender(customProperties: object): Promise<void> {

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -142,6 +142,7 @@ async function createRunImage(entrypoint?: string | string[], cmd?: string[]): P
     VirtualSize: 0,
     engineId: 'engineid',
     engineName: 'engineName',
+    engineType: 'podman',
   };
   (window.getImageInspect as Mock).mockResolvedValue(imageInfo);
   await waitRender();

--- a/packages/renderer/src/lib/image/imageDetailsFiles.spec.ts
+++ b/packages/renderer/src/lib/image/imageDetailsFiles.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ImageInfo } from '@podman-desktop/api';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -70,9 +71,10 @@ describe('ImageDetailsFiles component', () => {
     ])('$name', async ({ providers, calledExpected }) => {
       getCancellableTokenSourceMock.mockResolvedValue(101010);
       imageGetFilesystemLayersMock.mockResolvedValue({ layers: [] });
-      const imageInfo = {
+      const imageInfo: ImageInfo = {
         engineId: 'podman.Podman',
         engineName: 'Podman',
+        engineType: 'podman',
         Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
         ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
         RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -101,9 +103,10 @@ describe('ImageDetailsFiles component', () => {
       const TOKEN_ID = 101010;
       getCancellableTokenSourceMock.mockResolvedValue(TOKEN_ID);
       imageGetFilesystemLayersMock.mockResolvedValue({ layers: [] });
-      const imageInfo = {
+      const imageInfo: ImageInfo = {
         engineId: 'podman.Podman',
         engineName: 'Podman',
+        engineType: 'podman',
         Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
         ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
         RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -129,9 +132,10 @@ describe('ImageDetailsFiles component', () => {
     test('error during imageGetFilesystemLayers', async () => {
       getCancellableTokenSourceMock.mockResolvedValue(101010);
       imageGetFilesystemLayersMock.mockRejectedValue(new Error('an error'));
-      const imageInfo = {
+      const imageInfo: ImageInfo = {
         engineId: 'podman.Podman',
         engineName: 'Podman',
+        engineType: 'podman',
         Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
         ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
         RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -178,9 +182,10 @@ describe('ImageDetailsFiles component', () => {
     ])('$name', async ({ providers, displayedExpected }) => {
       getCancellableTokenSourceMock.mockResolvedValue(101010);
       imageGetFilesystemLayersMock.mockResolvedValue({ layers: [] });
-      const imageInfo = {
+      const imageInfo: ImageInfo = {
         engineId: 'podman.Podman',
         engineName: 'Podman',
+        engineType: 'podman',
         Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
         ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
         RepoTags: ['quay.io/user/image-name:v0.0.1'],
@@ -209,9 +214,10 @@ describe('ImageDetailsFiles component', () => {
     test('imageGetFilesystemLayers is called when the fetch button is clicked and button is hidden', async () => {
       getCancellableTokenSourceMock.mockResolvedValue(101010);
       imageGetFilesystemLayersMock.mockResolvedValue({ layers: [] });
-      const imageInfo = {
+      const imageInfo: ImageInfo = {
         engineId: 'podman.Podman',
         engineName: 'Podman',
+        engineType: 'podman',
         Id: 'sha256:3696f18be9a51a60395a7c2667e2fcebd2d913af0ad6da287e03810fda566833',
         ParentId: '7f8297e79d497136a7d75d506781b545b20ea599041f02ab14aa092e24f110b7',
         RepoTags: ['quay.io/user/image-name:v0.0.1'],


### PR DESCRIPTION
### What does this PR do?

Adding the missing `engineType` property to the ImageInfo interfaces. ContainerInfo, NetworkInfo & SecretInfo already have this property.

This is required for https://github.com/podman-desktop/podman-desktop/issues/17845 as we need to have something specific to the podman engine, and parsing the engineName is not ideal.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/18300

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should :green_circle: 
