### PR TITLE
feat(api): add extension navigation history push API

### DIFF
--- a/packages/api/src/api-sender/api-sender-channel-map.ts
+++ b/packages/api/src/api-sender/api-sender-channel-map.ts
@@ -20,6 +20,7 @@ import type { IConfigurationChangeEvent } from '/@/configuration/models.js';
 import type { ContributionInfo } from '/@/contribution-info.js';
 import type { CheckingState, ContextGeneralState } from '/@/kubernetes-contexts-states.js';
 import type { ForwardConfig } from '/@/kubernetes-port-forward-model.js';
+import type { NavigationHistoryPushInfo } from '/@/navigation-history-info.js';
 import type { PinOption } from '/@/status-bar/pin-option.js';
 import type { SystemOverviewStatusInfo } from '/@/system-overview-info.js';
 import type { NotificationTaskInfo, TaskInfo } from '/@/taskInfo.js';
@@ -109,6 +110,7 @@ export interface ApiSenderChannelMap {
   navigate: unknown;
   'navigation-go-back': never;
   'navigation-go-forward': never;
+  'navigation-history-push': NavigationHistoryPushInfo;
   'network-event': never;
   'notifications-updated': never;
   onDidChangeConfiguration: unknown;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -65,6 +65,7 @@ export * from './log-type.js';
 export * from './manifest-info.js';
 export * from './menu.js';
 export * from './menu-context.js';
+export * from './navigation-history-info.js';
 export * from './navigation-page.js';
 export * from './navigation-request.js';
 export * from './network-info.js';

--- a/packages/api/src/navigation-history-info.ts
+++ b/packages/api/src/navigation-history-info.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * Payload sent from the main process to the renderer when an extension calls
+ * `navigation.pushHistoryEntry`, so the entry can be added to the global
+ * back/forward navigation history stack.
+ */
+export interface NavigationHistoryPushInfo {
+  extensionId: string;
+  id: string;
+  label: string;
+}
+
+/**
+ * A single entry in the renderer's navigation history stack.
+ * Regular (router-based) entries only carry a `url`. Entries pushed by an
+ * extension via `navigation.pushHistoryEntry` also carry `extensionEntry`,
+ * and `url` is a synthetic display value (never passed to the router).
+ */
+export interface HistoryStackEntry {
+  url: string;
+  extensionEntry?: NavigationHistoryPushInfo;
+}

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5084,6 +5084,38 @@ declare module '@podman-desktop/api' {
     readonly searchTerm?: string;
   }
 
+  /**
+   * An entry that an extension pushes onto Podman Desktop's global back/forward
+   * navigation history, e.g. to reflect an internal SPA navigation inside one of
+   * its webviews.
+   */
+  export interface NavigationHistoryEntry {
+    /**
+     * Opaque identifier for this entry. Passed back verbatim to listeners registered
+     * with {@link navigation.onDidNavigateToHistoryEntry} when the user navigates
+     * back/forward to this entry. Only meaningful to the extension that pushed it.
+     */
+    readonly id: string;
+
+    /**
+     * Display label shown for this entry in the history dropdown.
+     */
+    readonly label: string;
+  }
+
+  /**
+   * Event payload fired by {@link navigation.onDidNavigateToHistoryEntry} when
+   * the user navigates back/forward to an entry previously pushed by this
+   * extension.
+   */
+  export interface NavigateToHistoryEvent {
+    /**
+     * The {@link NavigationHistoryEntry.id id} of the history entry the user
+     * navigated to. The extension should restore its webview state accordingly.
+     */
+    readonly id: string;
+  }
+
   export namespace navigation {
     // Navigate to the Dashboard page
     export function navigateToDashboard(): Promise<void>;
@@ -5207,6 +5239,31 @@ declare module '@podman-desktop/api' {
      * @param args the arguments to provide to the command linked to the routeId
      */
     export function navigate(routeId: string, ...args: unknown[]): Promise<void>;
+
+    /**
+     * Push a new entry onto Podman Desktop's global back/forward navigation history.
+     * Call this whenever the user navigates to a new page within the extension's
+     * own webview (e.g. a SPA route change), so that the global Back/Forward
+     * buttons can step through it.
+     *
+     * @example
+     * ```typescript
+     * import { navigation } from '@podman-desktop/api';
+     *
+     * navigation.pushHistoryEntry({ id: '/models/llama3', label: 'Model: llama3' });
+     * ```
+     *
+     * @param entry the entry to push.
+     */
+    export function pushHistoryEntry(entry: NavigationHistoryEntry): void;
+
+    /**
+     * Fired when the user navigates back/forward through Podman Desktop's global
+     * history and lands on an entry previously pushed by this extension via
+     * {@link navigation.pushHistoryEntry}. The extension is responsible for
+     * restoring its own webview state accordingly (e.g. via `postMessage`).
+     */
+    export const onDidNavigateToHistoryEntry: Event<NavigateToHistoryEvent>;
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?
Adds navigation.pushHistoryEntry and onDidNavigateToHistoryEntry to the extension API, plus the shared NavigationHistoryPushInfo/ HistoryStackEntry types and api-sender channel so extensions can push entries onto Podman Desktop's global back/forward navigation history.

### Screenshot / video of UI


### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/18434

### How to test this PR?


- [ ] Tests are covering the bug fix or the new feature
