### PR TITLE
refactor(renderer): migrate IngressRouteActions to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteActions.svelte
@@ -8,8 +8,12 @@ import { IngressRouteUtils } from './ingress-route-utils';
 import type { IngressUI } from './IngressUI';
 import type { RouteUI } from './RouteUI';
 
-export let ingressRoute: IngressUI | RouteUI;
-export let detailed = false;
+interface Props {
+  ingressRoute: IngressUI | RouteUI;
+  detailed?: boolean;
+}
+
+let { ingressRoute, detailed = false }: Props = $props();
 
 const ingressRouteUtils = new IngressRouteUtils();
 


### PR DESCRIPTION
### What does this PR do?
Migrates IngressRouteActions.svelte to Svelte 5 runes syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature