### PR TITLE
refactor: migrate OnboardingComponent.svelte to svelte5

### DIFF
--- a/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingComponent.svelte
@@ -9,22 +9,24 @@ import PreferencesConnectionCreationOrEditRendering from '/@/lib/preferences/Pre
 import { configurationProperties } from '/@/stores/configurationProperties';
 import { providerInfos } from '/@/stores/providers';
 
-export let component: OnboardingEmbeddedComponentType;
-export let extensionId: string;
+interface Props {
+  component: OnboardingEmbeddedComponentType;
+  extensionId: string;
+}
 
-let configurationItems: IConfigurationPropertyRecordedSchema[];
-$: configurationItems;
+let { component, extensionId }: Props = $props();
+
+let configurationItems = $state<IConfigurationPropertyRecordedSchema[]>();
 let providers: ProviderInfo[];
-let providerInfo: ProviderInfo | undefined;
-$: providerInfo;
+let providerInfo = $state<ProviderInfo | undefined>();
 
-let providerDisplayName: string | undefined;
-$: providerDisplayName =
+let providerDisplayName = $derived(
   (providerInfo?.containerProviderConnectionCreation
     ? (providerInfo?.containerProviderConnectionCreationDisplayName ?? undefined)
     : providerInfo?.kubernetesProviderConnectionCreation
       ? providerInfo?.kubernetesProviderConnectionCreationDisplayName
-      : undefined) ?? providerInfo?.name;
+      : undefined) ?? providerInfo?.name,
+);
 
 onMount(() => {
   configurationProperties.subscribe(value => {


### PR DESCRIPTION
### What does this PR do?
Migrates OnboardingComponent.svelte to Svelte 5 runes syntax.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
