### PR TITLE
fix(ui): add aria-label and aria-expanded to ListOrganizer trigger button

### DIFF
--- a/packages/ui/src/lib/layouts/ListOrganizer.spec.ts
+++ b/packages/ui/src/lib/layouts/ListOrganizer.spec.ts
@@ -49,6 +49,33 @@ test('Expect trigger button is visible and has correct title', async () => {
   expect(triggerButton).toHaveAttribute('tabindex', '0');
 });
 
+test('Expect trigger button has aria-label matching the title prop', () => {
+  const title = 'Manage Layout';
+  render(ListOrganizer, {
+    items: mockItems,
+    title,
+  });
+
+  const triggerButton = screen.getByTitle(title);
+  expect(triggerButton).toHaveAttribute('aria-label', title);
+});
+
+test('Expect trigger button aria-expanded reflects dropdown open state', async () => {
+  render(ListOrganizer, {
+    items: mockItems,
+    title: 'Manage Layout',
+  });
+
+  const triggerButton = screen.getByTitle('Manage Layout');
+  expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+
+  await fireEvent.click(triggerButton);
+  expect(triggerButton).toHaveAttribute('aria-expanded', 'true');
+
+  await fireEvent.click(triggerButton);
+  expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+});
+
 test('Expect dropdown opens when trigger button is clicked', async () => {
   render(ListOrganizer, {
     items: mockItems,

--- a/packages/ui/src/lib/layouts/ListOrganizer.svelte
+++ b/packages/ui/src/lib/layouts/ListOrganizer.svelte
@@ -250,6 +250,8 @@ function handleReset(): void {
     class:text-[var(--pd-action-button-hover-text)]={isOpen}
     onclick={toggleDropdown}
     title={title}
+    aria-label={title}
+    aria-expanded={isOpen}
     tabindex="0"
   >
     <Icon icon={faPen} />


### PR DESCRIPTION
### What does this PR do?

The "customize list" pencil-icon button in `ListOrganizer.svelte` opens a dropdown for reordering and toggling list/column visibility (used for "Configure Columns" in `Table.svelte` and "Configure Dashboard Sections" in `DashboardPage.svelte`).

It only showed its open/closed state through a text-color change, had a `title` attribute but no `aria-label`, and exposed no `aria-expanded` even though it's a disclosure control.

This PR adds two attributes to the trigger button:
1. `aria-label={title}` – reuses the existing `title` prop (already a meaningful label in both real consumers, e.g. "Configure Columns") as the accessible name, instead of relying on the `title` attribute alone.
2. `aria-expanded={isOpen}` – a raw boolean, matching the exact style already established at `Table.svelte:458-467` for row expand/collapse, so assistive technology can tell whether the dropdown is open or closed.

**No visual or behavioral change. This is additive ARIA markup only.**

No new props, no changes to `Table.svelte` or `DashboardPage.svelte`.

### Screenshot / video of UI

- **No visual changes.**
- This is an ARIA-attribute-only fix. The button's appearance and the dropdown's behavior are unchanged.
- State is now also exposed programmatically via `aria-label`/`aria-expanded`, verifiable in devtools or with a screen reader.

### What issues does this PR fix or reference?

- Resolves: #18584
- Part of: #17586

### How to test this PR?

1. Open a page that renders `ListOrganizer` (e.g. a table's "Configure Columns" button, or the Dashboard's "Configure Dashboard Sections" action).
2. Inspect the pencil-icon trigger button in devtools — it should have `aria-label` set to the button's tooltip text (e.g. "Configure Columns") and `aria-expanded="false"`.
3. Click the button to open the dropdown — `aria-expanded` should flip to `"true"`; click again (or close it) and it should return to `"false"`.
4. Automated coverage:
   - `packages/ui/src/lib/layouts/ListOrganizer.spec.ts` — two new tests: one asserting `aria-label` matches the `title` prop, one asserting `aria-expanded` cycles `false` -> `true` -> `false` across two clicks.
   - `packages/ui/src/lib/table/Table.spec.ts` — existing integration suite re-run to confirm the "Configure Columns" consumer still renders and behaves correctly.

Run: `npx vitest run packages/ui/src/lib/layouts/ListOrganizer.spec.ts packages/ui/src/lib/table/Table.spec.ts`

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>