### PR TITLE
refactor(renderer): update store instead of local pod copy

### DIFF
--- a/packages/renderer/src/lib/container/ContainerColumnActionsPod.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActionsPod.svelte
@@ -24,6 +24,5 @@ export let object: ContainerGroupInfoUI;
         Status: container.state,
       })),
     }}
-    dropdownMenu={true}
-    on:update />
+    dropdownMenu={true} />
 {/if}

--- a/packages/renderer/src/lib/pod/PodActions.spec.ts
+++ b/packages/renderer/src/lib/pod/PodActions.spec.ts
@@ -22,41 +22,36 @@ import type { ContainerInfo, Port } from '@podman-desktop/api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
+import { setPodStatus } from '/@/stores/pods';
+
 import PodActions from './PodActions.svelte';
 import type { PodInfoUI } from './PodInfoUI';
 
-class Pod {
-  #status: string;
-  #actionError: string;
-  constructor(
-    public id: string,
-    public containers: { Id: string; Status?: string }[],
-    initialStatus: string,
-    public kind: string,
-    actionError: string,
-  ) {
-    this.#status = initialStatus;
-    this.#actionError = actionError;
-  }
-  set acitonError(error: string) {
-    this.#actionError = error;
-  }
-  get acitonError(): string {
-    return this.#actionError;
-  }
-  set status(status: string) {
-    this.#status = status;
-  }
-  get status(): string {
-    return this.#status;
-  }
-}
+vi.mock(import('/@/stores/pods'), async importOriginal => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    setPodStatus: vi.fn(),
+    clearPodActionInProgress: vi.fn(),
+    setPodActionError: vi.fn(),
+  };
+});
 
-const podmanPod: PodInfoUI = new Pod('pod', [{ Id: 'pod' }], 'RUNNING', 'podman', '') as unknown as PodInfoUI;
+const podmanPod: PodInfoUI = {
+  id: 'pod',
+  shortId: 'pod',
+  name: 'my-pod',
+  engineId: 'engine1',
+  engineName: 'podman',
+  status: 'RUNNING',
+  age: '1 day',
+  created: '2025-01-01',
+  selected: false,
+  containers: [{ Id: 'pod', Names: 'container1', Status: 'running' }],
+};
 
 const listContainersMock = vi.fn();
 const getContributedMenusMock = vi.fn();
-const updateMock = vi.fn();
 const openExternalSpy = vi.fn();
 
 class ResizeObserver {
@@ -87,72 +82,63 @@ beforeEach(() => {
   getContributedMenusMock.mockResolvedValue([]);
 });
 
-test('Expect no error and status starting pod', async () => {
+test('Expect setPodStatus called with STARTING when starting pod', async () => {
   listContainersMock.mockResolvedValue([]);
 
-  render(PodActions, { pod: podmanPod, onUpdate: updateMock });
+  render(PodActions, { pod: podmanPod });
 
   // click on start button
   const startButton = screen.getByRole('button', { name: 'Start Pod' });
   await fireEvent.click(startButton);
 
-  expect(podmanPod.status).toEqual('STARTING');
-  expect(podmanPod.actionError).toEqual('');
-  expect(updateMock).toHaveBeenCalled();
+  expect(setPodStatus).toHaveBeenCalledWith('engine1', 'pod', 'STARTING');
 });
 
-test('Expect no error and status starting for unpausing pod', async () => {
+test('Expect unpausePod called when pod has paused containers', async () => {
   listContainersMock.mockResolvedValue([]);
 
   // set status to paused
   podmanPod.containers[0].Status = 'paused';
-  render(PodActions, { pod: podmanPod, onUpdate: updateMock });
 
+  render(PodActions, { pod: podmanPod });
   // click on start button
   const startButton = screen.getByRole('button', { name: 'Start Pod' });
   await fireEvent.click(startButton);
 
-  expect(podmanPod.status).toEqual('STARTING');
-  expect(podmanPod.actionError).toEqual('');
-  expect(window.unpausePod).toHaveBeenCalledWith(podmanPod.engineId, podmanPod.id);
+  expect(setPodStatus).toHaveBeenCalledWith('engine1', 'pod', 'STARTING');
+  expect(window.unpausePod).toHaveBeenCalledWith('engine1', 'pod');
   expect(window.startPod).not.toHaveBeenCalled();
-  expect(updateMock).toHaveBeenCalled();
 });
 
-test('Expect no error and status stopping pod', async () => {
+test('Expect setPodStatus called with STOPPING when stopping pod', async () => {
   listContainersMock.mockResolvedValue([]);
 
-  render(PodActions, { pod: podmanPod, onUpdate: updateMock });
+  render(PodActions, { pod: podmanPod });
 
-  // click on stop button
   const stopButton = screen.getByRole('button', { name: 'Stop Pod' });
   await fireEvent.click(stopButton);
 
-  expect(podmanPod.status).toEqual('STOPPING');
-  expect(podmanPod.actionError).toEqual('');
-  expect(updateMock).toHaveBeenCalled();
+  expect(setPodStatus).toHaveBeenCalledWith('engine1', 'pod', 'STOPPING');
 });
 
-test('Expect no error and status restarting pod', async () => {
+test('Expect setPodStatus called with RESTARTING when restarting pod', async () => {
   listContainersMock.mockResolvedValue([]);
 
-  render(PodActions, { pod: podmanPod, onUpdate: updateMock });
+  render(PodActions, { pod: podmanPod });
 
   // click on restart button
   const restartButton = screen.getByRole('button', { name: 'Restart Pod' });
   await fireEvent.click(restartButton);
 
-  expect(podmanPod.status).toEqual('RESTARTING');
-  expect(podmanPod.actionError).toEqual('');
-  expect(updateMock).toHaveBeenCalled();
+  expect(setPodStatus).toHaveBeenCalledWith('engine1', 'pod', 'RESTARTING');
 });
 
-test('Expect no error and status deleting pod', async () => {
+test('Expect setPodStatus called with DELETING when deleting pod', async () => {
   // Mock the showMessageBox to return 'Delete' (confirmed)
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
   listContainersMock.mockResolvedValue([]);
 
-  render(PodActions, { pod: podmanPod, onUpdate: updateMock });
+  render(PodActions, { pod: podmanPod });
   // click on delete button
   const deleteButton = screen.getByRole('button', { name: 'Delete Pod' });
   await fireEvent.click(deleteButton);
@@ -161,9 +147,5 @@ test('Expect no error and status deleting pod', async () => {
   await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
   // Wait for confirmation modal to disappear after clicking on delete
-  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-
-  expect(podmanPod.status).toEqual('DELETING');
-  expect(podmanPod.actionError).toEqual('');
-  expect(updateMock).toHaveBeenCalled();
+  expect(setPodStatus).toHaveBeenCalledWith('engine1', 'pod', 'DELETING');
 });

--- a/packages/renderer/src/lib/pod/PodActions.svelte
+++ b/packages/renderer/src/lib/pod/PodActions.svelte
@@ -11,7 +11,7 @@ import {
 import type { Menu } from '@podman-desktop/core-api';
 import { MenuContext } from '@podman-desktop/core-api';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
-import { createEventDispatcher, onMount } from 'svelte';
+import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import ContributionActions from '/@/lib/actions/ContributionActions.svelte';
@@ -19,25 +19,17 @@ import { ContainerUtils } from '/@/lib/container/container-utils';
 import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import FlatMenu from '/@/lib/ui/FlatMenu.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
+import { clearPodActionInProgress, setPodActionError, setPodStatus } from '/@/stores/pods';
 
 import type { PodInfoUI } from './PodInfoUI';
 
-const dispatch = createEventDispatcher<{ update: PodInfoUI }>();
 interface Props {
   pod: PodInfoUI;
   dropdownMenu?: boolean;
   detailed?: boolean;
-  onUpdate?: (update: PodInfoUI) => void;
 }
 
-let {
-  pod = $bindable(),
-  dropdownMenu = false,
-  detailed = false,
-  onUpdate = (update): void => {
-    dispatch('update', update);
-  },
-}: Props = $props();
+let { pod, dropdownMenu = false, detailed = false }: Props = $props();
 
 let contributions = $state<Menu[]>([]);
 onMount(async () => {
@@ -68,23 +60,16 @@ onMount(async () => {
   });
 });
 
-function inProgress(inProgress: boolean, state?: string): void {
-  pod.actionInProgress = inProgress;
-  // reset error when starting task
-  if (inProgress) {
-    pod.actionError = '';
-  }
+function inProgress(isStarting: boolean, state?: string): void {
   if (state) {
-    pod.status = state;
+    setPodStatus(pod.engineId, pod.id, state);
+  } else if (!isStarting) {
+    clearPodActionInProgress(pod.engineId, pod.id);
   }
-
-  onUpdate(pod);
 }
 
 function handleError(errorMessage: string): void {
-  pod.actionError = errorMessage;
-  pod.status = 'ERROR';
-  onUpdate(pod);
+  setPodActionError(pod.engineId, pod.id, errorMessage);
 }
 
 async function startPod(): Promise<void> {

--- a/packages/renderer/src/lib/pod/PodColumnActions.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnActions.svelte
@@ -16,6 +16,6 @@ export let object: PodInfoUI;
     {/if}
   </div>
   <div class="text-right w-full">
-    <PodActions pod={object} dropdownMenu={true} on:update />
+    <PodActions pod={object} dropdownMenu={true} />
   </div>
 </div>

--- a/packages/renderer/src/lib/pod/PodDetails.svelte
+++ b/packages/renderer/src/lib/pod/PodDetails.svelte
@@ -65,10 +65,7 @@ onMount(() => {
           <div>&nbsp;</div>
         {/if}
       </div>
-      <PodActions pod={pod} detailed={true} on:update={(): PodInfoUI => {
-        pod = pod; // Keep this assignment for svelte 4 - can be safely removed when migrating to svelte 5
-        return pod;
-      }} />
+      <PodActions pod={pod} detailed={true} />
     {/snippet}
     {#snippet detailSnippet()}
       <div class="flex py-2 w-full justify-end text-sm text-[var(--pd-content-text)]">

--- a/packages/renderer/src/lib/pod/PodsList.svelte
+++ b/packages/renderer/src/lib/pod/PodsList.svelte
@@ -19,7 +19,7 @@ import PodIcon from '/@/lib/images/PodIcon.svelte';
 import PodmanKubePlay from '/@/lib/kube/PodmanKubePlay.svelte';
 import ContainerEngineEnvironmentColumn from '/@/lib/table/columns/ContainerEngineEnvironmentColumn.svelte';
 import EnvironmentDropdown from '/@/lib/ui/EnvironmentDropdown.svelte';
-import { filtered, podsInfos, searchPattern } from '/@/stores/pods';
+import { filtered, podsInfos, searchPattern, setPodStatus } from '/@/stores/pods';
 import { providerInfos } from '/@/stores/providers';
 
 import { PodUtils } from './pod-utils';
@@ -104,8 +104,7 @@ async function deleteSelectedPods(): Promise<void> {
 
   // mark pods for deletion
   bulkDeleteInProgress = true;
-  selectedPods.forEach(pod => (pod.status = 'DELETING'));
-  pods = pods;
+  selectedPods.forEach(pod => setPodStatus(pod.engineId, pod.id, 'DELETING'));
 
   await Promise.all(
     selectedPods.map(async pod => {
@@ -272,8 +271,7 @@ function label(pod: PodInfoUI): string {
         defaultSortColumn="Name"
         enableLayoutConfiguration={true}
         key={key}
-        label={label}
-        on:update={(): PodInfoUI[] => (pods = pods)}>
+        label={label}>
       </Table>
     {/if}
   </div>

--- a/packages/renderer/src/stores/pods.spec.ts
+++ b/packages/renderer/src/stores/pods.spec.ts
@@ -23,7 +23,7 @@ import { get } from 'svelte/store';
 import type { Mock } from 'vitest';
 import { beforeAll, expect, test, vi } from 'vitest';
 
-import { podsEventStore, podsInfos } from './pods';
+import { clearPodActionInProgress, podsEventStore, podsInfos, setPodActionError, setPodStatus } from './pods';
 
 // first, path window object
 const callbacks = new Map<string, any>();
@@ -93,4 +93,55 @@ test.each([
   const podListResult = get(podsInfos);
   expect(podListResult.length).toBe(1);
   expect(podListResult[0].id).toEqual('id123');
+});
+
+test('setPodStatus updates the status and sets actionInProgress', () => {
+  podsInfos.set([
+    { id: 'pod1', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' },
+  ] as any);
+
+  setPodStatus('engine1', 'pod1', 'STARTING');
+
+  const result = get(podsInfos);
+  expect(result[0].status).toBe('STARTING');
+  expect(result[0].actionInProgress).toBe(true);
+  expect(result[0].actionError).toBe('');
+});
+
+test('clearPodActionInProgress clears the actionInProgress flag', () => {
+  podsInfos.set([
+    { id: 'pod1', engineId: 'engine1', status: 'STARTING', actionInProgress: true, actionError: '' },
+  ] as any);
+
+  clearPodActionInProgress('engine1', 'pod1');
+
+  const result = get(podsInfos);
+  expect(result[0].actionInProgress).toBe(false);
+  expect(result[0].status).toBe('STARTING');
+});
+
+test('setPodActionError sets the error and status to ERROR', () => {
+  podsInfos.set([
+    { id: 'pod1', engineId: 'engine1', status: 'STARTING', actionInProgress: true, actionError: '' },
+  ] as any);
+
+  setPodActionError('engine1', 'pod1', 'something went wrong');
+
+  const result = get(podsInfos);
+  expect(result[0].actionError).toBe('something went wrong');
+  expect(result[0].status).toBe('ERROR');
+  expect(result[0].actionInProgress).toBe(false);
+});
+
+test('setPodStatus does not affect other pods', () => {
+  podsInfos.set([
+    { id: 'pod1', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' },
+    { id: 'pod2', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' },
+  ] as any);
+
+  setPodStatus('engine1', 'pod1', 'STOPPING');
+
+  const result = get(podsInfos);
+  expect(result[0].status).toBe('STOPPING');
+  expect(result[1].status).toBe('RUNNING');
 });

--- a/packages/renderer/src/stores/pods.ts
+++ b/packages/renderer/src/stores/pods.ts
@@ -88,6 +88,30 @@ const listPods = async (): Promise<PodInfoUI[]> => {
   return (await window.listPods()).map(podInfo => podUtils.getPodInfoUI(podInfo));
 };
 
+export function setPodStatus(engineId: string, podId: string, status: string): void {
+  podsInfos.update(pods =>
+    pods.map(pod =>
+      pod.id === podId && pod.engineId === engineId ? { ...pod, status, actionInProgress: true, actionError: '' } : pod,
+    ),
+  );
+}
+
+export function clearPodActionInProgress(engineId: string, podId: string): void {
+  podsInfos.update(pods =>
+    pods.map(pod => (pod.id === podId && pod.engineId === engineId ? { ...pod, actionInProgress: false } : pod)),
+  );
+}
+
+export function setPodActionError(engineId: string, podId: string, error: string): void {
+  podsInfos.update(pods =>
+    pods.map(pod =>
+      pod.id === podId && pod.engineId === engineId
+        ? { ...pod, actionError: error, actionInProgress: false, status: 'ERROR' }
+        : pod,
+    ),
+  );
+}
+
 export const podsEventStore = new EventStore<PodInfoUI[]>(
   'pods',
   podsInfos,


### PR DESCRIPTION
### What does this PR do?

This PR updates the Pod actions in the renderer to update the store instead of the bound local copy. It will help to update to Svelte 5 allowing stable rerenders.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #14583

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

Navigate to the pod list, start and stop pod from the list and the details page, verify everything is still consistent.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
