### PR TITLE
refactor(Preferences): migrated PreferencesConnectionDetailsLogs to svelte5

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsLogs.svelte
@@ -13,14 +13,19 @@ import NoLogIcon from '/@/lib/ui/NoLogIcon.svelte';
 
 import { writeToTerminal } from './Util';
 
-export let providerInternalId: string | undefined = undefined;
-export let connectionInfo: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo | undefined = undefined;
-export let setNoLogs: () => void;
-export let noLog: boolean;
+interface Props {
+  providerInternalId?: string;
+  connectionInfo?: ProviderContainerConnectionInfo | ProviderKubernetesConnectionInfo;
+  setNoLogs: () => void;
+  noLog: boolean;
+}
+let { providerInternalId, connectionInfo, setNoLogs, noLog }: Props = $props();
 let logsTerminal: Terminal;
 
-$: noLog = !!noLog;
-let noLogs = !!noLog;
+$effect(() => {
+  noLog = !!noLog;
+});
+let noLogs = $state(!!noLog);
 
 // Log
 let logsXtermDiv: HTMLDivElement;


### PR DESCRIPTION
### What does this PR do?
Migrated PreferencesConnectionDetailsLogs to svelte5

### Screenshot / video of UI
Should be no changes

### What issues does this PR fix or reference?
Related to https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature