### PR TITLE
refactor(extension-loader): extract loading bundle extension logic

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -48,6 +48,7 @@ import type { CustomPickRegistry } from '/@/plugin/custompick/custompick-registr
 import type { DialogRegistry } from '/@/plugin/dialog-registry.js';
 import type { Directories } from '/@/plugin/directories.js';
 import type { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
+import type { ExtensionsBundle } from '/@/plugin/extension/local/extensions-bundle.js';
 import type { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import type { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import type { IconRegistry } from '/@/plugin/icon-registry.js';
@@ -324,6 +325,10 @@ const extensionAnalyzer = {
   analyzeExtension: vi.fn(),
 } as unknown as ExtensionAnalyzer;
 
+const extensionsBundle = {
+  all: vi.fn(),
+} as unknown as ExtensionsBundle;
+
 const createApi = (disposables?: { dispose(): unknown }[]): typeof containerDesktopAPI => {
   const analyzedExtension = {
     path: '/path',
@@ -394,6 +399,7 @@ beforeEach(() => {
     extensionAnalyzer,
     extensionApiVersion,
     featureRegistry,
+    extensionsBundle,
   );
 });
 
@@ -402,6 +408,8 @@ vi.mock(import('node:fs'));
 beforeEach(() => {
   telemetryTrackMock.mockResolvedValue(undefined);
   vi.clearAllMocks();
+
+  vi.mocked(extensionsBundle.all).mockReturnValue([]);
 
   configurationRegistryGetConfigurationMock.mockReturnValue({
     get: vi.fn().mockImplementation((key: string, defaultValue?: unknown) => {
@@ -415,33 +423,11 @@ beforeEach(() => {
 });
 
 describe('extensionLoader#start', () => {
-  test('should load extensions & extensions-extra', async () => {
-    vi.stubEnv('PROD', true);
-
-    const readProductionFoldersMock = vi.spyOn(extensionLoader, 'readProductionFolders');
-    readProductionFoldersMock.mockResolvedValue([]);
-    const readDevelopmentFoldersMock = vi.spyOn(extensionLoader, 'readDevelopmentFolders');
-    readDevelopmentFoldersMock.mockResolvedValue([]);
-
-    await extensionLoader.start();
-
-    expect(readProductionFoldersMock).toHaveBeenCalledOnce();
-    const prodFolder = readProductionFoldersMock.mock.calls[0]?.[0];
-    expect(prodFolder?.endsWith('extensions')).toBeTruthy();
-
-    expect(readDevelopmentFoldersMock).toHaveBeenCalledOnce();
-    const devFolder = readDevelopmentFoldersMock.mock.calls[0]?.[0];
-    expect(devFolder).toEqual(path.join(process.resourcesPath, 'extensions-extra'));
-  });
-
   test('error in one of analyzeExtension should not be dramatic', async () => {
     const fakeDirectory = '/fake/path/scanning';
 
     // fake scanning property
     extensionLoader.setPluginsScanDirectory(fakeDirectory);
-
-    vi.spyOn(extensionLoader, 'readProductionFolders').mockResolvedValue([]);
-    vi.spyOn(extensionLoader, 'readDevelopmentFolders').mockResolvedValue([]);
 
     const analyzeExtensionMock = vi.spyOn(extensionLoader, 'analyzeExtension');
     analyzeExtensionMock.mockRejectedValueOnce(new Error('Failed one'));
@@ -2778,172 +2764,6 @@ test('withProgress should add the extension id to the routeId', async () => {
     },
     expect.any(Function),
   );
-});
-
-describe('loading extension folders', () => {
-  const fileEntry = {
-    isDirectory: () => false,
-  } as unknown as fs.Dirent<string>;
-  const nodeModulesEntry = {
-    isDirectory: () => true,
-    name: 'node_modules',
-  } as unknown as fs.Dirent<string>;
-  const dirEntry = {
-    isDirectory: () => true,
-    name: 'extension1',
-  } as unknown as fs.Dirent<string>;
-  const dirEntry2 = {
-    isDirectory: () => true,
-    name: 'extension2',
-  } as unknown as fs.Dirent<string>;
-  const dirEntry3 = {
-    isDirectory: () => true,
-    name: 'extension3',
-  } as unknown as fs.Dirent<string>;
-  const dirEntry4 = {
-    isDirectory: () => true,
-    name: 'extension4',
-  } as unknown as fs.Dirent<string>;
-
-  describe('in dev mode', () => {
-    beforeEach(() => {
-      vi.restoreAllMocks();
-      vi.resetAllMocks();
-    });
-
-    test('ignores files', async () => {
-      readdirMock.mockResolvedValue([fileEntry]);
-
-      const folders = await extensionLoader.readDevelopmentFolders('path');
-
-      expect(folders).length(0);
-    });
-    test('if folder does not exists do not readdir', async () => {
-      vi.spyOn(fs, 'existsSync').mockReturnValue(false);
-      const folders = await extensionLoader.readDevelopmentFolders('path');
-
-      expect(folders).length(0);
-      expect(readdirMock).not.toHaveBeenCalled();
-    });
-    test('ignores node_modules folders', async () => {
-      readdirMock.mockResolvedValue([nodeModulesEntry]);
-
-      const folders = await extensionLoader.readDevelopmentFolders('path');
-
-      expect(folders).length(0);
-    });
-    test('ignores folders without package.json', async () => {
-      readdirMock.mockResolvedValue([dirEntry]);
-      vi.spyOn(fs, 'existsSync')
-        // existSync on the folder path => true
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
-      const folders = await extensionLoader.readDevelopmentFolders('path');
-
-      expect(folders).length(0);
-    });
-
-    test('recognizes a plain extension when only ext/package.json is present', async () => {
-      readdirMock.mockResolvedValue([dirEntry]);
-      vi.spyOn(fs, 'existsSync')
-        // existSync on the folder path => true
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true);
-      const folders = await extensionLoader.readDevelopmentFolders('path');
-
-      expect(folders).length(1);
-      expect(folders[0]).toBe(path.join('path', 'extension1'));
-    });
-
-    test('recognizes as an api extension when only ext/packages/extension/package.json is present', async () => {
-      readdirMock.mockResolvedValue([dirEntry]);
-      vi.spyOn(fs, 'existsSync')
-        // existSync on the folder path => true
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true);
-      const folders = await extensionLoader.readDevelopmentFolders('path');
-
-      expect(folders).length(1);
-      expect(folders[0]).toBe(path.join('path', 'extension1', 'packages', 'extension'));
-    });
-
-    test('recognizes as an api extension when ext/package.json and ext/packages/extension/package.json are present', async () => {
-      readdirMock.mockResolvedValue([dirEntry]);
-      vi.spyOn(fs, 'existsSync')
-        // existSync on the folder path => true
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
-      const folders = await extensionLoader.readDevelopmentFolders('path');
-
-      expect(folders).length(1);
-      expect(folders[0]).toBe(path.join('path', 'extension1', 'packages', 'extension'));
-    });
-
-    test('works correctly for multiple different extensions, files and empty folders', async () => {
-      readdirMock.mockResolvedValue([fileEntry, dirEntry, dirEntry2, dirEntry3, dirEntry4]);
-      vi.spyOn(fs, 'existsSync')
-        // existSync on the folder path => true
-        .mockReturnValueOnce(true)
-        // an api extension
-        .mockReturnValueOnce(true)
-        // an plain extension
-        .mockReturnValueOnce(false) // plain extension
-        // priority to an api extension
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true) // priority to api extension
-        // ignore no package.json folders
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(false);
-      const folders = await extensionLoader.readDevelopmentFolders('path');
-
-      expect(folders).length(3);
-      expect(folders[0]).toBe(path.join('path', 'extension1', 'packages', 'extension'));
-      expect(folders[1]).toBe(path.join('path', 'extension2'));
-      expect(folders[2]).toBe(path.join('path', 'extension3', 'packages', 'extension'));
-    });
-  });
-
-  describe('in prod mode', () => {
-    test('ignores files', async () => {
-      readdirMock.mockResolvedValue([fileEntry]);
-
-      const folders = await extensionLoader.readProductionFolders('path');
-
-      expect(folders).length(0);
-    });
-    test('ignores node_modules folders', async () => {
-      readdirMock.mockResolvedValue([nodeModulesEntry]);
-
-      const folders = await extensionLoader.readProductionFolders('path');
-
-      expect(folders).length(0);
-    });
-    test('recognizes a plain extension when only ext/package.json is present', async () => {
-      readdirMock.mockResolvedValue([dirEntry]);
-      vi.spyOn(fs, 'existsSync')
-        // existSync on the folder path => true
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true);
-      const folders = await extensionLoader.readProductionFolders('path');
-
-      expect(folders).length(1);
-      expect(folders[0]).toBe(path.join('path', 'extension1', 'builtin', 'extension1.cdix'));
-    });
-    test('recognizes an api extension when ext/package.json is not present', async () => {
-      readdirMock.mockResolvedValue([dirEntry]);
-      vi.spyOn(fs, 'existsSync')
-        // existSync on the folder path => true
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
-      const folders = await extensionLoader.readProductionFolders('path');
-
-      expect(folders).length(1);
-      expect(folders[0]).toBe(path.join('path', 'extension1', 'packages', 'extension', 'builtin', `extension1.cdix`));
-    });
-  });
 });
 
 test('reload extensions', async () => {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -47,6 +47,7 @@ import { DialogRegistry } from '/@/plugin/dialog-registry.js';
 import { Directories } from '/@/plugin/directories.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
 import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
+import { ExtensionsBundle } from '/@/plugin/extension/local/extensions-bundle.js';
 import { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { IconRegistry } from '/@/plugin/icon-registry.js';
@@ -225,6 +226,8 @@ export class ExtensionLoader implements IAsyncDisposable {
     private extensionApiVersion: ExtensionApiVersion,
     @inject(FeatureRegistry)
     private featureRegistry: FeatureRegistry,
+    @inject(ExtensionsBundle)
+    private extensionsBundle: ExtensionsBundle,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -482,36 +485,11 @@ export class ExtensionLoader implements IAsyncDisposable {
       fs.mkdirSync(this.extensionsStorageDirectory);
     }
 
-    let folders: string[];
-    // scan all extensions that we can find from the extensions folder
-    if (import.meta.env.PROD) {
-      // in production mode, use the extensions & extensions-extra locally
-      const promises = await Promise.all([
-        this.readProductionFolders(path.join(__dirname, '../../../extensions')),
-        this.readDevelopmentFolders(path.join(process.resourcesPath, 'extensions-extra')),
-      ]);
+    // Get the bundled extensions
+    const analyzedExtensions: AnalyzedExtension[] = this.extensionsBundle.all().filter(extension => !extension.error);
 
-      folders = promises.flat();
-    } else {
-      // in development mode, use the extensions locally
-      folders = await this.readDevelopmentFolders(path.join(__dirname, '../../../extensions'));
-    }
+    // Get the external foldr extensions
     const externalExtensions = await this.readExternalFolders();
-    // ok now load grab all extensions from these folders
-    const analyzedExtensions: AnalyzedExtension[] = [];
-
-    const analyzedFoldersExtension = (
-      await Promise.all(
-        folders.map(folder =>
-          this.analyzeExtension({
-            extensionPath: folder,
-            removable: false,
-          }),
-        ),
-      )
-    ).filter(extension => !extension.error);
-    analyzedExtensions.push(...analyzedFoldersExtension);
-
     const analyzedExternalExtensions = (
       await Promise.all(
         externalExtensions.map(folder =>
@@ -674,26 +652,6 @@ export class ExtensionLoader implements IAsyncDisposable {
     return sorted;
   }
 
-  async readDevelopmentFolders(folderPath: string): Promise<string[]> {
-    // only readdir on existing folder
-    if (!fs.existsSync(folderPath)) return [];
-
-    const entries = await fs.promises.readdir(folderPath, { withFileTypes: true });
-    // filter only directories ignoring node_modules directory
-    return entries
-      .filter(entry => entry.isDirectory() && entry.name !== 'node_modules')
-      .reduce((directories: string[], directory) => {
-        const apiExtFolder = path.join(folderPath, directory.name, 'packages', 'extension');
-        const plainExtFolder = path.join(folderPath, directory.name);
-        if (fs.existsSync(path.join(apiExtFolder, 'package.json'))) {
-          directories.push(apiExtFolder);
-        } else if (fs.existsSync(path.join(plainExtFolder, 'package.json'))) {
-          directories.push(plainExtFolder);
-        }
-        return directories;
-      }, []);
-  }
-
   async readExternalFolders(): Promise<string[]> {
     const pathes = [];
     for (let index = 0; index < process.argv.length; index++) {
@@ -703,22 +661,6 @@ export class ExtensionLoader implements IAsyncDisposable {
     }
     // filter all undefined values
     return pathes.filter(path => path !== undefined);
-  }
-
-  async readProductionFolders(folderPath: string): Promise<string[]> {
-    // only readdir on existing folder
-    if (!fs.existsSync(folderPath)) return [];
-
-    const entries = await fs.promises.readdir(folderPath, { withFileTypes: true });
-    return entries
-      .filter(entry => entry.isDirectory() && entry.name !== 'node_modules')
-      .map(directory => {
-        const rootExtPath = path.join(folderPath, directory.name);
-        const plainExtPath = path.join(rootExtPath, 'builtin', `${directory.name}.cdix`);
-        return fs.existsSync(plainExtPath)
-          ? plainExtPath
-          : path.join(rootExtPath, 'packages', 'extension', 'builtin', `${directory.name}.cdix`);
-      });
   }
 
   /**

--- a/packages/main/src/plugin/extension/local/extension-bundle.spec.ts
+++ b/packages/main/src/plugin/extension/local/extension-bundle.spec.ts
@@ -1,0 +1,244 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { type Dirent, existsSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import path, { join } from 'node:path';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ExtensionAnalyzer } from '/@/plugin/extension/extension-analyzer.js';
+import { ExtensionsBundle } from '/@/plugin/extension/local/extensions-bundle.js';
+
+vi.mock(import('node:fs'));
+vi.mock(import('node:fs/promises'));
+
+// mock fs.promises.readdir and use Dirent<string> as return type
+const readdirMock = vi.mocked(
+  readdir as (path: string, options?: { withFileTypes: true }) => Promise<Dirent<string>[]>,
+);
+
+const EXTENSION_ANALYZER = {
+  analyzeExtension: vi.fn(),
+} as unknown as ExtensionAnalyzer;
+
+class ExtensionBundleTest extends ExtensionsBundle {
+  public override async readDevelopmentFolders(folderPath: string): Promise<string[]> {
+    return super.readDevelopmentFolders(folderPath);
+  }
+
+  public override async readProductionFolders(folderPath: string): Promise<string[]> {
+    return super.readProductionFolders(folderPath);
+  }
+}
+
+let extensionBundle: ExtensionBundleTest;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.defineProperty(process, 'resourcesPath', {
+    value: '/resources',
+  });
+
+  extensionBundle = new ExtensionBundleTest(EXTENSION_ANALYZER);
+});
+
+test('should load extensions & extensions-extra', async () => {
+  vi.stubEnv('PROD', true);
+
+  const readProductionFoldersMock = vi.spyOn(extensionBundle, 'readProductionFolders');
+  readProductionFoldersMock.mockResolvedValue([]);
+  const readDevelopmentFoldersMock = vi.spyOn(extensionBundle, 'readDevelopmentFolders');
+  readDevelopmentFoldersMock.mockResolvedValue([]);
+
+  await extensionBundle.init();
+
+  expect(readProductionFoldersMock).toHaveBeenCalledOnce();
+  const prodFolder = readProductionFoldersMock.mock.calls[0]?.[0];
+  expect(prodFolder?.endsWith('extensions')).toBeTruthy();
+
+  expect(readDevelopmentFoldersMock).toHaveBeenCalledOnce();
+  const devFolder = readDevelopmentFoldersMock.mock.calls[0]?.[0];
+  expect(devFolder).toEqual(path.join(process.resourcesPath, 'extensions-extra'));
+});
+
+describe('loading extension folders', () => {
+  const fileEntry = {
+    isDirectory: () => false,
+  } as unknown as Dirent<string>;
+  const nodeModulesEntry = {
+    isDirectory: () => true,
+    name: 'node_modules',
+  } as unknown as Dirent<string>;
+  const dirEntry = {
+    isDirectory: () => true,
+    name: 'extension1',
+  } as unknown as Dirent<string>;
+  const dirEntry2 = {
+    isDirectory: () => true,
+    name: 'extension2',
+  } as unknown as Dirent<string>;
+  const dirEntry3 = {
+    isDirectory: () => true,
+    name: 'extension3',
+  } as unknown as Dirent<string>;
+  const dirEntry4 = {
+    isDirectory: () => true,
+    name: 'extension4',
+  } as unknown as Dirent<string>;
+
+  describe('in dev mode', () => {
+    beforeEach(() => {
+      vi.restoreAllMocks();
+      vi.resetAllMocks();
+    });
+
+    test('ignores files', async () => {
+      readdirMock.mockResolvedValue([fileEntry]);
+
+      const folders = await extensionBundle.readDevelopmentFolders('path');
+
+      expect(folders).length(0);
+    });
+    test('if folder does not exists do not readdir', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      const folders = await extensionBundle.readDevelopmentFolders('path');
+
+      expect(folders).length(0);
+      expect(readdirMock).not.toHaveBeenCalled();
+    });
+    test('ignores node_modules folders', async () => {
+      readdirMock.mockResolvedValue([nodeModulesEntry]);
+
+      const folders = await extensionBundle.readDevelopmentFolders('path');
+
+      expect(folders).length(0);
+    });
+    test('ignores folders without package.json', async () => {
+      readdirMock.mockResolvedValue([dirEntry]);
+      vi.mocked(existsSync)
+        // existSync on the folder path => true
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+      const folders = await extensionBundle.readDevelopmentFolders('path');
+
+      expect(folders).length(0);
+    });
+
+    test('recognizes a plain extension when only ext/package.json is present', async () => {
+      readdirMock.mockResolvedValue([dirEntry]);
+      vi.mocked(existsSync)
+        // existSync on the folder path => true
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+      const folders = await extensionBundle.readDevelopmentFolders('path');
+
+      expect(folders).length(1);
+      expect(folders[0]).toBe(join('path', 'extension1'));
+    });
+
+    test('recognizes as an api extension when only ext/packages/extension/package.json is present', async () => {
+      readdirMock.mockResolvedValue([dirEntry]);
+      vi.mocked(existsSync)
+        // existSync on the folder path => true
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true);
+      const folders = await extensionBundle.readDevelopmentFolders('path');
+
+      expect(folders).length(1);
+      expect(folders[0]).toBe(join('path', 'extension1', 'packages', 'extension'));
+    });
+
+    test('recognizes as an api extension when ext/package.json and ext/packages/extension/package.json are present', async () => {
+      readdirMock.mockResolvedValue([dirEntry]);
+      vi.mocked(existsSync)
+        // existSync on the folder path => true
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+      const folders = await extensionBundle.readDevelopmentFolders('path');
+
+      expect(folders).length(1);
+      expect(folders[0]).toBe(join('path', 'extension1', 'packages', 'extension'));
+    });
+
+    test('works correctly for multiple different extensions, files and empty folders', async () => {
+      readdirMock.mockResolvedValue([fileEntry, dirEntry, dirEntry2, dirEntry3, dirEntry4]);
+      vi.mocked(existsSync)
+        // existSync on the folder path => true
+        .mockReturnValueOnce(true)
+        // an api extension
+        .mockReturnValueOnce(true)
+        // an plain extension
+        .mockReturnValueOnce(false) // plain extension
+        // priority to an api extension
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true) // priority to api extension
+        // ignore no package.json folders
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(false);
+      const folders = await extensionBundle.readDevelopmentFolders('path');
+
+      expect(folders).length(3);
+      expect(folders[0]).toBe(join('path', 'extension1', 'packages', 'extension'));
+      expect(folders[1]).toBe(join('path', 'extension2'));
+      expect(folders[2]).toBe(join('path', 'extension3', 'packages', 'extension'));
+    });
+  });
+
+  describe('in prod mode', () => {
+    test('ignores files', async () => {
+      readdirMock.mockResolvedValue([fileEntry]);
+
+      const folders = await extensionBundle.readProductionFolders('path');
+
+      expect(folders).length(0);
+    });
+    test('ignores node_modules folders', async () => {
+      readdirMock.mockResolvedValue([nodeModulesEntry]);
+
+      const folders = await extensionBundle.readProductionFolders('path');
+
+      expect(folders).length(0);
+    });
+    test('recognizes a plain extension when only ext/package.json is present', async () => {
+      readdirMock.mockResolvedValue([dirEntry]);
+      vi.mocked(existsSync)
+        // existSync on the folder path => true
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true);
+      const folders = await extensionBundle.readProductionFolders('path');
+
+      expect(folders).length(1);
+      expect(folders[0]).toBe(join('path', 'extension1', 'builtin', 'extension1.cdix'));
+    });
+    test('recognizes an api extension when ext/package.json is not present', async () => {
+      readdirMock.mockResolvedValue([dirEntry]);
+      vi.mocked(existsSync)
+        // existSync on the folder path => true
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+      const folders = await extensionBundle.readProductionFolders('path');
+
+      expect(folders).length(1);
+      expect(folders[0]).toBe(join('path', 'extension1', 'packages', 'extension', 'builtin', `extension1.cdix`));
+    });
+  });
+});

--- a/packages/main/src/plugin/extension/local/extensions-bundle.ts
+++ b/packages/main/src/plugin/extension/local/extensions-bundle.ts
@@ -1,0 +1,102 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { existsSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { inject, injectable, postConstruct } from 'inversify';
+
+import { type AnalyzedExtension, ExtensionAnalyzer } from '/@/plugin/extension/extension-analyzer.js';
+
+@injectable()
+export class ExtensionsBundle {
+  #extensions: Array<AnalyzedExtension> = [];
+
+  constructor(
+    @inject(ExtensionAnalyzer)
+    private extensionAnalyzer: ExtensionAnalyzer,
+  ) {}
+
+  all(): ReadonlyArray<AnalyzedExtension> {
+    return this.#extensions;
+  }
+
+  @postConstruct()
+  async init(): Promise<void> {
+    let folders: string[];
+    // scan all extensions that we can find from the extensions folder
+    if (import.meta.env.PROD) {
+      // in production mode, use the extensions & extensions-extra locally
+      const promises = await Promise.all([
+        this.readProductionFolders(join(__dirname, '../../../extensions')),
+        this.readDevelopmentFolders(join(process.resourcesPath, 'extensions-extra')),
+      ]);
+
+      folders = promises.flat();
+    } else {
+      // in development mode, use the extensions locally
+      folders = await this.readDevelopmentFolders(join(__dirname, '../../../extensions'));
+    }
+
+    this.#extensions = await Promise.all(
+      folders.map(folder =>
+        this.extensionAnalyzer.analyzeExtension({
+          extensionPath: folder,
+          removable: false,
+          devMode: false,
+        }),
+      ),
+    );
+  }
+
+  protected async readDevelopmentFolders(folderPath: string): Promise<string[]> {
+    // only readdir on existing folder
+    if (!existsSync(folderPath)) return [];
+
+    const entries = await readdir(folderPath, { withFileTypes: true });
+    // filter only directories ignoring node_modules directory
+    return entries
+      .filter(entry => entry.isDirectory() && entry.name !== 'node_modules')
+      .reduce((directories: string[], directory) => {
+        const apiExtFolder = join(folderPath, directory.name, 'packages', 'extension');
+        const plainExtFolder = join(folderPath, directory.name);
+        if (existsSync(join(apiExtFolder, 'package.json'))) {
+          directories.push(apiExtFolder);
+        } else if (existsSync(join(plainExtFolder, 'package.json'))) {
+          directories.push(plainExtFolder);
+        }
+        return directories;
+      }, []);
+  }
+
+  protected async readProductionFolders(folderPath: string): Promise<string[]> {
+    // only readdir on existing folder
+    if (!existsSync(folderPath)) return [];
+
+    const entries = await readdir(folderPath, { withFileTypes: true });
+    return entries
+      .filter(entry => entry.isDirectory() && entry.name !== 'node_modules')
+      .map(directory => {
+        const rootExtPath = join(folderPath, directory.name);
+        const plainExtPath = join(rootExtPath, 'builtin', `${directory.name}.cdix`);
+        return existsSync(plainExtPath)
+          ? plainExtPath
+          : join(rootExtPath, 'packages', 'extension', 'builtin', `${directory.name}.cdix`);
+      });
+  }
+}

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -156,7 +156,6 @@ beforeEach(async () => {
   ]);
   vi.mocked(app.getVersion).mockReturnValue('100.0.0');
   vi.mocked(Updater.prototype.init).mockReturnValue(new Disposable(vi.fn()));
-  vi.mocked(ExtensionLoader.prototype.readDevelopmentFolders).mockResolvedValue([]);
   vi.mocked(ExtensionLoader.prototype.listExtensions).mockResolvedValue([]);
 
   vi.mocked(ProviderRegistry.prototype.getProviderInfos).mockReturnValue([]);

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -161,6 +161,7 @@ import { ContainerfileParser } from '/@/plugin/containerfile-parser.js';
 import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionWatcher } from '/@/plugin/extension/extension-watcher.js';
+import { ExtensionsBundle } from '/@/plugin/extension/local/extensions-bundle.js';
 import { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { LockedConfiguration } from '/@/plugin/locked-configuration.js';
@@ -802,9 +803,10 @@ export class PluginSystem {
     container.bind<ProgressImpl>(ProgressImpl).toSelf().inSingletonScope();
 
     container.bind<ExtensionApiVersion>(ExtensionApiVersion).toSelf().inSingletonScope();
+    container.bind<ExtensionsBundle>(ExtensionsBundle).toSelf().inSingletonScope();
 
     container.bind<ExtensionLoader>(ExtensionLoader).toSelf().inSingletonScope();
-    this.extensionLoader = container.get<ExtensionLoader>(ExtensionLoader);
+    this.extensionLoader = await container.getAsync<ExtensionLoader>(ExtensionLoader);
     await this.extensionLoader.init();
 
     container.bind<FeedbackHandler>(FeedbackHandler).toSelf().inSingletonScope();


### PR DESCRIPTION
### What does this PR do?

To achieve https://github.com/podman-desktop/podman-desktop/issues/15999 we need to be able to keep track of the list of bundled extensions. We can extract the logic of discovering the bundle extension from the `packages/main/src/plugin/extension/extension-loader.ts` to a dedicated class. This class will keep in memory the list of extensions for later use. 

> :information_source: a _bundle_ extension is an extension that is shipped with Podman Desktop.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18747

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

You can start Podman Desktop, start, stop extensions remove etc. no changes should be visible.