### PR TITLE
refactor(Extensions): migrated ExtensionBadge component to svelte5

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -3,10 +3,14 @@ import { Tooltip } from '@podman-desktop/ui-svelte';
 
 import Badge from '/@/lib/ui/Badge.svelte';
 
-export let extension: { type: 'dd' | 'pd'; removable: boolean; devMode: boolean };
+interface Props {
+  extension: { type: 'dd' | 'pd'; removable: boolean; devMode: boolean };
+  class?: string;
+}
+let { extension, class: className }: Props = $props();
 </script>
 
-<div class="flex flex-row gap-1 items-center {$$props.class}" role="region" aria-label="Extension Badge">
+<div class="flex flex-row gap-1 items-center {className}" role="region" aria-label="Extension Badge">
   {#if extension.type === 'dd'}
     <Tooltip right tip="Docker Desktop extension">
       <Badge class="text-[8px] text-[var(--pd-badge-dd-extension-text)]" color="bg-[var(--pd-badge-dd-extension-bg)]" label="Docker Desktop extension" />


### PR DESCRIPTION
## What does this PR do?
Migrated ExtensionBadge component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature