### PR TITLE
refactor(renderer): migrate ServiceActions to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/service/ServiceActions.svelte
+++ b/packages/renderer/src/lib/service/ServiceActions.svelte
@@ -6,8 +6,12 @@ import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 
 import type { ServiceUI } from './ServiceUI';
 
-export let service: ServiceUI;
-export let detailed = false;
+interface Props {
+  service: ServiceUI;
+  detailed?: boolean;
+}
+
+let { service, detailed = false }: Props = $props();
 
 async function deleteService(): Promise<void> {
   service.status = 'DELETING';


### PR DESCRIPTION
### What does this PR do?
Migrates ServiceActions.svelte to Svelte 5 runes syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature