### PR TITLE
fix(ui): change incorrect/misleading proxy settings update dialog message + add test coverage

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -18,6 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { PROXY_CONFIG_KEYS, ProxyState } from '@podman-desktop/core-api';
 import { Dropdown } from '@podman-desktop/ui-svelte';
 import { fireEvent, render } from '@testing-library/svelte';
@@ -552,6 +553,124 @@ describe('manual proxy settings persistence', () => {
 
     await vi.waitFor(() => {
       expect(manualProxySettings.settings?.httpProxy).toBe('http://new-proxy:8080');
+    });
+  });
+});
+
+describe('proxy update message', () => {
+  function setupUpdateTest(providers: ProviderInfo[]): void {
+    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_MANUAL);
+    vi.mocked(window.getProxySettings).mockResolvedValue({ httpProxy: '', httpsProxy: '', noProxy: '' });
+    vi.mocked(window.setProxyState).mockResolvedValue(undefined);
+    vi.mocked(window.updateProxySettings).mockResolvedValue(undefined);
+    vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Dismiss' });
+    vi.mocked(window.getProviderInfos).mockResolvedValue(providers);
+  }
+
+  async function clickUpdate(getByRole: (role: string, options?: object) => HTMLElement): Promise<void> {
+    const updateBtn = getByRole('button', { name: 'Update' });
+    await fireEvent.click(updateBtn);
+  }
+
+  test('should show info message when no running connections', async () => {
+    setupUpdateTest([]);
+
+    const { getByRole } = render(PreferencesProxiesRendering);
+    await vi.waitFor(() => expect(window.getProxyState).toHaveBeenCalled());
+    await clickUpdate(getByRole);
+
+    await vi.waitFor(() => {
+      expect(window.showMessageBox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'info',
+          message: 'Proxy settings have been applied.',
+        }),
+      );
+    });
+  });
+
+  test('should warn about Podman machine restart for machine connections', async () => {
+    setupUpdateTest([
+      {
+        containerConnections: [{ status: 'started', vmType: { id: 'applehv', name: 'Apple HV' } }],
+      } as unknown as ProviderInfo,
+    ]);
+
+    const { getByRole } = render(PreferencesProxiesRendering);
+    await vi.waitFor(() => expect(window.getProxyState).toHaveBeenCalled());
+    await clickUpdate(getByRole);
+
+    await vi.waitFor(() => {
+      expect(window.showMessageBox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'warning',
+          message: expect.stringContaining('restart the Podman machine'),
+        }),
+      );
+    });
+  });
+
+  test('should warn about restarting containers for native connections', async () => {
+    setupUpdateTest([
+      {
+        containerConnections: [{ status: 'started', vmType: undefined }],
+      } as unknown as ProviderInfo,
+    ]);
+
+    const { getByRole } = render(PreferencesProxiesRendering);
+    await vi.waitFor(() => expect(window.getProxyState).toHaveBeenCalled());
+    await clickUpdate(getByRole);
+
+    await vi.waitFor(() => {
+      expect(window.showMessageBox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'warning',
+          message: expect.stringContaining('Running containers will need to be restarted'),
+        }),
+      );
+    });
+  });
+
+  test('should include both warnings when machine and native connections are running', async () => {
+    setupUpdateTest([
+      {
+        containerConnections: [
+          { status: 'started', vmType: { id: 'libkrun', name: 'LibKrun' } },
+          { status: 'started', vmType: undefined },
+        ],
+      } as unknown as ProviderInfo,
+    ]);
+
+    const { getByRole } = render(PreferencesProxiesRendering);
+    await vi.waitFor(() => expect(window.getProxyState).toHaveBeenCalled());
+    await clickUpdate(getByRole);
+
+    await vi.waitFor(() => {
+      const call = vi.mocked(window.showMessageBox).mock.calls[0]?.[0];
+      expect(call?.type).toBe('warning');
+      expect(call?.message).toContain('restart the Podman machine');
+      expect(call?.message).toContain('Running containers will need to be restarted');
+    });
+  });
+
+  test('should not warn for stopped connections', async () => {
+    setupUpdateTest([
+      {
+        containerConnections: [{ status: 'stopped', vmType: { id: 'applehv', name: 'Apple HV' } }],
+      } as unknown as ProviderInfo,
+    ]);
+
+    const { getByRole } = render(PreferencesProxiesRendering);
+    await vi.waitFor(() => expect(window.getProxyState).toHaveBeenCalled());
+    await clickUpdate(getByRole);
+
+    await vi.waitFor(() => {
+      expect(window.showMessageBox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'info',
+          message: 'Proxy settings have been applied.',
+        }),
+      );
     });
   });
 });

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.spec.ts
@@ -558,14 +558,9 @@ describe('manual proxy settings persistence', () => {
 });
 
 describe('proxy update message', () => {
-  function setupUpdateTest(providers: ProviderInfo[]): void {
-    vi.mocked(window.getProxyState).mockResolvedValue(ProxyState.PROXY_MANUAL);
-    vi.mocked(window.getProxySettings).mockResolvedValue({ httpProxy: '', httpsProxy: '', noProxy: '' });
-    vi.mocked(window.setProxyState).mockResolvedValue(undefined);
-    vi.mocked(window.updateProxySettings).mockResolvedValue(undefined);
+  beforeEach(() => {
     vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Dismiss' });
-    vi.mocked(window.getProviderInfos).mockResolvedValue(providers);
-  }
+  });
 
   async function clickUpdate(getByRole: (role: string, options?: object) => HTMLElement): Promise<void> {
     const updateBtn = getByRole('button', { name: 'Update' });
@@ -573,8 +568,6 @@ describe('proxy update message', () => {
   }
 
   test('should show info message when no running connections', async () => {
-    setupUpdateTest([]);
-
     const { getByRole } = render(PreferencesProxiesRendering);
     await vi.waitFor(() => expect(window.getProxyState).toHaveBeenCalled());
     await clickUpdate(getByRole);
@@ -590,7 +583,7 @@ describe('proxy update message', () => {
   });
 
   test('should warn about Podman machine restart for machine connections', async () => {
-    setupUpdateTest([
+    vi.mocked(window.getProviderInfos).mockResolvedValue([
       {
         containerConnections: [{ status: 'started', vmType: { id: 'applehv', name: 'Apple HV' } }],
       } as unknown as ProviderInfo,
@@ -611,7 +604,7 @@ describe('proxy update message', () => {
   });
 
   test('should warn about restarting containers for native connections', async () => {
-    setupUpdateTest([
+    vi.mocked(window.getProviderInfos).mockResolvedValue([
       {
         containerConnections: [{ status: 'started', vmType: undefined }],
       } as unknown as ProviderInfo,
@@ -632,7 +625,7 @@ describe('proxy update message', () => {
   });
 
   test('should include both warnings when machine and native connections are running', async () => {
-    setupUpdateTest([
+    vi.mocked(window.getProviderInfos).mockResolvedValue([
       {
         containerConnections: [
           { status: 'started', vmType: { id: 'libkrun', name: 'LibKrun' } },
@@ -654,7 +647,7 @@ describe('proxy update message', () => {
   });
 
   test('should not warn for stopped connections', async () => {
-    setupUpdateTest([
+    vi.mocked(window.getProviderInfos).mockResolvedValue([
       {
         containerConnections: [{ status: 'stopped', vmType: { id: 'applehv', name: 'Apple HV' } }],
       } as unknown as ProviderInfo,

--- a/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesProxiesRendering.svelte
@@ -92,15 +92,21 @@ async function updateProxySettings(): Promise<void> {
 
   // loop over all providers and container connections to see if there are any running engines
   const providerInfos = await window.getProviderInfos();
-  const runningProviders =
-    providerInfos.filter(p => p.containerConnections.filter(c => c.status !== 'stopped').length > 0).length > 0;
+  const runningConnections = providerInfos.flatMap(p => p.containerConnections.filter(c => c.status !== 'stopped'));
+  const hasMachineConnections = runningConnections.some(c => c.vmType);
+  const hasNativeConnections = runningConnections.some(c => !c.vmType);
 
   // show a simple message to confirm that the settings are applied,
   // or a longer warning if the user may need to take action
   let message = 'Proxy settings have been applied.';
   let type: DialogType = 'info';
-  if (runningProviders) {
-    message += ' You might need to restart running container engines for the changes to take effect.';
+  if (hasMachineConnections) {
+    message +=
+      ' You might need to restart the Podman machine for the changes to take effect. Running containers without a restart policy will need to be restarted manually after the machine restart.';
+    type = 'warning';
+  }
+  if (hasNativeConnections) {
+    message += ' Running containers will need to be restarted to pick up the new proxy settings.';
     type = 'warning';
   }
 


### PR DESCRIPTION
### What does this PR do?

Changes message that is shown in warning dialog after user updates proxy settings. Takes into account that there are  different provider (Podman, Docker,..) connections options - native / VM. The message will inform user what to do after the update, so running containers would pick up the change. 

If all connections are stopped, it does not add more details to the warning, only informs user that the proxy settings have been updated.

Added test coverage for all options (running providers x VM connections x native connections).

### Screenshot / video of UI
<img width="583" height="311" alt="Screenshot 2026-07-20 at 11 41 31" src="https://github.com/user-attachments/assets/47d8b1c7-d9cf-47b4-a5fb-ea891cdff13e" />

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/17883 

### How to test this PR?

Go to Settings -> select Proxy -> change the proxy configuration on Proxy Settings page -> click Update button -> see the warning message.

- [X] Tests are covering the bug fix or the new feature
