### PR TITLE
refactor(Extensions): migrated ExtensionDetailsError component to svelte5

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetailsError.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsError.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import type { ExtensionDetailsUI } from './extension-details-ui';
 
-export let extension: ExtensionDetailsUI;
+interface Props {
+  extension: ExtensionDetailsUI;
+}
+let { extension }: Props = $props();
 </script>
 
 {#if extension.error}


### PR DESCRIPTION
## What does this PR do?
Migrated ExtensionDetailsError component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature