### PR TITLE
docs(skills): clarify tailwind shorthand guidance

### DIFF
--- a/.agents/skills/component-modernization/SKILL.md
+++ b/.agents/skills/component-modernization/SKILL.md
@@ -127,3 +127,5 @@ Key patterns established:
 - Outline borders for definition
 - `prefers-reduced-motion` support
 - Tailwind v4 CSS variable shorthand syntax
+- When introducing new Tailwind custom-property utility classes, prefer shorthand forms like `text-(--pd-state-success)` over `text-[var(--pd-state-success)]`.
+- Do not rewrite unrelated existing `text-[var(--token)]` or similar classes in the same file unless the task explicitly includes that cleanup.


### PR DESCRIPTION
### What does this PR do?
Document that new Tailwind custom-property utility classes should use the v4 shorthand syntax without broad cleanup of existing classes in the same file.

### Screenshot / video of UI

### What issues does this PR fix or reference?

### How to test this PR?

- [ ] Tests are covering the bug fix or the new feature
