### PR TITLE
fix(main): show the experimental feature dialog once the renderer is listening

### DIFF
--- a/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { Configuration } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import type Electron from 'electron';
 import { shell } from 'electron';
@@ -115,9 +116,27 @@ const setTimestampSpy = vi.spyOn(TestExperimentalFeatureFeedbackHandler.prototyp
 const disableFeatureSpy = vi.spyOn(TestExperimentalFeatureFeedbackHandler.prototype, 'disableFeature');
 
 let feedbackForm: TestExperimentalFeatureFeedbackHandler;
+
+/** Listeners registered through the fake api sender, by channel. */
+let listeners: Map<string, Array<() => void>>;
+const apiSenderDispose = vi.fn();
+const apiSender = {
+  send: vi.fn(),
+  receive: vi.fn((channel: string, func: () => void) => {
+    listeners.set(channel, [...(listeners.get(channel) ?? []), func]);
+    return { dispose: apiSenderDispose };
+  }),
+} as unknown as ApiSenderType;
+
+/** Fire a channel the way the plugin system does once extensions are up. */
+function emit(channel: string): void {
+  for (const listener of listeners.get(channel) ?? []) listener();
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
-  feedbackForm = new TestExperimentalFeatureFeedbackHandler(configurationRegistry, messageBox, telemetry);
+  listeners = new Map();
+  feedbackForm = new TestExperimentalFeatureFeedbackHandler(configurationRegistry, messageBox, telemetry, apiSender);
 
   vi.spyOn(feedbackForm, 'save').mockResolvedValue(undefined);
 });
@@ -167,18 +186,62 @@ describe('init', () => {
     expect(setReminderSpy).not.toBeCalled();
   });
 
-  test('should load existing configurations and show dialog', async () => {
+  test('should load existing configurations without showing the dialog', async () => {
     const conf = { remindAt: 123456, disabled: false };
     configurationGetMock.mockReturnValue(conf);
     vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
     vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
     const showFeedbackDialogSpy = vi.spyOn(feedbackForm, 'showFeedbackDialog').mockResolvedValue(undefined);
+
     await feedbackForm.init();
 
     expect(setReminderSpy).not.toHaveBeenCalled();
-
     expect(feedbackForm.experimentalFeatures.get('feat.feature1')).toEqual(conf);
-    expect(showFeedbackDialogSpy).toBeCalled();
+
+    // init() runs while the renderer is still loading: the dialog it would show
+    // has nobody listening for it yet, which is the defect this fixes.
+    expect(showFeedbackDialogSpy).not.toHaveBeenCalled();
+  });
+
+  test('should show the dialog when extensions have started', async () => {
+    const conf = { remindAt: 123456, disabled: false };
+    configurationGetMock.mockReturnValue(conf);
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
+    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
+    const showFeedbackDialogSpy = vi.spyOn(feedbackForm, 'showFeedbackDialog').mockResolvedValue(undefined);
+
+    await feedbackForm.init();
+    expect(showFeedbackDialogSpy).not.toHaveBeenCalled();
+
+    emit('extensions-started');
+
+    expect(showFeedbackDialogSpy).toHaveBeenCalledOnce();
+  });
+
+  test('should subscribe to the readiness event rather than to anything of its own', async () => {
+    configurationGetMock.mockReturnValue({});
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
+    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
+
+    await feedbackForm.init();
+
+    // The channel is the one the plugin system already sends and other main-side
+    // consumers already listen to; nothing feature-specific was invented for it.
+    expect(apiSender.receive).toHaveBeenCalledWith('extensions-started', expect.any(Function));
+  });
+
+  test('should drop the subscription when disposed', async () => {
+    // registerConfigurations is pushed onto the same disposables list, so it has
+    // to return one here — no test disposed this handler before now.
+    registerConfigurationsMock.mockReturnValue({ dispose: vi.fn() });
+    configurationGetMock.mockReturnValue({});
+    vi.mocked(configurationRegistry.getConfiguration).mockReturnValue(configuration);
+    vi.mocked(configurationRegistry.getConfigurationProperties).mockReturnValue(features);
+
+    await feedbackForm.init();
+    feedbackForm.dispose();
+
+    expect(apiSenderDispose).toHaveBeenCalled();
   });
 
   test(`should skip disabled features with 'false' value`, async () => {

--- a/packages/main/src/plugin/experimental-feature-feedback-handler.ts
+++ b/packages/main/src/plugin/experimental-feature-feedback-handler.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { IDisposable } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { IConfigurationNode, IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
 import { shell } from 'electron';
 import { inject, injectable } from 'inversify';
@@ -49,6 +50,8 @@ export class ExperimentalFeatureFeedbackHandler {
     private messageBox: MessageBox,
     @inject(Telemetry)
     private telemetry: Telemetry,
+    @inject(ApiSenderType)
+    private apiSender: ApiSenderType,
   ) {
     this.#configurationRegistry = this.configurationRegistry;
   }
@@ -123,8 +126,18 @@ export class ExperimentalFeatureFeedbackHandler {
         this.setReminder(configurationKey);
       }
     }
-    // When are all features set, show dialog
-    await this.showFeedbackDialog();
+    // The dialog is drawn by the renderer, and the renderer only mounts
+    // <MessageBox /> once it has received 'starting-extensions'. Showing it from
+    // here fires the event while nothing is listening, which is why the dialog
+    // was never seen. Waiting for 'extensions-started' means the renderer has
+    // been up long enough to have mounted it.
+    this.#disposables.push(
+      this.apiSender.receive('extensions-started', () => {
+        this.showFeedbackDialog().catch((err: unknown) =>
+          console.error('Unable to show the experimental feature feedback dialog', err),
+        );
+      }),
+    );
   }
 
   /**

--- a/tests/playwright/src/specs/experimental-feature-feedback.spec.ts
+++ b/tests/playwright/src/specs/experimental-feature-feedback.spec.ts
@@ -1,0 +1,69 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { RunnerOptions } from '/@/runner/runner-options';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+
+/**
+ * A reminder that fell due while the application was closed. The dialog is
+ * expected on the next start; before this was fixed it was shown during plugin
+ * system startup, when the renderer had not yet mounted the component that
+ * draws it, and the user saw nothing.
+ */
+const REMIND_AT_IN_THE_PAST = 1_766_965_484_260;
+
+test.use({
+  runnerOptions: new RunnerOptions({
+    customFolder: 'experimental-feature-feedback',
+    customSettings: {
+      'statusbarProviders.showProviders': {
+        remindAt: REMIND_AT_IN_THE_PAST,
+        disabled: false,
+      },
+    },
+  }),
+});
+
+test.beforeAll(async ({ runner }) => {
+  runner.setVideoAndTraceName('experimental-feature-feedback-e2e');
+});
+
+test.afterAll(async ({ runner }) => {
+  await runner.close();
+});
+
+test.describe('Experimental feature feedback dialog', { tag: ['@smoke'] }, () => {
+  // One test, not two: the dialog is a startup event and there is one of it per
+  // launch. A second test observing the same dialog would depend on what the
+  // first one left behind, which is how an e2e suite starts passing in one
+  // order and failing in another.
+  test('is shown on startup when a reminder is due, and closes when answered', async ({ page }) => {
+    // The welcome page is deliberately not dismissed first: the point is that
+    // the dialog survives startup on its own, without anybody asking for it.
+    const dialog = page.getByRole('dialog', { name: 'Share Feedback' });
+
+    await playExpect(dialog).toBeVisible({ timeout: 30_000 });
+
+    // 'Remind me later' opens the choices rather than answering; the answers are
+    // the RemindOption values the handler knows.
+    await dialog.getByRole('button', { name: 'Remind me later' }).click();
+    await dialog.getByRole('button', { name: 'Remind me tomorrow' }).click();
+
+    await playExpect(dialog).toBeHidden();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

The experimental feature feedback dialog was never shown at startup. `init()` showed it while the plugin system was still starting, and the renderer mounts `<MessageBox />` only after it receives `starting-extensions` — so the event had no listener and changing `remindAt` to a past date appeared to do nothing.

The handler now subscribes to `extensions-started`, the readiness event other main-side consumers already listen to, and shows the dialog from there. `init()` only populates the feature map.

This replaces #17577, which solved the same defect by having the renderer pull the dialog from `App.svelte`'s `onMount`. That approach was rejected — reasonably — for wiring one feature's needs into a shared startup path, and this one touches neither the renderer nor preload.

**Where to look**
- `packages/main/src/plugin/experimental-feature-feedback-handler.ts` — the whole fix: one call removed from `init()`, one subscription added. The pattern is the one `contribution-manager.ts` already uses for the same event.
- `packages/main/src/plugin/experimental-feature-feedback-handler.spec.ts` — four new tests. One unrelated line: `registerConfigurationsMock` now returns a disposable, because `init()` pushes its result onto `#disposables` and no test in this file had ever called `dispose()` after `init()` before. That is a fixture repair, not a behaviour change.
- `tests/playwright/src/specs/experimental-feature-feedback.spec.ts` — new e2e.

**Not in this PR**
n/a — single pull request. Nothing was split out.

### Screenshot / video of UI

n/a — no UI change. The dialog and its markup are untouched; what changed is when it is asked for.

### What issues does this PR fix or reference?

Closes #17221

| R-ID | Requirement | Where | Test |
|------|-------------|-------|------|
| R1 | A past `remindAt` shows the dialog after the next restart | `experimental-feature-feedback-handler.ts` subscription | `experimental-feature-feedback.spec.ts` (e2e) |
| R2 | The dialog is not shown before the renderer has been told the system is ready | same subscription | `…-handler.spec.ts` — `init()` shows nothing; the event shows it |
| R3 | Readiness is not wired feature-by-feature into a shared startup path | the diff: `index.ts`, `App.svelte` and preload are untouched | reviewed, not tested |
| R4 | A future `remindAt` still shows nothing, and an answered dialog is not re-fired | unchanged reminder arithmetic | `…-handler.spec.ts` regression tests |

### How to test this PR?

1. `pnpm test:main -- experimental-feature-feedback-handler.spec.ts` → 23 tests pass, including `should show the dialog when extensions have started`
2. Put a past `remindAt` in `settings.json`, e.g. `"statusbarProviders.showProviders": { "remindAt": 1766965484260, "disabled": false }` → the file is accepted on next launch
3. Start Podman Desktop → the **Share Feedback** dialog appears once the application has loaded, where before this change nothing appeared
4. Click **Remind me later → Remind me tomorrow** → the dialog closes and `remindAt` moves a day forward in `settings.json`
5. Restart with that future `remindAt` → nothing is shown, which is the regression this must not cause
6. `pnpm test:e2e:build && npx playwright test tests/playwright/src/specs/experimental-feature-feedback.spec.ts` → 1 passed; it ran four times in a row here before this was opened

**Notes for reviewers**
- **R3 is reviewed, not tested.** "No feature-specific wiring in a shared startup path" is a property of the diff, and the evidence attached for it is the diff itself rather than a run. It is the requirement this rework exists for, so it is worth a reviewer's eye rather than a green tick.
- **The ordering is strong, not a handshake.** `extensions-started` fires after extension loading, and the renderer mounts within milliseconds of `starting-extensions`, so the dialog cannot precede a renderer that has been told the system is ready. It is not a guarantee that `<MessageBox />` has finished mounting, and R2 is worded to say only what is delivered.
- **Measured on a development build.** Timing in a packaged build was not measured.

<sub>Prepared with podman-desktop-kit (automated workflow, PoC Claude Code Plugin), reviewed by @vzhukovs</sub>

- [ ] Tests are covering the bug fix or the new feature
