### PR TITLE
fix(AppNavigation): fixed glitching when resizing

### DIFF
--- a/packages/renderer/src/AppNavigation.spec.ts
+++ b/packages/renderer/src/AppNavigation.spec.ts
@@ -190,3 +190,31 @@ test('Expanded threshold controls text visibility', async () => {
   callbacks.get(NAV_BAR_WIDTH_KEY)?.({ detail: { key: NAV_BAR_WIDTH_KEY, value: 135 } });
   await vi.waitFor(() => screen.getByLabelText('Dashboard title'));
 });
+
+test('resize handle captures pointer and persists width on drag end', async () => {
+  const NAV_BAR_WIDTH_KEY = `${AppearanceSettings.SectionName}.${AppearanceSettings.NavigationBarWidth}`;
+  const meta = { url: '/' } as unknown as TinroRouteMeta;
+
+  // Use a non-default width so waiting for it proves onMount finished (avoids mid-drag overwrite)
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(150);
+
+  await fetchNavigationRegistries();
+  render(AppNavigation, {
+    meta,
+    exitSettingsCallback: (): void => {},
+  });
+
+  const handle = screen.getByRole('separator', { name: 'Resize navigation bar' });
+  const setPointerCapture = vi.fn();
+  handle.setPointerCapture = setPointerCapture;
+  await vi.waitFor(() => expect(handle).toHaveAttribute('aria-valuenow', '150'));
+
+  handle.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: 150, pointerId: 1 }));
+  expect(setPointerCapture).toHaveBeenCalledWith(1);
+
+  window.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: 180, pointerId: 1 }));
+  await vi.waitFor(() => expect(handle).toHaveAttribute('aria-valuenow', '180'));
+
+  window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }));
+  await vi.waitFor(() => expect(window.updateConfigurationValue).toHaveBeenCalledWith(NAV_BAR_WIDTH_KEY, 180));
+});

--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -121,6 +121,9 @@ function onResizeHandlePointerDown(e: PointerEvent): void {
   isDragging = true;
   resizeStartX = e.clientX;
   resizeStartWidth = navWidth;
+  if (e.currentTarget instanceof HTMLElement) {
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
   window.addEventListener('pointermove', onResizeMove);
   window.addEventListener('pointerup', onResizeUp);
 }


### PR DESCRIPTION
### What does this PR do?
Fixes glitching (or loding the handle when resizing while having openned extension)

### Screenshot / video of UI
Prev: 


https://github.com/user-attachments/assets/98cc03be-3b27-492b-aa59-4bebbe67d0f6



With this fix: 


https://github.com/user-attachments/assets/95975597-dea9-44df-bf7c-c9264ee6ca99



### What issues does this PR fix or reference?

### How to test this PR?
On 1.29.1 Try to open webview and try to resize the navbar

On this branch try to do the same thing

- [x] Tests are covering the bug fix or the new feature
