### PR TITLE
refactor(UI): migrated FlatMenu component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/FlatMenu.svelte
+++ b/packages/renderer/src/lib/ui/FlatMenu.svelte
@@ -1,1 +1,10 @@
-<slot />
+<script lang="ts">
+import type { Snippet } from 'svelte';
+
+interface Props {
+  children?: Snippet;
+}
+let { children }: Props = $props();
+</script>
+
+{@render children?.()}


### PR DESCRIPTION
## What does this PR do?
Migrated FlatMenu component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature