### PR TITLE
refactor(Preferences): migrated StringItem component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/StringItem.svelte
@@ -2,11 +2,18 @@
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Input } from '@podman-desktop/ui-svelte';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: string | undefined;
-export let onChange = async (_id: string, _value: string): Promise<void> => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: string;
+  onChange?: (_id: string, _value: string) => Promise<void>;
+}
+let {
+  record,
+  value = $bindable(),
+  onChange = async (_id: string, _value: string): Promise<void> => {},
+}: Props = $props();
 
-let invalidEntry = false;
+let invalidEntry = $state(false);
 
 function onInput(event: Event): void {
   const target = event.target as HTMLInputElement;


### PR DESCRIPTION
## What does this PR do?
Migrated StringItem component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature