### PR TITLE
refactor(navigation): make image run and image details consistent

### DIFF
--- a/packages/api/src/navigation-request.ts
+++ b/packages/api/src/navigation-request.ts
@@ -35,7 +35,7 @@ export interface NavigationParameters {
   [NavigationPage.IMAGES]: never;
   [NavigationPage.IMAGE_BUILD]: { taskId: number | undefined };
   [NavigationPage.IMAGE]: { id: string; engineId: string; tag: string };
-  [NavigationPage.IMAGE_RUN]: { id: string; engineId: string; base64RepoTag: string };
+  [NavigationPage.IMAGE_RUN]: { id: string; engineId: string; tag: string };
   [NavigationPage.MANIFEST]: { id: string; engineId: string; tag: string };
   [NavigationPage.ONBOARDING]: { extensionId: string };
   [NavigationPage.PODMAN_PODS]: never;

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.spec.ts
@@ -239,7 +239,7 @@ test('Expect a local image to have an active run image button', async () => {
     expect(handleNavigation).toHaveBeenCalledWith({
       page: NavigationPage.IMAGE_RUN,
       parameters: {
-        base64RepoTag: expect.any(String),
+        tag: expect.any(String),
         engineId: selected.engineId,
         id: selected.Id,
       },

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -304,7 +304,7 @@ async function buildContainerFromImage(): Promise<void> {
         parameters: {
           id: chosenImage[0].id,
           engineId: chosenImage[0].engineId,
-          base64RepoTag: chosenImage[0].base64RepoTag,
+          tag: chosenImage[0].tag ? `${chosenImage[0].name}:${chosenImage[0].tag}` : chosenImage[0].name,
         },
       });
     }

--- a/packages/renderer/src/lib/image/ImageActions.spec.ts
+++ b/packages/renderer/src/lib/image/ImageActions.spec.ts
@@ -18,19 +18,22 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import { NavigationPage } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { router } from 'tinro';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import ImageActions from '/@/lib/image/ImageActions.svelte';
 import type { ImageInfoUI } from '/@/lib/image/ImageInfoUI';
+import { handleNavigation } from '/@/navigation';
 
 import { ImageUtils } from './image-utils';
 
 const getContributedMenusMock = vi.fn();
 
+vi.mock(import('/@/navigation'));
 vi.mock(import('./image-utils'));
 vi.mock(import('/@/lib/dialogs/messagebox-utils'), () => ({
   withConfirmation: vi.fn(),
@@ -262,6 +265,55 @@ test('Expect withConfirmation to indicate image name and tag', async () => {
     expect(withConfirmation).toHaveBeenNthCalledWith(1, expect.anything(), 'delete image image-name:1.0', {
       title: 'Delete Image?',
       variant: 'delete',
+    });
+  });
+});
+
+describe('run', () => {
+  const image: ImageInfoUI = {
+    id: 'sha256:foobar',
+    name: 'localhost/foo',
+    engineId: 'podman.Podman',
+    tag: 'latest',
+    status: 'UNUSED',
+  } as ImageInfoUI;
+
+  beforeEach(() => {
+    getContributedMenusMock.mockResolvedValue([]);
+  });
+
+  test('Expect Run image to be there', async () => {
+    const { getByTitle } = render(ImageActions, {
+      onPushImage: vi.fn(),
+      onRenameImage: vi.fn(),
+      image,
+    });
+
+    const button = getByTitle('Run Image');
+    expect(button).toBeDefined();
+  });
+
+  test('Expect Run image to navigate to appropriate page', async () => {
+    const { getByTitle } = render(ImageActions, {
+      onPushImage: vi.fn(),
+      onRenameImage: vi.fn(),
+      image,
+    });
+
+    const button = getByTitle('Run Image');
+    expect(button).toBeDefined();
+
+    await fireEvent.click(button);
+
+    await vi.waitFor(() => {
+      expect(handleNavigation).toHaveBeenCalledExactlyOnceWith({
+        page: NavigationPage.IMAGE_RUN,
+        parameters: {
+          engineId: image.engineId,
+          id: image.id,
+          tag: `${image.name}:${image.tag}`,
+        },
+      });
     });
   });
 });

--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -64,7 +64,7 @@ async function runImage(): Promise<void> {
     parameters: {
       id: image.id,
       engineId: image.engineId,
-      base64RepoTag: image.base64RepoTag,
+      tag: image.tag ? `${image.name}:${image.tag}` : image.name,
     },
   });
 }

--- a/packages/renderer/src/lib/image/PullImage.spec.ts
+++ b/packages/renderer/src/lib/image/PullImage.spec.ts
@@ -452,7 +452,7 @@ test('Expect run action to set image info and go to run page', async () => {
     expect(handleNavigation).toHaveBeenCalledWith({
       page: NavigationPage.IMAGE_RUN,
       parameters: {
-        base64RepoTag: btoa(image.RepoTags?.[0] ?? ''),
+        tag: image.RepoTags?.[0],
         engineId: image.engineId,
         id: image.Id,
       },

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -235,7 +235,7 @@ async function gotoImageRun(): Promise<void> {
       parameters: {
         id: image.id,
         engineId: image.engineId,
-        base64RepoTag: image.base64RepoTag,
+        tag: image.tag ? `${image.name}:${image.tag}` : image.name,
       },
     });
   }

--- a/packages/renderer/src/navigation.spec.ts
+++ b/packages/renderer/src/navigation.spec.ts
@@ -116,6 +116,15 @@ test(`Test navigationHandle for ${NavigationPage.IMAGE}`, () => {
   expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/images/123/dummyEngineId/ZHVtbXlUYWc=/summary');
 });
 
+test(`Test navigationHandle for ${NavigationPage.IMAGE_RUN}`, () => {
+  handleNavigation({
+    page: NavigationPage.IMAGE_RUN,
+    parameters: { id: '123', engineId: 'dummyEngineId', tag: 'dummyTag' },
+  });
+
+  expect(vi.mocked(router.goto)).toHaveBeenCalledWith('/images/123/dummyEngineId/ZHVtbXlUYWc=/run/basic');
+});
+
 test(`Test navigationHandle for ${NavigationPage.MANIFEST}`, () => {
   handleNavigation({
     page: NavigationPage.MANIFEST,

--- a/packages/renderer/src/navigation.ts
+++ b/packages/renderer/src/navigation.ts
@@ -63,7 +63,7 @@ export const resolveRoute = (request: InferredNavigationRequest<NavigationPage>)
     case NavigationPage.IMAGE:
       return `/images/${request.parameters.id}/${request.parameters.engineId}/${btoa(request.parameters.tag)}/summary`;
     case NavigationPage.IMAGE_RUN:
-      return `/images/${request.parameters.id}/${request.parameters.engineId}/${request.parameters.base64RepoTag}/run/basic`;
+      return `/images/${request.parameters.id}/${request.parameters.engineId}/${btoa(request.parameters.tag)}/run/basic`;
     case NavigationPage.MANIFEST:
       return `/manifests/${request.parameters.id}/${request.parameters.engineId}/${btoa(request.parameters.tag)}/summary`;
     case NavigationPage.ONBOARDING:


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/18309 I am not satisfied with the interface we expose internally

https://github.com/podman-desktop/podman-desktop/blob/1666ab9eb5ba895c335ee4d0c70d6f83557b81eb/packages/api/src/navigation-request.ts#L37-L38

We have two different arguments for `IMAGE` and `IMAGE_RUN` but they are fundamentally the same, I tried to make it as simple as possible, but while working on https://github.com/podman-desktop/podman-desktop/issues/17941 which is exposing to the extension-api, I think we should focus on consistency over simplicity.

I copy paste the existing logic used to open the `IMAGE` page, so it is consistent now.

https://github.com/podman-desktop/podman-desktop/blob/0eddce773cea6af5cdf259c183257a8ee169a298/packages/renderer/src/lib/image/ImageColumnName.svelte#L16-L19

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/17941

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
