### PR TITLE
feat(renderer): add warning severity support to preflight checks UI

### DIFF
--- a/packages/renderer/src/lib/dashboard/PreflightChecks.spec.ts
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,6 +121,23 @@ test('Expect error icon to be displayed when check failed', async () => {
   const svg = title.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
   expect(svg).toHaveClass('text-(--pd-state-error)');
+});
+
+test('Expect warning icon to be displayed when check has warning severity', async () => {
+  render(PreflightChecks, {
+    preflightChecks: [
+      {
+        name: 'name',
+        successful: false,
+        severity: 'warning',
+      },
+    ],
+  });
+
+  const title = screen.getByLabelText('precheck-title');
+  const svg = title.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-(--pd-state-warning)');
 });
 
 test('Expect spinner to be displayed while check is pending', async () => {

--- a/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faCheck, faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faCircleExclamation, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import type { CheckStatus } from '@podman-desktop/core-api';
 import { Link, Spinner } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
@@ -26,6 +26,8 @@ async function openLink(url: string): Promise<void> {
             </div>
           {:else if preCheck.successful}
             <Icon class="text-(--pd-state-success)" icon={faCheck} />
+          {:else if preCheck.severity === 'warning'}
+            <Icon class="text-(--pd-state-warning)" icon={faTriangleExclamation} />
           {:else}
             <Icon class="text-(--pd-state-error)" icon={faCircleExclamation} />
           {/if}

--- a/packages/renderer/src/lib/dashboard/ProviderInstallationButton.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstallationButton.svelte
@@ -16,39 +16,51 @@ let checksStatus = $state<CheckStatus[]>([]);
 
 let preflightChecksFailed = $state(false);
 
-async function performInstallation(provider: ProviderInfo): Promise<void> {
+let hasWarnings = $state(false);
+
+async function performInstallation(): Promise<void> {
   installInProgress = true;
-  checksStatus = [];
-  let checkSuccess = false;
-  let currentCheck: CheckStatus;
   try {
-    checkSuccess = await window.runInstallPreflightChecks(provider.internalId, {
-      endCheck: status => {
-        if (currentCheck) {
-          currentCheck = status;
-        } else {
+    if (!hasWarnings) {
+      checksStatus = [];
+      let checkSuccess = false;
+      let currentCheck: CheckStatus;
+      try {
+        checkSuccess = await window.runInstallPreflightChecks(provider.internalId, {
+          endCheck: status => {
+            if (currentCheck) {
+              currentCheck = status;
+            } else {
+              return;
+            }
+            checksStatus.push(currentCheck);
+            onPreflightChecks(checksStatus);
+          },
+          startCheck: status => {
+            currentCheck = status;
+            onPreflightChecks([...checksStatus, currentCheck]);
+          },
+        });
+      } catch (err) {
+        console.error(err);
+      }
+      if (checkSuccess) {
+        if (checksStatus.some(c => c.successful === false && c.severity === 'warning')) {
+          hasWarnings = true;
           return;
         }
-        checksStatus.push(currentCheck);
-        onPreflightChecks(checksStatus);
-      },
-      startCheck: status => {
-        currentCheck = status;
-        onPreflightChecks([...checksStatus, currentCheck]);
-      },
-    });
-  } catch (err) {
-    console.error(err);
-  }
-  if (checkSuccess) {
-    await window.installProvider(provider.internalId);
-    // reset checks
-    onPreflightChecks([]);
-  } else {
-    preflightChecksFailed = true;
-  }
+      } else {
+        preflightChecksFailed = true;
+        return;
+      }
+    }
 
-  installInProgress = false;
+    await window.installProvider(provider.internalId);
+    onPreflightChecks([]);
+    hasWarnings = false;
+  } finally {
+    installInProgress = false;
+  }
 }
 </script>
 
@@ -57,7 +69,7 @@ async function performInstallation(provider: ProviderInfo): Promise<void> {
     inProgress={installInProgress}
     disabled={preflightChecksFailed}
     icon={faRocket}
-    on:click={(): Promise<void> => performInstallation(provider)}>
-    Install
+    onclick={performInstallation}>
+    {hasWarnings ? 'Proceed with installation' : 'Install'}
   </Button>
 {/if}

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
 
+import { faList } from '@fortawesome/free-solid-svg-icons';
 import type { CheckStatus, ProviderInfo } from '@podman-desktop/core-api';
 import { TerminalSettings } from '@podman-desktop/core-api/terminal';
-import { Spinner } from '@podman-desktop/ui-svelte';
+import { Button, Spinner } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
@@ -40,6 +41,30 @@ let resizeObserver: ResizeObserver;
 let termFit: FitAddon;
 let installationOptionsMenuVisible = false;
 let installationOptionSelected = InitializeAndStartMode;
+let checksInProgress = false;
+
+async function runChecks(): Promise<void> {
+  checksInProgress = true;
+  preflightChecks = [];
+  let currentCheck: CheckStatus;
+  try {
+    await window.runInstallPreflightChecks(provider.internalId, {
+      startCheck: (status: CheckStatus): void => {
+        currentCheck = status;
+        preflightChecks = [...preflightChecks, currentCheck];
+      },
+      endCheck: (status: CheckStatus): void => {
+        if (currentCheck) {
+          currentCheck = status;
+        }
+        preflightChecks = [...preflightChecks.slice(0, -1), currentCheck];
+      },
+    });
+  } catch (err) {
+    console.error(err);
+  }
+  checksInProgress = false;
+}
 
 // no initialize support, hide the button
 $: initializationButtonVisible =
@@ -142,6 +167,17 @@ async function onInstallationClick(): Promise<void> {
     <p class="text-sm text-[var(--pd-content-text)] w-2/3 text-center" aria-label="Suggested Actions">
       To start working with containers, {provider.name} needs to be initialized.
     </p>
+
+    <div class="flex space-x-2 mb-2">
+      {#if provider.installationSupport}
+        <Button
+          icon={faList}
+          inProgress={checksInProgress}
+          on:click={runChecks}>
+          Run checks
+        </Button>
+      {/if}
+    </div>
 
     <div class="min-w-[230px] w-1/3 flex justify-center" class:hidden={!initializationButtonVisible}>
       <div class="w-[212px] relative">

--- a/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
+++ b/packages/renderer/src/lib/markdown/micromark-warnings-directive.ts
@@ -85,7 +85,7 @@ export function warnings(this: CompileContext, d: Directive): boolean {
     this.tag('<div class="flex flex-row space-x-3 bg-[var(--pd-invert-content-card-bg)] p-4 rounded-md items-start">');
     // add icon representing the warning status
     this.tag('<div class="mr-2 flex justify-center">');
-    this.tag(item.state === 'successful' ? '✅' : '❌');
+    this.tag(item.state === 'successful' ? '✅' : item.state === 'warning' ? '⚠️' : '❌');
     this.tag('</div>');
     // add the warning description
     if (item.description) {


### PR DESCRIPTION
### What does this PR do?
Added support for severity warning flag 

Related PR https://github.com/podman-desktop/podman-desktop/pull/18267

### Screenshot / video of UI

<img width="1512" height="949" alt="Screenshot 2026-07-27 at 7 29 02" src="https://github.com/user-attachments/assets/19fbe2b4-72e7-47cc-b374-878411f6412d" />

https://github.com/user-attachments/assets/a1c332e3-7f33-4cc3-8915-46ebbb1c75f9


### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/pull/17989

### How to test this PR?
Can be tested in https://github.com/podman-desktop/podman-desktop/pull/18462

- [x] Tests are covering the bug fix or the new feature
