### PR TITLE
refactor(renderer): store PodInfoUI instead of PodInfo

### DIFF
--- a/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminalService.spec.ts
+++ b/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminalService.spec.ts
@@ -18,15 +18,16 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { PodContainerInfo, PodInfo } from '@podman-desktop/api';
+import type { PodContainerInfo } from '@podman-desktop/api';
 import { beforeEach, expect, test } from 'vitest';
 
 import { TerminalService } from '/@/lib/kube/pods/terminal/KubernetesTerminalService';
+import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
 
 let terminalService: TestableKubernetesTerminalService;
 
 class TestableKubernetesTerminalService extends TerminalService {
-  public testInvalidateCacheRecordOnStatusUpdate(podsInfos: PodInfo[]): void {
+  public testInvalidateCacheRecordOnStatusUpdate(podsInfos: PodInfoUI[]): void {
     return this.invalidateCacheRecordOnStatusUpdate(podsInfos);
   }
 
@@ -34,7 +35,7 @@ class TestableKubernetesTerminalService extends TerminalService {
     return super.toKey(podName, containerName);
   }
 
-  public testInvalidateCacheRecordOnPodRemove(podsInfos: PodInfo[]): void {
+  public testInvalidateCacheRecordOnPodRemove(podsInfos: PodInfoUI[]): void {
     return this.invalidateCacheRecordOnPodRemove(podsInfos);
   }
 
@@ -69,11 +70,11 @@ test('should check if the terminal exists in the cache', () => {
 
 test('should invalidate cache for non-running containers', () => {
   terminalService.testTerminalCache().set('pod1-container1', {});
-  const podsInfosMock: PodInfo[] = [
+  const podsInfosMock: PodInfoUI[] = [
     {
-      Name: 'pod1',
-      Containers: [{ Names: 'container1', Status: 'exited' } as PodContainerInfo],
-    } as PodInfo,
+      name: 'pod1',
+      containers: [{ Names: 'container1', Status: 'exited' } as PodContainerInfo],
+    } as PodInfoUI,
   ];
 
   terminalService.testInvalidateCacheRecordOnStatusUpdate(podsInfosMock);

--- a/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminalService.ts
+++ b/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminalService.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodContainerInfo, PodInfo } from '@podman-desktop/api';
+import type { PodContainerInfo } from '@podman-desktop/api';
 
 import KubernetesTerminal from '/@/lib/kube/pods/terminal/KubernetesTerminal.svelte';
+import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
 import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
 import { podsInfos } from '/@/stores/pods';
 
@@ -32,20 +33,20 @@ export class TerminalService {
     });
   }
 
-  protected invalidateCacheRecordOnStatusUpdate(podsInfos: PodInfo[]): void {
-    podsInfos.forEach((pod: PodInfo) => {
-      pod.Containers.forEach((container: PodContainerInfo) => {
+  protected invalidateCacheRecordOnStatusUpdate(podsInfos: PodInfoUI[]): void {
+    podsInfos.forEach((pod: PodInfoUI) => {
+      pod.containers.forEach((container: PodContainerInfo) => {
         if (container.Status !== 'running') {
-          this.terminalCache.delete(this.toKey(pod.Name, container.Names));
+          this.terminalCache.delete(this.toKey(pod.name, container.Names));
         }
       });
     });
   }
 
-  protected invalidateCacheRecordOnPodRemove(podsInfos: PodInfo[]): void {
+  protected invalidateCacheRecordOnPodRemove(podsInfos: PodInfoUI[]): void {
     const activePods = new Set(
-      podsInfos.flatMap((pod: PodInfo) =>
-        pod.Containers.map((container: PodContainerInfo) => this.toKey(pod.Name, container.Names)),
+      podsInfos.flatMap((pod: PodInfoUI) =>
+        pod.containers.map((container: PodContainerInfo) => this.toKey(pod.name, container.Names)),
       ),
     );
     for (const [key] of this.terminalCache) {

--- a/packages/renderer/src/lib/pod/PodDetails.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetails.spec.ts
@@ -70,7 +70,7 @@ test('Expect redirect to previous page if pod is deleted', async () => {
   // remove myPod from the store when we call 'removePod'
   // it will then refresh the store and update PodsDetails page
   vi.mocked(window.removePod).mockImplementation(async () => {
-    podsInfos.update(pods => pods.filter(pod => pod.Id !== myPod.Id));
+    podsInfos.update(pods => pods.filter(pod => pod.id !== myPod.Id));
   });
 
   // defines a fake lastPage so we can check where we will be redirected

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -10,7 +10,6 @@ import { getTabUrl, isTabSelected } from '/@/lib/ui/Util';
 import Route from '/@/Route.svelte';
 import { podsInfos } from '/@/stores/pods';
 
-import { PodUtils } from './pod-utils';
 import PodActions from './PodActions.svelte';
 import PodDetailsInspect from './PodDetailsInspect.svelte';
 import PodDetailsKube from './PodDetailsKube.svelte';
@@ -28,18 +27,16 @@ let detailsPage: DetailsPage;
 let currentRouterPath: string;
 
 onMount(() => {
-  const podUtils = new PodUtils();
-
   router.subscribe(route => {
     currentRouterPath = route.path;
   });
 
   // loading pod info
   return podsInfos.subscribe(pods => {
-    const matchingPod = pods.find(podInPods => podInPods.Name === podName && podInPods.engineId === engineId);
+    const matchingPod = pods.find(podInPods => podInPods.name === podName && podInPods.engineId === engineId);
     if (matchingPod) {
       try {
-        pod = podUtils.getPodInfoUI(matchingPod);
+        pod = matchingPod;
 
         if (currentRouterPath.endsWith('/')) {
           router.goto(`${currentRouterPath}logs`);

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -343,7 +343,7 @@ test('Expect the route to a pod details page is correctly encoded with an engine
   await vi.waitUntil(
     () => {
       const infos = get(podsInfos);
-      return infos.length === 1 && infos[0].Name === ocppod.Name;
+      return infos.length === 1 && infos[0].name === ocppod.Name;
     },
     { timeout: 5000 },
   );
@@ -471,8 +471,8 @@ test('Expect All tab to show all pods running and stopped (not running)', async 
 
   expect(get(filtered)).toEqual(
     expect.arrayContaining([
-      expect.objectContaining({ Status: 'Running' }),
-      expect.objectContaining({ Status: 'Stopped' }),
+      expect.objectContaining({ status: 'RUNNING' }),
+      expect.objectContaining({ status: 'STOPPED' }),
     ]),
   );
 });
@@ -496,7 +496,7 @@ test('Expect Running tab to show running pods only', async () => {
 
   await vi.waitUntil(() => get(filtered).length === 1, { timeout: 5000 });
 
-  expect(get(filtered)).toEqual(expect.arrayContaining([expect.objectContaining({ Status: 'Running' })]));
+  expect(get(filtered)).toEqual(expect.arrayContaining([expect.objectContaining({ status: 'RUNNING' })]));
 });
 
 test('Expect Stopped tab to show stopped (not running) pods only', async () => {
@@ -518,7 +518,7 @@ test('Expect Stopped tab to show stopped (not running) pods only', async () => {
 
   await vi.waitUntil(() => get(filtered).length === 1, { timeout: 5000 });
 
-  expect(get(filtered)).toEqual(expect.arrayContaining([expect.objectContaining({ Status: 'Stopped' })]));
+  expect(get(filtered)).toEqual(expect.arrayContaining([expect.objectContaining({ status: 'STOPPED' })]));
 });
 
 test('Expect tab filtering to not duplicate filter condition in the search bar', async () => {

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
-import type { PodInfo } from '@podman-desktop/core-api';
 import {
   Button,
   FilteredEmptyScreen,
@@ -70,7 +69,7 @@ const podUtils = new PodUtils();
 
 onMount(() => {
   return filtered.subscribe(value => {
-    const computedPods = value.map((podInfo: PodInfo) => podUtils.getPodInfoUI(podInfo)).flat();
+    const computedPods = value.map((podInfo: PodInfoUI) => podInfo).flat();
 
     // Map engineName, engineId and engineType from currentContainers to EngineInfoUI[]
     const engines = computedPods.map(container => {

--- a/packages/renderer/src/lib/pod/pod-utils.spec.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.spec.ts
@@ -22,6 +22,7 @@ import type { PodInfo } from '@podman-desktop/core-api';
 import { expect, test } from 'vitest';
 
 import { ensureRestrictedSecurityContext, PodUtils } from '/@/lib/pod/pod-utils';
+import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
 
 function verifyPodSecurityContext(containers: any[], type = 'RuntimeDefault'): void {
   containers.forEach(container => {
@@ -91,21 +92,21 @@ test('Expect return a valid name for a new pod', () => {
 
 test('Expect return a valid name for a new pod if there is a pod with the same name', () => {
   const podUtils = new PodUtils();
-  const newPodName = podUtils.calculateNewPodName([{ Name: 'my-pod' } as PodInfo]);
+  const newPodName = podUtils.calculateNewPodName([{ name: 'my-pod' } as PodInfoUI]);
 
   expect(newPodName).toBe('my-pod-1');
 });
 
 test('Expect return a valid name for a new pod if there is a pods with different names', () => {
   const podUtils = new PodUtils();
-  const newPodName = podUtils.calculateNewPodName([{ Name: 'my-super-pod' } as PodInfo]);
+  const newPodName = podUtils.calculateNewPodName([{ name: 'my-super-pod' } as PodInfoUI]);
 
   expect(newPodName).toBe('my-pod');
 });
 
 test('Expect return a valid name for a new pod if there are pods with the same name', () => {
   const podUtils = new PodUtils();
-  const newPodName = podUtils.calculateNewPodName([{ Name: 'my-pod' } as PodInfo, { Name: 'my-pod-1' } as PodInfo]);
+  const newPodName = podUtils.calculateNewPodName([{ name: 'my-pod' } as PodInfoUI, { name: 'my-pod-1' } as PodInfoUI]);
 
   expect(newPodName).toBe('my-pod-2');
 });

--- a/packages/renderer/src/lib/pod/pod-utils.ts
+++ b/packages/renderer/src/lib/pod/pod-utils.ts
@@ -74,14 +74,14 @@ export class PodUtils {
     };
   }
 
-  calculateNewPodName(existedPods?: PodInfo[]): string {
+  calculateNewPodName(existedPods?: PodInfoUI[]): string {
     const proposedPodName = 'my-pod';
 
     if (!existedPods) {
       return proposedPodName;
     }
 
-    const existedNames = existedPods.map(pod => pod.Name);
+    const existedNames = existedPods.map(pod => pod.name);
 
     if (!existedNames.includes(proposedPodName)) {
       return proposedPodName;

--- a/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodInfo } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
 import { podsInfos } from '/@/stores/pods';
 
 import { createNavigationPodEntry } from './navigation-registry-pod.svelte';
@@ -29,18 +29,33 @@ beforeEach(() => {
 
 test('createNavigationPodEntry', async () => {
   const entry = createNavigationPodEntry();
-  podsInfos.set([
-    {
-      Id: '1234',
-      Name: 'pod-a',
-      engineId: 'podman',
-    } as unknown as PodInfo,
-    {
-      Id: '3456',
-      Name: 'pod-b',
-      engineId: 'podman',
-    } as unknown as PodInfo,
-  ]);
+  const podA: PodInfoUI = {
+    id: '1234',
+    shortId: '1234',
+    name: 'pod-a',
+    engineId: 'podman',
+    engineName: 'Podman',
+    status: 'RUNNING',
+    age: '1 minute',
+    created: '2026-01-01T00:00:00.000Z',
+    selected: false,
+    containers: [],
+    namespace: '',
+  };
+  const podB: PodInfoUI = {
+    id: '3456',
+    shortId: '3456',
+    name: 'pod-b',
+    engineId: 'podman',
+    engineName: 'Podman',
+    status: 'RUNNING',
+    age: '1 minute',
+    created: '2026-01-01T00:00:00.000Z',
+    selected: false,
+    containers: [],
+    namespace: '',
+  };
+  podsInfos.set([podA, podB]);
 
   expect(entry).toBeDefined();
   expect(entry.name).toBe('Pods');

--- a/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-pod.svelte.ts
@@ -32,9 +32,9 @@ export function createNavigationPodEntry(): NavigationRegistryEntry {
     destinations = [
       ...pods.map(pod => ({
         page: NavigationPage.PODMAN_POD_SUMMARY as const,
-        parameters: { name: pod.Name, engineId: pod.engineId },
+        parameters: { name: pod.name, engineId: pod.engineId },
         icon: { iconComponent: PodIcon },
-        name: `Pod: ${pod.Name}`,
+        name: `Pod: ${pod.name}`,
       })),
       {
         page: NavigationPage.PODMAN_PODS as const,

--- a/packages/renderer/src/stores/pods.spec.ts
+++ b/packages/renderer/src/stores/pods.spec.ts
@@ -92,5 +92,5 @@ test.each([
   // now get list
   const podListResult = get(podsInfos);
   expect(podListResult.length).toBe(1);
-  expect(podListResult[0].Id).toEqual('id123');
+  expect(podListResult[0].id).toEqual('id123');
 });

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -16,10 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { PodInfo } from '@podman-desktop/core-api';
 import { derived, type Writable, writable } from 'svelte/store';
 
 import PodIcon from '/@/lib/images/PodIcon.svelte';
+import { PodUtils } from '/@/lib/pod/pod-utils';
+import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
 
 import { EventStore } from './event-store';
 import { findMatchInLeaves } from './search-util';
@@ -54,12 +55,12 @@ async function checkForUpdate(eventName: string): Promise<boolean> {
   return readyToUpdate;
 }
 
-export const podsInfos: Writable<PodInfo[]> = writable([]);
+export const podsInfos: Writable<PodInfoUI[]> = writable([]);
 
 export const searchPattern = writable('');
 
-export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $imagesInfos]) => {
-  return $imagesInfos
+export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $podsInfoUis]) =>
+  $podsInfoUis
     .filter(podInfo =>
       findMatchInLeaves(
         podInfo,
@@ -72,20 +73,22 @@ export const filtered = derived([searchPattern, podsInfos], ([$searchPattern, $i
     )
     .filter(pod => {
       if ($searchPattern.includes('is:running')) {
-        return pod.Status === 'Running';
+        return pod.status === 'RUNNING';
       }
       if ($searchPattern.includes('is:stopped')) {
-        return pod.Status !== 'Running';
+        return pod.status !== 'RUNNING';
       }
       return true;
-    });
-});
+    }),
+);
 
-const listPods = (): Promise<PodInfo[]> => {
-  return window.listPods();
+const podUtils = new PodUtils();
+
+const listPods = async (): Promise<PodInfoUI[]> => {
+  return (await window.listPods()).map(podInfo => podUtils.getPodInfoUI(podInfo));
 };
 
-export const podsEventStore = new EventStore<PodInfo[]>(
+export const podsEventStore = new EventStore<PodInfoUI[]>(
   'pods',
   podsInfos,
   checkForUpdate,


### PR DESCRIPTION
### What does this PR do?

This PR refactors the renderer to store the `PodInfoUI` instead of `PodInfo` to address comment https://github.com/podman-desktop/podman-desktop/issues/14583#issuecomment-4496201834

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/14583#issuecomment-4496201834

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

There should be no change.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
