### PR TITLE
feat(main): warn when a dialog is configured with more than 3 buttons

### DIFF
--- a/packages/main/src/plugin/message-box.spec.ts
+++ b/packages/main/src/plugin/message-box.spec.ts
@@ -18,7 +18,7 @@
 
 import type { DropdownType, IconButtonType } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { MessageBox } from './message-box.js';
 
@@ -219,6 +219,10 @@ describe('showMessageBox + onDidSelectButton integration', () => {
 });
 
 describe('button count warning', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('should warn when more than 3 buttons are provided', () => {
     const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
     const messageBox = new MessageBox(apiSender);
@@ -235,7 +239,6 @@ describe('button count warning', () => {
       .catch(() => {});
 
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Too many buttons'));
-    warnSpy.mockRestore();
   });
 
   test('should not warn when 3 or fewer buttons are provided', () => {
@@ -252,7 +255,6 @@ describe('button count warning', () => {
       .catch(() => {});
 
     expect(warnSpy).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   test('should not warn when buttons are omitted', () => {
@@ -268,7 +270,6 @@ describe('button count warning', () => {
       .catch(() => {});
 
     expect(warnSpy).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 });
 

--- a/packages/main/src/plugin/message-box.spec.ts
+++ b/packages/main/src/plugin/message-box.spec.ts
@@ -218,6 +218,60 @@ describe('showMessageBox + onDidSelectButton integration', () => {
   });
 });
 
+describe('button count warning', () => {
+  test('should warn when more than 3 buttons are provided', () => {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // fire-and-forget: the returned promise only resolves via onDidSelectButton, which
+    // this test doesn't call - the warning is emitted synchronously before that point
+    messageBox
+      .showMessageBox({
+        title: 'Too many buttons',
+        message: 'msg',
+        buttons: ['A', 'B', 'C', 'D'],
+      })
+      .catch(() => {});
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Too many buttons'));
+    warnSpy.mockRestore();
+  });
+
+  test('should not warn when 3 or fewer buttons are provided', () => {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    messageBox
+      .showMessageBox({
+        title: 'Fine',
+        message: 'msg',
+        buttons: ['A', 'B', 'C'],
+      })
+      .catch(() => {});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  test('should not warn when buttons are omitted', () => {
+    const apiSender = { send: vi.fn() } as unknown as ApiSenderType;
+    const messageBox = new MessageBox(apiSender);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    messageBox
+      .showMessageBox({
+        title: 'No buttons option',
+        message: 'msg',
+      })
+      .catch(() => {});
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
 describe('showDialog without mocking showMessageBox', () => {
   test('should return dropdown sub-button when dropdown is selected with dropdownIndex', async () => {
     const apiSender = { send: vi.fn() } as unknown as ApiSenderType;

--- a/packages/main/src/plugin/message-box.ts
+++ b/packages/main/src/plugin/message-box.ts
@@ -40,6 +40,12 @@ export class MessageBox {
   constructor(@inject(ApiSenderType) private apiSender: ApiSenderType) {}
 
   async showMessageBox(options: MessageBoxOptions): Promise<MessageBoxReturnValue> {
+    if (options.buttons && options.buttons.length > 3) {
+      console.warn(
+        `[MessageBox] "${options.title}" has ${options.buttons.length} buttons; dialogs should have at most 3 (see podman-desktop/podman-desktop#15960).`,
+      );
+    }
+
     this.callbackId++;
 
     const deferred = Promise.withResolvers<MessageBoxReturnValue>();


### PR DESCRIPTION
### What does this PR do?

Adds a safeguard against dialogs with too many buttons. `MessageBox` dialogs presented with four or more buttons force users to evaluate too many choices with no clear primary action (#15960).

Rather than only fixing the known offenders, this adds a console warning in `MessageBox.showMessageBox()` (the single chokepoint every dialog goes through) whenever a dialog is configured with more than three buttons, to catch future regressions.

This is a split-out of #18475 (three unrelated changes bundled into one PR); this is part one of three. The other two parts:
- #18491
- #18492

### Screenshot / video of UI

No UI change. This only adds a `console.warn` for dialogs with more than three buttons. The two visual changes from the original bundled PR (#18475) are covered by the other two split-out PRs, which reuse the before/after screenshots from that PR.

### What issues does this PR fix or reference?

- Relates to: #15960

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>
