### PR TITLE
fix: use sentence case for secret and network titles

### DIFF
--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -280,7 +280,7 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
           <Route path="/" breadcrumb="Networks" navigationHint="root">
             <NetworksList />
           </Route>
-          <Route path="/create/*" breadcrumb="Create Network">
+          <Route path="/create/*" breadcrumb="Create a network">
             <CreateNetwork />
           </Route>
           <Route path="/:name/:engineId/*" breadcrumb="Network Details" let:meta navigationHint="details">

--- a/packages/renderer/src/App.svelte
+++ b/packages/renderer/src/App.svelte
@@ -333,7 +333,7 @@ tablePersistence.storage = new PodmanDesktopStoragePersist();
           <Route path="/" breadcrumb="Secrets" navigationHint="root">
             <SecretsList />
           </Route>
-          <Route path="/create" breadcrumb="Create a Secret">
+          <Route path="/create" breadcrumb="Create a secret">
             <SecretCreate />
           </Route>
           <Route path="/:engineId/:secretId/*" breadcrumb="Secret Details" let:meta navigationHint="details">

--- a/packages/renderer/src/lib/network/CreateNetwork.svelte
+++ b/packages/renderer/src/lib/network/CreateNetwork.svelte
@@ -202,7 +202,7 @@ function removeDnsServer(index: number): void {
 
 <Route path="/*">
   <EngineFormPage
-    title="Create a Network"
+    title="Create a network"
     showEmptyScreen={providerConnections.length === 0 && !createNetworkInProgress}>
     {#snippet icon()}
       <Icon icon={NetworkIcon} class="2x" />

--- a/packages/renderer/src/lib/secrets/SecretCreate.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretCreate.spec.ts
@@ -56,6 +56,8 @@ test('Expect create secret to call API and navigate back', async () => {
 
   const { getByPlaceholderText, getByRole } = render(SecretCreate);
 
+  expect(getByRole('heading', { name: 'Create a secret' })).toBeInTheDocument();
+
   await fireEvent.input(getByPlaceholderText('Secret name'), { target: { value: 'my-secret' } });
   await fireEvent.input(getByPlaceholderText('Secret data'), { target: { value: 'my-secret-data' } });
 

--- a/packages/renderer/src/lib/secrets/SecretCreate.svelte
+++ b/packages/renderer/src/lib/secrets/SecretCreate.svelte
@@ -61,7 +61,7 @@ function close(): void {
 }
 </script>
 
-<EngineFormPage title="Create a Secret" showEmptyScreen={providerConnections.length === 0}>
+<EngineFormPage title="Create a secret" showEmptyScreen={providerConnections.length === 0}>
   {#snippet icon()}
     <Icon icon={SecretIcon} size={27} />
   {/snippet}


### PR DESCRIPTION
### What does this PR do?

Uses sentence case for the secret and network creation page titles and breadcrumbs. The network wording was added for consistency following the discussion on #18398.

### Screenshot / video of UI

N/A — these are text-only capitalization changes shown and discussed in the linked issue.

### What issues does this PR fix or reference?

Fixes #18398

### How to test this PR?

- Run `pnpm exec vitest --run --project=renderer packages/renderer/src/lib/secrets/SecretCreate.spec.ts packages/renderer/src/lib/network/CreateNetwork.spec.ts --passWithNoTests`.
- Run `pnpm exec eslint packages/renderer/src/App.svelte packages/renderer/src/lib/secrets/SecretCreate.svelte packages/renderer/src/lib/secrets/SecretCreate.spec.ts packages/renderer/src/lib/network/CreateNetwork.svelte`.
- Run `pnpm --dir packages/renderer check`.

- [x] Tests are covering the bug fix or the new feature
