### PR TITLE
feat(extension-api): expose navigateToImageRun

### DIFF
--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5115,7 +5115,7 @@ declare module '@podman-desktop/api' {
      * const helloWorld = images.find(image => image.RepoTags?.find(tag => tag === 'quay.io/podman/hello:latest'));
      *
      * if(helloWorld) {
-     *   await navigation.navigateToImage(helloWorld.Id, helloWorld.engineId, helloWorld.RepoTags?.[0] ?? '<none>');
+     *   await navigation.navigateToImageRun(helloWorld.Id, helloWorld.engineId, helloWorld.RepoTags?.[0] ?? '<none>');
      * }
      * ```
      */

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5104,6 +5104,22 @@ declare module '@podman-desktop/api' {
     // Navigate to a specific image referenced by id, engineId and tag
     export function navigateToImage(id: string, engineId: string, tag: string): Promise<void>;
 
+    /**
+     * Navigate to the Image Run referenced by id, engineId and tag
+     *
+     * @example
+     * ```ts
+     * import { navigation, containerEngine } from '@podman-desktop/api';
+     *
+     * const images = await containerEngine.listImages();
+     * const helloWorld = images.find(image => image.RepoTags?.find(tag => tag === 'quay.io/podman/hello:latest'));
+     *
+     * if(helloWorld) {
+     *   await navigation.navigateToImage(helloWorld.Id, helloWorld.engineId, helloWorld.RepoTags?.[0] ?? '<none>');
+     * }
+     * ```
+     */
+    export function navigateToImageRun(id: string, engineId: string, tag: string): Promise<void>;
     // Navigate to the Volumes page
     export function navigateToVolumes(): Promise<void>;
     // Navigate to a specific volume

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -1737,6 +1737,24 @@ describe('Navigation', async () => {
     // Valid we listed the contains properly each time
     expect(imageExistSpy).toHaveBeenCalledOnce();
   });
+  test('navigateToImageRun', async () => {
+    vi.mocked(containerProviderRegistry.imageExist).mockResolvedValue(true);
+
+    const api = createApi();
+
+    // Spy send method
+    const sendMock = vi.spyOn(apiSender, 'send');
+
+    await api.navigation.navigateToImageRun('sha256:55', 'podman.Podman', 'localhost/squid:latest');
+    expect(sendMock).toBeCalledWith('navigate', {
+      page: NavigationPage.IMAGE_RUN,
+      parameters: {
+        id: 'sha256:55',
+        engineId: 'podman.Podman',
+        tag: 'localhost/squid:latest',
+      },
+    });
+  });
   test('navigateToVolumes', async () => {
     const api = createApi();
 

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1619,6 +1619,9 @@ export class ExtensionLoader implements IAsyncDisposable {
       navigateToImage: async (id: string, engineId: string, tag: string): Promise<void> => {
         await this.navigationManager.navigateToImage(id, engineId, tag);
       },
+      navigateToImageRun: async (id: string, engineId: string, tag: string): Promise<void> => {
+        await this.navigationManager.navigateToImageRun(id, engineId, tag);
+      },
       navigateToVolumes: async (): Promise<void> => {
         await this.navigationManager.navigateToVolumes();
       },

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -47,7 +47,9 @@ const apiSender: ApiSenderType = {
   receive: vi.fn(),
 };
 
-const containerRegistry = {} as unknown as ContainerProviderRegistry;
+const containerRegistry = {
+  imageExist: vi.fn(),
+} as unknown as ContainerProviderRegistry;
 
 const contributionManager = {
   listContributions: vi.fn(),
@@ -150,6 +152,35 @@ test('check navigateToImageBuild', async () => {
     parameters: {
       taskId: undefined,
     },
+  });
+});
+
+describe('navigateToImageRun', () => {
+  test('expect to thrown error if image does not exists', async () => {
+    vi.mocked(containerRegistry.imageExist).mockResolvedValue(false);
+
+    await expect(async () => {
+      await navigationManager.navigateToImageRun('sha256:55', 'podman.Podman', 'localhost/squid:latest');
+    }).rejects.toThrow(
+      `Image with id sha256:55, engine id podman.Podman and tag localhost/squid:latest cannot be found.`,
+    );
+
+    expect(apiSender.send).not.toHaveBeenCalled();
+  });
+
+  test('check navigateToImageRun', async () => {
+    vi.mocked(containerRegistry.imageExist).mockResolvedValue(true);
+
+    await navigationManager.navigateToImageRun('sha256:55', 'podman.Podman', 'localhost/squid:latest');
+
+    expect(apiSender.send).toHaveBeenCalledWith('navigate', {
+      page: NavigationPage.IMAGE_RUN,
+      parameters: {
+        id: 'sha256:55',
+        engineId: 'podman.Podman',
+        tag: 'localhost/squid:latest',
+      },
+    });
   });
 });
 

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -259,6 +259,19 @@ export class NavigationManager {
     });
   }
 
+  async navigateToImageRun(id: string, engineId: string, tag: string): Promise<void> {
+    await this.assertImageExist(id, engineId, tag);
+
+    this.navigateTo({
+      page: NavigationPage.IMAGE_RUN,
+      parameters: {
+        id: id,
+        engineId: engineId,
+        tag: tag,
+      },
+    });
+  }
+
   async assertVolumeExist(id: string, engineId: string): Promise<void> {
     if (!(await this.containerRegistry.volumeExist(id, engineId)))
       throw new Error(`Volume with id ${id} and engine id ${engineId} cannot be found.`);


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/18331 we can expose a consistent `navigateToImageRun` function in our extension-api, this will be useful for extension that want to directly open the Run page for a given image.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/17941

Require rebase after:
- https://github.com/podman-desktop/podman-desktop/pull/18333
- https://github.com/podman-desktop/podman-desktop/pull/18331
- https://github.com/podman-desktop/podman-desktop/pull/18309


### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

You can try to do it yourself from an extension

```ts
import { navigation, containerEngine } from '@podman-desktop/api';

setTimeout(() => {
  const images = await containerEngine.listImages();
  await navigation.navigateToImage(images[0].Id, images[0].engineId, images[0].RepoTags?.[0] ?? '<none>');
}, 20_000);
```
