### PR TITLE
fix(ui): erase button for container logs is displayed above Tasks modal window

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogsClear.svelte
@@ -53,7 +53,7 @@ async function clear(): Promise<void> {
 }
 </script>
 
-<div class="absolute top-0 right-2 px-1 z-50 m-1 opacity-50 space-x-1">
+<div class="absolute top-0 right-2 px-1 z-1 m-1 opacity-50 space-x-1">
   <button title="Clear logs" onclick={clear} class="">
     <Icon
       class="cursor-pointer rounded-full bg-[var(--pd-button-disabled)] min-h-8 w-8 p-1.5 hover:bg-[var(--pd-button-close-hover-bg)]"


### PR DESCRIPTION
### What does this PR do?
Fixes z-index of erase button in container logs which was displayed above Tasks modal window.

### Screenshot / video of UI

https://github.com/user-attachments/assets/dc6ca910-c03b-4ded-8215-5f6db75859b8

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/18291

### How to test this PR?

- Start any container that logs something (e.g. nginx).
- Go to the container and see its logs, there should be an erase logs button at the top right corner.
- Open Tasks modal window and the erase logs button should not be above modal.  

- [X] Tests are covering the bug fix or the new feature
