### PR TITLE
feat(podman): detect and register rootful podman socket on Linux

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -4227,3 +4227,44 @@ function getContextMock() {
     },
   } as unknown as extensionApi.ExtensionContext;
 }
+
+// https://github.com/podman-desktop/podman-desktop/issues/2861
+describe('isLinuxRootfulSocketAccessible', () => {
+  test('returns false when the rootful socket does not exist', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    const accessSyncSpy = vi.spyOn(fs, 'accessSync');
+
+    const result = extension.isLinuxRootfulSocketAccessible('/run/podman/podman.sock');
+
+    expect(result).toBeFalsy();
+    // no point checking permissions on a socket that isn't there
+    expect(accessSyncSpy).not.toHaveBeenCalled();
+  });
+
+  test('returns false when the rootful socket exists but is not accessible to the current user', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'accessSync').mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const result = extension.isLinuxRootfulSocketAccessible('/run/podman/podman.sock');
+
+    expect(result).toBeFalsy();
+  });
+
+  test('returns true when the rootful socket exists and is readable/writable by the current user', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const accessSyncSpy = vi.spyOn(fs, 'accessSync').mockReturnValue(undefined);
+
+    const result = extension.isLinuxRootfulSocketAccessible('/run/podman/podman.sock');
+
+    expect(result).toBeTruthy();
+    expect(accessSyncSpy).toHaveBeenCalledWith('/run/podman/podman.sock', fs.constants.R_OK | fs.constants.W_OK);
+  });
+});
+
+describe('getLinuxRootfulSocketPath', () => {
+  test('returns the well-known system-wide rootful socket path', () => {
+    expect(extension.getLinuxRootfulSocketPath()).toBe('/run/podman/podman.sock');
+  });
+});

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -110,6 +110,7 @@ let defaultMachineMonitor = true;
 // current status of machines
 export const podmanMachinesStatuses = new Map<string, extensionApi.ProviderConnectionStatus>();
 let podmanProviderStatus: extensionApi.ProviderConnectionStatus = 'started';
+let podmanRootfulProviderStatus: extensionApi.ProviderConnectionStatus = 'started';
 const podmanMachinesInfo = new Map<string, MachineInfo>();
 const currentConnections = new Map<string, extensionApi.Disposable>();
 const containerProviderConnections = new Map<string, extensionApi.ContainerProviderConnection>();
@@ -581,6 +582,26 @@ function getLinuxSocketPath(): string {
   return `/run/user/${uid}/podman/podman.sock`;
 }
 
+// rootful podman exposes a system-wide socket, independent of the user's uid
+export function getLinuxRootfulSocketPath(): string {
+  return '/run/podman/podman.sock';
+}
+
+// returns true only if the socket exists AND the current user can read/write it
+// (e.g. via the SocketGroup override documented in #2861). We never try to
+// elevate privileges or start the rootful service ourselves - detection only.
+export function isLinuxRootfulSocketAccessible(socketPath: string): boolean {
+  if (!fs.existsSync(socketPath)) {
+    return false;
+  }
+  try {
+    fs.accessSync(socketPath, fs.constants.R_OK | fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // on linux, socket is started by the system service on a path like /run/user/1000/podman/podman.sock
 async function initDefaultLinux(provider: extensionApi.Provider): Promise<void> {
   const socketPath = getLinuxSocketPath();
@@ -590,6 +611,7 @@ async function initDefaultLinux(provider: extensionApi.Provider): Promise<void> 
 
   const containerProviderConnection: extensionApi.ContainerProviderConnection = {
     name: 'Podman',
+    displayName: 'Podman (rootless)',
     type: 'podman',
     status: () => podmanProviderStatus,
     endpoint: {
@@ -604,6 +626,53 @@ async function initDefaultLinux(provider: extensionApi.Provider): Promise<void> 
   const disposable = provider.registerContainerProviderConnection(containerProviderConnection);
   currentConnections.set('podman', disposable);
   storedExtensionContext?.subscriptions.push(disposable);
+}
+
+// on linux, if a rootful podman.socket unit is already enabled system-wide and the
+// current user has been granted access to it (see #2861), surface it as a second
+// connection alongside the rootless one. We only ever discover this socket, never
+// start or manage it, since that would require elevated privileges.
+async function initDefaultLinuxRootful(provider: extensionApi.Provider): Promise<void> {
+  const socketPath = getLinuxRootfulSocketPath();
+  if (!isLinuxRootfulSocketAccessible(socketPath)) {
+    return;
+  }
+
+  const containerProviderConnection: extensionApi.ContainerProviderConnection = {
+    name: 'Podman (rootful)',
+    displayName: 'Podman (rootful)',
+    type: 'podman',
+    status: () => podmanRootfulProviderStatus,
+    endpoint: {
+      socketPath,
+    },
+  };
+
+  monitorLinuxRootfulSocket(socketPath).catch((error: unknown) => {
+    console.error('Error monitoring rootful podman socket', error);
+  });
+
+  const disposable = provider.registerContainerProviderConnection(containerProviderConnection);
+  currentConnections.set('podman-rootful', disposable);
+  storedExtensionContext?.subscriptions.push(disposable);
+}
+
+// dedicated monitor loop for the rootful native-linux socket. Deliberately does not
+// reuse monitorPodmanSocket()'s machineName plumbing, since podmanMachinesStatuses is
+// actively pruned elsewhere based on the real list of podman machines (VMs), and a
+// synthetic "rootful" key there risks being garbage-collected by that unrelated logic.
+async function monitorLinuxRootfulSocket(socketPath: string): Promise<void> {
+  if (!stopLoop) {
+    try {
+      podmanRootfulProviderStatus = (await isPodmanSocketAlive(socketPath)) ? 'started' : 'stopped';
+    } catch {
+      // ignore errors, keep the last known status
+    }
+    await timeout(5000);
+    monitorLinuxRootfulSocket(socketPath).catch((error: unknown) => {
+      console.error('Error monitoring rootful podman socket', error);
+    });
+  }
 }
 
 async function isPodmanSocketAlive(socketPath: string): Promise<boolean> {
@@ -1642,6 +1711,9 @@ export async function start(
     extensionContext.subscriptions.push(disposable);
     initDefaultLinux(provider).catch((error: unknown) => {
       console.error('Error while initializing default linux', error);
+    });
+    initDefaultLinuxRootful(provider).catch((error: unknown) => {
+      console.error('Error while initializing default linux rootful', error);
     });
   }
 


### PR DESCRIPTION
### What does this PR do?

On native Linux, Podman Desktop only ever registered the rootless podman socket
(`/run/user/<uid>/podman/podman.sock`), so users with a system-wide rootful
`podman.socket` unit enabled never saw those containers in the UI.

This adds a second, detection-only container provider connection for the rootful
socket (`/run/podman/podman.sock`). Podman Desktop never starts or manages this
socket itself (that would require elevated privileges) - it only registers a
connection if the socket already exists and is accessible to the current user
(e.g. via a `SocketGroup` override). Both connections now get a distinct
`displayName` (`'Podman (rootless)'` / `'Podman (rootful)'`), which already
surfaces via the existing `engineName` column in the container/pod lists.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

N/A - no renderer/UI changes. The distinction is surfaced automatically through
the existing `engineName` column, since `displayName` already flows through to it.

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

Fixes #2861

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

1. On a Linux machine, enable the rootless podman socket as usual (Podman Desktop
   does this automatically), and additionally enable the rootful one:
```sh
   sudo systemctl enable --now podman.socket
```
2. Make sure your user can access the rootful socket (e.g. via a `SocketGroup`
   override on the `podman.socket` unit, as documented in #2861).
3. Start Podman Desktop and confirm **two** Podman connections now appear:
   `Podman (rootless)` and `Podman (rootful)`.
4. Create a rootful container (`sudo podman run ...`) and a rootless one
   (`podman run ...`), and confirm both show up in the containers list, each
   labeled with the correct engine/connection name.
5. Disable/stop the rootful socket and confirm Podman Desktop falls back
   gracefully to just the rootless connection, with no errors.

- [x] Tests are covering the bug fix or the new feature