### PR TITLE
feat(ui): add themed image support to Icon component

### DIFF
--- a/packages/ui/src/lib/icons/Icon.spec.ts
+++ b/packages/ui/src/lib/icons/Icon.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2025 Red Hat, Inc.
+ * Copyright (C) 2025-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -227,5 +227,38 @@ describe('string icon', () => {
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute('alt', 'test title');
     expect(img).toHaveAttribute('src', icon);
+  });
+});
+
+describe('themed image icon', () => {
+  const themedIcon = { light: 'light.png', dark: 'dark.png' };
+
+  test('renders light and dark sources with theme visibility classes', () => {
+    const { container } = render(Icon, { icon: themedIcon, size: 22, class: 'some-class', title: 'themed' });
+
+    const imgs = container.querySelectorAll('img');
+    expect(imgs).toHaveLength(2);
+
+    expect(imgs[0]).toHaveAttribute('src', 'light.png');
+    expect(imgs[0]).toHaveAttribute('alt', 'themed');
+    expect(imgs[0]).toHaveAttribute('title', 'themed');
+    expect(imgs[0]).toHaveAttribute('role', 'img');
+    expect(imgs[0]).toHaveClass('block', 'dark:hidden', 'some-class');
+    expect(imgs[0]).toHaveAttribute('style', 'width: 22px; height: 22px;');
+
+    expect(imgs[1]).toHaveAttribute('src', 'dark.png');
+    expect(imgs[1]).toHaveAttribute('alt', 'themed');
+    expect(imgs[1]).toHaveAttribute('title', 'themed');
+    expect(imgs[1]).toHaveAttribute('role', 'img');
+    expect(imgs[1]).toHaveClass('hidden', 'dark:block', 'some-class');
+    expect(imgs[1]).toHaveAttribute('style', 'width: 22px; height: 22px;');
+  });
+
+  test('renders a plain image path as an img', () => {
+    render(Icon, { icon: 'test.png', title: 'plain path' });
+
+    const img = screen.getByRole('img', { hidden: true });
+    expect(img).toHaveAttribute('src', 'test.png');
+    expect(img).toHaveAttribute('alt', 'plain path');
   });
 });

--- a/packages/ui/src/lib/icons/Icon.svelte
+++ b/packages/ui/src/lib/icons/Icon.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
-import type { Component } from 'svelte';
 import { Fa, type IconSize } from 'svelte-fa';
 
-import { isFontAwesomeIcon, isFontAwesomeSize } from '../utils/icon-utils';
+import { isFontAwesomeIcon, isFontAwesomeSize, isThemedIconImage } from '../utils/icon-utils';
+import type { IconType } from './Icon';
 
 interface Props {
-  icon: IconDefinition | Component | string;
+  icon: IconType;
   size?: IconSize | number | string;
   class?: string;
   title?: string;
@@ -17,7 +16,11 @@ let { icon, size, class: className, title, ariaHidden }: Props = $props();
 
 const role = $derived(ariaHidden ? undefined : 'img');
 const ariaHiddenAttr = $derived(ariaHidden ? 'true' : undefined);
-const IconComponent = icon;
+const alt = $derived(ariaHidden ? '' : (title ?? ''));
+const sizeStyle = $derived(typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : '');
+const IconComponent = $derived(
+  typeof icon !== 'string' && !isFontAwesomeIcon(icon) && !isThemedIconImage(icon) ? icon : undefined,
+);
 </script>
 
 
@@ -26,15 +29,15 @@ const IconComponent = icon;
         <Fa {icon} {size} class={className} title={ariaHidden ? undefined : title}/>
     {/if}
 {:else if typeof icon === 'string'}
-    <!-- fas fa- and far fa- and fab fa- for Font awesome icons -->
-    <!-- -icon for extension icons e.g. 'kind-icon' -->
+    <!-- fas fa- / far fa- / fab fa- Font Awesome classes, or extension CSS icons e.g. kind-icon -->
     {#if icon.startsWith('fas fa-') || icon.startsWith('far fa-') || icon.startsWith('fab fa-') || icon.endsWith('-icon')}
         <span class={`${icon} ${size} ${className}`} role={role} aria-hidden={ariaHiddenAttr} {title}></span>
-    {:else if icon.startsWith('data:image/')}
-        <img src={icon} alt={ariaHidden ? '' : (title ?? '')} {title} role={role} aria-hidden={ariaHiddenAttr} class={className} style={typeof size === 'number' ? `width: ${size}px; height: ${size}px;` : ''} />
+    {:else}
+        <img src={icon} {alt} {title} role={role} aria-hidden={ariaHiddenAttr} class={className} style={sizeStyle} />
     {/if}
-{:else}
-    {#if IconComponent && typeof IconComponent !== 'string' && !isFontAwesomeIcon(IconComponent)}
-        <span role={role} aria-hidden={ariaHiddenAttr} {title}><IconComponent class={className} {size}/></span>
-    {/if}
+{:else if isThemedIconImage(icon)}
+    <img src={icon.light} {alt} {title} role={role} aria-hidden={ariaHiddenAttr} class={['block dark:hidden', className]} style={sizeStyle} />
+    <img src={icon.dark} {alt} {title} role={role} aria-hidden={ariaHiddenAttr} class={['hidden dark:block', className]} style={sizeStyle} />
+{:else if IconComponent}
+    <span role={role} aria-hidden={ariaHiddenAttr} {title}><IconComponent class={className} {size}/></span>
 {/if}

--- a/packages/ui/src/lib/icons/Icon.ts
+++ b/packages/ui/src/lib/icons/Icon.ts
@@ -1,0 +1,30 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import type { Component } from 'svelte';
+
+/**
+ * Theme-aware image icon with separate light and dark sources.
+ */
+export type ThemedIconImage = {
+  light: string;
+  dark: string;
+};
+
+export type IconType = IconDefinition | Component | string | ThemedIconImage;

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -25,6 +25,7 @@ import Checkbox from './checkbox/Checkbox.svelte';
 import Dropdown from './dropdown/Dropdown.svelte';
 import DropdownMenu from './dropdownMenu';
 import ChevronExpander from './icons/ChevronExpander.svelte';
+import type { IconType, ThemedIconImage } from './icons/Icon';
 import Input from './inputs/Input.svelte';
 import NumberInput from './inputs/NumberInput.svelte';
 import SearchInput from './inputs/SearchInput.svelte';
@@ -52,7 +53,7 @@ import { tablePersistence } from './table/table-persistence-store.svelte';
 import Tooltip from './tooltip/Tooltip.svelte';
 import { isFontAwesomeIcon } from './utils/icon-utils';
 
-export type { ButtonType, ListOrganizerItem, TablePersistence };
+export type { ButtonType, IconType, ListOrganizerItem, TablePersistence, ThemedIconImage };
 export {
   Button,
   Carousel,

--- a/packages/ui/src/lib/utils/icon-utils.spec.ts
+++ b/packages/ui/src/lib/utils/icon-utils.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,18 +20,27 @@ import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { expect, test } from 'vitest';
 
-import { isFontAwesomeIcon, isFontAwesomeSize } from './icon-utils';
+import { isFontAwesomeIcon, isFontAwesomeSize, isThemedIconImage } from './icon-utils';
 
 test('ensure fas prefix is recognized', () => {
-  expect(isFontAwesomeIcon(faTrash)).toBeTruthy();
+  expect(isFontAwesomeIcon(faTrash)).toBe(true);
 });
 
 test('ensure fab prefix is recognized', () => {
-  expect(isFontAwesomeIcon(faGithub)).toBeTruthy();
+  expect(isFontAwesomeIcon(faGithub)).toBe(true);
 });
 
 test('ensure fontawesome size is recognized', () => {
-  expect(isFontAwesomeSize('xs')).toBeTruthy();
-  expect(isFontAwesomeSize('1x')).toBeTruthy();
-  expect(isFontAwesomeSize('4.2x')).toBeTruthy();
+  expect(isFontAwesomeSize('xs')).toBe(true);
+  expect(isFontAwesomeSize('1x')).toBe(true);
+  expect(isFontAwesomeSize('4.2x')).toBe(true);
+});
+
+test('ensure themed icon images are recognized', () => {
+  expect(isThemedIconImage({ light: 'light.png', dark: 'dark.png' })).toBe(true);
+  expect(isThemedIconImage({ light: 'light.png' })).toBe(false);
+  expect(isThemedIconImage({ dark: 'dark.png' })).toBe(false);
+  expect(isThemedIconImage(faTrash)).toBe(false);
+  expect(isThemedIconImage('light.png')).toBe(false);
+  expect(isThemedIconImage({})).toBe(false);
 });

--- a/packages/ui/src/lib/utils/icon-utils.ts
+++ b/packages/ui/src/lib/utils/icon-utils.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024-2025 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
 import type { IconSize } from 'svelte-fa';
 
+import type { ThemedIconImage } from '../icons/Icon';
+
 export const isFontAwesomeIcon = (icon: unknown): icon is IconDefinition => {
   return (
     !!icon &&
@@ -33,4 +35,15 @@ export const isFontAwesomeSize = (size: unknown): size is IconSize => {
   const fontAwesomeSizes = ['xs', 'sm', 'lg'];
   const fontAwesomePattern = /^\d+(?:\.\d+)?x$/;
   return !!size && typeof size === 'string' && (fontAwesomePattern.test(size) || fontAwesomeSizes.includes(size));
+};
+
+export const isThemedIconImage = (icon: unknown): icon is ThemedIconImage => {
+  return (
+    !!icon &&
+    typeof icon === 'object' &&
+    'light' in icon &&
+    typeof icon.light === 'string' &&
+    'dark' in icon &&
+    typeof icon.dark === 'string'
+  );
 };


### PR DESCRIPTION
### What does this PR do?
Introduce ThemedIconImage type with light/dark image sources, allowing the Icon component to automatically select the correct image based on the active theme.

Now the Icon component should finally support everything 🚀 

### Screenshot / video of UI


### What issues does this PR fix or reference?


### How to test this PR?
Unit tests

- [x] Tests are covering the bug fix or the new feature
