### PR TITLE
fix(ui): set release notes image to full height of parent

### DIFF
--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.spec.ts
@@ -76,6 +76,24 @@ test('expect banner to be visible', async () => {
   expect(screen.getByRole('img')).toHaveAttribute('src', responseJSON.image);
 });
 
+test('expect image to fill full height of parent with object-cover scaling', async () => {
+  render(ReleaseNotesBox);
+
+  const image: HTMLImageElement = await vi.waitFor(() => {
+    const img = screen.getByRole('img', {
+      name: 'Podman Desktop 1.1.0 release image',
+    });
+    expect(img).toBeInTheDocument();
+    return img as HTMLImageElement;
+  });
+
+  expect(image.classList.contains('h-full')).toBe(true);
+  expect(image.classList.contains('object-cover')).toBe(true);
+  expect(image.classList.contains('max-w-[20%]')).toBe(true);
+  expect(image.classList.contains('object-contain')).toBe(false);
+  expect(image.classList.contains('self-start')).toBe(false);
+});
+
 test('expect image to be hidden if there is a loading error', async () => {
   const { getByRole, queryByRole } = render(ReleaseNotesBox);
 

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -66,7 +66,7 @@ onDestroy(async () => {
 
 {#if showBanner}
   {#if notesAvailable}
-    <div class="flex bg-[var(--pd-content-card-bg)] rounded-md flex-row flex-nowrap h-[200px] overflow-hidden">
+    <div class="flex bg-(--pd-content-card-bg) rounded-md flex-row flex-nowrap h-[200px] overflow-hidden">
       {#if notesInfo?.image && !imageError}
         <img
           src={notesInfo.image}
@@ -76,14 +76,14 @@ onDestroy(async () => {
       {/if}
       <div class="flex flex-col flex-1 h-full p-5">
         <div class="flex flex-row items-center justify-between">
-          <p class="text-[var(--pd-content-card-header-text)] font-bold text-xl ml-2">
+          <p class="text-(--pd-content-card-header-text) font-bold text-xl ml-2">
             {notesInfo?.title ?? ''}
           </p>
           <CloseButton onclick={onClose} />
         </div>
         {#if notesInfo?.summary}
           <div class="flex-1 min-h-0 overflow-hidden">
-            <div class="text-[var(--pd-content-card-text)] line-clamp-6 overflow-hidden text-ellipsis">
+            <div class="text-(--pd-content-card-text) line-clamp-6 overflow-hidden text-ellipsis">
               <Markdown markdown={notesInfo?.summary}/>
             </div>
           </div>
@@ -95,9 +95,9 @@ onDestroy(async () => {
       </div>
     </div>
   {:else if notesURL}
-    <div class="flex bg-[var(--pd-content-card-bg)] rounded-md p-5 flex-col flex-nowrap h-auto items-center">
+    <div class="flex bg-(--pd-content-card-bg) rounded-md p-5 flex-col flex-nowrap h-auto items-center">
       <div class="flex flex-row items-center justify-between w-full">
-        <p class="text-[var(--pd-content-card-header-text)] font-bold text-lg w-full items-center">
+        <p class="text-(--pd-content-card-header-text) font-bold text-lg w-full items-center">
           Release notes are currently unavailable, please check again later
           {#if notesURL}
             or try this <Link on:click={openReleaseNotes}>link</Link>

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -66,15 +66,15 @@ onDestroy(async () => {
 
 {#if showBanner}
   {#if notesAvailable}
-    <div class="flex bg-[var(--pd-content-card-bg)] rounded-md p-5 gap-3 flex-row flex-nowrap h-[200px] items-center">
+    <div class="flex bg-[var(--pd-content-card-bg)] rounded-md flex-row flex-nowrap h-[200px] overflow-hidden">
       {#if notesInfo?.image && !imageError}
         <img
           src={notesInfo.image}
           onerror={onImageError}
-          class="max-h-[100%] w-auto max-w-[20%] object-contain rounded-md self-start"
+          class="h-full max-w-[20%] object-cover rounded-l-md"
           alt={`Podman Desktop ${currentVersion} release image`} />
       {/if}
-      <div class="flex flex-col flex-1 h-100% self-start">
+      <div class="flex flex-col flex-1 h-full p-5">
         <div class="flex flex-row items-center justify-between">
           <p class="text-[var(--pd-content-card-header-text)] font-bold text-xl ml-2">
             {notesInfo?.title ?? ''}
@@ -82,12 +82,13 @@ onDestroy(async () => {
           <CloseButton onclick={onClose} />
         </div>
         {#if notesInfo?.summary}
-          <div
-            class="text-[var(--pd-content-card-text)] truncate text-ellipsis overflow-hidden whitespace-pre-line line-clamp-6">
-            <Markdown markdown={notesInfo?.summary}/>
+          <div class="flex-1 min-h-0 overflow-hidden">
+            <div class="text-[var(--pd-content-card-text)] line-clamp-6 overflow-hidden text-ellipsis">
+              <Markdown markdown={notesInfo?.summary}/>
+            </div>
           </div>
         {/if}
-        <div class="flex flex-row justify-end items-center gap-3 mt-2">
+        <div class="flex flex-row justify-end items-center gap-3 mt-auto">
           <Link on:click={openReleaseNotes}>Learn more</Link>
           <Button on:click={updatePodmanDesktop} hidden={!$updateAvailable} icon={faCircleArrowUp}>Update</Button>
         </div>

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -83,7 +83,7 @@ onDestroy(async () => {
         </div>
         {#if notesInfo?.summary}
           <div class="flex-1 min-h-0 overflow-hidden">
-            <div class="text-(--pd-content-card-text) line-clamp-6 overflow-hidden text-ellipsis">
+            <div class="text-(--pd-content-card-text) line-clamp-6">
               <Markdown markdown={notesInfo?.summary}/>
             </div>
           </div>

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -71,7 +71,7 @@ onDestroy(async () => {
         <img
           src={notesInfo.image}
           onerror={onImageError}
-          class="h-full max-w-[20%] object-cover rounded-l-md"
+          class="h-full max-w-[20%] object-cover"
           alt={`Podman Desktop ${currentVersion} release image`} />
       {/if}
       <div class="flex flex-col flex-1 h-full p-5">

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -74,7 +74,7 @@ onDestroy(async () => {
           class="h-full max-w-[20%] object-cover"
           alt={`Podman Desktop ${currentVersion} release image`} />
       {/if}
-      <div class="flex flex-col flex-1 h-full p-5">
+      <div class="flex flex-col flex-1 h-100% self-start p-5">
         <div class="flex flex-row items-center justify-between">
           <p class="text-[var(--pd-content-card-header-text)] font-bold text-xl ml-2">
             {notesInfo?.title ?? ''}

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -87,7 +87,7 @@ onDestroy(async () => {
             <Markdown markdown={notesInfo?.summary}/>
           </div>
         {/if}
-        <div class="flex flex-row justify-end items-center gap-3 mt-auto">
+        <div class="flex flex-row justify-end items-center gap-3 mt-2">
           <Link on:click={openReleaseNotes}>Learn more</Link>
           <Button on:click={updatePodmanDesktop} hidden={!$updateAvailable} icon={faCircleArrowUp}>Update</Button>
         </div>

--- a/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
+++ b/packages/renderer/src/lib/dashboard/ReleaseNotesBox.svelte
@@ -66,7 +66,7 @@ onDestroy(async () => {
 
 {#if showBanner}
   {#if notesAvailable}
-    <div class="flex bg-(--pd-content-card-bg) rounded-md flex-row flex-nowrap h-[200px] overflow-hidden">
+    <div class="flex bg-[var(--pd-content-card-bg)] rounded-md gap-3 flex-row flex-nowrap h-[200px] items-center overflow-hidden">
       {#if notesInfo?.image && !imageError}
         <img
           src={notesInfo.image}
@@ -76,16 +76,15 @@ onDestroy(async () => {
       {/if}
       <div class="flex flex-col flex-1 h-full p-5">
         <div class="flex flex-row items-center justify-between">
-          <p class="text-(--pd-content-card-header-text) font-bold text-xl ml-2">
+          <p class="text-[var(--pd-content-card-header-text)] font-bold text-xl ml-2">
             {notesInfo?.title ?? ''}
           </p>
           <CloseButton onclick={onClose} />
         </div>
         {#if notesInfo?.summary}
-          <div class="flex-1 min-h-0 overflow-hidden">
-            <div class="text-(--pd-content-card-text) line-clamp-6">
-              <Markdown markdown={notesInfo?.summary}/>
-            </div>
+          <div
+            class="text-[var(--pd-content-card-text)] truncate text-ellipsis overflow-hidden whitespace-pre-line line-clamp-6">
+            <Markdown markdown={notesInfo?.summary}/>
           </div>
         {/if}
         <div class="flex flex-row justify-end items-center gap-3 mt-auto">
@@ -95,9 +94,9 @@ onDestroy(async () => {
       </div>
     </div>
   {:else if notesURL}
-    <div class="flex bg-(--pd-content-card-bg) rounded-md p-5 flex-col flex-nowrap h-auto items-center">
+    <div class="flex bg-[var(--pd-content-card-bg)] rounded-md p-5 flex-col flex-nowrap h-auto items-center">
       <div class="flex flex-row items-center justify-between w-full">
-        <p class="text-(--pd-content-card-header-text) font-bold text-lg w-full items-center">
+        <p class="text-[var(--pd-content-card-header-text)] font-bold text-lg w-full items-center">
           Release notes are currently unavailable, please check again later
           {#if notesURL}
             or try this <Link on:click={openReleaseNotes}>link</Link>


### PR DESCRIPTION
### What does this PR do?
Changes how the image in Release Notes is displayed and scaled.

### Screenshot / video of UI

https://github.com/user-attachments/assets/5f839311-1bc3-489a-8035-68ced7a98400

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/17850

### How to test this PR?
Go to Dashboard and then see the Release Notes (image) while you change/scale the window's width.

- [ ] Tests are covering the bug fix or the new feature
