### PR TITLE
fix: clarify macOS administrator privilege prompt

### DIFF
--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -324,6 +324,21 @@ describe('cli#update', () => {
     expect(disposeMock).toHaveBeenCalled();
   });
 
+  test('cancelled system-wide update should not update the recorded version', async () => {
+    vi.mocked(util.installBinaryToSystem).mockRejectedValue(new Error('cancelled'));
+
+    vi.mocked(KindInstaller.prototype.getKindCliStoragePath).mockReturnValue('storage-path');
+    vi.mocked(KindInstaller.prototype.promptUserForVersion).mockResolvedValue(mockV1Release);
+
+    const update: extensionApi.CliToolSelectUpdate = await getCliToolUpdate();
+    const providerUpdateCallCount = PROVIDER_MOCK.updateVersion.mock.calls.length;
+    await update.selectVersion();
+
+    await expect(update.doUpdate({} as unknown as extensionApi.Logger)).rejects.toThrowError('cancelled');
+    expect(CLI_TOOL_MOCK.updateVersion).not.toHaveBeenCalled();
+    expect(PROVIDER_MOCK.updateVersion).toHaveBeenCalledTimes(providerUpdateCallCount);
+  });
+
   test('uninstall updatable version should dispose update', async () => {
     vi.mocked(KindInstaller.prototype.getLatestVersionAsset).mockResolvedValue(mockV1Release);
 

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -559,11 +559,7 @@ async function registerCliTool(
       // download, install system wide and update cli version
       await installer.download(releaseToUpdateTo);
       let cliPath = installer.getKindCliStoragePath();
-      try {
-        cliPath = await installBinaryToSystem(cliPath, KIND_CLI_NAME);
-      } catch (err: unknown) {
-        console.log(`${KIND_CLI_NAME} not updated system-wide. Error: ${String(err)}`);
-      }
+      cliPath = await installBinaryToSystem(cliPath, KIND_CLI_NAME);
       kindCli?.updateVersion({
         version: releaseVersionToUpdateTo,
         installationSource: 'extension',

--- a/packages/main/src/plugin/util/exec.spec.ts
+++ b/packages/main/src/plugin/util/exec.spec.ts
@@ -342,7 +342,7 @@ describe('exec', () => {
       'osascript',
       expect.arrayContaining([
         '-e',
-        'do shell script "echo Hello,\\\\ \\\\\\"World\\\\\\"!" with prompt "Podman Desktop requires admin privileges " with administrator privileges',
+        'do shell script "echo Hello,\\\\ \\\\\\"World\\\\\\"!" with prompt "Podman Desktop needs administrator privileges for this system-wide operation. Cancel to skip it." with administrator privileges',
       ]),
       expect.anything(),
     );

--- a/packages/main/src/plugin/util/exec.ts
+++ b/packages/main/src/plugin/util/exec.ts
@@ -132,7 +132,7 @@ export class Exec {
         const escapedShellScript = shellScript.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         args = [
           '-e',
-          `do shell script "${escapedShellScript}" with prompt "Podman Desktop requires admin privileges " with administrator privileges`,
+          `do shell script "${escapedShellScript}" with prompt "Podman Desktop needs administrator privileges for this system-wide operation. Cancel to skip it." with administrator privileges`,
         ];
         command = 'osascript';
       } else if (isLinux()) {


### PR DESCRIPTION
## Summary

Clarify the macOS administrator-privilege prompt shown when Podman Desktop
executes a system-wide operation. The prompt now explains why authorization is
needed and that cancelling skips the operation, and the expectation is updated
to cover the exact user-facing text.

Fixes #11669.

## Validation

- focused suite: 24 passing, 3 skipped
- diff check

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the prompt
contract and test expectation, then independently ran the focused validation.
