### PR TITLE
fix(extension/podman): add missing qemu VMTYPE

### DIFF
--- a/extensions/podman/packages/extension/src/utils/util.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/util.spec.ts
@@ -29,6 +29,7 @@ import {
   HYPERV_LABEL,
   LIBKRUN_LABEL,
   normalizeWSLOutput,
+  QEMU_LABEL,
   VMTYPE,
   WSL_LABEL,
 } from './util';
@@ -124,6 +125,11 @@ test('expect hyperv label with hyperv provider', async () => {
   expect(label).equals(HYPERV_LABEL);
 });
 
+test('expect qemu label with qemu provider', async () => {
+  const label = getProviderLabel(VMTYPE.QEMU);
+  expect(label).equals(QEMU_LABEL);
+});
+
 test('expect provider name with provider different from libkrun and applehv', async () => {
   const label = getProviderLabel('unknown');
   expect(label).equals('unknown');
@@ -147,6 +153,11 @@ test('expect wsl label with wsl provider wsl label', async () => {
 test('expect hyperv label with hyperv provider wsl label', async () => {
   const provider = getProviderByLabel(HYPERV_LABEL);
   expect(provider).equals(VMTYPE.HYPERV);
+});
+
+test('expect qemu provider with qemu label', async () => {
+  const provider = getProviderByLabel(QEMU_LABEL);
+  expect(provider).equals(VMTYPE.QEMU);
 });
 
 describe('Check multiple Podman installations', () => {

--- a/extensions/podman/packages/extension/src/utils/util.ts
+++ b/extensions/podman/packages/extension/src/utils/util.ts
@@ -146,12 +146,14 @@ export enum VMTYPE {
   HYPERV = 'hyperv',
   APPLEHV = 'applehv',
   LIBKRUN = 'libkrun',
+  QEMU = 'qemu',
 }
 
 export const APPLEHV_LABEL = 'Apple HyperVisor';
 export const LIBKRUN_LABEL = 'default GPU enabled (LibKrun)';
 export const HYPERV_LABEL = 'Hyper-V';
 export const WSL_LABEL = 'WSL';
+export const QEMU_LABEL = 'QEMU';
 
 export function getProviderLabel(provider: string): string {
   switch (provider) {
@@ -163,6 +165,8 @@ export function getProviderLabel(provider: string): string {
       return WSL_LABEL;
     case VMTYPE.HYPERV:
       return HYPERV_LABEL;
+    case VMTYPE.QEMU:
+      return QEMU_LABEL;
     default:
       return provider;
   }
@@ -178,6 +182,8 @@ export function getProviderByLabel(label: string): string {
       return VMTYPE.WSL;
     case HYPERV_LABEL:
       return VMTYPE.HYPERV;
+    case QEMU_LABEL:
+      return VMTYPE.QEMU;
     default:
       return label;
   }


### PR DESCRIPTION
### What does this PR do?

Adds the missing `qemu` value to the `VMTYPE` enum in `extensions/podman/packages/extension/src/utils/util.ts`. On Linux, `podman machine init` uses the `qemu` provider, but the enum only listed `wsl`, `hyperv`, `applehv`, and `libkrun`. This PR adds `VMTYPE.QEMU` along with a `QEMU_LABEL` constant, and wires it into `getProviderLabel` and `getProviderByLabel` so it round-trips correctly like the other providers.

### Screenshot / video of UI

N/A — no UI changes, this is a data/enum fix.

### What issues does this PR fix or reference?

Fixes #17777

### How to test this PR?

1. Checkout this branch and run the podman extension unit tests:
npx vitest run extensions/podman/packages/extension/src/utils/util.spec.ts


2. Confirm `VMTYPE.QEMU`, `getProviderLabel(VMTYPE.QEMU)`, and `getProviderByLabel(QEMU_LABEL)` all resolve as expected.

- [x] Tests are covering the bug fix or the new feature
