### PR TITLE
refactor(Preferences): migrated BooleanItem component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/BooleanItem.svelte
@@ -3,10 +3,19 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 
 import SlideToggle from '/@/lib/ui/SlideToggle.svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let checked = false;
-export let onChange = async (_id: string, _value: boolean): Promise<void> => {};
-let invalidEntry = false;
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  checked?: boolean;
+  onChange?: (id: string, value: boolean) => Promise<void>;
+}
+
+let {
+  record,
+  checked = $bindable(false),
+  onChange = async (_id: string, _value: boolean): Promise<void> => {},
+}: Props = $props();
+
+let invalidEntry = $state(false);
 
 function onChecked(state: boolean): void {
   invalidEntry = false;


### PR DESCRIPTION
## What does this PR do?
Migrated BooleanItem component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature