### PR TITLE
refactor(UI): migrated LabelSpec component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/LabelSpec.svelte
+++ b/packages/renderer/src/lib/ui/LabelSpec.svelte
@@ -1,19 +1,36 @@
 <script lang="ts">
 import Label from './Label.svelte';
 
-export let name = '';
-export let tip = '';
-export let slot = '';
-export let role: string | undefined = undefined;
-export let capitalize: boolean = false;
-export let top: boolean | undefined = undefined;
-export let bottom: boolean | undefined = undefined;
-export let left: boolean | undefined = undefined;
-export let right: boolean | undefined = undefined;
-export let topLeft: boolean | undefined = undefined;
-export let topRight: boolean | undefined = undefined;
-export let bottomLeft: boolean | undefined = undefined;
-export let bottomRight: boolean | undefined = undefined;
+interface Props {
+  name?: string;
+  tip?: string;
+  slot?: string;
+  role?: string;
+  capitalize?: boolean;
+  top?: boolean;
+  bottom?: boolean;
+  left?: boolean;
+  right?: boolean;
+  topLeft?: boolean;
+  topRight?: boolean;
+  bottomLeft?: boolean;
+  bottomRight?: boolean;
+}
+let {
+  name = '',
+  tip = '',
+  slot = '',
+  role = undefined,
+  capitalize = false,
+  top = undefined,
+  bottom = undefined,
+  left = undefined,
+  right = undefined,
+  topLeft = undefined,
+  topRight = undefined,
+  bottomLeft = undefined,
+  bottomRight = undefined,
+}: Props = $props();
 </script>
 
 <Label tip={tip} role={role} name={name} capitalize={capitalize}


### PR DESCRIPTION
## What does this PR do?
Migrated LabelSpec component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature