### PR TITLE
fix(extensions): fix typos in extension code

### DIFF
--- a/extensions/compose/src/extension.ts
+++ b/extensions/compose/src/extension.ts
@@ -180,7 +180,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const onboardingPromptUserForVersionCommand = extensionApi.commands.registerCommand(
     'compose.onboarding.promptUserForVersion',
     async () => {
-      // Prompt the user for the verison
+      // Prompt the user for the version
       const composeRelease = await composeDownload.promptUserForVersion();
 
       // Update the context value that this is the version we are downloading

--- a/extensions/compose/src/handler.ts
+++ b/extensions/compose/src/handler.ts
@@ -76,7 +76,7 @@ export async function installComposeBinary(
       // Regardless of what happens, always update the configuration setting and context
       // for example, if this fails when installing, the configuration setting will be set back to false
       // again for the user to try again. If the installation succeeds, the configuration setting will be set to true
-      // and it will dissapear from the UI, etc.
+      // and it will disappear from the UI, etc.
       await checkAndUpdateComposeBinaryInstalledContexts(detect);
     }
   } else {

--- a/extensions/kind/src/kind-installer.spec.ts
+++ b/extensions/kind/src/kind-installer.spec.ts
@@ -73,7 +73,7 @@ test('Auth token is passed to Octokit factory', async () => {
   expect(mockOctokitFactory).toHaveBeenCalled();
 });
 
-test.skip('expect installBinaryToSystem to succesfully pass with a binary', async () => {
+test.skip('expect installBinaryToSystem to successfully pass with a binary', async () => {
   (extensionApi.env.isLinux as unknown as boolean) = true;
 
   // Create a tmp file using Node.js built-ins

--- a/extensions/kubectl-cli/src/extension.ts
+++ b/extensions/kubectl-cli/src/extension.ts
@@ -164,7 +164,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
         downloaded = true;
       } finally {
         // Make sure we log the telemetry even if we encounter an error
-        // If we have downloaded the binary, we can log it as being succcessfully downloaded
+        // If we have downloaded the binary, we can log it as being successfully downloaded
         telemetryLogger?.logUsage('kubectl.onboarding.downloadCommand', {
           successful: downloaded,
           version: kubectlVersionMetadata?.tag,
@@ -177,7 +177,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
   const onboardingPromptUserForVersionCommand = extensionApi.commands.registerCommand(
     'kubectl.onboarding.promptUserForVersion',
     async () => {
-      // Prompt the user for the verison
+      // Prompt the user for the version
       const kubectlRelease = await kubectlDownload.promptUserForVersion();
 
       // Update the context value that this is the version we are downloading

--- a/extensions/kubectl-cli/src/handler.ts
+++ b/extensions/kubectl-cli/src/handler.ts
@@ -76,7 +76,7 @@ export async function installKubectlBinary(
       // Regardless of what happens, always update the configuration setting and context
       // for example, if this fails when installing, the configuration setting will be set back to false
       // again for the user to try again. If the installation succeeds, the configuration setting will be set to true
-      // and it will dissapear from the UI, etc.
+      // and it will disappear from the UI, etc.
       await checkAndUpdateKubectlBinaryInstalledContexts(detect);
     }
   } else {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -200,7 +200,7 @@ async function doUpdateMachines(
 
   extensionApi.context.setValue(CLEANUP_REQUIRED_MACHINE_KEY, shouldCleanMachine);
 
-  // if there is at least one machine whihc does not need to be cleaned and the OS is not Linux
+  // if there is at least one machine which does not need to be cleaned and the OS is not Linux
   // podman is correctly setup so if there is an old notification asking the user to take action
   // we dispose it as not needed anymore
   if (!shouldCleanMachine && machines.length > 0 && !extensionApi.env.isLinux) {
@@ -699,7 +699,7 @@ export async function doMonitorProvider(provider: extensionApi.Provider): Promis
       provider.updateStatus('not-installed');
       extensionApi.context.setValue('podmanIsNotInstalled', true, 'onboarding');
       // if podman is not installed and the OS is linux we show the podman onboarding notification (if it has not been shown earlier)
-      // this should be limited to Linux as in other OSes the onboarding workflow is enabled based on the podman machine existance
+      // this should be limited to Linux as in other OSes the onboarding workflow is enabled based on the podman machine existence
       // and the notification is handled by checking the machine
       if (extensionApi.env.isLinux) {
         // push setup notification

--- a/extensions/podman/packages/extension/src/utils/notifications.ts
+++ b/extensions/podman/packages/extension/src/utils/notifications.ts
@@ -107,7 +107,7 @@ export class ExtensionNotifications {
   }
 
   private notifyDisguisedPodmanSocket(): void {
-    // Notification for if Docker Desktop has overriden the socket other tools are using it.
+    // Notification for if Docker Desktop has overridden the socket other tools are using it.
     this._disguisedPodmanNotificationDisposable ??= extensionApi.window.showNotification({
       title: 'Docker socket is not disguised correctly',
       body: 'The Docker socket (/var/run/docker.sock) is not being properly disguised by Podman. This could potentially cause docker-compatible tools to fail. Please disable any conflicting tools and re-enable Docker Compatibility.',

--- a/extensions/podman/packages/extension/src/utils/podman-configuration.ts
+++ b/extensions/podman/packages/extension/src/utils/podman-configuration.ts
@@ -160,7 +160,7 @@ export class PodmanConfiguration {
   }
 
   async updateRosettaSetting(useRosetta: boolean): Promise<void> {
-    // Initalize an empty configuration file for us to use
+    // Initialize an empty configuration file for us to use
     const containersConfContent = {
       containers: {},
       engine: {
@@ -220,7 +220,7 @@ export class PodmanConfiguration {
   }
 
   async updateMachineProviderSettings(provider: VMTYPE): Promise<void> {
-    // Initalize an empty configuration file for us to use
+    // Initialize an empty configuration file for us to use
     const containersConfContent = {
       containers: {},
       engine: {

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -2340,7 +2340,7 @@ declare module '@podman-desktop/api' {
      * export async function activate(extensionContext: api.ExtensionContext): Promise<void> {
      *   const statusBarItem = api.window.createStatusBarItem();
      *   statusBarItem.text = 'Information';
-     *   statusBarItem.tooltip = 'A problem occured';
+     *   statusBarItem.tooltip = 'A problem occurred';
      *   statusBarItem.command = 'extension-name.my-command';
      *   statusBarItem.iconClass = 'fa fa-exclamation-triangle';
      *   extensionContext.subscriptions.push(

--- a/packages/ui/src/lib/layouts/Page.spec.ts
+++ b/packages/ui/src/lib/layouts/Page.spec.ts
@@ -169,7 +169,7 @@ describe('Check for MutationObserver', () => {
     MutationObserver.prototype.disconnect = mutationObserverDisconnect;
   });
 
-  test('Expect disconected MutationObserver after onDestroy', async () => {
+  test('Expect disconnected MutationObserver after onDestroy', async () => {
     const subtitle = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
     const page = render(Page, {
       title: '',


### PR DESCRIPTION
### What does this PR do?

Fix typos in comments, JSDoc examples, and test names across extensions and related packages:

- "occured" → "occurred" (extension-api.d.ts)
- "disconected" → "disconnected" (packages/ui Page.spec.ts)
- "dissapear" → "disappear" (compose/handler.ts, kubectl-cli/handler.ts)
- "verison" → "version" (compose/extension.ts, kubectl-cli/extension.ts)
- "succcessfully" → "successfully" (kubectl-cli/extension.ts)
- "succesfully" → "successfully" (kind-installer.spec.ts)
- "whihc" → "which", "existance" → "existence" (podman/extension.ts)
- "overriden" → "overridden" (podman/notifications.ts)
- "Initalize" → "Initialize" (podman/podman-configuration.ts)

### Screenshot / video of UI

N/A — no UI changes, only text corrections in comments, JSDoc examples, and test names.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

Run affected unit tests:
```bash
npx vitest run extensions/kind/src/kind-installer.spec.ts
npx vitest run packages/ui/src/lib/layouts/Page.spec.ts
```

- [ ] Tests are covering the bug fix or the new feature