### PR TITLE
chore: add svg image support to convertImages

### DIFF
--- a/packages/main/src/util.spec.ts
+++ b/packages/main/src/util.spec.ts
@@ -50,6 +50,14 @@ test('getBase64Image - return base64 image', () => {
   expect(result).toBe('data:image/png;base64,aW1hZ2U=');
 });
 
+test('getBase64Image - return base64 image with svg mime type', () => {
+  vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+  vi.spyOn(fs, 'readFileSync').mockReturnValue('<svg></svg>');
+
+  const result = getBase64Image('icon.svg');
+  expect(result).toBe('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=');
+});
+
 describe('requireNonUndefined', () => {
   test('should return the value if it is defined', () => {
     const value = 'test';

--- a/packages/main/src/util.ts
+++ b/packages/main/src/util.ts
@@ -20,6 +20,7 @@ import { Buffer } from 'node:buffer';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import * as path from 'node:path';
 
 const windows = os.platform() === 'win32';
 export function isWindows(): boolean {
@@ -51,8 +52,9 @@ export function getBase64Image(imagePath: string): string | undefined {
       // convert to base64
       const base64Content = Buffer.from(imageContent).toString('base64');
 
-      // create base64 image content
-      return `data:image/png;base64,${base64Content}`;
+      const ext = path.extname(imagePath).toLowerCase();
+      const mimeType = ext === '.svg' ? 'svg+xml' : 'png';
+      return `data:image/${mimeType};base64,${base64Content}`;
     }
   } catch (error) {
     console.error(`Error while creating base64 image content for ${imagePath}`, error);


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Add svg support for icons provided by onboarding

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Related to SSO onboarding https://github.com/redhat-developer/podman-desktop-redhat-account-ext/pull/1237

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Try the SSO onboarding flow from the SSO extension -> `ghcr.io/soniasandler/podman-desktop-redhat-account-ext:next`
Ensure that the redhat logo and green check mark icons are visible in the flow

<img width="564" height="596" alt="Screenshot 2026-07-19 at 7 58 39 PM" src="https://github.com/user-attachments/assets/e5624c62-0c74-4948-b6e8-2f162be02ed1" />
<img width="559" height="590" alt="Screenshot 2026-07-19 at 7 58 01 PM" src="https://github.com/user-attachments/assets/9c9e152a-0619-46f3-a802-ba7970f993d1" />

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
