### PR TITLE
feat(api): allow extensions to expose searchable routes in command palette

### DIFF
--- a/packages/api/src/api-sender/api-sender-channel-map.ts
+++ b/packages/api/src/api-sender/api-sender-channel-map.ts
@@ -111,6 +111,7 @@ export interface ApiSenderChannelMap {
   'navigation-go-back': never;
   'navigation-go-forward': never;
   'navigation-history-push': NavigationHistoryPushInfo;
+  'navigation-searchable-route-update': never;
   'network-event': never;
   'notifications-updated': never;
   onDidChangeConfiguration: unknown;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -68,6 +68,7 @@ export * from './menu-context.js';
 export * from './navigation-history-info.js';
 export * from './navigation-page.js';
 export * from './navigation-request.js';
+export * from './navigation-search-entry-info.js';
 export * from './network-info.js';
 export * from './notification.js';
 export * from './onboarding.js';

--- a/packages/api/src/navigation-search-entry-info.ts
+++ b/packages/api/src/navigation-search-entry-info.ts
@@ -1,0 +1,23 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface NavigationSearchEntryInfo {
+  routeId: string;
+  label: string;
+  icon?: string | { light: string; dark: string };
+}

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5116,6 +5116,11 @@ declare module '@podman-desktop/api' {
     readonly id: string;
   }
 
+  export interface NavigationSearchEntry {
+    label: string;
+    icon?: string | { light: string; dark: string };
+  }
+
   export namespace navigation {
     // Navigate to the Dashboard page
     export function navigateToDashboard(): Promise<void>;
@@ -5229,7 +5234,7 @@ declare module '@podman-desktop/api' {
      * @param routeId a unique string value that could be used in {@link navigation.navigate}
      * @param commandId the command that will be executed on navigate
      */
-    export function register(routeId: string, commandId: string): Disposable;
+    export function register(routeId: string, commandId: string, searchEntry?: NavigationSearchEntry): Disposable;
 
     /**
      * Allow extension to navigate to a custom route.

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -2749,6 +2749,36 @@ test('when registering a navigation route, should be pushed to disposables', () 
   expect(disposables.length).toBe(1);
 });
 
+test('when registering a navigation route with searchEntry, the searchEntry should be passed through', () => {
+  const api = createApi();
+
+  const disposable = api.navigation.register('search-route', 'my-command', { label: 'My Label' });
+
+  const routes = navigationManager.getSearchableRoutes();
+  expect(routes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        routeId: 'publisher.extension-name.search-route',
+        label: 'My Label',
+      }),
+    ]),
+  );
+
+  disposable.dispose();
+});
+
+test('when registering a navigation route with searchEntry without icon and no extension icon, icon should be undefined', () => {
+  const api = createApi();
+
+  const disposable = api.navigation.register('icon-fallback-route', 'my-command', { label: 'My Label' });
+
+  const routes = navigationManager.getSearchableRoutes();
+  const route = routes.find(r => r.routeId === 'publisher.extension-name.icon-fallback-route');
+  expect(route?.icon).toBeUndefined();
+
+  disposable.dispose();
+});
+
 test('withProgress should add the extension id to the routeId', async () => {
   vi.mocked(progress.withProgress).mockResolvedValue(undefined);
   const api = createApi();

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -2742,6 +2742,36 @@ test('when registering a navigation route, should be pushed to disposables', () 
   expect(disposables.length).toBe(1);
 });
 
+test('when registering a navigation route with searchEntry, the searchEntry should be passed through', () => {
+  const api = createApi();
+
+  const disposable = api.navigation.register('search-route', 'my-command', { label: 'My Label' });
+
+  const routes = navigationManager.getSearchableRoutes();
+  expect(routes).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        routeId: 'publisher.extension-name.search-route',
+        label: 'My Label',
+      }),
+    ]),
+  );
+
+  disposable.dispose();
+});
+
+test('when registering a navigation route with searchEntry without icon and no extension icon, icon should be undefined', () => {
+  const api = createApi();
+
+  const disposable = api.navigation.register('icon-fallback-route', 'my-command', { label: 'My Label' });
+
+  const routes = navigationManager.getSearchableRoutes();
+  const route = routes.find(r => r.routeId === 'publisher.extension-name.icon-fallback-route');
+  expect(route?.icon).toBeUndefined();
+
+  disposable.dispose();
+});
+
 test('withProgress should add the extension id to the routeId', async () => {
   vi.mocked(progress.withProgress).mockResolvedValue(undefined);
   const api = createApi();

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1593,10 +1593,23 @@ export class ExtensionLoader implements IAsyncDisposable {
       navigate: async (routeId: string, ...args: unknown[]): Promise<void> => {
         return this.navigationManager.navigateToRoute(`${extensionInfo.id}.${routeId}`, args);
       },
-      register: (routeId: string, commandId: string): Disposable => {
+      register: (
+        routeId: string,
+        commandId: string,
+        searchEntry?: containerDesktopAPI.NavigationSearchEntry,
+      ): Disposable => {
+        let resolvedSearchEntry: containerDesktopAPI.NavigationSearchEntry | undefined;
+        if (searchEntry) {
+          resolvedSearchEntry = {
+            label: searchEntry.label,
+            icon: searchEntry.icon ? instance.updateImage(searchEntry.icon, extensionPath) : extensionInfo.icon,
+          };
+        }
+
         const disposable = this.navigationManager.registerRoute({
           routeId: `${extensionInfo.id}.${routeId}`,
           commandId: commandId,
+          searchEntry: resolvedSearchEntry,
         });
 
         disposables.push(disposable);

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -1673,10 +1673,23 @@ export class ExtensionLoader implements IAsyncDisposable {
       navigate: async (routeId: string, ...args: unknown[]): Promise<void> => {
         return this.navigationManager.navigateToRoute(`${extensionInfo.id}.${routeId}`, args);
       },
-      register: (routeId: string, commandId: string): Disposable => {
+      register: (
+        routeId: string,
+        commandId: string,
+        searchEntry?: containerDesktopAPI.NavigationSearchEntry,
+      ): Disposable => {
+        let resolvedSearchEntry: { label: string; icon?: string | { light: string; dark: string } } | undefined;
+        if (searchEntry) {
+          resolvedSearchEntry = {
+            label: searchEntry.label,
+            icon: searchEntry.icon ? instance.updateImage(searchEntry.icon, extensionPath) : extensionInfo.icon,
+          };
+        }
+
         const disposable = this.navigationManager.registerRoute({
           routeId: `${extensionInfo.id}.${routeId}`,
           commandId: commandId,
+          searchEntry: resolvedSearchEntry,
         });
 
         disposables.push(disposable);

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -1260,3 +1260,17 @@ describe('container-provider-registry:playKube', () => {
     expect(createdTask.error).toBe('Error: Dummy Foo');
   });
 });
+
+test('navigation:getSearchableRoutes handler should delegate to navigationManager', async () => {
+  const mockRoutes = [
+    { routeId: 'ext.dashboard', label: 'Dashboard' },
+    { routeId: 'ext.models', label: 'Models', icon: 'icon.png' },
+  ];
+  vi.mocked(NavigationManager.prototype.getSearchableRoutes).mockReturnValue(mockRoutes);
+
+  const handle = getHandler<() => Promise<{ result: unknown }>>('navigation:getSearchableRoutes');
+  const result = await handle();
+
+  expect(NavigationManager.prototype.getSearchableRoutes).toHaveBeenCalled();
+  expect(result).toEqual({ result: mockRoutes });
+});

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -1261,3 +1261,17 @@ describe('container-provider-registry:playKube', () => {
     expect(createdTask.error).toBe('Error: Dummy Foo');
   });
 });
+
+test('navigation:getSearchableRoutes handler should delegate to navigationManager', async () => {
+  const mockRoutes = [
+    { routeId: 'ext.dashboard', label: 'Dashboard' },
+    { routeId: 'ext.models', label: 'Models', icon: 'icon.png' },
+  ];
+  vi.mocked(NavigationManager.prototype.getSearchableRoutes).mockReturnValue(mockRoutes);
+
+  const handle = getHandler<() => Promise<{ result: unknown }>>('navigation:getSearchableRoutes');
+  const result = await handle();
+
+  expect(NavigationManager.prototype.getSearchableRoutes).toHaveBeenCalled();
+  expect(result).toEqual({ result: mockRoutes });
+});

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3269,6 +3269,10 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('navigation:getSearchableRoutes', async () => {
+      return navigationManager.getSearchableRoutes();
+    });
+
     this.ipcHandle('onboardingRegistry:listOnboarding', async (): Promise<OnboardingInfo[]> => {
       return onboardingRegistry.listOnboarding();
     });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -3276,6 +3276,10 @@ export class PluginSystem {
       },
     );
 
+    this.ipcHandle('navigation:getSearchableRoutes', async () => {
+      return navigationManager.getSearchableRoutes();
+    });
+
     this.ipcHandle('onboardingRegistry:listOnboarding', async (): Promise<OnboardingInfo[]> => {
       return onboardingRegistry.listOnboarding();
     });

--- a/packages/main/src/plugin/navigation/navigation-manager.spec.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.spec.ts
@@ -312,6 +312,109 @@ describe('register route', () => {
       return navigationManager.navigateToRoute(routeId);
     }).rejects.toThrowError('Dummy error');
   });
+
+  test('registering route with searchEntry should fire navigation-searchable-route-update event', () => {
+    navigationManager.registerRoute({
+      routeId: 'route-with-search',
+      commandId: 'some-command',
+      searchEntry: { label: 'My Route' },
+    });
+
+    expect(apiSender.send).toHaveBeenCalledWith('navigation-searchable-route-update');
+  });
+
+  test('registering route without searchEntry should not fire navigation-searchable-route-update event', () => {
+    navigationManager.registerRoute({
+      routeId: 'route-without-search',
+      commandId: 'some-command',
+    });
+
+    expect(apiSender.send).not.toHaveBeenCalledWith('navigation-searchable-route-update');
+  });
+
+  test('disposing route with searchEntry should fire navigation-searchable-route-update event', () => {
+    const disposable = navigationManager.registerRoute({
+      routeId: 'route-with-search',
+      commandId: 'some-command',
+      searchEntry: { label: 'My Route' },
+    });
+
+    vi.mocked(apiSender.send).mockClear();
+    disposable.dispose();
+
+    expect(apiSender.send).toHaveBeenCalledWith('navigation-searchable-route-update');
+  });
+
+  test('disposing route without searchEntry should not fire navigation-searchable-route-update event', () => {
+    const disposable = navigationManager.registerRoute({
+      routeId: 'route-without-search',
+      commandId: 'some-command',
+    });
+
+    vi.mocked(apiSender.send).mockClear();
+    disposable.dispose();
+
+    expect(apiSender.send).not.toHaveBeenCalledWith('navigation-searchable-route-update');
+  });
+});
+
+describe('getSearchableRoutes', () => {
+  test('should return empty array when no routes registered', () => {
+    expect(navigationManager.getSearchableRoutes()).toEqual([]);
+  });
+
+  test('should return only routes with searchEntry', () => {
+    navigationManager.registerRoute({
+      routeId: 'route-1',
+      commandId: 'cmd-1',
+      searchEntry: { label: 'Dashboard' },
+    });
+    navigationManager.registerRoute({
+      routeId: 'route-2',
+      commandId: 'cmd-2',
+    });
+    navigationManager.registerRoute({
+      routeId: 'route-3',
+      commandId: 'cmd-3',
+      searchEntry: { label: 'Models', icon: 'icon.png' },
+    });
+
+    const results = navigationManager.getSearchableRoutes();
+
+    expect(results).toHaveLength(2);
+    expect(results).toEqual([
+      { routeId: 'route-1', label: 'Dashboard', icon: undefined },
+      { routeId: 'route-3', label: 'Models', icon: 'icon.png' },
+    ]);
+  });
+
+  test('should not include disposed routes', () => {
+    const disposable = navigationManager.registerRoute({
+      routeId: 'route-1',
+      commandId: 'cmd-1',
+      searchEntry: { label: 'Dashboard' },
+    });
+
+    expect(navigationManager.getSearchableRoutes()).toHaveLength(1);
+
+    disposable.dispose();
+
+    expect(navigationManager.getSearchableRoutes()).toHaveLength(0);
+  });
+
+  test('should include icon with light and dark variants', () => {
+    navigationManager.registerRoute({
+      routeId: 'route-themed',
+      commandId: 'cmd-themed',
+      searchEntry: { label: 'Themed', icon: { light: 'light.png', dark: 'dark.png' } },
+    });
+
+    const results = navigationManager.getSearchableRoutes();
+
+    expect(results).toEqual([
+      { routeId: 'route-themed', label: 'Themed', icon: { light: 'light.png', dark: 'dark.png' } },
+    ]);
+  });
 });
 
 test('check navigateToCreateProviderConnection', async () => {

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -20,9 +20,10 @@ import type {
   NavigateToExtensionsCatalogOptions,
   NavigateToHistoryEvent,
   NavigationHistoryEntry,
+  NavigationSearchEntry,
   ProviderContainerConnection,
 } from '@podman-desktop/api';
-import type { DisposableGroup, NavigationRequest } from '@podman-desktop/core-api';
+import type { DisposableGroup, NavigationRequest, NavigationSearchEntryInfo } from '@podman-desktop/core-api';
 import { IDisposable, NavigationPage } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
@@ -39,6 +40,7 @@ import { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
 export interface NavigationRoute {
   routeId: string;
   commandId: string;
+  searchEntry?: NavigationSearchEntry;
 }
 
 @injectable()
@@ -119,9 +121,26 @@ export class NavigationManager {
     }
     this.#registry.set(route.routeId, route);
 
+    if (route.searchEntry) {
+      this.apiSender.send('navigation-searchable-route-update');
+    }
+
     return Disposable.create(() => {
       this.#registry.delete(route.routeId);
+      if (route.searchEntry) {
+        this.apiSender.send('navigation-searchable-route-update');
+      }
     });
+  }
+
+  getSearchableRoutes(): NavigationSearchEntryInfo[] {
+    return Array.from(this.#registry.values())
+      .filter(route => route.searchEntry !== undefined)
+      .map(route => ({
+        routeId: route.routeId,
+        label: route.searchEntry!.label,
+        icon: route.searchEntry!.icon,
+      }));
   }
 
   hasRoute(routeId: string): boolean {

--- a/packages/main/src/plugin/navigation/navigation-manager.ts
+++ b/packages/main/src/plugin/navigation/navigation-manager.ts
@@ -22,7 +22,7 @@ import type {
   NavigationHistoryEntry,
   ProviderContainerConnection,
 } from '@podman-desktop/api';
-import type { DisposableGroup, NavigationRequest } from '@podman-desktop/core-api';
+import type { DisposableGroup, NavigationRequest, NavigationSearchEntryInfo } from '@podman-desktop/core-api';
 import { IDisposable, NavigationPage } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { inject, injectable, postConstruct, preDestroy } from 'inversify';
@@ -39,6 +39,10 @@ import { WebviewRegistry } from '/@/plugin/webview/webview-registry.js';
 export interface NavigationRoute {
   routeId: string;
   commandId: string;
+  searchEntry?: {
+    label: string;
+    icon?: string | { light: string; dark: string };
+  };
 }
 
 @injectable()
@@ -119,9 +123,26 @@ export class NavigationManager {
     }
     this.#registry.set(route.routeId, route);
 
+    if (route.searchEntry) {
+      this.apiSender.send('navigation-searchable-route-update');
+    }
+
     return Disposable.create(() => {
       this.#registry.delete(route.routeId);
+      if (route.searchEntry) {
+        this.apiSender.send('navigation-searchable-route-update');
+      }
     });
+  }
+
+  getSearchableRoutes(): NavigationSearchEntryInfo[] {
+    return Array.from(this.#registry.values())
+      .filter(route => route.searchEntry !== undefined)
+      .map(route => ({
+        routeId: route.routeId,
+        label: route.searchEntry!.label,
+        icon: route.searchEntry!.icon,
+      }));
   }
 
   hasRoute(routeId: string): boolean {

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -249,6 +249,20 @@ describe('collect calls to exposeInMainWorld and ipcRenderer.on and calls initEx
     expect(result).toEqual(undefined);
   });
 
+  test('getSearchableNavigationRoutes', async () => {
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue({
+      result: [{ routeId: 'ext.dashboard', label: 'Dashboard', icon: 'icon.png' }],
+    });
+
+    const getSearchableNavigationRoutesExposure = getInMainWorld('getSearchableNavigationRoutes');
+
+    const result = await getSearchableNavigationRoutesExposure();
+
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('navigation:getSearchableRoutes');
+
+    expect(result).toEqual([{ routeId: 'ext.dashboard', label: 'Dashboard', icon: 'icon.png' }]);
+  });
+
   test('logger passed to createVmProviderConnection is called during provider-registry:taskConnection-onData', async () => {
     vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
     const createVmProviderConnectionExposure = getInMainWorld('createVmProviderConnection');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -95,6 +95,7 @@ import type {
   MessageBoxOptions,
   MessageBoxReturnValue,
   NavigationRequest,
+  NavigationSearchEntryInfo,
   NetworkCreateOptions,
   NetworkCreateResult,
   NetworkInspectInfo,
@@ -291,6 +292,10 @@ export function initExposure(): void {
       return ipcRenderer.invoke('navigation:navigateToHistoryEntry', extensionId, entryId);
     },
   );
+
+  contextBridge.exposeInMainWorld('getSearchableNavigationRoutes', async (): Promise<NavigationSearchEntryInfo[]> => {
+    return ipcInvoke('navigation:getSearchableRoutes');
+  });
 
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -95,6 +95,7 @@ import type {
   MessageBoxOptions,
   MessageBoxReturnValue,
   NavigationRequest,
+  NavigationSearchEntryInfo,
   NetworkCreateOptions,
   NetworkCreateResult,
   NetworkInspectInfo,
@@ -290,6 +291,10 @@ export function initExposure(): void {
       return ipcRenderer.invoke('navigation:navigateToHistoryEntry', extensionId, entryId);
     },
   );
+
+  contextBridge.exposeInMainWorld('getSearchableNavigationRoutes', async (): Promise<NavigationSearchEntryInfo[]> => {
+    return ipcInvoke('navigation:getSearchableRoutes');
+  });
 
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');

--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -28,6 +28,7 @@ import { commandsInfos } from '/@/stores/commands';
 import { containersInfos } from '/@/stores/containers';
 import { context } from '/@/stores/context';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
+import { navigationSearchEntries } from '/@/stores/navigation-search-entries';
 
 import CommandPalette from './CommandPalette.svelte';
 
@@ -53,6 +54,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  navigationSearchEntries.set([]);
   vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
   vi.mocked(window.getCommandPaletteSearchOptions).mockResolvedValue([
     { category: 'category 1', text: 'Category 1 text', placeholder: 'Enter category 1 item' },
@@ -705,6 +707,132 @@ describe('Command Palette', () => {
     expect(screen.getByRole('listitem', { name: 'Containers (1)' })).toBeInTheDocument();
     expect(screen.getByRole('listitem', { name: 'Extensions: AI Lab' })).toBeInTheDocument();
     expect(screen.getByRole('listitem', { name: 'Extensions: Nested' })).toBeInTheDocument();
+  });
+
+  test('Extension route items should appear in Go to tab', async () => {
+    navigationSearchEntries.set([
+      { routeId: 'ext.dashboard', label: 'Extension Dashboard' },
+      { routeId: 'ext.models', label: 'Extension Models', icon: 'models.png' },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    await waitFor(() => {
+      expect(screen.getByRole('listitem', { name: 'Extension Dashboard' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('listitem', { name: 'Extension Models' })).toBeInTheDocument();
+  });
+
+  test('Extension route items should appear in All tab', async () => {
+    navigationSearchEntries.set([{ routeId: 'ext.dashboard', label: 'Extension Dashboard' }]);
+    commandsInfos.set([{ id: 'my-cmd', title: 'My Command' }]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('listitem', { name: 'Extension Dashboard' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('listitem', { name: 'my-cmd' })).toBeInTheDocument();
+  });
+
+  test('Extension route items should be filtered by search input', async () => {
+    navigationSearchEntries.set([
+      { routeId: 'ext.dashboard', label: 'Extension Dashboard' },
+      { routeId: 'ext.models', label: 'Extension Models' },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    await waitFor(() => {
+      expect(screen.getByRole('listitem', { name: 'Extension Dashboard' })).toBeInTheDocument();
+    });
+
+    const filterInput = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    await userEvent.type(filterInput, 'Models');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('listitem', { name: 'Extension Dashboard' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('listitem', { name: 'Extension Models' })).toBeInTheDocument();
+  });
+
+  test('Clicking extension route item should call navigateToRoute', async () => {
+    navigationSearchEntries.set([{ routeId: 'ext.dashboard', label: 'Extension Dashboard' }]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const item = await screen.findByRole('button', { name: 'Extension Dashboard' });
+    await userEvent.click(item);
+
+    expect(vi.mocked(window.navigateToRoute)).toHaveBeenCalledWith('ext.dashboard');
+  });
+
+  test('Extension route item with light/dark icon should render both themed variants', async () => {
+    const darkIcon = 'data:image/png;base64,dark';
+    const lightIcon = 'data:image/png;base64,light';
+    navigationSearchEntries.set([
+      { routeId: 'ext.themed', label: 'Themed Route', icon: { light: lightIcon, dark: darkIcon } },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const listItem = await screen.findByRole('listitem', { name: 'Themed Route' });
+    const icons = listItem.querySelectorAll('img');
+    expect(icons).toHaveLength(2);
+    expect(icons[0]).toHaveAttribute('src', lightIcon);
+    expect(icons[1]).toHaveAttribute('src', darkIcon);
+  });
+
+  test('Extension route item without icon should use fallback FontAwesome icon', async () => {
+    navigationSearchEntries.set([{ routeId: 'ext.no-icon', label: 'No Icon Route' }]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const listItem = await screen.findByRole('listitem', { name: 'No Icon Route' });
+    expect(listItem).toBeInTheDocument();
+    const imgIcon = listItem.querySelector('img');
+    expect(imgIcon).not.toBeInTheDocument();
+    const svgIcon = listItem.querySelector('svg');
+    expect(svgIcon).toBeInTheDocument();
   });
 
   test('Expect hidden navigation entries are excluded from GoTo items', async () => {

--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -24,10 +24,12 @@ import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { isDark } from '/@/stores/appearance';
 import { commandsInfos } from '/@/stores/commands';
 import { containersInfos } from '/@/stores/containers';
 import { context } from '/@/stores/context';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
+import { navigationSearchEntries } from '/@/stores/navigation-search-entries';
 
 import CommandPalette from './CommandPalette.svelte';
 
@@ -53,6 +55,8 @@ beforeAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  navigationSearchEntries.set([]);
+  vi.mocked(window.navigateToRoute).mockResolvedValue(undefined);
   vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
   vi.mocked(window.getCommandPaletteSearchOptions).mockResolvedValue([
     { category: 'category 1', text: 'Category 1 text', placeholder: 'Enter category 1 item' },
@@ -705,6 +709,155 @@ describe('Command Palette', () => {
     expect(screen.getByRole('listitem', { name: 'Containers (1)' })).toBeInTheDocument();
     expect(screen.getByRole('listitem', { name: 'Extensions: AI Lab' })).toBeInTheDocument();
     expect(screen.getByRole('listitem', { name: 'Extensions: Nested' })).toBeInTheDocument();
+  });
+
+  test('Extension route items should appear in Go to tab', async () => {
+    navigationSearchEntries.set([
+      { routeId: 'ext.dashboard', label: 'Extension Dashboard' },
+      { routeId: 'ext.models', label: 'Extension Models', icon: 'models.png' },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    await waitFor(() => {
+      expect(screen.getByRole('listitem', { name: 'Extension Dashboard' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('listitem', { name: 'Extension Models' })).toBeInTheDocument();
+  });
+
+  test('Extension route items should appear in All tab', async () => {
+    navigationSearchEntries.set([{ routeId: 'ext.dashboard', label: 'Extension Dashboard' }]);
+    commandsInfos.set([{ id: 'my-cmd', title: 'My Command' }]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('listitem', { name: 'Extension Dashboard' })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('listitem', { name: 'my-cmd' })).toBeInTheDocument();
+  });
+
+  test('Extension route items should be filtered by search input', async () => {
+    navigationSearchEntries.set([
+      { routeId: 'ext.dashboard', label: 'Extension Dashboard' },
+      { routeId: 'ext.models', label: 'Extension Models' },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    await waitFor(() => {
+      expect(screen.getByRole('listitem', { name: 'Extension Dashboard' })).toBeInTheDocument();
+    });
+
+    const filterInput = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    await userEvent.type(filterInput, 'Models');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('listitem', { name: 'Extension Dashboard' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('listitem', { name: 'Extension Models' })).toBeInTheDocument();
+  });
+
+  test('Clicking extension route item should call navigateToRoute', async () => {
+    navigationSearchEntries.set([{ routeId: 'ext.dashboard', label: 'Extension Dashboard' }]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const item = await screen.findByRole('button', { name: 'Extension Dashboard' });
+    await userEvent.click(item);
+
+    expect(vi.mocked(window.navigateToRoute)).toHaveBeenCalledWith('ext.dashboard');
+  });
+
+  test('Extension route item with light/dark icon should select dark variant in dark mode', async () => {
+    isDark.set(true);
+    const darkIcon = 'data:image/png;base64,dark';
+    const lightIcon = 'data:image/png;base64,light';
+    navigationSearchEntries.set([
+      { routeId: 'ext.themed', label: 'Themed Route', icon: { light: lightIcon, dark: darkIcon } },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const listItem = await screen.findByRole('listitem', { name: 'Themed Route' });
+    const icon = listItem.querySelector('img');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('src', darkIcon);
+  });
+
+  test('Extension route item with light/dark icon should select light variant in light mode', async () => {
+    isDark.set(false);
+    const darkIcon = 'data:image/png;base64,dark';
+    const lightIcon = 'data:image/png;base64,light';
+    navigationSearchEntries.set([
+      { routeId: 'ext.themed', label: 'Themed Route', icon: { light: lightIcon, dark: darkIcon } },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const listItem = await screen.findByRole('listitem', { name: 'Themed Route' });
+    const icon = listItem.querySelector('img');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveAttribute('src', lightIcon);
+  });
+
+  test('Extension route item without icon should use fallback FontAwesome icon', async () => {
+    navigationSearchEntries.set([{ routeId: 'ext.no-icon', label: 'No Icon Route' }]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const listItem = await screen.findByRole('listitem', { name: 'No Icon Route' });
+    expect(listItem).toBeInTheDocument();
+    const imgIcon = listItem.querySelector('img');
+    expect(imgIcon).not.toBeInTheDocument();
+    const svgIcon = listItem.querySelector('svg');
+    expect(svgIcon).toBeInTheDocument();
   });
 
   test('Expect hidden navigation entries are excluded from GoTo items', async () => {

--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import {
   faArrowUpRightFromSquare,
   faChevronRight,
@@ -8,10 +7,16 @@ import {
   faMagnifyingGlass,
   faTerminal,
 } from '@fortawesome/free-solid-svg-icons';
-import type { CommandInfo, CommandPaletteSearchOption, DocumentationInfo, GoToInfo } from '@podman-desktop/core-api';
-import { Button, Input } from '@podman-desktop/ui-svelte';
+import type {
+  CommandInfo,
+  CommandPaletteSearchOption,
+  DocumentationInfo,
+  GoToInfo,
+  NavigationSearchEntryInfo,
+} from '@podman-desktop/core-api';
+import { Button, type IconType, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
-import { type Component, onMount, tick } from 'svelte';
+import { onMount, tick } from 'svelte';
 
 import ArrowDownIcon from '/@/lib/images/ArrowDownIcon.svelte';
 import ArrowUpIcon from '/@/lib/images/ArrowUpIcon.svelte';
@@ -22,6 +27,7 @@ import { handleNavigation, resolveRoute } from '/@/navigation';
 import { commandsInfos } from '/@/stores/commands';
 import { context } from '/@/stores/context';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
+import { navigationSearchEntries } from '/@/stores/navigation-search-entries';
 
 import TextHighLight from './TextHighLight.svelte';
 
@@ -37,7 +43,7 @@ interface Props {
   onclose?: () => void;
 }
 
-type CommandPaletteItem = CommandInfo | DocumentationInfo | GoToInfo;
+type CommandPaletteItem = CommandInfo | DocumentationInfo | GoToInfo | NavigationSearchEntryInfo;
 
 let { display = false, onclose }: Props = $props();
 
@@ -104,6 +110,12 @@ let filteredGoToItems = $derived(
   goToItems.filter(item => (inputValue ? item.name.toLowerCase().includes(inputValue.toLowerCase()) : true)),
 );
 
+let filteredExtensionRouteItems: NavigationSearchEntryInfo[] = $derived(
+  $navigationSearchEntries.filter(item =>
+    inputValue ? item.label.toLowerCase().includes(inputValue.toLowerCase()) : true,
+  ),
+);
+
 let filteredItems = $derived.by(() => {
   if (searchOptionsSelectedIndex === 1) {
     // Commands mode
@@ -112,11 +124,16 @@ let filteredItems = $derived.by(() => {
     // Documentation mode
     return filteredDocumentationInfoItems;
   } else if (searchOptionsSelectedIndex === 3) {
-    // Go to mode (could be different logic later)
-    return filteredGoToItems;
+    // Go to mode
+    return [...filteredGoToItems, ...filteredExtensionRouteItems];
   } else {
-    // All mode - combine both
-    return [...filteredGoToItems, ...filteredCommandInfoItems, ...filteredDocumentationInfoItems];
+    // All mode - combine all
+    return [
+      ...filteredGoToItems,
+      ...filteredExtensionRouteItems,
+      ...filteredCommandInfoItems,
+      ...filteredDocumentationInfoItems,
+    ];
   }
 });
 
@@ -252,6 +269,13 @@ async function executeAction(index: number): Promise<void> {
     }
     itemType = item.category;
     pageLink = item.url;
+  } else if (isExtensionRouteItem(item)) {
+    try {
+      await window.navigateToRoute(item.routeId);
+    } catch (error) {
+      console.error('Error navigating to extension route', error);
+    }
+    itemType = 'ExtensionRoute';
   } else if (isGoToItem(item)) {
     handleNavigation(item);
     itemType = item.page;
@@ -320,6 +344,10 @@ async function onAction(): Promise<void> {
     });
 }
 
+function isExtensionRouteItem(item: CommandPaletteItem): item is NavigationSearchEntryInfo {
+  return 'routeId' in item;
+}
+
 function isGoToItem(item: CommandPaletteItem): item is GoToInfo {
   return 'page' in item;
 }
@@ -329,6 +357,10 @@ function isDocItem(item: CommandPaletteItem): item is DocumentationInfo {
 }
 
 function getItemKey(item: CommandPaletteItem, index: number): string {
+  if (isExtensionRouteItem(item)) {
+    return `route:${item.routeId}`;
+  }
+
   if (isGoToItem(item)) {
     return `goto:${resolveRoute(item)}`;
   }
@@ -341,7 +373,9 @@ function getItemKey(item: CommandPaletteItem, index: number): string {
 }
 
 function getTextToHighlight(item: CommandPaletteItem): string {
-  if (isDocItem(item)) {
+  if (isExtensionRouteItem(item)) {
+    return item.label;
+  } else if (isDocItem(item)) {
     return `${item.category}: ${item.name}`;
   } else if (isGoToItem(item)) {
     return item.name;
@@ -350,19 +384,16 @@ function getTextToHighlight(item: CommandPaletteItem): string {
   }
 }
 
-function getIcon(item: CommandInfo | DocumentationInfo | GoToInfo): IconDefinition | Component | string {
-  if (isDocItem(item)) {
+function getIcon(item: CommandPaletteItem): IconType {
+  if (isExtensionRouteItem(item)) {
+    return item.icon ?? faTerminal;
+  } else if (isDocItem(item)) {
     return item.category === 'Tutorial' ? faFilePen : faFileLines;
   } else if (isGoToItem(item)) {
-    // All goto items now have icons set in Utils
     if (item.icon) {
-      return (item.icon.iconComponent ?? item.icon.faIcon ?? item.icon.iconImage ?? faTerminal) as
-        | IconDefinition
-        | Component
-        | string;
+      return (item.icon.iconComponent ?? item.icon.faIcon ?? item.icon.iconImage ?? faTerminal) as IconType;
     }
   }
-  // Commands and fallback
   return faTerminal;
 }
 </script>
@@ -417,10 +448,11 @@ function getIcon(item: CommandInfo | DocumentationInfo | GoToInfo): IconDefiniti
         </div>
         <ul class="max-h-[50vh] overflow-y-auto flex flex-col mt-1">
           {#each filteredItems as item, i (getItemKey(item, i))}
+            {@const extensionRouteItem = isExtensionRouteItem(item)}
             {@const goToItem = isGoToItem(item)}
             {@const docItem = isDocItem(item)}
             {@const itemIcon = getIcon(item)}
-            <li class="flex w-full flex-row" bind:this={scrollElements[i]} aria-label={goToItem ? item.name : (item.id)}>
+            <li class="flex w-full flex-row" bind:this={scrollElements[i]} aria-label={extensionRouteItem ? item.label : goToItem ? item.name : (item.id)}>
               <button
                 onclick={(): Promise<void> => clickOnItem(i)}
                 class="text-[var(--pd-dropdown-item-text)] text-left relative w-full rounded-sm {i === selectedFilteredIndex

--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -8,7 +8,13 @@ import {
   faMagnifyingGlass,
   faTerminal,
 } from '@fortawesome/free-solid-svg-icons';
-import type { CommandInfo, CommandPaletteSearchOption, DocumentationInfo, GoToInfo } from '@podman-desktop/core-api';
+import type {
+  CommandInfo,
+  CommandPaletteSearchOption,
+  DocumentationInfo,
+  GoToInfo,
+  NavigationSearchEntryInfo,
+} from '@podman-desktop/core-api';
 import { Button, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { type Component, onMount, tick } from 'svelte';
@@ -19,9 +25,11 @@ import EnterIcon from '/@/lib/images/EnterIcon.svelte';
 import NotFoundIcon from '/@/lib/images/NotFoundIcon.svelte';
 import { isPropertyValidInContext } from '/@/lib/preferences/Util';
 import { handleNavigation, resolveRoute } from '/@/navigation';
+import { isDark } from '/@/stores/appearance';
 import { commandsInfos } from '/@/stores/commands';
 import { context } from '/@/stores/context';
 import { navigationRegistry, type NavigationRegistryEntry } from '/@/stores/navigation/navigation-registry';
+import { navigationSearchEntries } from '/@/stores/navigation-search-entries';
 
 import TextHighLight from './TextHighLight.svelte';
 
@@ -37,7 +45,7 @@ interface Props {
   onclose?: () => void;
 }
 
-type CommandPaletteItem = CommandInfo | DocumentationInfo | GoToInfo;
+type CommandPaletteItem = CommandInfo | DocumentationInfo | GoToInfo | NavigationSearchEntryInfo;
 
 let { display = false, onclose }: Props = $props();
 
@@ -104,6 +112,12 @@ let filteredGoToItems = $derived(
   goToItems.filter(item => (inputValue ? item.name.toLowerCase().includes(inputValue.toLowerCase()) : true)),
 );
 
+let filteredExtensionRouteItems: NavigationSearchEntryInfo[] = $derived(
+  $navigationSearchEntries.filter(item =>
+    inputValue ? item.label.toLowerCase().includes(inputValue.toLowerCase()) : true,
+  ),
+);
+
 let filteredItems = $derived.by(() => {
   if (searchOptionsSelectedIndex === 1) {
     // Commands mode
@@ -112,11 +126,16 @@ let filteredItems = $derived.by(() => {
     // Documentation mode
     return filteredDocumentationInfoItems;
   } else if (searchOptionsSelectedIndex === 3) {
-    // Go to mode (could be different logic later)
-    return filteredGoToItems;
+    // Go to mode
+    return [...filteredGoToItems, ...filteredExtensionRouteItems];
   } else {
-    // All mode - combine both
-    return [...filteredGoToItems, ...filteredCommandInfoItems, ...filteredDocumentationInfoItems];
+    // All mode - combine all
+    return [
+      ...filteredGoToItems,
+      ...filteredExtensionRouteItems,
+      ...filteredCommandInfoItems,
+      ...filteredDocumentationInfoItems,
+    ];
   }
 });
 
@@ -252,6 +271,13 @@ async function executeAction(index: number): Promise<void> {
     }
     itemType = item.category;
     pageLink = item.url;
+  } else if (isExtensionRouteItem(item)) {
+    try {
+      await window.navigateToRoute(item.routeId);
+    } catch (error) {
+      console.error('Error navigating to extension route', error);
+    }
+    itemType = 'ExtensionRoute';
   } else if (isGoToItem(item)) {
     handleNavigation(item);
     itemType = item.page;
@@ -320,6 +346,10 @@ async function onAction(): Promise<void> {
     });
 }
 
+function isExtensionRouteItem(item: CommandPaletteItem): item is NavigationSearchEntryInfo {
+  return 'routeId' in item;
+}
+
 function isGoToItem(item: CommandPaletteItem): item is GoToInfo {
   return 'page' in item;
 }
@@ -329,6 +359,10 @@ function isDocItem(item: CommandPaletteItem): item is DocumentationInfo {
 }
 
 function getItemKey(item: CommandPaletteItem, index: number): string {
+  if (isExtensionRouteItem(item)) {
+    return `route:${item.routeId}`;
+  }
+
   if (isGoToItem(item)) {
     return `goto:${resolveRoute(item)}`;
   }
@@ -341,7 +375,9 @@ function getItemKey(item: CommandPaletteItem, index: number): string {
 }
 
 function getTextToHighlight(item: CommandPaletteItem): string {
-  if (isDocItem(item)) {
+  if (isExtensionRouteItem(item)) {
+    return item.label;
+  } else if (isDocItem(item)) {
     return `${item.category}: ${item.name}`;
   } else if (isGoToItem(item)) {
     return item.name;
@@ -350,11 +386,15 @@ function getTextToHighlight(item: CommandPaletteItem): string {
   }
 }
 
-function getIcon(item: CommandInfo | DocumentationInfo | GoToInfo): IconDefinition | Component | string {
-  if (isDocItem(item)) {
+function getIcon(item: CommandPaletteItem): IconDefinition | Component | string {
+  if (isExtensionRouteItem(item)) {
+    if (item.icon) {
+      return (typeof item.icon === 'string' ? item.icon : $isDark ? item.icon.dark : item.icon.light) as string;
+    }
+    return faTerminal;
+  } else if (isDocItem(item)) {
     return item.category === 'Tutorial' ? faFilePen : faFileLines;
   } else if (isGoToItem(item)) {
-    // All goto items now have icons set in Utils
     if (item.icon) {
       return (item.icon.iconComponent ?? item.icon.faIcon ?? item.icon.iconImage ?? faTerminal) as
         | IconDefinition
@@ -362,7 +402,6 @@ function getIcon(item: CommandInfo | DocumentationInfo | GoToInfo): IconDefiniti
         | string;
     }
   }
-  // Commands and fallback
   return faTerminal;
 }
 </script>
@@ -417,10 +456,11 @@ function getIcon(item: CommandInfo | DocumentationInfo | GoToInfo): IconDefiniti
         </div>
         <ul class="max-h-[50vh] overflow-y-auto flex flex-col mt-1">
           {#each filteredItems as item, i (getItemKey(item, i))}
+            {@const extensionRouteItem = isExtensionRouteItem(item)}
             {@const goToItem = isGoToItem(item)}
             {@const docItem = isDocItem(item)}
             {@const itemIcon = getIcon(item)}
-            <li class="flex w-full flex-row" bind:this={scrollElements[i]} aria-label={goToItem ? item.name : (item.id)}>
+            <li class="flex w-full flex-row" bind:this={scrollElements[i]} aria-label={extensionRouteItem ? item.label : goToItem ? item.name : (item.id)}>
               <button
                 onclick={(): Promise<void> => clickOnItem(i)}
                 class="text-[var(--pd-dropdown-item-text)] text-left relative w-full rounded-sm {i === selectedFilteredIndex

--- a/packages/renderer/src/stores/navigation-search-entries.spec.ts
+++ b/packages/renderer/src/stores/navigation-search-entries.spec.ts
@@ -1,0 +1,73 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { get } from 'svelte/store';
+import { assert, beforeEach, expect, test, vi } from 'vitest';
+
+import { navigationSearchEntries, navigationSearchEntriesEventStore } from './navigation-search-entries';
+
+const callbacks = new Map<string, (data?: unknown) => void | Promise<void>>();
+
+beforeEach(() => {
+  callbacks.clear();
+  vi.resetAllMocks();
+  vi.mocked(window.events.receive).mockImplementation((message, callback) => {
+    callbacks.set(message, callback);
+    return { dispose: vi.fn() };
+  });
+});
+
+test('navigation search entries should be updated on system-ready event', async () => {
+  vi.mocked(window.getSearchableNavigationRoutes).mockResolvedValue([
+    { routeId: 'ext.route-1', label: 'Dashboard' },
+    { routeId: 'ext.route-2', label: 'Models', icon: 'icon.png' },
+  ]);
+
+  navigationSearchEntriesEventStore.setup();
+
+  window.dispatchEvent(new CustomEvent('system-ready'));
+
+  await vi.waitFor(() => {
+    const entries = get(navigationSearchEntries);
+    expect(entries.length).toBe(2);
+    expect(entries[0]).toEqual({ routeId: 'ext.route-1', label: 'Dashboard' });
+    expect(entries[1]).toEqual({ routeId: 'ext.route-2', label: 'Models', icon: 'icon.png' });
+  });
+});
+
+test('navigation search entries should be updated on navigation-searchable-route-update event', async () => {
+  navigationSearchEntriesEventStore.setupWithDebounce(10, 10);
+
+  vi.mocked(window.getSearchableNavigationRoutes).mockResolvedValue([]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+  vi.mocked(window.getSearchableNavigationRoutes).mockClear();
+
+  vi.mocked(window.getSearchableNavigationRoutes).mockResolvedValue([{ routeId: 'ext.new-route', label: 'New Route' }]);
+
+  const callback = callbacks.get('navigation-searchable-route-update');
+  assert(callback);
+  await callback();
+
+  await vi.waitFor(() => {
+    const entries = get(navigationSearchEntries);
+    expect(entries.length).toBe(1);
+    expect(entries[0]).toEqual({ routeId: 'ext.new-route', label: 'New Route' });
+  });
+});

--- a/packages/renderer/src/stores/navigation-search-entries.ts
+++ b/packages/renderer/src/stores/navigation-search-entries.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { NavigationSearchEntryInfo } from '@podman-desktop/core-api';
+import { type Writable, writable } from 'svelte/store';
+
+import { EventStore } from './event-store';
+
+const windowEvents = ['navigation-searchable-route-update'];
+const windowListeners = ['system-ready'];
+
+async function checkForUpdate(): Promise<boolean> {
+  return true;
+}
+
+export const navigationSearchEntries: Writable<readonly NavigationSearchEntryInfo[]> = writable([]);
+
+const listSearchableRoutes = (): Promise<readonly NavigationSearchEntryInfo[]> => {
+  return window.getSearchableNavigationRoutes();
+};
+
+export const navigationSearchEntriesEventStore = new EventStore<readonly NavigationSearchEntryInfo[]>(
+  'navigation-search-entries',
+  navigationSearchEntries,
+  checkForUpdate,
+  windowEvents,
+  windowListeners,
+  listSearchableRoutes,
+);
+export const navigationSearchEntriesEventStoreInfo = navigationSearchEntriesEventStore.setup();


### PR DESCRIPTION
What does this PR do?

Extends the `navigation.register()` extension API with an optional third parameter `searchEntry` that makes registered navigation routes discoverable in the Command Palette (searchbar). When an extension registers a route with a `searchEntry`, it appears alongside built-in "Go to" items and can be filtered, selected, and navigated to from the palette.

**Changes across the stack:**

- **API layer** (`packages/api`): Added `NavigationSearchEntryInfo` type and a new `navigation-searchable-route-update` event channel
- **Extension API** (`packages/extension-api`): Added `NavigationSearchEntry` interface and updated `navigation.register()` signature to accept an optional `searchEntry` parameter
- **Main process** (`packages/main`): `NavigationManager.registerRoute()` now stores `searchEntry` metadata, fires update events on register/dispose, and exposes `getSearchableRoutes()`. `ExtensionLoader` resolves icons via `updateImage()` with fallback to the extension icon. New IPC handler `navigation:getSearchableRoutes`
- **Preload** (`packages/preload`): Exposes `getSearchableNavigationRoutes` to the renderer via context bridge
- **Renderer** (`packages/renderer`): New `navigationSearchEntries` EventStore that refreshes on `navigation-searchable-route-update`. `CommandPalette.svelte` integrates extension route items into both "All" and "Go to" filter modes with proper filtering, icon resolution (string/light+dark/fallback), keyboard navigation, and telemetry labeling

### Screenshot / video of UI

This is example of how it could look like. No UI changes was made

<img width="1398" height="202" alt="CleanShot 2026-07-31 at 15 05 33@2x" src="https://github.com/user-attachments/assets/55ebc3d4-1ad1-467e-9010-06e0604e9690" />

### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/18118
Part of https://github.com/podman-desktop/podman-desktop/issues/15650

### How to test this PR?

1. Apply a test registration in any built-in extension (e.g. kind):
   ```typescript
   extensionContext.subscriptions.push(
     extensionApi.navigation.register('test-search', 'kind.test-search', { label: 'Kind Cluster Manager' }),
   );
   ```
2. Run `pnpm watch`
3. Open the Command Palette (Ctrl/Cmd+K or click the searchbar)
4. Type "Kind" — the "Kind Cluster Manager" entry should appear under the "Go to" section
5. Select it — should navigate to the registered route
6. Deactivate/uninstall the extension — the entry should disappear from the palette

- [x] Tests are covering the bug fix or the new feature