### PR TITLE
refactor(Dashboard): migrated ProviderWarnings to svelte5

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderWarnings.svelte
@@ -5,13 +5,15 @@ import { Icon } from '@podman-desktop/ui-svelte/icons';
 
 import { providerInfos } from '/@/stores/providers';
 
-export let provider: ProviderInfo;
+interface Props {
+  provider: ProviderInfo;
+}
+let { provider }: Props = $props();
 
 // Retrieve the provider information from the store
-let providerInfo: ProviderInfo | undefined;
-$: {
-  providerInfo = $providerInfos.find(providerSearch => providerSearch.internalId === provider.internalId);
-}
+let providerInfo: ProviderInfo | undefined = $derived(
+  $providerInfos.find(providerSearch => providerSearch.internalId === provider.internalId),
+);
 </script>
 
 <!-- TODO: Add dismiss button / ignore warning? -->


### PR DESCRIPTION
### What does this PR do?
Migrated ProviderWarnings to svelte5

### Screenshot / video of UI
Should be no changes

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature