### PR TITLE
fix(renderer): revert extension details summary card to vertical sidebar

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetails.svelte
@@ -94,7 +94,7 @@ $: extension = derived(
     {/snippet}
 
     {#snippet contentSnippet()}
-      <div class="flex w-full h-full overflow-y-auto p-5 flex-col">
+      <div class="flex w-full h-full overflow-y-auto p-5 flex-col lg:flex-row">
         {#if screen === 'README'}
           <ExtensionDetailsSummaryCard extensionDetails={$extension} />
           <ExtensionDetailsReadme readme={$extension.readme} />

--- a/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsSummaryCard.svelte
@@ -9,8 +9,9 @@ interface Props {
 let { extensionDetails }: Props = $props();
 </script>
 
-<div class="w-full pb-4">
-  <div class="bg-[var(--pd-details-card-bg)] h-fit p-4 rounded-md flex flex-row w-full space-x-4">
+<div class="order-first lg:order-last w-full lg:w-48 flex flex-row grow justify-end pb-4 lg:pb-0">
+  <div
+    class="bg-[var(--pd-details-card-bg)] lg:w-40 h-fit lg:ml-4 p-4 rounded-md flex flex-row lg:flex-col w-full space-x-4 lg:space-x-0">
     <ExtensionDetailsSummaryCardEntry label="version" value={extensionDetails.version} />
 
     <ExtensionDetailsSummaryCardEntry label="released" value={extensionDetails.releaseDate} />

--- a/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.svelte
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionDetailsSummaryCardEntry.svelte
@@ -7,7 +7,7 @@ interface Props {
 let { label, value }: Props = $props();
 </script>
 
-<div class="flex flex-col items-start">
+<div class="flex flex-col lg:mb-4 items-start">
   <div class="uppercase text-sm text-[var(--pd-details-card-header)]">{label}</div>
   <div class="text-left font-thin text-sm text-[var(--pd-details-card-text)]">{value}</div>
 </div>


### PR DESCRIPTION
### What does this PR do?

Reverts #17976 to restore the `lg:` vertical sidebar layout for `ExtensionDetailsSummaryCard`.

This puts back the responsive classes that move summary metadata to the right sidebar on large screens and restores the previous content split between the summary card and readme area.

Reverted files:
- `ExtensionDetailsSummaryCard.svelte`
- `ExtensionDetails.svelte`
- `InstalledExtensionDetailsSummaryCardEntry.svelte`

### Screenshot / video of UI

N/A (layout revert only; can add screenshots during review if needed).

### What issues does this PR fix or reference?

Fixes #18296
Reverts #17976
Related to #17873
Related to #17299
Related to #15639

### How to test this PR?

1. Open Podman Desktop and navigate to `Extensions -> Compose -> Details` (or any extension details page).
2. Resize the window to a width above the `lg` breakpoint and verify the summary card is shown as a right vertical sidebar.
3. Confirm the readme content is displayed beside the summary sidebar on large screens.
4. Resize below `lg` and verify the summary card returns to the top horizontal layout.

- [ ] Tests are covering the bug fix or the new feature

🤖 Generated with AI assistance ([Cursor](https://cursor.com))

Made with [Cursor](https://cursor.com)