### PR TITLE
test(e2e): filter catalog extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "test:e2e:pdmachine:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @pdmachine",
     "test:e2e:experimental": "pnpm run test:e2e:build && pnpm run test:e2e:experimental:run",
     "test:e2e:experimental:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/  -g @experimental",
+    "test:e2e:extensionscatalog": "pnpm run test:e2e:build && pnpm run test:e2e:extensionscatalog:run",
+    "test:e2e:extensionscatalog:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/extension-catalog-smoke.spec.ts",
     "test:e2e:extension": "pnpm run test:e2e:build && pnpm run test:e2e:extension:run",
     "test:e2e:extension:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/extension-installation-smoke.spec.ts",
     "test:e2e:remote": "pnpm run test:e2e:build && pnpm run test:e2e:remote:run",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
     "test:e2e:pdmachine:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @pdmachine",
     "test:e2e:experimental": "pnpm run test:e2e:build && pnpm run test:e2e:experimental:run",
     "test:e2e:experimental:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/  -g @experimental",
-    "test:e2e:extensionscatalog": "pnpm run test:e2e:build && pnpm run test:e2e:extensionscatalog:run",
-    "test:e2e:extensionscatalog:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/extension-catalog-smoke.spec.ts",
     "test:e2e:extension": "pnpm run test:e2e:build && pnpm run test:e2e:extension:run",
     "test:e2e:extension:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/extension-installation-smoke.spec.ts",
     "test:e2e:remote": "pnpm run test:e2e:build && pnpm run test:e2e:remote:run",

--- a/tests/playwright/src/model/pages/extension-catalog-card-page.ts
+++ b/tests/playwright/src/model/pages/extension-catalog-card-page.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,11 @@ export class ExtensionCatalogCardPage extends BasePage {
   readonly downloadButton: Locator;
   readonly alreadyInstalledText: Locator;
 
-  constructor(page: Page, extensionName: string) {
+  constructor(page: Page, extensionName: string, container?: Locator) {
     super(page);
     this.extensionName = extensionName;
-    this.parent = this.page.getByRole('group', { name: this.extensionName });
+    const root = container ?? this.page;
+    this.parent = root.getByRole('group', { name: this.extensionName });
     this.detailsButton = this.parent.getByRole('button', {
       name: 'More details',
     });

--- a/tests/playwright/src/model/pages/extension-catalog-card-page.ts
+++ b/tests/playwright/src/model/pages/extension-catalog-card-page.ts
@@ -29,11 +29,10 @@ export class ExtensionCatalogCardPage extends BasePage {
   readonly downloadButton: Locator;
   readonly alreadyInstalledText: Locator;
 
-  constructor(page: Page, extensionName: string, container?: Locator) {
+  constructor(page: Page, extensionName: string) {
     super(page);
     this.extensionName = extensionName;
-    const root = container ?? this.page;
-    this.parent = root.getByRole('group', { name: this.extensionName });
+    this.parent = this.page.getByRole('group', { name: this.extensionName });
     this.detailsButton = this.parent.getByRole('button', {
       name: 'More details',
     });

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -103,7 +103,6 @@ export class ExtensionsPage extends MainPage{
 
   public async getCatalogExtension(extensionName: string, timeout = 10_000): Promise<ExtensionCatalogCardPage> {
     return test.step(`Get catalog extension: ${extensionName}`, async () => {
-      await this.openCatalogTab();
       const extensionCard = new ExtensionCatalogCardPage(this.page, extensionName, this.catalogExtensions);
       await playExpect(extensionCard.parent).toBeVisible({ timeout });
       return extensionCard;

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2025 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
 import { ExtensionCardPage } from './extension-card-page';
+import { ExtensionCatalogCardPage } from './extension-catalog-card-page';
 import type { ExtensionDetailsPage } from './extension-details-page';
 
 export class ExtensionsPage {
@@ -27,8 +28,11 @@ export class ExtensionsPage {
   readonly heading: Locator;
   readonly header: Locator;
   readonly search: Locator;
+  readonly searchInput: Locator;
+  readonly search: Locator;
   readonly content: Locator;
   readonly additionalActions: Locator;
+  readonly catalogExtensions: Locator;
   readonly installedTab: Locator;
   readonly catalogTab: Locator;
   readonly localExtensionsTab: Locator;
@@ -39,11 +43,14 @@ export class ExtensionsPage {
     this.page = page;
     this.header = page.getByRole('region', { name: 'header' });
     this.search = page.getByRole('region', { name: 'search' });
+    this.searchInput = this.search.getByLabel('search extensions');
+    this.search = page.getByRole('region', { name: 'search' });
     this.content = page.getByRole('region', { name: 'content' });
     this.heading = this.header.getByRole('heading', { name: 'extensions' });
     this.additionalActions = this.header.getByRole('group', {
       name: 'additionalActions',
     });
+    this.catalogExtensions = this.content.getByRole('region', { name: 'Catalog Extensions' });
     this.installedTab = this.page.getByRole('button', { name: 'Installed' });
     this.catalogTab = this.page.getByRole('button', { name: 'Catalog', exact: true });
     this.localExtensionsTab = this.page.getByRole('button', { name: 'Local Extensions' });
@@ -95,7 +102,36 @@ export class ExtensionsPage {
   }
 
   public async openCatalogTab(): Promise<void> {
-    await this.catalogTab.click();
+    return test.step('Open Catalog tab', async () => {
+      await playExpect(this.catalogTab).toBeVisible({ timeout: 10_000 });
+      await this.catalogTab.click();
+    });
+  }
+
+  public async filterByName(name: string): Promise<void> {
+    return test.step(`Filter extensions by name: ${name}`, async () => {
+      await playExpect(this.searchInput).toBeVisible();
+      await this.searchInput.fill(name);
+      await playExpect(this.searchInput).toHaveValue(name);
+    });
+  }
+
+  public async clearFilterByName(): Promise<void> {
+    return test.step('Clear extensions name filter', async () => {
+      await playExpect(this.searchInput).toBeVisible();
+      await this.searchInput.clear();
+      await playExpect(this.searchInput).toHaveValue('');
+    });
+  }
+
+  public getCatalogExtension(extensionName: string): ExtensionCatalogCardPage {
+    return new ExtensionCatalogCardPage(this.page, extensionName);
+  }
+
+  public async countCatalogExtensions(): Promise<number> {
+    return test.step('Count catalog extension cards', async () => {
+      return await this.catalogExtensions.getByRole('group').count();
+    });
   }
 
   public async openExtensionDetails(name: string, label: string, heading: string): Promise<ExtensionDetailsPage> {

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -22,14 +22,14 @@ import test, { expect as playExpect } from '@playwright/test';
 import { ExtensionCardPage } from './extension-card-page';
 import { ExtensionCatalogCardPage } from './extension-catalog-card-page';
 import type { ExtensionDetailsPage } from './extension-details-page';
+import { MainPage } from './main-page';
 
-export class ExtensionsPage {
+export class ExtensionsPage extends MainPage{
   readonly page: Page;
   readonly heading: Locator;
   readonly header: Locator;
   readonly search: Locator;
   readonly searchInput: Locator;
-  readonly search: Locator;
   readonly content: Locator;
   readonly additionalActions: Locator;
   readonly catalogExtensions: Locator;
@@ -37,24 +37,17 @@ export class ExtensionsPage {
   readonly catalogTab: Locator;
   readonly localExtensionsTab: Locator;
   readonly installExtensionFromOCIImageButton: Locator;
+  readonly clearFilterButton: Locator;
   readonly searchInput: Locator;
 
   constructor(page: Page) {
-    this.page = page;
-    this.header = page.getByRole('region', { name: 'header' });
-    this.search = page.getByRole('region', { name: 'search' });
-    this.searchInput = this.search.getByLabel('search extensions');
-    this.search = page.getByRole('region', { name: 'search' });
-    this.content = page.getByRole('region', { name: 'content' });
-    this.heading = this.header.getByRole('heading', { name: 'extensions' });
-    this.additionalActions = this.header.getByRole('group', {
-      name: 'additionalActions',
-    });
+    super(page, 'extensions');
     this.catalogExtensions = this.content.getByRole('region', { name: 'Catalog Extensions' });
     this.installedTab = this.page.getByRole('button', { name: 'Installed' });
     this.catalogTab = this.page.getByRole('button', { name: 'Catalog', exact: true });
     this.localExtensionsTab = this.page.getByRole('button', { name: 'Local Extensions' });
     this.installExtensionFromOCIImageButton = this.additionalActions.getByLabel('Install custom');
+    this.clearFilterButton = this.content.getByRole('button', { name: 'Clear filter' });
     this.searchInput = this.search.getByLabel('search extensions');
   }
 
@@ -108,29 +101,22 @@ export class ExtensionsPage {
     });
   }
 
-  public async filterByName(name: string): Promise<void> {
-    return test.step(`Filter extensions by name: ${name}`, async () => {
-      await playExpect(this.searchInput).toBeVisible();
-      await this.searchInput.fill(name);
-      await playExpect(this.searchInput).toHaveValue(name);
+  public async getCatalogExtension(extensionName: string, timeout = 10_000): Promise<ExtensionCatalogCardPage> {
+    return test.step(`Get catalog extension: ${extensionName}`, async () => {
+      await this.openCatalogTab();
+      const extensionCard = new ExtensionCatalogCardPage(this.page, extensionName, this.catalogExtensions);
+      await playExpect(extensionCard.parent).toBeVisible({ timeout });
+      return extensionCard;
     });
-  }
-
-  public async clearFilterByName(): Promise<void> {
-    return test.step('Clear extensions name filter', async () => {
-      await playExpect(this.searchInput).toBeVisible();
-      await this.searchInput.clear();
-      await playExpect(this.searchInput).toHaveValue('');
-    });
-  }
-
-  public getCatalogExtension(extensionName: string): ExtensionCatalogCardPage {
-    return new ExtensionCatalogCardPage(this.page, extensionName);
   }
 
   public async countCatalogExtensions(): Promise<number> {
     return test.step('Count catalog extension cards', async () => {
-      return await this.catalogExtensions.getByRole('group').count();
+      // Catalog cards are role=group entries that expose a details action
+      return await this.catalogExtensions
+        .getByRole('group')
+        .filter({ has: this.page.getByRole('button', { name: /details/i }) })
+        .count();
     });
   }
 

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -130,13 +130,6 @@ export class ExtensionsPage extends BasePage {
     });
   }
 
-  public async countCatalogExtensions(): Promise<number> {
-    return test.step('Count catalog extension cards', async () => {
-      // Each catalog card has a "More details" button (visible label)
-      return await this.catalogExtensions.getByText('More details', { exact: true }).count();
-    });
-  }
-
   public async openExtensionDetails(name: string, label: string, heading: string): Promise<ExtensionDetailsPage> {
     const extensionCard = await this.getInstalledExtension(name, label);
     return await extensionCard.openExtensionDetails(heading);
@@ -168,5 +161,30 @@ export class ExtensionsPage extends BasePage {
       console.log(`Could not get ${label} extension version:`, error);
       return undefined;
     }
+  }
+
+  public async countInstalledExtensionCards(): Promise<number> {
+    return test.step('Count installed extension cards', async () => {
+      const cards = this.content.getByRole('region');
+      return await cards.count();
+    });
+  }
+
+  public async countCatalogExtensionCards(): Promise<number> {
+    return test.step('Count catalog extension cards', async () => {
+      const cards = this.content.getByRole('group');
+      return await cards.count();
+    });
+  }
+
+  public async extensionCardIsVisible(label: string): Promise<boolean> {
+    return test.step(`Check if extension card ${label} is visible`, async () => {
+      const regionCard = this.content.getByRole('region', { name: label, exact: true });
+      if ((await regionCard.count()) > 0) {
+        return await regionCard.isVisible();
+      }
+      const groupCard = this.content.getByRole('group', { name: label, exact: true });
+      return (await groupCard.count()) > 0 && (await groupCard.isVisible());
+    });
   }
 }

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -19,13 +19,12 @@
 import type { Locator, Page } from '@playwright/test';
 import test, { expect as playExpect } from '@playwright/test';
 
+import { BasePage } from './base-page';
 import { ExtensionCardPage } from './extension-card-page';
 import { ExtensionCatalogCardPage } from './extension-catalog-card-page';
 import type { ExtensionDetailsPage } from './extension-details-page';
-import { MainPage } from './main-page';
 
-export class ExtensionsPage extends MainPage{
-  readonly page: Page;
+export class ExtensionsPage extends BasePage {
   readonly heading: Locator;
   readonly header: Locator;
   readonly search: Locator;
@@ -38,17 +37,23 @@ export class ExtensionsPage extends MainPage{
   readonly localExtensionsTab: Locator;
   readonly installExtensionFromOCIImageButton: Locator;
   readonly clearFilterButton: Locator;
-  readonly searchInput: Locator;
 
   constructor(page: Page) {
-    super(page, 'extensions');
+    super(page);
+    this.header = page.getByRole('region', { name: 'header' });
+    this.search = page.getByRole('region', { name: 'search' });
+    this.searchInput = this.search.getByLabel('search extensions');
+    this.content = page.getByRole('region', { name: 'content' });
+    this.heading = this.header.getByRole('heading', { name: 'extensions' });
+    this.additionalActions = this.header.getByRole('group', {
+      name: 'additionalActions',
+    });
     this.catalogExtensions = this.content.getByRole('region', { name: 'Catalog Extensions' });
     this.installedTab = this.page.getByRole('button', { name: 'Installed' });
     this.catalogTab = this.page.getByRole('button', { name: 'Catalog', exact: true });
     this.localExtensionsTab = this.page.getByRole('button', { name: 'Local Extensions' });
     this.installExtensionFromOCIImageButton = this.additionalActions.getByLabel('Install custom');
     this.clearFilterButton = this.content.getByRole('button', { name: 'Clear filter' });
-    this.searchInput = this.search.getByLabel('search extensions');
   }
 
   public async installExtensionFromOCIImage(extension: string, timeout = 100_000): Promise<ExtensionsPage> {
@@ -101,9 +106,25 @@ export class ExtensionsPage extends MainPage{
     });
   }
 
+  public async filterByName(name: string): Promise<void> {
+    return test.step(`Filter extensions by name: ${name}`, async () => {
+      await playExpect(this.searchInput).toBeVisible();
+      await this.searchInput.fill(name);
+      await playExpect(this.searchInput).toHaveValue(name);
+    });
+  }
+
+  public async clearFilterByName(): Promise<void> {
+    return test.step('Clear extensions name filter', async () => {
+      await playExpect(this.searchInput).toBeVisible();
+      await this.searchInput.clear();
+      await playExpect(this.searchInput).toHaveValue('');
+    });
+  }
+
   public async getCatalogExtension(extensionName: string, timeout = 10_000): Promise<ExtensionCatalogCardPage> {
     return test.step(`Get catalog extension: ${extensionName}`, async () => {
-      const extensionCard = new ExtensionCatalogCardPage(this.page, extensionName, this.catalogExtensions);
+      const extensionCard = new ExtensionCatalogCardPage(this.page, extensionName);
       await playExpect(extensionCard.parent).toBeVisible({ timeout });
       return extensionCard;
     });
@@ -111,11 +132,8 @@ export class ExtensionsPage extends MainPage{
 
   public async countCatalogExtensions(): Promise<number> {
     return test.step('Count catalog extension cards', async () => {
-      // Catalog cards are role=group entries that expose a details action
-      return await this.catalogExtensions
-        .getByRole('group')
-        .filter({ has: this.page.getByRole('button', { name: /details/i }) })
-        .count();
+      // Each catalog card has a "More details" button (visible label)
+      return await this.catalogExtensions.getByText('More details', { exact: true }).count();
     });
   }
 
@@ -150,46 +168,5 @@ export class ExtensionsPage extends MainPage{
       console.log(`Could not get ${label} extension version:`, error);
       return undefined;
     }
-  }
-
-  public async filterByName(name: string): Promise<void> {
-    return test.step(`Filter extensions by name: ${name}`, async () => {
-      await playExpect(this.searchInput).toBeVisible();
-      await this.searchInput.fill(name);
-      await playExpect(this.searchInput).toHaveValue(name);
-    });
-  }
-
-  public async clearFilterByName(): Promise<void> {
-    return test.step('Clear name filter on extensions page', async () => {
-      await playExpect(this.searchInput).toBeVisible();
-      await this.searchInput.clear();
-      await playExpect(this.searchInput).toHaveValue('');
-    });
-  }
-
-  public async countInstalledExtensionCards(): Promise<number> {
-    return test.step('Count installed extension cards', async () => {
-      const cards = this.content.getByRole('region');
-      return await cards.count();
-    });
-  }
-
-  public async countCatalogExtensionCards(): Promise<number> {
-    return test.step('Count catalog extension cards', async () => {
-      const cards = this.content.getByRole('group');
-      return await cards.count();
-    });
-  }
-
-  public async extensionCardIsVisible(label: string): Promise<boolean> {
-    return test.step(`Check if extension card ${label} is visible`, async () => {
-      const regionCard = this.content.getByRole('region', { name: label, exact: true });
-      if ((await regionCard.count()) > 0) {
-        return await regionCard.isVisible();
-      }
-      const groupCard = this.content.getByRole('group', { name: label, exact: true });
-      return (await groupCard.count()) > 0 && (await groupCard.isVisible());
-    });
   }
 }

--- a/tests/playwright/src/specs/extension-catalog-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-catalog-smoke.spec.ts
@@ -23,6 +23,7 @@ const MATCHING_EXTENSION_NAME_1 = minikubeExtension.extensionName;
 const MATCHING_EXTENSION_NAME_2 = bootcExtension.extensionName;
 const NONEXISTENT_FILTER = 'no-such-ext';
 const CATALOG_LOAD_TIMEOUT = 60_000;
+const ASSERT_TIMEOUT = 10_000;
 
 test.beforeAll(async ({ runner, welcomePage }) => {
   runner.setVideoAndTraceName('extension-catalog-e2e');
@@ -43,11 +44,14 @@ test.describe('Extensions Catalog filter', { tag: ['@smoke'] }, () => {
     await extensionsPage.openCatalogTab();
     await playExpect(extensionsPage.catalogExtensions).toBeVisible({ timeout: CATALOG_LOAD_TIMEOUT });
 
-    const matchingExtension1 = extensionsPage.getCatalogExtension(MATCHING_EXTENSION_NAME_1);
-    const matchingExtension2 = extensionsPage.getCatalogExtension(MATCHING_EXTENSION_NAME_2);
-
-    await playExpect(matchingExtension1.parent).toBeVisible({ timeout: CATALOG_LOAD_TIMEOUT });
-    await playExpect(matchingExtension2.parent).toBeVisible({ timeout: CATALOG_LOAD_TIMEOUT });
+    const matchingExtension1 = await extensionsPage.getCatalogExtension(
+      MATCHING_EXTENSION_NAME_1,
+      CATALOG_LOAD_TIMEOUT,
+    );
+    const matchingExtension2 = await extensionsPage.getCatalogExtension(
+      MATCHING_EXTENSION_NAME_2,
+      CATALOG_LOAD_TIMEOUT,
+    );
 
     const unfilteredCount = await extensionsPage.countCatalogExtensions();
     playExpect(unfilteredCount).toBeGreaterThanOrEqual(2);
@@ -55,33 +59,33 @@ test.describe('Extensions Catalog filter', { tag: ['@smoke'] }, () => {
     await test.step('Filter by known extension name shows only matching cards', async () => {
       await extensionsPage.filterByName(MATCHING_EXTENSION_NAME_1);
 
-      await playExpect(matchingExtension1.parent).toBeVisible({ timeout: 10_000 });
-      await playExpect(matchingExtension2.parent).not.toBeVisible({ timeout: 10_000 });
-      await playExpect.poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: 10_000 }).toBe(1);
-      await playExpect(extensionsPage.search.getByText(/Filtered out \d+ items of \d+/)).toBeVisible();
+      await playExpect(matchingExtension1.parent).toBeVisible({ timeout: ASSERT_TIMEOUT });
+      await playExpect(matchingExtension2.parent).not.toBeVisible({ timeout: ASSERT_TIMEOUT });
+      await playExpect
+        .poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: ASSERT_TIMEOUT })
+        .toBe(1);
     });
 
     await test.step('Filter with no matches shows empty state', async () => {
       await extensionsPage.filterByName(NONEXISTENT_FILTER);
 
-      await playExpect(matchingExtension1.parent).not.toBeVisible({ timeout: 10_000 });
-      await playExpect(matchingExtension2.parent).not.toBeVisible({ timeout: 10_000 });
-      await playExpect(
-        extensionsPage.content.getByRole('heading', {
-          name: `No extensions matching '${NONEXISTENT_FILTER}' found`,
-        }),
-      ).toBeVisible({ timeout: 10_000 });
+      await playExpect(matchingExtension1.parent).not.toBeVisible({ timeout: ASSERT_TIMEOUT });
+      await playExpect(matchingExtension2.parent).not.toBeVisible({ timeout: ASSERT_TIMEOUT });
+      await playExpect
+        .poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: ASSERT_TIMEOUT })
+        .toBe(0);
+      await playExpect(extensionsPage.clearFilterButton).toBeVisible({ timeout: ASSERT_TIMEOUT });
     });
 
     await test.step('Clearing filter restores full Catalog list', async () => {
       await extensionsPage.clearFilterByName();
 
-      await playExpect(matchingExtension1.parent).toBeVisible({ timeout: 10_000 });
-      await playExpect(matchingExtension2.parent).toBeVisible({ timeout: 10_000 });
+      await playExpect(matchingExtension1.parent).toBeVisible({ timeout: ASSERT_TIMEOUT });
+      await playExpect(matchingExtension2.parent).toBeVisible({ timeout: ASSERT_TIMEOUT });
       await playExpect
-        .poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: 10_000 })
+        .poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: ASSERT_TIMEOUT })
         .toBe(unfilteredCount);
-      await playExpect(extensionsPage.search.getByText(/Filtered out \d+ items of \d+/)).not.toBeVisible();
+      await playExpect(extensionsPage.clearFilterButton).not.toBeVisible();
     });
   });
 });

--- a/tests/playwright/src/specs/extension-catalog-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-catalog-smoke.spec.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { bootcExtension, minikubeExtension } from '/@/model/core/extensions';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+
+const MATCHING_EXTENSION_NAME_1 = minikubeExtension.extensionName;
+const MATCHING_EXTENSION_NAME_2 = bootcExtension.extensionName;
+const NONEXISTENT_FILTER = 'no-such-ext';
+const CATALOG_LOAD_TIMEOUT = 60_000;
+
+test.beforeAll(async ({ runner, welcomePage }) => {
+  runner.setVideoAndTraceName('extension-catalog-e2e');
+  await welcomePage.handleWelcomePage(true);
+});
+
+test.afterAll(async ({ runner }) => {
+  await runner.close();
+});
+
+test.describe('Extensions Catalog filter', { tag: ['@smoke'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('Filter box updates Catalog extension list', async ({ navigationBar }) => {
+    const extensionsPage = await navigationBar.openExtensions();
+    await playExpect(extensionsPage.heading).toBeVisible();
+
+    await extensionsPage.openCatalogTab();
+    await playExpect(extensionsPage.catalogExtensions).toBeVisible({ timeout: CATALOG_LOAD_TIMEOUT });
+
+    const matchingExtension1 = extensionsPage.getCatalogExtension(MATCHING_EXTENSION_NAME_1);
+    const matchingExtension2 = extensionsPage.getCatalogExtension(MATCHING_EXTENSION_NAME_2);
+
+    await playExpect(matchingExtension1.parent).toBeVisible({ timeout: CATALOG_LOAD_TIMEOUT });
+    await playExpect(matchingExtension2.parent).toBeVisible({ timeout: CATALOG_LOAD_TIMEOUT });
+
+    const unfilteredCount = await extensionsPage.countCatalogExtensions();
+    playExpect(unfilteredCount).toBeGreaterThanOrEqual(2);
+
+    await test.step('Filter by known extension name shows only matching cards', async () => {
+      await extensionsPage.filterByName(MATCHING_EXTENSION_NAME_1);
+
+      await playExpect(matchingExtension1.parent).toBeVisible({ timeout: 10_000 });
+      await playExpect(matchingExtension2.parent).not.toBeVisible({ timeout: 10_000 });
+      await playExpect.poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: 10_000 }).toBe(1);
+      await playExpect(extensionsPage.search.getByText(/Filtered out \d+ items of \d+/)).toBeVisible();
+    });
+
+    await test.step('Filter with no matches shows empty state', async () => {
+      await extensionsPage.filterByName(NONEXISTENT_FILTER);
+
+      await playExpect(matchingExtension1.parent).not.toBeVisible({ timeout: 10_000 });
+      await playExpect(matchingExtension2.parent).not.toBeVisible({ timeout: 10_000 });
+      await playExpect(
+        extensionsPage.content.getByRole('heading', {
+          name: `No extensions matching '${NONEXISTENT_FILTER}' found`,
+        }),
+      ).toBeVisible({ timeout: 10_000 });
+    });
+
+    await test.step('Clearing filter restores full Catalog list', async () => {
+      await extensionsPage.clearFilterByName();
+
+      await playExpect(matchingExtension1.parent).toBeVisible({ timeout: 10_000 });
+      await playExpect(matchingExtension2.parent).toBeVisible({ timeout: 10_000 });
+      await playExpect
+        .poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: 10_000 })
+        .toBe(unfilteredCount);
+      await playExpect(extensionsPage.search.getByText(/Filtered out \d+ items of \d+/)).not.toBeVisible();
+    });
+  });
+});

--- a/tests/playwright/src/specs/extension-catalog-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-catalog-smoke.spec.ts
@@ -53,7 +53,7 @@ test.describe('Extensions Catalog filter', { tag: ['@smoke'] }, () => {
       CATALOG_LOAD_TIMEOUT,
     );
 
-    const unfilteredCount = await extensionsPage.countCatalogExtensions();
+    const unfilteredCount = await extensionsPage.countCatalogExtensionCards();
     playExpect(unfilteredCount).toBeGreaterThanOrEqual(2);
 
     await test.step('Filter by known extension name shows only matching cards', async () => {
@@ -62,7 +62,7 @@ test.describe('Extensions Catalog filter', { tag: ['@smoke'] }, () => {
       await playExpect(matchingExtension1.parent).toBeVisible({ timeout: ASSERT_TIMEOUT });
       await playExpect(matchingExtension2.parent).not.toBeVisible({ timeout: ASSERT_TIMEOUT });
       await playExpect
-        .poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: ASSERT_TIMEOUT })
+        .poll(async () => await extensionsPage.countCatalogExtensionCards(), { timeout: ASSERT_TIMEOUT })
         .toBe(1);
     });
 
@@ -72,7 +72,7 @@ test.describe('Extensions Catalog filter', { tag: ['@smoke'] }, () => {
       await playExpect(matchingExtension1.parent).not.toBeVisible({ timeout: ASSERT_TIMEOUT });
       await playExpect(matchingExtension2.parent).not.toBeVisible({ timeout: ASSERT_TIMEOUT });
       await playExpect
-        .poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: ASSERT_TIMEOUT })
+        .poll(async () => await extensionsPage.countCatalogExtensionCards(), { timeout: ASSERT_TIMEOUT })
         .toBe(0);
       await playExpect(extensionsPage.clearFilterButton).toBeVisible({ timeout: ASSERT_TIMEOUT });
     });
@@ -83,7 +83,7 @@ test.describe('Extensions Catalog filter', { tag: ['@smoke'] }, () => {
       await playExpect(matchingExtension1.parent).toBeVisible({ timeout: ASSERT_TIMEOUT });
       await playExpect(matchingExtension2.parent).toBeVisible({ timeout: ASSERT_TIMEOUT });
       await playExpect
-        .poll(async () => await extensionsPage.countCatalogExtensions(), { timeout: ASSERT_TIMEOUT })
+        .poll(async () => await extensionsPage.countCatalogExtensionCards(), { timeout: ASSERT_TIMEOUT })
         .toBe(unfilteredCount);
       await playExpect(extensionsPage.clearFilterButton).not.toBeVisible();
     });


### PR DESCRIPTION
### What does this PR do?
Adds an E2E test case that checks the filter from the catalog extensions page

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes #18023 
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
Run `pnpm test:e2e` or run the added spec file individually
<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
