### PR TITLE
refactor(UI): migrated ExtensionStatus component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/ExtensionStatus.svelte
+++ b/packages/renderer/src/lib/ui/ExtensionStatus.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-export let status: string;
+interface Props {
+  status: string;
+}
+let { status }: Props = $props();
 
 interface ConnectionStatusStyle {
   bgColor: string;
@@ -58,11 +61,13 @@ const statusesStyle = new Map<string, ConnectionStatusStyle>([
     },
   ],
 ]);
-$: statusStyle = statusesStyle.get(status) ?? {
-  bgColor: 'bg-[var(--pd-status-unknown)]',
-  txtColor: 'text-[var(--pd-status-unknown)]',
-  label: status.toUpperCase(),
-};
+let statusStyle = $derived(
+  statusesStyle.get(status) ?? {
+    bgColor: 'bg-[var(--pd-status-unknown)]',
+    txtColor: 'text-[var(--pd-status-unknown)]',
+    label: status.toUpperCase(),
+  },
+);
 </script>
 
 <div aria-label="Extension Status Icon" class="bg-{roundIconStyle} {statusStyle.bgColor}"></div>


### PR DESCRIPTION
## What does this PR do?
Migrated ExtensionStatus component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature