### PR TITLE
refactor(Preferences): migrated PreferencesContainerConnectionEdit component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.spec.ts
@@ -1,0 +1,175 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { Buffer } from 'node:buffer';
+
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { providerInfos } from '/@/stores/providers';
+
+import * as PreferencesConnectionCreationRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
+import PreferencesContainerConnectionEdit from './PreferencesContainerConnectionEdit.svelte';
+
+vi.mock(import('./PreferencesConnectionCreationOrEditRendering.svelte'));
+
+const EMPTY_PROVIDER_MOCK: ProviderInfo = {
+  id: 'podman',
+  name: 'podman',
+  images: {
+    icon: 'img',
+  },
+  status: 'started',
+  warnings: [],
+  containerProviderConnectionCreation: true,
+  detectionChecks: [],
+  installationSupport: false,
+  internalId: '0',
+  containerConnections: [],
+  kubernetesConnections: [],
+  kubernetesProviderConnectionCreation: true,
+  vmConnections: [],
+  vmProviderConnectionCreation: false,
+  vmProviderConnectionInitialization: false,
+  links: [],
+  containerProviderConnectionInitialization: false,
+  containerProviderConnectionCreationDisplayName: 'Podman machine',
+  kubernetesProviderConnectionInitialization: false,
+  extensionId: '',
+  cleanupSupport: false,
+  canStart: false,
+  canStop: false,
+};
+
+const WARNING_MESSAGE =
+  'This may restart the container or Kubernetes engine. Existing containers or pods may be stopped.';
+
+function createProvider(connectionStatus: 'started' | 'stopped', connectionName = 'podman machine'): ProviderInfo {
+  return {
+    ...EMPTY_PROVIDER_MOCK,
+    containerConnections: [
+      {
+        connectionType: 'container',
+        name: connectionName,
+        displayName: connectionName,
+        status: connectionStatus,
+        endpoint: {
+          socketPath: '/tmp/podman.sock',
+        },
+        type: 'podman',
+        canStart: false,
+        canStop: false,
+        canEdit: true,
+        canDelete: false,
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  providerInfos.set([]);
+});
+
+describe('PreferencesContainerConnectionEdit', () => {
+  test('displays the connection name as page title', () => {
+    const connectionName = 'podman machine';
+    providerInfos.set([createProvider('started', connectionName)]);
+
+    render(PreferencesContainerConnectionEdit, {
+      providerInternalId: '0',
+      name: Buffer.from(connectionName).toString('base64'),
+      properties: [],
+    });
+
+    screen.getByRole('heading', { name: connectionName, level: 1 });
+  });
+
+  test('shows restart warning when connection is started', () => {
+    const connectionName = 'podman machine';
+    providerInfos.set([createProvider('started', connectionName)]);
+
+    render(PreferencesContainerConnectionEdit, {
+      providerInternalId: '0',
+      name: Buffer.from(connectionName).toString('base64'),
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(WARNING_MESSAGE);
+  });
+
+  test('does not show restart warning when connection is stopped', () => {
+    const connectionName = 'podman machine';
+    providerInfos.set([createProvider('stopped', connectionName)]);
+
+    render(PreferencesContainerConnectionEdit, {
+      providerInternalId: '0',
+      name: Buffer.from(connectionName).toString('base64'),
+    });
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('does not render details when connection name does not match', () => {
+    providerInfos.set([createProvider('started', 'podman machine')]);
+
+    render(PreferencesContainerConnectionEdit, {
+      providerInternalId: '0',
+      name: Buffer.from('unknown machine').toString('base64'),
+    });
+
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+    expect(PreferencesConnectionCreationRendering.default).not.toHaveBeenCalled();
+  });
+
+  test('passes ContainerConnection scope and connection info to creation form', () => {
+    const connectionName = 'podman machine';
+    const properties: IConfigurationPropertyRecordedSchema[] = [
+      {
+        id: 'test.property',
+        title: 'Test',
+        parentId: '',
+        description: 'test property',
+        scope: 'ContainerConnection',
+      },
+    ];
+    const providerInfo = createProvider('started', connectionName);
+    providerInfos.set([providerInfo]);
+
+    render(PreferencesContainerConnectionEdit, {
+      providerInternalId: '0',
+      name: Buffer.from(connectionName).toString('base64'),
+      properties,
+    });
+
+    expect(PreferencesConnectionCreationRendering.default).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        providerInfo,
+        connectionInfo: providerInfo.containerConnections[0],
+        properties,
+        propertyScope: 'ContainerConnection',
+        callback: expect.any(Function),
+      }),
+    );
+  });
+});

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
@@ -7,8 +7,6 @@ import type {
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { Buffer } from 'buffer';
-import { onDestroy, onMount } from 'svelte';
-import type { Unsubscriber } from 'svelte/store';
 
 import PreferencesConnectionCreationRendering from '/@/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
@@ -17,30 +15,21 @@ import { providerInfos } from '/@/stores/providers';
 
 import { isContainerConnection } from './Util';
 
-export let properties: IConfigurationPropertyRecordedSchema[] = [];
-export let providerInternalId: string | undefined = undefined;
-export let name: string | undefined = undefined;
+interface Props {
+  properties?: IConfigurationPropertyRecordedSchema[];
+  providerInternalId?: string;
+  name?: string;
+}
+let { properties = [], providerInternalId, name }: Props = $props();
 
-let connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo;
-let scope: string;
-let providerInfo: ProviderInfo;
-
-let providersUnsubscribe: Unsubscriber;
-onMount(async () => {
-  providersUnsubscribe = providerInfos.subscribe(providerInfosValue => {
-    const providers = providerInfosValue;
-    const connectionName = Buffer.from(name ?? '', 'base64').toString();
-    providerInfo = providers.filter(provider => provider.internalId === providerInternalId)[0];
-    connectionInfo = providerInfo.containerConnections.filter(connection => connection.name === connectionName)[0];
-  });
-  scope = isContainerConnection(connectionInfo) ? 'ContainerConnection' : 'KubernetesConnection';
-});
-
-onDestroy(() => {
-  if (providersUnsubscribe) {
-    providersUnsubscribe();
-  }
-});
+let connectionName = $derived(Buffer.from(name ?? '', 'base64').toString());
+let providerInfo: ProviderInfo = $derived(
+  $providerInfos.filter(provider => provider.internalId === providerInternalId)[0],
+);
+let connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo = $derived(
+  providerInfo.containerConnections.filter(connection => connection.name === connectionName)[0],
+);
+let scope: string = $derived(isContainerConnection(connectionInfo) ? 'ContainerConnection' : 'KubernetesConnection');
 
 async function editConnection(
   internalProviderId: string,

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionEdit.svelte
@@ -6,8 +6,6 @@ import type {
 } from '@podman-desktop/core-api';
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { Buffer } from 'buffer';
-import { onDestroy, onMount } from 'svelte';
-import type { Unsubscriber } from 'svelte/store';
 
 import IconImage from '/@/lib/appearance/IconImage.svelte';
 import PreferencesConnectionCreationRendering from '/@/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte';
@@ -17,30 +15,21 @@ import { providerInfos } from '/@/stores/providers';
 
 import { isContainerConnection } from './Util';
 
-export let properties: IConfigurationPropertyRecordedSchema[] = [];
-export let providerInternalId: string | undefined = undefined;
-export let name: string | undefined = undefined;
+interface Props {
+  properties?: IConfigurationPropertyRecordedSchema[];
+  providerInternalId?: string;
+  name?: string;
+}
+let { properties = [], providerInternalId, name }: Props = $props();
 
-let connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo;
-let scope: string;
-let providerInfo: ProviderInfo;
-
-let providersUnsubscribe: Unsubscriber;
-onMount(async () => {
-  providersUnsubscribe = providerInfos.subscribe(providerInfosValue => {
-    const providers = providerInfosValue;
-    const connectionName = Buffer.from(name ?? '', 'base64').toString();
-    providerInfo = providers.filter(provider => provider.internalId === providerInternalId)[0];
-    connectionInfo = providerInfo.containerConnections.filter(connection => connection.name === connectionName)[0];
-  });
-  scope = isContainerConnection(connectionInfo) ? 'ContainerConnection' : 'KubernetesConnection';
-});
-
-onDestroy(() => {
-  if (providersUnsubscribe) {
-    providersUnsubscribe();
-  }
-});
+let connectionName = $derived(Buffer.from(name ?? '', 'base64').toString());
+let providerInfo: ProviderInfo = $derived(
+  $providerInfos.filter(provider => provider.internalId === providerInternalId)[0],
+);
+let connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo = $derived(
+  providerInfo.containerConnections.filter(connection => connection.name === connectionName)[0],
+);
+let scope: string = $derived(isContainerConnection(connectionInfo) ? 'ContainerConnection' : 'KubernetesConnection');
 
 async function editConnection(
   internalProviderId: string,


### PR DESCRIPTION
## What does this PR do?
Migrated PreferencesContainerConnectionEdit component to Svelte 5 runes syntax.
- Added unit tests for PreferencesContainerConnectionEdit

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature