### PR TITLE
docs(blog): add Kathryn Yetter as blog author

### DIFF
--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -129,3 +129,9 @@ bmahabirbu:
   title: Software Engineer
   url: https://github.com/bmahabirbu
   image_url: https://github.com/bmahabirbu.png
+
+kyetter:
+  name: Kathryn Yetter
+  title: Product Manager
+  url: https://github.com/kyetter
+  image_url: https://github.com/kyetter.png


### PR DESCRIPTION
## Summary
- Register Kathryn Yetter as a website blog author in `authors.yml` (Product Manager)

## Test plan
- [ ] Confirm author metadata renders for posts using `authors: [kyetter]`
- [ ] Confirm semantic PR title and DCO pass

## Notes
Split out from #18485 per review feedback. Merge this before #18485.