### PR TITLE
fix: resolve GHSA-p2f4-r6v6-j797 in builder-util-runtime

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,7 @@ overrides:
   websocket-driver: '>=0.7.5'
   svgo: '>=3.3.4 <4.0.0'
   body-parser: '>=2.3.0'
+  builder-util-runtime: '>=9.7.0'
 
 importers:
 
@@ -6034,10 +6035,6 @@ packages:
   buildcheck@0.0.6:
     resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
     engines: {node: '>=10.0.0'}
-
-  builder-util-runtime@9.5.1:
-    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
-    engines: {node: '>=12.0.0'}
 
   builder-util-runtime@9.7.0:
     resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
@@ -18263,7 +18260,7 @@ snapshots:
       '@types/fs-extra': 9.0.13
       async-exit-hook: 2.0.1
       builder-util: 26.8.1(supports-color@8.1.1)
-      builder-util-runtime: 9.5.1(supports-color@8.1.1)
+      builder-util-runtime: 9.7.0(supports-color@8.1.1)
       chromium-pickle-js: 0.2.0
       ci-info: 4.3.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -18661,13 +18658,6 @@ snapshots:
   buildcheck@0.0.6:
     optional: true
 
-  builder-util-runtime@9.5.1(supports-color@8.1.1):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      sax: 1.6.0
-    transitivePeerDependencies:
-      - supports-color
-
   builder-util-runtime@9.7.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -18680,7 +18670,7 @@ snapshots:
       7zip-bin: 5.2.0
       '@types/debug': 4.1.12
       app-builder-bin: 5.0.0-alpha.12
-      builder-util-runtime: 9.5.1(supports-color@8.1.1)
+      builder-util-runtime: 9.7.0(supports-color@8.1.1)
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -19924,7 +19914,7 @@ snapshots:
     dependencies:
       app-builder-lib: 26.8.2(dmg-builder@26.8.2)(electron-builder-squirrel-windows@26.8.2)(supports-color@8.1.1)
       builder-util: 26.8.1(supports-color@8.1.1)
-      builder-util-runtime: 9.5.1(supports-color@8.1.1)
+      builder-util-runtime: 9.7.0(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 4.4.0
       dmg-builder: 26.8.2(electron-builder-squirrel-windows@26.8.2)(supports-color@8.1.1)
@@ -19954,7 +19944,7 @@ snapshots:
     dependencies:
       '@types/fs-extra': 9.0.13
       builder-util: 26.8.1(supports-color@8.1.1)
-      builder-util-runtime: 9.5.1(supports-color@8.1.1)
+      builder-util-runtime: 9.7.0(supports-color@8.1.1)
       chalk: 4.1.2
       form-data: 4.0.6
       fs-extra: 10.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,6 +67,7 @@ overrides:
   websocket-driver: '>=0.7.5'
   svgo: '>=3.3.4 <4.0.0'
   body-parser: '>=2.3.0'
+  builder-util-runtime: '>=9.7.0'
 nodeLinker: hoisted
 allowBuilds:
   '@biomejs/biome': true


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-p2f4-r6v6-j797 in `builder-util-runtime`.

**Advisory**: electron-updater: Cross-origin redirect leaks `PRIVATE-TOKEN` and mixed-case `Authorization` credentials in `builder-util-runtime`
**Vulnerable versions**: <9.7.0
**Patched versions**: >=9.7.0
**Advisory URL**: https://github.com/advisories/GHSA-p2f4-r6v6-j797

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-p2f4-r6v6-j797: _electron-updater: Cross-origin redirect leaks `PRIVATE-TOKEN` and mixed-case `Authorization` credentials in `builder-util-runtime`_

### How to test this PR?

Run `pnpm audit` and verify GHSA-p2f4-r6v6-j797 is no longer reported