### PR TITLE
chore: remove app icon progress bar when progress tracking ends

### DIFF
--- a/extensions/podman/packages/extension/src/installer/mac-os-installer.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/mac-os-installer.spec.ts
@@ -96,6 +96,8 @@ describe('MacOSInstaller', () => {
 
     await promiseArg(progress, token);
 
+    expect(progress.report).toHaveBeenCalledWith({ increment: -1 });
+
     await promiseResult;
 
     // check we've called the execution of the universal installer
@@ -140,6 +142,7 @@ describe('MacOSInstaller', () => {
     } as unknown as CancellationToken;
 
     await expect(promiseArg(progress, token)).rejects.toThrow(`Can't find Podman package`);
+    expect(progress.report).toHaveBeenCalledWith({ increment: -1 });
     expect(promiseResult).toBeDefined();
   });
 });

--- a/extensions/podman/packages/extension/src/installer/mac-os-installer.ts
+++ b/extensions/podman/packages/extension/src/installer/mac-os-installer.ts
@@ -35,6 +35,7 @@ export class MacOSInstaller extends BaseInstaller {
       progress.report({ increment: 5 });
       const pkgToInstall = path.resolve(getAssetsFolder(), getBundledFileName('darwin', process.arch));
       if (!fs.existsSync(pkgToInstall)) {
+        progress.report({ increment: -1 });
         throw new Error(`Can't find Podman package! Path: ${pkgToInstall} doesn't exist.`);
       }
 
@@ -58,6 +59,8 @@ export class MacOSInstaller extends BaseInstaller {
         console.error(err);
         await window.showErrorMessage('Unexpected error, during Podman installation: ' + err, 'OK');
         return false;
+      } finally {
+        progress.report({ increment: -1 });
       }
     });
   }


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Remove the app icon progress bar when progress tracking in no longer needed

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/18274

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
