### PR TITLE
feat(podman): add BIOS virtualization firmware preflight check on Windows

### DIFF
--- a/extensions/podman/packages/extension/src/checks/windows/constants.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/constants.ts
@@ -22,3 +22,8 @@ export const HYPER_V_DOC_LINKS: CheckResultLink = {
   url: 'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v',
   title: 'Hyper-V Manual Installation Steps',
 };
+
+export const VIRTUALIZATION_FIRMWARE_DOC_LINKS: CheckResultLink = {
+  url: 'https://support.microsoft.com/en-us/windows/experience/enable-virtualization-on-windows',
+  title: 'Enable Virtualization on Windows',
+};

--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-check.spec.ts
@@ -46,6 +46,8 @@ const POWERSHELL_CLIENT: PowerShellClient = {
   isUserAdmin: vi.fn(),
   isHyperVInstalled: vi.fn(),
   isVirtualMachineAvailable: vi.fn(),
+  isVirtualizationFirmwareEnabled: vi.fn(),
+  isHypervisorPresent: vi.fn(),
   isRunningElevated: vi.fn(),
   isHyperVRunning: vi.fn(),
 };

--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-installed-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-installed-check.spec.ts
@@ -36,6 +36,8 @@ const POWERSHELL_CLIENT: PowerShellClient = {
   isHyperVInstalled: vi.fn(),
   isHyperVRunning: vi.fn(),
   isVirtualMachineAvailable: vi.fn(),
+  isVirtualizationFirmwareEnabled: vi.fn(),
+  isHypervisorPresent: vi.fn(),
   isRunningElevated: vi.fn(),
 };
 

--- a/extensions/podman/packages/extension/src/checks/windows/hyper-v-running-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/hyper-v-running-check.spec.ts
@@ -36,6 +36,8 @@ const POWERSHELL_CLIENT: PowerShellClient = {
   isHyperVInstalled: vi.fn(),
   isHyperVRunning: vi.fn(),
   isVirtualMachineAvailable: vi.fn(),
+  isVirtualizationFirmwareEnabled: vi.fn(),
+  isHypervisorPresent: vi.fn(),
   isRunningElevated: vi.fn(),
 };
 

--- a/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/podman-desktop-elevated-check.spec.ts
@@ -35,6 +35,8 @@ const POWERSHELL_CLIENT: PowerShellClient = {
   isHyperVInstalled: vi.fn(),
   isHyperVRunning: vi.fn(),
   isVirtualMachineAvailable: vi.fn(),
+  isVirtualizationFirmwareEnabled: vi.fn(),
+  isHypervisorPresent: vi.fn(),
   isRunningElevated: vi.fn(),
 };
 

--- a/extensions/podman/packages/extension/src/checks/windows/user-admin-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/user-admin-check.spec.ts
@@ -36,6 +36,8 @@ const POWERSHELL_CLIENT: PowerShellClient = {
   isUserAdmin: vi.fn(),
   isHyperVInstalled: vi.fn(),
   isVirtualMachineAvailable: vi.fn(),
+  isVirtualizationFirmwareEnabled: vi.fn(),
+  isHypervisorPresent: vi.fn(),
   isRunningElevated: vi.fn(),
   isHyperVRunning: vi.fn(),
 };

--- a/extensions/podman/packages/extension/src/checks/windows/virtualization-firmware-check.spec.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/virtualization-firmware-check.spec.ts
@@ -1,0 +1,110 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { process, type TelemetryLogger } from '@podman-desktop/api';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { VirtualizationFirmwareCheck } from './virtualization-firmware-check';
+
+const mockTelemetryLogger = {} as TelemetryLogger;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('expect virtualization firmware check to return successful result when firmware virtualization is enabled', async () => {
+  vi.mocked(process.exec).mockResolvedValue({
+    stdout: 'True',
+    stderr: '',
+    command: 'command',
+  });
+
+  const check = new VirtualizationFirmwareCheck(mockTelemetryLogger);
+  const result = await check.execute();
+  expect(process.exec).toBeCalledWith(expect.anything(), expect.arrayContaining([expect.anything()]), {
+    encoding: 'utf16le',
+  });
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect virtualization firmware check to return successful when firmware reports False but hypervisor is present', async () => {
+  vi.mocked(process.exec)
+    .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'command' })
+    .mockResolvedValueOnce({ stdout: 'True', stderr: '', command: 'command' });
+
+  const check = new VirtualizationFirmwareCheck(mockTelemetryLogger);
+  const result = await check.execute();
+  expect(result.successful).toBeTruthy();
+});
+
+test('expect virtualization firmware check to return warning when firmware virtualization is disabled and no hypervisor', async () => {
+  vi.mocked(process.exec)
+    .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'command' })
+    .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'command' });
+
+  const check = new VirtualizationFirmwareCheck(mockTelemetryLogger);
+  const result = await check.execute();
+  expect(result.successful).toBeFalsy();
+  expect(result.severity).toEqual('warning');
+  expect(result.description).toEqual(
+    'CPU virtualization (Intel VT-x / AMD-V) is disabled in BIOS/UEFI. Enable it to run Podman machines with WSL2 or Hyper-V.',
+  );
+  expect(result.docLinksDescription).toEqual(
+    'Reboot into BIOS/UEFI settings, enable Virtualization Technology (Intel VT-x) or SVM Mode (AMD-V), save changes, reboot, then re-run checks.',
+  );
+  expect(result.docLinks?.[0].url).toEqual(
+    'https://support.microsoft.com/en-us/windows/experience/enable-virtualization-on-windows',
+  );
+  expect(result.docLinks?.[0].title).toEqual('Enable Virtualization on Windows');
+});
+
+test('expect virtualization firmware check to return warning when checking firmware virtualization fails and no hypervisor', async () => {
+  vi.mocked(process.exec)
+    .mockRejectedValueOnce(new Error())
+    .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'command' });
+
+  const check = new VirtualizationFirmwareCheck(mockTelemetryLogger);
+  const result = await check.execute();
+  expect(result.successful).toBeFalsy();
+  expect(result.severity).toEqual('warning');
+  expect(result.description).toEqual(
+    'CPU virtualization (Intel VT-x / AMD-V) is disabled in BIOS/UEFI. Enable it to run Podman machines with WSL2 or Hyper-V.',
+  );
+  expect(result.docLinksDescription).toEqual(
+    'Reboot into BIOS/UEFI settings, enable Virtualization Technology (Intel VT-x) or SVM Mode (AMD-V), save changes, reboot, then re-run checks.',
+  );
+  expect(result.docLinks?.[0].url).toEqual(
+    'https://support.microsoft.com/en-us/windows/experience/enable-virtualization-on-windows',
+  );
+  expect(result.docLinks?.[0].title).toEqual('Enable Virtualization on Windows');
+});
+
+test('expect virtualization firmware check to be memoized', async () => {
+  vi.mocked(process.exec).mockResolvedValue({
+    stdout: 'True',
+    stderr: '',
+    command: 'command',
+  });
+
+  const check = new VirtualizationFirmwareCheck(mockTelemetryLogger);
+  await check.execute();
+  expect(process.exec).toHaveBeenCalledOnce();
+
+  await check.execute();
+  expect(process.exec).toHaveBeenCalledOnce();
+});

--- a/extensions/podman/packages/extension/src/checks/windows/virtualization-firmware-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/virtualization-firmware-check.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type extensionApi from '@podman-desktop/api';
+import { inject, injectable } from 'inversify';
+
+import { MemoizedBaseCheck } from '/@/checks/memoized-base-check';
+import { TelemetryLoggerSymbol } from '/@/inject/symbols';
+import { getPowerShellClient } from '/@/utils/powershell';
+
+import { VIRTUALIZATION_FIRMWARE_DOC_LINKS } from './constants';
+
+@injectable()
+export class VirtualizationFirmwareCheck extends MemoizedBaseCheck {
+  title = 'BIOS Virtualization Enabled';
+
+  constructor(
+    @inject(TelemetryLoggerSymbol)
+    private telemetryLogger: extensionApi.TelemetryLogger,
+  ) {
+    super();
+  }
+
+  async executeImpl(): Promise<extensionApi.CheckResult> {
+    try {
+      const client = await getPowerShellClient(this.telemetryLogger);
+      const enabled = await client.isVirtualizationFirmwareEnabled();
+      if (enabled) {
+        return this.createSuccessfulResult();
+      }
+    } catch (err) {
+      // ignore error, this means that firmware virtualization could not be detected
+    }
+    return this.createFailureResult({
+      description:
+        'CPU virtualization (Intel VT-x / AMD-V) is disabled in BIOS/UEFI. Enable it to run Podman machines with WSL2 or Hyper-V.',
+      severity: 'warning',
+      docLinksDescription:
+        'Reboot into BIOS/UEFI settings, enable Virtualization Technology (Intel VT-x) or SVM Mode (AMD-V), save changes, reboot, then re-run checks.',
+      docLinks: VIRTUALIZATION_FIRMWARE_DOC_LINKS,
+    });
+  }
+}

--- a/extensions/podman/packages/extension/src/checks/windows/virtualization-firmware-check.ts
+++ b/extensions/podman/packages/extension/src/checks/windows/virtualization-firmware-check.ts
@@ -45,6 +45,7 @@ export class VirtualizationFirmwareCheck extends MemoizedBaseCheck {
       }
     } catch (err) {
       // ignore error, this means that firmware virtualization could not be detected
+      console.warn('Error checking virtualization firmware:', err);
     }
     return this.createFailureResult({
       description:

--- a/extensions/podman/packages/extension/src/inject/inversify-binding.ts
+++ b/extensions/podman/packages/extension/src/inject/inversify-binding.ts
@@ -27,6 +27,7 @@ import { HyperVRunningCheck } from '/@/checks/windows/hyper-v-running-check';
 import { PodmanDesktopElevatedCheck } from '/@/checks/windows/podman-desktop-elevated-check';
 import { UserAdminCheck } from '/@/checks/windows/user-admin-check';
 import { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
+import { VirtualizationFirmwareCheck } from '/@/checks/windows/virtualization-firmware-check';
 import { WinBitCheck } from '/@/checks/windows/win-bit-check';
 import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
 import { WinVersionCheck } from '/@/checks/windows/win-version-check';
@@ -71,6 +72,7 @@ export class InversifyBinding {
     this.#inversifyContainer.bind(WinMemoryCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(HyperVPodmanVersionCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(HyperVCheck).toSelf().inSingletonScope();
+    this.#inversifyContainer.bind(VirtualizationFirmwareCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(VirtualMachinePlatformCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WSLVersionCheck).toSelf().inSingletonScope();
     this.#inversifyContainer.bind(WSL2Check).toSelf().inSingletonScope();

--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -1,5 +1,5 @@
 /*********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,11 @@ import type { CheckResult, ExtensionContext, TelemetryLogger } from '@podman-des
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { WarningCheck } from '/@/checks/base-check';
 import type { HyperVCheck } from '/@/checks/windows/hyper-v-check';
 import type { HyperVPodmanVersionCheck } from '/@/checks/windows/hyper-v-podman-version-check';
 import type { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
+import type { VirtualizationFirmwareCheck } from '/@/checks/windows/virtualization-firmware-check';
 import type { WinBitCheck } from '/@/checks/windows/win-bit-check';
 import type { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
 import type { WinVersionCheck } from '/@/checks/windows/win-version-check';
@@ -39,6 +41,10 @@ const WIN_VERSION_CHECK_MOCK = { execute: vi.fn() } as unknown as WinVersionChec
 const WIN_MEMORY_CHECK_MOCK = { execute: vi.fn() } as unknown as WinMemoryCheck;
 const HYPERV_PODMAN_VERSION_CHECK_MOCK = { execute: vi.fn() } as unknown as HyperVPodmanVersionCheck;
 const HYPERV_CHECK_MOCK = { execute: vi.fn() } as unknown as HyperVCheck;
+const VIRTUALIZATION_FIRMWARE_CHECK_MOCK = {
+  title: 'BIOS Virtualization Enabled',
+  execute: vi.fn(),
+} as unknown as VirtualizationFirmwareCheck;
 const VIRTUAL_MACHINE_PLATFORM_CHECK_MOCK = { execute: vi.fn() } as unknown as VirtualMachinePlatformCheck;
 const WSL_VERSION_CHECK_MOCK = { execute: vi.fn() } as unknown as WSLVersionCheck;
 const WSL2_CHECK_MOCK = { execute: vi.fn() } as unknown as WSL2Check;
@@ -57,10 +63,18 @@ beforeEach(() => {
     WIN_MEMORY_CHECK_MOCK,
     HYPERV_PODMAN_VERSION_CHECK_MOCK,
     HYPERV_CHECK_MOCK,
+    VIRTUALIZATION_FIRMWARE_CHECK_MOCK,
     VIRTUAL_MACHINE_PLATFORM_CHECK_MOCK,
     WSL_VERSION_CHECK_MOCK,
     WSL2_CHECK_MOCK,
   );
+});
+
+test('getPreflightChecks should include a warning-wrapped BIOS virtualization check', () => {
+  const checks = winPlatform.getPreflightChecks();
+  expect(checks).toHaveLength(6);
+  expect(checks[3]).toBeInstanceOf(WarningCheck);
+  expect(checks[3].title).toEqual('BIOS Virtualization Enabled');
 });
 
 test('isHyperVEnabled should return false if it is not a Windows environment', async () => {
@@ -93,6 +107,19 @@ test('isHyperVEnabled should return true if all Hyper-V checks succeed', async (
   expect(hypervEnabled).toBeTruthy();
 });
 
+test('isHyperVEnabled is independent of BIOS virtualization firmware check', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(VIRTUALIZATION_FIRMWARE_CHECK_MOCK.execute).mockResolvedValue(FAILED_CHECK_RESULT);
+  vi.mocked(HYPERV_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+  vi.mocked(HYPERV_PODMAN_VERSION_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+
+  const hypervEnabled = await winPlatform.isHyperVEnabled();
+
+  expect(hypervEnabled).toBeTruthy();
+  expect(VIRTUALIZATION_FIRMWARE_CHECK_MOCK.execute).not.toHaveBeenCalled();
+});
+
 test('isWSLEnabled should return false if not on Windows', async () => {
   vi.mocked(extensionApi.env).isWindows = false;
 
@@ -123,6 +150,20 @@ test('isWSLEnabled should return true if all WSL checks succeed', async () => {
   const wslEnabled = await winPlatform.isWSLEnabled();
 
   expect(wslEnabled).toBeTruthy();
+});
+
+test('isWSLEnabled is independent of BIOS virtualization firmware check', async () => {
+  vi.mocked(extensionApi.env).isWindows = true;
+
+  vi.mocked(VIRTUALIZATION_FIRMWARE_CHECK_MOCK.execute).mockResolvedValue(FAILED_CHECK_RESULT);
+  vi.mocked(VIRTUAL_MACHINE_PLATFORM_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+  vi.mocked(WSL_VERSION_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+  vi.mocked(WSL2_CHECK_MOCK.execute).mockResolvedValue(SUCCESSFUL_CHECK_RESULT);
+
+  const wslEnabled = await winPlatform.isWSLEnabled();
+
+  expect(wslEnabled).toBeTruthy();
+  expect(VIRTUALIZATION_FIRMWARE_CHECK_MOCK.execute).not.toHaveBeenCalled();
 });
 
 describe('calcPipeName', () => {

--- a/extensions/podman/packages/extension/src/platforms/win-platform.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.ts
@@ -24,6 +24,7 @@ import { SequenceCheck, WarningCheck } from '/@/checks/base-check';
 import { HyperVCheck } from '/@/checks/windows/hyper-v-check';
 import { HyperVPodmanVersionCheck } from '/@/checks/windows/hyper-v-podman-version-check';
 import { VirtualMachinePlatformCheck } from '/@/checks/windows/virtual-machine-platform-check';
+import { VirtualizationFirmwareCheck } from '/@/checks/windows/virtualization-firmware-check';
 import { WinBitCheck } from '/@/checks/windows/win-bit-check';
 import { WinMemoryCheck } from '/@/checks/windows/win-memory-check';
 import { WinVersionCheck } from '/@/checks/windows/win-version-check';
@@ -53,6 +54,8 @@ export class WinPlatform {
     readonly hyperVPodmanVersionCheck: HyperVPodmanVersionCheck,
     @inject(HyperVCheck)
     readonly hyperVCheck: HyperVCheck,
+    @inject(VirtualizationFirmwareCheck)
+    readonly virtualizationFirmwareCheck: VirtualizationFirmwareCheck,
     @inject(VirtualMachinePlatformCheck)
     readonly virtualMachinePlatformCheck: VirtualMachinePlatformCheck,
     @inject(WSLVersionCheck)
@@ -74,6 +77,7 @@ export class WinPlatform {
       this.winBitCheck,
       this.winVersionCheck,
       this.winMemoryCheck,
+      new WarningCheck(this.virtualizationFirmwareCheck),
       new WarningCheck(this.wslCheck),
       new WarningCheck(this.hyperVSequenceCheck),
     ];

--- a/extensions/podman/packages/extension/src/utils/powershell.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.spec.ts
@@ -108,6 +108,14 @@ describe('PowerShellClient PS flags', () => {
       method: 'isVirtualMachineAvailable',
       call: (c: PowerShellClient): Promise<unknown> => c.isVirtualMachineAvailable(),
     },
+    {
+      method: 'isVirtualizationFirmwareEnabled',
+      call: (c: PowerShellClient): Promise<unknown> => c.isVirtualizationFirmwareEnabled(),
+    },
+    {
+      method: 'isHypervisorPresent',
+      call: (c: PowerShellClient): Promise<unknown> => c.isHypervisorPresent(),
+    },
     { method: 'isHyperVInstalled', call: (c: PowerShellClient): Promise<unknown> => c.isHyperVInstalled() },
     { method: 'isHyperVRunning', call: (c: PowerShellClient): Promise<unknown> => c.isHyperVRunning() },
     { method: 'isRunningElevated', call: (c: PowerShellClient): Promise<unknown> => c.isRunningElevated() },
@@ -188,6 +196,173 @@ describe('PowerShellClient#isVirtualMachineAvailable', () => {
     expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
       'check.isVirtualMachineAvailable',
       expect.objectContaining({ stdout: 'SomeOtherFeature', stderr: 'warn' }),
+    );
+  });
+});
+
+describe('PowerShellClient#isVirtualizationFirmwareEnabled', () => {
+  let client: PowerShellClient;
+
+  beforeEach(async () => {
+    client = await getPowerShellClient(TELEMETRY_LOGGER_MOCK);
+  });
+
+  test('should return true when stdout is True', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({
+      stdout: 'True',
+      stderr: '',
+      command: 'powershell.exe',
+    });
+
+    expect(await client.isVirtualizationFirmwareEnabled()).toBe(true);
+  });
+
+  test('should return true when stdout is True with surrounding whitespace', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({
+      stdout: '\r  True  \n',
+      stderr: '',
+      command: 'powershell.exe',
+    });
+
+    expect(await client.isVirtualizationFirmwareEnabled()).toBe(true);
+  });
+
+  test('should return true when firmware reports False but hypervisor is present', async () => {
+    vi.mocked(processAPI.exec)
+      .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'powershell.exe' })
+      .mockResolvedValueOnce({ stdout: 'True', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isVirtualizationFirmwareEnabled()).toBe(true);
+  });
+
+  test('should return false when firmware reports False and hypervisor is not present', async () => {
+    vi.mocked(processAPI.exec)
+      .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'powershell.exe' })
+      .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isVirtualizationFirmwareEnabled()).toBe(false);
+  });
+
+  test('should return false when firmware throws and hypervisor is not present', async () => {
+    const error = Object.assign(new Error('exec failed'), {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'error output',
+      cancelled: false,
+      killed: false,
+      command: 'powershell.exe',
+    });
+    vi.mocked(processAPI.exec)
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isVirtualizationFirmwareEnabled()).toBe(false);
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      'check.isVirtualizationFirmwareEnabled',
+      expect.objectContaining({ error }),
+    );
+  });
+
+  test('should return true when firmware throws but hypervisor is present', async () => {
+    vi.mocked(processAPI.exec)
+      .mockRejectedValueOnce(new Error('exec failed'))
+      .mockResolvedValueOnce({ stdout: 'True', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isVirtualizationFirmwareEnabled()).toBe(true);
+  });
+
+  test('should not log telemetry when firmware virtualization is enabled (early return path)', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({
+      stdout: 'True',
+      stderr: '',
+      command: 'powershell.exe',
+    });
+
+    await client.isVirtualizationFirmwareEnabled();
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).not.toHaveBeenCalled();
+  });
+
+  test('should not log firmware telemetry when hypervisor fallback succeeds', async () => {
+    vi.mocked(processAPI.exec)
+      .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'powershell.exe' })
+      .mockResolvedValueOnce({ stdout: 'True', stderr: '', command: 'powershell.exe' });
+
+    await client.isVirtualizationFirmwareEnabled();
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).not.toHaveBeenCalledWith(
+      'check.isVirtualizationFirmwareEnabled',
+      expect.anything(),
+    );
+  });
+
+  test('should log telemetry when both firmware and hypervisor checks fail', async () => {
+    vi.mocked(processAPI.exec)
+      .mockResolvedValueOnce({ stdout: 'False', stderr: 'warn', command: 'powershell.exe' })
+      .mockResolvedValueOnce({ stdout: 'False', stderr: '', command: 'powershell.exe' });
+
+    await client.isVirtualizationFirmwareEnabled();
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      'check.isVirtualizationFirmwareEnabled',
+      expect.objectContaining({ stdout: 'False', stderr: 'warn', hypervisorPresent: false }),
+    );
+  });
+});
+
+describe('PowerShellClient#isHypervisorPresent', () => {
+  let client: PowerShellClient;
+
+  beforeEach(async () => {
+    client = await getPowerShellClient(TELEMETRY_LOGGER_MOCK);
+  });
+
+  test('should return true when hypervisor is present', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: 'True', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isHypervisorPresent()).toBe(true);
+  });
+
+  test('should return false when hypervisor is not present', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: 'False', stderr: '', command: 'powershell.exe' });
+
+    expect(await client.isHypervisorPresent()).toBe(false);
+  });
+
+  test('should return false and record telemetry when exec throws', async () => {
+    const error = Object.assign(new Error('exec failed'), {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'error output',
+      cancelled: false,
+      killed: false,
+      command: 'powershell.exe',
+    });
+    vi.mocked(processAPI.exec).mockRejectedValue(error);
+
+    expect(await client.isHypervisorPresent()).toBe(false);
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      'check.isHypervisorPresent',
+      expect.objectContaining({ error }),
+    );
+  });
+
+  test('should not log telemetry when hypervisor is present (early return path)', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: 'True', stderr: '', command: 'powershell.exe' });
+
+    await client.isHypervisorPresent();
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).not.toHaveBeenCalled();
+  });
+
+  test('should log telemetry when hypervisor is not present', async () => {
+    vi.mocked(processAPI.exec).mockResolvedValue({ stdout: 'False', stderr: 'warn', command: 'powershell.exe' });
+
+    await client.isHypervisorPresent();
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      'check.isHypervisorPresent',
+      expect.objectContaining({ stdout: 'False', stderr: 'warn' }),
     );
   });
 });

--- a/extensions/podman/packages/extension/src/utils/powershell.ts
+++ b/extensions/podman/packages/extension/src/utils/powershell.ts
@@ -23,6 +23,8 @@ export async function getPowerShellClient(telemetryLogger: extensionApi.Telemetr
 
 export interface PowerShellClient {
   isVirtualMachineAvailable(): Promise<boolean>;
+  isVirtualizationFirmwareEnabled(): Promise<boolean>;
+  isHypervisorPresent(): Promise<boolean>;
   isUserAdmin(): Promise<boolean>;
   isHyperVInstalled(): Promise<boolean>;
   isHyperVRunning(): Promise<boolean>;
@@ -73,6 +75,80 @@ class PowerShell5Client implements PowerShellClient {
       telemetry['killed'] = execError.killed;
     }
     this.telemetryLogger.logUsage('check.isVirtualMachineAvailable', telemetry);
+    return false;
+  }
+
+  // When Hyper-V is active the OS runs as a guest under the hypervisor, so
+  // Win32_Processor.VirtualizationFirmwareEnabled reports False even though
+  // VT-x/AMD-V is enabled in BIOS. Fall back to Win32_ComputerSystem.HypervisorPresent.
+  // https://devblogs.microsoft.com/oldnewthing/20201216-00/?p=104550
+  // https://learn.microsoft.com/en-us/answers/questions/5523363
+  async isVirtualizationFirmwareEnabled(): Promise<boolean> {
+    const telemetry: Record<string, unknown> = {};
+    try {
+      const res = await extensionApi.process.exec(
+        PowerShell5Exe,
+        psArgs(
+          '[System.Console]::OutputEncoding = [System.Text.Encoding]::Unicode; (Get-CimInstance Win32_Processor | Select-Object -First 1 -ExpandProperty VirtualizationFirmwareEnabled)',
+        ),
+        { encoding: 'utf16le' },
+      );
+      telemetry['command'] = res.command;
+      telemetry['stdout'] = res.stdout;
+      telemetry['stderr'] = res.stderr;
+      if (res.stdout.trim() === 'True') {
+        return true;
+      }
+    } catch (err) {
+      telemetry['error'] = err;
+      const execError = err as extensionApi.RunError;
+      telemetry['message'] = execError.message;
+      telemetry['exitCode'] = execError.exitCode;
+      telemetry['command'] = execError.command;
+      telemetry['stdout'] = execError.stdout;
+      telemetry['stderr'] = execError.stderr;
+      telemetry['cancelled'] = execError.cancelled;
+      telemetry['killed'] = execError.killed;
+    }
+
+    const hypervisorPresent = await this.isHypervisorPresent();
+    telemetry['hypervisorPresent'] = hypervisorPresent;
+    if (hypervisorPresent) {
+      return true;
+    }
+
+    this.telemetryLogger.logUsage('check.isVirtualizationFirmwareEnabled', telemetry);
+    return false;
+  }
+
+  async isHypervisorPresent(): Promise<boolean> {
+    const telemetry: Record<string, unknown> = {};
+    try {
+      const res = await extensionApi.process.exec(
+        PowerShell5Exe,
+        psArgs(
+          '[System.Console]::OutputEncoding = [System.Text.Encoding]::Unicode; (Get-CimInstance Win32_ComputerSystem).HypervisorPresent',
+        ),
+        { encoding: 'utf16le' },
+      );
+      telemetry['command'] = res.command;
+      telemetry['stdout'] = res.stdout;
+      telemetry['stderr'] = res.stderr;
+      if (res.stdout.trim() === 'True') {
+        return true;
+      }
+    } catch (err) {
+      telemetry['error'] = err;
+      const execError = err as extensionApi.RunError;
+      telemetry['message'] = execError.message;
+      telemetry['exitCode'] = execError.exitCode;
+      telemetry['command'] = execError.command;
+      telemetry['stdout'] = execError.stdout;
+      telemetry['stderr'] = execError.stderr;
+      telemetry['cancelled'] = execError.cancelled;
+      telemetry['killed'] = execError.killed;
+    }
+    this.telemetryLogger.logUsage('check.isHypervisorPresent', telemetry);
     return false;
   }
 


### PR DESCRIPTION
### What does this PR do?
Adds Windows Virtualization check to preflight checks


| State | VirtualizationFirmwareEnabled | HypervisorPresent | Check result |
  |---|---|---|---|
  | Both off | False | False | Warning |
  | BIOS on, Hyper-V off | True | False | Success |
  | BIOS on, Hyper-V on | False | True | Success |

  You can verify each WMI value independently before running the full check:

  ```powershell
  (Get-CimInstance Win32_Processor | Select-Object -First 1 -ExpandProperty VirtualizationFirmwareEnabled)
  (Get-CimInstance Win32_ComputerSystem).HypervisorPresent
```

### Screenshot / video of UI

<img width="716" height="507" alt="Screenshot 2026-07-29 at 8 06 10" src="https://github.com/user-attachments/assets/f2f5c3ee-bec0-4769-a19c-7ef038c0a1b9" />

PS: the screenshot shows ❌ because https://github.com/podman-desktop/podman-desktop/pull/18461 is not merged yet

### What issues does this PR fix or reference?
Closes #15440

### How to test this PR?
Enable Windows Virtualization in BIOS
Try to install Podman using PD, thou should see a ✅ check for Windows Virtualization

Then 

Disable Windows virtualization in BIOS
Try to install Podman using PD, thou should see a ⚠️  check for Windows Virtualization

- [ ] Tests are covering the bug fix or the new feature
