### PR TITLE
feat(website): omit prompt symbols when manually copying commands from shell-session blocks

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -264,3 +264,8 @@ article .markdown ol ol {
 .navbar__items--right > *:nth-child(4) {
   order: 3;
 }
+
+/* Prevent shell prompt symbols from being included when manually selecting code from shell-session block */
+.token.shell-symbol {
+  user-select: none;
+}


### PR DESCRIPTION
### What does this PR do?
Makes shell symbols unselectable in shell-session blocks*, so when user copies command from shell-session block manually, it will automatically omit the shell symbols. 

If the shell symbols  (e.g. ``$``) would not be omitted after copying and running these commands in the terminal, it would end up in ``command not found`` error. This change makes it easier to manually copy and use commands from docs/blogs.

*Prism only tokenizes shell symbols in shell-session blocks.

### Screenshot / video of UI

https://github.com/user-attachments/assets/330bdd85-58cc-4c48-8320-a2c94287f4f8

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/18253

### How to test this PR?
See video as example. Find a shell-session code block and try to manually select and copy the command.