### PR TITLE
chore(ci): add unit-tests flag to codecov uploads

### DIFF
--- a/.github/workflows/codecov-next.yaml
+++ b/.github/workflows/codecov-next.yaml
@@ -55,3 +55,4 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -307,6 +307,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit-tests
 
   smoke-e2e-tests:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci') || !github.event.pull_request.draft }}


### PR DESCRIPTION
### What does this PR do?

Add `flags: unit-tests` to codecov uploads in `pr-check.yaml` and `codecov-next.yaml` so codecov can track unit test coverage separately, as required for the CodeCov Dashboard.

### Screenshot / video of UI

N/A
CI-only change, no UI impact.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18530

### How to test this PR?

1. Verify CI workflows run successfully
2. Confirm codecov reports show the `unit-tests` flag on the uploaded coverage

- [x] Tests are covering the bug fix or the new feature