### PR TITLE
refactor(UI): migrated Badge component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -3,11 +3,15 @@ import { onMount } from 'svelte';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 
-export let color: string | { light: string; dark: string } = 'bg-[var(--pd-badge-gray)]';
-export let label: string = '';
+interface Props {
+  color?: string | { light: string; dark: string };
+  label?: string;
+  class?: string;
+}
+let { color = 'bg-[var(--pd-badge-gray)]', label = '', class: className }: Props = $props();
 
-let customStyle: string = '';
-let customClass: string = '';
+let customStyle: string = $state('');
+let customClass: string = $state('');
 
 onMount(async () => {
   const appearanceUtil = new AppearanceUtil();
@@ -24,6 +28,6 @@ onMount(async () => {
 });
 </script>
 
-<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded-sm select-none {customClass} {$$props.class}" style={customStyle} aria-label="badge-{label}">
+<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded-sm select-none {customClass} {className}" style={customStyle} aria-label="badge-{label}">
   {label}
 </div>


### PR DESCRIPTION
## What does this PR do?
Migrated Badge component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature