### PR TITLE
feat(podman): reduce update dialog from four buttons to three

### DIFF
--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -394,16 +394,15 @@ describe('performUpdate', () => {
     await podmanInstall.performUpdate(providerMock, undefined);
 
     expect(extensionApi.window.showInformationMessage).toHaveBeenCalledWith(
-      'You have Podman 1.0.0.\nDo you want to update to 0.9.8?',
-      'Yes',
-      'No',
-      'Ignore',
-      'Open release notes',
+      'Podman 0.9.8 is available. Update now?',
+      'Update',
+      'Later',
+      'View Release Notes',
     );
   });
 
-  test('user clicking on Open release note should open external link', async () => {
-    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Open release notes');
+  test('user clicking on View Release Notes should open external link', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('View Release Notes');
 
     // mock initialized
     podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
@@ -424,6 +423,66 @@ describe('performUpdate', () => {
 
     expect(extensionApi.Uri.parse).toHaveBeenCalledWith(getBundledReleaseNotesHref());
     expect(extensionApi.env.openExternal).toHaveBeenCalled();
+  });
+
+  test('user clicking on Update should install the update and clear ignoreVersionUpdate', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Update');
+
+    const updateFn = vi.fn();
+    vi.spyOn(podmanInstall, 'getInstaller').mockReturnValue({ update: updateFn } as unknown as Installer);
+
+    const localProviderMock = {
+      updateDetectionChecks: vi.fn(),
+      updateVersion: vi.fn(),
+    } as unknown as extensionApi.Provider;
+
+    // mock initialized, with a previously-ignored version to verify it gets cleared
+    podmanInstall['podmanInfo'] = { ignoreVersionUpdate: '0.9.8' } as unknown as PodmanInfo;
+
+    // all podman machine are stopped
+    vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
+    // return true if data have been cleaned or if user skip it
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeMajorUpdate').mockResolvedValue(true);
+
+    // mock checkForUpdate
+    vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: true,
+      installedVersion: '1.0.0',
+      bundledVersion: '0.9.8',
+    });
+
+    await podmanInstall.performUpdate(localProviderMock, undefined);
+
+    expect(updateFn).toHaveBeenCalled();
+    expect(podmanInstall['podmanInfo'].ignoreVersionUpdate).toBeUndefined();
+    expect(extensionApi.env.openExternal).not.toHaveBeenCalled();
+  });
+
+  test('user clicking on Later should not perform any update action', async () => {
+    vi.mocked(extensionApi.window.showInformationMessage).mockResolvedValue('Later');
+
+    const updateFn = vi.fn();
+    vi.spyOn(podmanInstall, 'getInstaller').mockReturnValue({ update: updateFn } as unknown as Installer);
+
+    // mock initialized
+    podmanInstall['podmanInfo'] = {} as unknown as PodmanInfo;
+
+    // all podman machine are stopped
+    vi.spyOn(podmanInstall, 'stopPodmanMachinesIfAnyBeforeUpdating').mockResolvedValue(true);
+    // return true if data have been cleaned or if user skip it
+    vi.spyOn(podmanInstall, 'wipeAllDataBeforeMajorUpdate').mockResolvedValue(true);
+
+    // mock checkForUpdate
+    vi.spyOn(podmanInstall, 'checkForUpdate').mockResolvedValue({
+      hasUpdate: true,
+      installedVersion: '1.0.0',
+      bundledVersion: '0.9.8',
+    });
+
+    await podmanInstall.performUpdate(providerMock, undefined);
+
+    expect(updateFn).not.toHaveBeenCalled();
+    expect(extensionApi.env.openExternal).not.toHaveBeenCalled();
   });
 
   test('should not start instalation when updating from Podman 5.3.1 to 5.4.X', async () => {

--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -347,6 +347,27 @@ test('checkForUpdate should return installed version and update if the installed
   });
 });
 
+test('checkForUpdate should still report an update when a legacy ignoreVersionUpdate matches the bundled version', async () => {
+  vi.spyOn(podmanInstall, 'getInstaller').mockReturnValue({
+    requireUpdate: vi.fn().mockReturnValue(true),
+  } as unknown as Installer);
+  vi.spyOn(podmanInstall, 'getLastRunInfo').mockResolvedValue({
+    lastUpdateCheck: 0,
+    // legacy state from before the 'Ignore' button was removed (#15960) - there's no
+    // UI left to set or clear this, so checkForUpdate must not let it hide the prompt
+    ignoreVersionUpdate: getBundledPodmanVersion(),
+  });
+  const result = await podmanInstall.checkForUpdate({
+    version: '1.1',
+  });
+  expect(result).toStrictEqual({
+    installedVersion: '1.1',
+    hasUpdate: true,
+    bundledVersion: getBundledPodmanVersion(),
+  });
+  expect(podmanInstall['podmanInfo']?.ignoreVersionUpdate).toBeUndefined();
+});
+
 const providerMock: extensionApi.Provider = {} as unknown as extensionApi.Provider;
 
 describe('performUpdate', () => {

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -137,11 +137,15 @@ export class PodmanInstall {
     }
     const installer = this.getInstaller();
     const bundledVersion = getBundledPodmanVersion();
-    if (
-      installedVersion &&
-      installer?.requireUpdate(installedVersion) &&
-      this.podmanInfo.ignoreVersionUpdate !== bundledVersion
-    ) {
+
+    // legacy: the 'Ignore' button was removed (#15960), so a previously persisted
+    // ignored version can no longer be set - clear it so it can't silently suppress
+    // the update prompt forever with no UI left to undo it
+    if (this.podmanInfo.ignoreVersionUpdate) {
+      this.podmanInfo.ignoreVersionUpdate = undefined;
+    }
+
+    if (installedVersion && installer?.requireUpdate(installedVersion)) {
       return { installedVersion, hasUpdate: true, bundledVersion };
     }
     return { installedVersion, hasUpdate: false, bundledVersion };

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -297,13 +297,15 @@ export class PodmanInstall {
         }
       } else {
         const answer = await extensionApi.window.showInformationMessage(
-          `You have Podman ${updateInfo.installedVersion}.\nDo you want to update to ${updateInfo.bundledVersion}?`,
-          'Yes',
-          'No',
-          'Ignore',
-          'Open release notes',
+          `Podman ${updateInfo.bundledVersion} is available. Update now?`,
+          // Argument order is intentionally NOT the visual order: this API has no defaultId/cancelId,
+          // so MessageBox.svelte always treats the FIRST item as the primary (rightmost) button.
+          // Passing 'Update' first renders the buttons left-to-right as: Later, View Release Notes, Update.
+          'Update',
+          'Later',
+          'View Release Notes',
         );
-        if (answer === 'Yes') {
+        if (answer === 'Update') {
           await this.getInstaller()?.update();
           this.podmanInfo.podmanVersion = updateInfo.bundledVersion;
           provider.updateDetectionChecks(getDetectionChecks(installedPodman));
@@ -330,11 +332,10 @@ export class PodmanInstall {
             isPodman6OrLater(updateInfo.bundledVersion),
           );
           extensionApi.context.setValue(PODMAN_EDIT_IMPORT_NATIVE_CA, isPodman6OrLater(updateInfo.bundledVersion));
-        } else if (answer === 'Ignore') {
-          this.podmanInfo.ignoreVersionUpdate = updateInfo.bundledVersion;
-        } else if (answer === 'Open release notes') {
+        } else if (answer === 'View Release Notes') {
           await extensionApi.env.openExternal(extensionApi.Uri.parse(getBundledReleaseNotesHref()));
         }
+        // 'Later' / dismiss -> no-op
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?

The Podman extension's update-available dialog presented four buttons, forcing users to evaluate too many choices with no clear primary action (#15960). This PR replaces `Yes` / `No` / `Ignore` / `Open release notes` with `Update` / `Later` / `View Release Notes`, removing the redundant `No`/`Ignore` pair.

Note: this drops the old permanent "Ignore this version" behavior — `Later` is a plain dismiss with no persisted state, matching how the rest of the dialog's button count was reduced.

This is a split-out of #18475 (three unrelated changes bundled into one PR); this is part three of three. The other two parts:
- #18490
- #18491

### Screenshot / video of UI

Before (four buttons: `No` / `Ignore` / `Open release notes` / `Yes`):

<img width="1994" height="1642" alt="2-before@2x" src="https://github.com/user-attachments/assets/3d3ad588-ebe7-4cfc-8966-f5f92e9d34ff" />

Now (three buttons: `Later` / `View Release Notes` / `Update`):

<img width="1994" height="1642" alt="2-after@2x" src="https://github.com/user-attachments/assets/e9fdd145-6aeb-41a6-8b6e-c5fd627383f3" />

### What issues does this PR fix or reference?

- Relates to: #15960

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>
