### PR TITLE
chore(test): add filtering e2e tests for remaining entities

### DIFF
--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -26,16 +26,19 @@ export class ExtensionsPage {
   readonly page: Page;
   readonly heading: Locator;
   readonly header: Locator;
+  readonly search: Locator;
   readonly content: Locator;
   readonly additionalActions: Locator;
   readonly installedTab: Locator;
   readonly catalogTab: Locator;
   readonly localExtensionsTab: Locator;
   readonly installExtensionFromOCIImageButton: Locator;
+  readonly searchInput: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.header = page.getByRole('region', { name: 'header' });
+    this.search = page.getByRole('region', { name: 'search' });
     this.content = page.getByRole('region', { name: 'content' });
     this.heading = this.header.getByRole('heading', { name: 'extensions' });
     this.additionalActions = this.header.getByRole('group', {
@@ -45,6 +48,7 @@ export class ExtensionsPage {
     this.catalogTab = this.page.getByRole('button', { name: 'Catalog', exact: true });
     this.localExtensionsTab = this.page.getByRole('button', { name: 'Local Extensions' });
     this.installExtensionFromOCIImageButton = this.additionalActions.getByLabel('Install custom');
+    this.searchInput = this.search.getByLabel('search extensions');
   }
 
   public async installExtensionFromOCIImage(extension: string, timeout = 100_000): Promise<ExtensionsPage> {
@@ -125,5 +129,46 @@ export class ExtensionsPage {
       console.log(`Could not get ${label} extension version:`, error);
       return undefined;
     }
+  }
+
+  public async filterByName(name: string): Promise<void> {
+    return test.step(`Filter extensions by name: ${name}`, async () => {
+      await playExpect(this.searchInput).toBeVisible();
+      await this.searchInput.fill(name);
+      await playExpect(this.searchInput).toHaveValue(name);
+    });
+  }
+
+  public async clearFilterByName(): Promise<void> {
+    return test.step('Clear name filter on extensions page', async () => {
+      await playExpect(this.searchInput).toBeVisible();
+      await this.searchInput.clear();
+      await playExpect(this.searchInput).toHaveValue('');
+    });
+  }
+
+  public async countInstalledExtensionCards(): Promise<number> {
+    return test.step('Count installed extension cards', async () => {
+      const cards = this.content.getByRole('region');
+      return await cards.count();
+    });
+  }
+
+  public async countCatalogExtensionCards(): Promise<number> {
+    return test.step('Count catalog extension cards', async () => {
+      const cards = this.content.getByRole('group');
+      return await cards.count();
+    });
+  }
+
+  public async extensionCardIsVisible(label: string): Promise<boolean> {
+    return test.step(`Check if extension card ${label} is visible`, async () => {
+      const regionCard = this.content.getByRole('region', { name: label, exact: true });
+      if ((await regionCard.count()) > 0) {
+        return true;
+      }
+      const groupCard = this.content.getByRole('group', { name: label, exact: true });
+      return (await groupCard.count()) > 0;
+    });
   }
 }

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -165,10 +165,10 @@ export class ExtensionsPage {
     return test.step(`Check if extension card ${label} is visible`, async () => {
       const regionCard = this.content.getByRole('region', { name: label, exact: true });
       if ((await regionCard.count()) > 0) {
-        return true;
+        return await regionCard.isVisible();
       }
       const groupCard = this.content.getByRole('group', { name: label, exact: true });
-      return (await groupCard.count()) > 0;
+      return (await groupCard.count()) > 0 && (await groupCard.isVisible());
     });
   }
 }

--- a/tests/playwright/src/specs/builtin-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/builtin-extension-smoke.spec.ts
@@ -146,3 +146,56 @@ async function openExtensionsPodmanPage(ext: {
   const extensionsPage = await navigationBar.openExtensions();
   return extensionsPage.openExtensionDetails(ext.extensionLabelName, ext.regionAreaLabel, ext.extensionHeading);
 }
+
+test.describe('Extension search filtering', { tag: ['@smoke', '@windows_sanity', '@macos_sanity'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('Filter installed extensions by name', async () => {
+    const extensionsPage = await navigationBar.openExtensions();
+    await playExpect(extensionsPage.heading).toBeVisible();
+    await extensionsPage.openInstalledTab();
+
+    const totalCards = await extensionsPage.countInstalledExtensionCards();
+    playExpect(totalCards).toBeGreaterThan(0);
+
+    const extensionsToFilter = [
+      { search: 'podman', label: 'podman-desktop.podman' },
+      { search: 'compose', label: 'podman-desktop.compose' },
+    ];
+
+    for (const { search, label } of extensionsToFilter) {
+      await extensionsPage.filterByName(search);
+      await playExpect
+        .poll(async () => await extensionsPage.extensionCardIsVisible(label), { timeout: 10_000 })
+        .toBeTruthy();
+    }
+
+    await extensionsPage.clearFilterByName();
+    await playExpect
+      .poll(async () => await extensionsPage.countInstalledExtensionCards(), { timeout: 10_000 })
+      .toBe(totalCards);
+  });
+
+  test('Filter catalog extensions by name', async () => {
+    const extensionsPage = await navigationBar.openExtensions();
+    await playExpect(extensionsPage.heading).toBeVisible();
+    await extensionsPage.openCatalogTab();
+
+    await playExpect
+      .poll(async () => await extensionsPage.countCatalogExtensionCards(), { timeout: 10_000 })
+      .toBeGreaterThan(0);
+    const totalCards = await extensionsPage.countCatalogExtensionCards();
+
+    await extensionsPage.filterByName('bootc');
+    await playExpect
+      .poll(async () => await extensionsPage.countCatalogExtensionCards(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(1);
+    const filteredCards = await extensionsPage.countCatalogExtensionCards();
+    playExpect(filteredCards).toBeLessThan(totalCards);
+
+    await extensionsPage.clearFilterByName();
+    await playExpect
+      .poll(async () => await extensionsPage.countCatalogExtensionCards(), { timeout: 10_000 })
+      .toBe(totalCards);
+  });
+});

--- a/tests/playwright/src/specs/builtin-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/builtin-extension-smoke.spec.ts
@@ -186,7 +186,10 @@ test.describe('Extension search filtering', { tag: ['@smoke', '@windows_sanity',
       .toBeGreaterThan(0);
     const totalCards = await extensionsPage.countCatalogExtensionCards();
 
-    await extensionsPage.filterByName('bootc');
+    await extensionsPage.filterByName('Bootable Containers');
+    await playExpect
+      .poll(async () => await extensionsPage.extensionCardIsVisible('Bootable Containers'), { timeout: 10_000 })
+      .toBeTruthy();
     await playExpect
       .poll(async () => await extensionsPage.countCatalogExtensionCards(), { timeout: 10_000 })
       .toBeGreaterThanOrEqual(1);

--- a/tests/playwright/src/specs/network-smoke.spec.ts
+++ b/tests/playwright/src/specs/network-smoke.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import { ContainerState } from '/@/model/core/states';
+import { NetworksPage } from '/@/model/pages/networks-page';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { deleteContainer, deleteImage, deleteNetwork, isPodmanCliVersionAtLeast } from '/@/utility/operations';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
@@ -26,6 +27,8 @@ const testNetworkName = 'e2e-test-network';
 const testNetworkSubnet = '192.168.1.0/24';
 const testContainerName = 'e2e-network-test-container';
 const testImageName = 'ghcr.io/linuxcontainers/alpine';
+const networkList = ['e2e-net-first', 'e2e-net-second', 'e2e-net-third'];
+const networkSubnets = ['10.90.0.0/24', '10.91.0.0/24', '10.92.0.0/24'];
 
 test.skip(
   !isPodmanCliVersionAtLeast('5.7.0'),
@@ -45,6 +48,9 @@ test.describe
         await deleteContainer(page, testContainerName);
         await deleteNetwork(page, testNetworkName);
         await deleteImage(page, testImageName);
+        for (const network of networkList) {
+          await deleteNetwork(page, network);
+        }
       } finally {
         await runner.close();
       }
@@ -186,5 +192,45 @@ test.describe
           timeout: 30_000,
         })
         .toBeFalsy();
+    });
+
+    test('Filter and delete networks', async ({ page, navigationBar }) => {
+      test.setTimeout(120_000);
+
+      let networksPage = await navigationBar.openNetworks();
+      await playExpect(networksPage.heading).toBeVisible();
+
+      for (let i = 0; i < networkList.length; i++) {
+        const networkDetails = await networksPage.createNetwork(networkList[i], networkSubnets[i]);
+        await playExpect(networkDetails.heading).toBeVisible({ timeout: 30_000 });
+
+        networksPage = await navigationBar.openNetworks();
+        await playExpect(networksPage.heading).toBeVisible();
+        await playExpect
+          .poll(async () => await networksPage.getNetworkRowByName(networkList[i]), { timeout: 30_000 })
+          .toBeTruthy();
+      }
+
+      networksPage = new NetworksPage(page);
+      await test.step('Verify search filtering works for each network', async () => {
+        for (const network of networkList) {
+          await networksPage.filterByName(network);
+          await playExpect
+            .poll(async () => await networksPage.countRowsFromTable(), { timeout: 10_000 })
+            .toBeGreaterThanOrEqual(1);
+          await playExpect.poll(async () => await networksPage.networkExists(network), { timeout: 5_000 }).toBeTruthy();
+        }
+        await networksPage.clearFilterByName();
+        await playExpect
+          .poll(async () => await networksPage.countRowsFromTable(), { timeout: 10_000 })
+          .toBeGreaterThanOrEqual(networkList.length);
+      });
+
+      for (const network of networkList) {
+        await networksPage.deleteNetwork(network);
+        await playExpect
+          .poll(async () => await networksPage.getNetworkRowByName(network), { timeout: 30_000 })
+          .toBeFalsy();
+      }
     });
   });

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -338,7 +338,7 @@ test.describe
       });
 
       test('Pruning pods', async ({ page, navigationBar }) => {
-        test.setTimeout(90_000);
+        test.setTimeout(120_000);
 
         const portsList = [5001, 5002, 5003];
 
@@ -361,6 +361,21 @@ test.describe
           await playExpect(podsPage.heading).toBeVisible({ timeout: 60_000 });
           await playExpect.poll(async () => await podsPage.podExists(podNames[i]), { timeout: 15_000 }).toBeTruthy();
         }
+
+        const podsPageForFilter = new PodsPage(page);
+        await test.step('Verify search filtering works for each pod', async () => {
+          for (const pod of podNames) {
+            await podsPageForFilter.filterByName(pod);
+            await playExpect
+              .poll(async () => await podsPageForFilter.countRowsFromTable(), { timeout: 10_000 })
+              .toBeGreaterThanOrEqual(1);
+            await playExpect.poll(async () => await podsPageForFilter.podExists(pod), { timeout: 5_000 }).toBeTruthy();
+          }
+          await podsPageForFilter.clearFilterByName();
+          await playExpect
+            .poll(async () => await podsPageForFilter.countRowsFromTable(), { timeout: 10_000 })
+            .toBeGreaterThanOrEqual(podNames.length);
+        });
 
         for (const pod of podNames) {
           const podDetailsPage = await new PodsPage(page).openPodDetails(pod);

--- a/tests/playwright/src/specs/volume-smoke.spec.ts
+++ b/tests/playwright/src/specs/volume-smoke.spec.ts
@@ -19,6 +19,7 @@
 import { ContainerState, VolumeState } from '/@/model/core/states';
 import type { ContainerInteractiveParams } from '/@/model/core/types';
 import { ContainerDetailsPage } from '/@/model/pages/container-details-page';
+import { VolumesPage } from '/@/model/pages/volumes-page';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import { deleteContainer, deleteImage, readFileInVolumeFromCLI } from '/@/utility/operations';
 import { waitForPodmanMachineStartup } from '/@/utility/wait';
@@ -29,6 +30,7 @@ const noVolumeImageToPull = 'ghcr.io/linuxcontainers/alpine';
 const containerName = 'alpine';
 const containerToRun = 'bootc-image-builder';
 const volumeName = 'e2eVolume';
+const volumeList = ['e2e-vol-first', 'e2e-vol-second', 'e2e-vol-third'];
 const containerVolumePath = '/tmp/mount';
 const fileName = 'test.txt';
 const textContent = 'This is a test file created in the volume.';
@@ -120,6 +122,47 @@ test.describe
           timeout: 35_000,
         })
         .toBeTruthy();
