### PR TITLE
refactor(Preferences): migrated PreferencesConnectionsEmptyRendering component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionsEmptyRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionsEmptyRendering.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 
-export let message = '';
-export let hidden: boolean;
+interface Props {
+  message?: string;
+  hidden: boolean;
+}
+
+let { message = '', hidden }: Props = $props();
 </script>
 
 {#if !hidden}


### PR DESCRIPTION
## What does this PR do?
Migrated PreferencesConnectionsEmptyRendering component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature