### PR TITLE
refactor(Dashboard): migrated ProviderDetectionChecksButton to svelte5

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderDetectionChecksButton.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderDetectionChecksButton.svelte
@@ -4,11 +4,14 @@ import type { ProviderDetectionCheck } from '@podman-desktop/api';
 import type { ProviderInfo } from '@podman-desktop/core-api';
 import { Button } from '@podman-desktop/ui-svelte';
 
-export let provider: ProviderInfo;
-export let onDetectionChecks = (_detectionChecks: ProviderDetectionCheck[]): void => {};
-let viewInProgress = false;
+interface Props {
+  provider: ProviderInfo;
+  onDetectionChecks?: (detectionChecks: ProviderDetectionCheck[]) => void;
+}
+let { provider, onDetectionChecks = (_detectionChecks: ProviderDetectionCheck[]): void => {} }: Props = $props();
+let viewInProgress = $state(false);
 
-let mode: 'view' | 'hide' = 'view';
+let mode: 'view' | 'hide' = $state('view');
 
 async function toggleDetectionChecks(provider: ProviderInfo): Promise<void> {
   let detectionChecks: ProviderDetectionCheck[];


### PR DESCRIPTION
### What does this PR do?
Migrated ProviderDetectionChecksButton to svelte5

### Screenshot / video of UI
Should be no changes

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature