### PR TITLE
fix: resolve GHSA-2p49-hgcm-8545 in svgo

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,7 @@ overrides:
   webpack-dev-server: '>=5.2.5'
   '@babel/core': '>=7.29.6 <8.0.0'
   websocket-driver: '>=0.7.5'
+  svgo: '>=3.3.4 <4.0.0'
 
 importers:
 
@@ -11637,8 +11638,8 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
-  svgo@3.3.3:
-    resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
+  svgo@3.3.4:
+    resolution: {integrity: sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -16986,7 +16987,7 @@ snapshots:
       '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       cosmiconfig: 8.3.6(typescript@6.0.3)
       deepmerge: 4.3.1
-      svgo: 3.3.3
+      svgo: 3.3.4
     transitivePeerDependencies:
       - typescript
 
@@ -24063,7 +24064,7 @@ snapshots:
     dependencies:
       postcss: 8.5.22
       postcss-value-parser: 4.2.0
-      svgo: 3.3.3
+      svgo: 3.3.4
 
   postcss-unique-selectors@6.0.4(postcss@8.5.22):
     dependencies:
@@ -25513,7 +25514,7 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svgo@3.3.3:
+  svgo@3.3.4:
     dependencies:
       commander: 7.2.0
       css-select: 5.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ overrides:
   webpack-dev-server: '>=5.2.5'
   '@babel/core': '>=7.29.6 <8.0.0'
   websocket-driver: '>=0.7.5'
+  svgo: '>=3.3.4 <4.0.0'
 nodeLinker: hoisted
 allowBuilds:
   '@biomejs/biome': true


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-2p49-hgcm-8545 in `svgo`.

**Advisory**: SVGO removeScripts plugin leaves some executable scripts intact
**Vulnerable versions**: >=3.0.0 <3.3.4
**Patched versions**: >=3.3.4
**Advisory URL**: https://github.com/advisories/GHSA-2p49-hgcm-8545

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-2p49-hgcm-8545: _SVGO removeScripts plugin leaves some executable scripts intact_

### How to test this PR?

Run `pnpm audit` and verify GHSA-2p49-hgcm-8545 is no longer reported