### PR TITLE
fix(ui): adapt Checkbox tests for jsdom 30 computed style changes

### DIFF
--- a/packages/ui/src/lib/checkbox/Checkbox.spec.ts
+++ b/packages/ui/src/lib/checkbox/Checkbox.spec.ts
@@ -56,7 +56,7 @@ test('Basic check', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-unchecked)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-unchecked)]');
-  expect(icon).toHaveStyle('font-size: 1.33em');
+  expect(icon).toHaveAttribute('style', expect.stringContaining('font-size: 1.33em'));
 });
 
 test('Check checked state', async () => {
@@ -75,7 +75,7 @@ test('Check checked state', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-checked)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-checked)]');
-  expect(icon).toHaveStyle('font-size: 1.33em');
+  expect(icon).toHaveAttribute('style', expect.stringContaining('font-size: 1.33em'));
 });
 
 test('Check indeterminate state', async () => {
@@ -94,7 +94,7 @@ test('Check indeterminate state', async () => {
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-indeterminate)]');
   expect(icon).toHaveClass('hover:text-[var(--pd-input-checkbox-focused-indeterminate)]');
-  expect(icon).toHaveStyle('font-size: 1.33em');
+  expect(icon).toHaveAttribute('style', expect.stringContaining('font-size: 1.33em'));
 });
 
 test('Check disabled state', async () => {
@@ -113,7 +113,7 @@ test('Check disabled state', async () => {
   const icon = peer?.children[0];
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveClass('text-[var(--pd-input-checkbox-disabled)]');
-  expect(icon).toHaveStyle('font-size: 1.33em');
+  expect(icon).toHaveAttribute('style', expect.stringContaining('font-size: 1.33em'));
 });
 
 test('Check tooltips', async () => {


### PR DESCRIPTION
### What does this PR do?

jsdom 30 introduced a real `getComputedStyle` implementation that
resolves relative CSS units (like `em`) to absolute pixel values,
matching actual browser behavior. This causes `toHaveStyle('font-size:
1.33em')` assertions to fail because jsdom now returns `21.28px`.

This PR switches the 4 affected assertions in `Checkbox.spec.ts`
from `toHaveStyle` to `toHaveAttribute('style', ...)`, which checks
the raw inline `style` attribute instead of going through
`getComputedStyle`. This approach is already used in `Icon.spec.ts`
and `ChevronExpander.spec.ts` and works with both jsdom 29 and 30.

### Screenshot / video of UI

N/A - test-only change

### What issues does this PR fix or reference?

Fixes test failures introduced by the jsdom 29 → 30 upgrade.
https://github.com/podman-desktop/podman-desktop/pull/18510

### How to test this PR?

```bash
npx vitest run packages/ui/src/lib/checkbox/Checkbox.spec.ts
```

- [x] Tests are covering the bug fix or the new feature