### PR TITLE
feat(ui): add pressed prop to Button for aria-pressed toggle support

### DIFF
--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -289,3 +289,41 @@ test('Icon button with title should not throw', () => {
   expect(() => render(Button, { icon: faTrash, title: 'Delete' })).not.toThrow();
   expect(screen.getByRole('button')).toBeInTheDocument();
 });
+
+test('Button without pressed prop should not have aria-pressed attribute', async () => {
+  render(Button, { type: 'primary' });
+  const button = screen.getByRole('button');
+  expect(button).not.toHaveAttribute('aria-pressed');
+});
+
+test('Button with pressed true should have aria-pressed true and pressed styling', async () => {
+  render(Button, { type: 'primary', pressed: true });
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'true');
+  expect(button).toHaveClass('bg-[var(--pd-button-primary-hover-bg)]');
+  expect(button).toHaveClass('border-[var(--pd-button-tab-border-selected)]');
+});
+
+test('Button with pressed false should have aria-pressed false and regular styling', async () => {
+  render(Button, { type: 'primary', pressed: false });
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'false');
+  expect(button).toHaveClass('bg-[var(--pd-button-primary-bg)]');
+  expect(button).toHaveClass('border-[var(--pd-button-primary-border)]');
+});
+
+test('Pressed secondary button should have pressed styling', async () => {
+  render(Button, { type: 'secondary', pressed: true });
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'true');
+  expect(button).toHaveClass('bg-[var(--pd-button-secondary-hover-bg)]');
+  expect(button).toHaveClass('border-[var(--pd-button-tab-border-selected)]');
+});
+
+test('Disabled pressed button should keep aria-pressed but use disabled styling', async () => {
+  render(Button, { type: 'primary', pressed: true, disabled: true });
+  const button = screen.getByRole('button');
+  expect(button).toHaveAttribute('aria-pressed', 'true');
+  expect(button).toHaveClass('bg-[var(--pd-button-disabled-bg)]');
+  expect(button).not.toHaveClass('border-[var(--pd-button-tab-border-selected)]');
+});

--- a/packages/ui/src/lib/button/Button.svelte
+++ b/packages/ui/src/lib/button/Button.svelte
@@ -14,6 +14,7 @@ interface Props {
   type?: ButtonType;
   icon?: IconDefinition | Component | string;
   selected?: boolean;
+  pressed?: boolean;
   padding?: string;
   class?: string;
   hidden?: boolean;
@@ -32,6 +33,7 @@ let {
   type = 'primary',
   icon,
   selected,
+  pressed,
   padding,
   class: classNames,
   hidden,
@@ -46,25 +48,31 @@ if (untrack(() => icon !== undefined && !title && !children && !ariaLabel)) {
 
 let actualPadding = $derived(padding ?? 'px-[16px] ' + (type === 'tab' ? 'pb-1' : 'py-[5px]'));
 
+let pressedActive = $derived(pressed === true && !disabled && !inProgress);
+
 let classes = $derived.by(() => {
   let result: string;
   if (disabled || inProgress) {
     result = 'bg-[var(--pd-button-disabled-bg)] text-[var(--pd-button-disabled-text)] border border-transparent';
   } else if (type === 'primary') {
-    result =
-      'bg-[var(--pd-button-primary-bg)] text-[var(--pd-button-primary-text)] border border-[var(--pd-button-primary-border)] hover:bg-[var(--pd-button-primary-hover-bg)] shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]';
+    result = pressedActive
+      ? 'bg-[var(--pd-button-primary-hover-bg)] text-[var(--pd-button-primary-text)] border shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]'
+      : 'bg-[var(--pd-button-primary-bg)] text-[var(--pd-button-primary-text)] border border-[var(--pd-button-primary-border)] hover:bg-[var(--pd-button-primary-hover-bg)] shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]';
   } else if (type === 'secondary') {
-    result =
-      'bg-[var(--pd-button-secondary-bg)] text-[var(--pd-button-secondary-text)] border border-[var(--pd-button-secondary-border)] hover:bg-[var(--pd-button-secondary-hover-bg)] shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]';
+    result = pressedActive
+      ? 'bg-[var(--pd-button-secondary-hover-bg)] text-[var(--pd-button-secondary-text)] border shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]'
+      : 'bg-[var(--pd-button-secondary-bg)] text-[var(--pd-button-secondary-text)] border border-[var(--pd-button-secondary-border)] hover:bg-[var(--pd-button-secondary-hover-bg)] shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]';
   } else if (type === 'danger') {
-    result =
-      'bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] border border-[var(--pd-button-danger-border)] hover:bg-[var(--pd-button-danger-hover-bg)] shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring-danger)]';
+    result = pressedActive
+      ? 'bg-[var(--pd-button-danger-hover-bg)] text-[var(--pd-button-danger-text)] border shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring-danger)]'
+      : 'bg-[var(--pd-button-danger-bg)] text-[var(--pd-button-danger-text)] border border-[var(--pd-button-danger-border)] hover:bg-[var(--pd-button-danger-hover-bg)] shadow-[0px_1px_4px_0px_var(--pd-shadow-color)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring-danger)]';
   } else if (type === 'tab') {
     result =
       'border-b-[3px] border-[var(--pd-button-tab-border)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]';
   } else if (type === 'link') {
-    result =
-      'bg-[var(--pd-button-link-bg)] text-[var(--pd-button-link-text)] border border-transparent hover:bg-[var(--pd-button-link-hover-bg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]';
+    result = pressedActive
+      ? 'bg-[var(--pd-button-link-hover-bg)] text-[var(--pd-button-link-text)] border focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]'
+      : 'bg-[var(--pd-button-link-bg)] text-[var(--pd-button-link-text)] border border-transparent hover:bg-[var(--pd-button-link-hover-bg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pd-button-focus-ring)]';
   } else {
     console.warn(`Unknown button type: ${type}, falling back to primary`);
     result =
@@ -91,7 +99,8 @@ let classes = $derived.by(() => {
 <button
   type="button"
   class="relative {actualPadding} motion-reduce:transition-none min-h-[28px] min-w-[28px] leading-[15px] select-none {classes} {classNames}"
-  class:border-[var(--pd-button-tab-border-selected)]={type === 'tab' && selected && !disabled && !inProgress}
+  class:border-[var(--pd-button-tab-border-selected)]={(type === 'tab' && selected === true && !disabled && !inProgress) ||
+  pressedActive}
   class:hover:border-[var(--pd-button-tab-hover-border)]={type === 'tab' && !selected && !disabled && !inProgress}
   class:text-[var(--pd-button-tab-text-selected)]={type === 'tab' && selected && !disabled && !inProgress}
   class:text-[var(--pd-button-tab-text)]={type === 'tab' && !selected && !disabled && !inProgress}
@@ -101,7 +110,8 @@ let classes = $derived.by(() => {
   onclick={onclick}
   disabled={disabled || inProgress}
   aria-disabled={disabled || inProgress}
-  aria-busy={inProgress}>
+  aria-busy={inProgress}
+  aria-pressed={pressed}>
   {#if icon ?? inProgress}
     <div
       class="flex flex-row p-0 m-0 bg-transparent justify-center items-center space-x-[4px]"

--- a/storybook/src/stories/button/Button.stories.svelte
+++ b/storybook/src/stories/button/Button.stories.svelte
@@ -171,6 +171,22 @@ const tabVariants: ButtonVariant[] = [
   { name: 'Tab With Custom Class', args: { type: 'tab', content: 'Custom Tab', class: 'capitalize' } },
 ];
 
+const toggleVariants: ButtonVariant[] = [
+  { name: 'Toggle Pressed', args: { type: 'primary', content: 'Notifications', pressed: true } },
+  { name: 'Toggle Unpressed', args: { type: 'primary', content: 'Notifications', pressed: false } },
+  { name: 'Toggle Secondary Pressed', args: { type: 'secondary', content: 'Filter', pressed: true } },
+  { name: 'Toggle Secondary Unpressed', args: { type: 'secondary', content: 'Filter', pressed: false } },
+  {
+    name: 'Toggle Icon Only Pressed',
+    args: { type: 'secondary', icon: faBell, pressed: true, 'aria-label': 'Mute notifications' },
+  },
+  {
+    name: 'Toggle Icon Only Unpressed',
+    args: { type: 'secondary', icon: faBell, pressed: false, 'aria-label': 'Mute notifications' },
+  },
+  { name: 'Toggle Disabled Pressed', args: { type: 'secondary', content: 'Filter', pressed: true, disabled: true } },
+];
+
 // biome-ignore lint/correctness/noUnusedVariables: used in markup
 const groupKinds: Record<string, { label: string; variants: ButtonVariant[] }> = {
   basic: { label: 'Basic Types', variants: basicVariants },
@@ -179,6 +195,7 @@ const groupKinds: Record<string, { label: string; variants: ButtonVariant[] }> =
   examples: { label: 'Examples', variants: exampleVariants },
   patterns: { label: 'Patterns', variants: patternVariants },
   edges: { label: 'Edge Cases', variants: edgeVariants },
+  toggles: { label: 'Toggle Buttons', variants: toggleVariants },
   tabs: { label: 'Tabs', variants: tabVariants },
 };
 </script>
@@ -211,4 +228,5 @@ const groupKinds: Record<string, { label: string; variants: ButtonVariant[] }> =
 <Story name="Examples" args={{ kind: 'examples' }} />
 <Story name="Patterns" args={{ kind: 'patterns' }} />
 <Story name="Edge Cases" args={{ kind: 'edges' }} />
+<Story name="Toggle Buttons" args={{ kind: 'toggles' }} />
 <Story name="Tabs" args={{ kind: 'tabs' }} />


### PR DESCRIPTION
### What does this PR do?

Adds an optional `pressed` prop to the shared `Button` component so icon-toggle buttons get proper `aria-pressed` semantics instead of being hand-rolled throughout the codebase:

- `pressed?: boolean` — renders `aria-pressed` only when the prop is provided, so existing consumers are unaffected (no attribute, no visual change).
- Non-color visual feedback when pressed: persistent background (the type's hover token) plus an accent border (`--pd-button-tab-border-selected`, the token already used for the selected state), following the `KubePlayYAML.svelte` pattern referenced in the issue. Implemented by extending the existing `class:` directive, since a Svelte `class:` directive takes ownership of that class for the whole element.
- Disabled/in-progress buttons keep `aria-pressed` (the state is still announced) but use the disabled styling.
- New "Toggle Buttons" Storybook group demonstrating pressed/unpressed, icon-only and disabled usage.

One edge case worth noting: `pressed` on a `type="tab"` button currently renders like a selected tab (same border token). Tabs already have `selected` for this, so I left it as is — happy to add a `type !== 'tab'` guard to the pressed styling if you'd prefer that combination to be a visual no-op.

### Screenshot / video of UI
<img width="1200" height="560" alt="image" src="https://github.com/user-attachments/assets/66e5139b-c330-4572-8496-b10321c4a8dc" />

### What issues does this PR fix or reference?

Closes #18585

### How to test this PR?

- `pnpm --filter @podman-desktop/ui-svelte test` — includes 5 new unit tests: no prop → no `aria-pressed` attribute, `aria-pressed="true"`/`"false"` rendering, pressed styling for primary and secondary, and disabled+pressed keeping the attribute with disabled styling.
- Storybook → `Button / Toggle Buttons` shows all the variants side by side.
- Also verified locally: full `@podman-desktop/ui-svelte` suite (341 tests), `svelte-check`, ESLint, Biome, and a full Storybook build.

- [x] Tests are covering the bug fix or the new feature