### PR TITLE
refactor(docker): extract DockerDaemonMonitor from extension

### DIFF
--- a/extensions/docker/packages/extension/src/docker-daemon-monitor.spec.ts
+++ b/extensions/docker/packages/extension/src/docker-daemon-monitor.spec.ts
@@ -1,0 +1,191 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { EventEmitter } from 'node:events';
+import * as http from 'node:http';
+
+import type { ContainerProviderConnection, Disposable, ExtensionContext, Provider } from '@podman-desktop/api';
+import { provider as providerApi } from '@podman-desktop/api';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { UNIX_SOCKET_PATH } from './docker-api';
+import { getDockerInstallation } from './docker-cli';
+import { DockerDaemonMonitor } from './docker-daemon-monitor';
+
+vi.mock(import('node:http'));
+vi.mock(import('./docker-cli'));
+
+const connectionDisposable: Disposable = { dispose: vi.fn() };
+
+const fakeProvider: Provider = {
+  registerContainerProviderConnection: vi.fn().mockReturnValue(connectionDisposable),
+  updateStatus: vi.fn(),
+  updateVersion: vi.fn(),
+  status: 'ready',
+} as unknown as Provider;
+
+let extensionContext: ExtensionContext;
+let monitor: DockerDaemonMonitor;
+
+const originalConsoleDebug = console.debug;
+
+/**
+ * Mock node:http.get for socket-path pings (same EventEmitter approach as compose detect.spec).
+ * Pass status codes per path; omit a path to simulate a connection error.
+ */
+function mockHttpGet(statusByPath: Record<string, number>): void {
+  vi.mocked(http.get).mockImplementation(((options: unknown, callback?: (res: http.IncomingMessage) => void) => {
+    const path = (options as http.RequestOptions).path ?? '';
+    const request = new EventEmitter() as http.ClientRequest;
+
+    const statusCode = statusByPath[path];
+    if (statusCode === undefined) {
+      queueMicrotask(() => request.emit('error', new Error('connect error')));
+      return request;
+    }
+
+    const response = new EventEmitter() as http.IncomingMessage;
+    response.statusCode = statusCode;
+    callback?.(response);
+    response.emit('data', '');
+    response.emit('end');
+    return request;
+  }) as unknown as typeof http.get);
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  console.debug = vi.fn();
+
+  vi.mocked(getDockerInstallation).mockResolvedValue({ version: '24.0.0' });
+  vi.mocked(fakeProvider.registerContainerProviderConnection).mockReturnValue(connectionDisposable);
+  vi.mocked(providerApi.createProvider).mockReturnValue(fakeProvider);
+  Object.defineProperty(fakeProvider, 'status', { value: 'ready', configurable: true });
+
+  extensionContext = { subscriptions: [] } as unknown as ExtensionContext;
+  monitor = new DockerDaemonMonitor(extensionContext, UNIX_SOCKET_PATH);
+});
+
+afterEach(() => {
+  console.debug = originalConsoleDebug;
+});
+
+describe('updateProvider', () => {
+  test('registers a Docker connection when the daemon is alive and not Podman', async () => {
+    mockHttpGet({ '/_ping': 200 });
+
+    await monitor.updateProvider();
+
+    expect(providerApi.createProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Docker',
+        id: 'docker',
+      }),
+    );
+    expect(fakeProvider.registerContainerProviderConnection).toHaveBeenCalledTimes(1);
+    const connection = vi.mocked(fakeProvider.registerContainerProviderConnection).mock
+      .calls[0][0] as ContainerProviderConnection;
+    expect(connection.name).toBe('Docker');
+    expect(connection.type).toBe('docker');
+    expect(connection.endpoint.socketPath).toBe(UNIX_SOCKET_PATH);
+    expect(connection.status()).toBe('started');
+    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('started');
+    expect(extensionContext.subscriptions).toContain(fakeProvider);
+    expect(extensionContext.subscriptions).toContain(connectionDisposable);
+
+    // install/version updates run before provider creation on the first tick;
+    // a subsequent tick reports the Docker CLI version once the provider exists
+    await monitor.updateProvider();
+    expect(fakeProvider.updateVersion).toHaveBeenCalledWith('24.0.0');
+  });
+
+  test('does not register a connection when the socket answers as Podman', async () => {
+    mockHttpGet({ '/_ping': 200, '/libpod/_ping': 200 });
+
+    await monitor.updateProvider();
+
+    expect(providerApi.createProvider).not.toHaveBeenCalled();
+    expect(fakeProvider.registerContainerProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('does not register a connection when the daemon is unreachable', async () => {
+    mockHttpGet({});
+
+    await monitor.updateProvider();
+
+    expect(providerApi.createProvider).not.toHaveBeenCalled();
+    expect(fakeProvider.registerContainerProviderConnection).not.toHaveBeenCalled();
+  });
+
+  test('disposes the connection and marks the provider stopped when the daemon dies', async () => {
+    mockHttpGet({ '/_ping': 200 });
+    await monitor.updateProvider();
+
+    mockHttpGet({});
+    await monitor.updateProvider();
+
+    expect(connectionDisposable.dispose).toHaveBeenCalled();
+    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('stopped');
+  });
+
+  test('re-registers the connection when the daemon comes back after being stopped', async () => {
+    mockHttpGet({ '/_ping': 200 });
+    await monitor.updateProvider();
+
+    mockHttpGet({});
+    await monitor.updateProvider();
+
+    const secondDisposable = { dispose: vi.fn() };
+    vi.mocked(fakeProvider.registerContainerProviderConnection).mockReturnValue(secondDisposable);
+
+    mockHttpGet({ '/_ping': 200 });
+    await monitor.updateProvider();
+
+    expect(fakeProvider.registerContainerProviderConnection).toHaveBeenCalledTimes(2);
+    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('started');
+    expect(extensionContext.subscriptions).toContain(secondDisposable);
+  });
+
+  test('marks the provider not-installed when Docker CLI is missing', async () => {
+    mockHttpGet({ '/_ping': 200 });
+    await monitor.updateProvider();
+
+    vi.mocked(getDockerInstallation).mockResolvedValue(undefined);
+    await monitor.updateProvider();
+
+    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('not-installed');
+  });
+
+  test('updates provider status to installed when Docker appears after being not-installed', async () => {
+    mockHttpGet({ '/_ping': 200 });
+    await monitor.updateProvider();
+
+    Object.defineProperty(fakeProvider, 'status', { value: 'not-installed', configurable: true });
+    vi.mocked(getDockerInstallation).mockResolvedValue({ version: '25.0.0' });
+    await monitor.updateProvider();
+
+    expect(fakeProvider.updateVersion).toHaveBeenCalledWith('25.0.0');
+    expect(fakeProvider.updateStatus).toHaveBeenCalledWith('installed');
+  });
+});
+
+describe('stop', () => {
+  test('stops the monitoring loop', () => {
+    expect(() => monitor.stop()).not.toThrow();
+  });
+});

--- a/extensions/docker/packages/extension/src/docker-daemon-monitor.ts
+++ b/extensions/docker/packages/extension/src/docker-daemon-monitor.ts
@@ -1,0 +1,211 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as http from 'node:http';
+
+import * as extensionApi from '@podman-desktop/api';
+
+import { getDockerInstallation } from './docker-cli';
+
+/**
+ * Monitors the default Docker socket and registers a single ContainerProviderConnection
+ * while the daemon is reachable (and not a disguised Podman socket).
+ */
+export class DockerDaemonMonitor {
+  #extensionContext: extensionApi.ExtensionContext;
+  #socketPath: string;
+  #stopLoop = false;
+  #provider: extensionApi.Provider | undefined;
+  #providerState: extensionApi.ProviderConnectionStatus = 'stopped';
+  #containerProviderConnection: extensionApi.ContainerProviderConnection | undefined;
+  #containerProviderConnectionDisposable: extensionApi.Disposable | undefined;
+
+  constructor(extensionContext: extensionApi.ExtensionContext, socketPath: string) {
+    this.#extensionContext = extensionContext;
+    this.#socketPath = socketPath;
+  }
+
+  start(): void {
+    this.monitorDaemon().catch((err: unknown) => {
+      console.error('Error while monitoring docker daemon', err);
+      if (err instanceof Error) {
+        extensionApi.env.createTelemetryLogger().logError(err);
+      } else {
+        extensionApi.env.createTelemetryLogger().logError(String(err));
+      }
+    });
+  }
+
+  stop(): void {
+    this.#stopLoop = true;
+  }
+
+  async updateProvider(): Promise<void> {
+    try {
+      const installedDocker = await getDockerInstallation();
+      if (!installedDocker) {
+        this.#provider?.updateStatus('not-installed');
+      } else if (installedDocker.version) {
+        this.#provider?.updateVersion(installedDocker.version);
+        // update provider status if someone has installed docker externally
+        if (this.#provider?.status === 'not-installed') {
+          this.#provider.updateStatus('installed');
+        }
+      }
+    } catch (error) {
+      // ignore the update
+    }
+
+    // check if the daemon is alive
+    const isAlive = await this.isDockerDaemonAlive(this.#socketPath);
+
+    // alive
+    if (isAlive) {
+      // but was stopped before, needs to update the provider state
+      if (this.#providerState === 'stopped') {
+        // first we check that it's not podman behind
+        const isPodman = await this.isDisguisedPodman(this.#socketPath);
+        if (!isPodman) {
+          // if no provider, create one
+          if (!this.#provider) {
+            this.initProvider();
+          }
+          this.#providerState = 'started';
+          // register again the connection
+          if (this.#provider && this.#containerProviderConnection) {
+            this.#containerProviderConnectionDisposable = this.#provider.registerContainerProviderConnection(
+              this.#containerProviderConnection,
+            );
+            this.#extensionContext.subscriptions.push(this.#containerProviderConnectionDisposable);
+            this.#provider.updateStatus('started');
+          }
+        }
+      }
+    } else if (this.#providerState === 'started') {
+      // no longer alive but it was running before so we need to update status
+      // dispose the current connection
+      this.#containerProviderConnectionDisposable?.dispose();
+      this.#providerState = 'stopped';
+      this.#provider?.updateStatus('stopped');
+    }
+  }
+
+  protected initProvider(): void {
+    this.#provider = extensionApi.provider.createProvider({
+      name: 'Docker',
+      id: 'docker',
+      status: 'ready',
+      images: {
+        icon: './icon.png',
+        logo: './logo.png',
+      },
+    });
+
+    this.#containerProviderConnection = {
+      name: 'Docker',
+      type: 'docker',
+      status: (): extensionApi.ProviderConnectionStatus => this.#providerState,
+      endpoint: {
+        socketPath: this.#socketPath,
+      },
+    };
+
+    // provider is started
+    this.#providerState = 'started';
+    this.#extensionContext.subscriptions.push(this.#provider);
+  }
+
+  protected async isDockerDaemonAlive(socketPath: string): Promise<boolean> {
+    const pingUrl = {
+      path: '/_ping',
+      socketPath,
+    };
+
+    return new Promise<boolean>(resolve => {
+      const req = http.get(pingUrl, res => {
+        res.on('data', () => {
+          // do nothing
+        });
+
+        res.on('end', () => {
+          if (res.statusCode === 200) {
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        });
+      });
+
+      req.once('error', () => {
+        resolve(false);
+      });
+    });
+  }
+
+  protected async isDisguisedPodman(socketPath: string): Promise<boolean> {
+    const podmanPingUrl = {
+      path: '/libpod/_ping',
+      socketPath,
+    };
+    return new Promise<boolean>(resolve => {
+      const req = http.get(podmanPingUrl, res => {
+        res.on('data', () => {
+          // do nothing
+        });
+
+        res.on('end', () => {
+          if (res.statusCode === 200) {
+            resolve(true);
+          } else {
+            resolve(false);
+          }
+        });
+      });
+
+      req.once('error', err => {
+        console.debug('Error while pinging docker as podman', err);
+        resolve(false);
+      });
+    });
+  }
+
+  protected async timeout(time: number): Promise<void> {
+    return new Promise<void>(resolve => {
+      setTimeout(resolve, time);
+    });
+  }
+
+  protected async monitorDaemon(): Promise<void> {
+    if (!this.#stopLoop) {
+      try {
+        await this.updateProvider();
+      } catch (error) {
+        // ignore the update of machines
+      }
+      await this.timeout(5000);
+      this.monitorDaemon().catch((err: unknown) => {
+        console.error('Error while monitoring docker daemon', err);
+        if (err instanceof Error) {
+          extensionApi.env.createTelemetryLogger().logError(err);
+        } else {
+          extensionApi.env.createTelemetryLogger().logError(String(err));
+        }
+      });
+    }
+  }
+}

--- a/extensions/docker/packages/extension/src/extension.ts
+++ b/extensions/docker/packages/extension/src/extension.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2024 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,159 +16,21 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as http from 'node:http';
 import * as os from 'node:os';
 
-import * as extensionApi from '@podman-desktop/api';
+import type { ExtensionContext } from '@podman-desktop/api';
 import type { DockerExtensionApi } from '@podman-desktop/docker-extension-api';
 
 import { UNIX_SOCKET_PATH, WINDOWS_NPIPE } from './docker-api';
-import { getDockerInstallation } from './docker-cli';
 import { DockerCompatibilitySetup } from './docker-compatibility-setup';
 import { DockerConfig } from './docker-config';
 import { DockerContextHandler } from './docker-context-handler';
+import { DockerDaemonMonitor } from './docker-daemon-monitor';
 
-let stopLoop = false;
-let socketPath: string;
-let provider: extensionApi.Provider;
-let providerState: extensionApi.ProviderConnectionStatus = 'stopped';
-let containerProviderConnection: extensionApi.ContainerProviderConnection;
-let containerProviderConnectionDisposable: extensionApi.Disposable;
+let daemonMonitor: DockerDaemonMonitor | undefined;
 
-async function timeout(time: number): Promise<void> {
-  return new Promise<void>(resolve => {
-    setTimeout(resolve, time);
-  });
-}
-async function isDockerDaemonAlive(socketPath: string): Promise<boolean> {
-  const pingUrl = {
-    path: '/_ping',
-    socketPath,
-  };
-
-  return new Promise<boolean>(resolve => {
-    const req = http.get(pingUrl, res => {
-      res.on('data', () => {
-        // do nothing
-      });
-
-      res.on('end', () => {
-        if (res.statusCode === 200) {
-          resolve(true);
-        } else {
-          resolve(false);
-        }
-      });
-    });
-
-    req.once('error', () => {
-      resolve(false);
-    });
-  });
-}
-
-async function isDisguisedPodman(socketPath: string): Promise<boolean> {
-  const podmanPingUrl = {
-    path: '/libpod/_ping',
-    socketPath,
-  };
-  return new Promise<boolean>(resolve => {
-    const req = http.get(podmanPingUrl, res => {
-      res.on('data', () => {
-        // do nothing
-      });
-
-      res.on('end', () => {
-        if (res.statusCode === 200) {
-          resolve(true);
-        } else {
-          resolve(false);
-        }
-      });
-    });
-
-    req.once('error', err => {
-      console.debug('Error while pinging docker as podman', err);
-      resolve(false);
-    });
-  });
-}
-
-async function monitorDaemon(extensionContext: extensionApi.ExtensionContext): Promise<void> {
-  // call us again
-  if (!stopLoop) {
-    try {
-      await updateProvider(extensionContext);
-    } catch (error) {
-      // ignore the update of machines
-    }
-    await timeout(5000);
-    monitorDaemon(extensionContext).catch((err: unknown) => {
-      console.error('Error while monitoring docker daemon', err);
-      if (err instanceof Error) {
-        extensionApi.env.createTelemetryLogger().logError(err);
-      } else {
-        extensionApi.env.createTelemetryLogger().logError(String(err));
-      }
-    });
-  }
-}
-
-async function updateProvider(extensionContext: extensionApi.ExtensionContext): Promise<void> {
-  try {
-    const installedDocker = await getDockerInstallation();
-    if (!installedDocker) {
-      provider.updateStatus('not-installed');
-    } else if (installedDocker.version) {
-      provider.updateVersion(installedDocker.version);
-      // update provider status if someone has installed docker externally
-      if (provider.status === 'not-installed') {
-        provider.updateStatus('installed');
-      }
-    }
-  } catch (error) {
-    // ignore the update
-  }
-
-  // check if the daemon is alive
-  const isAlive = await isDockerDaemonAlive(socketPath);
-
-  // alive
-  if (isAlive) {
-    // but was stopped before, needs to update the provider state
-    if (providerState === 'stopped') {
-      // first we check that it's not podman behind
-      const isPodman = await isDisguisedPodman(socketPath);
-      if (!isPodman) {
-        // if no provider, create one
-        if (!provider) {
-          initProvider(extensionContext);
-        }
-        providerState = 'started';
-        // register again the connection
-        containerProviderConnectionDisposable =
-          provider.registerContainerProviderConnection(containerProviderConnection);
-        extensionContext.subscriptions.push(containerProviderConnectionDisposable);
-
-        provider.updateStatus('started');
-      }
-    }
-  } else if (providerState === 'started') {
-    // no longer alive but it was running before so we need to update status
-    // dispose the current connection
-    containerProviderConnectionDisposable?.dispose();
-    providerState = 'stopped';
-    provider.updateStatus('stopped');
-  }
-}
-
-export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<DockerExtensionApi> {
-  const isWindows = os.platform() === 'win32';
-  if (isWindows) {
-    socketPath = WINDOWS_NPIPE;
-  } else {
-    socketPath = UNIX_SOCKET_PATH;
-  }
+export async function activate(extensionContext: ExtensionContext): Promise<DockerExtensionApi> {
+  const socketPath = os.platform() === 'win32' ? WINDOWS_NPIPE : UNIX_SOCKET_PATH;
 
   const dockerConfig = new DockerConfig();
   const dockerContextHandler = new DockerContextHandler(dockerConfig);
@@ -177,47 +39,16 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
     console.error('Error while initializing docker compatibility setup', err);
   });
 
-  // monitor daemon
-  monitorDaemon(extensionContext).catch((err: unknown) => {
-    console.error('Error while monitoring docker daemon', err);
-    if (err instanceof Error) {
-      extensionApi.env.createTelemetryLogger().logError(err);
-    } else {
-      extensionApi.env.createTelemetryLogger().logError(String(err));
-    }
-  });
+  daemonMonitor = new DockerDaemonMonitor(extensionContext, socketPath);
+  daemonMonitor.start();
+
   return {
     createContext: dockerContextHandler.createContext.bind(dockerContextHandler),
     removeContext: dockerContextHandler.removeContext.bind(dockerContextHandler),
   };
 }
 
-function initProvider(extensionContext: extensionApi.ExtensionContext): void {
-  provider = extensionApi.provider.createProvider({
-    name: 'Docker',
-    id: 'docker',
-    status: 'ready',
-    images: {
-      icon: './icon.png',
-      logo: './logo.png',
-    },
-  });
-
-  containerProviderConnection = {
-    name: 'Docker',
-    type: 'docker',
-    status: (): extensionApi.ProviderConnectionStatus => providerState,
-    endpoint: {
-      socketPath,
-    },
-  };
-
-  // provider is started
-  providerState = 'started';
-  extensionContext.subscriptions.push(provider);
-}
-
 export function deactivate(): void {
-  stopLoop = true;
+  daemonMonitor?.stop();
   console.log('stopping docker extension');
 }


### PR DESCRIPTION
### What does this PR do?
Move single-socket daemon monitoring into a dedicated class so multi-context registration can land as a focused follow-up.

### Screenshot / video of UI

### What issues does this PR fix or reference?
Required for https://github.com/podman-desktop/podman-desktop/pull/18220

### How to test this PR?


- [x] Tests are covering the bug fix or the new feature
