### PR TITLE
fix(website): strip shell promp prefixes from all lines when copying code blocks

### DIFF
--- a/website/src/theme/CodeBlock/Buttons/CopyButton/stripPrompts.js
+++ b/website/src/theme/CodeBlock/Buttons/CopyButton/stripPrompts.js
@@ -16,13 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-// Strips a leading shell prompt prefix ('$ ', '# ', '> ') from code
+const PROMPT_RE = /^(?:\$ |# |> )/gm;
+
+// Strips a leading shell prompt prefix ('$ ', '# ', '> ') from each start of line of the given commands
 export function stripPrompts(code) {
-  if (
-    code?.length > 2 &&
-    (code.substring(0, 2) === '$ ' || code.substring(0, 2) === '# ' || code.substring(0, 2) === '> ')
-  ) {
-    return code.substring(2);
-  }
-  return code;
+  return code.replace(PROMPT_RE, '');
 }

--- a/website/src/theme/CodeBlock/Buttons/CopyButton/stripPrompts.spec.js
+++ b/website/src/theme/CodeBlock/Buttons/CopyButton/stripPrompts.spec.js
@@ -41,11 +41,22 @@ describe('stripPrompts', () => {
     expect(stripPrompts('')).toBe('');
   });
 
-  test('handles undefined', () => {
-    expect(stripPrompts(undefined)).toBe(undefined);
-  });
-
   test('only strips prompts at the start of a line', () => {
     expect(stripPrompts('echo "$ hello"')).toBe('echo "$ hello"');
+  });
+
+  test('strips $ prompt from each line in a multi-line block', () => {
+    const input = '$ podman pull nginx\n$ podman run -d nginx';
+    expect(stripPrompts(input)).toBe('podman pull nginx\npodman run -d nginx');
+  });
+
+  test('strips mixed prompt types across lines', () => {
+    const input = '$ echo hello\n# echo world\n> echo test';
+    expect(stripPrompts(input)).toBe('echo hello\necho world\necho test');
+  });
+
+  test('handles mixed lines with and without prompts', () => {
+    const input = '$ podman pull nginx\nnginx:latest pulled\n$ podman run nginx';
+    expect(stripPrompts(input)).toBe('podman pull nginx\nnginx:latest pulled\npodman run nginx');
   });
 });


### PR DESCRIPTION
### What does this PR do?
Fixes implementation of stripPrompts() function to remove prompt symbols from **all lines**, not just the first one. 

Added more unit tests to also account for the multiline prompts.

### Screenshot / video of UI

https://github.com/user-attachments/assets/dae40e62-17ed-44f5-b4ea-d92a70c0cea5

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/18253

### How to test this PR?

Try the copy button that is there on right for each code block to copy single line prompts and also multiline ones, both should be copied without prompt symbol e.g. ``$ `` on start of each line.

- [X] Tests are covering the bug fix or the new feature
