### PR TITLE
chore(test): create script to launch e2e test suites on demand

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "test:e2e:screenshots:run": "cross-env PLAYWRIGHT_SCREENSHOTS_PATH=./tests/playwright/output/screenshots xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/visual-testing/",
     "test:e2e:managed-configuration": "pnpm run test:e2e:build && pnpm run test:e2e:managed-configuration:run",
     "test:e2e:managed-configuration:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/managed-configuration/ -g @managed-configuration",
+    "test:e2e:suite": "node tests/playwright/scripts/run-e2e-suite.mjs",
+    "test:e2e:suite:build": "pnpm run test:e2e:build && pnpm run test:e2e:suite",
     "test:core-api": "vitest --run --project=@podman-desktop/core-api --passWithNoTests",
     "test:main": "vitest --run --project=@podman-desktop/main --passWithNoTests",
     "test:preload": "vitest --run --project=@podman-desktop/preload --passWithNoTests",

--- a/tests/playwright/scripts/run-e2e-suite.mjs
+++ b/tests/playwright/scripts/run-e2e-suite.mjs
@@ -37,7 +37,8 @@ if (!suite) {
   process.exit(1);
 }
 
-const matches = allSpecs.filter(f => f.includes(suite));
+const normalizedSuite = suite.toLowerCase();
+const matches = allSpecs.filter(f => f.toLowerCase().includes(normalizedSuite));
 
 if (matches.length === 0) {
   console.error(`No spec file matching "${suite}" found in ${SPECS_DIR_RELATIVE}/`);

--- a/tests/playwright/scripts/run-e2e-suite.mjs
+++ b/tests/playwright/scripts/run-e2e-suite.mjs
@@ -52,13 +52,16 @@ const playwrightArgs = ['playwright', 'test', ...files, ...extraArgs];
 
 const binDir = resolve(REPO_ROOT, 'node_modules/.bin');
 const env = { ...process.env };
-if (!env.PATH?.includes(binDir)) {
-  env.PATH = `${binDir}${delimiter}${env.PATH ?? ''}`;
+
+const pathKey = Object.keys(env).find(k => k.toUpperCase() === 'PATH') ?? 'PATH';
+if (!env[pathKey]?.includes(binDir)) {
+  env[pathKey] = `${binDir}${delimiter}${env[pathKey] ?? ''}`;
 }
 
 console.log(`Running: npx ${playwrightArgs.join(' ')}\n`);
 const result = spawnSync('xvfb-maybe', [...xvfbArgs, 'npx', ...playwrightArgs], {
   stdio: 'inherit',
+  shell: true,
   env,
 });
 

--- a/tests/playwright/scripts/run-e2e-suite.mjs
+++ b/tests/playwright/scripts/run-e2e-suite.mjs
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { spawnSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { delimiter, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const SPECS_DIR = resolve(REPO_ROOT, 'tests/playwright/src/specs');
+const SPECS_DIR_RELATIVE = 'tests/playwright/src/specs';
+
+const allSpecs = readdirSync(SPECS_DIR).filter(f => f.endsWith('.spec.ts'));
+
+const suite = process.argv[2];
+if (!suite) {
+  console.error('Usage: pnpm test:e2e:suite <suite-name>\n');
+  console.error('Available suites (substring match):');
+  for (const s of allSpecs.map(f => f.replace('.spec.ts', ''))) {
+    console.error(`  ${s}`);
+  }
+  process.exit(1);
+}
+
+const matches = allSpecs.filter(f => f.includes(suite));
+
+if (matches.length === 0) {
+  console.error(`No spec file matching "${suite}" found in ${SPECS_DIR_RELATIVE}/`);
+  process.exit(1);
+}
+
+const files = matches.map(f => `${SPECS_DIR_RELATIVE}/${f}`);
+const extraArgs = process.argv.slice(3);
+
+const xvfbArgs = ['--auto-servernum', '--server-args=-screen 0 1280x960x24', '--'];
+const playwrightArgs = ['playwright', 'test', ...files, ...extraArgs];
+
+const binDir = resolve(REPO_ROOT, 'node_modules/.bin');
+const env = { ...process.env };
+if (!env.PATH?.includes(binDir)) {
+  env.PATH = `${binDir}${delimiter}${env.PATH ?? ''}`;
+}
+
+console.log(`Running: npx ${playwrightArgs.join(' ')}\n`);
+const result = spawnSync('xvfb-maybe', [...xvfbArgs, 'npx', ...playwrightArgs], {
+  stdio: 'inherit',
+  env,
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
### What does this PR do?
Adds a script to the test/playwright/scripts folder to be used to execute any e2e test suite on demand from the cli without a custom script in package.json

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18514