### PR TITLE
fix(main): show the whole container command, not only its first argument

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1201,6 +1201,68 @@ describe('listContainers', () => {
     });
     expect(container?.State).toBe('running');
   });
+
+  test('list containers with Podman API and a multi-argument command', async () => {
+    const containersWithPodmanAPI = [
+      {
+        AutoRemove: false,
+        Command: ['ls', '-l', '/etc'],
+        Created: '2023-08-10T15:37:44.555961563+02:00',
+        CreatedAt: '',
+        Exited: true,
+        ExitedAt: 1691674673,
+        ExitCode: 0,
+        Id: '31a4b282691420be2611817f203765402d8da7e13cd530f80a6ddd1bb4aa63b4',
+        Image: 'docker.io/library/httpd:latest',
+        ImageID: '911d72fc5020723f0c003a134a8d2f062b4aea884474a11d1db7dcd28ce61d6a',
+        IsInfra: false,
+        Labels: {},
+        Mounts: [],
+        Names: ['admiring_wing'],
+        Namespaces: {},
+        Networks: ['podman'],
+        Pid: 0,
+        Pod: '',
+        PodName: '',
+        Ports: [],
+        Restarts: 0,
+        Size: null,
+        StartedAt: 1691674664,
+        State: 'running',
+        Status: '',
+      },
+    ];
+
+    const handlers = [
+      http.get('http://localhost/v4.2.0/libpod/containers/json', () => HttpResponse.json(containersWithPodmanAPI)),
+
+      http.get('http://localhost/v4.2.0/libpod/pods/json', () => HttpResponse.json([])),
+    ];
+    server = setupServer(...handlers);
+    server.listen({ onUnhandledRequest: 'error' });
+
+    const dockerAPI = new Dockerode({ protocol: 'http', host: 'localhost' });
+
+    const libpod = new LibpodDockerode();
+    libpod.enhancePrototypeWithLibPod();
+
+    containerRegistry.addInternalProvider('podman1', {
+      name: 'podman',
+      id: 'podman1',
+      api: dockerAPI,
+      libpodApi: dockerAPI,
+      connection: {
+        type: 'podman',
+      },
+    } as unknown as InternalContainerProvider);
+
+    const containers = await containerRegistry.listContainers();
+
+    // the whole command line, not only the executable: libpod reports Command
+    // as an array and the compatibility shape is a single string
+    expect(containers).toHaveLength(1);
+    expect(containers[0]?.Command).toBe('ls -l /etc');
+  });
 });
 
 test('pull unknown image fails with error 403', async () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -680,7 +680,7 @@ export class ContainerProviderRegistry {
                 Created: moment(podmanContainer.Created).unix(),
                 State: podmanContainer.State,
                 StartedAt,
-                Command: podmanContainer.Command?.length > 0 ? podmanContainer.Command[0] : undefined,
+                Command: podmanContainer.Command?.length > 0 ? podmanContainer.Command.join(' ') : undefined,
                 Labels,
                 Ports,
               };


### PR DESCRIPTION
### What does this PR do?

`listContainers` converts libpod containers into the Dockerode-compatible shape, where `Command` is a single string while libpod reports it as an array of arguments. The conversion kept only `Command[0]`, so a container started as `podman run -it fedora:44 ls .` showed `ls` on the container details page. It now joins the arguments.

**Where to look**
`packages/main/src/plugin/container-registry.ts` — one line, inside the libpod-to-compat mapping. The rest of the diff is a unit test alongside the existing `listContainers` cases.

**Not in this PR**
n/a — single pull request, nothing was split out.

### Screenshot / video of UI

n/a — no UI change. The container details page renders whatever `Command` it is given; the value reaching it was wrong, not the rendering.

### What issues does this PR fix or reference?

Fixes #18248

### How to test this PR?

1. `podman run -it --name multi-arg fedora:44 ls -l /etc` → the container is created and exits; `podman ps -a` shows `multi-arg`
2. Open Podman Desktop → Containers → `multi-arg` → the details page appears on the Summary tab
3. Read the Command field → it shows `ls -l /etc`; before this change it showed `ls`
4. Regression, single-word command: `podman run -d --name single httpd` → its details page still shows `httpd-foreground`, unchanged
5. Regression, no command reported: a container whose libpod `Command` is null → the Command field appears empty rather than showing `undefined`
6. `pnpm test:main -- container-registry.spec.ts` → 207 tests pass, including `list containers with Podman API and a multi-argument command`

**Notes for reviewers**
The unit test drives the libpod endpoint through msw, so CI covers the conversion itself. What CI does not exercise is the details page against a real podman machine — steps 1 to 3 were the reporter's reproduction and are worth one manual pass on review.

<sub>Prepared with podman-desktop-kit (automated workflow, PoC Claude Code Plugin), reviewed by @vzhukovs</sub>

- [ ] Tests are covering the bug fix or the new feature
