### PR TITLE
refactor(Preferences): migrated PreferencesKubernetesConnectionRendering component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -25,21 +25,25 @@ import PreferencesKubernetesConnectionDetailsSummary from './PreferencesKubernet
 import type { IConnectionRestart, IConnectionStatus } from './Util';
 import { getProviderConnectionName } from './Util';
 
-export let properties: IConfigurationPropertyRecordedSchema[] = [];
-export let providerInternalId: string | undefined = undefined;
-export let apiUrlBase64 = '';
+interface Props {
+  properties?: IConfigurationPropertyRecordedSchema[];
+  providerInternalId?: string;
+  apiUrlBase64?: string;
+}
+let { properties = [], providerInternalId, apiUrlBase64 = '' }: Props = $props();
 
-const apiURL: string = Buffer.from(apiUrlBase64, 'base64').toString();
+const apiURL: string = $derived(Buffer.from(apiUrlBase64, 'base64').toString());
 let connectionName = '';
-let connectionStatus: IConnectionStatus;
-let noLog = true;
-let connectionInfo: ProviderKubernetesConnectionInfo | undefined;
-let providerInfo: ProviderInfo | undefined;
+let connectionStatus: IConnectionStatus | undefined = $state();
+let noLog = $state(true);
+let connectionInfo: ProviderKubernetesConnectionInfo | undefined = $state();
+let providerInfo: ProviderInfo | undefined = $state();
 let loggerHandlerKey: symbol | undefined;
-let configurationKeys: IConfigurationPropertyRecordedSchema[];
-$: configurationKeys = properties
-  .filter(property => property.scope === 'KubernetesConnection')
-  .toSorted((a, b) => (a?.id ?? '').localeCompare(b?.id ?? ''));
+let configurationKeys: IConfigurationPropertyRecordedSchema[] = $derived(
+  properties
+    .filter(property => property.scope === 'KubernetesConnection')
+    .toSorted((a, b) => (a?.id ?? '').localeCompare(b?.id ?? '')),
+);
 
 let providersUnsubscribe: Unsubscriber;
 onMount(async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.svelte
@@ -25,21 +25,25 @@ import PreferencesKubernetesConnectionDetailsSummary from './PreferencesKubernet
 import type { IConnectionRestart, IConnectionStatus } from './Util';
 import { getProviderConnectionName } from './Util';
 
-export let properties: IConfigurationPropertyRecordedSchema[] = [];
-export let providerInternalId: string | undefined = undefined;
-export let apiUrlBase64 = '';
+interface Props {
+  properties?: IConfigurationPropertyRecordedSchema[];
+  providerInternalId?: string;
+  apiUrlBase64?: string;
+}
+let { properties = [], providerInternalId, apiUrlBase64 = '' }: Props = $props();
 
-const apiURL: string = Buffer.from(apiUrlBase64, 'base64').toString();
+const apiURL = $derived<string>(Buffer.from(apiUrlBase64, 'base64').toString());
 let connectionName = '';
-let connectionStatus: IConnectionStatus;
-let noLog = true;
-let connectionInfo: ProviderKubernetesConnectionInfo | undefined;
-let providerInfo: ProviderInfo | undefined;
-let loggerHandlerKey: symbol | undefined;
-let configurationKeys: IConfigurationPropertyRecordedSchema[];
-$: configurationKeys = properties
-  .filter(property => property.scope === 'KubernetesConnection')
-  .toSorted((a, b) => (a?.id ?? '').localeCompare(b?.id ?? ''));
+let connectionStatus = $state<IConnectionStatus>();
+let noLog = $state<boolean>(true);
+let connectionInfo = $state<ProviderKubernetesConnectionInfo>();
+let providerInfo = $state<ProviderInfo>();
+let loggerHandlerKey = $state<symbol>();
+let configurationKeys = $derived<IConfigurationPropertyRecordedSchema[]>(
+  properties
+    .filter(property => property.scope === 'KubernetesConnection')
+    .toSorted((a, b) => (a?.id ?? '').localeCompare(b?.id ?? '')),
+);
 
 let providersUnsubscribe: Unsubscriber;
 onMount(async () => {
@@ -96,7 +100,12 @@ async function startConnectionProvider(
   connectionInfo: ProviderKubernetesConnectionInfo,
   loggerHandlerKey: symbol,
 ): Promise<void> {
-  await window.startProviderConnectionLifecycle(provider.internalId, connectionInfo, loggerHandlerKey, eventCollect);
+  await window.startProviderConnectionLifecycle(
+    provider.internalId,
+    $state.snapshot(connectionInfo),
+    loggerHandlerKey,
+    eventCollect,
+  );
 }
 
 function updateConnectionStatus(


### PR DESCRIPTION
## What does this PR do?
Migrated PreferencesKubernetesConnectionRendering component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature