### PR TITLE
refactor(renderer): migrate lib/window-control-buttons/ components to svelte5

### DIFF
--- a/packages/renderer/src/lib/window-control-buttons/ControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButton.svelte
@@ -2,9 +2,13 @@
 import WindowControlLinuxButton from './LinuxControlButton.svelte';
 import WindowControlWindowsButton from './WindowsControlButton.svelte';
 
-export let name: string;
-export let action: () => void = () => {};
-export let platform: string;
+interface Props {
+  name: string;
+  action?: () => void;
+  platform: string;
+}
+
+let { name, action = (): void => {}, platform }: Props = $props();
 </script>
 
 {#if platform === 'linux'}

--- a/packages/renderer/src/lib/window-control-buttons/ControlButtons.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButtons.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 import WindowControlButton from './ControlButton.svelte';
 
-export let platform: string;
+interface Props {
+  platform: string;
+}
+
+let { platform }: Props = $props();
 
 async function minimize(): Promise<void> {
   return window.windowMinimize();

--- a/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.svelte
@@ -14,8 +14,7 @@ interface Props {
 
 let { name, action = (): void => {} }: Props = $props();
 
-let icon = $state<IconDefinition>(faMinus);
-
+let icon = $state<IconDefinition>();
 let titleName = $state<string>();
 
 onMount(() => {
@@ -35,5 +34,7 @@ onMount(() => {
   title={titleName}
   aria-label={name}
   class="h-[25px] w-[25px] cursor-pointer text-[var(--pd-titlebar-text)] hover:rounded-full hover:bg-[var(--pd-titlebar-hover-bg)] flex place-items-center justify-center">
-  <Icon size={iconSize} icon={icon} />
+  {#if icon}
+    <Icon size={iconSize} icon={icon} />
+  {/if}
 </button>

--- a/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/LinuxControlButton.svelte
@@ -7,12 +7,16 @@ import type { IconSize } from 'svelte-fa';
 
 const iconSize: IconSize | undefined = '0.875x';
 
-export let name: string;
-export let action: () => void = () => {};
+interface Props {
+  name: string;
+  action?: () => void;
+}
 
-let icon: IconDefinition;
+let { name, action = (): void => {} }: Props = $props();
 
-let titleName: string;
+let icon = $state<IconDefinition>(faMinus);
+
+let titleName = $state<string>();
 
 onMount(() => {
   if (name === 'Minimize') {
@@ -27,7 +31,7 @@ onMount(() => {
 </script>
 
 <button
-  on:click={action}
+  onclick={action}
   title={titleName}
   aria-label={name}
   class="h-[25px] w-[25px] cursor-pointer text-[var(--pd-titlebar-text)] hover:rounded-full hover:bg-[var(--pd-titlebar-hover-bg)] flex place-items-center justify-center">

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
@@ -7,14 +7,17 @@ import WindowsMinIcon from '/@/lib/images/WindowsMinIcon.svelte';
 import WindowsUnmaxIcon from '/@/lib/images/WindowsUnmaxIcon.svelte';
 
 const iconSize = '16';
-let icon: Component;
-let state = 'initial';
 
-export let name: string;
+interface Props {
+  name: string;
+  action?: () => void;
+}
 
-export let action: () => void = () => {};
+let { name, action = (): void => {} }: Props = $props();
 
-let titleName: string;
+let icon = $state<Component>(WindowsMinIcon);
+let windowState = $state('initial');
+let titleName = $state<string>();
 
 onMount(() => {
   if (name === 'Minimize') {
@@ -31,23 +34,23 @@ function executeAction(): void {
   // perform action
   action();
 
-  // update the state
+  // update the window state
   if (name === 'Minimize') {
-    state = 'minimized';
+    windowState = 'minimized';
   } else if (name === 'Maximize') {
-    if (state === 'maximized') {
-      state = 'restored';
+    if (windowState === 'maximized') {
+      windowState = 'restored';
     } else {
-      state = 'maximized';
+      windowState = 'maximized';
     }
   } else if (name === 'Close') {
-    state = 'closed';
+    windowState = 'closed';
   }
 
-  if (state === 'maximized') {
+  if (windowState === 'maximized') {
     icon = WindowsUnmaxIcon;
     titleName = 'Restore';
-  } else if (state === 'restored') {
+  } else if (windowState === 'restored') {
     icon = WindowsMaxIcon;
     titleName = 'Maximize';
   }
@@ -55,13 +58,14 @@ function executeAction(): void {
 </script>
 
 <button
-  on:click={executeAction}
+  onclick={executeAction}
   aria-label={name}
   title={titleName}
   class="h-[32px] w-[45px] cursor-pointer {name === 'Close'
     ? 'hover:bg-(--pd-titlebar-windows-hover-exit-bg) hover:text-(--pd-titlebar-windows-hover-exit-text)'
     : 'hover:bg-(--pd-titlebar-windows-hover-bg)'} text-(--pd-titlebar-icon) flex place-items-center justify-center">
   {#if icon}
-    <svelte:component this={icon} size={iconSize} />
+    {@const Icon = icon}
+    <Icon size={iconSize} />
   {/if}
 </button>

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
@@ -16,7 +16,7 @@ interface Props {
 let { name, action = (): void => {} }: Props = $props();
 
 let icon = $state<Component>(WindowsMinIcon);
-let state = $state('initial');
+let windowState = $state('initial');
 let titleName = $state<string>();
 
 onMount(() => {
@@ -34,23 +34,23 @@ function executeAction(): void {
   // perform action
   action();
 
-  // update the state
+  // update the window state
   if (name === 'Minimize') {
-    state = 'minimized';
+    windowState = 'minimized';
   } else if (name === 'Maximize') {
-    if (state === 'maximized') {
-      state = 'restored';
+    if (windowState === 'maximized') {
+      windowState = 'restored';
     } else {
-      state = 'maximized';
+      windowState = 'maximized';
     }
   } else if (name === 'Close') {
-    state = 'closed';
+    windowState = 'closed';
   }
 
-  if (state === 'maximized') {
+  if (windowState === 'maximized') {
     icon = WindowsUnmaxIcon;
     titleName = 'Restore';
-  } else if (state === 'restored') {
+  } else if (windowState === 'restored') {
     icon = WindowsMaxIcon;
     titleName = 'Maximize';
   }

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.svelte
@@ -7,14 +7,17 @@ import WindowsMinIcon from '/@/lib/images/WindowsMinIcon.svelte';
 import WindowsUnmaxIcon from '/@/lib/images/WindowsUnmaxIcon.svelte';
 
 const iconSize = '16';
-let icon: Component;
-let state = 'initial';
 
-export let name: string;
+interface Props {
+  name: string;
+  action?: () => void;
+}
 
-export let action: () => void = () => {};
+let { name, action = (): void => {} }: Props = $props();
 
-let titleName: string;
+let icon = $state<Component>(WindowsMinIcon);
+let state = $state('initial');
+let titleName = $state<string>();
 
 onMount(() => {
   if (name === 'Minimize') {
@@ -55,13 +58,14 @@ function executeAction(): void {
 </script>
 
 <button
-  on:click={executeAction}
+  onclick={executeAction}
   aria-label={name}
   title={titleName}
   class="h-[32px] w-[45px] cursor-pointer {name === 'Close'
     ? 'hover:bg-(--pd-titlebar-windows-hover-exit-bg) hover:text-(--pd-titlebar-windows-hover-exit-text)'
     : 'hover:bg-(--pd-titlebar-windows-hover-bg)'} text-(--pd-titlebar-icon) flex place-items-center justify-center">
   {#if icon}
-    <svelte:component this={icon} size={iconSize} />
+    {@const Icon = icon}
+    <Icon size={iconSize} />
   {/if}
 </button>


### PR DESCRIPTION
### What does this PR do?
Migrates ``renderer/**/lib/window-control-buttons/*.svelte`` components to svelte5

### Screenshot / video of UI
It should not change visuals.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?


- [X] Tests are covering the bug fix or the new feature
