### PR TITLE
refactor(core): replace `got` by native fetch in image-registry

### DIFF
--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -51,7 +51,6 @@
     "fzstd": "^0.1.1",
     "get-tsconfig": "^4.14.0",
     "getos": "^3.2.1",
-    "got": "^15.1.0",
     "hpagent": "^1.2.0",
     "inversify": "^8.2.3",
     "js-yaml": "^5.2.2",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -51,7 +51,6 @@
     "fzstd": "^0.1.1",
     "get-tsconfig": "^4.14.3",
     "getos": "^3.2.1",
-    "got": "^16.0.0",
     "hpagent": "^1.2.0",
     "inversify": "^8.2.3",
     "js-yaml": "^5.4.1",

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -1267,18 +1267,16 @@ test('getToken without registry auth', async () => {
   expect(token).toBe('12345');
 });
 
-test('getOptions uses proxy settings', () => {
-  pxoxyIsEnabledMock.mockReturnValue(true);
-  proxyGetProxyMock.mockReturnValue({
-    httpProxy: 'http://192.168.1.1:3128',
-    httpsProxy: 'http://192.168.1.1:3128',
-    noProxy: '',
-  });
+test('getFetchOptions returns dispatcher for insecure mode', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
-  const options = imageRegistry.getOptions();
-  expect(options.agent).toBeDefined();
-  expect(options.agent?.http).toBeDefined();
-  expect(options.agent?.https).toBeDefined();
+  const options = imageRegistry.getFetchOptions(true);
+  expect((options as any).dispatcher).toBeDefined();
+});
+
+test('getFetchOptions returns empty for non-insecure mode', () => {
+  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
+  const options = imageRegistry.getFetchOptions();
+  expect(options).toEqual({});
 });
 
 test('searchImages with proxy', async () => {
@@ -1300,7 +1298,7 @@ test('searchImages with proxy', async () => {
   server = setupServer(...handlers);
   server.listen({ onUnhandledRequest: 'error' });
 
-  await expect(imageRegistry.searchImages({ query: 'anything' })).rejects.toThrow('a proxy error');
+  await expect(imageRegistry.searchImages({ query: 'anything' })).rejects.toThrow('searching images');
 });
 
 test('searchImages without registry', async () => {
@@ -1379,7 +1377,7 @@ test('listImageTags', async () => {
     authUrl: 'https://auth.example.com',
     scheme: 'bearer',
   });
-  vi.spyOn(imageRegistry, 'getOptions').mockReturnValue({});
+  vi.spyOn(imageRegistry, 'getFetchOptions').mockReturnValue({});
   vi.spyOn(imageRegistry, 'getToken').mockResolvedValue('a.token');
   server = setupServer(
     http.get('https://registry.example.com/v2/a-name/tags/list', () => HttpResponse.json({ tags: ['1', '2', '3'] })),

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -1267,15 +1267,15 @@ test('getToken without registry auth', async () => {
   expect(token).toBe('12345');
 });
 
-test('getFetchOptions returns dispatcher for insecure mode', () => {
+test('getOptions returns dispatcher for insecure mode', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
-  const options = imageRegistry.getFetchOptions(true);
+  const options = imageRegistry.getOptions({ insecure: true });
   expect((options as any).dispatcher).toBeDefined();
 });
 
-test('getFetchOptions returns empty for non-insecure mode', () => {
+test('getOptions returns empty for non-insecure mode', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
-  const options = imageRegistry.getFetchOptions();
+  const options = imageRegistry.getOptions();
   expect(options).toEqual({});
 });
 
@@ -1377,7 +1377,7 @@ test('listImageTags', async () => {
     authUrl: 'https://auth.example.com',
     scheme: 'bearer',
   });
-  vi.spyOn(imageRegistry, 'getFetchOptions').mockReturnValue({});
+  vi.spyOn(imageRegistry, 'getOptions').mockReturnValue({});
   vi.spyOn(imageRegistry, 'getToken').mockResolvedValue('a.token');
   server = setupServer(
     http.get('https://registry.example.com/v2/a-name/tags/list', () => HttpResponse.json({ tags: ['1', '2', '3'] })),

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -1226,18 +1226,16 @@ test('getToken without registry auth', async () => {
   expect(token).toBe('12345');
 });
 
-test('getOptions uses proxy settings', () => {
-  pxoxyIsEnabledMock.mockReturnValue(true);
-  proxyGetProxyMock.mockReturnValue({
-    httpProxy: 'http://192.168.1.1:3128',
-    httpsProxy: 'http://192.168.1.1:3128',
-    noProxy: '',
-  });
+test('getFetchOptions returns dispatcher for insecure mode', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
-  const options = imageRegistry.getOptions();
-  expect(options.agent).toBeDefined();
-  expect(options.agent?.http).toBeDefined();
-  expect(options.agent?.https).toBeDefined();
+  const options = imageRegistry.getFetchOptions(true);
+  expect((options as any).dispatcher).toBeDefined();
+});
+
+test('getFetchOptions returns empty for non-insecure mode', () => {
+  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
+  const options = imageRegistry.getFetchOptions();
+  expect(options).toEqual({});
 });
 
 test('searchImages with proxy', async () => {
@@ -1259,7 +1257,7 @@ test('searchImages with proxy', async () => {
   server = setupServer(...handlers);
   server.listen({ onUnhandledRequest: 'error' });
 
-  await expect(imageRegistry.searchImages({ query: 'anything' })).rejects.toThrow('a proxy error');
+  await expect(imageRegistry.searchImages({ query: 'anything' })).rejects.toThrow('searching images');
 });
 
 test('searchImages without registry', async () => {
@@ -1316,7 +1314,7 @@ test('listImageTags', async () => {
     authUrl: 'https://auth.example.com',
     scheme: 'bearer',
   });
-  vi.spyOn(imageRegistry, 'getOptions').mockReturnValue({});
+  vi.spyOn(imageRegistry, 'getFetchOptions').mockReturnValue({});
   vi.spyOn(imageRegistry, 'getToken').mockResolvedValue('a.token');
   server = setupServer(
     http.get('https://registry.example.com/v2/a-name/tags/list', () => HttpResponse.json({ tags: ['1', '2', '3'] })),

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -246,6 +246,17 @@ describe('extract auth info', () => {
     expect(value?.authUrl).toBe('https://auth.docker.io/token?service=registry.docker.io');
     expect(value?.scheme).toBe('bearer');
   });
+
+  test('getAuthInfo surfaces the underlying network error instead of the generic fetch failure', async () => {
+    // fetch wraps network failures in `TypeError: fetch failed`, keeping the real reason in `cause`
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('fetch failed', { cause: new Error('getaddrinfo ENOTFOUND invalidurl') }),
+    );
+
+    await expect(imageRegistry.getAuthInfo('invalidUrl')).rejects.toThrow(
+      'Unable to find auth info for https://invalidUrl/v2/. Error: Error: getaddrinfo ENOTFOUND invalidurl',
+    );
+  });
 });
 
 describe('extractImageDataFromImageName', () => {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -1226,15 +1226,15 @@ test('getToken without registry auth', async () => {
   expect(token).toBe('12345');
 });
 
-test('getFetchOptions returns dispatcher for insecure mode', () => {
+test('getOptions returns dispatcher for insecure mode', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
-  const options = imageRegistry.getFetchOptions(true);
+  const options = imageRegistry.getOptions({ insecure: true });
   expect((options as any).dispatcher).toBeDefined();
 });
 
-test('getFetchOptions returns empty for non-insecure mode', () => {
+test('getOptions returns empty for non-insecure mode', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
-  const options = imageRegistry.getFetchOptions();
+  const options = imageRegistry.getOptions();
   expect(options).toEqual({});
 });
 
@@ -1314,7 +1314,7 @@ test('listImageTags', async () => {
     authUrl: 'https://auth.example.com',
     scheme: 'bearer',
   });
-  vi.spyOn(imageRegistry, 'getFetchOptions').mockReturnValue({});
+  vi.spyOn(imageRegistry, 'getOptions').mockReturnValue({});
   vi.spyOn(imageRegistry, 'getToken').mockResolvedValue('a.token');
   server = setupServer(
     http.get('https://registry.example.com/v2/a-name/tags/list', () => HttpResponse.json({ tags: ['1', '2', '3'] })),

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -29,7 +29,7 @@ import * as fzstd from 'fzstd';
 import { http, HttpResponse } from 'msw';
 import { type SetupServer, setupServer } from 'msw/node';
 import * as nodeTar from 'tar';
-import { ProxyAgent } from 'undici';
+import { ProxyAgent, type RequestInit } from 'undici';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
 import imageRegistryConfigJson from '/@tests/resources/data/plugin/image-registry-config.json' with { type: 'json' };
@@ -1240,8 +1240,8 @@ test('getToken without registry auth', async () => {
 
 test('getOptions returns dispatcher for insecure mode', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
-  const options = imageRegistry.getOptions({ insecure: true });
-  expect((options as any).dispatcher).toBeDefined();
+  const options = imageRegistry.getOptions({ insecure: true }) as RequestInit;
+  expect(options.dispatcher).toBeDefined();
 });
 
 test('getOptions selects the proxy matching the target protocol', () => {
@@ -1255,12 +1255,12 @@ test('getOptions selects the proxy matching the target protocol', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
 
   // an https target uses the https proxy
-  const secure = imageRegistry.getOptions({ url: 'https://registry.local/v2/', insecure: true });
-  expect((secure as any).dispatcher).toBeInstanceOf(ProxyAgent);
+  const secure = imageRegistry.getOptions({ url: 'https://registry.local/v2/', insecure: true }) as RequestInit;
+  expect(secure.dispatcher).toBeInstanceOf(ProxyAgent);
 
   // an http target must not fall back to the https proxy
-  const insecure = imageRegistry.getOptions({ url: 'http://registry.local/v2/', insecure: true });
-  expect((insecure as any).dispatcher).not.toBeInstanceOf(ProxyAgent);
+  const insecure = imageRegistry.getOptions({ url: 'http://registry.local/v2/', insecure: true }) as RequestInit;
+  expect(insecure.dispatcher).not.toBeInstanceOf(ProxyAgent);
 });
 
 test('getOptions returns empty for non-insecure mode', () => {

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -29,6 +29,7 @@ import * as fzstd from 'fzstd';
 import { http, HttpResponse } from 'msw';
 import { type SetupServer, setupServer } from 'msw/node';
 import * as nodeTar from 'tar';
+import { ProxyAgent } from 'undici';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 
 import imageRegistryConfigJson from '/@tests/resources/data/plugin/image-registry-config.json' with { type: 'json' };
@@ -1241,6 +1242,25 @@ test('getOptions returns dispatcher for insecure mode', () => {
   imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
   const options = imageRegistry.getOptions({ insecure: true });
   expect((options as any).dispatcher).toBeDefined();
+});
+
+test('getOptions selects the proxy matching the target protocol', () => {
+  pxoxyIsEnabledMock.mockReturnValue(true);
+  // only an https proxy is configured
+  proxyGetProxyMock.mockReturnValue({
+    httpProxy: undefined,
+    httpsProxy: 'http://127.0.0.1:3128',
+    noProxy: undefined,
+  });
+  imageRegistry = new ImageRegistry(apiSender, telemetry, certificates, proxy);
+
+  // an https target uses the https proxy
+  const secure = imageRegistry.getOptions({ url: 'https://registry.local/v2/', insecure: true });
+  expect((secure as any).dispatcher).toBeInstanceOf(ProxyAgent);
+
+  // an http target must not fall back to the https proxy
+  const insecure = imageRegistry.getOptions({ url: 'http://registry.local/v2/', insecure: true });
+  expect((insecure as any).dispatcher).not.toBeInstanceOf(ProxyAgent);
 });
 
 test('getOptions returns empty for non-insecure mode', () => {

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -21,7 +21,6 @@ import * as fs from 'node:fs';
 import { createWriteStream } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { pipeline } from 'node:stream/promises';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import type {
@@ -33,11 +32,9 @@ import type {
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type * as Dockerode from 'dockerode';
 import * as fzstd from 'fzstd';
-import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
-import got, { HTTPError, RequestError } from 'got';
-import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import { inject, injectable } from 'inversify';
 import * as nodeTar from 'tar';
+import { Agent, ProxyAgent } from 'undici';
 import validator from 'validator';
 
 import { isMac, isWindows } from '/@/util.js';
@@ -346,57 +343,31 @@ export class ImageRegistry {
     return undefined;
   }
 
-  getOptions(insecure?: boolean): OptionsOfTextResponseBody {
-    const httpsOptions: HttpsOptions = {};
-    const options: OptionsOfTextResponseBody = {
-      https: httpsOptions,
-    };
-
-    if (options.https) {
-      options.https.certificateAuthority = this.certificates.getAllCertificates();
-      if (insecure) {
-        options.https.rejectUnauthorized = false;
-      }
+  getFetchOptions(insecure?: boolean): RequestInit {
+    if (!insecure) {
+      return {};
     }
+
+    const ca = this.certificates.getAllCertificates();
 
     if (this.proxyEnabled) {
-      // use proxy when performing got request
-      const proxy = this.proxySettings;
-      const httpProxyUrl = proxy?.httpProxy;
-      const httpsProxyUrl = proxy?.httpsProxy;
-
-      if (httpProxyUrl) {
-        options.agent ??= {};
-        try {
-          options.agent.http = new HttpProxyAgent({
-            keepAlive: true,
-            keepAliveMsecs: 1000,
-            maxSockets: 256,
-            maxFreeSockets: 256,
-            scheduling: 'lifo',
-            proxy: httpProxyUrl,
-          });
-        } catch (error) {
-          throw new Error(`Failed to create http proxy agent from ${httpProxyUrl}: ${error}`);
-        }
-      }
-      if (httpsProxyUrl) {
-        options.agent ??= {};
-        try {
-          options.agent.https = new HttpsProxyAgent({
-            keepAlive: true,
-            keepAliveMsecs: 1000,
-            maxSockets: 256,
-            maxFreeSockets: 256,
-            scheduling: 'lifo',
-            proxy: httpsProxyUrl,
-          });
-        } catch (error) {
-          throw new Error(`Failed to create https proxy agent from ${httpsProxyUrl}: ${error}`);
-        }
+      const proxyUrl = this.proxySettings?.httpsProxy ?? this.proxySettings?.httpProxy;
+      if (proxyUrl) {
+        return {
+          dispatcher: new ProxyAgent({
+            uri: proxyUrl,
+            requestTls: { ca, rejectUnauthorized: false },
+            proxyTls: { ca },
+          }),
+        } as RequestInit;
       }
     }
-    return options;
+
+    return {
+      dispatcher: new Agent({
+        connect: { ca, rejectUnauthorized: false },
+      }),
+    } as RequestInit;
   }
 
   // Adds the missing registry URL to the image name
@@ -610,13 +581,6 @@ export class ImageRegistry {
     totalSize: number,
     logger: (event: { message: string; progress: number }) => void,
   ): Promise<void> {
-    const options = this.getOptions();
-    options.headers = options.headers ?? {};
-
-    // add the Bearer token
-    options.headers['Authorization'] = `Bearer ${token}`;
-
-    // replace all special characters with _ in digest
     const digestWithoutSpecialChars = digest.replace(/[^a-zA-Z0-9]/g, '_');
 
     if (!fs.existsSync(destFolder)) {
@@ -626,7 +590,6 @@ export class ImageRegistry {
     const suffix = compressionType === 'gzip' ? '.tar' : '.zst';
     const tmpFileName = path.resolve(os.tmpdir(), `${digestWithoutSpecialChars}${suffix}`);
 
-    // ensure the folder exists
     const parentDir = path.dirname(tmpFileName);
     if (!fs.existsSync(parentDir)) {
       await fs.promises.mkdir(parentDir, { recursive: true });
@@ -634,19 +597,36 @@ export class ImageRegistry {
 
     const blobURL = `${imageData.registryURL}/${imageData.name}/blobs/${digest}`;
 
-    const readStream = got.stream(blobURL, options);
-
-    readStream.on('downloadProgress', ({ transferred }) => {
-      const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
-      logger({
-        message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
-        progress: globalPercentage,
-      });
+    const response = await fetch(blobURL, {
+      headers: { Authorization: `Bearer ${token}` },
     });
-    await pipeline(readStream, createWriteStream(tmpFileName));
-    // in case of zstd, we need to unpack the file first
+
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to fetch blob ${blobURL}: ${response.statusText}`);
+    }
+
+    const reader = response.body.getReader();
+    const fileStream = createWriteStream(tmpFileName);
+    let transferred = 0;
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        transferred += value.byteLength;
+        const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
+        logger({
+          message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
+          progress: globalPercentage,
+        });
+        fileStream.write(value);
+      }
+    } finally {
+      fileStream.end();
+      await new Promise<void>((resolve, reject) => fileStream.on('finish', resolve).on('error', reject));
+    }
+
     if (compressionType === 'zstd') {
-      //use fstd library to extract the file
       const content = await fs.promises.readFile(tmpFileName);
       const decompressed = fzstd.decompress(content);
       const unpackedFileName = tmpFileName.replace('.zst', '.tar');
@@ -655,34 +635,26 @@ export class ImageRegistry {
     } else {
       await nodeTar.extract({ file: tmpFileName, cwd: destFolder });
     }
-    // remove the temporary file
     await fs.promises.rm(tmpFileName);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async fetchOciImageConfig(imageData: ImageRegistryNameTag, digest: string, token: string): Promise<any> {
-    const options = this.getOptions();
-    options.headers = options.headers ?? {};
-    // add the Bearer token
-    options.headers['Authorization'] = `Bearer ${token}`;
-
-    // say we want to return JSON from got
     const blobURL = `${imageData.registryURL}/${imageData.name}/blobs/${digest}`;
 
-    let jsonConfig: string | undefined;
-    try {
-      jsonConfig = await got.get(blobURL, options).json();
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Unable to get access');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      }
+    const response = await fetch(blobURL, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Unable to get access');
     }
-    return jsonConfig;
+
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+
+    return response.json();
   }
 
   /**
@@ -700,52 +672,33 @@ export class ImageRegistry {
     token: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<{ manifest: unknown; digest: string | undefined; listDigest?: string }> {
-    const options = this.getOptions();
-    options.headers = options.headers ?? {};
+    const acceptHeaders = [
+      'application/vnd.oci.image.manifest.v1+json',
+      'application/vnd.docker.distribution.manifest.v2+json',
+      'application/vnd.docker.distribution.manifest.v1+prettyjws',
+      'application/vnd.docker.distribution.manifest.v1+json',
+      'application/vnd.docker.distribution.manifest.list.v2+json',
+      'application/vnd.oci.image.index.v1+json',
+    ];
 
-    // add the Bearer token
-    options.headers['Authorization'] = `Bearer ${token}`;
+    const response = await fetch(manifestURL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: acceptHeaders.join(', '),
+      },
+    });
 
-    // add the manifest accept headers
-    const acceptHeaders = [];
-    if (options.headers['Accept']) {
-      if (typeof options.headers['Accept'] === 'string') {
-        acceptHeaders.push(options.headers['Accept']);
-      } else if (Array.isArray(options.headers['Accept'])) {
-        acceptHeaders.push(...options.headers['Accept']);
-      }
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Unable to get access');
     }
-    acceptHeaders.push('application/vnd.oci.image.manifest.v1+json');
-    acceptHeaders.push('application/vnd.docker.distribution.manifest.v2+json');
-    acceptHeaders.push('application/vnd.docker.distribution.manifest.v1+prettyjws');
-    acceptHeaders.push('application/vnd.docker.distribution.manifest.v1+json');
-    acceptHeaders.push('application/vnd.docker.distribution.manifest.list.v2+json');
-    acceptHeaders.push('application/vnd.oci.image.index.v1+json');
 
-    options.headers['Accept'] = acceptHeaders;
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let parsedManifest: any;
-    let digest: string | undefined;
-    try {
-      const response = await got.get(manifestURL, options);
-      parsedManifest = JSON.parse(response.body);
-      const digestHeader = response.headers['docker-content-digest'];
-      if (typeof digestHeader === 'string') {
-        digest = digestHeader;
-      } else if (Array.isArray(digestHeader)) {
-        digest = digestHeader[0];
-      }
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Unable to get access');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      }
-    }
+    const parsedManifest: any = await response.json();
+    const digest = response.headers.get('docker-content-digest') ?? undefined;
 
     // https://github.com/opencontainers/image-spec/blob/main/image-index.md
     // check schemaVersion and (mediaType of the manifest or if it contains manifests field being an array)
@@ -962,7 +915,6 @@ export class ImageRegistry {
 
   async getAuthInfo(serviceUrl: string, insecure?: boolean): Promise<{ authUrl: string; scheme: string }> {
     let registryUrl: string;
-    const options = this.getOptions(insecure);
 
     if (serviceUrl.includes('docker.io')) {
       registryUrl = 'https://index.docker.io/v2/';
@@ -974,44 +926,36 @@ export class ImageRegistry {
       }
     }
 
-    let authUrl: string | undefined;
-    let scheme = '';
-
+    let response: Response;
     try {
-      await got.get(registryUrl, options);
-    } catch (requestErr) {
-      if (requestErr instanceof HTTPError) {
-        const wwwAuthenticate = requestErr.response?.headers['www-authenticate'];
-        if (wwwAuthenticate) {
-          const authInfo = this.extractAuthData(wwwAuthenticate);
-          if (authInfo) {
-            scheme = authInfo.scheme?.toLowerCase();
-            // in case of basic auth, we use directly the registry URL
-            if (scheme === 'basic') {
-              return { authUrl: registryUrl, scheme };
-            }
-            const url = new URL(authInfo.authUrl);
-            if (authInfo.service) {
-              url.searchParams.set('service', authInfo.service);
-            }
-            if (authInfo.scope) {
-              url.searchParams.set('scope', authInfo.scope);
-            }
-            authUrl = url.toString();
+      response = await fetch(registryUrl, this.getFetchOptions(insecure));
+    } catch (error) {
+      throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${error}`);
+    }
+
+    if (!response.ok) {
+      const wwwAuthenticate = response.headers.get('www-authenticate');
+      if (wwwAuthenticate) {
+        const authInfo = this.extractAuthData(wwwAuthenticate);
+        if (authInfo) {
+          const scheme = authInfo.scheme?.toLowerCase();
+          if (scheme === 'basic') {
+            return { authUrl: registryUrl, scheme };
           }
-        } else {
-          throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${requestErr.message}`);
+          const url = new URL(authInfo.authUrl);
+          if (authInfo.service) {
+            url.searchParams.set('service', authInfo.service);
+          }
+          if (authInfo.scope) {
+            url.searchParams.set('scope', authInfo.scope);
+          }
+          return { authUrl: url.toString(), scheme };
         }
-      } else {
-        throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${requestErr}`);
       }
+      throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${response.statusText}`);
     }
 
-    if (authUrl === undefined) {
-      throw Error('Not a valid registry.');
-    }
-
-    return { authUrl, scheme };
+    throw Error('Not a valid registry.');
   }
 
   async checkCredentials(serviceUrl: string, username: string, password: string, insecure?: boolean): Promise<void> {
@@ -1046,43 +990,37 @@ export class ImageRegistry {
   }
 
   async getToken(authInfo: { authUrl: string; scheme: string }, imageData: ImageRegistryNameTag): Promise<string> {
-    let rawResponse: string | undefined;
-    const options = this.getOptions();
+    const headers: Record<string, string> = {};
 
-    // if we have auth for this registry, add basic auth to the headers
     const authServer = this.getAuthconfigForServer(imageData.registry);
     if (authServer) {
-      options.headers = options.headers ?? {};
       const loginAndPassWord = `${authServer.username}:${authServer.password}`;
-      options.headers['Authorization'] = `Basic ${Buffer.from(loginAndPassWord).toString('base64')}`;
+      headers['Authorization'] = `Basic ${Buffer.from(loginAndPassWord).toString('base64')}`;
     }
-    // need to replace repository%3Auser with repository:user coming from imageData
+
     let tokenUrl = authInfo.authUrl.replace('user%2Fimage', imageData.name.replaceAll('/', '%2F'));
 
-    // no scope ? we add it
     if (!tokenUrl.includes('scope')) {
       const url = new URL(tokenUrl);
       url.searchParams.set('scope', `repository:${imageData.name}:pull`);
       tokenUrl = url.toString();
     }
-    try {
-      const { body } = await got.get(tokenUrl, options);
-      rawResponse = body;
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Required authentication. Not supported.');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      }
+
+    const response = await fetch(tokenUrl, { headers });
+
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Required authentication. Not supported.');
     }
-    if (!rawResponse?.includes('token')) {
+
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+
+    const rawResponse = await response.text();
+    if (!rawResponse.includes('token')) {
       throw Error('Unable to validate registry URL.');
     }
-    const response = JSON.parse(rawResponse);
-    return response.token;
+    return JSON.parse(rawResponse).token;
   }
 
   async doCheckCredentials(
@@ -1092,34 +1030,29 @@ export class ImageRegistry {
     password: string,
     insecure?: boolean,
   ): Promise<void> {
-    const options = this.getOptions(insecure);
-
-    let rawResponse: string | undefined;
-    // add credentials in the header
-    // encode username:password in base64
     const token = Buffer.from(`${username}:${password}`).toString('base64');
-    options.headers = {
-      Authorization: `Basic ${token}`,
-    };
-    try {
-      const { body } = await got.get(authUrl, options);
-      rawResponse = body;
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Wrong Username or Password.');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      }
+
+    const response = await fetch(authUrl, {
+      ...this.getFetchOptions(insecure),
+      headers: {
+        Authorization: `Basic ${token}`,
+      },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Wrong Username or Password.');
     }
 
-    // no error with basic scheme, it means it's a valid connection
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+
     if (scheme === 'basic') {
       return;
     }
-    if (!rawResponse?.includes('token')) {
+
+    const rawResponse = await response.text();
+    if (!rawResponse.includes('token')) {
       throw Error('Unable to validate provided credentials.');
     }
   }
@@ -1133,11 +1066,12 @@ export class ImageRegistry {
       if (!options.registry.startsWith('http')) {
         options.registry = 'https://' + options.registry;
       }
-      const resultJSON = await got.get(
-        `${options.registry}/v1/search?q=${options.query}&n=${options.limit ?? 25}`,
-        this.getOptions(),
-      );
-      return JSON.parse(resultJSON.body).results;
+      const response = await fetch(`${options.registry}/v1/search?q=${options.query}&n=${options.limit ?? 25}`);
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      const result = await response.json();
+      return result.results;
     } catch (e: unknown) {
       throw new Error(`searching images. ${String(e)}`);
     }
@@ -1146,20 +1080,21 @@ export class ImageRegistry {
   async listImageTags(options: ImageTagsListOptions): Promise<string[]> {
     const imageData = this.extractImageDataFromImageName(options.image);
 
-    // grab auth info from the registry
     const authInfo = await this.getAuthInfo(imageData.registry);
     const token = await this.getToken(authInfo, imageData);
     if (authInfo.scheme.toLowerCase() !== 'bearer') {
       throw new Error(`Unsupported auth scheme: ${authInfo.scheme}`);
     }
-    const opts = this.getOptions();
-    opts.headers = opts.headers ?? {};
-    // add the Bearer token
-    opts.headers['Authorization'] = `Bearer ${token}`;
 
     try {
-      const catalog = await got.get(`${imageData.registryURL}/${imageData.name}/tags/list`, opts);
-      return JSON.parse(catalog.body).tags;
+      const response = await fetch(`${imageData.registryURL}/${imageData.name}/tags/list`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      const result = await response.json();
+      return result.tags;
     } catch (e: unknown) {
       throw new Error(`getting tags of image ${options.image}. ${String(e)}`);
     }

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -343,9 +343,11 @@ export class ImageRegistry {
     return undefined;
   }
 
-  getFetchOptions(insecure?: boolean): RequestInit {
-    if (!insecure) {
-      return {};
+  getOptions(options?: { insecure?: boolean; headers?: Record<string, string> }): RequestInit {
+    if (!options?.insecure) {
+      return {
+        headers: options?.headers,
+      };
     }
 
     const ca = this.certificates.getAllCertificates();
@@ -359,6 +361,7 @@ export class ImageRegistry {
             requestTls: { ca, rejectUnauthorized: false },
             proxyTls: { ca },
           }),
+          headers: options?.headers,
         } as RequestInit;
       }
     }
@@ -367,6 +370,7 @@ export class ImageRegistry {
       dispatcher: new Agent({
         connect: { ca, rejectUnauthorized: false },
       }),
+      headers: options?.headers,
     } as RequestInit;
   }
 
@@ -581,6 +585,13 @@ export class ImageRegistry {
     totalSize: number,
     logger: (event: { message: string; progress: number }) => void,
   ): Promise<void> {
+    const options = this.getOptions({
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    // replace all special characters with _ in digest
     const digestWithoutSpecialChars = digest.replace(/[^a-zA-Z0-9]/g, '_');
 
     if (!fs.existsSync(destFolder)) {
@@ -590,6 +601,7 @@ export class ImageRegistry {
     const suffix = compressionType === 'gzip' ? '.tar' : '.zst';
     const tmpFileName = path.resolve(os.tmpdir(), `${digestWithoutSpecialChars}${suffix}`);
 
+    // ensure the folder exists
     const parentDir = path.dirname(tmpFileName);
     if (!fs.existsSync(parentDir)) {
       await fs.promises.mkdir(parentDir, { recursive: true });
@@ -597,29 +609,28 @@ export class ImageRegistry {
 
     const blobURL = `${imageData.registryURL}/${imageData.name}/blobs/${digest}`;
 
-    const response = await fetch(blobURL, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
+    const response = await fetch(blobURL, options);
 
     if (!response.ok || !response.body) {
       throw new Error(`Failed to fetch blob ${blobURL}: ${response.statusText}`);
     }
 
-    const reader = response.body.getReader();
     const fileStream = createWriteStream(tmpFileName);
     let transferred = 0;
 
     try {
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        transferred += value.byteLength;
-        const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
+      for await (const chunk of response.body) {
+        transferred += chunk.byteLength;
+
+        const downloaded = currentDownloaded + transferred;
+        const progress = Math.round((downloaded / totalSize) * 100);
+
         logger({
-          message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
-          progress: globalPercentage,
+          message: `Downloading ${digest}${suffix} - ${progress}% - (${downloaded}/${totalSize})`,
+          progress,
         });
-        fileStream.write(value);
+
+        fileStream.write(chunk);
       }
     } finally {
       fileStream.end();
@@ -627,6 +638,7 @@ export class ImageRegistry {
     }
 
     if (compressionType === 'zstd') {
+      //use fstd library to extract the file
       const content = await fs.promises.readFile(tmpFileName);
       const decompressed = fzstd.decompress(content);
       const unpackedFileName = tmpFileName.replace('.zst', '.tar');
@@ -635,6 +647,7 @@ export class ImageRegistry {
     } else {
       await nodeTar.extract({ file: tmpFileName, cwd: destFolder });
     }
+    // remove the temporary file
     await fs.promises.rm(tmpFileName);
   }
 
@@ -928,7 +941,7 @@ export class ImageRegistry {
 
     let response: Response;
     try {
-      response = await fetch(registryUrl, this.getFetchOptions(insecure));
+      response = await fetch(registryUrl, this.getOptions({ insecure }));
     } catch (error) {
       throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${error}`);
     }
@@ -1032,12 +1045,15 @@ export class ImageRegistry {
   ): Promise<void> {
     const token = Buffer.from(`${username}:${password}`).toString('base64');
 
-    const response = await fetch(authUrl, {
-      ...this.getFetchOptions(insecure),
-      headers: {
-        Authorization: `Basic ${token}`,
-      },
-    });
+    const response = await fetch(
+      authUrl,
+      this.getOptions({
+        insecure,
+        headers: {
+          Authorization: `Basic ${token}`,
+        },
+      }),
+    );
 
     if (response.status === 401 || response.status === 403) {
       throw Error('Wrong Username or Password.');

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -21,7 +21,6 @@ import * as fs from 'node:fs';
 import { createWriteStream } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { pipeline } from 'node:stream/promises';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import type {
@@ -33,11 +32,9 @@ import type {
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type * as Dockerode from 'dockerode';
 import * as fzstd from 'fzstd';
-import type { HttpsOptions, OptionsOfTextResponseBody } from 'got';
-import got, { HTTPError, RequestError } from 'got';
-import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import { inject, injectable } from 'inversify';
 import * as nodeTar from 'tar';
+import { Agent, ProxyAgent } from 'undici';
 import { isURL } from 'validator';
 
 import { isMac, isWindows } from '/@/util.js';
@@ -346,57 +343,31 @@ export class ImageRegistry {
     return undefined;
   }
 
-  getOptions(insecure?: boolean): OptionsOfTextResponseBody {
-    const httpsOptions: HttpsOptions = {};
-    const options: OptionsOfTextResponseBody = {
-      https: httpsOptions,
-    };
-
-    if (options.https) {
-      options.https.certificateAuthority = this.certificates.getAllCertificates();
-      if (insecure) {
-        options.https.rejectUnauthorized = false;
-      }
+  getFetchOptions(insecure?: boolean): RequestInit {
+    if (!insecure) {
+      return {};
     }
+
+    const ca = this.certificates.getAllCertificates();
 
     if (this.proxyEnabled) {
-      // use proxy when performing got request
-      const proxy = this.proxySettings;
-      const httpProxyUrl = proxy?.httpProxy;
-      const httpsProxyUrl = proxy?.httpsProxy;
-
-      if (httpProxyUrl) {
-        options.agent ??= {};
-        try {
-          options.agent.http = new HttpProxyAgent({
-            keepAlive: true,
-            keepAliveMsecs: 1000,
-            maxSockets: 256,
-            maxFreeSockets: 256,
-            scheduling: 'lifo',
-            proxy: httpProxyUrl,
-          });
-        } catch (error) {
-          throw new Error(`Failed to create http proxy agent from ${httpProxyUrl}: ${error}`);
-        }
-      }
-      if (httpsProxyUrl) {
-        options.agent ??= {};
-        try {
-          options.agent.https = new HttpsProxyAgent({
-            keepAlive: true,
-            keepAliveMsecs: 1000,
-            maxSockets: 256,
-            maxFreeSockets: 256,
-            scheduling: 'lifo',
-            proxy: httpsProxyUrl,
-          });
-        } catch (error) {
-          throw new Error(`Failed to create https proxy agent from ${httpsProxyUrl}: ${error}`);
-        }
+      const proxyUrl = this.proxySettings?.httpsProxy ?? this.proxySettings?.httpProxy;
+      if (proxyUrl) {
+        return {
+          dispatcher: new ProxyAgent({
+            uri: proxyUrl,
+            requestTls: { ca, rejectUnauthorized: false },
+            proxyTls: { ca },
+          }),
+        } as RequestInit;
       }
     }
-    return options;
+
+    return {
+      dispatcher: new Agent({
+        connect: { ca, rejectUnauthorized: false },
+      }),
+    } as RequestInit;
   }
 
   // Adds the missing registry URL to the image name
@@ -610,13 +581,6 @@ export class ImageRegistry {
     totalSize: number,
     logger: (event: { message: string; progress: number }) => void,
   ): Promise<void> {
-    const options = this.getOptions();
-    options.headers = options.headers ?? {};
-
-    // add the Bearer token
-    options.headers['Authorization'] = `Bearer ${token}`;
-
-    // replace all special characters with _ in digest
     const digestWithoutSpecialChars = digest.replace(/[^a-zA-Z0-9]/g, '_');
 
     if (!fs.existsSync(destFolder)) {
@@ -626,7 +590,6 @@ export class ImageRegistry {
     const suffix = compressionType === 'gzip' ? '.tar' : '.zst';
     const tmpFileName = path.resolve(os.tmpdir(), `${digestWithoutSpecialChars}${suffix}`);
 
-    // ensure the folder exists
     const parentDir = path.dirname(tmpFileName);
     if (!fs.existsSync(parentDir)) {
       await fs.promises.mkdir(parentDir, { recursive: true });
@@ -634,19 +597,36 @@ export class ImageRegistry {
 
     const blobURL = `${imageData.registryURL}/${imageData.name}/blobs/${digest}`;
 
-    const readStream = got.stream(blobURL, options);
-
-    readStream.on('downloadProgress', ({ transferred }) => {
-      const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
-      logger({
-        message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
-        progress: globalPercentage,
-      });
+    const response = await fetch(blobURL, {
+      headers: { Authorization: `Bearer ${token}` },
     });
-    await pipeline(readStream, createWriteStream(tmpFileName));
-    // in case of zstd, we need to unpack the file first
+
+    if (!response.ok || !response.body) {
+      throw new Error(`Failed to fetch blob ${blobURL}: ${response.statusText}`);
+    }
+
+    const reader = response.body.getReader();
+    const fileStream = createWriteStream(tmpFileName);
+    let transferred = 0;
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        transferred += value.byteLength;
+        const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
+        logger({
+          message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
+          progress: globalPercentage,
+        });
+        fileStream.write(value);
+      }
+    } finally {
+      fileStream.end();
+      await new Promise<void>((resolve, reject) => fileStream.on('finish', resolve).on('error', reject));
+    }
+
     if (compressionType === 'zstd') {
-      //use fstd library to extract the file
       const content = await fs.promises.readFile(tmpFileName);
       const decompressed = fzstd.decompress(content);
       const unpackedFileName = tmpFileName.replace('.zst', '.tar');
@@ -655,34 +635,26 @@ export class ImageRegistry {
     } else {
       await nodeTar.extract({ file: tmpFileName, cwd: destFolder });
     }
-    // remove the temporary file
     await fs.promises.rm(tmpFileName);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async fetchOciImageConfig(imageData: ImageRegistryNameTag, digest: string, token: string): Promise<any> {
-    const options = this.getOptions();
-    options.headers = options.headers ?? {};
-    // add the Bearer token
-    options.headers['Authorization'] = `Bearer ${token}`;
-
-    // say we want to return JSON from got
     const blobURL = `${imageData.registryURL}/${imageData.name}/blobs/${digest}`;
 
-    let jsonConfig: string | undefined;
-    try {
-      jsonConfig = await got.get(blobURL, options).json();
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Unable to get access');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      }
+    const response = await fetch(blobURL, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Unable to get access');
     }
-    return jsonConfig;
+
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+
+    return response.json();
   }
 
   /**
@@ -700,52 +672,33 @@ export class ImageRegistry {
     token: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<{ manifest: unknown; digest: string | undefined; listDigest?: string }> {
-    const options = this.getOptions();
-    options.headers = options.headers ?? {};
+    const acceptHeaders = [
+      'application/vnd.oci.image.manifest.v1+json',
+      'application/vnd.docker.distribution.manifest.v2+json',
+      'application/vnd.docker.distribution.manifest.v1+prettyjws',
+      'application/vnd.docker.distribution.manifest.v1+json',
+      'application/vnd.docker.distribution.manifest.list.v2+json',
+      'application/vnd.oci.image.index.v1+json',
+    ];
 
-    // add the Bearer token
-    options.headers['Authorization'] = `Bearer ${token}`;
+    const response = await fetch(manifestURL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: acceptHeaders.join(', '),
+      },
+    });
 
-    // add the manifest accept headers
-    const acceptHeaders = [];
-    if (options.headers['Accept']) {
-      if (typeof options.headers['Accept'] === 'string') {
-        acceptHeaders.push(options.headers['Accept']);
-      } else if (Array.isArray(options.headers['Accept'])) {
-        acceptHeaders.push(...options.headers['Accept']);
-      }
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Unable to get access');
     }
-    acceptHeaders.push('application/vnd.oci.image.manifest.v1+json');
-    acceptHeaders.push('application/vnd.docker.distribution.manifest.v2+json');
-    acceptHeaders.push('application/vnd.docker.distribution.manifest.v1+prettyjws');
-    acceptHeaders.push('application/vnd.docker.distribution.manifest.v1+json');
-    acceptHeaders.push('application/vnd.docker.distribution.manifest.list.v2+json');
-    acceptHeaders.push('application/vnd.oci.image.index.v1+json');
 
-    options.headers['Accept'] = acceptHeaders;
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let parsedManifest: any;
-    let digest: string | undefined;
-    try {
-      const response = await got.get(manifestURL, options);
-      parsedManifest = JSON.parse(response.body);
-      const digestHeader = response.headers['docker-content-digest'];
-      if (typeof digestHeader === 'string') {
-        digest = digestHeader;
-      } else if (Array.isArray(digestHeader)) {
-        digest = digestHeader[0];
-      }
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Unable to get access');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      }
-    }
+    const parsedManifest: any = await response.json();
+    const digest = response.headers.get('docker-content-digest') ?? undefined;
 
     // https://github.com/opencontainers/image-spec/blob/main/image-index.md
     // check schemaVersion and (mediaType of the manifest or if it contains manifests field being an array)
@@ -962,7 +915,6 @@ export class ImageRegistry {
 
   async getAuthInfo(serviceUrl: string, insecure?: boolean): Promise<{ authUrl: string; scheme: string }> {
     let registryUrl: string;
-    const options = this.getOptions(insecure);
 
     if (serviceUrl.includes('docker.io')) {
       registryUrl = 'https://index.docker.io/v2/';
@@ -974,44 +926,36 @@ export class ImageRegistry {
       }
     }
 
-    let authUrl: string | undefined;
-    let scheme = '';
-
+    let response: Response;
     try {
-      await got.get(registryUrl, options);
-    } catch (requestErr) {
-      if (requestErr instanceof HTTPError) {
-        const wwwAuthenticate = requestErr.response?.headers['www-authenticate'];
-        if (wwwAuthenticate) {
-          const authInfo = this.extractAuthData(wwwAuthenticate);
-          if (authInfo) {
-            scheme = authInfo.scheme?.toLowerCase();
-            // in case of basic auth, we use directly the registry URL
-            if (scheme === 'basic') {
-              return { authUrl: registryUrl, scheme };
-            }
-            const url = new URL(authInfo.authUrl);
-            if (authInfo.service) {
-              url.searchParams.set('service', authInfo.service);
-            }
-            if (authInfo.scope) {
-              url.searchParams.set('scope', authInfo.scope);
-            }
-            authUrl = url.toString();
+      response = await fetch(registryUrl, this.getFetchOptions(insecure));
+    } catch (error) {
+      throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${error}`);
+    }
+
+    if (!response.ok) {
+      const wwwAuthenticate = response.headers.get('www-authenticate');
+      if (wwwAuthenticate) {
+        const authInfo = this.extractAuthData(wwwAuthenticate);
+        if (authInfo) {
+          const scheme = authInfo.scheme?.toLowerCase();
+          if (scheme === 'basic') {
+            return { authUrl: registryUrl, scheme };
           }
-        } else {
-          throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${requestErr.message}`);
+          const url = new URL(authInfo.authUrl);
+          if (authInfo.service) {
+            url.searchParams.set('service', authInfo.service);
+          }
+          if (authInfo.scope) {
+            url.searchParams.set('scope', authInfo.scope);
+          }
+          return { authUrl: url.toString(), scheme };
         }
-      } else {
-        throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${requestErr}`);
       }
+      throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${response.statusText}`);
     }
 
-    if (authUrl === undefined) {
-      throw Error('Not a valid registry.');
-    }
-
-    return { authUrl, scheme };
+    throw Error('Not a valid registry.');
   }
 
   async checkCredentials(serviceUrl: string, username: string, password: string, insecure?: boolean): Promise<void> {
@@ -1046,43 +990,37 @@ export class ImageRegistry {
   }
 
   async getToken(authInfo: { authUrl: string; scheme: string }, imageData: ImageRegistryNameTag): Promise<string> {
-    let rawResponse: string | undefined;
-    const options = this.getOptions();
+    const headers: Record<string, string> = {};
 
-    // if we have auth for this registry, add basic auth to the headers
     const authServer = this.getAuthconfigForServer(imageData.registry);
     if (authServer) {
-      options.headers = options.headers ?? {};
       const loginAndPassWord = `${authServer.username}:${authServer.password}`;
-      options.headers['Authorization'] = `Basic ${Buffer.from(loginAndPassWord).toString('base64')}`;
+      headers['Authorization'] = `Basic ${Buffer.from(loginAndPassWord).toString('base64')}`;
     }
-    // need to replace repository%3Auser with repository:user coming from imageData
+
     let tokenUrl = authInfo.authUrl.replace('user%2Fimage', imageData.name.replaceAll('/', '%2F'));
 
-    // no scope ? we add it
     if (!tokenUrl.includes('scope')) {
       const url = new URL(tokenUrl);
       url.searchParams.set('scope', `repository:${imageData.name}:pull`);
       tokenUrl = url.toString();
     }
-    try {
-      const { body } = await got.get(tokenUrl, options);
-      rawResponse = body;
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Required authentication. Not supported.');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      }
+
+    const response = await fetch(tokenUrl, { headers });
+
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Required authentication. Not supported.');
     }
-    if (!rawResponse?.includes('token')) {
+
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+
+    const rawResponse = await response.text();
+    if (!rawResponse.includes('token')) {
       throw Error('Unable to validate registry URL.');
     }
-    const response = JSON.parse(rawResponse);
-    return response.token;
+    return JSON.parse(rawResponse).token;
   }
 
   async doCheckCredentials(
@@ -1092,34 +1030,29 @@ export class ImageRegistry {
     password: string,
     insecure?: boolean,
   ): Promise<void> {
-    const options = this.getOptions(insecure);
-
-    let rawResponse: string | undefined;
-    // add credentials in the header
-    // encode username:password in base64
     const token = Buffer.from(`${username}:${password}`).toString('base64');
-    options.headers = {
-      Authorization: `Basic ${token}`,
-    };
-    try {
-      const { body } = await got.get(authUrl, options);
-      rawResponse = body;
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Wrong Username or Password.');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      }
+
+    const response = await fetch(authUrl, {
+      ...this.getFetchOptions(insecure),
+      headers: {
+        Authorization: `Basic ${token}`,
+      },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Wrong Username or Password.');
     }
 
-    // no error with basic scheme, it means it's a valid connection
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+
     if (scheme === 'basic') {
       return;
     }
-    if (!rawResponse?.includes('token')) {
+
+    const rawResponse = await response.text();
+    if (!rawResponse.includes('token')) {
       throw Error('Unable to validate provided credentials.');
     }
   }
@@ -1133,11 +1066,12 @@ export class ImageRegistry {
       if (!options.registry.startsWith('http')) {
         options.registry = 'https://' + options.registry;
       }
-      const resultJSON = await got.get(
-        `${options.registry}/v1/search?q=${options.query}&n=${options.limit ?? 25}`,
-        this.getOptions(),
-      );
-      return JSON.parse(resultJSON.body).results;
+      const response = await fetch(`${options.registry}/v1/search?q=${options.query}&n=${options.limit ?? 25}`);
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      const result = await response.json();
+      return result.results;
     } catch (e: unknown) {
       throw new Error(`searching images. ${String(e)}`);
     }
@@ -1146,20 +1080,21 @@ export class ImageRegistry {
   async listImageTags(options: ImageTagsListOptions): Promise<string[]> {
     const imageData = this.extractImageDataFromImageName(options.image);
 
-    // grab auth info from the registry
     const authInfo = await this.getAuthInfo(imageData.registry);
     const token = await this.getToken(authInfo, imageData);
     if (authInfo.scheme.toLowerCase() !== 'bearer') {
       throw new Error(`Unsupported auth scheme: ${authInfo.scheme}`);
     }
-    const opts = this.getOptions();
-    opts.headers = opts.headers ?? {};
-    // add the Bearer token
-    opts.headers['Authorization'] = `Bearer ${token}`;
 
     try {
-      const catalog = await got.get(`${imageData.registryURL}/${imageData.name}/tags/list`, opts);
-      return JSON.parse(catalog.body).tags;
+      const response = await fetch(`${imageData.registryURL}/${imageData.name}/tags/list`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+      const result = await response.json();
+      return result.tags;
     } catch (e: unknown) {
       throw new Error(`getting tags of image ${options.image}. ${String(e)}`);
     }

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -21,6 +21,7 @@ import * as fs from 'node:fs';
 import { createWriteStream } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
 import type {
@@ -343,7 +344,7 @@ export class ImageRegistry {
     return undefined;
   }
 
-  getOptions(options?: { insecure?: boolean; headers?: Record<string, string> }): RequestInit {
+  getOptions(options?: { url?: string; insecure?: boolean; headers?: Record<string, string> }): RequestInit {
     if (!options?.insecure) {
       return {
         headers: options?.headers,
@@ -353,7 +354,9 @@ export class ImageRegistry {
     const ca = this.certificates.getAllCertificates();
 
     if (this.proxyEnabled) {
-      const proxyUrl = this.proxySettings?.httpsProxy ?? this.proxySettings?.httpProxy;
+      // pick the proxy matching the target protocol, like the global fetch override does
+      const secure = options.url ? new URL(options.url).protocol === 'https:' : true;
+      const proxyUrl = secure ? this.proxySettings?.httpsProxy : this.proxySettings?.httpProxy;
       if (proxyUrl) {
         return {
           dispatcher: new ProxyAgent({
@@ -615,11 +618,12 @@ export class ImageRegistry {
       throw new Error(`Failed to fetch blob ${blobURL}: ${response.statusText}`);
     }
 
-    const fileStream = createWriteStream(tmpFileName);
+    const body = response.body;
     let transferred = 0;
 
-    try {
-      for await (const chunk of response.body) {
+    // pipeline handles backpressure, error propagation and stream teardown
+    await pipeline(async function* () {
+      for await (const chunk of body) {
         transferred += chunk.byteLength;
 
         const downloaded = currentDownloaded + transferred;
@@ -630,12 +634,9 @@ export class ImageRegistry {
           progress,
         });
 
-        fileStream.write(chunk);
+        yield chunk;
       }
-    } finally {
-      fileStream.end();
-      await new Promise<void>((resolve, reject) => fileStream.on('finish', resolve).on('error', reject));
-    }
+    }, createWriteStream(tmpFileName));
 
     if (compressionType === 'zstd') {
       //use fstd library to extract the file
@@ -941,7 +942,7 @@ export class ImageRegistry {
 
     let response: Response;
     try {
-      response = await fetch(registryUrl, this.getOptions({ insecure }));
+      response = await fetch(registryUrl, this.getOptions({ url: registryUrl, insecure }));
     } catch (error) {
       // fetch reports network failures as a generic `TypeError: fetch failed` and keeps the actual
       // reason (DNS, TLS, refused connection) in `cause`
@@ -1051,6 +1052,7 @@ export class ImageRegistry {
     const response = await fetch(
       authUrl,
       this.getOptions({
+        url: authUrl,
         insecure,
         headers: {
           Authorization: `Basic ${token}`,

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -943,7 +943,10 @@ export class ImageRegistry {
     try {
       response = await fetch(registryUrl, this.getOptions({ insecure }));
     } catch (error) {
-      throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${error}`);
+      // fetch reports network failures as a generic `TypeError: fetch failed` and keeps the actual
+      // reason (DNS, TLS, refused connection) in `cause`
+      const reason = error instanceof Error ? (error.cause ?? error) : error;
+      throw new Error(`Unable to find auth info for ${registryUrl}. Error: ${reason}`);
     }
 
     if (!response.ok) {

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -25,7 +25,8 @@ import type { IDisposable } from '@podman-desktop/core-api';
 import { ProxyState } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { createProxy, type ProxyServer } from 'proxy';
-import { beforeAll, describe, expect, test, vi } from 'vitest';
+import { Agent } from 'undici';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { Certificates } from '/@/plugin/certificates.js';
 import { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
@@ -104,7 +105,9 @@ async function buildProxy(): Promise<ProxyServer> {
 let proxy: Proxy | undefined;
 let configurationRegistry: ConfigurationRegistry;
 
-beforeAll(async () => {
+beforeEach(async () => {
+  vi.resetAllMocks();
+
   // Set up filesystem mocks
   readFileSync.mockReturnValue(JSON.stringify({}));
   writeFileSync.mockReturnValue(undefined);
@@ -217,4 +220,23 @@ test('check isEnabled returns true when proxy is system and some proxy is enable
   await proxy?.setState(ProxyState.PROXY_SYSTEM);
   await proxy?.setProxy(undefined);
   expect(proxy?.isEnabled()).toBe(true);
+});
+
+test('fetch with caller-provided dispatcher should not be overridden', async () => {
+  const proxyServer = await buildProxy();
+  const address = proxyServer.address() as AddressInfo;
+  await proxy?.setState(ProxyState.PROXY_MANUAL);
+  await proxy?.setProxy({
+    httpsProxy: `127.0.0.1:${address.port}`,
+    httpProxy: undefined,
+    noProxy: undefined,
+  });
+
+  const customDispatcher = new Agent();
+  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+  await fetch(URL, { dispatcher: customDispatcher } as RequestInit);
+
+  expect(fetchSpy).toHaveBeenCalledWith(URL, expect.objectContaining({ dispatcher: customDispatcher }));
+  fetchSpy.mockRestore();
 });

--- a/packages/main/src/plugin/proxy.spec.ts
+++ b/packages/main/src/plugin/proxy.spec.ts
@@ -223,20 +223,27 @@ test('check isEnabled returns true when proxy is system and some proxy is enable
 });
 
 test('fetch with caller-provided dispatcher should not be overridden', async () => {
-  const proxyServer = await buildProxy();
-  const address = proxyServer.address() as AddressInfo;
-  await proxy?.setState(ProxyState.PROXY_MANUAL);
-  await proxy?.setProxy({
-    httpsProxy: `127.0.0.1:${address.port}`,
-    httpProxy: undefined,
-    noProxy: undefined,
-  });
+  // install our own fetch as the one the override will delegate to, so we can assert what it receives
+  const originalFetch = vi.fn().mockResolvedValue(new Response());
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = originalFetch as unknown as typeof globalThis.fetch;
 
-  const customDispatcher = new Agent();
-  const fetchSpy = vi.spyOn(globalThis, 'fetch');
+  try {
+    const localProxy = new Proxy(configurationRegistry, certificates);
+    await localProxy.init();
+    await localProxy.setState(ProxyState.PROXY_MANUAL);
+    await localProxy.setProxy({
+      httpsProxy: '127.0.0.1:8888',
+      httpProxy: undefined,
+      noProxy: undefined,
+    });
 
-  await fetch(URL, { dispatcher: customDispatcher } as RequestInit);
+    const customDispatcher = new Agent();
+    await globalThis.fetch(URL, { dispatcher: customDispatcher } as RequestInit);
 
-  expect(fetchSpy).toHaveBeenCalledWith(URL, expect.objectContaining({ dispatcher: customDispatcher }));
-  fetchSpy.mockRestore();
+    // without the bypass the override would replace the dispatcher with its own ProxyAgent
+    expect(originalFetch).toHaveBeenCalledWith(URL, expect.objectContaining({ dispatcher: customDispatcher }));
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
 });

--- a/packages/main/src/plugin/proxy.ts
+++ b/packages/main/src/plugin/proxy.ts
@@ -20,6 +20,7 @@ import type { Event, ProxySettings } from '@podman-desktop/api';
 import { PROXY_CONFIG_KEYS, ProxyState } from '@podman-desktop/core-api';
 import { type IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { inject, injectable } from 'inversify';
+import type { fetch, RequestInfo, RequestInit, Response } from 'undici';
 import { Agent, ProxyAgent } from 'undici';
 
 import { Certificates } from '/@/plugin/certificates.js';
@@ -205,10 +206,15 @@ export class Proxy {
   }
 
   private overrideFetch(): void {
-    const original = globalThis.fetch;
+    const original = globalThis.fetch as unknown as typeof fetch;
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const _me = this;
-    globalThis.fetch = function (url: URL | RequestInfo, opts?: object): Promise<Response> {
+    (globalThis.fetch as unknown as typeof fetch) = function (url: RequestInfo, opts?: RequestInit): Promise<Response> {
+      // respect a caller-provided dispatcher (e.g. for insecure TLS)
+      if (opts && 'dispatcher' in opts) {
+        return original(url, opts);
+      }
+
       const urlObj = asURL(url);
       const isHttps = urlObj.protocol === 'https:';
       const proxyurl = getProxyUrl(_me, isHttps);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,9 +606,6 @@ importers:
       getos:
         specifier: ^3.2.1
         version: 3.2.1
-      got:
-        specifier: ^15.1.0
-        version: 15.1.0
       hpagent:
         specifier: ^1.2.0
         version: 1.2.0
@@ -3422,9 +3419,6 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@keyv/serialize@1.1.1':
-    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
-
   '@kubernetes/client-node@1.4.0':
     resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
 
@@ -4262,9 +4256,6 @@ packages:
   '@rushstack/ts-command-line@5.1.5':
     resolution: {integrity: sha512-YmrFTFUdHXblYSa+Xc9OO9FsL/XFcckZy0ycQ6q7VSBsVs5P0uD9vcges5Q9vctGlVdu27w+Ct6IuJ458V0cTQ==}
 
-  '@sec-ant/readable-stream@0.4.1':
-    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-
   '@segment/analytics-core@1.8.3':
     resolution: {integrity: sha512-63X8e2DWb2ZnJ9S3H8iSOFnbeDXMkTGhA8kZG4eFAO07QBwBVyWo5BCpv6vmuOMEkv2le6t2FMg1p6ZeJQA/4A==}
 
@@ -4317,10 +4308,6 @@ packages:
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
-
-  '@sindresorhus/is@8.1.0':
-    resolution: {integrity: sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==}
-    engines: {node: '>=22'}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -5956,10 +5943,6 @@ packages:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
 
-  byte-counter@0.1.0:
-    resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
-    engines: {node: '>=20'}
-
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
@@ -5983,10 +5966,6 @@ packages:
   cacheable-request@10.2.14:
     resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
     engines: {node: '>=14.16'}
-
-  cacheable-request@13.0.19:
-    resolution: {integrity: sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==}
-    engines: {node: '>=18'}
 
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
@@ -6127,10 +6106,6 @@ packages:
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
-
-  chunk-data@0.1.0:
-    resolution: {integrity: sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==}
-    engines: {node: '>=20'}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -6817,10 +6792,6 @@ packages:
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
-
-  decompress-response@10.0.0:
-    resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
-    engines: {node: '>=20'}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -7779,10 +7750,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-stream@9.0.1:
-    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
-    engines: {node: '>=18'}
-
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -7890,10 +7857,6 @@ packages:
   got@12.6.1:
     resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
     engines: {node: '>=14.16'}
-
-  got@15.1.0:
-    resolution: {integrity: sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==}
-    engines: {node: '>=22'}
 
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -8687,9 +8650,6 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  keyv@5.6.0:
-    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
-
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
@@ -8927,10 +8887,6 @@ packages:
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  lowercase-keys@4.0.1:
-    resolution: {integrity: sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==}
-    engines: {node: '>=20'}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -10710,10 +10666,6 @@ packages:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
 
-  responselike@4.0.2:
-    resolution: {integrity: sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==}
-    engines: {node: '>=20'}
-
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -11696,10 +11648,6 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
-
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -15464,8 +15412,6 @@ snapshots:
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@keyv/serialize@1.1.1': {}
-
   '@kubernetes/client-node@1.4.0(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
       '@types/js-yaml': 4.0.9
@@ -16365,8 +16311,6 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@sec-ant/readable-stream@0.4.1': {}
-
   '@segment/analytics-core@1.8.3':
     dependencies:
       '@lukeed/uuid': 2.0.1
@@ -16426,8 +16370,6 @@ snapshots:
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/is@5.6.0': {}
-
-  '@sindresorhus/is@8.1.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -18310,8 +18252,6 @@ snapshots:
 
   byline@5.0.0: {}
 
-  byte-counter@0.1.0: {}
-
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
@@ -18331,16 +18271,6 @@ snapshots:
       mimic-response: 4.0.0
       normalize-url: 8.1.1
       responselike: 3.0.0
-
-  cacheable-request@13.0.19:
-    dependencies:
-      '@types/http-cache-semantics': 4.2.0
-      get-stream: 9.0.1
-      http-cache-semantics: 4.2.0
-      keyv: 5.6.0
-      mimic-response: 4.0.0
-      normalize-url: 8.1.1
-      responselike: 4.0.2
 
   cacheable-request@7.0.4:
     dependencies:
@@ -18502,8 +18432,6 @@ snapshots:
   chrome-trace-event@1.0.4: {}
 
   chromium-pickle-js@0.2.0: {}
-
-  chunk-data@0.1.0: {}
 
   ci-info@3.9.0: {}
 
@@ -19229,10 +19157,6 @@ snapshots:
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
-
-  decompress-response@10.0.0:
-    dependencies:
-      mimic-response: 4.0.0
 
   decompress-response@6.0.0:
     dependencies:
@@ -20412,11 +20336,6 @@ snapshots:
 
   get-stream@6.0.1: {}
 
-  get-stream@9.0.1:
-    dependencies:
-      '@sec-ant/readable-stream': 0.4.1
-      is-stream: 4.0.1
-
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -20560,21 +20479,6 @@ snapshots:
       lowercase-keys: 3.0.0
       p-cancelable: 3.0.0
       responselike: 3.0.0
-
-  got@15.1.0:
-    dependencies:
-      '@sindresorhus/is': 8.1.0
-      byte-counter: 0.1.0
-      cacheable-lookup: 7.0.0
-      cacheable-request: 13.0.19
-      chunk-data: 0.1.0
-      decompress-response: 10.0.0
-      http2-wrapper: 2.2.1
-      keyv: 5.6.0
-      lowercase-keys: 4.0.1
-      responselike: 4.0.2
-      type-fest: 5.8.0
-      uint8array-extras: 1.5.0
 
   graceful-fs@4.2.10: {}
 
@@ -21392,10 +21296,6 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  keyv@5.6.0:
-    dependencies:
-      '@keyv/serialize': 1.1.1
-
   khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
@@ -21579,8 +21479,6 @@ snapshots:
   lowercase-keys@2.0.0: {}
 
   lowercase-keys@3.0.0: {}
-
-  lowercase-keys@4.0.1: {}
 
   lru-cache@11.3.5: {}
 
@@ -23908,10 +23806,6 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
-  responselike@4.0.2:
-    dependencies:
-      lowercase-keys: 3.0.0
-
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -25083,8 +24977,6 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
-
-  uint8array-extras@1.5.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,9 +622,6 @@ importers:
       getos:
         specifier: ^3.2.1
         version: 3.2.1
-      got:
-        specifier: ^16.0.0
-        version: 16.0.0
       hpagent:
         specifier: ^1.2.0
         version: 1.2.0
@@ -4437,9 +4434,6 @@ packages:
   '@rushstack/ts-command-line@5.1.5':
     resolution: {integrity: sha512-YmrFTFUdHXblYSa+Xc9OO9FsL/XFcckZy0ycQ6q7VSBsVs5P0uD9vcges5Q9vctGlVdu27w+Ct6IuJ458V0cTQ==}
 
-  '@sec-ant/readable-stream@0.4.1':
-    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-
   '@segment/analytics-core@1.8.3':
     resolution: {integrity: sha512-63X8e2DWb2ZnJ9S3H8iSOFnbeDXMkTGhA8kZG4eFAO07QBwBVyWo5BCpv6vmuOMEkv2le6t2FMg1p6ZeJQA/4A==}
 
@@ -4492,10 +4486,6 @@ packages:
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
-
-  '@sindresorhus/is@8.1.0':
-    resolution: {integrity: sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==}
-    engines: {node: '>=22'}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -6173,10 +6163,6 @@ packages:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
 
-  byte-counter@0.1.0:
-    resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
-    engines: {node: '>=20'}
-
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
@@ -6200,10 +6186,6 @@ packages:
   cacheable-request@10.2.14:
     resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
     engines: {node: '>=14.16'}
-
-  cacheable-request@13.0.19:
-    resolution: {integrity: sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==}
-    engines: {node: '>=18'}
 
   cacheable-request@7.0.4:
     resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
@@ -6347,10 +6329,6 @@ packages:
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
-
-  chunk-data@0.1.0:
-    resolution: {integrity: sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==}
-    engines: {node: '>=20'}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -7034,10 +7012,6 @@ packages:
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
-
-  decompress-response@10.0.0:
-    resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
-    engines: {node: '>=20'}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -7992,10 +7966,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-stream@9.0.1:
-    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
-    engines: {node: '>=18'}
-
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -8099,10 +8069,6 @@ packages:
   got@12.6.1:
     resolution: {integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==}
     engines: {node: '>=14.16'}
-
-  got@16.0.0:
-    resolution: {integrity: sha512-UtzSUebtRHHAUaNB/X37X1LQgHvdSrgXUIWGUBDhLu05CYtUr9svjeN6wmG333nzdJASFUjXMOuRBjZLf8oF1w==}
-    engines: {node: '>=22'}
 
   graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
@@ -9199,10 +9165,6 @@ packages:
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  lowercase-keys@4.0.1:
-    resolution: {integrity: sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==}
-    engines: {node: '>=20'}
 
   lru-cache@11.4.0:
     resolution: {integrity: sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==}
@@ -10995,10 +10957,6 @@ packages:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
 
-  responselike@4.0.2:
-    resolution: {integrity: sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==}
-    engines: {node: '>=20'}
-
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -12003,10 +11961,6 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
-
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -16724,8 +16678,6 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@sec-ant/readable-stream@0.4.1': {}
-
   '@segment/analytics-core@1.8.3':
     dependencies:
       '@lukeed/uuid': 2.0.1
@@ -16785,8 +16737,6 @@ snapshots:
   '@sindresorhus/is@4.6.0': {}
 
   '@sindresorhus/is@5.6.0': {}
-
-  '@sindresorhus/is@8.1.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -18687,8 +18637,6 @@ snapshots:
 
   byline@5.0.0: {}
 
-  byte-counter@0.1.0: {}
-
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
@@ -18708,16 +18656,6 @@ snapshots:
       mimic-response: 4.0.0
       normalize-url: 8.1.1
       responselike: 3.0.0
-
-  cacheable-request@13.0.19:
-    dependencies:
-      '@types/http-cache-semantics': 4.2.0
-      get-stream: 9.0.1
-      http-cache-semantics: 4.2.0
-      keyv: 5.6.0
-      mimic-response: 4.0.0
-      normalize-url: 8.1.1
-      responselike: 4.0.2
 
   cacheable-request@7.0.4:
     dependencies:
@@ -18887,8 +18825,6 @@ snapshots:
   chrome-trace-event@1.0.4: {}
 
   chromium-pickle-js@0.2.0: {}
-
-  chunk-data@0.1.0: {}
 
   ci-info@3.9.0: {}
 
@@ -19607,10 +19543,6 @@ snapshots:
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
-
-  decompress-response@10.0.0:
-    dependencies:
-      mimic-response: 4.0.0
 
   decompress-response@6.0.0:
     dependencies:
@@ -20813,11 +20745,6 @@ snapshots:
 
   get-stream@6.0.1: {}
 
-  get-stream@9.0.1:
-    dependencies:
-      '@sec-ant/readable-stream': 0.4.1
-      is-stream: 4.0.1
-
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -20957,19 +20884,6 @@ snapshots:
       lowercase-keys: 3.0.0
       p-cancelable: 3.0.0
       responselike: 3.0.0
-
-  got@16.0.0:
-    dependencies:
-      '@sindresorhus/is': 8.1.0
-      byte-counter: 0.1.0
-      cacheable-request: 13.0.19
-      chunk-data: 0.1.0
-      decompress-response: 10.0.0
-      keyv: 5.6.0
-      lowercase-keys: 4.0.1
-      responselike: 4.0.2
-      type-fest: 5.8.0
-      uint8array-extras: 1.5.0
 
   graceful-fs@4.2.10: {}
 
@@ -22015,8 +21929,6 @@ snapshots:
   lowercase-keys@2.0.0: {}
 
   lowercase-keys@3.0.0: {}
-
-  lowercase-keys@4.0.1: {}
 
   lru-cache@11.4.0: {}
 
@@ -24356,10 +24268,6 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
-  responselike@4.0.2:
-    dependencies:
-      lowercase-keys: 3.0.0
-
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -25535,8 +25443,6 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
-
-  uint8array-extras@1.5.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/tests/playwright/src/specs/registry.spec.ts
+++ b/tests/playwright/src/specs/registry.spec.ts
@@ -75,7 +75,7 @@ test.describe
 
       await registryPage.submitRegistryForm('invalidUrl', 'invalidName', 'invalidPswd');
       const urlErrorMsg = page.getByText(
-        /Unable to find auth info for https:\/\/invalidUrl\/v2\/\. Error: RequestError: getaddrinfo [A-Z_]+ invalidurl$/,
+        /Unable to find auth info for https:\/\/invalidUrl\/v2\/\. Error: Error: getaddrinfo [A-Z_]+ invalidurl$/,
       );
       await playExpect(urlErrorMsg).toBeVisible({ timeout: 60_000 });
       await registryPage.cancelDialogButton.click();


### PR DESCRIPTION
### What does this PR do?

Pretty complicated scenario; when using a proxy with a custom certificate installed in the system, we cannot install an extension from the catalog.

The main problem is coming from the usage of the `got` library, which does not seems to be able to properly be configured with the system certificate when using a https proxy.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/18134

Fixes https://github.com/podman-desktop/podman-desktop/issues/18356

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

> You gonna have some fun :face_exhaling: 
> :warning: this is for Linux, I have no idea how to adapt this to other platform :)

1. Clone the testing repository I made

```
git clone https://github.com/axel7083/pd-squid-container
```

2. Generate the certificate
```
cd pd-squid-container && ./generate-certs.sh
```

3. Build the container
```bash
podman build -t localhost/squid:latest -f ./Containerfile .
```

4. Run the container
```
podman run -d -v ./pki/:/etc/pki/squid:z -p 3128:3128 -p 3129:3129 --name squid localhost/squid:latest
```

5. Try the proxy

```bash
curl --proxy https://localhost:3129 --proxy-cacert ./pki/rootCA.crt https://example.com
```

6. Move the certificate to system wide
```
sudo cp ./pki/rootCA.crt /etc/pki/ca-trust/source/anchors/squid-proxy-rootCA.crt
sudo update-ca-trust
```

7. Configure Podman Desktop to use the `https://localhost:3129` **https** proxy

<img width="1263" height="508" alt="Image" src="https://github.com/user-attachments/assets/dae4bbd9-33ce-4034-9fdf-936f4d855e96" />

8. **Restart Podman Desktop** for the proxy changes to take effect.

9. Check proxy accesses

```bash
podman exec squid tail -f /var/log/squid/access.log
```

10. Start Podman Desktop, navigate to the extension catalog
11. Try to pull any extension
12. Assert it works :tada: 

13. You can check the logs from step 9, you should have something like
```
[...]
1785328359.505   4295 2a01:cb1c:8297:ea00:251b:152:7dcc:9567 TCP_TUNNEL/200 7102 CONNECT pkg-containers.githubusercontent.com:443 - HIER_DIRECT/185.199.111.154 -
1785328359.738   4230 2a01:cb1c:8297:ea00:251b:152:7dcc:9567 TCP_TUNNEL/200 6608 CONNECT ghcr.io:443 - HIER_DIRECT/140.82.121.34 -
1785328359.951   4211 2a01:cb1c:8297:ea00:251b:152:7dcc:9567 TCP_TUNNEL/200 6518 CONNECT ghcr.io:443 - HIER_DIRECT/140.82.121.34 -
1785328360.301   4347 2a01:cb1c:8297:ea00:251b:152:7dcc:9567 TCP_TUNNEL/200 7125 CONNECT ghcr.io:443 - HIER_DIRECT/140.82.121.34 -
1785328360.573   4246 2a01:cb1c:8297:ea00:251b:152:7dcc:9567 TCP_TUNNEL/200 6946 CONNECT ghcr.io:443 - HIER_DIRECT/140.82.121.34 -
1785328361.392   4817 2a01:cb1c:8297:ea00:251b:152:7dcc:9567 TCP_TUNNEL/200 17409092 CONNECT pkg-containers.githubusercontent.com:443 - HIER_DIRECT/185.199.111.154 -

```
