### PR TITLE
refactor(Extensions): migrated ActionsColumn component to svelte5

### DIFF
--- a/packages/renderer/src/lib/extensions/dev-mode/table/ActionsColumn.svelte
+++ b/packages/renderer/src/lib/extensions/dev-mode/table/ActionsColumn.svelte
@@ -2,7 +2,10 @@
 import type { SelectableExtensionDevelopmentFolderInfoUI } from '/@/lib/extensions/dev-mode/development-folder-info-ui';
 import Actions from '/@/lib/extensions/dev-mode/selectable/Actions.svelte';
 
-export let object: SelectableExtensionDevelopmentFolderInfoUI;
+interface Props {
+  object: SelectableExtensionDevelopmentFolderInfoUI;
+}
+let { object }: Props = $props();
 </script>
 
 <Actions extensionFolder={object} />


### PR DESCRIPTION
## What does this PR do?
Migrated ActionsColumn component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature