### PR TITLE
fix(renderer): answer replaced message boxes

### DIFF
--- a/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
+++ b/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
@@ -398,6 +398,10 @@ describe('MessageBox', () => {
     };
 
     function renderAndOpenBoth(): void {
+      // The real bridge returns a promise; the shared mock returns undefined,
+      // which would break the .catch() on the answer sent for the replaced box.
+      vi.mocked(window.sendShowMessageBoxOnSelect).mockResolvedValue(undefined);
+
       let openMessageBox: ((options: MessageBoxOptions) => void) | undefined;
 
       vi.mocked(window.events.receive).mockImplementation(
@@ -416,20 +420,32 @@ describe('MessageBox', () => {
       openMessageBox?.(secondOptions);
     }
 
-    test('Expect the displayed message box not to be replaced by the next one', async () => {
+    // Replacing in place is the behaviour the updater depends on: it shows
+    // "an update is being downloaded" and then swaps in "restart now?" without
+    // anyone dismissing the first one. Queueing the second box instead broke
+    // that flow — the restart prompt never rendered.
+    test('Expect the next message box to replace the displayed one', async () => {
       renderAndOpenBoth();
 
-      expect(await screen.findByText('First dialog')).toBeInTheDocument();
-      expect(screen.queryByText('Second dialog')).not.toBeInTheDocument();
+      expect(await screen.findByText('Second dialog')).toBeInTheDocument();
+      expect(screen.queryByText('First dialog')).not.toBeInTheDocument();
+    });
+
+    // The regression this PR is about. The replaced box's id used to be
+    // overwritten before anyone answered it, so the deferred promise the main
+    // process holds for it was never settled and its caller waited forever.
+    test('Expect the replaced message box to be answered with its cancel id', async () => {
+      renderAndOpenBoth();
+
+      expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(801, undefined);
     });
 
     test('Expect every requested message box to be answered', async () => {
       renderAndOpenBoth();
 
-      await fireEvent.click(await screen.findByRole('button', { name: 'Answer 1' }));
       await fireEvent.click(await screen.findByRole('button', { name: 'Answer 2' }));
 
-      expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(801, 0, undefined);
+      expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(801, undefined);
       expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(802, 0, undefined);
     });
   });

--- a/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
+++ b/packages/renderer/src/lib/dialogs/MessageBox.spec.ts
@@ -382,4 +382,55 @@ describe('MessageBox', () => {
     await fireEvent.click(screen.getByRole('button', { name: 'Run' }));
     expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(idRequest, 0, undefined);
   });
+
+  describe('several message boxes requested at once', () => {
+    const firstOptions: MessageBoxOptions = {
+      id: 801,
+      title: 'First dialog',
+      message: 'First message',
+      buttons: ['Answer 1'],
+    };
+    const secondOptions: MessageBoxOptions = {
+      id: 802,
+      title: 'Second dialog',
+      message: 'Second message',
+      buttons: ['Answer 2'],
+    };
+
+    function renderAndOpenBoth(): void {
+      let openMessageBox: ((options: MessageBoxOptions) => void) | undefined;
+
+      vi.mocked(window.events.receive).mockImplementation(
+        (message: string, callback: (options: MessageBoxOptions) => void) => {
+          if (message === 'showMessageBox:open') {
+            openMessageBox = callback;
+          }
+          return { dispose: vi.fn() };
+        },
+      );
+
+      render(MessageBox, {});
+
+      // both requests reach the renderer before the user answers the first one
+      openMessageBox?.(firstOptions);
+      openMessageBox?.(secondOptions);
+    }
+
+    test('Expect the displayed message box not to be replaced by the next one', async () => {
+      renderAndOpenBoth();
+
+      expect(await screen.findByText('First dialog')).toBeInTheDocument();
+      expect(screen.queryByText('Second dialog')).not.toBeInTheDocument();
+    });
+
+    test('Expect every requested message box to be answered', async () => {
+      renderAndOpenBoth();
+
+      await fireEvent.click(await screen.findByRole('button', { name: 'Answer 1' }));
+      await fireEvent.click(await screen.findByRole('button', { name: 'Answer 2' }));
+
+      expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(801, 0, undefined);
+      expect(window.sendShowMessageBoxOnSelect).toBeCalledWith(802, 0, undefined);
+    });
+  });
 });

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -24,8 +24,21 @@ let footerMarkdownDescription: string | undefined = $state();
 
 let display = $state(false);
 
+// message boxes received while another one is being displayed, kept in order
+const pendingMessageBoxes: MessageBoxOptions[] = [];
+
 const showMessageBoxCallback = (messageBoxParameter: unknown): void => {
   const options: MessageBoxOptions | undefined = messageBoxParameter as MessageBoxOptions;
+  // do not overwrite the message box currently displayed: its id would be lost and
+  // the caller waiting on it would never be answered
+  if (display) {
+    pendingMessageBoxes.push(options);
+    return;
+  }
+  showMessageBox(options);
+};
+
+function showMessageBox(options: MessageBoxOptions): void {
   currentId = options?.id || 0;
   title = options?.title || '';
   message = options?.message || '';
@@ -77,7 +90,7 @@ const showMessageBoxCallback = (messageBoxParameter: unknown): void => {
   });
 
   display = true;
-};
+}
 
 onMount(() => {
   // handle the showMessageBox event
@@ -94,14 +107,27 @@ function cleanup(): void {
   message = '';
 }
 
+// display the next queued message box, if any, otherwise close the dialog
+function showNextMessageBox(): void {
+  const next = pendingMessageBoxes.shift();
+  if (next) {
+    showMessageBox(next);
+  } else {
+    cleanup();
+  }
+}
+
 async function clickButton(index?: number, dropdownIndex?: number): Promise<void> {
-  cleanup();
-  await window.sendShowMessageBoxOnSelect(currentId, index, dropdownIndex);
+  const answeredId = currentId;
+  showNextMessageBox();
+  await window.sendShowMessageBoxOnSelect(answeredId, index, dropdownIndex);
 }
 
 async function onClose(): Promise<void> {
-  cleanup();
-  await window.sendShowMessageBoxOnSelect(currentId, cancelId >= 0 ? cancelId : undefined);
+  const answeredId = currentId;
+  const answeredCancelId = cancelId >= 0 ? cancelId : undefined;
+  showNextMessageBox();
+  await window.sendShowMessageBoxOnSelect(answeredId, answeredCancelId);
 }
 
 function getButtonType(b: boolean): ButtonType {

--- a/packages/renderer/src/lib/dialogs/MessageBox.svelte
+++ b/packages/renderer/src/lib/dialogs/MessageBox.svelte
@@ -24,16 +24,19 @@ let footerMarkdownDescription: string | undefined = $state();
 
 let display = $state(false);
 
-// message boxes received while another one is being displayed, kept in order
-const pendingMessageBoxes: MessageBoxOptions[] = [];
-
 const showMessageBoxCallback = (messageBoxParameter: unknown): void => {
   const options: MessageBoxOptions | undefined = messageBoxParameter as MessageBoxOptions;
-  // do not overwrite the message box currently displayed: its id would be lost and
-  // the caller waiting on it would never be answered
+  // A new box replaces the one on screen, which is what callers such as the
+  // updater rely on: it shows "an update is being downloaded" and then swaps in
+  // "restart now?" without anyone dismissing the first one.
+  //
+  // What was wrong was replacing it *silently*: currentId was overwritten, so
+  // the deferred promise held in the main process for the replaced box was
+  // never settled and its caller waited forever. Answer it on the way out.
   if (display) {
-    pendingMessageBoxes.push(options);
-    return;
+    window
+      .sendShowMessageBoxOnSelect(currentId, cancelId >= 0 ? cancelId : undefined)
+      .catch((err: unknown) => console.error('Error answering the replaced message box', err));
   }
   showMessageBox(options);
 };
@@ -107,26 +110,16 @@ function cleanup(): void {
   message = '';
 }
 
-// display the next queued message box, if any, otherwise close the dialog
-function showNextMessageBox(): void {
-  const next = pendingMessageBoxes.shift();
-  if (next) {
-    showMessageBox(next);
-  } else {
-    cleanup();
-  }
-}
-
 async function clickButton(index?: number, dropdownIndex?: number): Promise<void> {
   const answeredId = currentId;
-  showNextMessageBox();
+  cleanup();
   await window.sendShowMessageBoxOnSelect(answeredId, index, dropdownIndex);
 }
 
 async function onClose(): Promise<void> {
   const answeredId = currentId;
   const answeredCancelId = cancelId >= 0 ? cancelId : undefined;
-  showNextMessageBox();
+  cleanup();
   await window.sendShowMessageBoxOnSelect(answeredId, answeredCancelId);
 }
 


### PR DESCRIPTION
Fixes #18592

## Summary

When a second `showMessageBox:open` event arrives while a message box is displayed,
the renderer replaces the displayed box. That replacement is intentional: the updater
uses it to replace its "download in progress" message with the "restart now?" prompt.

Before this change, replacement overwrote the first request ID without answering it.
The corresponding deferred promise in the main process therefore never settled, which
could leave an extension waiting forever.

This change preserves replacement-in-place and answers the replaced request before its
ID is overwritten. If the replaced box has a cancel button, its cancel index is sent;
otherwise the response index is `undefined`, which the main process resolves as
`{ response: undefined }`.

## Implementation

- Before displaying the incoming box, answer the currently displayed request with its
  cancel index, or `undefined` when no cancel action exists.
- Capture the active request ID before cleanup in both button and close handlers.
- Keep the updater's existing replacement behavior; no FIFO queue is introduced.

## Tests

The renderer tests cover:

- the incoming box replaces the displayed box;
- the replaced request is answered before its ID is overwritten;
- both the replaced and the newly displayed requests receive an answer.

Current CI for head `49e532eea994c45e0b3901d3507eeab2b8c8dffd` has all completed checks passing,
including the four update E2E jobs. `Domain Review Status` remains in progress pending
review resolution.

Local verification on Node 24.19.0 and pnpm 11.15.1:

- `vitest run packages/renderer/src/lib/dialogs/MessageBox.spec.ts`: 17 passed.
- `vitest run packages/main/src/plugin/message-box.spec.ts`: 16 passed.

## Not verified locally

- A manual extension-to-renderer IPC reproduction.
- The full renderer or unit suite against the current upstream main branch.
