### PR TITLE
refactor(PreflightChecks): migrated to Font Awesome icons

### DIFF
--- a/packages/renderer/src/lib/dashboard/PreflightChecks.spec.ts
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.spec.ts
@@ -90,3 +90,51 @@ test('Expect preCheck to be displayed when having all props', async () => {
   // check openExternal is called
   expect(window.openExternal).toHaveBeenCalledWith('url');
 });
+
+test('Expect success icon to be displayed when check succeeded', async () => {
+  render(PreflightChecks, {
+    preflightChecks: [
+      {
+        name: 'name',
+        successful: true,
+      },
+    ],
+  });
+
+  const title = screen.getByLabelText('precheck-title');
+  const svg = title.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-(--pd-state-success)');
+});
+
+test('Expect error icon to be displayed when check failed', async () => {
+  render(PreflightChecks, {
+    preflightChecks: [
+      {
+        name: 'name',
+        successful: false,
+      },
+    ],
+  });
+
+  const title = screen.getByLabelText('precheck-title');
+  const svg = title.parentElement?.querySelector('svg');
+  expect(svg).toBeInTheDocument();
+  expect(svg).toHaveClass('text-(--pd-state-error)');
+});
+
+test('Expect spinner to be displayed while check is pending', async () => {
+  render(PreflightChecks, {
+    preflightChecks: [
+      {
+        name: 'name',
+      },
+    ],
+  });
+
+  const title = screen.getByLabelText('precheck-title');
+  expect(title).toBeInTheDocument();
+  // the FA icon is rendered with role="img", the pending Spinner is not
+  const faIcon = title.parentElement?.querySelector('svg[role="img"]');
+  expect(faIcon).not.toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
+++ b/packages/renderer/src/lib/dashboard/PreflightChecks.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+import { faCheck, faCircleExclamation } from '@fortawesome/free-solid-svg-icons';
 import type { CheckStatus } from '@podman-desktop/core-api';
 import { Link, Spinner } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 interface Props {
   preflightChecks: CheckStatus[];
@@ -17,13 +19,15 @@ async function openLink(url: string): Promise<void> {
   <div class="flex flex-col w-full p-2 rounded-lg bg-[var(--pd-invert-content-card-bg)]">
     {#each preflightChecks as preCheck, index (index)}
       <div class="flex flex-col">
-        <div class="mb-4 flex flex-row">
+        <div class="mb-4 flex flex-row items-center">
           {#if preCheck.successful === undefined}
             <div class="mr-1">
               <Spinner size="1em" />
             </div>
+          {:else if preCheck.successful}
+            <Icon class="text-(--pd-state-success)" icon={faCheck} />
           {:else}
-            {preCheck.successful ? '✅' : '❌'}
+            <Icon class="text-(--pd-state-error)" icon={faCircleExclamation} />
           {/if}
           <div aria-label="precheck-title" class="ml-2">{preCheck.name}</div>
         </div>


### PR DESCRIPTION
### What does this PR do?
Migrates icons to font awesome ones + alignment of the icons

### Screenshot / video of UI


<img width="1151" height="922" alt="Screenshot 2026-07-28 at 21 53 53" src="https://github.com/user-attachments/assets/83d437b6-3062-443e-86b6-6caaa1e3010d" />


### What issues does this PR fix or reference?
Needs rebase after https://github.com/podman-desktop/podman-desktop/pull/18504

### How to test this PR?


- [ ] Tests are covering the bug fix or the new feature
