### PR TITLE
refactor(renderer): migrate TaskManagerTableActionsColumn to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/task-manager/table/TaskManagerTableActionsColumn.svelte
+++ b/packages/renderer/src/lib/task-manager/table/TaskManagerTableActionsColumn.svelte
@@ -3,7 +3,11 @@ import type { TaskInfoUI } from '/@/stores/tasks';
 
 import TaskManagerActions from './action/TaskManagerActions.svelte';
 
-export let object: TaskInfoUI;
+interface Props {
+  object: TaskInfoUI;
+}
+
+let { object }: Props = $props();
 </script>
 
 <TaskManagerActions task={object} />


### PR DESCRIPTION
### What does this PR do?
Migrates TaskManagerTableActionsColumn.svelte to Svelte 5 syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature