### PR TITLE
refactor(Compose): migrated Compose* components to svelte5

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeActions.svelte
+++ b/packages/renderer/src/lib/compose/ComposeActions.svelte
@@ -13,26 +13,36 @@ import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
-export let compose: ComposeInfoUI;
-export let dropdownMenu = false;
-export let detailed = false;
-
 const dispatch = createEventDispatcher<{ update: ComposeInfoUI }>();
-export let onUpdate: (update: ComposeInfoUI) => void = update => {
-  dispatch('update', update);
-};
+
+interface Props {
+  compose: ComposeInfoUI;
+  dropdownMenu?: boolean;
+  detailed?: boolean;
+  onUpdate?: (update: ComposeInfoUI) => void;
+}
+
+let {
+  compose,
+  dropdownMenu = false,
+  detailed = false,
+  onUpdate = (update): void => {
+    dispatch('update', update);
+  },
+}: Props = $props();
+
 const composeLabel = 'com.docker.compose.project';
 
-let contributions: Menu[] = [];
+let contributions: Menu[] = $state([]);
 onMount(async () => {
   contributions = await window.getContributedMenus(MenuContext.DASHBOARD_COMPOSE);
 });
 
-let hideStartForStop = false;
-let hideStopForStart = false;
+let hideStartForStop = $state(false);
+let hideStopForStart = $state(false);
 
-$: someNeedStart = compose.containers?.some(c => c.state !== 'RUNNING');
-$: someNeedStop = compose.containers?.some(c => c.state === 'RUNNING');
+let someNeedStart = $derived(compose.containers?.some(c => c.state !== 'RUNNING'));
+let someNeedStop = $derived(compose.containers?.some(c => c.state === 'RUNNING'));
 
 function inProgress(inProgress: boolean, state?: string): void {
   compose.actionInProgress = inProgress;
@@ -119,12 +129,7 @@ function openGenerateKube(): void {
 
 // If dropdownMenu = true, we'll change style to the imported dropdownMenu style
 // otherwise, leave blank.
-let actionsStyle: typeof DropdownMenu | typeof FlatMenu;
-if (dropdownMenu) {
-  actionsStyle = DropdownMenu;
-} else {
-  actionsStyle = FlatMenu;
-}
+let ActionsStyle = $derived(dropdownMenu ? DropdownMenu : FlatMenu);
 </script>
 
 <ListItemButtonIcon
@@ -161,7 +166,7 @@ if (dropdownMenu) {
   inProgress={compose.actionInProgress && compose.status === 'DELETING'} />
 
 <!-- If dropdownMenu is true, use it, otherwise just show the regular buttons -->
-<svelte:component this={actionsStyle}>
+<ActionsStyle>
   {#if !detailed}
     <ListItemButtonIcon
       title="Generate Kube"
@@ -190,4 +195,4 @@ if (dropdownMenu) {
     contributions={contributions}
     detailed={detailed}
     onError={handleError} />
-</svelte:component>
+</ActionsStyle>

--- a/packages/renderer/src/lib/compose/ComposeDetailsInspect.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsInspect.svelte
@@ -6,9 +6,13 @@ import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
 
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
-export let compose: ComposeInfoUI;
+interface Props {
+  compose: ComposeInfoUI;
+}
 
-let inspectDetails: string;
+let { compose }: Props = $props();
+
+let inspectDetails: string = $state('');
 
 onMount(async () => {
   // Go through each container and grab the inspect result, add it to inspectDetails / stringify

--- a/packages/renderer/src/lib/compose/ComposeDetailsKube.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsKube.svelte
@@ -5,9 +5,13 @@ import MonacoEditor from '/@/lib/editor/MonacoEditor.svelte';
 
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
-export let compose: ComposeInfoUI;
+interface Props {
+  compose: ComposeInfoUI;
+}
 
-let kubeDetails: string;
+let { compose }: Props = $props();
+
+let kubeDetails: string = $state('');
 
 onMount(async () => {
   // Grab all the container ID's from compose.containers

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.svelte
@@ -13,22 +13,25 @@ import TerminalWindow from '/@/lib/ui/TerminalWindow.svelte';
 
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
-export let compose: ComposeInfoUI;
+interface Props {
+  compose: ComposeInfoUI;
+}
 
-let refCompose: ComposeInfoUI;
+let { compose }: Props = $props();
+
+let refCompose: ComposeInfoUI | undefined;
 
 // Log initialization
-let noLogs = true;
-let logsTerminal: Terminal;
+let noLogs = $state(true);
+let logsTerminal: Terminal | undefined = $state(undefined);
 
-$: {
+$effect(() => {
   if (refCompose && refCompose.status !== compose.status) {
     logsTerminal?.clear();
     fetchComposeLogs().catch((err: unknown) => console.error('Error fetching compose logs', err));
   }
-  // eslint-disable-next-line no-useless-assignment
   refCompose = compose;
-}
+});
 
 // Create a map that will store the ANSI 256 colour for each container name
 // if we run out of colours, we'll start from the beginning.

--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.svelte
@@ -9,7 +9,11 @@ import { handleNavigation } from '/@/navigation';
 
 import type { ComposeInfoUI } from './ComposeInfoUI';
 
-export let compose: ComposeInfoUI;
+interface Props {
+  compose: ComposeInfoUI;
+}
+
+let { compose }: Props = $props();
 
 function openContainer(containerID: string): void {
   handleNavigation({
@@ -48,7 +52,7 @@ function openContainer(containerID: string): void {
     {#each compose.containers as container (container.id)}
       <tr>
         <DetailsCell>
-          <Link on:click={(): void => openContainer(container.id)}>{container.name}</Link>
+          <Link onclick={openContainer.bind(undefined, container.id)}>{container.name}</Link>
         </DetailsCell>
         <DetailsCell>{container.id}</DetailsCell>
       </tr>


### PR DESCRIPTION
### What does this PR do?
Migrates Compose* to svelte5
So far misses the ComposeDetails.svelte migration (there might be similar problem as it is in PodDetails with updating the value in Actions)

### Screenshot / video of UI
Should be no changes

### What issues does this PR fix or reference?


### How to test this PR?
Should be no functional/visual change

- [x] Tests are covering the bug fix or the new feature
