### PR TITLE
refactor(Preferences): migrated PreferencesVmConnectionRendering component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesVmConnectionRendering.svelte
@@ -22,12 +22,15 @@ import PreferencesConnectionDetailsTerminal from './PreferencesConnectionDetails
 import type { IConnectionRestart, IConnectionStatus } from './Util';
 import { getProviderConnectionName } from './Util';
 
-export let providerInternalId: string | undefined = undefined;
-export let connectionName = '';
+interface Props {
+  providerInternalId?: string;
+  connectionName?: string;
+}
+let { providerInternalId, connectionName = '' }: Props = $props();
 
-let connectionStatus: IConnectionStatus;
-let connectionInfo: ProviderVmConnectionInfo | undefined;
-let providerInfo: ProviderInfo | undefined;
+let connectionStatus: IConnectionStatus | undefined = $state();
+let connectionInfo: ProviderVmConnectionInfo | undefined = $state();
+let providerInfo: ProviderInfo | undefined = $state();
 let loggerHandlerKey: symbol | undefined;
 
 let providersUnsubscribe: Unsubscriber;


### PR DESCRIPTION
## What does this PR do?
Migrated PreferencesVmConnectionRendering component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
In preferences there should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature