### PR TITLE
refactor(Extensions): migrated ExtensionDetailsLink component to svelte5

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionDetailsLink.svelte
@@ -6,9 +6,12 @@ import { router } from 'tinro';
 
 import type { CombinedExtensionInfoUI } from '/@/stores/all-installed-extensions';
 
-export let extension: CombinedExtensionInfoUI;
-
-export let displayIcon: boolean = true;
+interface Props {
+  extension: CombinedExtensionInfoUI;
+  displayIcon?: boolean;
+  class?: string;
+}
+let { extension, displayIcon = true, class: className }: Props = $props();
 
 function openDetailsExtension(): void {
   router.goto(`/extensions/details/${encodeURIComponent(extension.id)}/`);
@@ -16,12 +19,12 @@ function openDetailsExtension(): void {
 </script>
 
 <Tooltip top tip="{extension.name} extension details">
-  <button aria-label="{extension.name} extension details" type="button" on:click={openDetailsExtension}>
+  <button aria-label="{extension.name} extension details" type="button" onclick={openDetailsExtension}>
     <div class="flex flex-row items-center text-[var(--pd-content-header)]">
       {#if displayIcon}
         <Icon icon={faCircleInfo} />
       {/if}
-      <div class="text-left before:{$$props.class}">
+      <div class="text-left before:{className}">
         {extension.displayName} extension
       </div>
     </div>


### PR DESCRIPTION
## What does this PR do?
Migrated ExtensionDetailsLink component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature