### PR TITLE
refactor(UI): migrated WarningMessage component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/WarningMessage.svelte
+++ b/packages/renderer/src/lib/ui/WarningMessage.svelte
@@ -3,8 +3,13 @@ import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import { Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 
-export let error: string;
-export let icon = false;
+interface Props {
+  error?: string;
+  icon?: boolean;
+  class?: string;
+}
+
+let { error, icon = false, class: className }: Props = $props();
 </script>
 
 {#if icon}
@@ -15,7 +20,7 @@ export let icon = false;
   {/if}
 {:else}
   <div
-    class="text-[var(--pd-state-warning)] p-1 flex flex-row items-center {$$props.class}"
+    class="text-[var(--pd-state-warning)] p-1 flex flex-row items-center {className}"
     class:opacity-0={error === undefined || error === ''}>
     <Icon size="1.125x" class="cursor-pointer text-[var(--pd-state-warning)]" icon={faTriangleExclamation} />
     <div role="alert" class="ml-2">{error}</div>


### PR DESCRIPTION
## What does this PR do?
Migrated WarningMessage component to Svelte 5 runes syntax.

## Screenshot / video of UI

## What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

## How to test this PR?
There should be no functional/visual changes

- [x] Tests are covering the bug fix or the new feature