### PR TITLE
refactor(container-registry): remove unnecessary podman prefix

### DIFF
--- a/packages/api/src/image-info.ts
+++ b/packages/api/src/image-info.ts
@@ -193,7 +193,7 @@ export interface BuildImageOptions {
   validateRegistries?: boolean;
 }
 
-export interface PodmanListImagesOptions {
+export interface ListImagesOptions {
   /**
    * Show all images. By default all images from a final layer (no children) are shown.
    * @defaultValue false

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4844,7 +4844,7 @@ describe('getContainerCreateMountOptionFromBind', () => {
   });
 });
 
-test('list images with podmanListImages correctly', async () => {
+test('list images with listImages correctly', async () => {
   const imagesList = [
     {
       Id: 'dummyImageId',

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -4867,7 +4867,7 @@ test('list images with podmanListImages correctly', async () => {
     },
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
   // ensure the field are correct
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
@@ -4901,7 +4901,7 @@ test('expect images with podmanListImages to also include History as well as eng
     },
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
   // ensure the field are correct
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
@@ -4935,7 +4935,7 @@ test('expect images with podmanListImages to also include Digest as engineId and
     },
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
   // ensure the field are correct
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
@@ -4970,7 +4970,7 @@ test('If image does not have Digest in list images, expect the Digest to be sha2
     },
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
 
   // ensure the field are correct
   expect(images).toBeDefined();
@@ -5012,7 +5012,7 @@ test('expect to fall back to compat api images if podman provider does not have 
     // purposely NOT have libpodApi
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
   // ensure the field are correct
   expect(images).toBeDefined();
   expect(images).toHaveLength(1);
@@ -5036,7 +5036,7 @@ test('pass options to compat api when using podmanListImages', async () => {
     },
   } as unknown as InternalContainerProvider);
 
-  await containerRegistry.podmanListImages({ all: true, filters: '{"dangling":["false"]}' });
+  await containerRegistry.listImages({ all: true, filters: '{"dangling":["false"]}' });
 
   expect(vi.mocked(listImagesSpy)).toHaveBeenCalledWith({
     all: true,
@@ -5055,7 +5055,7 @@ test('expect a blank array if there is no api or libpod API when doing podmanLis
     // purposely NOT have api or libpodApi
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
   // ensure the field are correct
   expect(images).toBeDefined();
   expect(images).toHaveLength(0);
@@ -5071,7 +5071,7 @@ test('expect to get get zero images if podman provider has neither libpod API no
     // purposely NOT have libpod API or compat api
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
   // ensure the field are correct
   expect(images).toBeDefined();
   expect(images).toHaveLength(0);
@@ -5123,7 +5123,7 @@ test('expect podmanListImages to return images from working providers even if on
     },
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
 
   // Should return images from working provider despite the error
   expect(images).toBeDefined();
@@ -5738,7 +5738,7 @@ test('manifest is listed as true with podmanListImages correctly', async () => {
     },
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
   // ensure the field are correct
   expect(images).toBeDefined();
   expect(images).toHaveLength(4);
@@ -5803,7 +5803,7 @@ test('if configuration setting is disabled for using libpodApi, it should fall b
     },
   } as unknown as InternalContainerProvider);
 
-  const images = await containerRegistry.podmanListImages();
+  const images = await containerRegistry.listImages();
 
   // ensure the field are correct
   expect(images).toBeDefined();

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -41,6 +41,7 @@ import type {
   ImageLoadOptions,
   ImagesSaveOptions,
   LibPodPodInfo,
+  ListImagesOptions,
   ManifestCreateOptions,
   ManifestInspectInfo,
   ManifestPushOptions,
@@ -50,7 +51,6 @@ import type {
   PodCreateOptions,
   PodInfo,
   PodInspectInfo,
-  PodmanListImagesOptions,
   ProviderContainerConnectionInfo,
   PullEvent,
   SecretCreateOptions,
@@ -757,7 +757,7 @@ export class ContainerProviderRegistry {
 
   // Podman list images will prefer to use libpod API of the provider
   // before falling back to using the regular API
-  async podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]> {
+  async listImages(options?: ListImagesOptions): Promise<ImageInfo[]> {
     // Get timeout from configuration
     const timeoutSeconds = this.configurationRegistry
       .getConfiguration(ContainerRegistrySettings.SectionName)

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -755,7 +755,7 @@ export class ContainerProviderRegistry {
     return flattenedContainers;
   }
 
-  // Podman list images will prefer to use libpod API of the provider
+  // list images will prefer to use libpod API of the provider if podman
   // before falling back to using the regular API
   async listImages(options?: ListImagesOptions): Promise<ImageInfo[]> {
     // Get timeout from configuration

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -23,7 +23,7 @@ import type { RequestOptions } from 'node:http';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import type { PodmanListImagesOptions } from '@podman-desktop/core-api';
+import type { ListImagesOptions } from '@podman-desktop/core-api';
 import type { PlayKubeInfo } from '@podman-desktop/core-api/libpod';
 import type DockerModem from 'docker-modem';
 import Dockerode from 'dockerode';
@@ -96,7 +96,7 @@ test('Check list of images using Podman API', async () => {
   server.listen({ onUnhandledRequest: 'error' });
 
   const api = new Dockerode({ protocol: 'http', host: 'localhost' });
-  const listOfImages = await (api as unknown as LibPod).podmanListImages({} as PodmanListImagesOptions);
+  const listOfImages = await (api as unknown as LibPod).podmanListImages({} as ListImagesOptions);
   expect(listOfImages.length).toBe(1);
   const firstImage = listOfImages[0];
   expect(firstImage?.Id).toBe('sha256:1234567890');

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -19,7 +19,7 @@
 import type { RequestOptions } from 'node:http';
 
 import type { ManifestCreateOptions, ManifestInspectInfo, ManifestPushOptions } from '@podman-desktop/api';
-import type { ImageInfo, LibPodPodInfo, LibPodPodInspectInfo, PodmanListImagesOptions } from '@podman-desktop/core-api';
+import type { ImageInfo, LibPodPodInfo, LibPodPodInspectInfo, ListImagesOptions } from '@podman-desktop/core-api';
 import type { ContainerCreateOptions, PlayKubeInfo, PodCreatePortOptions } from '@podman-desktop/core-api/libpod';
 import type DockerModem from 'docker-modem';
 import type { DialOptions } from 'docker-modem';
@@ -251,7 +251,7 @@ export interface LibPod {
   pruneAllImages(dangling: boolean): Promise<void>;
   podmanInfo(): Promise<Info>;
   getImages(options: GetImagesOptions): Promise<NodeJS.ReadableStream>;
-  podmanListImages(options?: PodmanListImagesOptions): Promise<ImageInfo[]>;
+  podmanListImages(options?: ListImagesOptions): Promise<ImageInfo[]>;
   podmanCreateManifest(manifestOptions: ManifestCreateOptions): Promise<{ engineId: string; Id: string }>;
   podmanInspectManifest(manifestName: string): Promise<ManifestInspectInfo>;
   podmanPushManifest(manifestOptions: ManifestPushOptions, authInfo?: Dockerode.AuthConfig): Promise<void>;
@@ -344,7 +344,7 @@ export class LibpodDockerode {
     };
 
     // add listImages
-    prototypeOfDockerode.podmanListImages = function (options?: PodmanListImagesOptions): Promise<ImageInfo[]> {
+    prototypeOfDockerode.podmanListImages = function (options?: ListImagesOptions): Promise<ImageInfo[]> {
       const optsf = {
         path: '/v4.2.0/libpod/images/json',
         method: 'GET',

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -2433,7 +2433,7 @@ describe('containerEngine', async () => {
   });
 
   test('listImages without option ', async () => {
-    vi.mocked(containerProviderRegistry.podmanListImages).mockResolvedValue([]);
+    vi.mocked(containerProviderRegistry.listImages).mockResolvedValue([]);
 
     const api = createApi();
 
@@ -2441,11 +2441,11 @@ describe('containerEngine', async () => {
 
     const images = await api.containerEngine.listImages();
     expect(images.length).toBe(0);
-    expect(containerProviderRegistry.podmanListImages).toHaveBeenCalledWith(undefined);
+    expect(containerProviderRegistry.listImages).toHaveBeenCalledWith(undefined);
   });
 
   test('listImages with provider option', async () => {
-    vi.mocked(containerProviderRegistry.podmanListImages).mockResolvedValue([]);
+    vi.mocked(containerProviderRegistry.listImages).mockResolvedValue([]);
     const api = createApi();
 
     expect(api).toBeDefined();
@@ -2454,7 +2454,7 @@ describe('containerEngine', async () => {
       provider: CONTAINER_PROVIDER_MOCK,
     });
     expect(images.length).toBe(0);
-    expect(containerProviderRegistry.podmanListImages).toHaveBeenCalledWith({
+    expect(containerProviderRegistry.listImages).toHaveBeenCalledWith({
       provider: CONTAINER_PROVIDER_MOCK,
     });
   });

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1313,7 +1313,7 @@ export class ExtensionLoader implements IAsyncDisposable {
         );
       },
       listImages(options?: containerDesktopAPI.ListImagesOptions): Promise<containerDesktopAPI.ImageInfo[]> {
-        return containerProviderRegistry.podmanListImages(options);
+        return containerProviderRegistry.listImages(options);
       },
       saveImage(engineId: string, id: string, filename: string, token?: containerDesktopAPI.CancellationToken) {
         return containerProviderRegistry.saveImage(engineId, id, filename, token);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -916,7 +916,7 @@ export class PluginSystem {
     this.ipcHandle(
       'container-provider-registry:listImages',
       async (_listener, options?: ListImagesOptions): Promise<ImageInfo[]> => {
-        return containerProviderRegistry.podmanListImages(options);
+        return containerProviderRegistry.listImages(options);
       },
     );
     this.ipcHandle('container-provider-registry:listPods', async (): Promise<PodInfo[]> => {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -83,6 +83,7 @@ import type {
   KubeContext,
   KubernetesContextResources,
   KubernetesTroubleshootingInformation,
+  ListImagesOptions,
   ListOrganizerItem,
   LogType,
   ManifestCreateOptions,
@@ -100,7 +101,6 @@ import type {
   OnboardingStatus,
   PodInfo,
   PodInspectInfo,
-  PodmanListImagesOptions,
   PreflightCheckEvent,
   PreflightChecksCallback,
   ProviderConnectionInfo,
@@ -915,7 +915,7 @@ export class PluginSystem {
     });
     this.ipcHandle(
       'container-provider-registry:listImages',
-      async (_listener, options?: PodmanListImagesOptions): Promise<ImageInfo[]> => {
+      async (_listener, options?: ListImagesOptions): Promise<ImageInfo[]> => {
         return containerProviderRegistry.podmanListImages(options);
       },
     );

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -85,6 +85,7 @@ import type {
   KubeContext,
   KubernetesContextResources,
   KubernetesTroubleshootingInformation,
+  ListImagesOptions,
   ListOrganizerItem,
   LogType,
   ManifestCreateOptions,
@@ -104,7 +105,6 @@ import type {
   PodCreateOptions,
   PodInfo,
   PodInspectInfo,
-  PodmanListImagesOptions,
   PreflightCheckEvent,
   PreflightChecksCallback,
   ProviderConnectionInfo,
@@ -311,7 +311,7 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld('listImages', async (options?: PodmanListImagesOptions): Promise<ImageInfo[]> => {
+  contextBridge.exposeInMainWorld('listImages', async (options?: ListImagesOptions): Promise<ImageInfo[]> => {
     return ipcInvoke('container-provider-registry:listImages', options);
   });
 


### PR DESCRIPTION
### What does this PR do?

Following https://github.com/podman-desktop/podman-desktop/pull/18333 we can now safely rename without conflict the `podmanListImages` to `listImages`, this better reflect the real logic of the function, as this function has a fallback to use the compatibility API if libpod is not available.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18343

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Existing tests ensure no regression
