### PR TITLE
chore: fix broken pnpm-lock.yaml with duplicated YAML key

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18375,15 +18375,6 @@ snapshots:
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  autoprefixer@10.5.4(postcss@8.5.26):
-    dependencies:
-      browserslist: 4.28.6
-      caniuse-lite: 1.0.30001806
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.26
-      postcss-value-parser: 4.2.0
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0


### PR DESCRIPTION
### What does this PR do?

The lockfile had a duplicated mapping key (autoprefixer entry at line 18378) causing pnpm to ignore it entirely on CI. This resulted in fresh dependency resolution picking up newer eslint-plugin-sonarjs with breaking lint rules (sonarjs/parameterized-tests), failing all PR checks.

Regenerated with pnpm install to fix the YAML syntax error.



### What issues does this PR fix or reference?
