### PR TITLE
refactor(Preferences): migrated ExtensionIcon component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/ExtensionIcon.svelte
+++ b/packages/renderer/src/lib/preferences/ExtensionIcon.svelte
@@ -4,9 +4,12 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
 
-export let extension: { icon?: string | { light: string; dark: string }; name: string; state: string };
+interface Props {
+  extension: { icon?: string | { light: string; dark: string }; name: string; state: string };
+}
+let { extension }: Props = $props();
 
-$: fade = extension.state !== 'started' ? ' brightness-50' : '';
+let fade = $derived(extension.state !== 'started' ? ' brightness-50' : '');
 </script>
 
 {#if extension.icon}


### PR DESCRIPTION
## What does this PR do?
Migrated ExtensionIcon component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature