### PR TITLE
refactor(Preferences): migrated item-formats components to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -3,10 +3,19 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 
 import SlideToggle from '/@/lib/ui/SlideToggle.svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let checked = false;
-export let onChange = async (_id: string, _value: boolean): Promise<void> => {};
-let invalidEntry = false;
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  checked?: boolean;
+  onChange?: (id: string, value: boolean) => Promise<void>;
+}
+
+let {
+  record,
+  checked = $bindable(false),
+  onChange = async (_id: string, _value: boolean): Promise<void> => {},
+}: Props = $props();
+
+let invalidEntry = $state(false);
 
 function onChecked(state: boolean): void {
   invalidEntry = false;

--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
@@ -6,12 +6,15 @@ import { getNormalizedDefaultNumberValue } from '/@/lib/preferences/Util';
 
 import EditableItem from './EditableItem.svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: number | undefined = undefined;
-export let onSave = (_recordId: string, _value: number): void => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: number;
+  onSave?: (_recordId: string, _value: number) => void;
+}
 
-let recordValue: DisplayConfigurationValue | undefined;
-$: recordValue = getDisplayConfigurationValue(record, value);
+let { record, value = $bindable(), onSave = (_recordId: string, _value: number): void => {} }: Props = $props();
+
+let recordValue = $derived(getDisplayConfigurationValue(record, value));
 
 function onChangeInput(_recordId: string, _value: number): void {
   innerOnSave(_recordId, _value);

--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
@@ -6,18 +6,27 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import FloatNumberItem from './FloatNumberItem.svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: number;
-export let description: string | undefined = undefined;
-export let onSave = (_recordId: string, _value: number): void => {};
-export let onChange = (_recordId: string, _value: number): void => {};
-export let onCancel = (_recordId: string, _originalValue: number): void => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value: number;
+  description?: string;
+  onSave?: (_recordId: string, _value: number) => void;
+  onChange?: (_recordId: string, _value: number) => void;
+  onCancel?: (_recordId: string, _originalValue: number) => void;
+}
 
-let editingInProgress = false;
-let editedValue: number;
-$: editedValue = value;
-let disableSaveButton: boolean;
-$: disableSaveButton = !editingInProgress;
+let {
+  record,
+  value,
+  description = undefined,
+  onSave = (_recordId: string, _value: number): void => {},
+  onChange = (_recordId: string, _value: number): void => {},
+  onCancel = (_recordId: string, _originalValue: number): void => {},
+}: Props = $props();
+
+let editingInProgress = $state(false);
+let editedValue = $derived(value);
+let disableSaveButton = $derived(!editingInProgress);
 let originalValue: number;
 
 function invalidRecord(_error: string): void {

--- a/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EnumItem.svelte
@@ -2,11 +2,19 @@
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Dropdown } from '@podman-desktop/ui-svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: string | undefined;
-export let onChange = async (_id: string, _value: string): Promise<void> => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: string;
+  onChange?: (_id: string, _value: string) => Promise<void>;
+}
 
-let invalidEntry = false;
+let {
+  record,
+  value = $bindable(),
+  onChange = async (_id: string, _value: string): Promise<void> => {},
+}: Props = $props();
+
+let invalidEntry = $state(false);
 
 function onChangeHandler(newValue: unknown): void {
   invalidEntry = false;

--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -4,15 +4,23 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 
 import FileInput from '/@/lib/ui/FileInput.svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: string = '';
-export let onChange = async (_id: string, _value: string): Promise<void> => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: string;
+  onChange?: (_id: string, _value: string) => Promise<void>;
+}
 
-let invalidEntry = false;
-let dialogOptions: OpenDialogOptions = {
+let {
+  record,
+  value = $bindable(''),
+  onChange = async (_id: string, _value: string): Promise<void> => {},
+}: Props = $props();
+
+let invalidEntry = $state(false);
+let dialogOptions: OpenDialogOptions = $derived({
   title: `Select ${record.description}`,
   selectors: record.format === 'folder' ? ['openDirectory'] : ['openFile'],
-};
+});
 
 function onChangeFileInput(value: string): void {
   if (record.id) {

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -3,9 +3,16 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 
 import { uncertainStringToNumber } from '/@/lib/preferences/Util';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: number;
-export let onChange = async (_id: string, _value: number): Promise<void> => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: number;
+  onChange?: (_id: string, _value: number) => Promise<void>;
+}
+let {
+  record,
+  value = $bindable(),
+  onChange = async (_id: string, _value: number): Promise<void> => {},
+}: Props = $props();
 
 async function onInput(event: Event): Promise<void> {
   const target = event.currentTarget as HTMLInputElement;
@@ -23,6 +30,6 @@ async function onInput(event: Event): Promise<void> {
   step={record.step}
   value={value}
   aria-label={record.description}
-  on:input={onInput}
+  oninput={onInput}
   disabled={!!record.readonly || !!record.locked}
   class="w-full h-1 bg-[var(--pd-input-toggle-on-bg)] rounded-lg appearance-none accent-[var(--pd-input-toggle-on-bg)] cursor-pointer range-xs mt-2" />

--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -2,11 +2,18 @@
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Input } from '@podman-desktop/ui-svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: string | undefined;
-export let onChange = async (_id: string, _value: string): Promise<void> => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: string;
+  onChange?: (_id: string, _value: string) => Promise<void>;
+}
+let {
+  record,
+  value = $bindable(),
+  onChange = async (_id: string, _value: string): Promise<void> => {},
+}: Props = $props();
 
-let invalidEntry = false;
+let invalidEntry = $state(false);
 
 function onInput(event: Event): void {
   const target = event.target as HTMLInputElement;


### PR DESCRIPTION
### What does this PR do?
Migrated item-formats components to svelte5

### Screenshot / video of UI

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613
### How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature
