### PR TITLE
feat(SecretsList): adding key and label prop to Table component

### DIFF
--- a/packages/renderer/src/lib/secrets/SecretsList.spec.ts
+++ b/packages/renderer/src/lib/secrets/SecretsList.spec.ts
@@ -146,8 +146,8 @@ test('Expect secrets table to be rendered with data', async () => {
   const table = screen.getByRole('table');
   expect(table).toBeInTheDocument();
 
-  expect(screen.getByText('my-secret-1')).toBeInTheDocument();
-  expect(screen.getByText('my-secret-2')).toBeInTheDocument();
+  expect(screen.getByRole('row', { name: 'my-secret-1' })).toBeInTheDocument();
+  expect(screen.getByRole('row', { name: 'my-secret-2' })).toBeInTheDocument();
 });
 
 test('Expect create button to be displayed when engine is available', async () => {

--- a/packages/renderer/src/lib/secrets/SecretsList.svelte
+++ b/packages/renderer/src/lib/secrets/SecretsList.svelte
@@ -137,6 +137,8 @@ function gotoCreateSecret(): void {
           data={secrets}
           columns={columns}
           row={row}
+          key={(secret): string => `${secret.engineId}:${secret.Id}`}
+          label={(secret): string => secret.Name}
           defaultSortColumn="Id">
         </Table>
       {/if}


### PR DESCRIPTION
### What does this PR do?

While working on the SecretsList I forgot to set the `key` and `label` props, setting it to ensure everything works as expected.

:warning: this is required for e2e to work, as the row get no name otherwise.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
