### PR TITLE
fix: resolve GHSA-xv26-6w52-cph6 in websocket-driver

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,7 @@ overrides:
   launch-editor: '>=2.14.1'
   webpack-dev-server: '>=5.2.5'
   '@babel/core': '>=7.29.6 <8.0.0'
+  websocket-driver: '>=0.7.5'
 
 importers:
 
@@ -12514,8 +12515,8 @@ packages:
       webpack:
         optional: true
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -20795,7 +20796,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -25215,7 +25216,7 @@ snapshots:
     dependencies:
       faye-websocket: 0.11.4
       uuid: 14.0.0
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   socks-proxy-agent@8.0.5:
     dependencies:
@@ -26555,7 +26556,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.105.0(esbuild@0.28.1)
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.8
       safe-buffer: 5.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,6 +64,7 @@ overrides:
   launch-editor: '>=2.14.1'
   webpack-dev-server: '>=5.2.5'
   '@babel/core': '>=7.29.6 <8.0.0'
+  websocket-driver: '>=0.7.5'
 nodeLinker: hoisted
 allowBuilds:
   '@biomejs/biome': true


### PR DESCRIPTION
### What does this PR do?

Fix critical severity vulnerability GHSA-xv26-6w52-cph6 in `websocket-driver`.

**Advisory**: websocket-driver: Message corruption via abuse of protocol length headers
**Vulnerable versions**: <0.7.5
**Patched versions**: >=0.7.5
**Advisory URL**: https://github.com/advisories/GHSA-xv26-6w52-cph6

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-xv26-6w52-cph6: _websocket-driver: Message corruption via abuse of protocol length headers_

### How to test this PR?

Run `pnpm audit` and verify GHSA-xv26-6w52-cph6 is no longer reported