### PR TITLE
fix(website): use shell-session language for code blocks with prompts

### DIFF
--- a/website/blog/2024-08-08-release-1.12.md
+++ b/website/blog/2024-08-08-release-1.12.md
@@ -50,7 +50,7 @@ This seamless setup can be enabled during Podman Machine creation by selecting t
 
 After enablement, you can test that the GPU has been supported by running a custom container with `--device /dev/dri` passed through:
 
-```sh
+```shell-session
 $ podman run --rm -it --device /dev/dri --name gpu-info quay.io/slopezpa/fedora-vgpu vulkaninfo | grep "GPU"
 ```
 

--- a/website/blog/2024-11-08-bootc-microshift.md
+++ b/website/blog/2024-11-08-bootc-microshift.md
@@ -61,7 +61,7 @@ We will be using the Containerfile from the [MicroShift image mode GitHub docume
 
 Copy the Containerfile from the above link to a new file which we will be building with Podman Desktop:
 
-```sh
+```shell-session
 $ curl https://raw.githubusercontent.com/openshift/microshift/main/docs/config/Containerfile.bootc-rhel9 -o Containerfile
 ```
 
@@ -121,19 +121,19 @@ When using Hyper-V, create a `.vhd` image with BootC:
 
 2. Install QEMU:
 
-```sh
+```shell-session
 $ brew install qemu
 ```
 
 3. Navigate to the directory containing your `disk.raw` file:
 
-```sh
+```shell-session
 $ cd ~/output
 ```
 
 4. Run the `qemu` command:
 
-```sh
+```shell-session
 $  qemu-system-aarch64 \
     -m 8G \
     -M virt \
@@ -152,7 +152,7 @@ $  qemu-system-aarch64 \
 
 With the above `qemu` command, a port has now been opened locally at :2222 to SSH forward to the bootable image. You can now access your virtual machine by doing the following:
 
-```sh
+```shell-session
 $ ssh redhat@localhost -p 2222
 ```
 
@@ -165,13 +165,13 @@ $ ssh redhat@localhost -p 2222
 
 3. Navigate to the directory containing your `disk.raw` file:
 
-```sh
+```shell-session
 $ cd ~/output
 ```
 
 4. Run the `qemu` command:
 
-```sh
+```shell-session
 $ qemu-system-x86_64 \
     -m 8G \
     -cpu Broadwell-v4 \
@@ -185,7 +185,7 @@ $ qemu-system-x86_64 \
 
 With the above `qemu` command, a port has now been opened locally at :2222 to SSH forward to the bootable image. You can now access your virtual machine by doing the following:
 
-```sh
+```shell-session
 $ ssh redhat@localhost -p 2222
 ```
 
@@ -206,25 +206,25 @@ Below we will copy the OpenShift secret you had previously downloaded to the vir
 
 2. Use `scp` to copy over to the virtual machine:
 
-```sh
+```shell-session
 $ scp -P 2222 pull-secret.txt redhat@localhost:~/
 ```
 
 3. SSH into the VM:
 
-```sh
+```shell-session
 $ ssh redhat@localhost -p 2222
 ```
 
 4. Move the secret to `/etc/crio/openshift-pull-secret`:
 
-```sh
+```shell-session
 $ sudo mv pull-secret.txt /etc/crio/openshift-pull-secret
 ```
 
 5. Restart the `microshift` service:
 
-```sh
+```shell-session
 $ sudo systemctl restart microshift
 ```
 
@@ -234,13 +234,13 @@ Below we will SSH into the virtual machine and confirm that MicroShift is deploy
 
 1. SSH into the VM:
 
-```sh
+```shell-session
 $ ssh redhat@localhost -p 2222
 ```
 
 2. Copy the generated `kubeconfig` file to `~/.kube/config`:
 
-```sh
+```shell-session
 $ mkdir -p ~/.kube
 $ sudo cp /var/lib/microshift/resources/kubeadmin/kubeconfig ~/.kube/config
 $ sudo chown redhat ~/.kube/config
@@ -248,7 +248,7 @@ $ sudo chown redhat ~/.kube/config
 
 3. Verify Pods are running by using `oc` or `kubectl`:
 
-```sh
+```shell-session
 $ kubectl get pods -A
 NAMESPACE                  NAME                                       READY   STATUS    RESTARTS   AGE
 kube-system                csi-snapshot-controller-856bb8b9bc-9n7lj   1/1     Running   1          3d23h
@@ -267,7 +267,7 @@ Alternatively, you can copy the MicroShift configuration file to your local mach
 
 1. On your local machine, create the `.kube` directory if it does not exist already:
 
-```sh
+```shell-session
 $ mkdir ~/.kube
 ```
 

--- a/website/blog/2025-03-06-mirror-registry-configuration-blog.md
+++ b/website/blog/2025-03-06-mirror-registry-configuration-blog.md
@@ -42,13 +42,13 @@ There is no direct way to verify the mirror configuration from the UI. But, you 
 
 1. Start an interactive session with the default Podman machine:
 
-```sh
+```shell-session
 $ podman machine ssh <machine_name>
 ```
 
 2. Pull an invalid image from `docker.io`.
 
-```sh
+```shell-session
 $ podman pull docker.io/invalid
 ```
 

--- a/website/blog/2025-08-25-podman-desktop-availability-on-rhel10.md
+++ b/website/blog/2025-08-25-podman-desktop-availability-on-rhel10.md
@@ -53,13 +53,13 @@ The installation and verification procedure includes:
 
 1. Open a terminal, and enable the RHEL extensions repository:
 
-   ```sh
+   ```shell-session
    $ sudo subscription-manager repos --enable rhel-10-for-$(arch)-extensions-rpms
    ```
 
 1. Enter your password when prompted.
 1. Install Podman Desktop:
-   ```sh
+   ```shell-session
    $ sudo dnf install podman-desktop
    ```
 1. Enter `y` to confirm the installed size.

--- a/website/docs/installation/linux-install/install-on-rhel10.md
+++ b/website/docs/installation/linux-install/install-on-rhel10.md
@@ -19,13 +19,13 @@ You can use the subscription manager package to install Podman Desktop on a Red 
 
 1. Open a terminal, and enable the RHEL extensions repository:
 
-   ```sh
+   ```shell-session
    $ sudo subscription-manager repos --enable rhel-10-for-$(arch)-extensions-rpms
    ```
 
 1. Enter your password when prompted.
 1. Install Podman Desktop:
-   ```sh
+   ```shell-session
    $ sudo dnf install podman-desktop
    ```
 1. Enter `y` to confirm the installed size.

--- a/website/docs/podman/adding-certificates-to-a-podman-machine.md
+++ b/website/docs/podman/adding-certificates-to-a-podman-machine.md
@@ -28,19 +28,19 @@ On Windows, the Podman commands use the CAs from the certificate store. For exam
 
 1. Start an interactive session with the default Podman machine:
 
-```sh
+```shell-session
 $ podman machine ssh <machine_name>
 ```
 
 2. Optional: Switch to a root shell only if Podman runs in the default rootless mode:
 
-```sh
+```shell-session
 $ sudo su -
 ```
 
 3. Change to the directory where the certificates must be placed:
 
-```sh
+```shell-session
 $ cd /etc/pki/ca-trust/source/anchors
 ```
 
@@ -48,7 +48,7 @@ $ cd /etc/pki/ca-trust/source/anchors
 
 - Use the `curl` command to download a certificate:
 
-  ```sh
+  ```shell-session
   $ curl [-k] -o <my-certificate> https://<my-server.com/my-certificate>
   ```
 
@@ -62,13 +62,13 @@ $ cd /etc/pki/ca-trust/source/anchors
 
 5. Add the certificate to the list of trusted certificates:
 
-```sh
+```shell-session
 $ update-ca-trust
 ```
 
 6. Optional: Run the `exit` command to exit the root shell.
 
-```sh
+```shell-session
 $ exit
 ```
 
@@ -76,7 +76,7 @@ $ exit
 
 8. Optional: Reboot the Podman machine.
 
-```sh
+```shell-session
 $ podman machine stop <machine_name>
 $ podman machine start <machine_name>
 ```

--- a/website/docs/podman/gpu.md
+++ b/website/docs/podman/gpu.md
@@ -35,13 +35,13 @@ This can be installed by following the [official NVIDIA guide](https://docs.nvid
 
 SSH into the Podman Machine:
 
-```sh
+```shell-session
 $ podman machine ssh
 ```
 
 Run the following commands **on the Podman Machine, not the host system**:
 
-```sh
+```shell-session
 $ curl -s -L https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | \
  tee /etc/yum.repos.d/nvidia-container-toolkit.repo && \
  yum install -y nvidia-container-toolkit && \
@@ -61,13 +61,13 @@ To verify that containers created can access the GPU, you can use `nvidia-smi` f
 
 Run the following official NVIDIA container on your host machine:
 
-```sh
+```shell-session
 $ podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
 ```
 
 Example output:
 
-```sh
+```shell-session
 PS C:\Users\admin>  podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
 Fri Aug 16 18:58:14 2024
 +---------------------------------------------------------------------------------------+
@@ -160,13 +160,13 @@ RUN dnf -y install dnf-plugins-core && \
 
 3. Verify you can see the GPU by running a test container:
 
-```sh
+```shell-session
 $  podman run --rm -it --device /dev/dri --name gpu-info <gpu-container-image>  vulkaninfo | grep "GPU"
 ```
 
 Example output:
 
-```sh
+```shell-session
 $  podman run --rm -it --device /dev/dri --name gpu-info quay.io/slopezpa/fedora-vgpu vulkaninfo | grep "GPU"
   GPU id = 0 (Virtio-GPU Venus (Apple M1 Pro))
   GPU id = 1 (llvmpipe (LLVM 17.0.6, 128 bits))
@@ -202,13 +202,13 @@ Important note that the virtualized GPU (Virtio-GPU Venus (Apple M1 Pro)) only s
 
    Generate the CDI file:
 
-   ```sh
+   ```shell-session
    $ nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
    ```
 
    Check the list of generated devices:
 
-   ```sh
+   ```shell-session
    $ nvidia-ctk cdi list
    ```
 
@@ -220,14 +220,14 @@ Important note that the virtualized GPU (Virtio-GPU Venus (Apple M1 Pro)) only s
 
    Check whether SELinux is installed and enabled:
 
-   ```sh
+   ```shell-session
    $ getenforce
    ```
 
    - If `getenforce` is not found or its output is `Permissive` or `Disabled`, no action is needed.
    - If the output is `Enforcing`, configure SELinux to enable device access for containers:
 
-     ```sh
+     ```shell-session
      $ sudo setsebool -P container_use_devices true
      ```
 
@@ -237,7 +237,7 @@ To verify that containers created can access the GPU, you can use `nvidia-smi` f
 
 Run the following official NVIDIA container on your host machine:
 
-```sh
+```shell-session
 $ podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
 ```
 

--- a/website/docs/podman/gpu.md
+++ b/website/docs/podman/gpu.md
@@ -67,7 +67,7 @@ $ podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.0
 
 Example output:
 
-```shell-session
+```sh
 PS C:\Users\admin>  podman run --rm --device nvidia.com/gpu=all nvidia/cuda:11.0.3-base-ubuntu20.04 nvidia-smi
 Fri Aug 16 18:58:14 2024
 +---------------------------------------------------------------------------------------+

--- a/website/docs/podman/podman-remote.md
+++ b/website/docs/podman/podman-remote.md
@@ -35,7 +35,7 @@ If you have not added a remote podman connection yet, you can follow the [offici
 
 1. Generate a local ed25519 key:
 
-```sh
+```shell-session
 $ ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519
 ```
 
@@ -47,7 +47,7 @@ Your public SSH key needs to be copied to the `~/.ssh/authorized_keys` file on t
 
 <TabItem value="win" label="Windows">
 
-```sh
+```shell-session
 $ type ~\.ssh\id_ed25519.pub | ssh user@my-server-ip "cat >> .ssh/authorized_keys"
 ```
 
@@ -55,7 +55,7 @@ $ type ~\.ssh\id_ed25519.pub | ssh user@my-server-ip "cat >> .ssh/authorized_key
 
 <TabItem value="linux-macos" label="Linux & MacOS">
 
-```sh
+```shell-session
 $ ssh-copy-id -i ~/.ssh/id_ed25519.pub user@my-server-ip
 ```
 
@@ -66,14 +66,14 @@ $ ssh-copy-id -i ~/.ssh/id_ed25519.pub user@my-server-ip
 
 By default, the podman.socket is **disabled** in Podman installations. Enabling the systemd socket allows remote clients to control Podman.
 
-```sh
+```shell-session
 $ systemctl enable podman.socket
 $ systemctl start podman.socket
 ```
 
 Confirm that the socket is enabled by checking the status:
 
-```sh
+```shell-session
 $ systemctl status --user podman.socket
 ```
 
@@ -83,21 +83,21 @@ It's important to know which socket path you are using, as this varies between r
 
 Use `podman info` to determine the correct socket path:
 
-```sh
+```shell-session
 $ ssh user@my-server-ip podman info | grep sock
    path: /run/user/1000/podman/podman.sock
 ```
 
 If you are using root, it may appear as:
 
-```sh
+```shell-session
 $ ssh root@my-server-ip podman info | grep sock
    path: /run/podman/podman.sock
 ```
 
 Now you are ready to add the connection. Add it with a distinct name to the Podman system connection list:
 
-```sh
+```shell-session
 # non-root
 $ podman system connection add my-remote-machine --identity ~/.ssh/id_ed25519 ssh://myuser@my-server-ip/run/user/1000/podman/podman.sock
 
@@ -119,7 +119,7 @@ On Windows, you need to use an absolute path for the identities; a path with ~ w
 
 1. Run a helloworld container on the remote machine:
 
-```sh
+```shell-session
 $ ssh user@my-server-ip podman run -d quay.io/podman/hello
 ```
 
@@ -129,13 +129,13 @@ $ ssh user@my-server-ip podman run -d quay.io/podman/hello
 
 1. Set your remote connection as the default:
 
-```sh
+```shell-session
 $ podman system connection default my-remote-machine
 ```
 
 2. Verify that the container appears in the CLI:
 
-```sh
+```shell-session
 $ podman ps
 ```
 

--- a/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
@@ -12,7 +12,7 @@ description: How to investigate when Podman does not work as expected.
 
 When setting a custom binary path (under Preferences -> Custom binary path), Podman is unable to find `gvproxy` and `podman-mac-helper`:
 
-```sh
+```shell-session
 Error: unable to start host networking: "could not find \"gvproxy\" in one of [/usr/local/opt/podman/libexec /opt/homebrew/bin /opt/homebrew/opt/podman/libexec /usr/local/bin /usr/local/libexec/podman /usr/local/lib/podman /usr/libexec/podman /usr/lib/podman $BINDIR/../libexec/podman].  To resolve this error, set the helper_binaries_dir key in the `[engine]` section of containers.conf to the directory containing your helper binaries."
 ```
 
@@ -22,7 +22,7 @@ Error: unable to start host networking: "could not find \"gvproxy\" in one of [/
 2. Build the `podman-mac-helper` from the source code on the [Podman GitHub page](https://github.com/podman-container-tools/podman/tree/main/cmd/podman-mac-helper).
 3. Add the `helper_binaries_dir` entry to `~/.config/containers/containers.conf`:
 
-```sh
+```shell-session
 [containers]
 
 helper_binaries_dir=["/Users/user/example_directory"]
@@ -46,7 +46,7 @@ The Podman Installer and Homebrew use different locations to store the Podman En
 
 To check where exactly is your Podman Engine installed, run the command-
 
-```sh
+```shell-session
 which podman
 ```
 
@@ -54,13 +54,13 @@ This returns the path where the Podman Engine would be installed. This would hel
 
 For example, if you’re looking to completely uninstall Podman Engine from your system for a fresh installation, running `which podman` returns the exact path where Podman still exists. This could be the path where Podman Installer stores Podman Engine, such as `/opt/podman`. Once you know the path, run:
 
-```sh
+```shell-session
 sudo rm -rf /opt/podman
 ```
 
 Or
 
-```sh
+```shell-session
 sudo rm -rf path-where-podman-exists
 ```
 
@@ -281,7 +281,7 @@ With Podman Desktop 1.16, the log files are automatically cleaned at the restart
 
 Check the size of the Podman Desktop log files to troubleshoot:
 
-```sh
+```shell-session
 $ ls -la ~/Library/Logs/Podman\ Desktop/*.log
 ```
 
@@ -304,7 +304,7 @@ When you use Homebrew to upgrade to the latest version of Podman Desktop, you mi
 
 To resolve the error, use the `--greedy` flag with the `upgrade` command:
 
-```sh
+```shell-session
 $ brew upgrade --greedy podman-desktop
 ```
 

--- a/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
+++ b/website/docs/troubleshooting/troubleshooting-podman-on-macos.md
@@ -12,7 +12,7 @@ description: How to investigate when Podman does not work as expected.
 
 When setting a custom binary path (under Preferences -> Custom binary path), Podman is unable to find `gvproxy` and `podman-mac-helper`:
 
-```shell-session
+```sh
 Error: unable to start host networking: "could not find \"gvproxy\" in one of [/usr/local/opt/podman/libexec /opt/homebrew/bin /opt/homebrew/opt/podman/libexec /usr/local/bin /usr/local/libexec/podman /usr/local/lib/podman /usr/libexec/podman /usr/lib/podman $BINDIR/../libexec/podman].  To resolve this error, set the helper_binaries_dir key in the `[engine]` section of containers.conf to the directory containing your helper binaries."
 ```
 
@@ -22,7 +22,7 @@ Error: unable to start host networking: "could not find \"gvproxy\" in one of [/
 2. Build the `podman-mac-helper` from the source code on the [Podman GitHub page](https://github.com/podman-container-tools/podman/tree/main/cmd/podman-mac-helper).
 3. Add the `helper_binaries_dir` entry to `~/.config/containers/containers.conf`:
 
-```shell-session
+```sh
 [containers]
 
 helper_binaries_dir=["/Users/user/example_directory"]
@@ -46,7 +46,7 @@ The Podman Installer and Homebrew use different locations to store the Podman En
 
 To check where exactly is your Podman Engine installed, run the command-
 
-```shell-session
+```sh
 which podman
 ```
 
@@ -54,13 +54,13 @@ This returns the path where the Podman Engine would be installed. This would hel
 
 For example, if you’re looking to completely uninstall Podman Engine from your system for a fresh installation, running `which podman` returns the exact path where Podman still exists. This could be the path where Podman Installer stores Podman Engine, such as `/opt/podman`. Once you know the path, run:
 
-```shell-session
+```sh
 sudo rm -rf /opt/podman
 ```
 
 Or
 
-```shell-session
+```sh
 sudo rm -rf path-where-podman-exists
 ```
 

--- a/website/docs/uninstall/index.md
+++ b/website/docs/uninstall/index.md
@@ -36,7 +36,7 @@ Uninstalling Podman Desktop does not automatically remove the created Kubernetes
 You can delete all pods, containers, and images by removing the Podman machine.
 
 1. Remove all Podman machines:
-   ```sh
+   ```shell-session
    $ podman machine reset -f
    ```
 1. Uninstall Podman from the Start menu, Settings, or Control Panel. For more details, see the [resource](https://support.microsoft.com/en-us/windows/uninstall-or-remove-apps-and-programs-in-windows-4b55f974-2cc6-2d2b-d092-5905080eaf98).
@@ -51,27 +51,27 @@ You can delete all pods, containers, and images by removing the Podman machine.
 <TabItem value="macOS" label="macOS" className="markdown">
 
 1. Remove all Podman machines:
-   ```sh
+   ```shell-session
    $ podman machine reset -f
    ```
 1. Perform one of the following steps based on your installation:
    - If you have installed Podman using `brew`, run the following command:
-     ```sh
+     ```shell-session
      $ brew uninstall podman
      ```
    - If you have installed Podman using the Podman Desktop setup, run the following commands one by one:
-     ```sh
+     ```shell-session
      $ sudo /opt/podman/bin/podman-mac-helper uninstall
      $ sudo rm /etc/paths.d/podman-pkg
      $ sudo rm -rfv /opt/podman
      ```
 1. Remove the Podman files and configurations:
-   ```sh
+   ```shell-session
    $ rm -rf ~/.local/share/containers/podman
    $ rm -rf ~/.config/containers/podman
    ```
 1. Optional: Delete storage configuration:
-   ```sh
+   ```shell-session
    $ rm -rf ~/.local/share/containers/storage
    ```
 
@@ -145,7 +145,7 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
 
 1. Perform one of the following steps based on your installation:
    - If you have installed Podman Desktop using `brew`, run the following command:
-     ```sh
+     ```shell-session
      $ brew uninstall podman-desktop
      ```
    - If you have installed Podman Desktop using the `.dmg` file, perform the following steps:
@@ -153,7 +153,7 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
      1. Drag the Podman Desktop icon and drop it to the trash folder.
 
 1. Remove the Podman Desktop configuration files:
-   ```sh
+   ```shell-session
    $ rm -rf ~/.local/share/containers/podman-desktop
    ```
 
@@ -162,12 +162,12 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
 
 1. Uninstall Podman Desktop using flatpak or flathub:
 
-   ```sh
+   ```shell-session
    $ flatpak uninstall io.podman_desktop.PodmanDesktop
    ```
 
 1. Remove the Podman Desktop configuration folder:
-   ```sh
+   ```shell-session
    $ rm -rf ~/.local/share/containers/podman-desktop
    ```
 


### PR DESCRIPTION
### What does this PR do?
Replaces ``sh`` for ``shell-session`` language, so Prism can correctly detect prompt symbols.

If there is prompt symbol like ``$``, ``#`` or ``%`` used in code block, it should be defined as ``shell-session`` language.
Languages ``sh``/``bash``/``shell`` are script grammars - they treat ``$`` as a variable sigil (e.g. ``$HOME``) and there is no concept of a prompt.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18253