### PR TITLE
refactor(Preferences): migrated PreferencesResourcesRenderingCopyButton component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRenderingCopyButton.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRenderingCopyButton.svelte
@@ -3,9 +3,14 @@ import { onMount } from 'svelte';
 
 import CopyToClipboard from '/@/lib/ui/CopyToClipboard.svelte';
 
-let url: string | undefined;
+interface Props {
+  path: string;
+  class?: string;
+}
 
-export let path: string;
+let { path, class: className }: Props = $props();
+
+let url: string | undefined = $state();
 
 onMount(async () => {
   try {
@@ -27,5 +32,5 @@ onMount(async () => {
 </script>
 
 {#if url}
-  <CopyToClipboard title={url} clipboardData={url} class={$$props.class} />
+  <CopyToClipboard title={url} clipboardData={url} class={className} />
 {/if}


### PR DESCRIPTION
## What does this PR do?
Migrated PreferencesResourcesRenderingCopyButton component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature