### PR TITLE
refactor(Pod): migrated PodColumnContainers to svelte5

### DIFF
--- a/packages/renderer/src/lib/pod/PodColumnContainers.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnContainers.svelte
@@ -5,13 +5,17 @@ import Dots from '/@/lib/ui/Dots.svelte';
 
 import type { PodInfoUI } from './PodInfoUI';
 
-export let object: PodInfoUI;
+interface Props {
+  object: PodInfoUI;
+}
+
+let { object }: Props = $props();
 
 function openContainersFromPod(pod: PodInfoUI): void {
   router.goto(`/containers/?filter=${pod.shortId}`);
 }
 </script>
 
-<button class:cursor-pointer={object.containers.length > 0} on:click={(): void => openContainersFromPod(object)}>
+<button class:cursor-pointer={object.containers.length > 0} onclick={(): void => openContainersFromPod(object)}>
   <Dots containers={object.containers} />
 </button>


### PR DESCRIPTION
### What does this PR do?
Migrated PodColumnContainers to svelte5

### Screenshot / video of UI
Should be no changes

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature