### PR TITLE
refactor(Preferences): migrated FileItem component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FileItem.svelte
@@ -4,15 +4,23 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 
 import FileInput from '/@/lib/ui/FileInput.svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: string = '';
-export let onChange = async (_id: string, _value: string): Promise<void> => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: string;
+  onChange?: (_id: string, _value: string) => Promise<void>;
+}
 
-let invalidEntry = false;
-let dialogOptions: OpenDialogOptions = {
+let {
+  record,
+  value = $bindable(''),
+  onChange = async (_id: string, _value: string): Promise<void> => {},
+}: Props = $props();
+
+let invalidEntry = $state(false);
+let dialogOptions: OpenDialogOptions = $derived({
   title: `Select ${record.description}`,
   selectors: record.format === 'folder' ? ['openDirectory'] : ['openFile'],
-};
+});
 
 function onChangeFileInput(value: string): void {
   if (record.id) {


### PR DESCRIPTION
## What does this PR do?
Migrated FileItem component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature