### PR TITLE
refactor(renderer): migrate ConfigMapDetailsSummary to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetailsSummary.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/ConfigMapDetailsSummary.svelte
@@ -6,8 +6,12 @@ import Table from '/@/lib/details/DetailsTable.svelte';
 import KubeConfigMapArtifact from '/@/lib/kube/details/KubeConfigMapArtifact.svelte';
 import KubeObjectMetaArtifact from '/@/lib/kube/details/KubeObjectMetaArtifact.svelte';
 
-export let configMap: V1ConfigMap | undefined;
-export let kubeError: string | undefined = undefined;
+interface Props {
+  configMap?: V1ConfigMap;
+  kubeError?: string;
+}
+
+let { configMap, kubeError }: Props = $props();
 </script>
 
 <!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the


### PR DESCRIPTION
### What does this PR do?
Migrates ConfigMapDetailsSummary.svelte to Svelte 5 runes syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature