### PR TITLE
refactor(UI): migrated ConnectionErrorInfoButton component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.svelte
+++ b/packages/renderer/src/lib/ui/ConnectionErrorInfoButton.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 import type { IConnectionStatus } from '/@/lib/preferences/Util';
 
-export let status: IConnectionStatus | undefined;
+interface Props {
+  status?: IConnectionStatus;
+}
+let { status }: Props = $props();
 
 async function showTaskManager(): Promise<void> {
   // call the command show-task-manager'
@@ -13,5 +16,5 @@ async function showTaskManager(): Promise<void> {
   <button
     aria-label="{status.action} failed"
     class="ml-3 text-[9px] text-[var(--pd-state-error)] underline"
-    on:click={showTaskManager}>{status.action} failed</button>
+    onclick={showTaskManager}>{status.action} failed</button>
 {/if}


### PR DESCRIPTION
## What does this PR do?
Migrated ConnectionErrorInfoButton component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature