### PR TITLE
fix(container-registry): remove legacy listImages

### DIFF
--- a/packages/api/src/image-info.ts
+++ b/packages/api/src/image-info.ts
@@ -193,15 +193,6 @@ export interface BuildImageOptions {
   validateRegistries?: boolean;
 }
 
-export interface ListImagesOptions {
-  /**
-   * The provider we want to list the images. If not provided, will return all container images across all container engines.
-   *
-   * @defaultValue undefined
-   */
-  provider?: ContainerProviderConnection | ProviderContainerConnectionInfo;
-}
-
 export interface PodmanListImagesOptions {
   /**
    * Show all images. By default all images from a final layer (no children) are shown.

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -28,7 +28,7 @@ import type {
   ContainerCreateOptions,
   ContainerInspectInfo,
   HostConfig,
-  ImageInfo,
+  ImageInspectInfo,
   ProviderContainerConnectionInfo,
 } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
@@ -4844,57 +4844,6 @@ describe('getContainerCreateMountOptionFromBind', () => {
   });
 });
 
-describe('listImages', () => {
-  test('list images without arguments', async () => {
-    const result = await containerRegistry.listImages();
-    expect(result.length).toBe(0);
-
-    expect(vi.spyOn(containerRegistry, 'getMatchingContainerProvider')).not.toHaveBeenCalled();
-  });
-
-  test('list images on a specific provider', async () => {
-    const getMatchingContainerProviderMock = vi.spyOn(containerRegistry, 'getMatchingContainerProvider');
-    const internalContainerProvider = {
-      name: 'dummyName',
-      id: 'dummyId',
-      connection: {
-        type: 'podman',
-      },
-      api: {
-        listImages: vi.fn(),
-      },
-    } as unknown as InternalContainerProvider;
-    getMatchingContainerProviderMock.mockReturnValue(internalContainerProvider);
-
-    const api = internalContainerProvider.api;
-    if (api === undefined) throw new Error('api should not be undefined');
-    vi.spyOn(api, 'listImages').mockResolvedValue([
-      {
-        Id: 'dummyImageId',
-      } as unknown as ImageInfo,
-    ]);
-
-    // List images
-    const result = await containerRegistry.listImages({
-      provider: {
-        id: 'dummyProviderId',
-      } as unknown as podmanDesktopAPI.ContainerProviderConnection,
-    });
-
-    expect(getMatchingContainerProviderMock).toHaveBeenCalled();
-    expect(api.listImages).toHaveBeenCalled();
-
-    expect(result.length).toBe(1);
-    expect(result[0]).toStrictEqual({
-      Id: 'dummyImageId',
-      engineId: 'dummyId',
-      engineName: 'dummyName',
-      engineType: 'podman',
-      Digest: 'sha256:dummyImageId',
-    });
-  });
-});
-
 test('list images with podmanListImages correctly', async () => {
   const imagesList = [
     {
@@ -7259,5 +7208,70 @@ describe('inspectSecret', () => {
       CreatedAt: '2024-01-01T00:00:00Z',
       UpdatedAt: '2024-01-02T00:00:00Z',
     });
+  });
+});
+
+describe('getImageInspect', () => {
+  test('should throw if no matching engine', async () => {
+    await expect(containerRegistry.getImageInspect('nonexistent', 'secret1')).rejects.toThrow(
+      'no engine matching this container',
+    );
+  });
+
+  test('should use the getImage & inspect', async () => {
+    // setup
+    const imageMock: Dockerode.Image = {
+      inspect: vi.fn(),
+    } as unknown as Dockerode.Image;
+    const imageInspectMock: Dockerode.ImageInspectInfo = {} as unknown as Dockerode.ImageInspectInfo;
+
+    const internalContainerProvider: InternalContainerProvider & { api: Dockerode } = {
+      name: 'podman',
+      id: 'podman1',
+      api: {
+        getImage: vi.fn(),
+      } as unknown as Dockerode,
+      connection: {
+        type: 'podman',
+        name: 'podman',
+        displayName: 'podman',
+        endpoint: {
+          socketPath: '/endpoint1.sock',
+        },
+        status: () => 'started',
+      },
+    };
+    vi.mocked(internalContainerProvider.api.getImage).mockReturnValue(imageMock);
+    vi.mocked(imageMock.inspect).mockResolvedValue(imageInspectMock);
+    containerRegistry.addInternalProvider('podman1', internalContainerProvider);
+
+    // get the inspect
+    const image = await containerRegistry.getImageInspect('podman1', 'bar');
+    expect(image).toEqual(expect.objectContaining(imageInspectMock));
+    expect(image.engineType).toBe(internalContainerProvider.connection.type);
+
+    expect(internalContainerProvider.api.getImage).toHaveBeenCalledExactlyOnceWith('bar');
+    expect(imageMock.inspect).toHaveBeenCalledOnce();
+  });
+});
+
+describe('imageExist', () => {
+  test('should use ContainerRegistry#getImageInspect', async () => {
+    // mock error on getImageInspect
+    vi.spyOn(containerRegistry, 'getImageInspect').mockRejectedValue(new Error('does not exists'));
+
+    const exists = await containerRegistry.imageExist('foo', 'bar', 'fi');
+    expect(exists).toBeFalsy();
+  });
+
+  test('should match tag in RepoTags', async () => {
+    const imageInspectMock: ImageInspectInfo = {
+      RepoTags: ['localhost/foo:latest'],
+    } as unknown as ImageInspectInfo;
+
+    vi.spyOn(containerRegistry, 'getImageInspect').mockResolvedValue(imageInspectMock);
+
+    const exists = await containerRegistry.imageExist('foo', 'bar', 'localhost/foo:latest');
+    expect(exists).toBeTruthy();
   });
 });

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -41,7 +41,6 @@ import type {
   ImageLoadOptions,
   ImagesSaveOptions,
   LibPodPodInfo,
-  ListImagesOptions,
   ManifestCreateOptions,
   ManifestInspectInfo,
   ManifestPushOptions,
@@ -754,46 +753,6 @@ export class ContainerProviderRegistry {
     this.telemetryService.track('listContainers', { total: flattenedContainers.length, ...telemetryOptions });
 
     return flattenedContainers;
-  }
-
-  async listImages(options?: ListImagesOptions): Promise<ImageInfo[]> {
-    let telemetryOptions = {};
-
-    let providers: InternalContainerProvider[];
-    if (options?.provider === undefined) {
-      providers = Array.from(this.internalProviders.values());
-    } else {
-      providers = [this.getMatchingContainerProvider(options?.provider)];
-    }
-
-    const images = await Promise.all(
-      Array.from(providers).map(async provider => {
-        try {
-          if (!provider.api) {
-            return [];
-          }
-          const images = await provider.api.listImages({ all: false, digests: true });
-          return images.map(image => {
-            const imageInfo: ImageInfo = {
-              ...image,
-              engineName: provider.name,
-              engineId: provider.id,
-              engineType: provider.connection.type,
-              Digest: `sha256:${image.Id}`,
-            };
-            return imageInfo;
-          });
-        } catch (error) {
-          this.notifyConsole(`error in engine ${provider.name} ${error}`);
-          telemetryOptions = { error: error };
-          return [];
-        }
-      }),
-    );
-    const flattenedImages = images.flat();
-    this.telemetryService.track('listImages', { total: flattenedImages.length, ...telemetryOptions });
-
-    return flattenedImages;
   }
 
   // Podman list images will prefer to use libpod API of the provider
@@ -3013,9 +2972,12 @@ export class ContainerProviderRegistry {
   }
 
   async imageExist(id: string, engineId: string, tag: string): Promise<boolean> {
-    const images = await this.listImages();
-    const imageInfo = images.find(c => c.Id === id && c.engineId === engineId);
-    return imageInfo?.RepoTags?.some(repoTag => repoTag === tag) ?? false;
+    try {
+      const { RepoTags } = await this.getImageInspect(engineId, id);
+      return RepoTags?.some(repoTag => repoTag === tag) ?? false;
+    } catch (_: unknown) {
+      return false;
+    }
   }
 
   async volumeExist(name: string, engineId: string): Promise<boolean> {


### PR DESCRIPTION
### What does this PR do?

Pretty complex issue, we have two method for listing images in the container registry, but one is only used in a single place, and looking at the history we slowly stopped using it in favour of the `podmanListImage` (which is badly named, it is not only specific to podman).

But anyway; this method is only used in a single place, so removing it, so we clenaup some code.

To remove it, I update the logic of the `imageExist` to try to inspect instead of listing all images.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18332

Required for https://github.com/podman-desktop/podman-desktop/issues/17941

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
