### PR TITLE
refactor(Preferences): migrated FloatNumberItem component to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -7,16 +7,27 @@ import { uncertainStringToNumber } from '/@/lib/preferences/Util';
 
 import { checkNumericValueValid } from './NumberItemUtils';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: number | undefined;
-export let onChange = (_id: string, _value: number): void => {};
-export let invalidRecord = (_error: string): void => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: number;
+  onChange?: (_id: string, _value: number) => void;
+  invalidRecord?: (_error: string) => void;
+}
+let {
+  record,
+  value,
+  onChange = (_id: string, _value: number): void => {},
+  invalidRecord = (_error: string): void => {},
+}: Props = $props();
 
-let recordValue: string;
-$: recordValue = value?.toString() ?? '0';
+// eslint-disable-next-line svelte/prefer-writable-derived
+let recordValue: string = $state(value?.toString() ?? '0');
+$effect(() => {
+  recordValue = value?.toString() ?? '0';
+});
 
-let numberInputErrorMessage = '';
-let numberInputInvalid = false;
+let numberInputErrorMessage = $state('');
+let numberInputInvalid = $state(false);
 
 onMount(() => {
   if (value && assertNumericValueIsValid(value)) {
@@ -78,8 +89,8 @@ function assertNumericValueIsValid(value: number): boolean {
       class="w-full px-2 outline-hidden focus:outline-hidden text-[var(--pd-input-field-focused-text)] text-sm py-0.5"
       name={record.id}
       bind:value={recordValue}
-      on:keypress={onNumberInputKeyPress}
-      on:input={onInput}
+      onkeypress={onNumberInputKeyPress}
+      oninput={onInput}
       disabled={!!record.readonly}
       aria-label={record.description} />
   </Tooltip>

--- a/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/FloatNumberItem.svelte
@@ -7,16 +7,22 @@ import { uncertainStringToNumber } from '/@/lib/preferences/Util';
 
 import { checkNumericValueValid } from './NumberItemUtils';
 
-export let record: IConfigurationPropertyRecordedSchema;
-export let value: number | undefined;
-export let onChange = (_id: string, _value: number): void => {};
-export let invalidRecord = (_error: string): void => {};
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: number;
+  onChange?: (_id: string, _value: number) => void;
+  invalidRecord?: (_error: string) => void;
+}
+let {
+  record,
+  value,
+  onChange = (_id: string, _value: number): void => {},
+  invalidRecord = (_error: string): void => {},
+}: Props = $props();
 
-let recordValue: string;
-$: recordValue = value?.toString() ?? '0';
-
-let numberInputErrorMessage = '';
-let numberInputInvalid = false;
+let recordValue: string = $state('0');
+let numberInputErrorMessage = $state('');
+let numberInputInvalid = $state(false);
 
 onMount(() => {
   if (value && assertNumericValueIsValid(value)) {
@@ -78,8 +84,8 @@ function assertNumericValueIsValid(value: number): boolean {
       class="w-full px-2 outline-hidden focus:outline-hidden text-[var(--pd-input-field-focused-text)] text-sm py-0.5"
       name={record.id}
       bind:value={recordValue}
-      on:keypress={onNumberInputKeyPress}
-      on:input={onInput}
+      onkeypress={onNumberInputKeyPress}
+      oninput={onInput}
       disabled={!!record.readonly}
       aria-label={record.description} />
   </Tooltip>


### PR DESCRIPTION
## What does this PR do?
Migrated FloatNumberItem component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature