### PR TITLE
fix(build): kill spawned processes when watch exits

### DIFF
--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -98,6 +98,15 @@ function cleanupAndExit(signal) {
   }
 }
 
+/**
+ * Preserve whether a child exited with a status code or a signal.
+ * @param {number | null} code
+ * @param {NodeJS.Signals | null} signal
+ */
+function cleanupOnChildExit(code, signal) {
+  cleanupAndExit(signal ?? code ?? 0);
+}
+
 // Ensure termination propagates to all child processes.
 process.on('SIGINT', cleanupAndExit);
 process.on('SIGTERM', cleanupAndExit);
@@ -179,7 +188,7 @@ const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
     configFile: 'packages/main/vite.config.js',
     writeBundle() {
       if (spawnProcess !== null) {
-        spawnProcess.off('exit', cleanupAndExit);
+        spawnProcess.off('exit', cleanupOnChildExit);
         killChild(spawnProcess, 'SIGINT');
         spawnProcess = null;
       }
@@ -204,7 +213,7 @@ const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
       });
 
       // Stops the watch script when the application has been quit
-      spawnProcess.on('exit', cleanupAndExit);
+      spawnProcess.on('exit', cleanupOnChildExit);
 
       // Register cleanup first so the process group remains tracked while
       // cleanupAndExit terminates any surviving descendants.
@@ -234,7 +243,7 @@ const setupUiPackageWatcher = () => {
     cwd: './packages/ui/',
     env: { PATH: newPath, ...process.env },
     shell: process.platform === 'win32',
-    detached: true,
+    detached: process.platform !== 'win32',
   });
 
   spawnProcess.stdout.on('data', d => d.toString().trim() && logger.warn(d.toString(), { timestamp: true }));
@@ -247,7 +256,7 @@ const setupUiPackageWatcher = () => {
   });
 
   // Stops the watch script when the application has been quit
-  spawnProcess.on('exit', cleanupAndExit);
+  spawnProcess.on('exit', cleanupOnChildExit);
 
   trackChildProcess(spawnProcess);
   spawnProcess.unref();
@@ -341,7 +350,7 @@ const setupExtensionApiWatcher = name => {
   const spawnProcess = spawn('pnpm', ['watch'], {
     cwd: folderName,
     shell: process.platform === 'win32',
-    detached: true,
+    detached: process.platform !== 'win32',
   });
 
   spawnProcess.stdout.on('data', d => d.toString().trim() && console.warn(d.toString(), { timestamp: true }));
@@ -352,7 +361,7 @@ const setupExtensionApiWatcher = name => {
   });
 
   // Stops the watch script when the application has been quit
-  spawnProcess.on('exit', cleanupAndExit);
+  spawnProcess.on('exit', cleanupOnChildExit);
 
   // Register cleanup first so the process group remains tracked while
   // cleanupAndExit terminates any surviving descendants.

--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -20,7 +20,7 @@
 
 import { createServer, build, createLogger } from 'vite';
 import electronPath from 'electron';
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { generateAsync } from 'dts-for-context-bridge';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -28,6 +28,80 @@ import { readdirSync, existsSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Spawned child processes tracked so we can tear them all down on exit.
+ * @type {Set<import('node:child_process').ChildProcess>}
+ */
+const childrenProcesses = new Set();
+
+/**
+ * Track a child process so it can be killed together with the watch script.
+ * @param {import('node:child_process').ChildProcess} child
+ */
+function trackChildProcess(child) {
+  childrenProcesses.add(child);
+  child.once('exit', () => childrenProcesses.delete(child));
+}
+
+/**
+ * Kill a single child process and its descendants using platform-specific
+ * process-tree termination.
+ * @param {import('node:child_process').ChildProcess} child
+ * @param {NodeJS.Signals} signal
+ */
+function killChild(child, signal) {
+  if (child.pid === undefined) {
+    return;
+  }
+  try {
+    if (process.platform === 'win32') {
+      spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+    } else {
+      process.kill(-child.pid, signal);
+    }
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Process already exited.
+    }
+  }
+}
+
+/**
+ * Kill every tracked child process by sending the signal to its whole
+ * process group (which also kills its own descendants, e.g. pnpm → vite).
+ * @param {NodeJS.Signals} signal
+ */
+function killChildren(signal) {
+  for (const child of childrenProcesses) {
+    killChild(child, signal);
+  }
+  childrenProcesses.clear();
+}
+
+/**
+ * Kill everything spawned by this script and exit. The default terminal
+ * behavior only kills the direct `pnpm watch` process, leaving spawned
+ * package watchers (and their vite processes) orphaned.
+ * @param {NodeJS.Signals | number} signal
+ */
+function cleanupAndExit(signal) {
+  killChildren('SIGTERM');
+  if (typeof signal === 'string' && signal.startsWith('SIG')) {
+    // Re-raise so the parent shell sees the real exit reason.
+    process.removeListener(signal, cleanupAndExit);
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(typeof signal === 'number' ? signal : 0);
+  }
+}
+
+// Ensure termination propagates to all child processes.
+process.on('SIGINT', cleanupAndExit);
+process.on('SIGTERM', cleanupAndExit);
+process.on('SIGQUIT', cleanupAndExit);
 
 /** @type 'production' | 'development'' */
 const mode = (process.env.MODE = process.env.MODE || 'development');
@@ -105,8 +179,8 @@ const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
     configFile: 'packages/main/vite.config.js',
     writeBundle() {
       if (spawnProcess !== null) {
-        spawnProcess.off('exit', process.exit);
-        spawnProcess.kill('SIGINT');
+        spawnProcess.off('exit', cleanupAndExit);
+        killChild(spawnProcess, 'SIGINT');
         spawnProcess = null;
       }
 
@@ -117,6 +191,7 @@ const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
       });
       spawnProcess = spawn(String(electronPath), ['--remote-debugging-port=9223', '.', ...extensionArgs], {
         env: { ...process.env, ELECTRON_IS_DEV: 1 },
+        detached: process.platform !== 'win32',
       });
 
       spawnProcess.stdout.on('data', d => d.toString().trim() && logger.warn(d.toString(), { timestamp: true }));
@@ -129,7 +204,11 @@ const setupMainPackageWatcher = ({ config: { server, extensions } }) => {
       });
 
       // Stops the watch script when the application has been quit
-      spawnProcess.on('exit', process.exit);
+      spawnProcess.on('exit', cleanupAndExit);
+
+      // Register cleanup first so the process group remains tracked while
+      // cleanupAndExit terminates any surviving descendants.
+      trackChildProcess(spawnProcess);
     },
   });
 };
@@ -155,6 +234,7 @@ const setupUiPackageWatcher = () => {
     cwd: './packages/ui/',
     env: { PATH: newPath, ...process.env },
     shell: process.platform === 'win32',
+    detached: true,
   });
 
   spawnProcess.stdout.on('data', d => d.toString().trim() && logger.warn(d.toString(), { timestamp: true }));
@@ -167,7 +247,10 @@ const setupUiPackageWatcher = () => {
   });
 
   // Stops the watch script when the application has been quit
-  spawnProcess.on('exit', process.exit);
+  spawnProcess.on('exit', cleanupAndExit);
+
+  trackChildProcess(spawnProcess);
+  spawnProcess.unref();
 };
 
 /**
@@ -252,11 +335,14 @@ const setupPreloadWebviewPackageWatcher = ({ ws }) =>
  * @param {{ws: import('vite').WebSocketServer}} WebSocketServer
  */
 const setupExtensionApiWatcher = name => {
-  let spawnProcess;
   const folderName = resolve(name);
 
   console.log('dirname is', folderName);
-  spawnProcess = spawn('pnpm', ['watch'], { cwd: folderName, shell: process.platform === 'win32' });
+  const spawnProcess = spawn('pnpm', ['watch'], {
+    cwd: folderName,
+    shell: process.platform === 'win32',
+    detached: true,
+  });
 
   spawnProcess.stdout.on('data', d => d.toString().trim() && console.warn(d.toString(), { timestamp: true }));
   spawnProcess.stderr.on('data', d => {
@@ -266,7 +352,12 @@ const setupExtensionApiWatcher = name => {
   });
 
   // Stops the watch script when the application has been quit
-  spawnProcess.on('exit', process.exit);
+  spawnProcess.on('exit', cleanupAndExit);
+
+  // Register cleanup first so the process group remains tracked while
+  // cleanupAndExit terminates any surviving descendants.
+  trackChildProcess(spawnProcess);
+  spawnProcess.unref();
 };
 
 (async () => {


### PR DESCRIPTION
### What does this PR do?

Tracks every process spawned by `scripts/watch.mjs` and terminates the complete process tree when the watch command exits. On Unix, watchers are placed in detached process groups and terminated through their group PID; on Windows, cleanup uses `taskkill /T /F`. Signal exits are re-raised so callers retain the correct exit status.

The Electron restart path uses the same platform-specific single-child cleanup helper, and exit handlers are registered before child tracking so descendants remain tracked while cleanup runs. This incorporates the review feedback from openkaiden/kaiden#2656.

### Screenshot / video of UI

Not applicable; this changes development-process cleanup only.

### What issues does this PR fix or reference?

Port of openkaiden/kaiden#2656.

### How to test this PR?

1. Run `pnpm watch`.
2. Wait for Electron and extension watchers to start.
3. Stop the command with Ctrl-C.
4. Confirm no child Vite, Electron, or extension watcher processes remain.
5. Repeat on Windows to validate `taskkill` process-tree cleanup.

Validation performed:

- `node --check scripts/watch.mjs`
- `prettier --check scripts/watch.mjs`
- `git diff --check`

- [ ] Tests are covering the bug fix or the new feature

AI assistance: OpenAI Codex helped adapt the Kaiden change, incorporate review feedback, and validate the result.