### PR TITLE
refactor: migrate ExtensionBadge component to svelte5

### DIFF
--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -3,10 +3,15 @@ import { Tooltip } from '@podman-desktop/ui-svelte';
 
 import Badge from '/@/lib/ui/Badge.svelte';
 
-export let extension: { type: 'dd' | 'pd'; removable: boolean; devMode: boolean };
+interface Props {
+  extension: { type: 'dd' | 'pd'; removable: boolean; devMode: boolean };
+  class?: string;
+}
+
+let { extension, class: className = '' }: Props = $props();
 </script>
 
-<div class="flex flex-row gap-1 items-center {$$props.class}" role="region" aria-label="Extension Badge">
+<div class="flex flex-row gap-1 items-center {className}" role="region" aria-label="Extension Badge">
   {#if extension.type === 'dd'}
     <Tooltip right tip="Docker Desktop extension">
       <Badge class="text-[8px] text-[var(--pd-badge-dd-extension-text)]" color="bg-[var(--pd-badge-dd-extension-bg)]" label="Docker Desktop extension" />

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
 import { Tooltip } from '@podman-desktop/ui-svelte';
+import type { HTMLAttributes } from 'svelte/elements';
 
 import Badge from '/@/lib/ui/Badge.svelte';
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLDivElement> {
   extension: { type: 'dd' | 'pd'; removable: boolean; devMode: boolean };
-  class?: string;
 }
 
-let { extension, class: className = '' }: Props = $props();
+let { extension, class: className = '', ...restProps }: Props = $props();
 </script>
 
-<div class="flex flex-row gap-1 items-center {className}" role="region" aria-label="Extension Badge">
+<div class="flex flex-row gap-1 items-center {className}" role="region" aria-label="Extension Badge" {...restProps}>
   {#if extension.type === 'dd'}
     <Tooltip right tip="Docker Desktop extension">
       <Badge class="text-[8px] text-[var(--pd-badge-dd-extension-text)]" color="bg-[var(--pd-badge-dd-extension-bg)]" label="Docker Desktop extension" />


### PR DESCRIPTION
### What does this PR do?
Migrates ExtensionBadge.svelte component to Svelte 5 runes syntax.

### Screenshot / video of UI
<img width="210" height="133" alt="Screenshot 2026-08-10 at 8 56 52" src="https://github.com/user-attachments/assets/1615dfc8-5202-4723-9880-8c9d3859d7ba" />

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

See ExtensionBadge on Extensions page at some built-in extension - you should see not visually changed "built-in Extension" badge.

- [X] Tests are covering the bug fix or the new feature
