### PR TITLE
chore(eslint): disabled sonarjs/*tests rules implicitly enabled in 4.2.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -251,6 +251,9 @@ export default [
       'sonarjs/prefer-specific-assertions': 'off',
       'sonarjs/super-linear-regex': 'off',
       'sonarjs/no-trivial-assertions': 'off',
+      'sonarjs/parameterized-tests': 'off',
+      'sonarjs/no-fixed-wait-in-tests': 'off',
+      'sonarjs/explicit-test-skip': 'off',
 
       // redundant-undefined custom rules
       'redundant-undefined/redundant-undefined': 'error',


### PR DESCRIPTION
### What does this PR do?
Disables sonarjs/parameterized-tests, sonarjs/no-fixed-wait-in-tests, sonarjs/explicit-test-skip
rules implicitly enabled in 4.2.0

### Screenshot / video of UI

### What issues does this PR fix or reference?
Should fix the failing linter checks

### How to test this PR?
CI 

- [ ] Tests are covering the bug fix or the new feature
