### PR TITLE
refactor: migrate OnboardingItem component to svelte5

### DIFF
--- a/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingItem.svelte
@@ -14,20 +14,18 @@ import { context } from '/@/stores/context';
 
 import { replaceContextKeyPlaceholders, replaceContextKeyPlaceHoldersByRegex } from './onboarding-utils';
 
-export let extension: string;
-export let item: OnboardingStepItem;
-export let inProgressCommandExecution: (
-  command: string,
-  state: 'starting' | 'failed' | 'successful',
-  value?: unknown,
-) => void;
+interface Props {
+  extension: string;
+  item: OnboardingStepItem;
+  inProgressCommandExecution: (command: string, state: 'starting' | 'failed' | 'successful', value?: unknown) => void;
+}
+
+let { extension, item, inProgressCommandExecution }: Props = $props();
 
 const configurationRegex = new RegExp(/\${configuration:(.+?)}/g);
-let html: string;
-$: html;
+let html = $state<string>('');
 let configurationItems: IConfigurationPropertyRecordedSchema[];
-let configurationItem: IConfigurationPropertyRecordedSchema | undefined;
-$: configurationItem;
+let configurationItem = $state<IConfigurationPropertyRecordedSchema | undefined>();
 
 let globalContext: ContextUI;
 let contextsUnsubscribe: Unsubscriber;


### PR DESCRIPTION
### What does this PR do?
Migrates OnboardingItem.svelte component to Svelte 5 runes syntax.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?
There should be no visual or functional change.

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
