### PR TITLE
fix: dashboard podman tile socket liveness updates on linux

### DIFF
--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -64,6 +64,7 @@ import {
   registerOnboardingMachineExistsCommand,
   registerOnboardingUnsupportedPodmanMachineCommand,
   setWSLEnabled,
+  updateProviderStatus,
 } from './extension';
 import { InversifyBinding } from './inject/inversify-binding';
 import type { UpdateCheck } from './installer/podman-install';
@@ -4466,6 +4467,53 @@ describe('getImportNativeCAFromConfig', () => {
     const configDir = path.join('home', 'user', '.config', 'containers', 'podman', 'machine', 'applehv');
     await getImportNativeCAFromConfig('my-vm', { ConfigDir: { Path: configDir } });
     expect(readFile).toHaveBeenCalledWith(path.join(configDir, 'my-vm.json'), 'utf-8');
+  });
+});
+
+describe('updateProviderStatus on Linux updates the provider tile', () => {
+  beforeEach(() => {
+    vi.mocked(extensionApi.env).isLinux = true;
+    vi.spyOn(provider, 'updateStatus').mockImplementation(() => {});
+    extension.podmanMachinesStatuses.clear();
+  });
+
+  test.each([
+    { from: 'started' as const, to: 'stopped' as const, expectedProviderStatus: 'stopped' },
+    { from: 'stopped' as const, to: 'started' as const, expectedProviderStatus: 'ready' },
+  ])(
+    'sets provider to $expectedProviderStatus when native socket transitions from $from to $to',
+    ({ from, to, expectedProviderStatus }) => {
+      updateProviderStatus(provider, from);
+      vi.mocked(provider.updateStatus).mockClear();
+
+      updateProviderStatus(provider, to);
+
+      expect(provider.updateStatus).toHaveBeenCalledWith(expectedProviderStatus);
+    },
+  );
+
+  test('does not call provider.updateStatus when status has not changed', () => {
+    updateProviderStatus(provider, 'started');
+    vi.mocked(provider.updateStatus).mockClear();
+
+    updateProviderStatus(provider, 'started');
+
+    expect(provider.updateStatus).not.toHaveBeenCalled();
+  });
+
+  test('does not call provider.updateStatus on non-Linux', () => {
+    vi.mocked(extensionApi.env).isLinux = false;
+
+    updateProviderStatus(provider, 'started');
+
+    expect(provider.updateStatus).not.toHaveBeenCalled();
+  });
+
+  test('updates machine status map when machineName is provided', () => {
+    updateProviderStatus(provider, 'started', 'my-machine');
+
+    expect(extension.podmanMachinesStatuses.get('my-machine')).toBe('started');
+    expect(provider.updateStatus).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -19,8 +19,10 @@
 
 import type * as proc from 'node:child_process';
 import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import * as http from 'node:http';
 import { arch } from 'node:os';
 import path from 'node:path';
 
@@ -61,8 +63,11 @@ import * as extension from './extension';
 import {
   getImportNativeCAFromConfig,
   initCheckAndRegisterUpdate,
+  initDefaultLinux,
+  monitorPodmanSocket,
   registerOnboardingMachineExistsCommand,
   registerOnboardingUnsupportedPodmanMachineCommand,
+  resetStopLoop,
   setWSLEnabled,
   updateProviderStatus,
 } from './extension';
@@ -306,6 +311,13 @@ const originalConsoleTrace = console.trace;
 const consoleTraceMock = vi.fn();
 
 vi.mock(import('node:fs'));
+vi.mock(import('node:http'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    get: vi.fn(),
+  };
+});
 vi.mock(import('node:fs/promises'), async importOriginal => {
   const actual = await importOriginal();
   return {
@@ -4470,17 +4482,36 @@ describe('getImportNativeCAFromConfig', () => {
   });
 });
 
-describe('updateProviderStatus on Linux updates the provider tile', () => {
-  beforeEach(() => {
-    vi.mocked(extensionApi.env).isLinux = true;
-  });
+describe('provider status updates on podman socket liveness change', () => {
+  function setupSocketMonitorWithStatus(alive: boolean): void {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    resetStopLoop();
+    if (alive) {
+      vi.mocked(http.get).mockImplementation(((_options: unknown, callback?: (res: http.IncomingMessage) => void) => {
+        const request = new EventEmitter() as http.ClientRequest;
+        const response = new EventEmitter() as http.IncomingMessage;
+        response.statusCode = 200;
+        callback?.(response);
+        response.emit('data', '');
+        response.emit('end');
+        return request;
+      }) as typeof http.get);
+    } else {
+      vi.mocked(http.get).mockImplementation(((_options: unknown, _callback?: (res: http.IncomingMessage) => void) => {
+        const request = new EventEmitter() as http.ClientRequest;
+        queueMicrotask(() => request.emit('error', new Error('connect error')));
+        return request;
+      }) as typeof http.get);
+    }
+  }
 
   test.each([
     { from: 'started' as const, to: 'stopped' as const, expectedProviderStatus: 'stopped' },
     { from: 'stopped' as const, to: 'started' as const, expectedProviderStatus: 'ready' },
   ])(
-    'sets provider to $expectedProviderStatus when native socket transitions from $from to $to',
+    'sets provider to $expectedProviderStatus when native socket transitions from $from to $to on Linux',
     ({ from, to, expectedProviderStatus }) => {
+      vi.mocked(extensionApi.env).isLinux = true;
       updateProviderStatus(provider, from);
       updateProviderStatus(provider, to);
 
@@ -4489,7 +4520,7 @@ describe('updateProviderStatus on Linux updates the provider tile', () => {
   );
 
   test('does not call provider.updateStatus when status has not changed', () => {
-    // Initial status is 'started'
+    vi.mocked(extensionApi.env).isLinux = true;
     updateProviderStatus(provider, 'started');
 
     expect(provider.updateStatus).not.toHaveBeenCalled();
@@ -4508,6 +4539,67 @@ describe('updateProviderStatus on Linux updates the provider tile', () => {
 
     expect(extension.podmanMachinesStatuses.get('my-machine')).toBe('started');
     expect(provider.updateStatus).not.toHaveBeenCalled();
+  });
+
+  test('monitorPodmanSocket updates provider to stopped when native socket is not alive', async () => {
+    vi.mocked(extensionApi.env).isLinux = true;
+    setupSocketMonitorWithStatus(false);
+    updateProviderStatus(provider, 'started');
+    vi.mocked(provider.updateStatus).mockClear();
+
+    const promise = monitorPodmanSocket(provider, '/socket');
+    await vi.advanceTimersByTimeAsync(5000);
+    await promise;
+
+    expect(provider.updateStatus).toHaveBeenCalledWith('stopped');
+  });
+
+  test('monitorPodmanSocket updates provider to ready when native socket is alive', async () => {
+    vi.mocked(extensionApi.env).isLinux = true;
+    setupSocketMonitorWithStatus(true);
+    updateProviderStatus(provider, 'stopped');
+    vi.mocked(provider.updateStatus).mockClear();
+
+    const promise = monitorPodmanSocket(provider, '/socket');
+    await vi.advanceTimersByTimeAsync(5000);
+    await promise;
+
+    expect(provider.updateStatus).toHaveBeenCalledWith('ready');
+  });
+
+  test('monitorPodmanSocket sets machine status to started when machine socket is alive', async () => {
+    setupSocketMonitorWithStatus(true);
+    extension.podmanMachinesStatuses.set('test-machine', 'stopped');
+
+    const promise = monitorPodmanSocket(provider, '/socket', 'test-machine');
+    await vi.advanceTimersByTimeAsync(5000);
+    await promise;
+
+    expect(extension.podmanMachinesStatuses.get('test-machine')).toBe('started');
+  });
+
+  test('monitorPodmanSocket sets machine status to stopped when machine socket is not alive', async () => {
+    setupSocketMonitorWithStatus(false);
+    extension.podmanMachinesStatuses.set('test-machine', 'started');
+
+    const promise = monitorPodmanSocket(provider, '/socket', 'test-machine');
+    await vi.advanceTimersByTimeAsync(5000);
+    await promise;
+
+    expect(extension.podmanMachinesStatuses.get('test-machine')).toBe('stopped');
+  });
+
+  test('initDefaultLinux registers container connection when socket exists', async () => {
+    vi.mocked(extensionApi.env).isLinux = true;
+    setupSocketMonitorWithStatus(false);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    extension.initExtensionContext(getContextMock());
+
+    await initDefaultLinux(provider);
+
+    expect(provider.registerContainerProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Podman', type: 'podman' }),
+    );
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -4473,8 +4473,6 @@ describe('getImportNativeCAFromConfig', () => {
 describe('updateProviderStatus on Linux updates the provider tile', () => {
   beforeEach(() => {
     vi.mocked(extensionApi.env).isLinux = true;
-    vi.spyOn(provider, 'updateStatus').mockImplementation(() => {});
-    extension.podmanMachinesStatuses.clear();
   });
 
   test.each([
@@ -4484,8 +4482,6 @@ describe('updateProviderStatus on Linux updates the provider tile', () => {
     'sets provider to $expectedProviderStatus when native socket transitions from $from to $to',
     ({ from, to, expectedProviderStatus }) => {
       updateProviderStatus(provider, from);
-      vi.mocked(provider.updateStatus).mockClear();
-
       updateProviderStatus(provider, to);
 
       expect(provider.updateStatus).toHaveBeenCalledWith(expectedProviderStatus);
@@ -4493,9 +4489,7 @@ describe('updateProviderStatus on Linux updates the provider tile', () => {
   );
 
   test('does not call provider.updateStatus when status has not changed', () => {
-    updateProviderStatus(provider, 'started');
-    vi.mocked(provider.updateStatus).mockClear();
-
+    // Initial status is 'started'
     updateProviderStatus(provider, 'started');
 
     expect(provider.updateStatus).not.toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -64,6 +64,7 @@ import {
   registerOnboardingMachineExistsCommand,
   registerOnboardingUnsupportedPodmanMachineCommand,
   setWSLEnabled,
+  updateProviderStatus,
 } from './extension';
 import { InversifyBinding } from './inject/inversify-binding';
 import type { UpdateCheck } from './installer/podman-install';
@@ -4370,6 +4371,53 @@ describe('getImportNativeCAFromConfig', () => {
     const configDir = path.join('home', 'user', '.config', 'containers', 'podman', 'machine', 'applehv');
     await getImportNativeCAFromConfig('my-vm', { ConfigDir: { Path: configDir } });
     expect(readFile).toHaveBeenCalledWith(path.join(configDir, 'my-vm.json'), 'utf-8');
+  });
+});
+
+describe('updateProviderStatus on Linux updates the provider tile', () => {
+  beforeEach(() => {
+    vi.mocked(extensionApi.env).isLinux = true;
+    vi.spyOn(provider, 'updateStatus').mockImplementation(() => {});
+    extension.podmanMachinesStatuses.clear();
+  });
+
+  test.each([
+    { from: 'started' as const, to: 'stopped' as const, expectedProviderStatus: 'stopped' },
+    { from: 'stopped' as const, to: 'started' as const, expectedProviderStatus: 'ready' },
+  ])(
+    'sets provider to $expectedProviderStatus when native socket transitions from $from to $to',
+    ({ from, to, expectedProviderStatus }) => {
+      updateProviderStatus(provider, from);
+      vi.mocked(provider.updateStatus).mockClear();
+
+      updateProviderStatus(provider, to);
+
+      expect(provider.updateStatus).toHaveBeenCalledWith(expectedProviderStatus);
+    },
+  );
+
+  test('does not call provider.updateStatus when status has not changed', () => {
+    updateProviderStatus(provider, 'started');
+    vi.mocked(provider.updateStatus).mockClear();
+
+    updateProviderStatus(provider, 'started');
+
+    expect(provider.updateStatus).not.toHaveBeenCalled();
+  });
+
+  test('does not call provider.updateStatus on non-Linux', () => {
+    vi.mocked(extensionApi.env).isLinux = false;
+
+    updateProviderStatus(provider, 'started');
+
+    expect(provider.updateStatus).not.toHaveBeenCalled();
+  });
+
+  test('updates machine status map when machineName is provided', () => {
+    updateProviderStatus(provider, 'started', 'my-machine');
+
+    expect(extension.podmanMachinesStatuses.get('my-machine')).toBe('started');
+    expect(provider.updateStatus).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/podman/packages/extension/src/extension.spec.ts
+++ b/extensions/podman/packages/extension/src/extension.spec.ts
@@ -4377,8 +4377,6 @@ describe('getImportNativeCAFromConfig', () => {
 describe('updateProviderStatus on Linux updates the provider tile', () => {
   beforeEach(() => {
     vi.mocked(extensionApi.env).isLinux = true;
-    vi.spyOn(provider, 'updateStatus').mockImplementation(() => {});
-    extension.podmanMachinesStatuses.clear();
   });
 
   test.each([
@@ -4388,8 +4386,6 @@ describe('updateProviderStatus on Linux updates the provider tile', () => {
     'sets provider to $expectedProviderStatus when native socket transitions from $from to $to',
     ({ from, to, expectedProviderStatus }) => {
       updateProviderStatus(provider, from);
-      vi.mocked(provider.updateStatus).mockClear();
-
       updateProviderStatus(provider, to);
 
       expect(provider.updateStatus).toHaveBeenCalledWith(expectedProviderStatus);
@@ -4397,9 +4393,7 @@ describe('updateProviderStatus on Linux updates the provider tile', () => {
   );
 
   test('does not call provider.updateStatus when status has not changed', () => {
-    updateProviderStatus(provider, 'started');
-    vi.mocked(provider.updateStatus).mockClear();
-
+    // Initial status is 'started'
     updateProviderStatus(provider, 'started');
 
     expect(provider.updateStatus).not.toHaveBeenCalled();

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -699,7 +699,7 @@ function stopMonitoringPodmanSocket(machineName?: string): boolean {
   return stopLoop;
 }
 
-function updateProviderStatus(
+export function updateProviderStatus(
   provider: extensionApi.Provider,
   status: extensionApi.ProviderConnectionStatus,
   machineName?: string,

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -620,7 +620,7 @@ function getLinuxSocketPath(): string {
 }
 
 // on linux, socket is started by the system service on a path like /run/user/1000/podman/podman.sock
-async function initDefaultLinux(provider: extensionApi.Provider): Promise<void> {
+export async function initDefaultLinux(provider: extensionApi.Provider): Promise<void> {
   const socketPath = getLinuxSocketPath();
   if (!fs.existsSync(socketPath)) {
     return;
@@ -668,7 +668,7 @@ async function isPodmanSocketAlive(socketPath: string): Promise<boolean> {
   });
 }
 
-async function monitorPodmanSocket(
+export async function monitorPodmanSocket(
   provider: extensionApi.Provider,
   socketPath: string,
   machineName?: string,
@@ -1997,6 +1997,10 @@ export async function getJSONMachineList(): Promise<MachineJSONListOutput> {
 export async function getJSONMachineListByProvider(containerMachineProvider?: string): Promise<MachineListOutput> {
   const { stdout, stderr } = await execPodman(['machine', 'list', '--format', 'json'], containerMachineProvider);
   return { stdout, stderr };
+}
+
+export function resetStopLoop(): void {
+  stopLoop = false;
 }
 
 export async function deactivate(): Promise<void> {

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -635,7 +635,7 @@ async function initDefaultLinux(provider: extensionApi.Provider): Promise<void> 
     },
   };
 
-  monitorPodmanSocket(socketPath).catch((error: unknown) => {
+  monitorPodmanSocket(provider, socketPath).catch((error: unknown) => {
     console.error('Error monitoring podman socket', error);
   });
 
@@ -668,21 +668,25 @@ async function isPodmanSocketAlive(socketPath: string): Promise<boolean> {
   });
 }
 
-async function monitorPodmanSocket(socketPath: string, machineName?: string): Promise<void> {
+async function monitorPodmanSocket(
+  provider: extensionApi.Provider,
+  socketPath: string,
+  machineName?: string,
+): Promise<void> {
   // call us again
   if (!stopMonitoringPodmanSocket(machineName)) {
     try {
       const alive = await isPodmanSocketAlive(socketPath);
       if (!alive) {
-        updateProviderStatus('stopped', machineName);
+        updateProviderStatus(provider, 'stopped', machineName);
       } else {
-        updateProviderStatus('started', machineName);
+        updateProviderStatus(provider, 'started', machineName);
       }
     } catch (error) {
       // ignore the update of machines
     }
     await timeout(5000);
-    monitorPodmanSocket(socketPath, machineName).catch((error: unknown) => {
+    monitorPodmanSocket(provider, socketPath, machineName).catch((error: unknown) => {
       console.error('Error monitoring podman socket', error);
     });
   }
@@ -695,11 +699,20 @@ function stopMonitoringPodmanSocket(machineName?: string): boolean {
   return stopLoop;
 }
 
-function updateProviderStatus(status: extensionApi.ProviderConnectionStatus, machineName?: string): void {
+function updateProviderStatus(
+  provider: extensionApi.Provider,
+  status: extensionApi.ProviderConnectionStatus,
+  machineName?: string,
+): void {
   if (machineName) {
     podmanMachinesStatuses.set(machineName, status);
   } else {
+    const previousStatus = podmanProviderStatus;
     podmanProviderStatus = status;
+
+    if (extensionApi.env.isLinux && previousStatus !== status) {
+      provider.updateStatus(status === 'started' ? 'ready' : 'stopped');
+    }
   }
 }
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -606,7 +606,7 @@ async function initDefaultLinux(provider: extensionApi.Provider): Promise<void> 
     },
   };
 
-  monitorPodmanSocket(socketPath).catch((error: unknown) => {
+  monitorPodmanSocket(provider, socketPath).catch((error: unknown) => {
     console.error('Error monitoring podman socket', error);
   });
 
@@ -639,21 +639,25 @@ async function isPodmanSocketAlive(socketPath: string): Promise<boolean> {
   });
 }
 
-async function monitorPodmanSocket(socketPath: string, machineName?: string): Promise<void> {
+async function monitorPodmanSocket(
+  provider: extensionApi.Provider,
+  socketPath: string,
+  machineName?: string,
+): Promise<void> {
   // call us again
   if (!stopMonitoringPodmanSocket(machineName)) {
     try {
       const alive = await isPodmanSocketAlive(socketPath);
       if (!alive) {
-        updateProviderStatus('stopped', machineName);
+        updateProviderStatus(provider, 'stopped', machineName);
       } else {
-        updateProviderStatus('started', machineName);
+        updateProviderStatus(provider, 'started', machineName);
       }
     } catch (error) {
       // ignore the update of machines
     }
     await timeout(5000);
-    monitorPodmanSocket(socketPath, machineName).catch((error: unknown) => {
+    monitorPodmanSocket(provider, socketPath, machineName).catch((error: unknown) => {
       console.error('Error monitoring podman socket', error);
     });
   }
@@ -666,11 +670,20 @@ function stopMonitoringPodmanSocket(machineName?: string): boolean {
   return stopLoop;
 }
 
-function updateProviderStatus(status: extensionApi.ProviderConnectionStatus, machineName?: string): void {
+function updateProviderStatus(
+  provider: extensionApi.Provider,
+  status: extensionApi.ProviderConnectionStatus,
+  machineName?: string,
+): void {
   if (machineName) {
     podmanMachinesStatuses.set(machineName, status);
   } else {
+    const previousStatus = podmanProviderStatus;
     podmanProviderStatus = status;
+
+    if (extensionApi.env.isLinux && previousStatus !== status) {
+      provider.updateStatus(status === 'started' ? 'ready' : 'stopped');
+    }
   }
 }
 

--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -670,7 +670,7 @@ function stopMonitoringPodmanSocket(machineName?: string): boolean {
   return stopLoop;
 }
 
-function updateProviderStatus(
+export function updateProviderStatus(
   provider: extensionApi.Provider,
   status: extensionApi.ProviderConnectionStatus,
   machineName?: string,


### PR DESCRIPTION
### What does this PR do?
Adds updates of provider status after socket liveness changes that is then displayed on Dashboard Podman tile. Includes unit tests.

### Screenshot / video of UI

https://github.com/user-attachments/assets/59b3797f-72e3-4556-8e69-3e262662cf9a


### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/18100

### How to test this PR?
1. Open Podman Desktop on Linux system with native podman running
2. See that dashboard podman tile shows "Running" (ready state)
3. Kill the podman system service process ``pkill -f "podman system service"``
4. Observe the dashboard tile displays "Stopped"

- [X] Tests are covering the bug fix or the new feature
