### PR TITLE
feat(navigation): let extensions push entries onto global history

### DIFF
--- a/packages/api/src/api-sender/api-sender-channel-map.ts
+++ b/packages/api/src/api-sender/api-sender-channel-map.ts
@@ -20,6 +20,7 @@ import type { IConfigurationChangeEvent } from '/@/configuration/models.js';
 import type { ContributionInfo } from '/@/contribution-info.js';
 import type { CheckingState, ContextGeneralState } from '/@/kubernetes-contexts-states.js';
 import type { ForwardConfig } from '/@/kubernetes-port-forward-model.js';
+import type { NavigationHistoryPushInfo } from '/@/navigation-history-info.js';
 import type { PinOption } from '/@/status-bar/pin-option.js';
 import type { SystemOverviewStatusInfo } from '/@/system-overview-info.js';
 import type { NotificationTaskInfo, TaskInfo } from '/@/taskInfo.js';
@@ -109,6 +110,7 @@ export interface ApiSenderChannelMap {
   navigate: unknown;
   'navigation-go-back': never;
   'navigation-go-forward': never;
+  'navigation-history-push': NavigationHistoryPushInfo;
   'network-event': never;
   'notifications-updated': never;
   onDidChangeConfiguration: unknown;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -65,6 +65,7 @@ export * from './log-type.js';
 export * from './manifest-info.js';
 export * from './menu.js';
 export * from './menu-context.js';
+export * from './navigation-history-info.js';
 export * from './navigation-page.js';
 export * from './navigation-request.js';
 export * from './network-info.js';

--- a/packages/api/src/navigation-history-info.ts
+++ b/packages/api/src/navigation-history-info.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Payload sent from the main process to the renderer when an extension calls
+ * `navigation.pushHistoryEntry`, so the entry can be added to the global
+ * back/forward navigation history stack.
+ */
+export interface NavigationHistoryPushInfo {
+  extensionId: string;
+  id: string;
+  label: string;
+}
+
+/**
+ * A single entry in the renderer's navigation history stack.
+ * Regular (router-based) entries only carry a `url`. Entries pushed by an
+ * extension via `navigation.pushHistoryEntry` also carry `extensionEntry`,
+ * and `url` is a synthetic display value (never passed to the router).
+ */
+export interface HistoryStackEntry {
+  url: string;
+  extensionEntry?: NavigationHistoryPushInfo;
+}

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5084,6 +5084,38 @@ declare module '@podman-desktop/api' {
     readonly searchTerm?: string;
   }
 
+  /**
+   * An entry that an extension pushes onto Podman Desktop's global back/forward
+   * navigation history, e.g. to reflect an internal SPA navigation inside one of
+   * its webviews.
+   */
+  export interface NavigationHistoryEntry {
+    /**
+     * Opaque identifier for this entry. Passed back verbatim to listeners registered
+     * with {@link navigation.onDidNavigateToHistoryEntry} when the user navigates
+     * back/forward to this entry. Only meaningful to the extension that pushed it.
+     */
+    readonly id: string;
+
+    /**
+     * Display label shown for this entry in the history dropdown.
+     */
+    readonly label: string;
+  }
+
+  /**
+   * Event payload fired by {@link navigation.onDidNavigateToHistoryEntry} when
+   * the user navigates back/forward to an entry previously pushed by this
+   * extension.
+   */
+  export interface NavigateToHistoryEvent {
+    /**
+     * The {@link NavigationHistoryEntry.id id} of the history entry the user
+     * navigated to. The extension should restore its webview state accordingly.
+     */
+    readonly id: string;
+  }
+
   export namespace navigation {
     // Navigate to the Dashboard page
     export function navigateToDashboard(): Promise<void>;
@@ -5207,6 +5239,31 @@ declare module '@podman-desktop/api' {
      * @param args the arguments to provide to the command linked to the routeId
      */
     export function navigate(routeId: string, ...args: unknown[]): Promise<void>;
+
+    /**
+     * Push a new entry onto Podman Desktop's global back/forward navigation history.
+     * Call this whenever the user navigates to a new page within the extension's
+     * own webview (e.g. a SPA route change), so that the global Back/Forward
+     * buttons can step through it.
+     *
+     * @example
+     * ```typescript
+     * import { navigation } from '@podman-desktop/api';
+     *
+     * navigation.pushHistoryEntry({ id: '/models/llama3', label: 'Model: llama3' });
+     * ```
+     *
+     * @param entry the entry to push.
+     */
+    export function pushHistoryEntry(entry: NavigationHistoryEntry): void;
+
+    /**
+     * Fired when the user navigates back/forward through Podman Desktop's global
+     * history and lands on an entry previously pushed by this extension via
+     * {@link navigation.pushHistoryEntry}. The extension is responsible for
+     * restoring its own webview state accordingly (e.g. via `postMessage`).
+     */
+    export const onDidNavigateToHistoryEntry: Event<NavigateToHistoryEvent>;
   }
 
   /**

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -2020,6 +2020,46 @@ describe('Navigation', async () => {
   });
 });
 
+describe('navigation history', () => {
+  test('pushHistoryEntry delegates to navigationManager with the calling extension id', () => {
+    const api = createApi();
+
+    const pushHistoryEntrySpy = vi.spyOn(navigationManager, 'pushHistoryEntry');
+
+    const entry = { id: 'model-1', label: 'Model 1' };
+    api.navigation.pushHistoryEntry(entry);
+
+    expect(pushHistoryEntrySpy).toHaveBeenCalledWith('publisher.extension-name', entry);
+  });
+
+  test('onDidNavigateToHistoryEntry delegates to navigationManager with the calling extension id', () => {
+    const api = createApi();
+
+    const onDidNavigateToHistoryEntrySpy = vi.spyOn(navigationManager, 'onDidNavigateToHistoryEntry');
+
+    const listener = vi.fn();
+    api.navigation.onDidNavigateToHistoryEntry(listener);
+
+    expect(onDidNavigateToHistoryEntrySpy).toHaveBeenCalledWith(
+      'publisher.extension-name',
+      listener,
+      undefined,
+      undefined,
+    );
+  });
+
+  test('onDidNavigateToHistoryEntry fires the listener when the extension navigates back to its own entry', () => {
+    const api = createApi();
+
+    const listener = vi.fn();
+    api.navigation.onDidNavigateToHistoryEntry(listener);
+
+    navigationManager.navigateToHistoryEntry('publisher.extension-name', 'model-1');
+
+    expect(listener).toHaveBeenCalledWith({ id: 'model-1' });
+  });
+});
+
 test('check listWebviews', async () => {
   const api = createApi();
 

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1683,6 +1683,12 @@ export class ExtensionLoader implements IAsyncDisposable {
 
         return disposable;
       },
+      pushHistoryEntry: (entry: containerDesktopAPI.NavigationHistoryEntry): void => {
+        this.navigationManager.pushHistoryEntry(extensionInfo.id, entry);
+      },
+      onDidNavigateToHistoryEntry: (listener, thisArg, disposables) => {
+        return this.navigationManager.onDidNavigateToHistoryEntry(extensionInfo.id, listener, thisArg, disposables);
+      },
     };
 
     const net: typeof containerDesktopAPI.net = {

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3269,6 +3269,13 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle(
+      'navigation:navigateToHistoryEntry',
+      async (_listener, extensionId: string, entryId: string): Promise<void> => {
+        navigationManager.navigateToHistoryEntry(extensionId, entryId);
+      },
+    );
+
     this.ipcHandle('onboardingRegistry:listOnboarding', async (): Promise<OnboardingInfo[]> => {
       return onboardingRegistry.listOnboarding();
     });

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -27,6 +27,7 @@ import type { ContainerProviderRegistry } from '/@/plugin/container-registry.js'
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
 import type { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
+import { Disposable } from '/@/plugin/types/disposable.js';
 import type { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
 
 import { NavigationManager } from './navigation-manager.js';
@@ -359,5 +360,73 @@ describe('register navigation commands', () => {
       expect.objectContaining({ command: 'navigation.goBack', title: 'Go Back', category: 'Navigation' }),
       expect.objectContaining({ command: 'navigation.goForward', title: 'Go Forward', category: 'Navigation' }),
     );
+  });
+});
+
+describe('pushHistoryEntry', () => {
+  test('sends the navigation-history-push payload', () => {
+    navigationManager.pushHistoryEntry('my.extension', {
+      id: 'entry-1',
+      label: 'Entry 1',
+    });
+
+    expect(apiSender.send).toHaveBeenCalledWith('navigation-history-push', {
+      extensionId: 'my.extension',
+      id: 'entry-1',
+      label: 'Entry 1',
+    });
+  });
+});
+
+describe('onDidNavigateToHistoryEntry / navigateToHistoryEntry', () => {
+  test('a registered listener is called with a NavigateToHistoryEvent when the extension navigates back to it', () => {
+    const listener = vi.fn();
+    navigationManager.onDidNavigateToHistoryEntry('extensionA', listener);
+
+    navigationManager.navigateToHistoryEntry('extensionA', 'entry-1');
+
+    expect(listener).toHaveBeenCalledWith({ id: 'entry-1' });
+  });
+
+  test('two extensions with the same entry id do not cross-fire', () => {
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+    navigationManager.onDidNavigateToHistoryEntry('extensionA', listenerA);
+    navigationManager.onDidNavigateToHistoryEntry('extensionB', listenerB);
+
+    navigationManager.navigateToHistoryEntry('extensionA', 'entry-1');
+
+    expect(listenerA).toHaveBeenCalledWith({ id: 'entry-1' });
+    expect(listenerB).not.toHaveBeenCalled();
+  });
+
+  test('is a safe no-op when no listener is registered for the extension', () => {
+    expect(() => navigationManager.navigateToHistoryEntry('unknown.extension', 'entry-1')).not.toThrow();
+  });
+});
+
+describe('dispose', () => {
+  test('clears the history emitters so previously registered listeners no longer fire', () => {
+    const listener = vi.fn();
+    navigationManager.onDidNavigateToHistoryEntry('extensionA', listener);
+
+    navigationManager.dispose();
+
+    navigationManager.navigateToHistoryEntry('extensionA', 'entry-1');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('disposes the disposables registered during init', () => {
+    const commandDisposeFn = vi.fn();
+    vi.mocked(commandRegistry.registerCommand).mockReturnValue(Disposable.create(commandDisposeFn));
+    const paletteDisposeFn = vi.fn();
+    vi.mocked(commandRegistry.registerCommandPalette).mockReturnValue(Disposable.create(paletteDisposeFn));
+
+    navigationManager.init();
+    navigationManager.dispose();
+
+    expect(commandDisposeFn).toHaveBeenCalled();
+    expect(paletteDisposeFn).toHaveBeenCalled();
   });
 });

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -16,8 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { NavigateToExtensionsCatalogOptions, ProviderContainerConnection } from '@podman-desktop/api';
-import type { NavigationRequest } from '@podman-desktop/core-api';
+import type {
+  NavigateToExtensionsCatalogOptions,
+  NavigateToHistoryEvent,
+  NavigationHistoryEntry,
+  ProviderContainerConnection,
+} from '@podman-desktop/api';
+import type { DisposableGroup, NavigationRequest } from '@podman-desktop/core-api';
 import { IDisposable, NavigationPage } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
@@ -25,6 +30,7 @@ import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 import { CommandRegistry } from '/@/plugin/command-registry.js';
 import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
 import { ContributionManager } from '/@/plugin/contribution-manager.js';
+import { Emitter } from '/@/plugin/events/emitter.js';
 import { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { Disposable } from '/@/plugin/types/disposable.js';
@@ -38,6 +44,7 @@ export interface NavigationRoute {
 @injectable()
 export class NavigationManager {
   #registry: Map<string, NavigationRoute>;
+  #historyEmitters = new Map<string, Emitter<NavigateToHistoryEvent>>();
   #disposables: IDisposable[] = [];
 
   constructor(
@@ -98,6 +105,8 @@ export class NavigationManager {
   @preDestroy()
   dispose(): void {
     this.#disposables.forEach(disposable => disposable.dispose());
+    this.#historyEmitters.forEach(emitter => emitter.dispose());
+    this.#historyEmitters.clear();
   }
 
   navigateTo<T extends NavigationPage>(navigateRequest: NavigationRequest<T>): void {
@@ -130,6 +139,47 @@ export class NavigationManager {
     }
 
     return this.commandRegistry.executeCommand(route.commandId, ...args);
+  }
+
+  pushHistoryEntry(extensionId: string, entry: NavigationHistoryEntry): void {
+    console.log(`[navigation-history] extension ${extensionId} pushed history entry ${entry.id} (${entry.label})`);
+
+    this.apiSender.send('navigation-history-push', {
+      extensionId,
+      id: entry.id,
+      label: entry.label,
+    });
+  }
+
+  onDidNavigateToHistoryEntry(
+    extensionId: string,
+    listener: (e: NavigateToHistoryEvent) => unknown,
+    thisArgs?: unknown,
+    disposables?: DisposableGroup,
+  ): IDisposable {
+    return this.getOrCreateHistoryEmitter(extensionId).event(listener, thisArgs, disposables);
+  }
+
+  navigateToHistoryEntry(extensionId: string, entryId: string): void {
+    const emitter = this.#historyEmitters.get(extensionId);
+    if (!emitter) {
+      console.warn(
+        `[navigation-history] navigated to history entry ${entryId} for extension ${extensionId} but no listener is registered`,
+      );
+      return;
+    }
+
+    console.log(`[navigation-history] navigated to history entry ${entryId} for extension ${extensionId}`);
+    emitter.fire({ id: entryId });
+  }
+
+  private getOrCreateHistoryEmitter(extensionId: string): Emitter<NavigateToHistoryEvent> {
+    let emitter = this.#historyEmitters.get(extensionId);
+    if (!emitter) {
+      emitter = new Emitter<NavigateToHistoryEvent>();
+      this.#historyEmitters.set(extensionId, emitter);
+    }
+    return emitter;
   }
 
   async navigateToProviderTask(internalProviderId: string, taskId?: number): Promise<void> {

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -284,6 +284,13 @@ export function initExposure(): void {
     return ipcRenderer.invoke('navigation:navigateToRoute', routeId, ...args);
   });
 
+  contextBridge.exposeInMainWorld(
+    'navigateToExtensionHistoryEntry',
+    async (extensionId: string, entryId: string): Promise<void> => {
+      return ipcRenderer.invoke('navigation:navigateToHistoryEntry', extensionId, entryId);
+    },
+  );
+
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');
   });

--- a/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
+++ b/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
@@ -66,7 +66,7 @@ describe('button states', () => {
   });
 
   test('back button should be enabled when can go back', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 1;
 
     const { findByTitle } = render(NavigationButtons);
@@ -78,7 +78,7 @@ describe('button states', () => {
   });
 
   test('forward button should be enabled when can go forward', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 0;
 
     const { findByTitle } = render(NavigationButtons);
@@ -92,7 +92,7 @@ describe('button states', () => {
 
 describe('click navigation', () => {
   test('clicking back button should call goBack', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 1;
 
     const { findByTitle } = render(NavigationButtons);
@@ -105,7 +105,7 @@ describe('click navigation', () => {
   });
 
   test('clicking forward button should call goForward', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 0;
 
     const { findByTitle } = render(NavigationButtons);
@@ -228,7 +228,7 @@ describe('keyboard navigation - macOS', () => {
 
 describe('trackpad swipe navigation', () => {
   test('swipe right (negative deltaX) should trigger goBack', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 1;
 
     render(NavigationButtons);
@@ -241,7 +241,7 @@ describe('trackpad swipe navigation', () => {
   });
 
   test('swipe left (positive deltaX) should trigger goForward', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 0;
 
     render(NavigationButtons);
@@ -254,7 +254,7 @@ describe('trackpad swipe navigation', () => {
   });
 
   test('horizontal wheel handled by nested content should not trigger history navigation', async () => {
-    navigationHistory.stack = ['/dashboard', '/containers'];
+    navigationHistory.stack = [{ url: '/dashboard' }, { url: '/containers' }];
     navigationHistory.index = 1;
 
     render(NavigationButtons);
@@ -298,7 +298,7 @@ describe('trackpad swipe navigation', () => {
 
 describe('long press dropdown', () => {
   test('long press on back button should show dropdown', async () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }, { url: '/pods' }];
     navigationHistory.index = 2;
 
     vi.mocked(getBackEntries).mockReturnValue([
@@ -323,8 +323,32 @@ describe('long press dropdown', () => {
     });
   });
 
+  test('long press on back button should show dropdown with extension-sourced entries', async () => {
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/__extension__/my.extension/model-1' }];
+    navigationHistory.index = 1;
+
+    vi.mocked(getBackEntries).mockReturnValue([
+      { index: 0, name: 'My Extension > Model 1', icon: { iconImage: 'data:image/png;base64,abc' } },
+    ]);
+
+    const { findByTitle } = render(NavigationButtons);
+
+    await vi.waitFor(async () => {
+      const backButton = await findByTitle('Back (hold for history)');
+
+      // Start long press
+      await fireEvent.mouseDown(backButton, { button: 0 });
+
+      // Advance timer past long press delay (500ms)
+      vi.advanceTimersByTime(600);
+
+      // Dropdown should show the extension-sourced entry's label
+      expect(await findByTitle('My Extension > Model 1')).toBeInTheDocument();
+    });
+  });
+
   test('long press on forward button should show dropdown', async () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }, { url: '/pods' }];
     navigationHistory.index = 0;
 
     vi.mocked(getForwardEntries).mockReturnValue([
@@ -350,7 +374,7 @@ describe('long press dropdown', () => {
   });
 
   test('short click should not show dropdown', async () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 1;
 
     vi.mocked(getBackEntries).mockReturnValue([{ index: 0, name: 'Containers' }]);
@@ -373,7 +397,7 @@ describe('long press dropdown', () => {
 
 describe('dropdown item selection', () => {
   test('clicking dropdown item should navigate to that index', async () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }, { url: '/pods' }];
     navigationHistory.index = 2;
 
     vi.mocked(getBackEntries).mockReturnValue([

--- a/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
+++ b/packages/renderer/src/lib/ui/NavigationButtons.spec.ts
@@ -328,7 +328,7 @@ describe('long press dropdown', () => {
     navigationHistory.index = 1;
 
     vi.mocked(getBackEntries).mockReturnValue([
-      { index: 0, name: 'My Extension > Model 1', icon: { iconImage: 'data:image/png;base64,abc' } },
+      { index: 0, name: 'My Extension → Model 1', icon: { iconImage: 'data:image/png;base64,abc' } },
     ]);
 
     const { findByTitle } = render(NavigationButtons);
@@ -343,7 +343,7 @@ describe('long press dropdown', () => {
       vi.advanceTimersByTime(600);
 
       // Dropdown should show the extension-sourced entry's label
-      expect(await findByTitle('My Extension > Model 1')).toBeInTheDocument();
+      expect(await findByTitle('My Extension → Model 1')).toBeInTheDocument();
     });
   });
 

--- a/packages/renderer/src/lib/ui/NavigationButtons.svelte
+++ b/packages/renderer/src/lib/ui/NavigationButtons.svelte
@@ -227,7 +227,7 @@ onMount(() => {
           options={dropdownOptions}
           ariaLabel={btn.ariaLabel}
           onChange={handleHistorySelect}
-          class="absolute left-0 top-full z-50 mt-1" />
+          class="absolute left-0 top-full z-50 mt-1 max-w-96" />
       </div>
     {/each}
 </div>

--- a/packages/renderer/src/stores/navigation-history.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.spec.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NavigationHistoryPushInfo } from '@podman-desktop/core-api';
 import { writable } from 'svelte/store';
 import { router, type TinroRoute } from 'tinro';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -30,6 +31,17 @@ import {
   goToHistoryIndex,
   navigationHistory,
 } from '/@/stores/navigation-history.svelte';
+
+// The store registers a `window.events.receive('navigation-history-push', ...)` listener at
+// module-load time, so `window.events` must be patched before the module is first imported.
+const { eventsReceiveMock } = vi.hoisted(() => {
+  const eventsReceiveMock = vi.fn();
+  Object.defineProperty(window, 'events', {
+    value: { receive: eventsReceiveMock },
+    configurable: true,
+  });
+  return { eventsReceiveMock };
+});
 
 let routerSubscribeCallback = vi.hoisted(() => {
   return vi.fn() as unknown as (navigation: TinroRoute) => void;
@@ -93,15 +105,23 @@ vi.mock(import('/@/stores/navigation/navigation-registry'), async () => {
   };
 });
 
+// Captured once: the listener the store registered via `window.events.receive('navigation-history-push', ...)`
+let navigationHistoryPushCallback: (entry: NavigationHistoryPushInfo) => void;
+
 beforeAll(() => {
   expect(router.subscribe).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
   routerSubscribeCallback = vi.mocked(router.subscribe).mock.calls[0][0];
+
+  const pushCall = eventsReceiveMock.mock.calls.find(call => call[0] === 'navigation-history-push');
+  expect(pushCall).toBeDefined();
+  navigationHistoryPushCallback = pushCall?.[1] as (entry: NavigationHistoryPushInfo) => void;
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
+  vi.mocked(window.navigateToExtensionHistoryEntry).mockResolvedValue(undefined);
   vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(true);
 
   vi.mocked(navigationRegistry).set([
@@ -132,7 +152,7 @@ describe('goBack', () => {
   });
 
   test('should not navigate when at first entry', () => {
-    navigationHistory.stack = ['/containers'];
+    navigationHistory.stack = [{ url: '/containers' }];
     navigationHistory.index = 0;
 
     goBack();
@@ -142,7 +162,7 @@ describe('goBack', () => {
   });
 
   test('should navigate to previous entry', () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 1;
 
     goBack();
@@ -166,7 +186,7 @@ describe('goForward', () => {
   });
 
   test('should not navigate when at last entry', () => {
-    navigationHistory.stack = ['/containers'];
+    navigationHistory.stack = [{ url: '/containers' }];
     navigationHistory.index = 0;
 
     goForward();
@@ -176,7 +196,7 @@ describe('goForward', () => {
   });
 
   test('should navigate to next entry', () => {
-    navigationHistory.stack = ['/containers', '/images'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }];
     navigationHistory.index = 0;
 
     goForward();
@@ -199,7 +219,7 @@ describe('kubernetes dashboard submenu', () => {
     routerSubscribeCallback({ url: '/kubernetes/dashboard' } as TinroRoute);
 
     // Stack should contain / and /kubernetes/dashboard, but NOT /kubernetes
-    expect(navigationHistory.stack).toEqual(['/', '/kubernetes/dashboard']);
+    expect(navigationHistory.stack).toEqual([{ url: '/' }, { url: '/kubernetes/dashboard' }]);
     expect(navigationHistory.index).toBe(1);
   });
 
@@ -212,7 +232,7 @@ describe('kubernetes dashboard submenu', () => {
     routerSubscribeCallback({ url: '/kubernetes' } as TinroRoute);
 
     // Stack should contain both / and /kubernetes
-    expect(navigationHistory.stack).toEqual(['/', '/kubernetes']);
+    expect(navigationHistory.stack).toEqual([{ url: '/' }, { url: '/kubernetes' }]);
     expect(navigationHistory.index).toBe(1);
   });
 });
@@ -224,8 +244,26 @@ describe('router navigation events', () => {
     routerSubscribeCallback({ url: '/index.html' } as TinroRoute);
     routerSubscribeCallback({ url: '/' } as TinroRoute);
 
-    expect(navigationHistory.stack).not.toContain('/index.html');
-    expect(navigationHistory.stack).toContain('/');
+    expect(navigationHistory.stack).not.toContainEqual({ url: '/index.html' });
+    expect(navigationHistory.stack).toContainEqual({ url: '/' });
+    expect(navigationHistory.index).toBe(0);
+  });
+
+  test('should not store /webviews/ URLs in the history stack', () => {
+    // Extensions with their own history providers push their own entries via
+    // navigation.pushHistoryEntry; the router-level /webviews/ URL change should be ignored.
+    routerSubscribeCallback({ url: '/' } as TinroRoute);
+    routerSubscribeCallback({ url: '/webviews/my-webview-id' } as TinroRoute);
+
+    expect(navigationHistory.stack).toEqual([{ url: '/' }]);
+    expect(navigationHistory.index).toBe(0);
+  });
+
+  test('should not store /contribs/ URLs in the history stack', () => {
+    routerSubscribeCallback({ url: '/' } as TinroRoute);
+    routerSubscribeCallback({ url: '/contribs/my-contrib/' } as TinroRoute);
+
+    expect(navigationHistory.stack).toEqual([{ url: '/' }]);
     expect(navigationHistory.index).toBe(0);
   });
 });
@@ -236,7 +274,7 @@ describe('goToHistoryIndex', () => {
   });
 
   test('should not navigate to invalid negative index', () => {
-    navigationHistory.stack = ['/containers'];
+    navigationHistory.stack = [{ url: '/containers' }];
     navigationHistory.index = 0;
     goToHistoryIndex(-1);
 
@@ -244,7 +282,7 @@ describe('goToHistoryIndex', () => {
   });
 
   test('should not navigate to index beyond stack', () => {
-    navigationHistory.stack = ['/containers'];
+    navigationHistory.stack = [{ url: '/containers' }];
     navigationHistory.index = 0;
 
     goToHistoryIndex(5);
@@ -253,7 +291,7 @@ describe('goToHistoryIndex', () => {
   });
 
   test('should not navigate to current index', () => {
-    navigationHistory.stack = ['/containers'];
+    navigationHistory.stack = [{ url: '/containers' }];
     navigationHistory.index = 0;
 
     goToHistoryIndex(0);
@@ -262,13 +300,27 @@ describe('goToHistoryIndex', () => {
   });
 
   test('should navigate to valid index', () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }, { url: '/pods' }];
     navigationHistory.index = 2;
 
     goToHistoryIndex(0);
 
     expect(navigationHistory.index).toBe(0);
     expect(router.goto).toHaveBeenCalledWith('/containers');
+  });
+
+  test('should call window.navigateToExtensionHistoryEntry instead of router.goto for an extension-sourced entry', () => {
+    // Uses a dedicated extensionId (not reused elsewhere) so this test doesn't leave the
+    // module-level `extensionsNavigatingHistory` guard "dirty" for unrelated tests below.
+    const extensionEntry: NavigationHistoryPushInfo = { extensionId: 'ext.goto-test', id: 'model-1', label: 'Model 1' };
+    navigationHistory.stack = [{ url: '/__extension__/ext.goto-test/model-1', extensionEntry }, { url: '/containers' }];
+    navigationHistory.index = 1;
+
+    goToHistoryIndex(0);
+
+    expect(navigationHistory.index).toBe(0);
+    expect(window.navigateToExtensionHistoryEntry).toHaveBeenCalledWith('ext.goto-test', 'model-1');
+    expect(router.goto).not.toHaveBeenCalled();
   });
 });
 
@@ -279,7 +331,7 @@ describe('getBackEntries', () => {
   });
 
   test('should return empty array when at first entry', () => {
-    navigationHistory.stack = ['/containers'];
+    navigationHistory.stack = [{ url: '/containers' }];
     navigationHistory.index = 0;
 
     const entries = getBackEntries();
@@ -287,7 +339,7 @@ describe('getBackEntries', () => {
   });
 
   test('should return previous entries in reverse order with computed names', () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }, { url: '/pods' }];
     navigationHistory.index = 2;
 
     const entries = getBackEntries();
@@ -306,7 +358,7 @@ describe('getForwardEntries', () => {
   });
 
   test('should return empty array when at last entry', () => {
-    navigationHistory.stack = ['/containers'];
+    navigationHistory.stack = [{ url: '/containers' }];
     navigationHistory.index = 0;
 
     const entries = getForwardEntries();
@@ -314,7 +366,7 @@ describe('getForwardEntries', () => {
   });
 
   test('should return forward entries in order with computed names', () => {
-    navigationHistory.stack = ['/containers', '/images', '/pods'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }, { url: '/pods' }];
     navigationHistory.index = 0;
 
     const entries = getForwardEntries();
@@ -329,7 +381,11 @@ describe('getForwardEntries', () => {
 describe('submenu navigation', () => {
   test('should show submenu parent > resource type breadcrumb', () => {
     // Simulate navigation: Dashboard -> Kubernetes Pods list -> Specific pod
-    navigationHistory.stack = ['/', '/kubernetes/pods', '/kubernetes/pods/nginx-pod/default/summary'];
+    navigationHistory.stack = [
+      { url: '/' },
+      { url: '/kubernetes/pods' },
+      { url: '/kubernetes/pods/nginx-pod/default/summary' },
+    ];
     navigationHistory.index = 2;
 
     const backEntries = getBackEntries();
@@ -349,9 +405,9 @@ describe('submenu navigation', () => {
   test('should preserve special characters in submenu breadcrumbs', () => {
     // Test ConfigMaps & Secrets with special character '&'
     navigationHistory.stack = [
-      '/',
-      '/kubernetes/configmapsSecrets',
-      '/kubernetes/configmapsSecrets/my-config/default/summary',
+      { url: '/' },
+      { url: '/kubernetes/configmapsSecrets' },
+      { url: '/kubernetes/configmapsSecrets/my-config/default/summary' },
     ];
     navigationHistory.index = 2;
 
@@ -368,8 +424,8 @@ describe('submenu navigation', () => {
   test('should show full breadcrumb for detail pages including tab', () => {
     // Test detail page shows: parent > resource type > resource name > tab
     navigationHistory.stack = [
-      '/kubernetes/configmapsSecrets/my-config/default/summary',
-      '/kubernetes/configmapsSecrets',
+      { url: '/kubernetes/configmapsSecrets/my-config/default/summary' },
+      { url: '/kubernetes/configmapsSecrets' },
     ];
     navigationHistory.index = 1;
 
@@ -383,26 +439,30 @@ describe('tab navigation for detail pages', () => {
   test('should add new entry for each tab change', () => {
     // Start by navigating to containers list
     routerSubscribeCallback({ url: '/containers' } as TinroRoute);
-    expect(navigationHistory.stack).toEqual(['/containers']);
+    expect(navigationHistory.stack).toEqual([{ url: '/containers' }]);
     expect(navigationHistory.index).toBe(0);
 
     // Navigate to container detail page summary tab (should add new entry)
     routerSubscribeCallback({ url: '/containers/abc123/summary' } as TinroRoute);
-    expect(navigationHistory.stack).toEqual(['/containers', '/containers/abc123/summary']);
+    expect(navigationHistory.stack).toEqual([{ url: '/containers' }, { url: '/containers/abc123/summary' }]);
     expect(navigationHistory.index).toBe(1);
 
     // Switch to logs tab (should ADD a new entry)
     routerSubscribeCallback({ url: '/containers/abc123/logs' } as TinroRoute);
 
     // Stack should now have 3 entries (each tab is a separate history entry)
-    expect(navigationHistory.stack).toEqual(['/containers', '/containers/abc123/summary', '/containers/abc123/logs']);
+    expect(navigationHistory.stack).toEqual([
+      { url: '/containers' },
+      { url: '/containers/abc123/summary' },
+      { url: '/containers/abc123/logs' },
+    ]);
     expect(navigationHistory.stack.length).toBe(3);
     expect(navigationHistory.index).toBe(2);
   });
 
   test('should show tab name in display for different tabs', () => {
     // Set up stack with different tabs
-    navigationHistory.stack = ['/containers', '/containers/abc123/inspect'];
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/containers/abc123/inspect' }];
     navigationHistory.index = 0;
 
     const entries = getForwardEntries();
@@ -415,12 +475,109 @@ describe('tab navigation for detail pages', () => {
 
   test('should show resource name with tab for submenu resources', () => {
     // Kubernetes pod with tab navigation
-    navigationHistory.stack = ['/kubernetes/pods', '/kubernetes/pods/nginx-pod/default/logs'];
+    navigationHistory.stack = [{ url: '/kubernetes/pods' }, { url: '/kubernetes/pods/nginx-pod/default/logs' }];
     navigationHistory.index = 0;
 
     const entries = getForwardEntries();
 
     expect(entries.length).toBe(1);
     expect(entries[0].name).toBe('Kubernetes > Pods > nginx-pod > Logs');
+  });
+});
+
+describe('navigation-history-push event', () => {
+  test('appends a new stack entry sourced from the extension and moves the index to it', () => {
+    const pushInfo: NavigationHistoryPushInfo = { extensionId: 'ext.a', id: 'model-1', label: 'Model 1' };
+
+    navigationHistoryPushCallback(pushInfo);
+
+    expect(navigationHistory.stack).toEqual([{ url: '/__extension__/ext.a/model-1', extensionEntry: pushInfo }]);
+    expect(navigationHistory.index).toBe(0);
+  });
+
+  test('appends on top of existing router-based history', () => {
+    navigationHistory.stack = [{ url: '/containers' }];
+    navigationHistory.index = 0;
+
+    const pushInfo: NavigationHistoryPushInfo = { extensionId: 'ext.a', id: 'model-1', label: 'Model 1' };
+    navigationHistoryPushCallback(pushInfo);
+
+    expect(navigationHistory.stack).toEqual([
+      { url: '/containers' },
+      { url: '/__extension__/ext.a/model-1', extensionEntry: pushInfo },
+    ]);
+    expect(navigationHistory.index).toBe(1);
+  });
+
+  test('does not create a duplicate entry when the same extensionId+id is pushed twice in a row', () => {
+    const pushInfo: NavigationHistoryPushInfo = { extensionId: 'ext.a', id: 'model-1', label: 'Model 1' };
+
+    navigationHistoryPushCallback(pushInfo);
+    navigationHistoryPushCallback(pushInfo);
+
+    expect(navigationHistory.stack).toEqual([{ url: '/__extension__/ext.a/model-1', extensionEntry: pushInfo }]);
+    expect(navigationHistory.index).toBe(0);
+  });
+
+  test('still pushes a new entry when only the id differs from the current top entry', () => {
+    const first: NavigationHistoryPushInfo = { extensionId: 'ext.a', id: 'model-1', label: 'Model 1' };
+    const second: NavigationHistoryPushInfo = { extensionId: 'ext.a', id: 'model-2', label: 'Model 2' };
+
+    navigationHistoryPushCallback(first);
+    navigationHistoryPushCallback(second);
+
+    expect(navigationHistory.stack).toEqual([
+      { url: '/__extension__/ext.a/model-1', extensionEntry: first },
+      { url: '/__extension__/ext.a/model-2', extensionEntry: second },
+    ]);
+    expect(navigationHistory.index).toBe(1);
+  });
+
+  test('truncates forward history when a push happens after navigating back', () => {
+    navigationHistory.stack = [{ url: '/containers' }, { url: '/images' }, { url: '/pods' }];
+    // Simulate having navigated back to '/containers' (forward history: '/images', '/pods')
+    navigationHistory.index = 0;
+
+    const pushInfo: NavigationHistoryPushInfo = { extensionId: 'ext.a', id: 'model-1', label: 'Model 1' };
+    navigationHistoryPushCallback(pushInfo);
+
+    expect(navigationHistory.stack).toEqual([
+      { url: '/containers' },
+      { url: '/__extension__/ext.a/model-1', extensionEntry: pushInfo },
+    ]);
+    expect(navigationHistory.index).toBe(1);
+    expect(getForwardEntries()).toEqual([]);
+  });
+});
+
+describe('extensionsNavigatingHistory guard', () => {
+  test('suppresses the first push from an extension right after navigating back/forward to one of its entries, then processes the next one normally', () => {
+    const originalEntry: NavigationHistoryPushInfo = { extensionId: 'ext.guard', id: 'entry-1', label: 'Entry 1' };
+    navigationHistory.stack = [
+      { url: '/__extension__/ext.guard/entry-1', extensionEntry: originalEntry },
+      { url: '/containers' },
+    ];
+    navigationHistory.index = 1;
+
+    // Simulate the user clicking "back" to the extension's history entry
+    goToHistoryIndex(0);
+    expect(navigationHistory.index).toBe(0);
+    expect(window.navigateToExtensionHistoryEntry).toHaveBeenCalledWith('ext.guard', 'entry-1');
+
+    // The webview re-mounts and replays its initial route as a "push" - this is stale and must be ignored
+    navigationHistoryPushCallback({ extensionId: 'ext.guard', id: 'entry-1', label: 'Entry 1' });
+
+    expect(navigationHistory.stack).toHaveLength(2);
+    expect(navigationHistory.index).toBe(0);
+
+    // A subsequent, genuine push from the same extension is processed normally (guard only suppresses once)
+    const nextEntry: NavigationHistoryPushInfo = { extensionId: 'ext.guard', id: 'entry-2', label: 'Entry 2' };
+    navigationHistoryPushCallback(nextEntry);
+
+    expect(navigationHistory.stack).toEqual([
+      { url: '/__extension__/ext.guard/entry-1', extensionEntry: originalEntry },
+      { url: '/__extension__/ext.guard/entry-2', extensionEntry: nextEntry },
+    ]);
+    expect(navigationHistory.index).toBe(1);
   });
 });

--- a/packages/renderer/src/stores/navigation-history.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.spec.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { NavigationHistoryPushInfo } from '@podman-desktop/core-api';
+import type { ExtensionInfo, NavigationHistoryPushInfo } from '@podman-desktop/core-api';
 import { writable } from 'svelte/store';
 import { router, type TinroRoute } from 'tinro';
-import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { extensionInfos } from '/@/stores/extensions';
 import * as kubernetesNoCurrentContext from '/@/stores/kubernetes-no-current-context';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
 import {
@@ -123,6 +124,7 @@ beforeEach(() => {
   vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
   vi.mocked(window.navigateToExtensionHistoryEntry).mockResolvedValue(undefined);
   vi.mocked(kubernetesNoCurrentContext).kubernetesNoCurrentContext = writable(true);
+  extensionInfos.set([]);
 
   vi.mocked(navigationRegistry).set([
     { type: 'root', link: '/', title: 'Dashboard' } as unknown as NavigationRegistryEntry,
@@ -379,7 +381,7 @@ describe('getForwardEntries', () => {
 });
 
 describe('submenu navigation', () => {
-  test('should show submenu parent > resource type breadcrumb', () => {
+  test('should show submenu parent → resource type breadcrumb', () => {
     // Simulate navigation: Dashboard -> Kubernetes Pods list -> Specific pod
     navigationHistory.stack = [
       { url: '/' },
@@ -393,7 +395,7 @@ describe('submenu navigation', () => {
     expect(backEntries.length).toBe(2);
     // getBackEntries returns in reverse order, so [0] is index 1, [1] is index 0
     // backEntries[0] = '/kubernetes/pods' - should show full breadcrumb from registry
-    expect(backEntries[0].name).toBe('Kubernetes > Pods');
+    expect(backEntries[0].name).toBe('Kubernetes → Pods');
     // backEntries[1] = '/' - should show Dashboard
     expect(backEntries[1].name).toBe('Dashboard');
 
@@ -416,13 +418,13 @@ describe('submenu navigation', () => {
     expect(backEntries.length).toBe(2);
     // backEntries[0] = '/kubernetes/configmapsSecrets' base route
     // Should show proper name from registry with '&' preserved
-    expect(backEntries[0].name).toBe('Kubernetes > ConfigMaps & Secrets');
+    expect(backEntries[0].name).toBe('Kubernetes → ConfigMaps & Secrets');
     // backEntries[1] = '/' Dashboard
     expect(backEntries[1].name).toBe('Dashboard');
   });
 
   test('should show full breadcrumb for detail pages including tab', () => {
-    // Test detail page shows: parent > resource type > resource name > tab
+    // Test detail page shows: parent → resource type → resource name → tab
     navigationHistory.stack = [
       { url: '/kubernetes/configmapsSecrets/my-config/default/summary' },
       { url: '/kubernetes/configmapsSecrets' },
@@ -431,7 +433,7 @@ describe('submenu navigation', () => {
 
     const entries = getBackEntries();
     expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('Kubernetes > ConfigMaps & Secrets > my-config > Summary');
+    expect(entries[0].name).toBe('Kubernetes → ConfigMaps & Secrets → my-config → Summary');
   });
 });
 
@@ -468,7 +470,7 @@ describe('tab navigation for detail pages', () => {
     const entries = getForwardEntries();
 
     // Should show resource name WITH tab name
-    expect(entries).toEqual([{ index: 1, name: 'Containers > abc123 > Inspect', icon: {} }]);
+    expect(entries).toEqual([{ index: 1, name: 'Containers → abc123 → Inspect', icon: {} }]);
     // Tab name should appear in display
     expect(entries[0].name).toContain('Inspect');
   });
@@ -481,7 +483,7 @@ describe('tab navigation for detail pages', () => {
     const entries = getForwardEntries();
 
     expect(entries.length).toBe(1);
-    expect(entries[0].name).toBe('Kubernetes > Pods > nginx-pod > Logs');
+    expect(entries[0].name).toBe('Kubernetes → Pods → nginx-pod → Logs');
   });
 });
 
@@ -579,5 +581,65 @@ describe('extensionsNavigatingHistory guard', () => {
       { url: '/__extension__/ext.guard/entry-2', extensionEntry: nextEntry },
     ]);
     expect(navigationHistory.index).toBe(1);
+  });
+});
+
+describe('extension history entry display names', () => {
+  afterEach(() => {
+    extensionInfos.set([]);
+  });
+
+  test('formats extension entries with an arrow separator between displayName and label', () => {
+    extensionInfos.set([{ id: 'ext.a', displayName: 'My Extension' } as ExtensionInfo]);
+    const pushInfo: NavigationHistoryPushInfo = { extensionId: 'ext.a', id: 'model-1', label: 'Model 1' };
+    navigationHistory.stack = [
+      { url: '/__extension__/ext.a/model-1', extensionEntry: pushInfo },
+      { url: '/containers' },
+    ];
+    navigationHistory.index = 1;
+
+    expect(getBackEntries()).toEqual([{ index: 0, name: 'My Extension → Model 1', icon: undefined }]);
+  });
+
+  test('truncates long displayName and label parts to 24 characters', () => {
+    extensionInfos.set([
+      {
+        id: 'ext.long',
+        displayName: 'A Very Long Extension Display Name That Exceeds Limit',
+      } as ExtensionInfo,
+    ]);
+    const pushInfo: NavigationHistoryPushInfo = {
+      extensionId: 'ext.long',
+      id: 'entry-1',
+      label: 'An Extremely Long History Entry Label For Testing',
+    };
+    navigationHistory.stack = [
+      { url: '/__extension__/ext.long/entry-1', extensionEntry: pushInfo },
+      { url: '/containers' },
+    ];
+    navigationHistory.index = 1;
+
+    expect(getBackEntries()).toEqual([
+      {
+        index: 0,
+        name: 'A Very Long Extension Di... → An Extremely Long Histor...',
+        icon: undefined,
+      },
+    ]);
+  });
+
+  test('falls back to truncated label when extension is not found', () => {
+    const pushInfo: NavigationHistoryPushInfo = {
+      extensionId: 'ext.missing',
+      id: 'entry-1',
+      label: 'An Extremely Long History Entry Label For Testing',
+    };
+    navigationHistory.stack = [
+      { url: '/__extension__/ext.missing/entry-1', extensionEntry: pushInfo },
+      { url: '/containers' },
+    ];
+    navigationHistory.index = 1;
+
+    expect(getBackEntries()).toEqual([{ index: 0, name: 'An Extremely Long Histor...', icon: undefined }]);
   });
 });

--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -165,13 +165,13 @@ function extractResourceInfo(parts: string[]): { typeLabel: string; name?: strin
  * // => 'Containers'
  *
  * urlToDisplayName('/containers/abc123/logs')
- * // => 'Containers > abc123 > logs'
+ * // => 'Containers → abc123 → logs'
  *
  * urlToDisplayName('/kubernetes/pods', ['Kubernetes', 'Pods'])
- * // => 'Kubernetes > Pods'
+ * // => 'Kubernetes → Pods'
  *
  * urlToDisplayName('/kubernetes/pods/my-pod/default/logs', ['Kubernetes', 'Pods'])
- * // => 'Kubernetes > Pods > my-pod > logs'
+ * // => 'Kubernetes → Pods → my-pod → logs'
  */
 function urlToDisplayName(url: string, registryBreadcrumb?: string[]): string {
   const { parts } = parseUrl(url);
@@ -203,10 +203,10 @@ function urlToDisplayName(url: string, registryBreadcrumb?: string[]): string {
       breadcrumb.push(capitalize(tabSegment));
     }
 
-    return breadcrumb.join(' > ');
+    return breadcrumb.join(' → ');
   }
 
-  return registryBreadcrumb?.length ? registryBreadcrumb.join(' > ') : typeLabel;
+  return registryBreadcrumb?.length ? registryBreadcrumb.join(' → ') : typeLabel;
 }
 
 /**
@@ -281,7 +281,7 @@ function matchesRoute(url: string, routeHref: string): boolean {
  * // => { name: 'Containers', icon: { ... } }
  *
  * getEntryInfo('/containers/abc123/logs')
- * // => { name: 'Containers > abc123', icon: { ... } }
+ * // => { name: 'Containers → abc123', icon: { ... } }
  *
  * getEntryInfo('/preferences/default/resources')
  * // => { name: 'Resources', icon: { iconComponent: SettingsIcon } }
@@ -334,7 +334,7 @@ function getEntryInfo(url: string): { name: string; icon?: HistoryEntryIcon } {
  *   url: '/__extension__/my-extension/model-1',
  *   extensionEntry: { extensionId: 'my-extension', id: 'model-1', label: 'Model 1' },
  * })
- * // => { name: 'My Extension > Model 1', icon: { iconImage: '...' } }
+ * // => { name: 'My Extension → Model 1', icon: { iconImage: '...' } }
  */
 function getStackEntryInfo(stackEntry: HistoryStackEntry): { name: string; icon?: HistoryEntryIcon } {
   const { extensionEntry } = stackEntry;
@@ -343,9 +343,10 @@ function getStackEntryInfo(stackEntry: HistoryStackEntry): { name: string; icon?
   }
 
   const extension = get(extensionInfos).find(ext => ext.id === extensionEntry.extensionId);
+  const label = truncate(extensionEntry.label, 24);
 
   return {
-    name: extension ? `${extension.displayName} > ${extensionEntry.label}` : extensionEntry.label,
+    name: extension ? `${truncate(extension.displayName, 24)} → ${label}` : label,
     icon: extension?.icon ? { iconImage: extension.icon } : undefined,
   };
 }

--- a/packages/renderer/src/stores/navigation-history.svelte.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.ts
@@ -16,12 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { HistoryStackEntry, NavigationHistoryPushInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
 
 import DashboardIcon from '/@/lib/images/DashboardIcon.svelte';
 import SettingsIcon from '/@/lib/images/SettingsIcon.svelte';
 import { settingsNavigationEntries } from '/@/PreferencesNavigation';
+import { extensionInfos } from '/@/stores/extensions';
 import { kubernetesNoCurrentContext } from '/@/stores/kubernetes-no-current-context';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
 
@@ -41,11 +43,11 @@ export interface HistoryEntry {
 /**
  * Navigation history store
  *
- * @property stack - An array of URLs
+ * @property stack - An array of history stack entries
  * @property index - The current index in the stack
  */
 export const navigationHistory = $state<{
-  stack: string[];
+  stack: HistoryStackEntry[];
   index: number;
 }>({
   stack: [],
@@ -53,6 +55,10 @@ export const navigationHistory = $state<{
 });
 
 let isNavigatingHistory = false;
+
+// Extensions being navigated to via back/forward — ignore their pushes
+// until the navigation settles (webview re-mounts and replays initial route)
+const extensionsNavigatingHistory = new Set<string>();
 
 interface ParsedUrl {
   path: string;
@@ -317,6 +323,34 @@ function getEntryInfo(url: string): { name: string; icon?: HistoryEntryIcon } {
 }
 
 /**
+ * Get display name and icon for a history stack entry
+ * @param stackEntry - The history stack entry to get info for
+ * @returns Object with display name and optional icon
+ * @example
+ * getStackEntryInfo({ url: '/containers' })
+ * // => { name: 'Containers', icon: { ... } }
+ *
+ * getStackEntryInfo({
+ *   url: '/__extension__/my-extension/model-1',
+ *   extensionEntry: { extensionId: 'my-extension', id: 'model-1', label: 'Model 1' },
+ * })
+ * // => { name: 'My Extension > Model 1', icon: { iconImage: '...' } }
+ */
+function getStackEntryInfo(stackEntry: HistoryStackEntry): { name: string; icon?: HistoryEntryIcon } {
+  const { extensionEntry } = stackEntry;
+  if (!extensionEntry) {
+    return getEntryInfo(stackEntry.url);
+  }
+
+  const extension = get(extensionInfos).find(ext => ext.id === extensionEntry.extensionId);
+
+  return {
+    name: extension ? `${extension.displayName} > ${extensionEntry.label}` : extensionEntry.label,
+    icon: extension?.icon ? { iconImage: extension.icon } : undefined,
+  };
+}
+
+/**
  * Navigate to a specific index in the history stack
  * @param index - The history stack index to navigate to
  * @returns True if navigation occurred, false if index is invalid or current
@@ -331,11 +365,16 @@ function navigateToIndex(index: number): boolean {
     return false;
   }
 
-  isNavigatingHistory = true;
   navigationHistory.index = index;
-  const url = navigationHistory.stack[index];
-  if (url) {
-    router.goto(url);
+  const entry = navigationHistory.stack[index];
+  if (entry?.extensionEntry) {
+    extensionsNavigatingHistory.add(entry.extensionEntry.extensionId);
+    window
+      .navigateToExtensionHistoryEntry(entry.extensionEntry.extensionId, entry.extensionEntry.id)
+      .catch(console.error);
+  } else if (entry) {
+    isNavigatingHistory = true;
+    router.goto(entry.url);
   }
   return true;
 }
@@ -414,7 +453,7 @@ function getEntries(direction: Direction): HistoryEntry[] {
   for (let i = start; condition(i); i += step) {
     const url = navigationHistory.stack[i];
     if (url) {
-      const info = getEntryInfo(url);
+      const info = getStackEntryInfo(url);
       entries.push({
         index: i,
         name: info.name,
@@ -492,16 +531,24 @@ router.subscribe(navigation => {
       return;
     }
 
+    // Skip webview/contribs URLs — extensions push their own history entries via
+    // navigation.pushHistoryEntry, so recording the plain URL too would cause
+    // duplicate/interleaved entries for the same navigation.
+    const urlPath = navigation.url.split('?')[0];
+    if (urlPath.startsWith('/webviews/') || urlPath.startsWith('/contribs/')) {
+      return;
+    }
+
     // Truncate forward history if we're not at the end
     if (navigationHistory.index < navigationHistory.stack.length - 1) {
       navigationHistory.stack = navigationHistory.stack.slice(0, navigationHistory.index + 1);
     }
 
-    const currentUrl = navigationHistory.stack[navigationHistory.index];
+    const currentEntry = navigationHistory.stack[navigationHistory.index];
 
     // Add every URL change to history (including tab changes)
-    if (currentUrl !== navigation.url) {
-      navigationHistory.stack = [...navigationHistory.stack, navigation.url];
+    if (currentEntry?.url !== navigation.url) {
+      navigationHistory.stack = [...navigationHistory.stack, { url: navigation.url }];
       navigationHistory.index = navigationHistory.stack.length - 1;
     }
   }
@@ -514,4 +561,32 @@ window.events?.receive('navigation-go-back', () => {
 
 window.events?.receive('navigation-go-forward', () => {
   goForward();
+});
+
+// Listen for history entries pushed by extensions via navigation.pushHistoryEntry
+window.events?.receive('navigation-history-push', (entry: NavigationHistoryPushInfo) => {
+  // The extension is replaying its initial route after being navigated to via
+  // back/forward (webview re-mount) — this push is stale, ignore it once.
+  if (extensionsNavigatingHistory.has(entry.extensionId)) {
+    extensionsNavigatingHistory.delete(entry.extensionId);
+    return;
+  }
+
+  // Truncate forward history if we're not at the end
+  if (navigationHistory.index < navigationHistory.stack.length - 1) {
+    navigationHistory.stack = navigationHistory.stack.slice(0, navigationHistory.index + 1);
+  }
+
+  const currentEntry = navigationHistory.stack[navigationHistory.index];
+  const isSameEntry =
+    currentEntry?.extensionEntry?.extensionId === entry.extensionId && currentEntry?.extensionEntry?.id === entry.id;
+
+  if (!isSameEntry) {
+    const stackEntry: HistoryStackEntry = {
+      url: `/__extension__/${entry.extensionId}/${entry.id}`,
+      extensionEntry: entry,
+    };
+    navigationHistory.stack = [...navigationHistory.stack, stackEntry];
+    navigationHistory.index = navigationHistory.stack.length - 1;
+  }
 });


### PR DESCRIPTION
### What does this PR do?

Adds navigation.pushHistoryEntry / onDidNavigateToHistoryEntry to the extension API so extensions with their own in-webview routing (e.g. SPA navigation) can register entries in Podman Desktop's global back/forward history stack, and be notified when the user navigates back/forward to one of their entries.

- packages/api: NavigationHistoryPushInfo / HistoryStackEntry types and the navigation-history-push IPC channel
- extension-api: NavigationHistoryEntry type and the new navigation API
- main: NavigationManager tracks push events and per-extension history listeners; ExtensionLoader wires the API to it; new IPC handler to route back/forward navigation to the originating extension
- preload: exposes navigateToExtensionHistoryEntry to the renderer
- renderer: navigation-history store tracks stack entries (not just URLs), ignores /webviews/ and /contribs/ router URLs (extensions report their own entries instead), and guards against replaying a stale push right after navigating back/forward into a webview

### Screenshot / video of UI


### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/15835

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