+    });
+
+    test('Filter and prune volumes', async ({ page, navigationBar }) => {
+      test.setTimeout(120_000);
+
+      let volumesPage = await navigationBar.openVolumes();
+      await playExpect(volumesPage.heading).toBeVisible();
+
+      for (const volume of volumeList) {
+        const createVolumePage = await volumesPage.openCreateVolumePage(volume);
+        volumesPage = await createVolumePage.createVolume(volume);
+        await playExpect
+          .poll(async () => await volumesPage.waitForVolumeExists(volume), { timeout: 25_000 })
+          .toBeTruthy();
+      }
+
+      volumesPage = new VolumesPage(page);
+      await test.step('Verify search filtering works for each volume', async () => {
+        for (const volume of volumeList) {
+          await volumesPage.filterByName(volume);
+          await playExpect
+            .poll(async () => await volumesPage.countRowsFromTable(), { timeout: 10_000 })
+            .toBeGreaterThanOrEqual(1);
+          await playExpect
+            .poll(async () => await volumesPage.getVolumeRowByName(volume), { timeout: 5_000 })
+            .toBeDefined();
+        }
+        await volumesPage.clearFilterByName();
+        await playExpect
+          .poll(async () => await volumesPage.countRowsFromTable(), { timeout: 10_000 })
+          .toBeGreaterThanOrEqual(volumeList.length);
+      });
+
+      volumesPage = await navigationBar.openVolumes();
+      await playExpect(volumesPage.heading).toBeVisible();
+      volumesPage = await volumesPage.pruneVolumes();
+      for (const volume of volumeList) {
+        await playExpect
+          .poll(async () => await volumesPage.waitForVolumeDelete(volume), { timeout: 35_000 })
+          .toBeTruthy();
+      }
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
Adds missing filtering e2e tests from some entities.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18055
https://github.com/podman-desktop/podman-desktop/issues/18054
https://github.com/podman-desktop/podman-desktop/issues/18053
https://github.com/podman-desktop/podman-desktop/issues/18050

