### PR TITLE
fix(lima): treat empty configuration values as unset

### DIFF
--- a/extensions/lima/src/extension.spec.ts
+++ b/extensions/lima/src/extension.spec.ts
@@ -18,10 +18,11 @@
 
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import * as path from 'node:path';
 
 import type * as extensionApi from '@podman-desktop/api';
 import * as podmanDesktopApi from '@podman-desktop/api';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { activate, deactivate } from './extension';
 import { ImageHandler } from './image-handler';
@@ -96,6 +97,53 @@ describe('activate', () => {
 
     expect(podmanDesktopApi.provider.createProvider).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Lima', id: 'lima' }),
+    );
+  });
+});
+
+describe('unset settings returning an empty string', () => {
+  // the configuration schema in package.json declares `""` as the default value of
+  // lima.home, lima.name and lima.socket, so `get()` hands back an empty string
+  // (not undefined) for every setting the user did not touch.
+  beforeEach(() => {
+    vi.stubEnv('LIMA_HOME', undefined);
+
+    vi.mocked(podmanDesktopApi.configuration.getConfiguration).mockReturnValue({
+      get: vi.fn().mockImplementation((key: string) => {
+        switch (key) {
+          case 'type':
+            return 'docker';
+          default:
+            return '';
+        }
+      }),
+    } as unknown as podmanDesktopApi.Configuration);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('should derive the socket path from the engine type', async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    await activate(createExtensionContext());
+
+    expect(fs.existsSync).toHaveBeenCalledWith(path.resolve('/home/testuser/.lima', 'docker/sock/docker.sock'));
+  });
+
+  test('should register the container provider connection found at the derived socket path', async () => {
+    const expectedSocketPath = path.resolve('/home/testuser/.lima', 'docker/sock/docker.sock');
+    vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => String(p) === expectedSocketPath);
+
+    await activate(createExtensionContext());
+
+    expect(PROVIDER_MOCK.registerContainerProviderConnection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Lima docker',
+        type: 'docker',
+        endpoint: { socketPath: expectedSocketPath },
+      }),
     );
   });
 });

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -100,12 +100,19 @@ function registerProvider(
   console.log('Lima extension is active');
 }
 
+// The configuration schema declares an empty string as the default value of lima.home,
+// lima.name and lima.socket, so an unset setting is read back as '' rather than as
+// undefined. Map it to undefined so that the fallbacks below are actually applied.
+function getLimaConfigurationValue(section: string): string | undefined {
+  const value = configuration.getConfiguration('lima').get<string>(section);
+  return value === '' ? undefined : value;
+}
+
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
-  const engineType: string = configuration.getConfiguration('lima').get('type') ?? 'podman';
-  const instanceName: string = configuration.getConfiguration('lima').get('name') ?? engineType;
-  const socketName: string = configuration.getConfiguration('lima').get('socket') ?? engineType + '.sock';
-  const limaHome: string =
-    configuration.getConfiguration('lima').get('home') ?? process.env['LIMA_HOME'] ?? os.homedir() + '/.lima';
+  const engineType: string = getLimaConfigurationValue('type') ?? 'podman';
+  const instanceName: string = getLimaConfigurationValue('name') ?? engineType;
+  const socketName: string = getLimaConfigurationValue('socket') ?? engineType + '.sock';
+  const limaHome: string = getLimaConfigurationValue('home') ?? process.env['LIMA_HOME'] ?? os.homedir() + '/.lima';
 
   const socketPath = path.resolve(limaHome ?? '', instanceName + '/sock/' + socketName);
   const configPath = path.resolve(limaHome ?? '', instanceName + '/copied-from-guest/kubeconfig.yaml');

--- a/extensions/lima/src/extension.ts
+++ b/extensions/lima/src/extension.ts
@@ -100,19 +100,22 @@ function registerProvider(
   console.log('Lima extension is active');
 }
 
-// The configuration schema declares an empty string as the default value of lima.home,
-// lima.name and lima.socket, so an unset setting is read back as '' rather than as
-// undefined. Map it to undefined so that the fallbacks below are actually applied.
-function getLimaConfigurationValue(section: string): string | undefined {
-  const value = configuration.getConfiguration('lima').get<string>(section);
-  return value === '' ? undefined : value;
-}
-
 export async function activate(extensionContext: extensionApi.ExtensionContext): Promise<void> {
-  const engineType: string = getLimaConfigurationValue('type') ?? 'podman';
-  const instanceName: string = getLimaConfigurationValue('name') ?? engineType;
-  const socketName: string = getLimaConfigurationValue('socket') ?? engineType + '.sock';
-  const limaHome: string = getLimaConfigurationValue('home') ?? process.env['LIMA_HOME'] ?? os.homedir() + '/.lima';
+  // The configuration schema declares an empty string as the default value of lima.home,
+  // lima.name and lima.socket, so a setting the user never touched is read back as '' rather
+  // than as undefined. '' is not nullish, so it has to be rejected explicitly for the fallbacks
+  // below to apply.
+  const limaConfiguration = configuration.getConfiguration('lima');
+  const type = limaConfiguration.get<string>('type');
+  const name = limaConfiguration.get<string>('name');
+  const socket = limaConfiguration.get<string>('socket');
+  const home = limaConfiguration.get<string>('home');
+
+  const engineType: string = type === undefined || type === '' ? 'podman' : type;
+  const instanceName: string = name === undefined || name === '' ? engineType : name;
+  const socketName: string = socket === undefined || socket === '' ? engineType + '.sock' : socket;
+  const limaHome: string =
+    home === undefined || home === '' ? (process.env['LIMA_HOME'] ?? os.homedir() + '/.lima') : home;
 
   const socketPath = path.resolve(limaHome ?? '', instanceName + '/sock/' + socketName);
   const configPath = path.resolve(limaHome ?? '', instanceName + '/copied-from-guest/kubeconfig.yaml');


### PR DESCRIPTION
# fix(lima): treat empty configuration values as unset

Fixes #18575

## Summary

The Lima extension silently fails to register any container provider when the
user only sets `lima.type` and relies on the documented defaults for
`lima.name`, `lima.socket` and `lima.home`. Podman Desktop shows
"No Container Engine" and the only trace is a `console.debug` line that never
reaches the UI.

The cause is that the three settings declare `""` as their schema default, so
`configuration.get()` returns an empty string rather than `undefined`, which
makes the `??` fallbacks in `activate()` dead code.

## Mechanism

1. `extensions/lima/package.json` declares an empty-string default for the
   three settings — `lima.home` (lines 30-34), `lima.name` (lines 45-49) and
   `lima.socket` (lines 50-54).

2. On registration, `ConfigurationRegistry` copies the declared default into
   the default scope
   (`packages/main/src/plugin/configuration-registry.ts:229-238`):

   ```ts
   if (
     configProperty.default !== undefined &&
     this.isDefaultScope(configProperty.scope) &&
     configurationValue[key] === undefined
   ) {
     configurationValue[key] = configProperty.default;
   }
   ```

   So a setting the user never touched reads back as `''`, not `undefined`.

3. `''` is not nullish, so none of the `??` fallbacks in
   `extensions/lima/src/extension.ts:104-108` fire:

   ```ts
   const engineType: string = configuration.getConfiguration('lima').get('type') ?? 'podman';
   const instanceName: string = configuration.getConfiguration('lima').get('name') ?? engineType;
   const socketName: string = configuration.getConfiguration('lima').get('socket') ?? engineType + '.sock';
   const limaHome: string =
     configuration.getConfiguration('lima').get('home') ?? process.env['LIMA_HOME'] ?? os.homedir() + '/.lima';
   ```

   `instanceName`, `socketName` and `limaHome` all end up as `''`.

4. `extensions/lima/src/extension.ts:110` then builds the socket path as
   `path.resolve('', '' + '/sock/' + '')`. The second argument is `/sock/`,
   which looks absolute, so `path.resolve` discards the home directory
   altogether and the whole path collapses to `/sock`.

5. `fs.existsSync('/sock')` is false, so no provider is created and
   `extensions/lima/src/extension.ts:136` logs
   `Could not find socket at /sock` to stdout only.

`lima.type` is unaffected because its declared default is `"podman"`, which is
why the failure only shows up for the derived name/socket/home values.

## Fix

Read the three settings through a helper that maps `''` to `undefined`, so the
existing fallbacks apply again:

```ts
function getLimaConfigurationValue(section: string): string | undefined {
  const value = configuration.getConfiguration('lima').get<string>(section);
  return value === '' ? undefined : value;
}
```

This is the second alternative proposed in the issue ("treat an empty string as
unset explicitly"), which is also the one requested in the issue discussion.
A plain `||` cannot be used: the repo enables
`@typescript-eslint/prefer-nullish-coalescing` without `ignorePrimitives`
(`eslint.config.mjs:177-182`), and that is precisely the rule that turned the
original `||` into `??` in 61eefc784b.

The schema defaults in `package.json` are intentionally left untouched: the
explicit empty-string check also covers users who already have `""` persisted
in their `settings.json`, which removing the schema default would not.

## Tests

Two tests were added to `extensions/lima/src/extension.spec.ts` in a
`unset settings returning an empty string` block: the configuration mock
returns `'docker'` for `type` and `''` for everything else, mirroring what the
schema defaults produce.

### Red (before the fix)

```
 ❯ |lima| src/extension.spec.ts (9 tests | 2 failed) 20ms
     × should derive the socket path from the engine type 6ms
     × should register the container provider connection found at the derived socket path 1ms

 FAIL  |lima| src/extension.spec.ts > unset settings returning an empty string > should derive the socket path from the engine type
AssertionError: expected "vi.fn()" to be called with arguments: [ Array(1) ]

Received:

  1st vi.fn() call:

  [
-   "C:\\home\\testuser\\.lima\\docker\\sock\\docker.sock",
+   "C:\\sock",
  ]

 FAIL  |lima| src/extension.spec.ts > unset settings returning an empty string > should register the container provider connection found at the derived socket path
AssertionError: expected "vi.fn()" to be called with arguments: [ ObjectContaining{…} ]

Number of calls: 0

 Test Files  1 failed (1)
      Tests  2 failed | 7 passed (9)
```

(`C:\sock` is the Windows rendering of the `/sock` collapse described in the
issue; the run above was made on Windows.)

### Green (after the fix)

`pnpm run test:extensions:lima`

```
 ✓ |lima| src/extension.spec.ts (9 tests) 13ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Also run and clean:

- `pnpm run typecheck:extensions:lima` — no errors
- `eslint extensions/lima/src/extension.ts extensions/lima/src/extension.spec.ts` — clean
- `biome format` on both files — clean

## What I did not verify

- **No manual end-to-end run.** I did not start Podman Desktop against a real
  Lima instance. The reproduction and the fix were verified only through unit
  tests with `node:fs`, `node:os` and the extension API mocked.
- **macOS.** The issue was reported on macOS Sequoia; every command above was
  run on Windows. The behaviour is platform independent in principle (the same
  `path.resolve` absolute-path rule applies), but the concrete failing path
  differs (`C:\sock` vs `/sock`).
- **`LIMA_HOME=""`.** An explicitly empty `LIMA_HOME` environment variable is
  still not treated as unset. That is a distinct path from the reported bug and
  I deliberately left it alone rather than widen the change.
- **Existing user settings.** I did not check what happens for a user whose
  `settings.json` already contains explicit non-empty values; that path is
  unchanged by this patch, but it was not exercised by a test.
- **The kubernetes branch of `activate()`.** The new tests cover the
  `docker` container-provider path. The `kubernetes` path is covered only by the
  pre-existing tests, which keep passing.
- **CI.** I did not run the full `pnpm run test:unit`, only the Lima project
  suite and the whole `pnpm run test:extensions` suite.
