### PR TITLE
feat(renderer): cancel long press on pointer movement and leave

### DIFF
--- a/packages/renderer/src/lib/ui/attachments/longpress.spec.ts
+++ b/packages/renderer/src/lib/ui/attachments/longpress.spec.ts
@@ -1,0 +1,196 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { longPress } from '/@/lib/ui/attachments/longpress';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+function attachLongPress(
+  cb: () => void,
+  button = 0,
+  threshold = 350,
+  moveCancelPx = 5,
+): { node: HTMLDivElement; destroy: () => void } {
+  const node = document.createElement('div');
+  const destroy = longPress(cb, button, threshold, moveCancelPx)(node)!;
+  return { node, destroy };
+}
+
+function mouseDown(node: HTMLElement, clientX = 10, clientY = 20, button = 0): void {
+  node.dispatchEvent(new MouseEvent('mousedown', { button, clientX, clientY, bubbles: true }));
+}
+
+describe('longPress', () => {
+  describe('original behavior', () => {
+    test('fires callback after the configured threshold', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb, 0, 350);
+
+      mouseDown(node);
+      expect(cb).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(349);
+      expect(cb).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(cb).toHaveBeenCalledOnce();
+
+      destroy();
+    });
+
+    test('uses the default 500ms threshold when none is provided', () => {
+      const cb = vi.fn();
+      const node = document.createElement('div');
+      const destroy = longPress(cb)(node)!;
+
+      mouseDown(node);
+      vi.advanceTimersByTime(499);
+      expect(cb).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(cb).toHaveBeenCalledOnce();
+
+      destroy();
+    });
+
+    test('does not fire when mouseup happens before the threshold', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb);
+
+      mouseDown(node);
+      node.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+
+      vi.advanceTimersByTime(400);
+      expect(cb).not.toHaveBeenCalled();
+
+      destroy();
+    });
+
+    test('ignores mousedown from a different mouse button', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb, 0, 350);
+
+      mouseDown(node, 10, 20, 2);
+      vi.advanceTimersByTime(400);
+      expect(cb).not.toHaveBeenCalled();
+
+      destroy();
+    });
+
+    test('respects a custom button index', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb, 2, 350);
+
+      mouseDown(node, 10, 20, 2);
+      vi.advanceTimersByTime(350);
+      expect(cb).toHaveBeenCalledOnce();
+
+      destroy();
+    });
+
+    test('destroy clears a pending long-press', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb);
+
+      mouseDown(node);
+      destroy();
+
+      vi.advanceTimersByTime(400);
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancel on movement and leave', () => {
+    test('fires when the pointer stays still until the threshold', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb, 0, 350);
+
+      mouseDown(node, 10, 20);
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 10, clientY: 20, bubbles: true }));
+
+      vi.advanceTimersByTime(350);
+      expect(cb).toHaveBeenCalledOnce();
+
+      destroy();
+    });
+
+    test('fires when the pointer moves within the cancel distance', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb, 0, 350, 5);
+
+      mouseDown(node, 10, 20);
+      // 3px < default 5px cancel threshold
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 13, clientY: 20, bubbles: true }));
+
+      vi.advanceTimersByTime(350);
+      expect(cb).toHaveBeenCalledOnce();
+
+      destroy();
+    });
+
+    test('does not fire when the pointer moves beyond the cancel distance', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb, 0, 350, 5);
+
+      mouseDown(node, 10, 20);
+      // 10px > 5px cancel threshold
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 20, clientY: 20, bubbles: true }));
+
+      vi.advanceTimersByTime(400);
+      expect(cb).not.toHaveBeenCalled();
+
+      destroy();
+    });
+
+    test('respects a custom move cancel distance', () => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb, 0, 350, 20);
+
+      mouseDown(node, 10, 20);
+      // 10px is beyond the default 5px but within the custom 20px threshold
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 20, clientY: 20, bubbles: true }));
+
+      vi.advanceTimersByTime(350);
+      expect(cb).toHaveBeenCalledOnce();
+
+      destroy();
+    });
+
+    test.each([
+      { event: 'mouseleave', create: (): Event => new MouseEvent('mouseleave', { bubbles: true }) },
+      { event: 'pointerleave', create: (): Event => new PointerEvent('pointerleave', { bubbles: true }) },
+      { event: 'pointercancel', create: (): Event => new PointerEvent('pointercancel', { bubbles: true }) },
+    ])('does not fire when $event happens before the threshold', ({ create }) => {
+      const cb = vi.fn();
+      const { node, destroy } = attachLongPress(cb);
+
+      mouseDown(node);
+      node.dispatchEvent(create());
+
+      vi.advanceTimersByTime(400);
+      expect(cb).not.toHaveBeenCalled();
+
+      destroy();
+    });
+  });
+});

--- a/packages/renderer/src/lib/ui/attachments/longpress.ts
+++ b/packages/renderer/src/lib/ui/attachments/longpress.ts
@@ -18,28 +18,55 @@
 
 import type { Attachment } from 'svelte/attachments';
 
-export function longPress(cb: () => void, button = 0, threshold = 500): Attachment {
+export function longPress(cb: () => void, button = 0, threshold = 500, moveCancelPx = 5): Attachment {
   return node => {
     let timeout: ReturnType<typeof setTimeout> | undefined = undefined;
-
-    const handleMouseDown = (event: Event): void => {
-      const mouseEvent = event as MouseEvent;
-      if (mouseEvent.button !== button) return;
-      timeout = setTimeout(cb, threshold);
-    };
+    let startX = 0;
+    let startY = 0;
 
     const handleCancel = (): void => {
       if (!timeout) return;
       clearTimeout(timeout);
       timeout = undefined;
+      window.removeEventListener('pointermove', handlePointerMove);
+    };
+
+    const handlePointerMove = (event: PointerEvent): void => {
+      if (!timeout) return;
+      const dx = event.clientX - startX;
+      const dy = event.clientY - startY;
+      if (dx * dx + dy * dy > moveCancelPx * moveCancelPx) {
+        handleCancel();
+      }
+    };
+
+    const handleMouseDown = (event: Event): void => {
+      const mouseEvent = event as MouseEvent;
+      if (mouseEvent.button !== button) return;
+      startX = mouseEvent.clientX;
+      startY = mouseEvent.clientY;
+      handleCancel();
+      timeout = setTimeout(() => {
+        timeout = undefined;
+        window.removeEventListener('pointermove', handlePointerMove);
+        cb();
+      }, threshold);
+      window.addEventListener('pointermove', handlePointerMove);
     };
 
     node.addEventListener('mousedown', handleMouseDown);
     node.addEventListener('mouseup', handleCancel);
+    node.addEventListener('mouseleave', handleCancel);
+    node.addEventListener('pointerleave', handleCancel);
+    node.addEventListener('pointercancel', handleCancel);
 
     return () => {
+      handleCancel();
       node.removeEventListener('mousedown', handleMouseDown);
       node.removeEventListener('mouseup', handleCancel);
+      node.removeEventListener('mouseleave', handleCancel);
+      node.removeEventListener('pointerleave', handleCancel);
+      node.removeEventListener('pointercancel', handleCancel);
     };
   };
 }


### PR DESCRIPTION
### What does this PR do?
Add moveCancelPx parameter to longPress() that cancels the gesture when the pointer moves beyond a configurable distance (default 5px). Also cancel on mouseleave, pointerleave, and pointercancel events to prevent stale timers when the pointer exits the element.

### Screenshot / video of UI


https://github.com/user-attachments/assets/f31fb477-01d3-4423-807d-17dd773e8d2e



### What issues does this PR fix or reference?


### How to test this PR?
You can go to navigation buttons and try to while longpressing move to the other side of the button (action should cancel and you should not see the history then)
or of you just longpress within 5px the action continue 


- [x] Tests are covering the bug fix or the new feature
