### PR TITLE
fix(renderer): tighten markdown description spacing

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -456,6 +456,34 @@ test(`Check itemsAudit receive updated values`, async () => {
   });
 });
 
+test('Expect a markdown factory-property description to use the compact spacing wrapper', async () => {
+  const callback = mockCallback(async () => {});
+  const markdownDescription = 'Import host trusted CA certificates into the machine during startup.';
+
+  render(PreferencesConnectionCreationOrEditRendering, {
+    properties: [
+      {
+        title: 'Import host trusted CA certs',
+        parentId: '',
+        scope: 'ContainerProviderConnectionFactory',
+        id: 'test.import-native-ca',
+        type: 'boolean',
+        default: true,
+        markdownDescription,
+      },
+    ],
+    providerInfo,
+    connectionInfo: undefined,
+    propertyScope,
+    callback,
+    pageIsLoading: false,
+  });
+
+  const description = await screen.findByText(markdownDescription);
+  expect(description.closest('.connection-creation-markdown-description')).toBeInTheDocument();
+  expect(screen.getByRole('checkbox', { name: markdownDescription })).toBeInTheDocument();
+});
+
 test(`Expect create with unchecked and checked checkboxes`, async () => {
   const taskId = 4;
   const callback = mockCallback(async () => {});

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -582,7 +582,9 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
                   {#if configurationKey.description}
                     {configurationKey.description}:
                   {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}
-                    <Markdown markdown={configurationKey.markdownDescription} />
+                    <div class="connection-creation-markdown-description">
+                      <Markdown markdown={configurationKey.markdownDescription} />
+                    </div>
                   {/if}
                   {#if configurationKey.format === 'memory' || configurationKey.format === 'diskSize' || configurationKey.format === 'cpu'}
                     <div class="text-[var(--pd-content-text)]">
@@ -620,3 +622,10 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
     </div>
   {/if}
 </div>
+
+<style lang="postcss">
+  .connection-creation-markdown-description :global(.markdown > p:last-child) {
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary

- remove trailing Markdown paragraph spacing before machine-creation controls
- retain the configuration documentation link
- cover Markdown factory descriptions next to their Boolean controls

Fixes #18544.

## Testing

- `pnpm exec vitest run packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts` (22 tests)
- ESLint on both changed files
- `git diff --check`
- `pnpm run typecheck:renderer` (0 errors; 17 pre-existing warnings)

The issue screenshot was reviewed directly. A live Podman 6 machine form was
not launched locally, so maintainers should confirm the final pixel spacing in
the full application.

## AI assistance

AI assistance was used to investigate and draft this change. I reviewed the
form and Markdown contracts, inspected the issue screenshot, and independently
ran the focused renderer test and type check.
