### PR TITLE
refactor(Preferences): migrated SliderItem component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -3,9 +3,16 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 
 import { uncertainStringToNumber } from '/@/lib/preferences/Util';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: number;
-export let onChange = async (_id: string, _value: number): Promise<void> => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: number;
+  onChange?: (_id: string, _value: number) => Promise<void>;
+}
+let {
+  record,
+  value = $bindable(),
+  onChange = async (_id: string, _value: number): Promise<void> => {},
+}: Props = $props();
 
 async function onInput(event: Event): Promise<void> {
   const target = event.currentTarget as HTMLInputElement;
@@ -23,6 +30,6 @@ async function onInput(event: Event): Promise<void> {
   step={record.step}
   value={value}
   aria-label={record.description}
-  on:input={onInput}
+  oninput={onInput}
   disabled={!!record.readonly || !!record.locked}
   class="w-full h-1 bg-[var(--pd-input-toggle-on-bg)] rounded-lg appearance-none accent-[var(--pd-input-toggle-on-bg)] cursor-pointer range-xs mt-2" />


### PR DESCRIPTION
## What does this PR do?
Migrated SliderItem component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature