### PR TITLE
fix(website): strip shell prompt prefixes when copying code blocks

### DIFF
--- a/website/src/theme/CodeBlock/Buttons/CopyButton/index.js
+++ b/website/src/theme/CodeBlock/Buttons/CopyButton/index.js
@@ -1,0 +1,37 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { CodeBlockContextProvider, useCodeBlockContext } from '@docusaurus/theme-common/internal';
+import CopyButton from '@theme-original/CodeBlock/Buttons/CopyButton';
+import React from 'react';
+
+import { stripPrompts } from './stripPrompts.js';
+
+// Update the CopyButton to remove the '$ ' or '# ' or '> ' from the code it copies
+export default function CopyButtonWrapper(props) {
+  const { metadata, wordWrap } = useCodeBlockContext();
+  const updatedMetadata = { ...metadata, code: stripPrompts(metadata.code) };
+
+  return (
+    // CopyButton receives the new code without the prompt prefixes
+    // trough the CodeBlockContextProvider's metadata prop, that which contains the new code value
+    <CodeBlockContextProvider metadata={updatedMetadata} wordWrap={wordWrap}>
+      <CopyButton {...props} />
+    </CodeBlockContextProvider>
+  );
+}

--- a/website/src/theme/CodeBlock/Buttons/CopyButton/stripPrompts.js
+++ b/website/src/theme/CodeBlock/Buttons/CopyButton/stripPrompts.js
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import CopyButton from '@theme-original/CodeBlock/CopyButton';
-import React from 'react';
+// Matches shell prompt prefixes ('$ ', '# ', '> ') at the start of each line
+const PROMPT_RE = /^(?:\$ |# |> )/gm;
 
-// Update the CopyButton to remove the '$ ' or '# ' from the code
-export default function CopyButtonWrapper(props) {
-  const updatedProps = { ...props };
-  if (
-    updatedProps?.code?.length > 2 &&
-    (updatedProps.code.substring(0, 2) === '$ ' ||
-      updatedProps.code.substring(0, 2) === '# ' ||
-      updatedProps.code.substring(0, 2) === '> ')
-  ) {
-    updatedProps.code = updatedProps.code.substring(2);
-  }
-  return (
-    <>
-      <CopyButton {...updatedProps} />
-    </>
-  );
+// Strips prompt prefixes so users copy only the actual commands
+export function stripPrompts(code) {
+  return code.replace(PROMPT_RE, '');
 }

--- a/website/src/theme/CodeBlock/Buttons/CopyButton/stripPrompts.spec.js
+++ b/website/src/theme/CodeBlock/Buttons/CopyButton/stripPrompts.spec.js
@@ -1,0 +1,61 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+import { stripPrompts } from './stripPrompts.js';
+
+describe('stripPrompts', () => {
+  test('strips $ prompt from a single line', () => {
+    expect(stripPrompts('$ podman run nginx')).toBe('podman run nginx');
+  });
+
+  test('strips # prompt from a single line', () => {
+    expect(stripPrompts('# dnf install podman')).toBe('dnf install podman');
+  });
+
+  test('strips > prompt from a single line', () => {
+    expect(stripPrompts('> Get-Command podman')).toBe('Get-Command podman');
+  });
+
+  test('strips prompts from each line in a multi-line block', () => {
+    const input = '$ podman pull nginx\n$ podman run -d nginx';
+    expect(stripPrompts(input)).toBe('podman pull nginx\npodman run -d nginx');
+  });
+
+  test('strips mixed prompt types across lines', () => {
+    const input = '$ echo hello\n# echo world\n> echo test';
+    expect(stripPrompts(input)).toBe('echo hello\necho world\necho test');
+  });
+
+  test('leaves lines without prompts unchanged', () => {
+    expect(stripPrompts('podman run nginx')).toBe('podman run nginx');
+  });
+
+  test('only strips prompts at the start of a line', () => {
+    expect(stripPrompts('echo "$ hello"')).toBe('echo "$ hello"');
+  });
+
+  test('handles empty string', () => {
+    expect(stripPrompts('')).toBe('');
+  });
+
+  test('handles mixed lines with and without prompts', () => {
+    const input = '$ podman pull nginx\nnginx:latest pulled\n$ podman run nginx';
+    expect(stripPrompts(input)).toBe('podman pull nginx\nnginx:latest pulled\npodman run nginx');
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Fixes the copy button on code blocks in the Docusaurus website including shell prompt prefixes ($ , # , > ) when copying commands to clipboard.

The previous swizzle override at ``src/theme/CodeBlock/CopyButton/`` stopped working after upgrading to Docusaurus 3.9+, which moved the CopyButton component to new swizzle path ``src/theme/CodeBlock/Buttons/CopyButton/`` and changed its API from receiving ``code`` as a prop to reading it from ``useCodeBlockContext()``. 

So this PR removes the old file that was used before and implements the same thing, but based on the new changes in Docusaurus version. The unit tests for ``stripPrompts()`` where added also.

### Screenshot / video of UI

https://github.com/user-attachments/assets/74d6e606-1b4e-43b1-b96c-942e1fe78ca4

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/18253

### How to test this PR?
1. Go to https://podman-desktop.io/docs/installation/linux-install
2. Click the copy button on any code block (or manually select the command text)
3. Paste the copied text into a terminal
4. Observe the $ is included, causing a command-not-found or syntax error

- [X] Tests are covering the bug fix or the new feature
