### PR TITLE
refactor(Preferences): migrated EditableConnectionResourceItem component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.svelte
@@ -6,12 +6,15 @@ import { getNormalizedDefaultNumberValue } from '/@/lib/preferences/Util';
 
 import EditableItem from './EditableItem.svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: number | undefined = undefined;
-export let onSave = (_recordId: string, _value: number): void => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: number;
+  onSave?: (_recordId: string, _value: number) => void;
+}
 
-let recordValue: DisplayConfigurationValue | undefined;
-$: recordValue = getDisplayConfigurationValue(record, value);
+let { record, value = $bindable(), onSave = (_recordId: string, _value: number): void => {} }: Props = $props();
+
+let recordValue = $derived(getDisplayConfigurationValue(record, value));
 
 function onChangeInput(_recordId: string, _value: number): void {
   innerOnSave(_recordId, _value);


### PR DESCRIPTION
## What does this PR do?
Migrated EditableConnectionResourceItem component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature