### PR TITLE
refactor(Preferences): migrated EditableItem component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableItem.svelte
@@ -6,18 +6,27 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import FloatNumberItem from './FloatNumberItem.svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: number;
-export let description: string | undefined = undefined;
-export let onSave = (_recordId: string, _value: number): void => {};
-export let onChange = (_recordId: string, _value: number): void => {};
-export let onCancel = (_recordId: string, _originalValue: number): void => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value: number;
+  description?: string;
+  onSave?: (_recordId: string, _value: number) => void;
+  onChange?: (_recordId: string, _value: number) => void;
+  onCancel?: (_recordId: string, _originalValue: number) => void;
+}
 
-let editingInProgress = false;
-let editedValue: number;
-$: editedValue = value;
-let disableSaveButton: boolean;
-$: disableSaveButton = !editingInProgress;
+let {
+  record,
+  value,
+  description = undefined,
+  onSave = (_recordId: string, _value: number): void => {},
+  onChange = (_recordId: string, _value: number): void => {},
+  onCancel = (_recordId: string, _originalValue: number): void => {},
+}: Props = $props();
+
+let editingInProgress = $state(false);
+let editedValue = $derived(value);
+let disableSaveButton = $derived(!editingInProgress);
 let originalValue: number;
 
 function invalidRecord(_error: string): void {


### PR DESCRIPTION
## What does this PR do?
Migrated EditableItem component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature