### PR TITLE
fix: fix typos in top-level markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -418,7 +418,7 @@ If you're unsure where to add code (renderer, UI, extensions, plugins) see the b
 - `packages/preload`: Electron code that runs before the page gets rendered. Typically has access to APIs and used to setup communication processes between the main and renderer code.
 - `packages/preload-docker-extension`: Electron preload code specific to the Docker Desktop extension.
 - `packages/renderer`: Electron code that runs in the renderer process. The renderer runs separate to the main process and is responsible for typically rendering the main pages of Podman Desktop. Typically, this is where you find the `.svelte` code that renders the main Podman Desktop UI.
-- `scripts`: Scripts Podman Desktop requires such as `pnpm watch` functionality and updating Electron vendorered modules.
+- `scripts`: Scripts Podman Desktop requires such as `pnpm watch` functionality and updating Electron vendored modules.
 - `tests`: Contains e2e tests for Podman Desktop.
 - `types`: Additional types required for TypeScript.
 - `website`: The documentation as well as [Podman Desktop website](https://podman-desktop.io) developed in [Docusaurus](https://docusaurus.io).
@@ -442,9 +442,9 @@ Example:
 
 1. Choose what UI component you want to add: Ex. I want to add a new primary button.
 2. Look under `initColors()` and pick `this.initButton()` and scroll down to `protected initButton()`.
-3. Pick a color. I want to use the the "primary" button. So I will pick: `${button}primary-bg`.
+3. Pick a color. I want to use the "primary" button. So I will pick: `${button}primary-bg`.
 4. Scroll up and note the `const` below `protected initButton()` which is `const button = 'button-';`
-5. The color can be referenced with `[var(--pd-button-primary-bg)]`. The `[var(--pd-` portion will always be consistent when refering to a color variable.
+5. The color can be referenced with `[var(--pd-button-primary-bg)]`. The `[var(--pd-` portion will always be consistent when referring to a color variable.
 6. For example:
 
 ```ts

--- a/CUSTOM_UPDATE_SERVER.md
+++ b/CUSTOM_UPDATE_SERVER.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Downstream forks can point the auto-updater at any HTTPS server by setting `update.url` in `product.json`. 
+Downstream forks can point the auto-updater at any HTTPS server by setting `update.url` in `product.json`.
 When empty (default), the existing GitHub Releases behavior is preserved.
 
 ```json
@@ -23,7 +23,6 @@ Test the full update flow locally using nginx in a Podman container. Build 2 ver
 
 #### Step 1: Clean assets directory
 
-
 For testing locally remove old `.pkg` files and `.zst` machine images in `extensions/podman/packages/extension/assets/` before building. These inflate the ZIP from ~200MB to 1.5GB+, causing Squirrel.Mac to crash (it buffers the entire download in memory).
 
 ```bash
@@ -32,7 +31,7 @@ rm extensions/podman/packages/extension/assets/*
 
 #### Step 2: Create a self-signed code signing certificate
 
-Squirrel.Mac (how it downloads) requires both the running app and the update to share the same code signing identity. 
+Squirrel.Mac (how it downloads) requires both the running app and the update to share the same code signing identity.
 Ad-hoc signatures (`--sign -`) produce a unique identity per signing, so you need to generate a named certificate.
 
 ```bash
@@ -102,7 +101,7 @@ CSC_NAME="Podman Desktop Test" pnpm compile:current
 
 #### Step 5: Re-sign, repackage, and host the update
 
-electron-builder signs the main executable, but the Electron Framework inside the bundle may retains a different Team ID. You must re-sign with `--deep`, repackage the ZIP, and update the checksum.
+electron-builder signs the main executable, but the Electron Framework inside the bundle may retain a different Team ID. You must re-sign with `--deep`, repackage the ZIP, and update the checksum.
 
 ```bash
 # Re-sign with --deep
@@ -121,7 +120,7 @@ NEW_SIZE=$(stat -f%z /tmp/update-repack/podman-desktop-99.0.0-arm64.zip)
 echo "sha512: $NEW_SHA512"
 echo "size: $NEW_SIZE"
 
-# Copy to to a server directory (we will use ~/update-server dir, or use whatever you'd like)
+# Copy to a server directory (we will use ~/update-server dir, or use whatever you'd like)
 mkdir -p ~/update-server
 cp dist/latest-mac.yml ~/update-server/
 cp /tmp/update-repack/podman-desktop-99.0.0-arm64.zip ~/update-server/

--- a/WEBSITE_CONTRIBUTING.md
+++ b/WEBSITE_CONTRIBUTING.md
@@ -16,7 +16,7 @@ The below information outlines details on how to both contribute as well as our 
 Here is a brief description of the folders for the website of Podman Desktop and how they are organized.
 
 - `blog`: All the blog posts published on [https://podman-desktop.io/blog](https://podman-desktop.io/blog).
-- `blog/img`: Store all the images used in the the blog posts.
+- `blog/img`: Store all the images used in the blog posts.
 - `docs`: All documentation published on [https://podman-desktop.io/docs](https://podman-desktop.io/docs).
 - `tutorials`: All tutorials published on [https://podman-desktop.io/tutorial](https://podman-desktop.io/tutorial).
 - `src`: Content for the website.
@@ -193,7 +193,7 @@ Links to further information (could be podman desktop documentation, or outside 
 A "typical" list of troubleshooting scenarios and their solutions.
 
 ```markdown
-# <Title of the troubshooting section>
+# <Title of the troubleshooting section>
 
 ## <Specific issue>
 


### PR DESCRIPTION
### What does this PR do?

Fix typos in top-level markdown files:

- "vendorered" → "vendored" (CONTRIBUTING.md)
- "the the" → "the" (CONTRIBUTING.md, WEBSITE_CONTRIBUTING.md)
- "refering" → "referring" (CONTRIBUTING.md)
- "may retains" → "may retain" (CUSTOM_UPDATE_SERVER.md)
- "to to" → "to" (CUSTOM_UPDATE_SERVER.md)
- "troubshooting" → "troubleshooting" (WEBSITE_CONTRIBUTING.md)

### Screenshot / video of UI

N/A — no UI changes, only text corrections in documentation.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A — documentation-only changes.

- [ ] Tests are covering the bug fix or the new feature