### PR TITLE
fix(website): remove prompt symbol '>' from shell-session block

### DIFF
--- a/website/docs/installation/windows-install/index.md
+++ b/website/docs/installation/windows-install/index.md
@@ -39,7 +39,7 @@ _**Using WinGet**_
 1. Install from the terminal:
 
    ```shell-session
-   > winget install RedHat.Podman-Desktop
+   winget install RedHat.Podman-Desktop
    ```
 
 <details>
@@ -57,7 +57,7 @@ Alternate installation methods:
 1. To install without user interaction, run the Windows installer with the silent flag `/S` from the Command Prompt:
 
    ```shell-session
-   > podman-desktop-1.6.4-setup-x64.exe /S
+   podman-desktop-1.6.4-setup-x64.exe /S
    ```
 
 #### Chocolatey
@@ -67,7 +67,7 @@ Alternate installation methods:
 1. Install from the terminal:
 
    ```shell-session
-   > choco install podman-desktop
+   choco install podman-desktop
    ```
 
 #### Scoop package manager for Windows
@@ -77,8 +77,8 @@ Alternate installation methods:
 1. Install from the terminal:
 
    ```shell-session
-   > scoop bucket add extras
-   > scoop install podman-desktop
+   scoop bucket add extras
+   scoop install podman-desktop
    ```
 
 </details>
@@ -117,8 +117,8 @@ Check that your environment meets the following requirements:
 1. Run the following commands to enable the WSL feature without installing the default Ubuntu distribution of Linux:
 
    ```shell-session
-   > wsl --update
-   > wsl --install --no-distribution
+   wsl --update
+   wsl --install --no-distribution
    ```
 
    :::note
@@ -159,13 +159,13 @@ Check that your environment meets the following requirements:
    **Using command prompt**
 
    ```shell-session
-   > DISM /Online /Enable-Feature /All /FeatureName:Microsoft-Hyper-V
+   DISM /Online /Enable-Feature /All /FeatureName:Microsoft-Hyper-V
    ```
 
    **Using PowerShell**
 
    ```shell-session
-   > Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
+   Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
    ```
 
 1. Restart your machine.
@@ -177,13 +177,13 @@ Check that your environment meets the following requirements:
   **Using command prompt**
 
   ```shell-session
-  > systeminfo
+  systeminfo
   ```
 
   **Using PowerShell**
 
   ```shell-session
-  > Get-Service vmcompute
+  Get-Service vmcompute
   ```
 
 ### Install Podman Desktop dependencies

--- a/website/docs/podman/accessing-podman-from-another-wsl-instance.md
+++ b/website/docs/podman/accessing-podman-from-another-wsl-instance.md
@@ -27,7 +27,7 @@ In foldable details, you can find alternative steps for least common contexts:
 1. Start a session in your WSL distribution:
 
    ```shell-session
-   > wsl --distribution your-distribution-name
+   wsl --distribution your-distribution-name
    ```
 
 1. To communicate with the remote Podman Machine, you need a Podman client.
@@ -108,7 +108,7 @@ In foldable details, you can find alternative steps for least common contexts:
       Open a new Command Prompt, and list your Podman system connections:
 
       ```shell-session
-      > podman system connection list
+      podman system connection list
       ```
 
       The default connection line ends with `true`.
@@ -153,7 +153,7 @@ Verify that, on your WSL distribution, the Podman CLI communicates with your Pod
 1. Start a session in your WSL distribution:
 
    ```shell-session
-   > wsl
+   wsl
    ```
 
 1. Verify that your user is member of the group delivering access to the remote Podman Machine socket:

--- a/website/docs/proxy/index.md
+++ b/website/docs/proxy/index.md
@@ -56,7 +56,7 @@ However, it does not contain additional utilities, such as Compose or Kind.
    Open the Command Prompt, and run:.
 
    ```shell-session
-   > wsl --install --no-distribution
+   wsl --install --no-distribution
    ```
 
 1. Restart your computer.

--- a/website/docs/uninstall/index.md
+++ b/website/docs/uninstall/index.md
@@ -111,21 +111,21 @@ By default, Podman is available on Linux distributions, such as CentOS Stream, F
    - Run the following command:
 
      ```shell-session
-     > choco uninstall podman-desktop
+     choco uninstall podman-desktop
      ```
 
    #### Scoop package manager for Windows
    - Run the following command:
 
      ```shell-session
-     > scoop uninstall podman-desktop
+     scoop uninstall podman-desktop
      ```
 
    #### Winget
    - Run the following command:
 
      ```shell-session
-     > winget uninstall -e --id RedHat.Podman-Desktop
+     winget uninstall -e --id RedHat.Podman-Desktop
      ```
 
    </details>


### PR DESCRIPTION
### What does this PR do?
Removes ``>`` used as prompt symbol in shell-session blocks. Its not supported and Prism doesn't tokenize it. Fixes the need to manually remove it from commands when user selects and copies the command **manually** (not by using copy button).

*The ``>`` prompt prefix isn't recognized by ``powershell`` language (Prism grammar) either - its designed for scripts, not interactive sessions.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/18253

