### PR TITLE
refactor: migrate Badge component to svelte5

### DIFF
--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -3,11 +3,16 @@ import { onMount } from 'svelte';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 
-export let color: string | { light: string; dark: string } = 'bg-[var(--pd-badge-gray)]';
-export let label: string = '';
+interface Props {
+  color?: string | { light: string; dark: string };
+  label?: string;
+  class?: string;
+}
 
-let customStyle: string = '';
-let customClass: string = '';
+let { color = 'bg-[var(--pd-badge-gray)]', label = '', class: className = '' }: Props = $props();
+
+let customStyle = $state('');
+let customClass = $state('');
 
 onMount(async () => {
   const appearanceUtil = new AppearanceUtil();
@@ -24,6 +29,6 @@ onMount(async () => {
 });
 </script>
 
-<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded-sm select-none {customClass} {$$props.class}" style={customStyle} aria-label="badge-{label}">
+<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded-sm select-none {customClass} {className}" style={customStyle} aria-label="badge-{label}">
   {label}
 </div>

--- a/packages/renderer/src/lib/ui/Badge.svelte
+++ b/packages/renderer/src/lib/ui/Badge.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 import { onMount } from 'svelte';
+import type { HTMLAttributes } from 'svelte/elements';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 
-interface Props {
+interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'color'> {
   color?: string | { light: string; dark: string };
   label?: string;
-  class?: string;
 }
 
-let { color = 'bg-[var(--pd-badge-gray)]', label = '', class: className = '' }: Props = $props();
+let { color = 'bg-[var(--pd-badge-gray)]', label = '', class: className = '', ...restProps }: Props = $props();
 
 let customStyle = $state('');
 let customClass = $state('');
@@ -29,6 +29,6 @@ onMount(async () => {
 });
 </script>
 
-<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded-sm select-none {customClass} {className}" style={customStyle} aria-label="badge-{label}">
+<div class="text-[var(--pd-badge-text)] text-xs me-2 px-1 py-0.5 rounded-sm select-none {customClass} {className}" style={customStyle} aria-label="badge-{label}" {...restProps}>
   {label}
 </div>


### PR DESCRIPTION
### What does this PR do?
Migrates Badge.svelte component to Svelte 5 runes syntax.

### Screenshot / video of UI
<img width="218" height="138" alt="Screenshot 2026-08-10 at 8 47 31" src="https://github.com/user-attachments/assets/355cc4dd-6bdb-4b5a-8a09-bf4c64d6a5bf" />


### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?
See "built-in Extension" badge on built-in extensions. No visual change should be seen.

- [X] Tests are covering the bug fix or the new feature
