### PR TITLE
fix: prevent tooltip from reappearing after menu closes

### DIFF
--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -20,6 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { autoUpdate, computePosition } from '@floating-ui/dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { resetTooltipHideCount } from './tooltip-store';
@@ -49,7 +50,7 @@ describe('Tooltip', () => {
     vi.clearAllMocks();
   });
 
-  test('tooltip is hidden when tooltipHidden is true', async () => {
+  test('tooltip remains hidden after tooltipHidden resets until pointer re-enters', async () => {
     render(TooltipTestComponent, { tip: 'test 1' });
 
     const slot = screen.getByTestId('tooltip-trigger');
@@ -69,6 +70,9 @@ describe('Tooltip', () => {
 
     // Simulate dropdown closing (shows tooltips)
     window.dispatchEvent(new Event('tooltip-show'));
+    await tick();
+    expect(screen.queryByText('test 1')).not.toBeInTheDocument();
+
     await fireEvent.mouseEnter(slot);
 
     await waitFor(() => {

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -20,7 +20,6 @@ import '@testing-library/jest-dom/vitest';
 
 import { autoUpdate, computePosition } from '@floating-ui/dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { tick } from 'svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { resetTooltipHideCount } from './tooltip-store';
@@ -70,8 +69,10 @@ describe('Tooltip', () => {
 
     // Simulate dropdown closing (shows tooltips)
     window.dispatchEvent(new Event('tooltip-show'));
-    await tick();
-    expect(screen.queryByText('test 1')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByText('test 1')).not.toBeInTheDocument();
+    });
 
     await fireEvent.mouseEnter(slot);
 

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -160,6 +160,12 @@ function handleFocusOut(event: FocusEvent): void {
   handleMouseLeave();
 }
 
+$effect(() => {
+  if ($tooltipHidden) {
+    handleMouseLeave();
+  }
+});
+
 $effect((): (() => void) => {
   if (isVisible && referenceElement && tooltipElement) {
     // Initial positioning


### PR DESCRIPTION
## Summary

- clear local tooltip visibility when a dropdown or context menu hides tooltips
- prevent a tooltip from reappearing automatically when the menu closes
- require a new hover or keyboard focus before displaying it again
- add regression coverage for the dropdown open and close sequence

## Root cause

The global tooltip state temporarily hid tooltips while a menu was open, but the tooltip retained its local visible state. When the menu closed, the old tooltip could become visible again without a new pointer or focus event.

## Testing

- focused Tooltip component suite: 26 tests passed
- Biome check
- ESLint
- Svelte type check
- `git diff --check`

Closes #14879

AI assistance was used to investigate the state interaction and prepare the initial patch. I reproduced the regression, reviewed the implementation, and ran the focused repository checks.