### PR TITLE
chore: add update channel support from product.json

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -311,7 +311,7 @@ if (process.env.AIRGAP_DOWNLOAD) {
     publishAutoUpdate: false,
     provider: product.update?.url ? 'generic' : 'github',
     ...(product.update?.url ? { url: product.update.url } : {}),
-    ...(product.update?.updateChannel ? { channel: product.update.url } : {}),
+    ...(product.update?.updateChannel ? { channel: product.update.updateChannel } : {}),
   };
 }
 

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -293,10 +293,12 @@ const config = {
         provider: 'generic',
         url: product.update.url,
         timeout: 10000,
+        ...(product.update?.updateChannel ? { channel: product.update.url } : {}),
       }
     : {
         provider: 'github',
         timeout: 10000,
+        ...(product.update?.updateChannel ? { channel: product.update.url } : {}),
       },
   /*extraMetadata: {
     version: process.env.VITE_APP_VERSION,
@@ -309,6 +311,7 @@ if (process.env.AIRGAP_DOWNLOAD) {
     publishAutoUpdate: false,
     provider: product.update?.url ? 'generic' : 'github',
     ...(product.update?.url ? { url: product.update.url } : {}),
+    ...(product.update?.updateChannel ? { channel: product.update.url } : {}),
   };
 }
 

--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -293,12 +293,12 @@ const config = {
         provider: 'generic',
         url: product.update.url,
         timeout: 10000,
-        ...(product.update?.updateChannel ? { channel: product.update.url } : {}),
+        ...(product.update?.updateChannel ? { channel: product.update.updateChannel } : {}),
       }
     : {
         provider: 'github',
         timeout: 10000,
-        ...(product.update?.updateChannel ? { channel: product.update.url } : {}),
+        ...(product.update?.updateChannel ? { channel: product.update.updateChannel } : {}),
       },
   /*extraMetadata: {
     version: process.env.VITE_APP_VERSION,

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -252,7 +252,7 @@ test('expect configuration description to use product name', () => {
 });
 
 test('expect setFeedURL not to be called when product.update.url is empty', () => {
-  vi.mocked(product).update = { url: '' };
+  vi.mocked(product).update = { url: '', updateChannel: '' };
 
   new Updater(
     messageBoxMock,
@@ -267,7 +267,7 @@ test('expect setFeedURL not to be called when product.update.url is empty', () =
 });
 
 test('expect setFeedURL to be called with generic provider when product.update.url is set', () => {
-  vi.mocked(product).update = { url: 'https://updates.example.com/releases' };
+  vi.mocked(product).update = { url: 'https://updates.example.com/releases', updateChannel: '' };
 
   new Updater(
     messageBoxMock,
@@ -285,7 +285,7 @@ test('expect setFeedURL to be called with generic provider when product.update.u
 });
 
 test('expect setFeedURL to be called before checkForUpdates', () => {
-  vi.mocked(product).update = { url: 'https://updates.example.com/releases' };
+  vi.mocked(product).update = { url: 'https://updates.example.com/releases', updateChannel: '' };
 
   const callOrder: string[] = [];
   vi.mocked(autoUpdater.setFeedURL).mockImplementation(() => {

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -171,6 +171,7 @@ beforeEach(() => {
 
   vi.mocked(product).update = {
     url: '',
+    updateChannel: '',
   };
 
   vi.mocked(commandRegistryMock.executeCommand).mockResolvedValue(undefined);
@@ -306,6 +307,36 @@ test('expect setFeedURL to be called before checkForUpdates', () => {
   ).init();
 
   expect(callOrder).toStrictEqual(['setFeedURL', 'checkForUpdates']);
+});
+
+test('expect channel not to be called when product.update.updateChannel is empty', () => {
+  vi.mocked(product).update = { url: '', updateChannel: '' };
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  expect(autoUpdater.channel).toBeUndefined();
+});
+
+test('expect channel to be called with generic provider when product.update.updateChannel is set', () => {
+  vi.mocked(product).update = { url: '', updateChannel: 'next' };
+
+  new Updater(
+    messageBoxMock,
+    configurationRegistryMock,
+    statusBarRegistryMock,
+    commandRegistryMock,
+    taskManagerMock,
+    apiSenderMock,
+  ).init();
+
+  expect(autoUpdater.channel).toBe('next');
 });
 
 describe('differential download', () => {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -495,6 +495,13 @@ export class Updater {
       });
     }
 
+    if (product.update?.updateChannel) {
+      autoUpdater.channel = product.update?.updateChannel;
+
+      // https://www.electron.build/docs/api/electron-updater.class.appupdater/#channel
+      autoUpdater.allowDowngrade = false;
+    }
+
     /**
      * Differential updates take **a lot** of memory
      * and have lead to constant JavaScript heap out of memory on windows

--- a/product.json
+++ b/product.json
@@ -79,7 +79,8 @@
     ]
   },
   "update": {
-    "url": ""
+    "url": "",
+    "updateChannel": ""
   },
   "releaseNotes": {
     "url": "",


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds update channel support for the auto updater. The channel can be set up in `product.json`, and the auto updater will use it to fetch and create the latest files relevant to that channel

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/18190

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
