### PR TITLE
chore: remove duplicate addresses when checking for free ports

### DIFF
--- a/packages/main/src/plugin/util/port.spec.ts
+++ b/packages/main/src/plugin/util/port.spec.ts
@@ -18,10 +18,19 @@
 
 import { once } from 'node:events';
 import * as net from 'node:net';
+import { type NetworkInterfaceInfo, networkInterfaces } from 'node:os';
 
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import * as port from './port.js';
+
+vi.mock(import('node:os'), async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    networkInterfaces: vi.fn(original.networkInterfaces),
+  };
+});
 
 const hosts = ['127.0.0.1', '0.0.0.0'];
 
@@ -192,4 +201,36 @@ test('should fail if all ports are exhausted starting near the upper limit', asy
   );
 
   await closeServer(server);
+});
+
+test('should find a free port when the same IP appears on multiple interfaces', async () => {
+  const mockedNetworkInterfaces = vi.mocked(networkInterfaces);
+  mockedNetworkInterfaces.mockReturnValue({
+    lo: [
+      {
+        address: '127.0.0.1',
+        netmask: '255.0.0.0',
+        family: 'IPv4',
+        mac: '00:00:00:00:00:00',
+        internal: true,
+        cidr: '127.0.0.1/8',
+      },
+    ] as NetworkInterfaceInfo[],
+    'nm-xfrm-1234': [
+      {
+        address: '127.0.0.1',
+        netmask: '255.255.255.255',
+        family: 'IPv4',
+        mac: '00:00:00:00:00:00',
+        internal: false,
+        cidr: '127.0.0.1/32',
+      },
+    ] as NetworkInterfaceInfo[],
+  });
+
+  const freePort = await port.getFreePort(65000);
+  expect(freePort).toBeGreaterThanOrEqual(65000);
+  expect(freePort).toBeLessThanOrEqual(65535);
+
+  mockedNetworkInterfaces.mockRestore();
 });

--- a/packages/main/src/plugin/util/port.ts
+++ b/packages/main/src/plugin/util/port.ts
@@ -111,8 +111,9 @@ function getIPv4Interfaces(): string[] {
   if (!intfs) {
     return [];
   }
-  return Object.values(intfs)
+  const addresses = Object.values(intfs)
     .flat()
     .filter((intf): intf is NetworkInterfaceInfoIPv4 => !!intf && intf.family === 'IPv4' && !!intf.address)
     .map(intf => intf.address);
+  return [...new Set(addresses)];
 }


### PR DESCRIPTION
### What does this PR do?
VPNs like strongswan create 2 network interfaces with the same address, example:
```
nm-xfrm-1743037: family=IPv4 address=10.6.0.14 internal=false netmask=255.255.255.255 mac=00:00:00:00
lo: family=IPv4 address=127.0.0.1 internal=true netmask=255.0.0.0 mac=00:00:00:00
lo: family=IPv4 address=10.6.0.14 internal=true netmask=255.255.255.255 mac=00:00:00:00
```
When checking for free ports, in the `Promise.all` block, it tried to listen twice to the same ports on the same address, getting EADDRINUSE for all ports. This fix ensures that all addresses show up only once during this check

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/6843

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Set up ikev2/ipsec VPN (e.g. strongswan) and assert that Podman Desktop loads up and works as expected

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
