### PR TITLE
feat(ci): add e2e-prerelease workflow and release_tag for report-portal

### DIFF
--- a/.github/workflows/e2e-main-tf.yaml
+++ b/.github/workflows/e2e-main-tf.yaml
@@ -16,6 +16,11 @@
 
 name: PD E2E Testing Farm
 
+run-name: >-
+  ${{ inputs.release_tag
+      && format('PD E2E Testing Farm [{0}]', inputs.release_tag)
+      || '' }}
+
 on:
   schedule:
     - cron:  '0 0 * * *'
@@ -35,6 +40,11 @@ on:
         default: 'main'
         description: 'Podman Desktop repo branch'
         type: string
+        required: false
+      release_tag:
+        description: 'Tag to identify this run for report-portal'
+        type: string
+        default: ''
         required: false
 
 permissions:

--- a/.github/workflows/e2e-main-tf.yaml
+++ b/.github/workflows/e2e-main-tf.yaml
@@ -19,7 +19,7 @@ name: PD E2E Testing Farm
 run-name: >-
   ${{ inputs.release_tag
       && format('PD E2E Testing Farm [{0}]', inputs.release_tag)
-      || '' }}
+      || github.workflow }}
 
 on:
   schedule:

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -17,6 +17,11 @@
 
 name: e2e-tests-main
 
+run-name: >-
+  ${{ inputs.release_tag
+      && format('e2e-tests-main [{0}]', inputs.release_tag)
+      || '' }}
+
 on:
   push:
     branches: [main]
@@ -74,6 +79,11 @@ on:
         - 'true'
         - 'false'
         default: 'true'
+        required: false
+      release_tag:
+        description: 'Tag to identify this run for report-portal'
+        type: string
+        default: ''
         required: false
 
 permissions:

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -20,7 +20,7 @@ name: e2e-tests-main
 run-name: >-
   ${{ inputs.release_tag
       && format('e2e-tests-main [{0}]', inputs.release_tag)
-      || '' }}
+      || github.workflow }}
 
 on:
   push:

--- a/.github/workflows/e2e-prerelease.yaml
+++ b/.github/workflows/e2e-prerelease.yaml
@@ -35,13 +35,14 @@ jobs:
       - name: Trigger e2e-tests-main with all targets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REF: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
           gh workflow run e2e-main.yaml \
             --repo ${{ github.repository }} \
             -f organization=podman-desktop \
             -f repositoryName=podman-desktop \
             -f npm_target=test:e2e:all \
-            -f branch=${{ github.event.release.name || github.ref_name }} \
+            -f branch="$TARGET_REF" \
             -f release_tag=release
 
   trigger-testing-farm:
@@ -50,13 +51,15 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.release.name || github.ref_name }}
+          ref: ${{ github.event.release.tag_name || github.ref_name }}
+          persist-credentials: false
           sparse-checkout: extensions/podman/packages/extension/src
           sparse-checkout-cone-mode: false
 
       - name: Read bundled Podman version and trigger Testing Farm
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REF: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
           PODMAN_VERSION=$(jq -r '.version' extensions/podman/packages/extension/src/podman*.json)
           echo "Podman version from JSON: $PODMAN_VERSION"
@@ -65,6 +68,7 @@ jobs:
             --repo ${{ github.repository }} \
             -f podman_version="$PODMAN_VERSION" \
             -f npm_target=all \
+            -f branch="$TARGET_REF" \
             -f release_tag=release
 
   trigger-managed-configuration:
@@ -74,8 +78,9 @@ jobs:
       - name: Trigger managed configuration tests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REF: ${{ github.event.release.tag_name || github.ref_name }}
         run: |
           gh workflow run managed-configuration.yaml \
             --repo ${{ github.repository }} \
-            --ref ${{ github.event.release.name || github.ref_name }} \
+            --ref "$TARGET_REF" \
             -f release_tag=release

--- a/.github/workflows/e2e-prerelease.yaml
+++ b/.github/workflows/e2e-prerelease.yaml
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: e2e-tests-prerelease
+
+on:
+  release:
+    types: [prereleased]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  trigger-e2e:
+    name: Trigger E2E tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger e2e-tests-main with all targets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run e2e-main.yaml \
+            --repo ${{ github.repository }} \
+            -f organization=podman-desktop \
+            -f repositoryName=podman-desktop \
+            -f npm_target=test:e2e:all \
+            -f branch=${{ github.event.release.name || github.ref_name }} \
+            -f release_tag=release
+
+  trigger-testing-farm:
+    name: Trigger Testing Farm E2E tests
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.release.name || github.ref_name }}
+          sparse-checkout: extensions/podman/packages/extension/src
+          sparse-checkout-cone-mode: false
+
+      - name: Read bundled Podman version and trigger Testing Farm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PODMAN_VERSION=$(jq -r '.version' extensions/podman/packages/extension/src/podman*.json)
+          echo "Podman version from JSON: $PODMAN_VERSION"
+
+          gh workflow run e2e-main-tf.yaml \
+            --repo ${{ github.repository }} \
+            -f podman_version="$PODMAN_VERSION" \
+            -f npm_target=all \
+            -f release_tag=release
+
+  trigger-managed-configuration:
+    name: Trigger managed configuration tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger managed configuration tests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run managed-configuration.yaml \
+            --repo ${{ github.repository }} \
+            --ref ${{ github.event.release.name || github.ref_name }} \
+            -f release_tag=release

--- a/.github/workflows/managed-configuration.yaml
+++ b/.github/workflows/managed-configuration.yaml
@@ -1,7 +1,18 @@
 name: Managed configuration tests
 
+run-name: >-
+  ${{ inputs.release_tag
+      && format('Managed configuration tests [{0}]', inputs.release_tag)
+      || '' }}
+
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag to identify this run for report-portal'
+        type: string
+        default: ''
+        required: false
   push:
     branches: [ main ]
 

--- a/.github/workflows/managed-configuration.yaml
+++ b/.github/workflows/managed-configuration.yaml
@@ -3,7 +3,7 @@ name: Managed configuration tests
 run-name: >-
   ${{ inputs.release_tag
       && format('Managed configuration tests [{0}]', inputs.release_tag)
-      || '' }}
+      || github.workflow }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### What does this PR do?
Add a new workflow that triggers E2E tests on pre-release publish
should be merged after: https://github.com/podman-desktop/podman-desktop/pull/18396

### What issues does this PR fix or reference?
https://github.com/containers/podman-desktop-internal/issues/1029

### How to test this PR?
Tested in my fork: https://github.com/amisskii/podman-desktop/actions/runs/29811171358