### PR TITLE
refactor(Preferences): migrated PreferencesKubernetesConnectionDetailsSummary component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionDetailsSummary.svelte
@@ -5,35 +5,39 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 
 import type { IProviderConnectionConfigurationPropertyRecorded } from './Util';
 
-export let properties: IConfigurationPropertyRecordedSchema[] = [];
-export let providerInternalId: string | undefined = undefined;
-export let kubernetesConnectionInfo: ProviderKubernetesConnectionInfo | undefined = undefined;
+interface Props {
+  properties?: IConfigurationPropertyRecordedSchema[];
+  providerInternalId?: string;
+  kubernetesConnectionInfo?: ProviderKubernetesConnectionInfo;
+}
+let { properties = [], providerInternalId, kubernetesConnectionInfo }: Props = $props();
 
 let tmpProviderContainerConfiguration: IProviderConnectionConfigurationPropertyRecorded[] = [];
 function updateTmpProviderContainerConfiguration(value: IProviderConnectionConfigurationPropertyRecorded[]): void {
   tmpProviderContainerConfiguration = value;
 }
 
-$: Promise.all(
-  properties.map(async configurationKey => {
-    return {
-      ...configurationKey,
-      value: configurationKey.id
-        ? await window.getConfigurationValue(
-            configurationKey.id,
-            kubernetesConnectionInfo as unknown as KubernetesProviderConnection,
-          )
-        : undefined,
-      connection: kubernetesConnectionInfo?.name ?? '',
-      providerId: providerInternalId ?? '',
-    };
-  }),
-)
-  .then(value => updateTmpProviderContainerConfiguration(value.flat()))
-  .catch((err: unknown) => console.error('Error collecting providers', err));
-
-$: providerConnectionConfiguration = tmpProviderContainerConfiguration.filter(
-  configurationKey => configurationKey.value !== undefined,
+$effect(() => {
+  Promise.all(
+    properties.map(async configurationKey => {
+      return {
+        ...configurationKey,
+        value: configurationKey.id
+          ? await window.getConfigurationValue(
+              configurationKey.id,
+              kubernetesConnectionInfo as unknown as KubernetesProviderConnection,
+            )
+          : undefined,
+        connection: kubernetesConnectionInfo?.name ?? '',
+        providerId: providerInternalId ?? '',
+      };
+    }),
+  )
+    .then(value => updateTmpProviderContainerConfiguration(value.flat()))
+    .catch((err: unknown) => console.error('Error collecting providers', err));
+});
+let providerConnectionConfiguration: IProviderConnectionConfigurationPropertyRecorded[] = $derived(
+  tmpProviderContainerConfiguration.filter(configurationKey => configurationKey.value !== undefined),
 );
 </script>
 


### PR DESCRIPTION
## What does this PR do?
Migrated PreferencesKubernetesConnectionDetailsSummary component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature