### PR TITLE
fix(main): properly dispose Inversify container on application quit with async support

### DIFF
--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -125,6 +125,18 @@ class TestPluginSystem extends PluginSystem {
   setQuitting(value: boolean): void {
     this.isQuitting = value;
   }
+
+  setContainer(container?: InversifyContainer): void {
+    this.container = container;
+  }
+}
+
+type Listener = (...args: unknown[]) => void;
+
+function getElectronAppListener(event: string): Listener {
+  const callback = vi.mocked(app.on).mock.calls.find(([mEvent]) => mEvent === event)?.[1];
+  assert(callback, `cannot find listener for event ${event}`);
+  return callback;
 }
 
 let inversifyContainer: InversifyContainer;
@@ -1259,5 +1271,67 @@ describe('container-provider-registry:playKube', () => {
     const createdTask = vi.mocked(TaskManager.prototype.createTask).mock.results[0]?.value;
     expect(createdTask.status).toBe('failure');
     expect(createdTask.error).toBe('Error: Dummy Foo');
+  });
+});
+
+describe('before-quit container disposal', () => {
+  test('should call unbindAllAsync and app.quit when before-quit is emitted with a container', async () => {
+    const unbindAllAsyncMock = vi.fn().mockResolvedValue(undefined);
+    const mockContainer = { unbindAllAsync: unbindAllAsyncMock } as unknown as InversifyContainer;
+    pluginSystem.setContainer(mockContainer);
+    pluginSystem.setQuitting(false);
+
+    const listener = getElectronAppListener('before-quit');
+    const event = { preventDefault: vi.fn() };
+    listener(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(app.quit).toHaveBeenCalled();
+    });
+    expect(unbindAllAsyncMock).toHaveBeenCalled();
+  });
+
+  test('should log error and still call app.quit if unbindAllAsync throws', async () => {
+    const error = new Error('dispose error');
+    const unbindAllAsyncMock = vi.fn().mockRejectedValue(error);
+    const mockContainer = { unbindAllAsync: unbindAllAsyncMock } as unknown as InversifyContainer;
+    pluginSystem.setContainer(mockContainer);
+    pluginSystem.setQuitting(false);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const listener = getElectronAppListener('before-quit');
+    const event = { preventDefault: vi.fn() };
+    listener(event);
+
+    await vi.waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith('[PluginSystem] error disposing container:', error);
+    });
+    expect(app.quit).toHaveBeenCalled();
+  });
+
+  test('should not call preventDefault when container is undefined', () => {
+    pluginSystem.setContainer();
+    pluginSystem.setQuitting(false);
+
+    const listener = getElectronAppListener('before-quit');
+    const event = { preventDefault: vi.fn() };
+    listener(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test('should skip disposal on re-entrant before-quit call', () => {
+    const unbindAllAsyncMock = vi.fn().mockResolvedValue(undefined);
+    const mockContainer = { unbindAllAsync: unbindAllAsyncMock } as unknown as InversifyContainer;
+    pluginSystem.setContainer(mockContainer);
+    pluginSystem.setQuitting(true);
+
+    const listener = getElectronAppListener('before-quit');
+    const event = { preventDefault: vi.fn() };
+    listener(event);
+
+    expect(unbindAllAsyncMock).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
   });
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -287,13 +287,21 @@ export class PluginSystem {
   // The yet to be init ExtensionLoader
   private extensionLoader!: ExtensionLoader;
   private validExtList!: ExtensionInfo[];
+  protected container?: Container;
 
   constructor(
     private trayMenu: TrayMenu,
     private mainWindowDeferred: PromiseWithResolvers<BrowserWindow>,
   ) {
-    app.on('before-quit', () => {
+    app.on('before-quit', event => {
+      if (this.isQuitting) return;
       this.isQuitting = true;
+      if (!this.container) return;
+      event.preventDefault();
+      this.container
+        .unbindAllAsync()
+        .catch((err: unknown) => console.error('[PluginSystem] error disposing container:', err))
+        .finally(() => app.quit());
     });
   }
 
@@ -515,7 +523,8 @@ export class PluginSystem {
 
     // init api sender
     const apiSender = this.getApiSender(this.getWebContentsSender());
-    const container = new Container();
+    this.container = new Container();
+    const container = this.container;
     container.bind<ApiSenderType>(ApiSenderType).toConstantValue(apiSender);
     container.bind<IPCHandle>(IPCHandle).toConstantValue(this.ipcHandle);
     container.bind<IPCMainOn>(IPCMainOn).toConstantValue(this.ipcMainOn);


### PR DESCRIPTION
### What does this PR do?

When the application quits, the Inversify container is never properly disposed. Services relying on `@preDestroy` lifecycle hooks (e.g., `ExtensionLoader`, `TempFileService`) are not called, which can leave resources like gateways, connections, or temp files open during shutdown.

This fix:
- Stores the Inversify container as a class field on `PluginSystem`
- Uses `event.preventDefault()` in the `before-quit` handler to pause Electron's quit flow
- Calls `container.unbindAllAsync()` to properly await async `@preDestroy` hooks
- Re-calls `app.quit()` in `.finally()` after disposal completes
- Uses a re-entrancy guard (`isQuitting`) to prevent infinite loops since the second `app.quit()` re-fires `before-quit`

### Screenshot / video of UI

No UI changes.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18153

Supersedes https://github.com/podman-desktop/podman-desktop/pull/18154 (closed), addressing the review feedback about handling async `@preDestroy` hooks within Electron's synchronous `before-quit` callback.

### How to test this PR?

1. Add a `@preDestroy` method with a log statement to any Inversify-managed service
2. Quit the application
3. Verify the `@preDestroy` method is called (log appears)

- [x] Tests are covering the bug fix or the new feature