### PR TITLE
refactor(renderer): migrate NodeEmptyScreen to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/node/NodeEmptyScreen.svelte
+++ b/packages/renderer/src/lib/node/NodeEmptyScreen.svelte
@@ -15,7 +15,7 @@ function getText(state: ContextGeneralState | undefined): string {
   return 'Try switching to a different context or namespace';
 }
 
-$: text = getText($kubernetesCurrentContextState);
+let text = $derived(getText($kubernetesCurrentContextState));
 </script>
 
 <KubernetesEmptyScreen icon={NodeIcon} resources={['nodes']} titleEmpty='No nodes' titleNotPermitted='Nodes not accessible' message={text} />


### PR DESCRIPTION
### What does this PR do?
Migrates NodeEmptyScreen.svelte to Svelte 5 runes syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature