### PR TITLE
refactor(UI): migrated NoLogIcon component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/NoLogIcon.svelte
+++ b/packages/renderer/src/lib/ui/NoLogIcon.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
-export let size = '40';
+interface Props {
+  size?: string;
+  class?: string;
+  style?: string;
+}
+let { size = '40', class: className, style: styleName }: Props = $props();
 </script>
 
 <svg
   width={size}
   height={size}
-  class={$$props.class}
-  style={$$props.style}
+  class={className}
+  style={styleName}
   aria-hidden="true"
   data-prefix="far"
   data-icon="terminal"


### PR DESCRIPTION
## What does this PR do?
Migrated NoLogIcon component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature