### PR TITLE
feat(ui): add ButtonRow component

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/button/Button.svelte.d.ts",
       "svelte": "./dist/button/Button.svelte"
     },
+    "./ButtonRow": {
+      "types": "./dist/buttonRow/ButtonRow.svelte.d.ts",
+      "svelte": "./dist/buttonRow/ButtonRow.svelte"
+    },
     "./Table": {
       "types": "./dist/table/Table.svelte.d.ts",
       "svelte": "./dist/table/Table.svelte"

--- a/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
@@ -26,8 +26,6 @@ import ButtonRowTest from './ButtonRowTest.svelte';
 test('renders actions in DOM order and right-aligns the row', () => {
   const { container } = render(ButtonRowTest);
 
-  expect(container.textContent).not.toContain('Copyright (C) 2026 Red Hat, Inc.');
-
   const actions = screen.getAllByRole('button');
   expect(actions.map(action => action.textContent)).toEqual(['Cancel', 'Save']);
 
@@ -76,6 +74,19 @@ test('skips a hidden first action when choosing the first action to focus', () =
 
 test('skips an action in an aria-hidden wrapper when choosing the first action to focus', () => {
   render(ButtonRowTest, { initialFocus: 'first', ariaHiddenCancel: true });
+
+  expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus();
+});
+
+test('only focuses enabled button children, not links or inputs', () => {
+  render(ButtonRowTest, { initialFocus: 'first', includeNonButtons: true });
+
+  expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+  expect(screen.getByRole('link', { name: 'Link' })).not.toHaveFocus();
+});
+
+test('last focus ignores a trailing input', () => {
+  render(ButtonRowTest, { initialFocus: 'last', includeNonButtons: true });
 
   expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus();
 });

--- a/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ButtonRowTest from './ButtonRowTest.svelte';
+
+test('renders actions in DOM order and right-aligns the row', () => {
+  const { container } = render(ButtonRowTest);
+
+  expect(container.textContent).not.toContain('Copyright (C) 2026 Red Hat, Inc.');
+
+  const actions = screen.getAllByRole('button');
+  expect(actions.map(action => action.textContent)).toEqual(['Cancel', 'Save']);
+
+  const row = container.firstElementChild;
+  expect(row).toHaveClass('flex');
+  expect(row).toHaveClass('justify-end');
+  expect(row).not.toHaveClass('justify-center');
+  expect(row).not.toHaveClass('w-full');
+});
+
+test('does not move focus by default', () => {
+  render(ButtonRowTest);
+
+  expect(document.activeElement).toBe(document.body);
+});
+
+test('focuses the first action when requested', () => {
+  render(ButtonRowTest, { initialFocus: 'first' });
+
+  expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+});
+
+test('focuses the last enabled action when requested', () => {
+  render(ButtonRowTest, { initialFocus: 'last' });
+
+  expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus();
+});
+
+test('skips disabled actions when choosing the last action to focus', () => {
+  render(ButtonRowTest, { initialFocus: 'last', disabledPrimary: true });
+
+  expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+});
+
+test('skips a disabled first action when choosing the first action to focus', () => {
+  render(ButtonRowTest, { initialFocus: 'first', disabledCancel: true });
+
+  expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus();
+});
+
+test('skips a hidden first action when choosing the first action to focus', () => {
+  render(ButtonRowTest, { initialFocus: 'first', hiddenCancel: true });
+
+  expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus();
+});

--- a/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
@@ -21,6 +21,7 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
+import ButtonRow from './ButtonRow.svelte';
 import ButtonRowTest from './ButtonRowTest.svelte';
 
 test('renders actions in DOM order and right-aligns the row', () => {
@@ -34,6 +35,12 @@ test('renders actions in DOM order and right-aligns the row', () => {
   expect(row).toHaveClass('justify-end');
   expect(row).not.toHaveClass('justify-center');
   expect(row).not.toHaveClass('w-full');
+});
+
+test('forwards extra HTML attributes onto the row', () => {
+  const { container } = render(ButtonRow, { 'data-testid': 'dialog-actions' });
+
+  expect(container.firstElementChild).toHaveAttribute('data-testid', 'dialog-actions');
 });
 
 test('does not move focus by default', () => {

--- a/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
@@ -73,3 +73,9 @@ test('skips a hidden first action when choosing the first action to focus', () =
 
   expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus();
 });
+
+test('skips an action in an aria-hidden wrapper when choosing the first action to focus', () => {
+  render(ButtonRowTest, { initialFocus: 'first', ariaHiddenCancel: true });
+
+  expect(screen.getByRole('button', { name: 'Save' })).toHaveFocus();
+});

--- a/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.spec.ts
@@ -21,7 +21,6 @@ import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
 import { expect, test } from 'vitest';
 
-import ButtonRow from './ButtonRow.svelte';
 import ButtonRowTest from './ButtonRowTest.svelte';
 
 test('renders actions in DOM order and right-aligns the row', () => {
@@ -35,12 +34,6 @@ test('renders actions in DOM order and right-aligns the row', () => {
   expect(row).toHaveClass('justify-end');
   expect(row).not.toHaveClass('justify-center');
   expect(row).not.toHaveClass('w-full');
-});
-
-test('forwards extra HTML attributes onto the row', () => {
-  const { container } = render(ButtonRow, { 'data-testid': 'dialog-actions' });
-
-  expect(container.firstElementChild).toHaveAttribute('data-testid', 'dialog-actions');
 });
 
 test('does not move focus by default', () => {

--- a/packages/ui/src/lib/buttonRow/ButtonRow.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+import { onMount, type Snippet } from 'svelte';
+
+type InitialFocus = 'first' | 'last' | 'none';
+
+interface Props {
+  /**
+   * Which enabled action should receive focus when the row is mounted.
+   * Use `last` for a primary action and `first` for a cancel action in a destructive dialog.
+   */
+  initialFocus?: InitialFocus;
+  class?: string;
+  children?: Snippet;
+}
+
+let { initialFocus = 'none', class: classNames, children }: Props = $props();
+
+let buttonRow: HTMLDivElement;
+
+function focusInitialAction(): void {
+  if (initialFocus === 'none') {
+    return;
+  }
+
+  const focusableActions = Array.from(
+    buttonRow.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter(action => !action.hidden && action.getAttribute('aria-hidden') !== 'true');
+  const action = initialFocus === 'first' ? focusableActions[0] : focusableActions[focusableActions.length - 1];
+  action?.focus();
+}
+
+onMount(focusInitialAction);
+</script>
+
+<div class="flex flex-row flex-wrap justify-end gap-2 {classNames}" bind:this={buttonRow}>
+  {@render children?.()}
+</div>

--- a/packages/ui/src/lib/buttonRow/ButtonRow.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
 import { onMount, type Snippet } from 'svelte';
+import type { HTMLAttributes } from 'svelte/elements';
 
 type InitialFocus = 'first' | 'last' | 'none';
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLDivElement> {
   /**
    * Which enabled action should receive focus when the row is mounted.
    * Use `last` for a primary action and `first` for a cancel action in a destructive dialog.
    */
   initialFocus?: InitialFocus;
-  class?: string;
   children?: Snippet;
 }
 
-let { initialFocus = 'none', class: classNames, children }: Props = $props();
+let { initialFocus = 'none', class: className, children, ...restProps }: Props = $props();
 
 let buttonRow: HTMLDivElement;
 
@@ -32,6 +32,6 @@ function focusInitialAction(): void {
 onMount(focusInitialAction);
 </script>
 
-<div class="flex flex-row flex-wrap justify-end gap-2 {classNames}" bind:this={buttonRow}>
+<div class="flex flex-row flex-wrap justify-end gap-2 {className}" bind:this={buttonRow} {...restProps}>
   {@render children?.()}
 </div>

--- a/packages/ui/src/lib/buttonRow/ButtonRow.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.svelte
@@ -22,9 +22,9 @@ function focusInitialAction(): void {
     return;
   }
 
-  const focusableActions = Array.from(
-    buttonRow.querySelectorAll<HTMLElement>('button:not([disabled])'),
-  ).filter(action => action.closest('[hidden], [aria-hidden="true"]') === null);
+  const focusableActions = Array.from(buttonRow.querySelectorAll<HTMLElement>('button:not([disabled])')).filter(
+    action => action.closest('[hidden], [aria-hidden="true"]') === null,
+  );
   const action = initialFocus === 'first' ? focusableActions[0] : focusableActions[focusableActions.length - 1];
   action?.focus();
 }

--- a/packages/ui/src/lib/buttonRow/ButtonRow.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.svelte
@@ -23,9 +23,7 @@ function focusInitialAction(): void {
   }
 
   const focusableActions = Array.from(
-    buttonRow.querySelectorAll<HTMLElement>(
-      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ),
+    buttonRow.querySelectorAll<HTMLElement>('button:not([disabled])'),
   ).filter(action => action.closest('[hidden], [aria-hidden="true"]') === null);
   const action = initialFocus === 'first' ? focusableActions[0] : focusableActions[focusableActions.length - 1];
   action?.focus();

--- a/packages/ui/src/lib/buttonRow/ButtonRow.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRow.svelte
@@ -26,7 +26,7 @@ function focusInitialAction(): void {
     buttonRow.querySelectorAll<HTMLElement>(
       'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
     ),
-  ).filter(action => !action.hidden && action.getAttribute('aria-hidden') !== 'true');
+  ).filter(action => action.closest('[hidden], [aria-hidden="true"]') === null);
   const action = initialFocus === 'first' ? focusableActions[0] : focusableActions[focusableActions.length - 1];
   action?.focus();
 }

--- a/packages/ui/src/lib/buttonRow/ButtonRowTest.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRowTest.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import Button from '../button/Button.svelte';
+import ButtonRow from './ButtonRow.svelte';
+
+type InitialFocus = 'first' | 'last' | 'none';
+
+interface Props {
+  initialFocus?: InitialFocus;
+  disabledCancel?: boolean;
+  disabledPrimary?: boolean;
+  hiddenCancel?: boolean;
+}
+
+let { initialFocus, disabledCancel = false, disabledPrimary = false, hiddenCancel = false }: Props = $props();
+</script>
+
+<ButtonRow {initialFocus}>
+  <Button type="secondary" disabled={disabledCancel} hidden={hiddenCancel}>Cancel</Button>
+  <Button type="primary" disabled={disabledPrimary}>Save</Button>
+</ButtonRow>

--- a/packages/ui/src/lib/buttonRow/ButtonRowTest.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRowTest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import Button from '../button/Button.svelte';
+import Button from '/@/lib/button/Button.svelte';
 import ButtonRow from './ButtonRow.svelte';
 
 type InitialFocus = 'first' | 'last' | 'none';
@@ -10,6 +10,7 @@ interface Props {
   disabledPrimary?: boolean;
   ariaHiddenCancel?: boolean;
   hiddenCancel?: boolean;
+  includeNonButtons?: boolean;
 }
 
 let {
@@ -18,12 +19,19 @@ let {
   disabledPrimary = false,
   ariaHiddenCancel = false,
   hiddenCancel = false,
+  includeNonButtons = false,
 }: Props = $props();
 </script>
 
 <ButtonRow {initialFocus}>
+  {#if includeNonButtons}
+    <a href="#link">Link</a>
+  {/if}
   <div aria-hidden={ariaHiddenCancel ? 'true' : undefined}>
     <Button type="secondary" disabled={disabledCancel} hidden={hiddenCancel}>Cancel</Button>
   </div>
   <Button type="primary" disabled={disabledPrimary}>Save</Button>
+  {#if includeNonButtons}
+    <input aria-label="field" />
+  {/if}
 </ButtonRow>

--- a/packages/ui/src/lib/buttonRow/ButtonRowTest.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRowTest.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Button from '/@/lib/button/Button.svelte';
+
 import ButtonRow from './ButtonRow.svelte';
 
 type InitialFocus = 'first' | 'last' | 'none';

--- a/packages/ui/src/lib/buttonRow/ButtonRowTest.svelte
+++ b/packages/ui/src/lib/buttonRow/ButtonRowTest.svelte
@@ -8,13 +8,22 @@ interface Props {
   initialFocus?: InitialFocus;
   disabledCancel?: boolean;
   disabledPrimary?: boolean;
+  ariaHiddenCancel?: boolean;
   hiddenCancel?: boolean;
 }
 
-let { initialFocus, disabledCancel = false, disabledPrimary = false, hiddenCancel = false }: Props = $props();
+let {
+  initialFocus,
+  disabledCancel = false,
+  disabledPrimary = false,
+  ariaHiddenCancel = false,
+  hiddenCancel = false,
+}: Props = $props();
 </script>
 
 <ButtonRow {initialFocus}>
-  <Button type="secondary" disabled={disabledCancel} hidden={hiddenCancel}>Cancel</Button>
+  <div aria-hidden={ariaHiddenCancel ? 'true' : undefined}>
+    <Button type="secondary" disabled={disabledCancel} hidden={hiddenCancel}>Cancel</Button>
+  </div>
   <Button type="primary" disabled={disabledPrimary}>Save</Button>
 </ButtonRow>

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -20,6 +20,7 @@ import type { ButtonType } from './button/Button';
 import Button from './button/Button.svelte';
 import CloseButton from './button/CloseButton.svelte';
 import Expandable from './button/Expandable.svelte';
+import ButtonRow from './buttonRow/ButtonRow.svelte';
 import Carousel from './carousel/Carousel.svelte';
 import Checkbox from './checkbox/Checkbox.svelte';
 import Dropdown from './dropdown/Dropdown.svelte';
@@ -56,6 +57,7 @@ import { isFontAwesomeIcon } from './utils/icon-utils';
 export type { ButtonType, IconType, ListOrganizerItem, TablePersistence, ThemedIconImage };
 export {
   Button,
+  ButtonRow,
   Carousel,
   Checkbox,
   ChevronExpander,

--- a/storybook/src/stories/button/ButtonRow.stories.svelte
+++ b/storybook/src/stories/button/ButtonRow.stories.svelte
@@ -1,0 +1,57 @@
+<script context="module" lang="ts">
+import { Button, ButtonRow } from '@podman-desktop/ui-svelte';
+import { type Args, defineMeta, type StoryContext } from '@storybook/addon-svelte-csf';
+
+const { Story } = defineMeta({
+  component: ButtonRow,
+  render: template,
+  title: 'Button/ButtonRow',
+  tags: ['autodocs'],
+  argTypes: {
+    initialFocus: {
+      control: 'select',
+      options: ['none', 'first', 'last'],
+      description: 'The enabled action that receives focus when the row mounts.',
+    },
+  },
+});
+</script>
+
+{#snippet template({ ...args }: Args<typeof Story>, _context: StoryContext<typeof Story>)}
+  <div class="bg-(--pd-content-card-bg) p-4" dir={args.dir ?? 'ltr'}>
+    <ButtonRow initialFocus={args.initialFocus}>
+      <Button type="secondary">Cancel</Button>
+      <Button type="primary">Save</Button>
+    </ButtonRow>
+  </div>
+{/snippet}
+
+<Story name="One Button" args={{ initialFocus: 'none' }}>
+  {#snippet template()}
+    <div class="bg-(--pd-content-card-bg) p-4">
+      <ButtonRow>
+        <Button type="primary">Save</Button>
+      </ButtonRow>
+    </div>
+  {/snippet}
+</Story>
+
+<Story name="Two Buttons" args={{ initialFocus: 'none' }} />
+
+<Story name="Three Buttons" args={{ initialFocus: 'none' }}>
+  {#snippet template()}
+    <div class="bg-(--pd-content-card-bg) p-4">
+      <ButtonRow>
+        <Button type="link">Back</Button>
+        <Button type="secondary">Cancel</Button>
+        <Button type="primary">Save</Button>
+      </ButtonRow>
+    </div>
+  {/snippet}
+</Story>
+
+<Story name="RTL" args={{ initialFocus: 'none', dir: 'rtl' }} />
+<Story name="Initial Focus Primary" args={{ initialFocus: 'last' }} />
+<Story name="Initial Focus Cancel" args={{ initialFocus: 'first' }} />
+
+<!-- Use the Themes toolbar to verify light, dark, hc-light, and hc-dark variants. -->

--- a/storybook/src/stories/button/ButtonRow.stories.svelte
+++ b/storybook/src/stories/button/ButtonRow.stories.svelte
@@ -1,6 +1,11 @@
 <script context="module" lang="ts">
 import { Button, ButtonRow } from '@podman-desktop/ui-svelte';
-import { type Args, defineMeta, type StoryContext } from '@storybook/addon-svelte-csf';
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import type { ComponentProps } from 'svelte';
+
+type ButtonRowStoryArgs = ComponentProps<typeof ButtonRow> & {
+  dir?: 'ltr' | 'rtl';
+};
 
 const { Story } = defineMeta({
   component: ButtonRow,
@@ -10,6 +15,7 @@ const { Story } = defineMeta({
   argTypes: {
     initialFocus: {
       control: 'select',
+      defaultValue: 'none',
       options: ['none', 'first', 'last'],
       description: 'The enabled action that receives focus when the row mounts.',
     },
@@ -17,9 +23,9 @@ const { Story } = defineMeta({
 });
 </script>
 
-{#snippet template({ ...args }: Args<typeof Story>, _context: StoryContext<typeof Story>)}
-  <div class="bg-(--pd-content-card-bg) p-4" dir={args.dir ?? 'ltr'}>
-    <ButtonRow initialFocus={args.initialFocus}>
+{#snippet template({ initialFocus = 'none', dir = 'ltr' }: ButtonRowStoryArgs)}
+  <div class="bg-(--pd-content-card-bg) p-4" {dir}>
+    <ButtonRow {initialFocus}>
       <Button type="secondary">Cancel</Button>
       <Button type="primary">Save</Button>
     </ButtonRow>


### PR DESCRIPTION
### What does this PR do?

Adds a shared `ButtonRow` component to `@podman-desktop/ui-svelte`.

- Right-aligns actions in LTR and RTL without changing their DOM order.
- Lets callers focus the first or last available action.
- Skips disabled and hidden actions when setting focus.
- Adds package exports, unit tests, and Storybook examples.

### Screenshot / video of UI

Verified with the new Storybook examples.

### What issues does this PR fix or reference?

Closes #18716

### How to test this PR?

- `pnpm --filter @podman-desktop/ui-svelte test src/lib/buttonRow/ButtonRow.spec.ts`
- `pnpm --filter @podman-desktop/ui-svelte build`
- `pnpm --filter @podman-desktop/ui-svelte svelte:check`
- Build Storybook and check the one-, two-, three-button, RTL, and focus examples.

- [x] Tests are covering the new component
