### PR TITLE
refactor(Pod): migrated PodColumnStatus to svelte5

### DIFF
--- a/packages/renderer/src/lib/pod/PodColumnStatus.svelte
+++ b/packages/renderer/src/lib/pod/PodColumnStatus.svelte
@@ -5,7 +5,11 @@ import PodIcon from '/@/lib/images/PodIcon.svelte';
 
 import type { PodInfoUI } from './PodInfoUI';
 
-export let object: PodInfoUI;
+interface Props {
+  object: PodInfoUI;
+}
+
+let { object }: Props = $props();
 </script>
 
 <StatusIcon icon={PodIcon} status={object.status} />


### PR DESCRIPTION
### What does this PR do?
Migrated PodColumnStatus to svelte5

### Screenshot / video of UI
Should be no changes

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature