### PR TITLE
refactor(UI): migrated NewContentBadge component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/NewContentBadge.svelte
+++ b/packages/renderer/src/lib/ui/NewContentBadge.svelte
@@ -3,15 +3,17 @@ import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
-export let pagePath: string;
-export let show: boolean = false;
-export let onHide: () => void = () => {};
+interface Props {
+  pagePath: string;
+  show?: boolean;
+  onHide?: () => void;
+}
+let { pagePath, show = false, onHide = (): void => {} }: Props = $props();
 
-let isInPage = $router.path === pagePath;
-let hasNew: boolean;
-$: hasNew = !isInPage && show;
+let isInPage = $derived($router.path === pagePath);
+let hasNew = $derived(!isInPage && show);
 
-let routerUnsubscribe: Unsubscriber;
+let routerUnsubscribe: Unsubscriber | undefined;
 
 onMount(() => {
   // listen to router change, so we can reset the changes and update the dot visibility


### PR DESCRIPTION
## What does this PR do?
Migrated NewContentBadge component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature