### PR TITLE
refactor(Extensions): migrated EmbeddableCatalogExtensionList component to svelte5

### DIFF
--- a/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/EmbeddableCatalogExtensionList.svelte
@@ -10,18 +10,26 @@ import type { CatalogExtensionInfoUI } from './catalog-extension-info-ui';
 import CatalogExtensionList from './CatalogExtensionList.svelte';
 import { ExtensionsUtils } from './extensions-utils';
 
-// restricted category to display
-export let category: string | undefined = undefined;
-export let keywords: string[] = [];
-export let title = 'Available extensions';
-export let showEmptyScreen: boolean = true;
-export let oninstall: (extensionId: string) => void = () => {};
-export let ondetails: (extensionId: string) => void = () => {};
+interface Props {
+  category?: string;
+  keywords?: string[];
+  title?: string;
+  showEmptyScreen?: boolean;
+  oninstall?: (extensionId: string) => void;
+  ondetails?: (extensionId: string) => void;
+  showInstalled?: boolean;
+}
+let {
+  category,
+  keywords = [],
+  title = 'Available extensions',
+  showEmptyScreen = true,
+  oninstall = (_extensionId: string): void => {},
+  ondetails = (_extensionId: string): void => {},
+  showInstalled = true,
+}: Props = $props();
 
-// show installed extensions
-export let showInstalled: boolean = true;
-
-let enableCatalog = true;
+let enableCatalog = $state(true);
 
 onMount(async () => {
   const value = await window.getConfigurationValue<boolean>('extensions.catalog.enabled');


### PR DESCRIPTION
## What does this PR do?
Migrated EmbeddableCatalogExtensionList component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature