### PR TITLE
chore: suggest users to wipe data for all major updates of podman

### DIFF
--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -143,8 +143,8 @@ class TestPodmanInstall extends PodmanInstall {
     return super.stopPodmanMachinesIfAnyBeforeUpdating();
   }
 
-  async wipeAllDataBeforeUpdatingToV5(installed: InstalledPodman, updateCheck: UpdateCheck): Promise<boolean> {
-    return super.wipeAllDataBeforeUpdatingToV5(installed, updateCheck);
+  async wipeAllDataBeforeMajorUpdate(installed: InstalledPodman, updateCheck: UpdateCheck): Promise<boolean> {
+    return super.wipeAllDataBeforeMajorUpdate(installed, updateCheck);
   }
 
   getInstaller(): Installer | undefined {
@@ -200,7 +200,7 @@ describe('update checks', () => {
     expect(utils.execPodman).toHaveBeenCalledWith(['machine', 'stop', 'test']);
   });
 
-  test('wipeAllDataBeforeUpdatingToV5 with podman 4.9 -> 5.0', async () => {
+  test('wipeAllDataBeforeMajorUpdate with podman 4.9 -> 5.0', async () => {
     // fake actions
     const action1Exectute = vi.fn();
     const action1 = {
@@ -213,7 +213,7 @@ describe('update checks', () => {
     // mock user response
     vi.spyOn(extensionApi.window, 'showInformationMessage').mockResolvedValue('Yes');
 
-    await podmanInstall.wipeAllDataBeforeUpdatingToV5(
+    await podmanInstall.wipeAllDataBeforeMajorUpdate(
       {
         version: '4.9.3',
       } as unknown as InstalledPodman,
@@ -232,8 +232,58 @@ describe('update checks', () => {
     expect(action1Exectute).toHaveBeenCalled();
   });
 
-  test('wipeAllDataBeforeUpdatingToV5 no action with podman 4.9.1 -> 4.9.2', async () => {
-    await podmanInstall.wipeAllDataBeforeUpdatingToV5(
+  test('wipeAllDataBeforeMajorUpdate with podman 5.8 -> 6.0', async () => {
+    const action1Execute = vi.fn();
+    const action1 = {
+      name: 'test',
+      execute: action1Execute,
+    };
+
+    vi.mocked(PROVIDER_CLEANUP_MOCK.getActions).mockResolvedValue([action1]);
+
+    vi.spyOn(extensionApi.window, 'showInformationMessage').mockResolvedValue('Yes');
+
+    await podmanInstall.wipeAllDataBeforeMajorUpdate(
+      {
+        version: '5.8.5',
+      } as unknown as InstalledPodman,
+      {
+        bundledVersion: '6.0.1',
+      } as unknown as UpdateCheck,
+    );
+
+    expect(extensionApi.window.showInformationMessage).toHaveBeenCalled();
+    expect(PROVIDER_CLEANUP_MOCK.getActions).toHaveBeenCalled();
+    expect(action1Execute).toHaveBeenCalled();
+  });
+
+  test('wipeAllDataBeforeMajorUpdate with podman 4.9 -> 6.0', async () => {
+    const action1Execute = vi.fn();
+    const action1 = {
+      name: 'test',
+      execute: action1Execute,
+    };
+
+    vi.mocked(PROVIDER_CLEANUP_MOCK.getActions).mockResolvedValue([action1]);
+
+    vi.spyOn(extensionApi.window, 'showInformationMessage').mockResolvedValue('Yes');
+
+    await podmanInstall.wipeAllDataBeforeMajorUpdate(
+      {
+        version: '4.9.3',
+      } as unknown as InstalledPodman,
+      {
+        bundledVersion: '6.0.1',
+      } as unknown as UpdateCheck,
+    );
+
+    expect(extensionApi.window.showInformationMessage).toHaveBeenCalled();
+    expect(PROVIDER_CLEANUP_MOCK.getActions).toHaveBeenCalled();
+    expect(action1Execute).toHaveBeenCalled();
+  });
+
+  test('wipeAllDataBeforeMajorUpdate no action with podman 4.9.1 -> 4.9.2', async () => {
+    await podmanInstall.wipeAllDataBeforeMajorUpdate(
       {
         version: '4.9.1',
       } as unknown as InstalledPodman,
@@ -333,7 +383,7 @@ describe('performUpdate', () => {
     // all podman machine are stopped
     vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
     // return true if data have been cleaned or if user skip it
-    vi.spyOn(podmanInstall, 'wipeAllDataBeforeUpdatingToV5').mockResolvedValue(true);
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeMajorUpdate').mockResolvedValue(true);
 
     // mock checkForUpdate
     vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
@@ -362,7 +412,7 @@ describe('performUpdate', () => {
     // all podman machine are stopped
     vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
     // return true if data have been cleaned or if user skip it
-    vi.spyOn(podmanInstall, 'wipeAllDataBeforeUpdatingToV5').mockResolvedValue(true);
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeMajorUpdate').mockResolvedValue(true);
 
     // mock checkForUpdate
     vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
@@ -383,7 +433,7 @@ describe('performUpdate', () => {
     // all podman machine are stopped
     vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
     // return true if data have been cleaned or if user skip it
-    vi.spyOn(podmanInstall, 'wipeAllDataBeforeUpdatingToV5').mockResolvedValue(true);
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeMajorUpdate').mockResolvedValue(true);
 
     // mock initialized
     podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -21,7 +21,7 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 import { inject, injectable, optional } from 'inversify';
-import { compare } from 'semver';
+import { compare, major } from 'semver';
 
 import { getDetectionChecks } from '/@/checks/detection-checks';
 import {
@@ -184,15 +184,15 @@ export class PodmanInstall {
 
   // return true if data have been cleaned or if user skip it
   // return false if user cancel
-  protected async wipeAllDataBeforeUpdatingToV5(
+  protected async wipeAllDataBeforeMajorUpdate(
     installedPodman: InstalledPodman,
     updateInfo: UpdateCheck,
   ): Promise<boolean> {
-    // if (v4 --> v5)
+    // major update, prompt user to wipe all data
     if (
-      installedPodman.version.startsWith('4.') &&
-      updateInfo.bundledVersion?.startsWith('5.') &&
-      this.providerCleanup
+      updateInfo.bundledVersion &&
+      this.providerCleanup &&
+      major(updateInfo.bundledVersion) > major(installedPodman.version)
     ) {
       // prompt if user wants to wipe all data
       const answer = await extensionApi.window.showInformationMessage(
@@ -253,8 +253,8 @@ export class PodmanInstall {
         return;
       }
 
-      // podman v4 -> v5 migration: ask to wipe all data before doing the update
-      const wipeAllDataCompleted = await this.wipeAllDataBeforeUpdatingToV5(
+      // podman major update (first digit change ), prompt user to wipe all data before doing the update
+      const wipeAllDataCompleted = await this.wipeAllDataBeforeMajorUpdate(
         { version: updateInfo.installedVersion },
         updateInfo,
       );


### PR DESCRIPTION
### What does this PR do?
for now it was done only for v4->v5

make it more generic so it applies to all upgrades from any major to a more recent major version so matching v4-->v5 or v5-->v6 or even v4-->v6

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/18404

### How to test this PR?

I would recommend to apply before https://github.com/podman-desktop/podman-desktop/pull/18408 to check manually
but there is a unit test
- [x] Tests are covering the bug fix or the new feature
