### PR TITLE
fix(renderer): add aria-pressed to shared ToggleButton component

### DIFF
--- a/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderResultPage.spec.ts
@@ -236,7 +236,11 @@ describe('test ProviderResultPage', async () => {
     });
 
     const criticalButton = screen.getByRole('button', { name: 'Critical (2)' });
+    expect(criticalButton).toHaveAttribute('aria-pressed', 'true');
+
     await fireEvent.click(criticalButton);
+    expect(criticalButton).toHaveAttribute('aria-pressed', 'false');
+
     results.filter(r => r.check.severity === 'critical').forEach(result => checkResultNotDisplayed(result));
     results.filter(r => r.check.severity !== 'critical').forEach(result => checkResultDisplayed(result));
   });

--- a/packages/renderer/src/lib/ui/ToggleButton.spec.ts
+++ b/packages/renderer/src/lib/ui/ToggleButton.spec.ts
@@ -1,0 +1,65 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { faCheckSquare } from '@fortawesome/free-solid-svg-icons';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ToggleButton from './ToggleButton.svelte';
+
+test('button has aria-pressed="true" when selected is true', () => {
+  render(ToggleButton, { icon: faCheckSquare, selected: true });
+
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'true');
+});
+
+test('button has aria-pressed="false" when selected is false', () => {
+  render(ToggleButton, { icon: faCheckSquare, selected: false });
+
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('button has aria-pressed="false" by default when selected is not provided', () => {
+  render(ToggleButton, { icon: faCheckSquare });
+
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('clicking the button flips aria-pressed from true to false', async () => {
+  render(ToggleButton, { icon: faCheckSquare, selected: true });
+
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'true');
+
+  await fireEvent.click(button);
+
+  expect(button).toHaveAttribute('aria-pressed', 'false');
+});
+
+test('disabled button still exposes aria-pressed reflecting selected', () => {
+  render(ToggleButton, { icon: faCheckSquare, selected: true, disabled: true });
+
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'true');
+  expect(button).toBeDisabled();
+});

--- a/packages/renderer/src/lib/ui/ToggleButton.svelte
+++ b/packages/renderer/src/lib/ui/ToggleButton.svelte
@@ -20,6 +20,7 @@ function onclick(): void {
 
 <button
   disabled={disabled}
+  aria-pressed={selected ? 'true' : 'false'}
   class="first:rounded-l last:rounded-r"
   class:bg-[var(--pd-content-card-carousel-card-bg)]={!disabled && !selected}
   class:hover:bg-[var(--pd-content-card-carousel-card-hover-bg)]={!disabled && !selected}


### PR DESCRIPTION
### What does this PR do?

`ToggleButton.svelte` is the closest thing we have to a reusable toggle-button component (see the issue in #18583). It's used for the severity filter chips (Critical/High/Medium/Low/Passed) on the image-check results page (`ProviderResultPage.svelte`), but its selected/unselected state was differentiated only by a background-color class swap. There was no `aria-pressed`, so a11y tech had no way to announce whether a filter chip was currently on or off.

This PR adds `aria-pressed={selected ? 'true' : 'false'}` to the button element in `ToggleButton.svelte`, following the same string-ternary pattern already established at `KubePlayYAML.svelte:215,260`.

Since this is a shared component, the fix is good for every current and future consumer, not just the severity filters.

**No visual or behavioral change, this is additive ARIA markup only.**

### Screenshot / video of UI

- **No visual changes, this is an ARIA-attribute-only fix.**
- The on/off appearance of the severity filter chips is unchanged.
- State is now also exposed programmatically via `aria-pressed`, verifiable in devtools or with a screen reader.

### What issues does this PR fix or reference?

- Resolves: #18583
- Part of: #17586 

### How to test this PR?

1. Open the image-check / provider results page and locate the severity filter chips (Critical/High/Medium/Low/Passed).
2. Click a chip to toggle it and inspect the button element in devtools — `aria-pressed` should read `"true"` when the filter is active and `"false"` when it's off.
3. Automated coverage:
   - `packages/renderer/src/lib/ui/ToggleButton.spec.ts` — new component-level tests covering `selected=true`, `selected=false`, default/unset, click-toggle, and disabled+selected.
   - `packages/renderer/src/lib/ui/ProviderResultPage.spec.ts` — extended the existing severity-filter test to assert `aria-pressed` transitions from `"true"` to `"false"` on the real "Critical" chip.

Run: `npx vitest run packages/renderer/src/lib/ui/ToggleButton.spec.ts packages/renderer/src/lib/ui/ProviderResultPage.spec.ts`

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>