### PR TITLE
fix(tests): fix typos in E2E tests

### DIFF
--- a/tests/playwright/src/model/pages/forms/machine-creation-form.ts
+++ b/tests/playwright/src/model/pages/forms/machine-creation-form.ts
@@ -37,7 +37,7 @@ export class MachineCreationForm extends BasePage {
   readonly podmanMachineCPUs: Locator;
   readonly podmanMachineMemory: Locator;
   readonly podmanMachineDiskSize: Locator;
-  readonly rootPriviledgesCheckbox: Locator;
+  readonly rootPrivilegesCheckbox: Locator;
   readonly userModeNetworkingCheckbox: Locator;
   readonly providerTypeDropdown: DropdownComponent;
   readonly startNowCheckbox: Locator;
@@ -58,7 +58,7 @@ export class MachineCreationForm extends BasePage {
     this.podmanMachineCPUs = this.podmanMachineConfiguration.getByRole('slider', { name: 'CPU(s)' });
     this.podmanMachineMemory = this.podmanMachineConfiguration.getByRole('slider', { name: 'Memory' });
     this.podmanMachineDiskSize = this.podmanMachineConfiguration.getByRole('slider', { name: 'Disk size' });
-    this.rootPriviledgesCheckbox = this.podmanMachineConfiguration.getByRole('checkbox', {
+    this.rootPrivilegesCheckbox = this.podmanMachineConfiguration.getByRole('checkbox', {
       name: 'Machine with root privileges',
     });
     this.userModeNetworkingCheckbox = this.podmanMachineConfiguration.getByRole('checkbox', {
@@ -94,7 +94,7 @@ export class MachineCreationForm extends BasePage {
       await this.podmanMachineName.fill(machineName);
       await playExpect(this.podmanMachineName).toHaveValue(machineName);
 
-      await this.ensureCheckboxState(isRootful, this.rootPriviledgesCheckbox);
+      await this.ensureCheckboxState(isRootful, this.rootPrivilegesCheckbox);
       if (!!isWindows && getVirtualizationProvider() === PodmanVirtualizationProviders.WSL) {
         await this.ensureCheckboxState(enableUserNet, this.userModeNetworkingCheckbox);
       }

--- a/tests/playwright/src/model/pages/registries-page.ts
+++ b/tests/playwright/src/model/pages/registries-page.ts
@@ -214,7 +214,7 @@ export class RegistriesPage extends SettingsPage {
         );
         await loginButton.click({ timeout: 3000 });
       } catch (err) {
-        throw Error(`An error occured when trying to log into registry: ${(err as Error).message}`);
+        throw Error(`An error occurred when trying to log into registry: ${(err as Error).message}`);
       }
     });
   }

--- a/tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts
@@ -150,7 +150,7 @@ test.describe
       await test.step('Verify default form values', async () => {
         await playExpect(machineCreationForm.podmanMachineName).toHaveValue(PODMAN_MACHINE_NAME);
         await playExpect(machineCreationForm.imagePathBox).toHaveValue('');
-        await playExpect(machineCreationForm.rootPriviledgesCheckbox).toBeChecked();
+        await playExpect(machineCreationForm.rootPrivilegesCheckbox).toBeChecked();
         await playExpect(machineCreationForm.startNowCheckbox).toBeChecked();
       });
 


### PR DESCRIPTION
### What does this PR do?

Fix typos in E2E test files:
- `registries-page.ts`: "occured" → "occurred"
- `machine-creation-form.ts`: "rootPriviledgesCheckbox" → "rootPrivilegesCheckbox" (×3)
- `z-podman-machine-onboarding.spec.ts`: "rootPriviledgesCheckbox" → "rootPrivilegesCheckbox"

### Screenshot / video of UI

N/A — no UI changes, only text corrections in test code.

### What issues does this PR fix or reference?

N/A

### How to test this PR?

- [ ] `npx eslint tests/playwright/src/model/pages/registries-page.ts tests/playwright/src/model/pages/forms/machine-creation-form.ts tests/playwright/src/specs/z-podman-machine-onboarding.spec.ts`
- [ ] `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)