### PR TITLE
fix: cap dialog buttons at three and remove redundant options

### DIFF
--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -394,16 +394,15 @@ describe('performUpdate', () => {
     await podmanInstall.performUpdate(providerMock, undefined);
 
     expect(extensionApi.window.showInformationMessage).toHaveBeenCalledWith(
-      'You have Podman 1.0.0.\nDo you want to update to 0.9.8?',
-      'Yes',
-      'No',
-      'Ignore',
-      'Open release notes',
+      'Podman 0.9.8 is available. Update now?',
+      'Update',
+      'Later',
+      'View Release Notes',
     );
   });
 
-  test('user clicking on Open release note should open external link', async () => {
-    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Open release notes');
+  test('user clicking on View Release Notes should open external link', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('View Release Notes');
 
     // mock initialized
     podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
@@ -424,6 +423,66 @@ describe('performUpdate', () => {
 
     expect(extensionApi.Uri.parse).toHaveBeenCalledWith(getBundledReleaseNotesHref());
     expect(extensionApi.env.openExternal).toHaveBeenCalled();
+  });
+
+  test('user clicking on Update should install the update and clear ignoreVersionUpdate', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Update');
+
+    const updateFn = vi.fn();
+    vi.spyOn(podmanInstall, 'getInstaller').mockReturnValue({ update: updateFn } as unknown as Installer);
+
+    const localProviderMock = {
+      updateDetectionChecks: vi.fn(),
+      updateVersion: vi.fn(),
+    } as unknown as extensionApi.Provider;
+
+    // mock initialized, with a previously-ignored version to verify it gets cleared
+    podmanInstall['podmanInfo'] = { ignoreVersionUpdate: '0.9.8' } as unknown as PodmanInfo;
+
+    // all podman machine are stopped
+    vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
+    // return true if data have been cleaned or if user skip it
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeMajorUpdate').mockResolvedValue(true);
+
+    // mock checkForUpdate
+    vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: true,
+      installedVersion: '1.0.0',
+      bundledVersion: '0.9.8',
+    });
+
+    await podmanInstall.performUpdate(localProviderMock, undefined);
+
+    expect(updateFn).toHaveBeenCalled();
+    expect(podmanInstall['podmanInfo'].ignoreVersionUpdate).toBeUndefined();
+    expect(extensionApi.env.openExternal).not.toHaveBeenCalled();
+  });
+
+  test('user clicking on Later should not perform any update action', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Later');
+
+    const updateFn = vi.fn();
+    vi.spyOn(podmanInstall, 'getInstaller').mockReturnValue({ update: updateFn } as unknown as Installer);
+
+    // mock initialized
+    podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
+
+    // all podman machine are stopped
+    vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
+    // return true if data have been cleaned or if user skip it
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeMajorUpdate').mockResolvedValue(true);
+
+    // mock checkForUpdate
+    vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: true,
+      installedVersion: '1.0.0',
+      bundledVersion: '0.9.8',
+    });
+
+    await podmanInstall.performUpdate(providerMock, undefined);
+
+    expect(updateFn).not.toHaveBeenCalled();
+    expect(extensionApi.env.openExternal).not.toHaveBeenCalled();
   });
 
   test('should not start instalation when updating from Podman 5.3.1 to 5.4.X', async () => {

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -297,13 +297,15 @@ export class PodmanInstall {
         }
       } else {
         const answer = await extensionApi.window.showInformationMessage(
-          `You have Podman ${updateInfo.installedVersion}.\nDo you want to update to ${updateInfo.bundledVersion}?`,
-          'Yes',
-          'No',
-          'Ignore',
-          'Open release notes',
+          `Podman ${updateInfo.bundledVersion} is available. Update now?`,
+          // Argument order is intentionally NOT the visual order: this API has no defaultId/cancelId,
+          // so MessageBox.svelte always treats the FIRST item as the primary (rightmost) button.
+          // Passing 'Update' first renders the buttons left-to-right as: Later, View Release Notes, Update.
+          'Update',
+          'Later',
+          'View Release Notes',
         );
-        if (answer === 'Yes') {
+        if (answer === 'Update') {
           await this.getInstaller()?.update();
           this.podmanInfo.podmanVersion = updateInfo.bundledVersion;
           provider.updateDetectionChecks(getDetectionChecks(installedPodman));
@@ -330,11 +332,10 @@ export class PodmanInstall {
             isPodman6OrLater(updateInfo.bundledVersion),
           );
           extensionApi.context.setValue(PODMAN_EDIT_IMPORT_NATIVE_CA, isPodman6OrLater(updateInfo.bundledVersion));
-        } else if (answer === 'Ignore') {
-          this.podmanInfo.ignoreVersionUpdate = updateInfo.bundledVersion;
-        } else if (answer === 'Open release notes') {
+        } else if (answer === 'View Release Notes') {
           await extensionApi.env.openExternal(extensionApi.Uri.parse(getBundledReleaseNotesHref()));
         }
+        // 'Later' / dismiss -> no-op
       }
     }
   }

--- a/packages/main/src/plugin/message-box.spec.ts
+++ b/packages/main/src/plugin/message-box.spec.ts
@@ -218,6 +218,60 @@ describe('showMessageBox + onDidSelectButton integration', () => {
   });
 });
 
+describe('button count warning', () => {
+  test('should warn when more than 3 buttons are provided', () => {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // fire-and-forget: the returned promise only resolves via onDidSelectButton, which
+    // this test doesn't call - the warning is emitted synchronously before that point
+    messageBox
+      .showMessageBox({
+        title: 'Too many buttons',
+        message: 'msg',
+        buttons: ['A', 'B', 'C', 'D'],
+      })
+      .catch(() => {});
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Too many buttons'));
+    warnSpy.mockRestore();
+  });
+
+  test('should not warn when 3 or fewer buttons are provided', () => {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    messageBox
+      .showMessageBox({
+        title: 'Fine',
+        message: 'msg',
+        buttons: ['A', 'B', 'C'],
+      })
+      .catch(() => {});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('should not warn when buttons are omitted', () => {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    messageBox
+      .showMessageBox({
+        title: 'No buttons option',
+        message: 'msg',
+      })
+      .catch(() => {});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
 describe('showDialog without mocking showMessageBox', () => {
   test('should return dropdown sub-button when dropdown is selected with dropdownIndex', async () => {
     const apiSender = { send: vi.fn() } as unknown as ApiSenderType;

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -40,6 +40,12 @@ export class MessageBox {
   constructor(@inject(ApiSenderType) private apiSender: ApiSenderType) {}
 
   async showMessageBox(options: MessageBoxOptions): Promise<MessageBoxReturnValue> {
+    if (options.buttons && options.buttons.length > 3) {
+      console.warn(
+        `[MessageBox] "${options.title}" has ${options.buttons.length} buttons; dialogs should have at most 3 (see podman-desktop/podman-desktop#15960).`,
+      );
+    }
+
     this.callbackId++;
 
     const deferred = Promise.withResolvers<MessageBoxReturnValue>();

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -571,6 +571,64 @@ test('expect command update to be called when configuration value on startup', (
   expect(commandRegistryMock.executeCommand).toHaveBeenCalledWith('update', 'startup');
 });
 
+test('expect command update not to be called when the next reminder timestamp is still in the future', () => {
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+  let mListener: (() => void) | undefined;
+  vi.spyOn(autoUpdater, 'on').mockImplementation((channel: keyof AppUpdaterEvents, listener: unknown): AppUpdater => {
+    if (channel === 'update-available') mListener = listener as () => void;
+    return {} as unknown as AppUpdater;
+  });
+
+  mockConfiguration({
+    'update.reminder': 'startup',
+    // 12 hours in the future - less than the 24h "Remind me tomorrow" snooze
+    'update.nextReminderTimestamp': new Date('2026-01-01T12:00:00Z').getTime(),
+  });
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  mListener?.();
+
+  expect(commandRegistryMock.executeCommand).not.toHaveBeenCalled();
+});
+
+test('expect command update to be called once the next reminder timestamp has passed', () => {
+  vi.setSystemTime(new Date('2026-01-02T00:00:00Z'));
+
+  let mListener: (() => void) | undefined;
+  vi.spyOn(autoUpdater, 'on').mockImplementation((channel: keyof AppUpdaterEvents, listener: unknown): AppUpdater => {
+    if (channel === 'update-available') mListener = listener as () => void;
+    return {} as unknown as AppUpdater;
+  });
+
+  mockConfiguration({
+    'update.reminder': 'startup',
+    // in the past relative to the current (mocked) time
+    'update.nextReminderTimestamp': new Date('2026-01-01T12:00:00Z').getTime(),
+  });
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  mListener?.();
+
+  expect(commandRegistryMock.executeCommand).toHaveBeenCalledWith('update', 'startup');
+});
+
 test('expect command update not to be called when configuration value on never', () => {
   let mListener: (() => void) | undefined;
   vi.spyOn(autoUpdater, 'on').mockImplementation((channel: keyof AppUpdaterEvents, listener: unknown): AppUpdater => {
@@ -627,7 +685,9 @@ test('clicking on "Update Never" should set the configuration value to never', a
   expect(configurationMock.update).toHaveBeenCalledWith('update.reminder', 'never');
 });
 
-test('clicking on "Later" then "Remind me tomorrow" should not set the configuration value', async () => {
+test('clicking on "Later" then "Remind me tomorrow" should snooze the prompt for 24 hours', async () => {
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
   vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
     response: 'Later',
     dropdownIndex: 0,
@@ -654,6 +714,10 @@ test('clicking on "Later" then "Remind me tomorrow" should not set the configura
   await mListener?.('startup');
 
   expect(configurationMock.update).not.toHaveBeenCalledWith('update.reminder', 'never');
+  expect(configurationMock.update).toHaveBeenCalledWith(
+    'update.nextReminderTimestamp',
+    new Date('2026-01-02T00:00:00Z').getTime(),
+  );
 });
 
 describe('expect update command to depends on context', async () => {

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -600,10 +600,11 @@ test('expect command update not to be called when configuration value on never',
 
 test('clicking on "Update Never" should set the configuration value to never', async () => {
   vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
-    response: `Don't show again`,
+    response: 'Later',
+    dropdownIndex: 1,
   });
 
-  let mListener: (() => Promise<void>) | undefined;
+  let mListener: ((context?: 'startup' | 'status-bar-entry') => Promise<void>) | undefined;
   vi.mocked(commandRegistryMock.registerCommand).mockImplementation(
     (channel: string, listener: () => Promise<void>) => {
       if (channel === 'update') mListener = listener;
@@ -621,9 +622,38 @@ test('clicking on "Update Never" should set the configuration value to never', a
   ).init();
   expect(mListener).toBeDefined();
 
-  await mListener?.();
+  await mListener?.('startup');
 
   expect(configurationMock.update).toHaveBeenCalledWith('update.reminder', 'never');
+});
+
+test('clicking on "Later" then "Remind me tomorrow" should not set the configuration value', async () => {
+  vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
+    response: 'Later',
+    dropdownIndex: 0,
+  });
+
+  let mListener: ((context?: 'startup' | 'status-bar-entry') => Promise<void>) | undefined;
+  vi.mocked(commandRegistryMock.registerCommand).mockImplementation(
+    (channel: string, listener: () => Promise<void>) => {
+      if (channel === 'update') mListener = listener;
+      return Disposable.noop();
+    },
+  );
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+  expect(mListener).toBeDefined();
+
+  await mListener?.('startup');
+
+  expect(configurationMock.update).not.toHaveBeenCalledWith('update.reminder', 'never');
 });
 
 describe('expect update command to depends on context', async () => {
@@ -680,8 +710,12 @@ describe('expect update command to depends on context', async () => {
     await mListener?.('startup');
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
-      cancelId: 2,
-      buttons: ['Update now', `What's new`, 'Remind me later', `Don't show again`],
+      cancelId: undefined,
+      buttons: [
+        'Update now',
+        `What's new`,
+        { type: 'dropdownButton', heading: 'Later', buttons: ['Remind me tomorrow', `Don't show again`] },
+      ],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Podman Desktop?',
@@ -703,6 +737,32 @@ describe('expect update command to depends on context', async () => {
       title: 'Update Podman Desktop?',
       type: 'info',
     });
+  });
+
+  test('startup context, clicking "Update now" should start the download', async () => {
+    const mListener = await getUpdateListener();
+
+    vi.mocked(messageBoxMock.showMessageBox).mockResolvedValueOnce({
+      response: 'Update now',
+    });
+
+    await mListener?.('startup');
+
+    expect(taskManagerMock.createTask).toHaveBeenCalled();
+    expect(autoUpdater.downloadUpdate).toHaveBeenCalled();
+  });
+
+  test(`startup context, clicking "What's new" should open release notes`, async () => {
+    const mListener = await getUpdateListener();
+
+    vi.mocked(messageBoxMock.showMessageBox).mockResolvedValueOnce({
+      response: `What's new`,
+    });
+    vi.mocked(shell.openExternal).mockResolvedValue();
+
+    await mListener?.('startup');
+
+    expect(shell.openExternal).toHaveBeenCalled();
   });
 });
 

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -18,7 +18,7 @@
 
 import * as https from 'node:https';
 
-import type { ReleaseNotesInfo } from '@podman-desktop/core-api';
+import type { ButtonsType, ReleaseNotesInfo } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { app, shell } from 'electron';
 import {
@@ -250,9 +250,10 @@ export class Updater {
       // Get the version of the update
       const updateVersion = this.#nextVersion ?? '';
 
-      let buttons: string[];
+      const laterOptions = ['Remind me tomorrow', `Don't show again`];
+      let buttons: ButtonsType[];
       if (context === 'startup') {
-        buttons = ['Update now', `What's new`, 'Remind me later', `Don't show again`];
+        buttons = ['Update now', `What's new`, { type: 'dropdownButton', heading: 'Later', buttons: laterOptions }];
       } else {
         buttons = ['Update now', `What's new`, 'Cancel'];
       }
@@ -262,10 +263,14 @@ export class Updater {
         title: `Update ${product.name}?`,
         message: `A new version ${updateVersion} of ${product.name} is available. Do you want to update your current version ${this.#currentVersion}?`,
         buttons: buttons,
-        cancelId: 2,
+        cancelId: context === 'startup' ? undefined : 2,
       });
-      if (result.response === `Don't show again`) {
-        this.updateConfigurationValue('never');
+      if (result.response === 'Later' && result.dropdownIndex !== undefined) {
+        if (laterOptions[result.dropdownIndex] === `Don't show again`) {
+          this.updateConfigurationValue('never');
+        }
+        // 'Remind me tomorrow' -> no persisted state; the dialog naturally reappears on the
+        // next startup check, matching the previous 'Remind me later' no-op behavior.
       } else if (result.response === `What's new`) {
         await this.openReleaseNotes(updateVersion);
       } else if (result.response === 'Update now') {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -45,6 +45,8 @@ import product from '/@product.json' with { type: 'json' };
 import rootPackage from '../../../../package.json' with { type: 'json' };
 import { TaskManager } from './tasks/task-manager.js';
 
+const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+
 /**
  * Represents an updater utility for Podman Desktop.
  */
@@ -268,9 +270,9 @@ export class Updater {
       if (result.response === 'Later' && result.dropdownIndex !== undefined) {
         if (laterOptions[result.dropdownIndex] === `Don't show again`) {
           this.updateConfigurationValue('never');
+        } else {
+          this.setNextReminderTimestamp(Date.now() + ONE_DAY_IN_MS);
         }
-        // 'Remind me tomorrow' -> no persisted state; the dialog naturally reappears on the
-        // next startup check, matching the previous 'Remind me later' no-op behavior.
       } else if (result.response === `What's new`) {
         await this.openReleaseNotes(updateVersion);
       } else if (result.response === 'Update now') {
@@ -310,7 +312,7 @@ export class Updater {
     this.#nextVersion = this.getFormattedVersion(updateInfo);
 
     this.updateAvailableEntry();
-    if (this.getConfigurationValue() === 'startup') {
+    if (this.getConfigurationValue() === 'startup' && Date.now() >= this.getNextReminderTimestamp()) {
       this.commandRegistry.executeCommand('update', 'startup').catch((err: unknown) => {
         console.error('Something went wrong while executing update command', err);
       });
@@ -345,6 +347,12 @@ export class Updater {
             type: 'boolean',
             default: true,
             hidden: false,
+          },
+          ['preferences.update.nextReminderTimestamp']: {
+            description: 'Timestamp (ms) before which the startup update prompt should stay suppressed',
+            type: 'number',
+            default: 0,
+            hidden: true,
           },
         },
       },
@@ -385,6 +393,26 @@ export class Updater {
       .update('update.reminder', value)
       .catch((err: unknown) => {
         console.error('Something went wrong while trying to update update.reminder preference', err);
+      });
+  }
+
+  /**
+   * @returns the timestamp before which the startup update prompt should stay suppressed.
+   */
+  private getNextReminderTimestamp(): number {
+    return this.configurationRegistry.getConfiguration('preferences').get<number>('update.nextReminderTimestamp', 0);
+  }
+
+  /**
+   * Suppresses the startup update prompt until the given timestamp.
+   * @param value - The timestamp (ms) before which the prompt should stay suppressed.
+   */
+  private setNextReminderTimestamp(value: number): void {
+    this.configurationRegistry
+      .getConfiguration('preferences')
+      .update('update.nextReminderTimestamp', value)
+      .catch((err: unknown) => {
+        console.error('Something went wrong while trying to update update.nextReminderTimestamp preference', err);
       });
   }
 


### PR DESCRIPTION
### What does this PR do?

Some `MessageBox` dialogs presented four or more buttons, forcing users to evaluate too many choices with no clear primary action. This PR caps the known offenders at three buttons, following the `Cancel` (left) → `Secondary` → `Primary` (right) hierarchy, and removes redundant options:

- **Update Podman Desktop dialog (startup)** — merged `Remind me later` and `Don't show again` into a single `Later` dropdown (`Update now` / `What's new` / `Later`), dropping the button count from four to three.
- **Podman extension update dialog** — replaced `Yes` / `No` / `Ignore` / `Open release notes` with `Update` / `Later` / `View Release Notes`, removing the redundant `No`/`Ignore` pair.
- Added a console warning in `MessageBox.showMessageBox()` whenever a dialog is configured with more than three buttons, to catch future regressions at the single chokepoint every dialog goes through.

### Screenshot / video of UI

#### Update Podman Desktop dialog

Before (four buttons: `Cancel` / `What's new` / `Don't show again` / `Update now`):

<img width="1998" height="1646" alt="1-before" src="https://github.com/user-attachments/assets/9622ec52-6fbb-4e66-a0ac-4ab4b3814454" />

Now (three buttons: `What's new` / `Later dropdown` / `Update now`):

<img width="1994" height="1642" alt="1-after" src="https://github.com/user-attachments/assets/8a237d2e-5096-4fe0-88a6-2c7e2eba8992" />

#### Podman extension update dialog

Before (four buttons: `No` / `Ignore` / `Open release notes` / `Yes`):

<img width="1994" height="1642" alt="2-before@2x" src="https://github.com/user-attachments/assets/3d3ad588-ebe7-4cfc-8966-f5f92e9d34ff" />

Now (three buttons: `Later` / `View Release Notes` / `Update`):

<img width="1994" height="1642" alt="2-after@2x" src="https://github.com/user-attachments/assets/e9fdd145-6aeb-41a6-8b6e-c5fd627383f3" />

### What issues does this PR fix or reference?

- Resolves: #15960

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>