### PR TITLE
chore: remove podman-desktop.io link from kubernetes empty page

### DIFF
--- a/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesEmptyPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import type { ProviderInfo } from '@podman-desktop/core-api';
-import { Button, Link } from '@podman-desktop/ui-svelte';
+import { Button } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
 
@@ -10,8 +10,6 @@ import EmbeddableCatalogExtensionList from '/@/lib/extensions/EmbeddableCatalogE
 import KubeIcon from '/@/lib/images/KubeIcon.svelte';
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import { providerInfos } from '/@/stores/providers';
-
-const kubernetesExternalDocs = 'https://podman-desktop.io/docs/kubernetes';
 
 async function createNew(provider: ProviderInfo): Promise<void> {
   await window.telemetryTrack('kubernetes.nocontext.createNew', {
@@ -88,9 +86,5 @@ async function ondetails(extensionId: string): Promise<void> {
       category="Kubernetes"
       keywords={['provider']}
       showInstalled={false} />
-
-    <div class="text-[var(--pd-details-empty-sub-header)] text-pretty">
-     Want to learn more about Kubernetes on Podman Desktop? <Link on:click={(): Promise<void> => window.openExternal(kubernetesExternalDocs)}>Check out our documentation.</Link>
-    </div>
   </div>
 </div>


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Removes the `podman-desktop.io` link from the empty kubernetes page in core. This way it will also be  removed downstream.
Since there is a plan to move to the Kubernetes dashboard extension at some point, we'll need to make any `podman-desktop.io` links there configurable https://github.com/podman-desktop/extension-kubernetes-dashboard/issues/1181

### Screenshot / video of UI
No link at the bottom of the page

<img width="1582" height="972" alt="Screenshot 2026-07-19 at 6 44 23 PM" src="https://github.com/user-attachments/assets/846dea2c-3d6e-4642-befa-f65db9b130b1" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/18098

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
