### PR TITLE
refactor: fix pr-checks for lint and typecheck

### DIFF
--- a/packages/renderer/src/lib/container/ContainerColumnActions.svelte
+++ b/packages/renderer/src/lib/container/ContainerColumnActions.svelte
@@ -17,10 +17,10 @@ const containerUtils = new ContainerUtils();
 
 {#if containerUtils.isContainerGroupInfoUI(object)}
   {#if object.type === ContainerGroupInfoTypeUI.POD}
-    <ContainerColumnActionsPod object={object} on:update />
+    <ContainerColumnActionsPod object={object} />
   {:else if object.type === ContainerGroupInfoTypeUI.COMPOSE}
-    <ContainerColumnActionsCompose object={object} on:update />
+    <ContainerColumnActionsCompose object={object} />
   {/if}
 {:else if containerUtils.isContainerInfoUI(object)}
-  <ContainerColumnActionsContainer object={object} on:update />
+  <ContainerColumnActionsContainer object={object} />
 {/if}

--- a/packages/renderer/src/stores/pods.spec.ts
+++ b/packages/renderer/src/stores/pods.spec.ts
@@ -20,6 +20,8 @@ import type { PodInfo } from '@podman-desktop/core-api';
 import { get } from 'svelte/store';
 import { assert, beforeEach, expect, test, vi } from 'vitest';
 
+import type { PodInfoUI } from '/@/lib/pod/PodInfoUI';
+
 import { clearPodActionInProgress, podsEventStore, podsInfos, setPodActionError, setPodStatus } from './pods';
 
 const callbacks = new Map<string, (data?: unknown) => void | Promise<void>>();
@@ -80,8 +82,8 @@ test.each([
 
 test('setPodStatus updates the status and sets actionInProgress', () => {
   podsInfos.set([
-    { id: 'pod1', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' },
-  ] as any);
+    { id: 'pod1', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' } as PodInfoUI,
+  ]);
 
   setPodStatus('engine1', 'pod1', 'STARTING');
 
@@ -93,8 +95,8 @@ test('setPodStatus updates the status and sets actionInProgress', () => {
 
 test('clearPodActionInProgress clears the actionInProgress flag', () => {
   podsInfos.set([
-    { id: 'pod1', engineId: 'engine1', status: 'STARTING', actionInProgress: true, actionError: '' },
-  ] as any);
+    { id: 'pod1', engineId: 'engine1', status: 'STARTING', actionInProgress: true, actionError: '' } as PodInfoUI,
+  ]);
 
   clearPodActionInProgress('engine1', 'pod1');
 
@@ -105,8 +107,8 @@ test('clearPodActionInProgress clears the actionInProgress flag', () => {
 
 test('setPodActionError sets the error and status to ERROR', () => {
   podsInfos.set([
-    { id: 'pod1', engineId: 'engine1', status: 'STARTING', actionInProgress: true, actionError: '' },
-  ] as any);
+    { id: 'pod1', engineId: 'engine1', status: 'STARTING', actionInProgress: true, actionError: '' } as PodInfoUI,
+  ]);
 
   setPodActionError('engine1', 'pod1', 'something went wrong');
 
@@ -118,9 +120,9 @@ test('setPodActionError sets the error and status to ERROR', () => {
 
 test('setPodStatus does not affect other pods', () => {
   podsInfos.set([
-    { id: 'pod1', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' },
-    { id: 'pod2', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' },
-  ] as any);
+    { id: 'pod1', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' } as PodInfoUI,
+    { id: 'pod2', engineId: 'engine1', status: 'RUNNING', actionInProgress: false, actionError: '' } as PodInfoUI,
+  ]);
 
   setPodStatus('engine1', 'pod1', 'STOPPING');
 


### PR DESCRIPTION
### What does this PR do?
Refactors `ContainerColumnActions.svelte` and `pods.spec.ts` to fix pr-checks for linter and typecheck on main branch. The tests failing can be seen on my last PR (https://github.com/podman-desktop/podman-desktop/pull/18754).

<img width="1699" height="1271" alt="Screenshot 2026-08-11 at 17 33 09" src="https://github.com/user-attachments/assets/4447b66b-02b0-4d3e-b5c2-3509d28006e1" />

<img width="1688" height="795" alt="Screenshot 2026-08-11 at 18 03 39" src="https://github.com/user-attachments/assets/0f2758ea-914c-43ff-8eab-0f25b9d3c300" />


### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?
1. to see if the linter will pass use `pnpm lint:check` 
2. to see if the typecheck will pass use `pnpm typecheck`


- [ ] Tests are covering the bug fix or the new feature
