### PR TITLE
refactor(container-registry): use Promise.withResolvers in pull image

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1416,12 +1416,8 @@ export class ContainerProviderRegistry {
         platform,
         abortSignal: abortController?.signal,
       });
-      let resolve: () => void;
-      let reject: (err: Error) => void;
-      const promise = new Promise<void>((res, rej) => {
-        resolve = res;
-        reject = rej;
-      });
+
+      const { resolve, reject, promise } = Promise.withResolvers<void>();
 
       const onFinished = (err: Error | null): void => {
         if (err) {


### PR DESCRIPTION
### What does this PR do?

Noticed wile reviewing https://github.com/podman-desktop/podman-desktop/pull/18337 that we had some old syntax prior to the existence of `Promise.withResolvers()`

Fixing it now as this is a one liner :rescue_worker_helmet: 

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18344

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
