### PR TITLE
fix(main): fix typos in main process code

### DIFF
--- a/packages/main/src/plugin/certificates.ts
+++ b/packages/main/src/plugin/certificates.ts
@@ -147,7 +147,7 @@ export class Certificates {
       spawnArgs.push(key);
     }
 
-    // call the spawn command (as we've lot ot output)
+    // call the spawn command (as we've lot of output)
     const spawnResult = await spawnWithPromise(command, spawnArgs);
     if (spawnResult.error) {
       console.log('error while executing command', command, spawnArgs, spawnResult.error);

--- a/packages/main/src/plugin/close-behavior.spec.ts
+++ b/packages/main/src/plugin/close-behavior.spec.ts
@@ -53,13 +53,13 @@ test('should register a configuration', async () => {
   expect(after).toBeDefined();
 });
 
-test('should set default value of configuraton registry on Linux and FreeBSD to true', async () => {
+test('should set default value of configuration registry on Linux and FreeBSD to true', async () => {
   vi.spyOn(util, 'isUnixLike').mockReturnValue(true);
   await closeBehavior.init();
   expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose']?.default).toBeTruthy();
 });
 
-test('should set default value of configuraton registry if not Linux or FreeBSD', async () => {
+test('should set default value of configuration registry if not Linux or FreeBSD', async () => {
   vi.spyOn(util, 'isUnixLike').mockReturnValue(false);
   await closeBehavior.init();
   expect(configurationRegistry.getConfigurationProperties()['preferences.ExitOnClose']?.default).toBeFalsy();

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -6287,7 +6287,7 @@ test('resolve Podman image shortname to FQN', async () => {
   expect(imagesNames[0]).toBe('shortname');
 });
 
-test('resolve Dokcer image shortname to FQN', async () => {
+test('resolve Docker image shortname to FQN', async () => {
   const getMatchingContainerProviderMock = vi.spyOn(containerRegistry, 'getMatchingContainerProvider');
   const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -504,7 +504,7 @@ export class ContainerProviderRegistry {
     try {
       const engine = this.internalProviders.get(engineId);
       if (engine?.libpodApi) {
-        // we cannot use the /secrets (compact) api to retreive secret with podman
+        // we cannot use the /secrets (compact) api to retrieve secret with podman
         // endpoint is malformed
         // https://github.com/containers/podman/issues/27548
         await engine.libpodApi.removeSecret(secretId);
@@ -2735,7 +2735,7 @@ export class ContainerProviderRegistry {
       const kubePlay = KubePlayContext.fromFile(kubernetesYamlFilePath);
       await kubePlay.init();
 
-      // if we have no context let's just use the the yaml
+      // if we have no context let's just use the yaml
       if (kubePlay.getBuildContexts().length === 0) {
         return provider.libpodApi.playKube(kubernetesYamlFilePath, options);
       }

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -842,7 +842,7 @@ export class LibpodDockerode {
         },
         headers: headers,
         // We require all=true to always be present in the URL in order for the manifest to be pushed correctly.
-        // If you do not provide it, it will return a "uknown manifest blob" error as it's trying to push a manifest blob with no images.
+        // If you do not provide it, it will return a "unknown manifest blob" error as it's trying to push a manifest blob with no images.
         options: {
           all: 'true',
         },

--- a/packages/main/src/plugin/provider-registry.ts
+++ b/packages/main/src/plugin/provider-registry.ts
@@ -181,7 +181,7 @@ export class ProviderRegistry {
 
     // Every 2 seconds, we will check:
     // * The status of the providers
-    // * Any new warnings or informations for each provider
+    // * Any new warnings or information for each provider
     setInterval(() => {
       for (const [providerKey] of this.providers) {
         // Get the provider and its lifecycle

--- a/packages/main/src/plugin/telemetry/telemetry.ts
+++ b/packages/main/src/plugin/telemetry/telemetry.ts
@@ -137,7 +137,7 @@ export class Telemetry {
     // track changes on enablement
     this.listenForTelemetryUpdates();
 
-    // initalize objects
+    // initialize objects
     this.analytics = new Analytics({ writeKey: Telemetry.SEGMENT_KEY });
     this.analytics.on('error', err => {
       console.log(`Telemetry request error: ${err}`);
@@ -524,8 +524,8 @@ export class Telemetry {
   protected async getDistribution(): Promise<string | undefined> {
     if (os.platform() === 'linux') {
       try {
-        const platorm = (await promisify(getos)()) as LinuxOs;
-        return platorm.dist;
+        const platform = (await promisify(getos)()) as LinuxOs;
+        return platform.dist;
       } catch {
         return undefined;
       }

--- a/packages/main/src/plugin/util/manifest.ts
+++ b/packages/main/src/plugin/util/manifest.ts
@@ -43,7 +43,7 @@ export function guessIsManifest(image: ImageInfo, connectionType: string): boole
   // if it is a manifest or not.
   // ex. podman image tag testmanifest testmanifest123
 
-  // This is a "hacky" way to do it, but we can check to see if the image has been renamed by anaylzing the digests
+  // This is a "hacky" way to do it, but we can check to see if the image has been renamed by analyzing the digests
   // as they will be pointed
 
   // Create a map to count occurrences of each digest


### PR DESCRIPTION
### What does this PR do?

Fix typos in comments, test names, and a variable name in the main process code:

- "initalize" → "initialize", `platorm` → `platform` (telemetry.ts)
- "retreive" → "retrieve", "the the" → "the" (container-registry.ts)
- "uknown" → "unknown" (libpod-dockerode.ts)
- "lot ot" → "lot of" (certificates.ts)
- "anaylzing" → "analyzing" (manifest.ts)
- "informations" → "information" (provider-registry.ts)
- "configuraton" → "configuration" (close-behavior.spec.ts)
- "Dokcer" → "Docker" (container-registry.spec.ts)

### Screenshot / video of UI

N/A — no UI changes, only text corrections in comments/test names and a variable rename.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Run affected unit tests:
```bash
npx vitest run packages/main/src/plugin/close-behavior.spec.ts
npx vitest run packages/main/src/plugin/container-registry.spec.ts
```

- [ ] Tests are covering the bug fix or the new feature