### PR TITLE
refactor(renderer): migrate SecretDetailsSummary to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/configmaps-secrets/SecretDetailsSummary.svelte
+++ b/packages/renderer/src/lib/configmaps-secrets/SecretDetailsSummary.svelte
@@ -6,8 +6,12 @@ import Table from '/@/lib/details/DetailsTable.svelte';
 import KubeObjectMetaArtifact from '/@/lib/kube/details/KubeObjectMetaArtifact.svelte';
 import KubeSecretArtifact from '/@/lib/kube/details/KubeSecretArtifact.svelte';
 
-export let secret: V1Secret | undefined;
-export let kubeError: string | undefined = undefined;
+interface Props {
+  secret?: V1Secret;
+  kubeError?: string;
+}
+
+let { secret, kubeError }: Props = $props();
 </script>
 
 <!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the


### PR DESCRIPTION
### What does this PR do?
Migrates SecretDetailsSummary.svelte to Svelte 5 runes syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature