### PR TITLE
fix(container-registry): use memAvailable for accurate podman memory usage

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -53,7 +53,7 @@ import * as util from '/@/util.js';
 
 import { CancellationTokenRegistry } from './cancellation-token-registry.js';
 import type { ConfigurationRegistry } from './configuration-registry.js';
-import type { LibPod } from './dockerode/libpod-dockerode.js';
+import type { Info, LibPod } from './dockerode/libpod-dockerode.js';
 import { LibpodDockerode } from './dockerode/libpod-dockerode.js';
 import type { EnvfileParser } from './env-file-parser.js';
 import type { ProviderRegistry } from './provider-registry.js';
@@ -2557,6 +2557,83 @@ test('updateNetwork', async () => {
   await containerRegistry.updateNetwork('podman1', 'network1', ['1.1.1.1'], []);
 
   expect(libPodApi.updateNetwork).toHaveBeenCalledWith('network1', ['1.1.1.1'], []);
+});
+
+describe('info', () => {
+  function mockPodmanInfo(host: Partial<Info['host']>): LibPod {
+    return {
+      podmanInfo: vi.fn().mockResolvedValue({
+        host: {
+          cpus: 4,
+          cpuUtilization: { idlePercent: 90 },
+          memTotal: 1000,
+          memFree: 100,
+          ...host,
+        },
+        store: {
+          graphRootAllocated: 2000,
+          graphRootUsed: 500,
+        },
+      } as unknown as Info),
+    } as unknown as LibPod;
+  }
+
+  test('memAvailable present and valid computes memoryUsed from memAvailable', async () => {
+    const libPodApi = mockPodmanInfo({ memAvailable: 400 });
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman1',
+      id: 'podman1',
+      connection: {
+        type: 'podman',
+      },
+      api: {} as unknown as Dockerode,
+      libpodApi: libPodApi,
+    } as InternalContainerProvider);
+
+    const info = await containerRegistry.info('podman1');
+
+    expect(info.memory).toBe(1000);
+    expect(info.memoryUsed).toBe(600);
+  });
+
+  test('memAvailable absent falls back to memTotal - memFree (older Podman)', async () => {
+    const libPodApi = mockPodmanInfo({});
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman1',
+      id: 'podman1',
+      connection: {
+        type: 'podman',
+      },
+      api: {} as unknown as Dockerode,
+      libpodApi: libPodApi,
+    } as InternalContainerProvider);
+
+    const info = await containerRegistry.info('podman1');
+
+    expect(info.memory).toBe(1000);
+    expect(info.memoryUsed).toBe(900);
+  });
+
+  test('memAvailable equal to -1 (non-Linux sentinel) falls back to memTotal - memFree', async () => {
+    const libPodApi = mockPodmanInfo({ memAvailable: -1 });
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman1',
+      id: 'podman1',
+      connection: {
+        type: 'podman',
+      },
+      api: {} as unknown as Dockerode,
+      libpodApi: libPodApi,
+    } as InternalContainerProvider);
+
+    const info = await containerRegistry.info('podman1');
+
+    expect(info.memory).toBe(1000);
+    expect(info.memoryUsed).toBe(900);
+  });
 });
 
 describe('createVolume', () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2910,14 +2910,16 @@ export class ContainerProviderRegistry {
     }
     if (provider.libpodApi) {
       const podmanInfo = await provider.libpodApi.podmanInfo();
+      const { memTotal, memFree, memAvailable } = podmanInfo.host;
+      const memoryUsed = memAvailable !== undefined && memAvailable >= 0 ? memTotal - memAvailable : memTotal - memFree;
       return {
         engineId: provider.id,
         engineName: provider.name,
         engineType: provider.connection.type,
         cpus: podmanInfo.host.cpus,
         cpuIdle: podmanInfo.host.cpuUtilization.idlePercent,
-        memory: podmanInfo.host.memTotal,
-        memoryUsed: podmanInfo.host.memTotal - podmanInfo.host.memFree,
+        memory: memTotal,
+        memoryUsed,
         diskSize: podmanInfo.store.graphRootAllocated,
         diskUsed: podmanInfo.store.graphRootUsed,
       };

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -2911,7 +2911,14 @@ export class ContainerProviderRegistry {
     if (provider.libpodApi) {
       const podmanInfo = await provider.libpodApi.podmanInfo();
       const { memTotal, memFree, memAvailable } = podmanInfo.host;
-      const memoryUsed = memAvailable !== undefined && memAvailable >= 0 ? memTotal - memAvailable : memTotal - memFree;
+      let memoryUsed: number;
+      // Podman version >= 6.1.0 expose the memAvailable which is the amount of memory available to the system
+      if (memAvailable !== undefined && memAvailable >= 0) {
+        memoryUsed = memTotal - memAvailable;
+      } else {
+        memoryUsed = memTotal - memFree;
+      }
+
       return {
         engineId: provider.id,
         engineName: provider.name,

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -83,6 +83,7 @@ interface Host {
   idMappings: IdMappings;
   kernel: string;
   logDriver: string;
+  memAvailable?: number;
   memFree: number;
   memTotal: number;
   networkBackend: string;

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -83,6 +83,8 @@ interface Host {
   idMappings: IdMappings;
   kernel: string;
   logDriver: string;
+  // This property is being set in Podman 6.1.0+
+  // https://github.com/podman-container-tools/podman/issues/29116
   memAvailable?: number;
   memFree: number;
   memTotal: number;


### PR DESCRIPTION
### What does this PR do?
Podman's memAvailable reports memory available for use (excluding reclaimable caches/buffers), giving a more accurate memoryUsed value than memTotal - memFree. Falls back to the old calculation when memAvailable is missing or reports the non-Linux sentinel (-1).

Need to wait for new Podman 6.1 Release, for any other verison of podman this should report same mamory uasge 

### Screenshot / video of UI
Should now report more correct value

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/17488

### How to test this PR?
Production & this PR should report different usage 

- [x] Tests are covering the bug fix or the new feature
