### PR TITLE
fix(onboarding): restore translucent skip-dialog backdrop

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
+++ b/packages/renderer/src/lib/onboarding/Onboarding.spec.ts
@@ -408,6 +408,7 @@ test('Expect that Esc closes', async () => {
   // Espect the div 'Skip Setup Popup' to be in the document
   const skipSetupPopup = screen.getByLabelText('Skip Setup Popup');
   expect(skipSetupPopup).toBeInTheDocument();
+  expect(skipSetupPopup.parentElement).toHaveClass('bg-(--pd-modal-fade)/60');
 });
 
 test('Expect onboarding to handle two extension ids and global onboarding set to true', async () => {

--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -495,7 +495,7 @@ let globalOnboarding = $derived(global);
 {/if}
 {#if displayCancelSetup}
   <!-- Create overlay-->
-  <div class="fixed top-0 left-0 right-0 bottom-0 bg-(--pd-modal-fade) bg-opacity-60 bg-blend-multiply h-full grid z-50">
+  <div class="fixed top-0 left-0 right-0 bottom-0 bg-(--pd-modal-fade)/60 bg-blend-multiply h-full grid z-50">
     <div
       class="flex flex-col place-self-center w-[550px] rounded-xl bg-[var(--pd-modal-bg)] shadow-xl shadow-(--pd-modal-shadow)"
       role="dialog"


### PR DESCRIPTION
## Summary

- Replace the removed Tailwind 3 opacity utility with Tailwind 4 color-opacity syntax for the Skip Setup overlay.
- Add a regression assertion for the translucent backdrop class.

Fixes #14146

## Validation

- `pnpm --filter renderer exec vitest run src/lib/onboarding/Onboarding.spec.ts --coverage=false` (13 passed)
- `pnpm run build:renderer`
- `git diff --check`

The change was reviewed against the current Tailwind 4 compiler and the affected onboarding contract. AI assistance was used for implementation and review; the final diff and validation were checked before publication.