### PR TITLE
fix(podman): support spaces in registry configuration paths

### DIFF
--- a/extensions/podman/packages/extension/src/configuration/playbook-setup-registry-conf-file.mustache
+++ b/extensions/podman/packages/extension/src/configuration/playbook-setup-registry-conf-file.mustache
@@ -4,4 +4,7 @@
   become: true
   tasks:
     - name: Create symbolic link with sudo from the host
-      command: sudo ln -s {{{configurationFileInsideVmPath}}} /etc/containers/registries.conf.d/{{{configurationFileName}}}
+      ansible.builtin.file:
+        src: "{{{configurationFileInsideVmPath}}}"
+        dest: "/etc/containers/registries.conf.d/{{{configurationFileName}}}"
+        state: link

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
@@ -98,7 +98,9 @@ describe('getPlaybookScriptPath', () => {
     vi.mocked(env).isMac = true;
 
     // mock the config path being usually computed
-    vi.spyOn(registryConfiguration, 'getPathToRegistriesConfInsideVM').mockReturnValue('/fake/path/inside/vm');
+    vi.spyOn(registryConfiguration, 'getPathToRegistriesConfInsideVM').mockReturnValue(
+      '/fake/path with spaces/inside/vm',
+    );
 
     // call the method
     const playbookPath = await registryConfiguration.getPlaybookScriptPath();
@@ -109,7 +111,7 @@ describe('getPlaybookScriptPath', () => {
     expect(vi.mocked(writeFile)).toBeCalledWith(
       expect.stringContaining('playbook-setup-registry-conf-file.yml'),
       expect.stringContaining(
-        'sudo ln -s /fake/path/inside/vm /etc/containers/registries.conf.d/999-podman-desktop-registries-from-host.conf',
+        'ansible.builtin.file:\n        src: "/fake/path with spaces/inside/vm"\n        dest: "/etc/containers/registries.conf.d/999-podman-desktop-registries-from-host.conf"\n        state: link',
       ),
       'utf-8',
     );


### PR DESCRIPTION
### What does this PR do?

Replaces the free-form `sudo ln -s` registry playbook command with the structured `ansible.builtin.file` module. The source and destination are now YAML string values, so a Windows home directory such as `/mnt/c/Users/First Last/...` is not split into multiple command arguments.

The existing unit test now renders a source path containing spaces and verifies the complete structured Ansible task.

### Screenshot / video of UI

N/A — this changes the generated registry synchronization playbook only.

### What issues does this PR fix or reference?

Fixes #14881

### How to test this PR?

- `pnpm vitest --run --project=podman extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts`
- `pnpm run typecheck:extensions:podman`
- `pnpm run build:extensions:podman`
- `pnpm lint-staged`

- [x] Tests are covering the bug fix or the new feature

The implementation was AI-assisted and reviewed and validated by the contributor.
