### PR TITLE
fix(renderer): fix typos in renderer code

### DIFF
--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -482,7 +482,7 @@ test('Expect filter empty screen', async () => {
   expect(filterButton).toBeInTheDocument();
 });
 
-test('Expect clear filter in empty screen to clear serach term, except is:...', async () => {
+test('Expect clear filter in empty screen to clear search term, except is:...', async () => {
   vi.mocked(window.getProviderInfos).mockResolvedValue([
     {
       name: 'podman',
@@ -983,7 +983,7 @@ test('pods with same name on different engines should have separate group', asyn
     Status: 'Running',
     pod: {
       name: 'my-pod',
-      id: `podman-engine-${index}`, // unique pod id (only pod-id is unique accross all engines)
+      id: `podman-engine-${index}`, // unique pod id (only pod-id is unique across all engines)
       status: 'Running',
       engineId: `podman-${index}`,
     },

--- a/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
+++ b/packages/renderer/src/lib/container/CreateContainerFromExistingImage.svelte
@@ -72,7 +72,7 @@ async function resolveShortname(): Promise<void> {
     shortnameImages = [];
     usePodmanFQN = false;
   }
-  // checks if there is no FQN that is from dokcer hub
+  // checks if there is no FQN that is from docker hub
   if (!shortnameImages.find(name => name.includes('docker.io'))) {
     podmanFQN = shortnameImages[0];
   } else {

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -44,7 +44,7 @@ export class ContainerUtils {
     /*
       When deploying with compose, the container name will be <project>-<service-name>-<container-number> under Names[0].
       This is added to the container name to make it unique.
-      HOWEVER, if you specify container_name in the compose file, the container name will be whatever is is set to and
+      HOWEVER, if you specify container_name in the compose file, the container name will be whatever is set to and
       will not have either the project or service number.
       Thus the easier way to show the correct name is to get the  containerInfo.Labels?.['com.docker.compose.project'] label
       remove it from the Names[0] and return the result.

--- a/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/GitHubIssueFeedback.spec.ts
@@ -99,7 +99,7 @@ function renderGitHubIssueFeedback(props: ComponentProps<typeof GitHubIssueFeedb
   };
 }
 
-test('Expect feedback form to to be GitHub issue feedback form', async () => {
+test('Expect feedback form to be GitHub issue feedback form', async () => {
   const { title, description, includeSystemInfo } = renderGitHubIssueFeedback({
     category: 'bug',
     onCloseForm: vi.fn(),

--- a/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
+++ b/packages/renderer/src/lib/image/BuildImageFromContainerfile.svelte
@@ -300,7 +300,7 @@ let providerConnections = $derived(
 let selectedProvider = $derived(providerConnections.length > 0 ? providerConnections[0] : undefined);
 $effect(() => {
   if (taskId && taskId !== buildImageInfo.taskId) {
-    // switching previous task wich could be finished or still running
+    // switching previous task which could be finished or still running
     if (buildImageInfo.buildImageKey) {
       // disconnect UI regardless of state
       disconnectUI(buildImageInfo.buildImageKey);

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -324,7 +324,7 @@ test.each([
 
   // now assert status item contains the icon
   const subElement = statusElement.getElementsByClassName('podman-desktop-icon-my-custom-icon');
-  // should not be overriden for list contribution
+  // should not be overridden for list contribution
   if (IMAGE_LIST_VIEW_ICONS === viewIdContrib) {
     expect(subElement.length).toBe(0);
   } else {
@@ -379,7 +379,7 @@ test.each([
   // grab badge with label 'my-custom-badge'
   const badge = screen.queryByText('my-custom-badge');
 
-  // should not be overriden for list contribution
+  // should not be overridden for list contribution
 
   if (IMAGE_LIST_VIEW_BADGES === viewIdContrib) {
     expect(badge).not.toBeInTheDocument();

--- a/packages/renderer/src/lib/image/ImagesList.spec.ts
+++ b/packages/renderer/src/lib/image/ImagesList.spec.ts
@@ -335,7 +335,7 @@ describe('Contributions', () => {
 
       await waitRender({});
 
-      // check image icon of status being overrided due to contributed menu
+      // check image icon of status being overridden due to contributed menu
 
       const fedoraOld = screen.getByRole('cell', { name: 'fedora 123456789012 old' });
       expect(fedoraOld).toBeInTheDocument();

--- a/packages/renderer/src/lib/image/PullImage.svelte
+++ b/packages/renderer/src/lib/image/PullImage.svelte
@@ -73,7 +73,7 @@ async function resolveShortname(): Promise<void> {
     shortnameImages = [];
     usePodmanFQN = false;
   }
-  // checks if there is no FQN that is from dokcer hub
+  // checks if there is no FQN that is from docker hub
   if (!shortnameImages.find(name => name.includes('docker.io'))) {
     podmanFQN = shortnameImages[0];
   } else {

--- a/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
+++ b/packages/renderer/src/lib/kube/KubePlayYAML.spec.ts
@@ -145,7 +145,7 @@ test('error: When pressing the Play button, expect us to show the errors to the 
   await userEvent.click(playButton);
 
   // Since we error out with the mocked kubePlay function (see very top of tests)
-  // Expect the following error to be in in the document.
+  // Expect the following error to be in the document.
   const error = screen.getByText('The following pods were created but failed to start: error 1, error 2');
   expect(error).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/kube/details/KubeDeploymentArtifact.spec.ts
+++ b/packages/renderer/src/lib/kube/details/KubeDeploymentArtifact.spec.ts
@@ -65,7 +65,7 @@ test('DeploymentSpec artifact renders with correct values', async () => {
   expect(screen.getByText('RollingUpdate')).toBeInTheDocument();
 });
 
-test('Container compoennt called for each container in the template', async () => {
+test('Container component called for each container in the template', async () => {
   const containerSpy = vi.spyOn(Container, 'default');
   render(KubeDeploymentArtifact, {
     artifact: fakeDeploymentSpec,

--- a/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.svelte
+++ b/packages/renderer/src/lib/kube/pods/terminal/KubernetesTerminal.svelte
@@ -12,7 +12,7 @@ import { terminalStates } from '/@/stores/kubernetes-terminal-state-store';
 export let podName: string;
 export let containerName: string;
 
-// On load, we collect the the original pod and container name,
+// On load, we collect the original pod and container name,
 // and we will use these to correctly save the terminal state when the component is destroyed.
 // Due to the way Svelte works, we need to store the original pod and container name in a separate / safe manner so that
 // the original values are not written over when the component is re-rendered.

--- a/packages/renderer/src/lib/kube/resource-permission.spec.ts
+++ b/packages/renderer/src/lib/kube/resource-permission.spec.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 });
 
 describe('listenResourcePermitted', () => {
-  test('resource shoudl be permitted', async () => {
+  test('resource should be permitted', async () => {
     const callbackMock = vi.fn();
     vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
 
@@ -61,7 +61,7 @@ describe('listenResourcePermitted', () => {
     expect(callbackMock).toBeCalledWith(true);
   });
 
-  test('resource shoudl be not permitted', async () => {
+  test('resource should be not permitted', async () => {
     const callbackMock = vi.fn();
     vi.mocked(window.isExperimentalConfigurationEnabled).mockResolvedValue(true);
 

--- a/packages/renderer/src/lib/markdown/micromark-listener-handler.spec.ts
+++ b/packages/renderer/src/lib/markdown/micromark-listener-handler.spec.ts
@@ -77,7 +77,7 @@ test('command button check: calls executeButtonCommand with args if data (with a
   expect(window.executeCommand).toHaveBeenCalledWith('foo', 'foo,bar,baz');
 });
 
-test('expect executeCommand is called if target is HTMLAnchorElement with NO commmand data', () => {
+test('expect executeCommand is called if target is HTMLAnchorElement with NO command data', () => {
   const target = document.createElement('a');
   target.dataset.command = 'foo';
   target.href = 'https://example.com';

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -299,7 +299,7 @@ describe.each([
       providerId: providerInfo.id,
       name: providerInfo.name,
     });
-    // expect it is sucessful
+    // expect it is successful
     await vi.waitFor(() => expect(cancelTokenMock).toBeCalled(), { timeout: 3000 });
   });
 

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
@@ -78,7 +78,7 @@ test('Expect to see one record when filtering with boolean keyword', async () =>
 });
 
 test('Expect to see one record when filtering with unknown keyword', async () => {
-  render(PreferencesRendering, { properties: records, key: 'key', searchValue: 'unknwon' });
+  render(PreferencesRendering, { properties: records, key: 'key', searchValue: 'unknown' });
   const noSettingsDiv = screen.getAllByText('No Settings Found');
   expect(noSettingsDiv.length > 0).toBe(true);
   expect(noSettingsDiv[0].parentElement).toHaveClass('text-[var(--pd-content-header)]');

--- a/packages/renderer/src/lib/task-manager/TaskManager.svelte
+++ b/packages/renderer/src/lib/task-manager/TaskManager.svelte
@@ -17,7 +17,7 @@ interface Props {
 
 let { searchTerm = $bindable('') }: Props = $props();
 
-// display or not the tasks manager (defaut is false)
+// display or not the tasks manager (default is false)
 let showTaskManager = $state(false);
 
 // to filter

--- a/packages/renderer/src/stores/event-store-manager.spec.ts
+++ b/packages/renderer/src/stores/event-store-manager.spec.ts
@@ -68,7 +68,7 @@ test('should get object into store-manager', async () => {
 
 test('should update object into store-manager', async () => {
   const eventStoreInfo: EventStoreInfo = {
-    name: 'test-udpdate',
+    name: 'test-update',
     size: 0,
     bufferEvents: [],
   } as unknown as EventStoreInfo;
@@ -82,12 +82,12 @@ test('should update object into store-manager', async () => {
   // take first item
   const storeInfo = allEvents[0];
   // check the name
-  expect(storeInfo.name).toBe('test-udpdate');
+  expect(storeInfo.name).toBe('test-update');
   expect(storeInfo.size).toBe(0);
 
   // create a new object with different size
   const updatedEventStoreInfo: EventStoreInfo = {
-    name: 'test-udpdate',
+    name: 'test-update',
     size: 1234,
   } as unknown as EventStoreInfo;
   updateStore(updatedEventStoreInfo);
@@ -98,6 +98,6 @@ test('should update object into store-manager', async () => {
   // take first item
   const afterUpdateInfo = allEventsAfterUpdate[0];
   // check the name
-  expect(afterUpdateInfo.name).toBe('test-udpdate');
+  expect(afterUpdateInfo.name).toBe('test-update');
   expect(afterUpdateInfo.size).toBe(1234);
 });

--- a/packages/renderer/src/stores/event-store.ts
+++ b/packages/renderer/src/stores/event-store.ts
@@ -137,7 +137,7 @@ export class EventStore<T> {
     eventName: string,
     args?: unknown[],
   ): Promise<void> {
-    // not intialized yet
+    // not initialized yet
     if (!this.updater) {
       return;
     }


### PR DESCRIPTION
### What does this PR do?

Fix typos in comments, test names, and test values in the renderer package:

- "overriden"/"overrided" → "overridden" (ImageDetails.spec.ts, ImagesList.spec.ts)
- "wich" → "which" (BuildImageFromContainerfile.svelte)
- "dokcer" → "docker" (PullImage.svelte, CreateContainerFromExistingImage.svelte)
- "is is" → "is" (container-utils.ts)
- "serach" → "search", "accross" → "across" (ContainerList.spec.ts)
- "the the" → "the" (KubernetesTerminal.svelte)
- "in in" → "in" (KubePlayYAML.spec.ts)
- "shoudl" → "should" (resource-permission.spec.ts)
- "compoennt" → "component" (KubeDeploymentArtifact.spec.ts)
- "sucessful" → "successful" (PreferencesConnectionCreationOrEditRendering.spec.ts)
- "unknwon" → "unknown" (PreferencesRendering.spec.ts)
- "commmand" → "command" (micromark-listener-handler.spec.ts)
- "defaut" → "default" (TaskManager.svelte)
- "to to" → "to" (GitHubIssueFeedback.spec.ts)
- "intialized" → "initialized" (event-store.ts)
- "udpdate" → "update" (event-store-manager.spec.ts)

### Screenshot / video of UI

N/A — no UI changes, only text corrections in comments and test names.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Run affected unit tests:
```bash
npx vitest run packages/renderer/src/lib/image/ImageDetails.spec.ts
npx vitest run packages/renderer/src/lib/kube/resource-permission.spec.ts
npx vitest run packages/renderer/src/stores/event-store-manager.spec.ts
```

- [ ] Tests are covering the bug fix or the new feature