### PR TITLE
fix(renderer): overlay terminal search controls

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsLogs.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { Terminal } from '@xterm/xterm';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
@@ -93,5 +93,14 @@ test('Render container logs ', async () => {
 
   // expect the button to clear
   const clearButton = screen.getByRole('button', { name: 'Clear logs' });
+  expect(clearButton).toBeInTheDocument();
+
+  expect(screen.queryByRole('textbox', { name: 'Find' })).not.toBeInTheDocument();
+  await fireEvent.keyDown(screen.getByRole('term'), {
+    key: 'f',
+    ctrlKey: true,
+  });
+
+  expect(await screen.findByRole('textbox', { name: 'Find' })).toHaveFocus();
   expect(clearButton).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/pod/PodDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/pod/PodDetailsLogs.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render } from '@testing-library/svelte';
+import { fireEvent, render } from '@testing-library/svelte';
 import { SearchAddon } from '@xterm/addon-search';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -77,11 +77,18 @@ test('No logs should display EmptyScreen', async () => {
 });
 
 test('terminal used should have search enabled', async () => {
-  render(PodDetailsLogs, {
+  const { getByRole } = render(PodDetailsLogs, {
     pod: PODMAN_POD,
   });
 
+  expect(SearchAddon).not.toHaveBeenCalled();
+
+  await fireEvent.keyDown(getByRole('term'), {
+    key: 'f',
+    ctrlKey: true,
+  });
+
   await vi.waitFor(() => {
-    expect(SearchAddon).toHaveBeenCalled();
+    expect(SearchAddon).toHaveBeenCalledOnce();
   });
 });

--- a/packages/renderer/src/lib/ui/TerminalSearchControls.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalSearchControls.spec.ts
@@ -39,18 +39,14 @@ beforeEach(() => {
 });
 
 test('search addon should be loaded to the terminal', () => {
-  render(TerminalSearchControls, {
-    terminal: TerminalMock,
-  });
+  render(TerminalSearchControls, { terminal: TerminalMock, closeSearch: vi.fn() });
 
   expect(SearchAddon.prototype.activate).toHaveBeenCalledOnce();
   expect(SearchAddon.prototype.activate).toHaveBeenCalledWith(TerminalMock);
 });
 
 test('search addon should be disposed on component destroy', async () => {
-  const { unmount } = render(TerminalSearchControls, {
-    terminal: TerminalMock,
-  });
+  const { unmount } = render(TerminalSearchControls, { terminal: TerminalMock, closeSearch: vi.fn() });
 
   unmount();
 
@@ -61,9 +57,7 @@ test('search addon should be disposed on component destroy', async () => {
 
 test('input should call findNext on search addon', async () => {
   const user = userEvent.setup();
-  const { getByRole } = render(TerminalSearchControls, {
-    terminal: TerminalMock,
-  });
+  const { getByRole } = render(TerminalSearchControls, { terminal: TerminalMock, closeSearch: vi.fn() });
 
   const searchTextbox = getByRole('textbox', {
     name: 'Find',
@@ -81,9 +75,7 @@ test('input should call findNext on search addon', async () => {
 
 test('key Enter should call findNext with incremental', async () => {
   const user = userEvent.setup();
-  const { getByRole } = render(TerminalSearchControls, {
-    terminal: TerminalMock,
-  });
+  const { getByRole } = render(TerminalSearchControls, { terminal: TerminalMock, closeSearch: vi.fn() });
 
   const searchTextbox = getByRole('textbox', {
     name: 'Find',
@@ -100,9 +92,7 @@ test('key Enter should call findNext with incremental', async () => {
 });
 
 test('arrow down should call findNext', async () => {
-  const { getByRole } = render(TerminalSearchControls, {
-    terminal: TerminalMock,
-  });
+  const { getByRole } = render(TerminalSearchControls, { terminal: TerminalMock, closeSearch: vi.fn() });
 
   const upBtn = getByRole('button', {
     name: 'Next Match',
@@ -119,9 +109,7 @@ test('arrow down should call findNext', async () => {
 });
 
 test('arrow up should call findPrevious', async () => {
-  const { getByRole } = render(TerminalSearchControls, {
-    terminal: TerminalMock,
-  });
+  const { getByRole } = render(TerminalSearchControls, { terminal: TerminalMock, closeSearch: vi.fn() });
 
   const upBtn = getByRole('button', {
     name: 'Previous Match',
@@ -137,23 +125,33 @@ test('arrow up should call findPrevious', async () => {
   });
 });
 
-test('ctrl+F should focus input', async () => {
-  const { getByRole, container } = render(TerminalSearchControls, {
-    terminal: TerminalMock,
-  });
+test('input should be focused on mount', () => {
+  const { getByRole } = render(TerminalSearchControls, { terminal: TerminalMock, closeSearch: vi.fn() });
 
   const searchTextbox: HTMLInputElement = getByRole('textbox', {
     name: 'Find',
   }) as HTMLInputElement;
 
-  const focusSpy = vi.spyOn(searchTextbox, 'focus');
+  expect(searchTextbox).toHaveFocus();
+});
 
-  await fireEvent.keyUp(container, {
-    ctrlKey: true,
-    key: 'f',
-  });
+test('close button should close search', async () => {
+  const closeSearch = vi.fn();
+  const { getByRole } = render(TerminalSearchControls, { terminal: TerminalMock, closeSearch });
+
+  await fireEvent.click(
+    getByRole('button', {
+      name: 'Close Search',
+    }),
+  );
 
   await vi.waitFor(() => {
-    expect(focusSpy).toHaveBeenCalled();
+    expect(closeSearch).toHaveBeenCalledOnce();
   });
+});
+
+test('search controls should float above the terminal', () => {
+  const { getByRole } = render(TerminalSearchControls, { terminal: TerminalMock, closeSearch: vi.fn() });
+
+  expect(getByRole('search')).toHaveClass('absolute', 'right-12');
 });

--- a/packages/renderer/src/lib/ui/TerminalSearchControls.svelte
+++ b/packages/renderer/src/lib/ui/TerminalSearchControls.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowDown, faArrowUp } from '@fortawesome/free-solid-svg-icons';
+import { faArrowDown, faArrowUp, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { SearchAddon } from '@xterm/addon-search';
@@ -8,9 +8,10 @@ import { onDestroy, onMount } from 'svelte';
 
 interface Props {
   terminal: Terminal;
+  closeSearch: () => void;
 }
 
-let { terminal }: Props = $props();
+let { terminal, closeSearch }: Props = $props();
 
 let searchAddon: SearchAddon | undefined;
 let searchTerm: string = $state('');
@@ -20,6 +21,7 @@ let input: HTMLInputElement | undefined = $state();
 onMount(() => {
   searchAddon = new SearchAddon();
   searchAddon.activate(terminal);
+  focus();
 });
 
 onDestroy(() => {
@@ -44,22 +46,27 @@ function onSearchPrevious(incremental = false): void {
   });
 }
 
+function onSearchNextIncremental(): void {
+  onSearchNext(true);
+}
+
+function onSearchPreviousIncremental(): void {
+  onSearchPrevious(true);
+}
+
 function onSearch(event: Event): void {
   searchTerm = (event.target as HTMLInputElement).value;
   onSearchNext();
 }
 
-function onKeyUp(e: KeyboardEvent): void {
-  if (e.ctrlKey && e.key === 'f') {
-    input?.focus();
-  }
+export function focus(): void {
+  input?.focus();
 }
 </script>
 
-<svelte:window
-  on:keyup|preventDefault={onKeyUp}
-/>
-<div class="flex flex-row py-2 h-[40px] items-center">
+<div
+  class="absolute top-1 right-12 z-10 flex flex-row h-[40px] px-1 items-center rounded shadow-lg bg-[var(--pd-terminal-background)]"
+  role="search">
   <div
     class="w-200px mx-4">
     <Input
@@ -72,11 +79,14 @@ function onKeyUp(e: KeyboardEvent): void {
     />
   </div>
   <div class="space-x-1">
-    <button aria-label="Previous Match" class="p-2 rounded-sm hover:bg-[var(--pd-action-button-details-bg)]" onclick={(): void => onSearchPrevious(true)}>
+    <button aria-label="Previous Match" class="p-2 rounded-sm hover:bg-[var(--pd-action-button-details-bg)]" onclick={onSearchPreviousIncremental}>
       <Icon icon={faArrowUp}/>
     </button>
-    <button aria-label="Next Match" class="p-2 rounded-sm hover:bg-[var(--pd-action-button-details-bg)]" onclick={(): void => onSearchNext(true)}>
+    <button aria-label="Next Match" class="p-2 rounded-sm hover:bg-[var(--pd-action-button-details-bg)]" onclick={onSearchNextIncremental}>
       <Icon icon={faArrowDown}/>
+    </button>
+    <button aria-label="Close Search" class="p-2 rounded-sm hover:bg-[var(--pd-action-button-details-bg)]" onclick={closeSearch}>
+      <Icon icon={faXmark}/>
     </button>
   </div>
 </div>

--- a/packages/renderer/src/lib/ui/TerminalWindow.svelte
+++ b/packages/renderer/src/lib/ui/TerminalWindow.svelte
@@ -4,7 +4,7 @@ import '@xterm/xterm/css/xterm.css';
 import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
-import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';
 import TerminalSearchControls from '/@/lib/ui/TerminalSearchControls.svelte';
@@ -30,7 +30,10 @@ let {
 }: Props = $props();
 
 let logsXtermDiv: HTMLDivElement | undefined;
+let terminalWindowDiv: HTMLDivElement | undefined;
 let resizeHandler: () => void;
+let searchControls: TerminalSearchControls | undefined = $state();
+let searchVisible = $state(false);
 
 const dispatch = createEventDispatcher();
 
@@ -79,18 +82,45 @@ async function refreshTerminal(): Promise<void> {
 }
 
 onMount(async () => {
+  terminalWindowDiv?.addEventListener('keydown', onKeyDown, true);
   await refreshTerminal();
   dispatch('init');
 });
 
 onDestroy(() => {
+  terminalWindowDiv?.removeEventListener('keydown', onKeyDown, true);
   window.removeEventListener('resize', resizeHandler);
   terminal?.dispose();
 });
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (search && (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'f') {
+    event.preventDefault();
+    event.stopPropagation();
+    searchVisible = true;
+    tick()
+      .then(() => searchControls?.focus())
+      .catch((error: unknown) => console.error('Error focusing terminal search controls', error));
+  } else if (searchVisible && event.key === 'Escape') {
+    event.preventDefault();
+    closeSearch();
+  }
+}
+
+function closeSearch(): void {
+  searchVisible = false;
+  tick()
+    .then(() => terminal?.focus())
+    .catch((error: unknown) => console.error('Error restoring terminal focus', error));
+}
 </script>
 
-{#if search && terminal}
-  <TerminalSearchControls {terminal} />
-{/if}
-
-<div class="{className} overflow-hidden p-[5px] pr-0 bg-[var(--pd-terminal-background)]" role="term" bind:this={logsXtermDiv}></div>
+<div
+  class="{className} relative overflow-hidden bg-[var(--pd-terminal-background)]"
+  role="term"
+  bind:this={terminalWindowDiv}>
+  <div class="h-full p-[5px] pr-0" bind:this={logsXtermDiv}></div>
+  {#if search && terminal && searchVisible}
+    <TerminalSearchControls bind:this={searchControls} {terminal} {closeSearch} />
+  {/if}
+</div>

--- a/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
+++ b/packages/renderer/src/lib/ui/TerminalWindows.spec.ts
@@ -19,7 +19,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { TerminalSettings } from '@podman-desktop/core-api/terminal';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render, within } from '@testing-library/svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { writable } from 'svelte/store';
@@ -155,15 +155,139 @@ test('matchMedia resize listener should trigger fit addon', async () => {
   expect(FitAddon.prototype.fit).toHaveBeenCalled();
 });
 
-test('search props should add terminal search controls', async () => {
+test('search controls should open without changing the terminal mount point', async () => {
+  const { findByRole, getByRole, queryByRole } = render(TerminalWindow, {
+    terminal: createTerminalMock(),
+    search: true,
+  });
+
+  expect(queryByRole('textbox', { name: 'Find' })).not.toBeInTheDocument();
+
+  const terminalWindow = getByRole('term');
+  const xtermMountPoint = terminalWindow.firstElementChild;
+  expect(xtermMountPoint).toHaveClass('h-full');
+
+  const findEvent = new KeyboardEvent('keydown', {
+    key: 'f',
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  terminalWindow.dispatchEvent(findEvent);
+
+  const searchTextbox = await findByRole('textbox', { name: 'Find' });
+  expect(findEvent.defaultPrevented).toBeTruthy();
+  expect(searchTextbox).toHaveFocus();
+  expect(xtermMountPoint).not.toContainElement(searchTextbox);
+  expect(getByRole('search')).toHaveClass('absolute');
+});
+
+test('search shortcut should be captured before xterm handles it', async () => {
+  const xtermKeydown = vi.fn((event: KeyboardEvent): void => event.stopPropagation());
+  vi.mocked(Terminal.prototype.open).mockImplementation((element: HTMLElement) => {
+    const xterm = document.createElement('div');
+    const textarea = document.createElement('textarea');
+    textarea.className = 'xterm-helper-textarea';
+    xterm.appendChild(textarea);
+    textarea.addEventListener('keydown', xtermKeydown, true);
+    element.appendChild(xterm);
+  });
+
+  const { container, findByRole } = render(TerminalWindow, {
+    terminal: createTerminalMock(),
+    search: true,
+  });
+
+  const textarea = await vi.waitFor(() => {
+    const element = container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea');
+    expect(element).toBeInTheDocument();
+    return element as HTMLTextAreaElement;
+  });
+
+  const findEvent = new KeyboardEvent('keydown', {
+    key: 'f',
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  textarea.dispatchEvent(findEvent);
+
+  expect(await findByRole('textbox', { name: 'Find' })).toHaveFocus();
+  expect(findEvent.defaultPrevented).toBeTruthy();
+  expect(xtermKeydown).not.toHaveBeenCalled();
+});
+
+test('search shortcut should work with the macOS modifier', async () => {
+  const { findByRole, getByRole } = render(TerminalWindow, {
+    terminal: createTerminalMock(),
+    search: true,
+  });
+
+  await fireEvent.keyDown(getByRole('term'), {
+    key: 'F',
+    metaKey: true,
+  });
+
+  expect(await findByRole('textbox', { name: 'Find' })).toHaveFocus();
+});
+
+test('unrelated shortcuts should not be prevented', () => {
   const { getByRole } = render(TerminalWindow, {
     terminal: createTerminalMock(),
     search: true,
   });
 
-  const searchTextbox = getByRole('textbox', {
-    name: 'Find',
+  const unrelatedEvent = new KeyboardEvent('keydown', {
+    key: 'g',
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  getByRole('term').dispatchEvent(unrelatedEvent);
+
+  expect(unrelatedEvent.defaultPrevented).toBeFalsy();
+});
+
+test('search shortcut should only open controls for its terminal', async () => {
+  const first = render(TerminalWindow, {
+    terminal: createTerminalMock(),
+    search: true,
+  });
+  const second = render(TerminalWindow, {
+    terminal: createTerminalMock(),
+    search: true,
   });
 
-  expect(searchTextbox).toBeInTheDocument();
+  const firstTerminal = within(first.container);
+  const secondTerminal = within(second.container);
+
+  await fireEvent.keyDown(secondTerminal.getByRole('term'), {
+    key: 'f',
+    ctrlKey: true,
+  });
+
+  expect(firstTerminal.queryByRole('textbox', { name: 'Find' })).not.toBeInTheDocument();
+  expect(await secondTerminal.findByRole('textbox', { name: 'Find' })).toHaveFocus();
+});
+
+test('Escape should close search and restore terminal focus', async () => {
+  const { findByRole, getByRole, queryByRole } = render(TerminalWindow, {
+    terminal: createTerminalMock(),
+    search: true,
+  });
+
+  await fireEvent.keyDown(getByRole('term'), {
+    key: 'f',
+    ctrlKey: true,
+  });
+  const searchTextbox = await findByRole('textbox', { name: 'Find' });
+
+  await fireEvent.keyDown(searchTextbox, {
+    key: 'Escape',
+  });
+
+  await vi.waitFor(() => {
+    expect(queryByRole('textbox', { name: 'Find' })).not.toBeInTheDocument();
+    expect(Terminal.prototype.focus).toHaveBeenCalledOnce();
+  });
 });


### PR DESCRIPTION
### What does this PR do?

- hide terminal search until Ctrl+F or Cmd+F is pressed in the active terminal
- render search as a floating overlay outside xterm's managed DOM so terminal geometry does not shift
- dispose search state on close and restore terminal focus
- scope shortcuts correctly when multiple terminals are mounted
- add focused regressions for search lifecycle, xterm event capture, Pod logs, and Container logs

AI assistance disclosure: OpenAI Codex assisted with implementation and tests. The complete diff was independently reviewed and all changed lines were checked before submission.

### Screenshot / video of UI

A running Electron UI was not available in this environment. The regression suite verifies that the search control is outside the xterm mount point, uses absolute positioning, and leaves the existing Container Logs clear control mounted.

### What issues does this PR fix or reference?

Closes #10819

### How to test this PR?

1. Open Container or Pod logs.
2. Confirm search is initially hidden and the terminal/clear control retain their normal layout.
3. Focus the terminal and press Ctrl+F (Cmd+F on macOS).
4. Confirm search floats over the terminal and receives focus.
5. Search forward/backward, then press Escape or the close button and confirm terminal focus is restored.

Validation performed:

- `pnpm install --frozen-lockfile`
- `pnpm run build:preload:types`
- `pnpm run build:ui`
- focused renderer suite: 25/25 passed
- `pnpm run typecheck:renderer` (0 errors; pre-existing warnings only)
- focused ESLint
- `pnpm format:check`
- `pnpm lint-staged`
- `git diff --check`

- [x] Tests are covering the bug fix or the new feature