### PR TITLE
refactor(renderer): migrate NodeDetailsSummary to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/node/NodeDetailsSummary.svelte
+++ b/packages/renderer/src/lib/node/NodeDetailsSummary.svelte
@@ -9,9 +9,13 @@ import KubeNodeArtifact from '/@/lib/kube/details/KubeNodeArtifact.svelte';
 import KubeNodeStatusArtifact from '/@/lib/kube/details/KubeNodeStatusArtifact.svelte';
 import KubeObjectMetaArtifact from '/@/lib/kube/details/KubeObjectMetaArtifact.svelte';
 
-export let node: V1Node | undefined;
-export let kubeError: string | undefined = undefined;
-export let events: EventUI[];
+interface Props {
+  node?: V1Node;
+  kubeError?: string;
+  events: EventUI[];
+}
+
+let { node, kubeError, events }: Props = $props();
 </script>
 
 <!-- Show the kube error if we're unable to retrieve the data correctly, but we still want to show the


### PR DESCRIPTION
### What does this PR do?
Migrates NodeDetailsSummary.svelte to Svelte 5 runes syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature