### PR TITLE
refactor(Extensions): migrated CatalogExtension component to svelte5

### DIFF
--- a/packages/renderer/src/lib/extensions/CatalogExtension.svelte
+++ b/packages/renderer/src/lib/extensions/CatalogExtension.svelte
@@ -8,9 +8,16 @@ import FeaturedExtensionDownload from '/@/lib/featured/FeaturedExtensionDownload
 
 import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 
-export let catalogExtensionUI: CatalogExtensionInfoUI;
-export let oninstall: (extensionId: string) => void = () => {};
-export let ondetails: (extensionId: string) => void = () => {};
+interface Props {
+  catalogExtensionUI: CatalogExtensionInfoUI;
+  oninstall?: (extensionId: string) => void;
+  ondetails?: (extensionId: string) => void;
+}
+let {
+  catalogExtensionUI,
+  oninstall = (_extensionId: string): void => {},
+  ondetails = (_extensionId: string): void => {},
+}: Props = $props();
 
 function openExtensionDetails(): void {
   ondetails(catalogExtensionUI.id);


### PR DESCRIPTION
## What does this PR do?
Migrated CatalogExtension component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature