### PR TITLE
feat(api): add image update result contract

### DIFF
--- a/packages/api/src/image-registry.ts
+++ b/packages/api/src/image-registry.ts
@@ -60,3 +60,28 @@ export interface ImageUpdateStatus {
    */
   message: string;
 }
+
+/**
+ * Describes a single image to be updated via the backend.
+ */
+export interface ImageUpdateInfo {
+  engineId: string;
+  /** Full image reference, e.g. "quay.io/podman/hello:latest" */
+  image: string;
+  /** Image tag, e.g. "latest" */
+  tag: string;
+  /** Current local digest of the image */
+  digest: string;
+  /** Current local repository digests of the image */
+  repoDigests?: string[];
+}
+
+/**
+ * Per-image result returned by the backend updateImages call.
+ */
+export interface ImageUpdateResult {
+  imageRef: string;
+  updated: boolean;
+  status: ImageUpdateStatus['status'] | 'updated';
+  message: string;
+}


### PR DESCRIPTION
## Summary
- add API types for backend image update requests
- add per-image update result types for follow-up backend and renderer slices

Split out from draft PR #18003 so the API contract can be reviewed independently.

See https://github.com/podman-desktop/podman-desktop/pull/18003/commits 2nd pr out of 7

## Verification
- npx eslint packages/api/src/image-registry.ts