### PR TITLE
refactor(renderer): migrate IngressRouteDetailsSummary to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.svelte
+++ b/packages/renderer/src/lib/ingresses-routes/IngressRouteDetailsSummary.svelte
@@ -9,8 +9,12 @@ import KubeIngressStatusArtifact from '/@/lib/kube/details/KubeIngressStatusArti
 import KubeObjectMetaArtifact from '/@/lib/kube/details/KubeObjectMetaArtifact.svelte';
 import OpenshiftRouteArtifact from '/@/lib/kube/details/OpenshiftRouteArtifact.svelte';
 
-export let ingressRoute: V1Ingress | V1Route | undefined;
-export let kubeError: string | undefined = undefined;
+interface Props {
+  ingressRoute?: V1Ingress | V1Route;
+  kubeError?: string;
+}
+
+let { ingressRoute, kubeError }: Props = $props();
 
 // Determine if the artifact is an Ingress or a Route
 function isIngress(ingressRoute: V1Ingress | V1Route): ingressRoute is V1Ingress {


### PR DESCRIPTION
### What does this PR do?
Migrates IngressRouteDetailsSummary.svelte to Svelte 5 runes syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature