### PR TITLE
test(website): add coverage for CopyButton

### DIFF
--- a/website/src/theme/CodeBlock/CopyButton/stripPrompts.js
+++ b/website/src/theme/CodeBlock/CopyButton/stripPrompts.js
@@ -16,17 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import CopyButton from '@theme-original/CodeBlock/CopyButton';
-import React from 'react';
-
-import { stripPrompts } from './stripPrompts.js';
-
-// Update the CopyButton to remove the '$ ' or '# ' from the code
-export default function CopyButtonWrapper(props) {
-  const updatedProps = { ...props, code: stripPrompts(props.code) };
-  return (
-    <>
-      <CopyButton {...updatedProps} />
-    </>
-  );
+// Strips a leading shell prompt prefix ('$ ', '# ', '> ') from code
+export function stripPrompts(code) {
+  if (
+    code?.length > 2 &&
+    (code.substring(0, 2) === '$ ' || code.substring(0, 2) === '# ' || code.substring(0, 2) === '> ')
+  ) {
+    return code.substring(2);
+  }
+  return code;
 }

--- a/website/src/theme/CodeBlock/CopyButton/stripPrompts.spec.js
+++ b/website/src/theme/CodeBlock/CopyButton/stripPrompts.spec.js
@@ -1,0 +1,51 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, expect, test } from 'vitest';
+
+import { stripPrompts } from './stripPrompts.js';
+
+describe('stripPrompts', () => {
+  test('strips $ prompt from a single line', () => {
+    expect(stripPrompts('$ podman run nginx')).toBe('podman run nginx');
+  });
+
+  test('strips # prompt from a single line', () => {
+    expect(stripPrompts('# dnf install podman')).toBe('dnf install podman');
+  });
+
+  test('strips > prompt from a single line', () => {
+    expect(stripPrompts('> Get-Command podman')).toBe('Get-Command podman');
+  });
+
+  test('leaves code without prompts unchanged', () => {
+    expect(stripPrompts('podman run nginx')).toBe('podman run nginx');
+  });
+
+  test('handles empty string', () => {
+    expect(stripPrompts('')).toBe('');
+  });
+
+  test('handles undefined', () => {
+    expect(stripPrompts(undefined)).toBe(undefined);
+  });
+
+  test('only strips prompts at the start of a line', () => {
+    expect(stripPrompts('echo "$ hello"')).toBe('echo "$ hello"');
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Adds unit test coverage for function that strips prompts like '$ ' or '# ' or '> ' from input string. Its used when user clicks on CopyButton in documentation, so it doesn't copy the prompt. 

The logic was moved to a function so it can be tested with Vitest. 

Merging this PR will enable me to proceed with fix for issue https://github.com/podman-desktop/podman-desktop/issues/18253.