### PR TITLE
feat(main): global navigation hide/show nav items

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -66,6 +66,7 @@ export * from './manifest-info.js';
 export * from './menu.js';
 export * from './menu-context.js';
 export * from './navigation-history-info.js';
+export * from './navigation-items-info.js';
 export * from './navigation-page.js';
 export * from './navigation-request.js';
 export * from './network-info.js';

--- a/packages/api/src/navigation-items-info.ts
+++ b/packages/api/src/navigation-items-info.ts
@@ -1,0 +1,27 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface NavigationItemInfo {
+  name: string;
+  visible: boolean;
+}
+
+export interface NavigationItemsPayload {
+  items: NavigationItemInfo[];
+  activeItem?: string;
+}

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -28,11 +28,13 @@ import { DevelopmentModeTracker } from './development-mode-tracker.js';
 import { NavigationItemsMenuBuilder } from './navigation-items-menu-builder.js';
 import { OpenDevTools } from './open-dev-tools.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import type { MessageBox } from './plugin/message-box.js';
 import type { WindowHandler } from './system/window/window-handler.js';
 import { isLinux, isMac, stoppedExtensions } from './util.js';
 
 const openDevTools = new OpenDevTools();
 let navigationItemsMenuBuilder: NavigationItemsMenuBuilder;
+let messageBox: MessageBox | undefined;
 
 // development mode for extensions
 let isExtensionsDevelopmentModeEnabled = false;
@@ -156,10 +158,19 @@ async function createWindow(): Promise<BrowserWindow> {
     });
     developmentModeTracker.init();
 
-    navigationItemsMenuBuilder = new NavigationItemsMenuBuilder(configurationRegistry);
+    navigationItemsMenuBuilder = new NavigationItemsMenuBuilder(configurationRegistry, options => {
+      if (!messageBox) {
+        throw new Error('MessageBox not available');
+      }
+      return messageBox.showMessageBox(options);
+    });
 
     // open dev tools (if required)
     openDevTools.open(browserWindow, configurationRegistry);
+  });
+
+  ipcMain.on('message-box', (_, data) => {
+    messageBox = data as MessageBox;
   });
 
   let windowHandler: WindowHandler | undefined;

--- a/packages/main/src/navigation-items-menu-builder.spec.ts
+++ b/packages/main/src/navigation-items-menu-builder.spec.ts
@@ -261,6 +261,66 @@ describe('buildNavigationToggleMenuItems', () => {
       'DEFAULT',
     );
   });
+
+  test('should disable excluded items in toggle menu', () => {
+    getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
+
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'Containers', visible: true },
+        { name: 'Dashboard', visible: true },
+        { name: 'Pods', visible: true },
+      ],
+    });
+
+    const menu = navigationItemsMenuBuilder.buildNavigationToggleMenuItems();
+
+    const containersItem = menu.find(m => m.label === 'Containers');
+    expect(containersItem?.enabled).toBe(false);
+
+    const dashboardItem = menu.find(m => m.label === 'Dashboard');
+    expect(dashboardItem?.enabled).toBe(false);
+
+    const podsItem = menu.find(m => m.label === 'Pods');
+    expect(podsItem?.enabled).toBe(true);
+  });
+
+  test('should disable active item in toggle menu', () => {
+    getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
+
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'Pods', visible: true },
+        { name: 'Volumes', visible: true },
+      ],
+      activeItem: 'Pods',
+    });
+
+    const menu = navigationItemsMenuBuilder.buildNavigationToggleMenuItems();
+
+    const podsItem = menu.find(m => m.label === 'Pods');
+    expect(podsItem?.enabled).toBe(false);
+
+    const volumesItem = menu.find(m => m.label === 'Volumes');
+    expect(volumesItem?.enabled).toBe(true);
+  });
+
+  test('should not hide excluded items via updateNavbarHiddenItem', () => {
+    getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
+
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'Containers', visible: true },
+        { name: 'Pods', visible: true },
+      ],
+    });
+
+    const menu = navigationItemsMenuBuilder.buildNavigationToggleMenuItems();
+    const containersItem = menu.find(m => m.label === 'Containers');
+    containersItem?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    expect(configurationRegistryMock.updateConfigurationValue).not.toHaveBeenCalled();
+  });
 });
 
 describe('buildShowHiddenItemsSubmenu', () => {

--- a/packages/main/src/navigation-items-menu-builder.spec.ts
+++ b/packages/main/src/navigation-items-menu-builder.spec.ts
@@ -367,6 +367,67 @@ describe('buildShowHiddenItemsSubmenu', () => {
       'DEFAULT',
     );
   });
+
+  test('item can be hidden again after being restored via Show Hidden Items', async () => {
+    getConfigurationMock.mockReturnValue({
+      get: (key: string) => (key === 'hideConfirmationDismissed' ? true : []),
+    } as unknown as ConfigurationRegistry);
+    vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
+
+    // Step 1: Start with Kubernetes visible
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'Kubernetes', visible: true },
+        { name: 'Pods', visible: true },
+      ],
+    });
+
+    // Step 2: Hide Kubernetes
+    const hideMenu = navigationItemsMenuBuilder.buildHideMenuItem('Kubernetes');
+    expect(hideMenu?.label).toBe('Hide Kubernetes From Navigation Bar');
+    hideMenu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    await vi.waitFor(() => {
+      expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+        'navbar.disabledItems',
+        ['Kubernetes'],
+        'DEFAULT',
+      );
+    });
+
+    // Step 3: Verify "Show Hidden Items" submenu appears
+    const showHiddenMenu = navigationItemsMenuBuilder.buildShowHiddenItemsSubmenu();
+    expect(showHiddenMenu?.label).toBe('Show Hidden Items');
+    const submenu = showHiddenMenu?.submenu as MenuItemConstructorOptions[];
+    expect(submenu).toHaveLength(1);
+    expect(submenu[0]?.label).toBe('Kubernetes');
+
+    // Step 4: Restore Kubernetes via "Show Hidden Items"
+    vi.mocked(configurationRegistryMock.updateConfigurationValue).mockClear();
+    submenu[0]?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    await vi.waitFor(() => {
+      expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+        'navbar.disabledItems',
+        [],
+        'DEFAULT',
+      );
+    });
+
+    // Step 5: Verify Kubernetes can be hidden again (this is the bug - should not fail)
+    vi.mocked(configurationRegistryMock.updateConfigurationValue).mockClear();
+    const reHideMenu = navigationItemsMenuBuilder.buildHideMenuItem('Kubernetes');
+    expect(reHideMenu?.label).toBe('Hide Kubernetes From Navigation Bar');
+    reHideMenu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    await vi.waitFor(() => {
+      expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+        'navbar.disabledItems',
+        ['Kubernetes'],
+        'DEFAULT',
+      );
+    });
+  });
 });
 
 describe('buildResetMenuItem', () => {

--- a/packages/main/src/navigation-items-menu-builder.spec.ts
+++ b/packages/main/src/navigation-items-menu-builder.spec.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
   navigationItemsMenuBuilder = new TestNavigationItemsMenuBuilder(configurationRegistryMock, showMessageBoxMock);
 });
 
-describe('buildHideMenuItem', () => {
+describe('buildHideMenuItem', async () => {
   test('build hide item with updated label', () => {
     getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
 
@@ -215,10 +215,11 @@ describe('buildHideMenuItem', () => {
   });
 });
 
-describe('buildNavigationToggleMenuItems', () => {
-  test('build navigation toggle menu items', () => {
+describe('buildNavigationToggleMenuItems', async () => {
+  test('build navigation toggle menu items', async () => {
     getConfigurationMock.mockReturnValue({ get: () => ['existing'] } as unknown as ConfigurationRegistry);
 
+    // send 3 items, two being visible, one being hidden
     navigationItemsMenuBuilder.receiveNavigationItems({
       items: [
         { name: 'A & A', visible: true },
@@ -229,8 +230,13 @@ describe('buildNavigationToggleMenuItems', () => {
 
     const menu = navigationItemsMenuBuilder.buildNavigationToggleMenuItems();
 
+    // 4 items (first one being a separator)
     expect(menu.length).toBe(4);
+
+    // check the first item is a separator
     expect(menu[0]?.type).toBe('separator');
+
+    // label should be escaped as we have an &
     expect(menu[1]?.label).toBe('A && A');
     expect(menu[1]?.checked).toBe(true);
     expect(menu[2]?.label).toBe('B');
@@ -238,17 +244,22 @@ describe('buildNavigationToggleMenuItems', () => {
     expect(menu[3]?.label).toBe('C');
     expect(menu[3]?.checked).toBe(true);
 
+    // click on the A item
     menu[1]?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
 
     expect(getConfigurationMock).toBeCalled();
+    // if clicking it should send the item to the configuration as being disabled
     expect(configurationRegistryMock.updateConfigurationValue).toBeCalledWith(
       'navbar.disabledItems',
+      // item A & A should not be escaped
       ['existing', 'A & A'],
       'DEFAULT',
     );
 
+    // reset the calls
     vi.mocked(configurationRegistryMock.updateConfigurationValue).mockClear();
 
+    // click on the B item should unhide it so disabled items should be empty
     menu[2]?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
     expect(configurationRegistryMock.updateConfigurationValue).toBeCalledWith(
       'navbar.disabledItems',
@@ -375,8 +386,8 @@ describe('buildResetMenuItem', () => {
   });
 });
 
-describe('buildNavigationMenu', () => {
-  test('no items if no linktext and outside navbar', () => {
+describe('buildNavigationMenu', async () => {
+  test('no items if no linktext and outside navbar', async () => {
     getConfigurationMock.mockReturnValue({ get: () => 160 });
     const parameters = {} as unknown as ContextMenuParams;
 
@@ -385,7 +396,7 @@ describe('buildNavigationMenu', () => {
     expect(menu).toStrictEqual([]);
   });
 
-  test('no items if outside of range of navbar', () => {
+  test('no items if outside of range of navbar', async () => {
     getConfigurationMock.mockReturnValue({ get: () => 160 });
     const parameters = {
       linkText: 'outside',

--- a/packages/main/src/navigation-items-menu-builder.spec.ts
+++ b/packages/main/src/navigation-items-menu-builder.spec.ts
@@ -17,17 +17,12 @@
  ***********************************************************************/
 
 import type { BrowserWindow, ContextMenuParams, MenuItem, MenuItemConstructorOptions } from 'electron';
-import { dialog } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { NavigationItemsMenuBuilder } from './navigation-items-menu-builder.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
 
-vi.mock(import('electron'), async () => ({
-  dialog: {
-    showMessageBox: vi.fn(),
-  },
-}));
+const showMessageBoxMock = vi.fn();
 
 let navigationItemsMenuBuilder: TestNavigationItemsMenuBuilder;
 
@@ -61,7 +56,7 @@ class TestNavigationItemsMenuBuilder extends NavigationItemsMenuBuilder {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  navigationItemsMenuBuilder = new TestNavigationItemsMenuBuilder(configurationRegistryMock);
+  navigationItemsMenuBuilder = new TestNavigationItemsMenuBuilder(configurationRegistryMock, showMessageBoxMock);
 });
 
 describe('buildHideMenuItem', () => {
@@ -124,14 +119,14 @@ describe('buildHideMenuItem', () => {
     getConfigurationMock.mockReturnValue({
       get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
     } as unknown as ConfigurationRegistry);
-    vi.mocked(dialog.showMessageBox).mockResolvedValue({ response: 0, checkboxChecked: false });
+    showMessageBoxMock.mockResolvedValue({ response: 'Hide' });
     vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
 
     const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
     menu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
 
     await vi.waitFor(() => {
-      expect(dialog.showMessageBox).toHaveBeenCalled();
+      expect(showMessageBoxMock).toHaveBeenCalled();
     });
   });
 
@@ -139,7 +134,7 @@ describe('buildHideMenuItem', () => {
     getConfigurationMock.mockReturnValue({
       get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
     } as unknown as ConfigurationRegistry);
-    vi.mocked(dialog.showMessageBox).mockResolvedValue({ response: 0, checkboxChecked: false });
+    showMessageBoxMock.mockResolvedValue({ response: 'Hide' });
     vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
 
     const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
@@ -158,13 +153,13 @@ describe('buildHideMenuItem', () => {
     getConfigurationMock.mockReturnValue({
       get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
     } as unknown as ConfigurationRegistry);
-    vi.mocked(dialog.showMessageBox).mockResolvedValue({ response: 2, checkboxChecked: false });
+    showMessageBoxMock.mockResolvedValue({ response: 'Cancel' });
 
     const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
     menu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
 
     await vi.waitFor(() => {
-      expect(dialog.showMessageBox).toHaveBeenCalled();
+      expect(showMessageBoxMock).toHaveBeenCalled();
     });
 
     expect(configurationRegistryMock.updateConfigurationValue).not.toHaveBeenCalledWith(
@@ -178,7 +173,7 @@ describe('buildHideMenuItem', () => {
     getConfigurationMock.mockReturnValue({
       get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
     } as unknown as ConfigurationRegistry);
-    vi.mocked(dialog.showMessageBox).mockResolvedValue({ response: 1, checkboxChecked: false });
+    showMessageBoxMock.mockResolvedValue({ response: "Don't show again" });
     vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
 
     const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
@@ -216,7 +211,7 @@ describe('buildHideMenuItem', () => {
       );
     });
 
-    expect(dialog.showMessageBox).not.toHaveBeenCalled();
+    expect(showMessageBoxMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/main/src/navigation-items-menu-builder.spec.ts
+++ b/packages/main/src/navigation-items-menu-builder.spec.ts
@@ -173,7 +173,7 @@ describe('buildHideMenuItem', async () => {
     getConfigurationMock.mockReturnValue({
       get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
     } as unknown as ConfigurationRegistry);
-    showMessageBoxMock.mockResolvedValue({ response: "Don't show again" });
+    showMessageBoxMock.mockResolvedValue({ response: `Don't show again` });
     vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
 
     const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');

--- a/packages/main/src/navigation-items-menu-builder.spec.ts
+++ b/packages/main/src/navigation-items-menu-builder.spec.ts
@@ -17,10 +17,17 @@
  ***********************************************************************/
 
 import type { BrowserWindow, ContextMenuParams, MenuItem, MenuItemConstructorOptions } from 'electron';
+import { dialog } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { NavigationItemsMenuBuilder } from './navigation-items-menu-builder.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+
+vi.mock(import('electron'), async () => ({
+  dialog: {
+    showMessageBox: vi.fn(),
+  },
+}));
 
 let navigationItemsMenuBuilder: TestNavigationItemsMenuBuilder;
 
@@ -41,6 +48,12 @@ class TestNavigationItemsMenuBuilder extends NavigationItemsMenuBuilder {
   override buildNavigationToggleMenuItems(): MenuItemConstructorOptions[] {
     return super.buildNavigationToggleMenuItems();
   }
+  override buildShowHiddenItemsSubmenu(): MenuItemConstructorOptions | undefined {
+    return super.buildShowHiddenItemsSubmenu();
+  }
+  override buildResetMenuItem(): MenuItemConstructorOptions {
+    return super.buildResetMenuItem();
+  }
   override getNavWidth(): number {
     return super.getNavWidth();
   }
@@ -51,75 +64,178 @@ beforeEach(() => {
   navigationItemsMenuBuilder = new TestNavigationItemsMenuBuilder(configurationRegistryMock);
 });
 
-describe('buildHideMenuItem', async () => {
-  test('build hide item', async () => {
+describe('buildHideMenuItem', () => {
+  test('build hide item with updated label', () => {
     getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
 
     const menu = navigationItemsMenuBuilder.buildHideMenuItem('Hello');
-    expect(menu?.label).toBe(`Hide Hello`);
+    expect(menu?.label).toBe('Hide Hello From Navigation Bar');
     expect(menu?.click).toBeDefined();
     expect(menu?.visible).toBe(true);
-
-    // click on the menu
-    menu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
-
-    expect(getConfigurationMock).toBeCalled();
-    // if clicking it should send the item to the configuration as being disabled
-    expect(configurationRegistryMock.updateConfigurationValue).toBeCalledWith(
-      'navbar.disabledItems',
-      ['Hello'],
-      'DEFAULT',
-    );
   });
 
-  test('build hide item with line feed', async () => {
+  test('build hide item with line feed', () => {
     getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
 
     const menu = navigationItemsMenuBuilder.buildHideMenuItem('Hello\nHallo');
-    expect(menu?.label).toBe('Hide Hello');
+    expect(menu?.label).toBe('Hide Hello From Navigation Bar');
     expect(menu?.click).toBeDefined();
     expect(menu?.visible).toBe(true);
+  });
 
-    // click on the menu
+  test('should not create a menu item if in excluded list', () => {
+    getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
+
+    expect(navigationItemsMenuBuilder.buildHideMenuItem('Accounts')).toBeUndefined();
+    expect(navigationItemsMenuBuilder.buildHideMenuItem('Settings')).toBeUndefined();
+    expect(navigationItemsMenuBuilder.buildHideMenuItem('Containers')).toBeUndefined();
+    expect(navigationItemsMenuBuilder.buildHideMenuItem('Images')).toBeUndefined();
+    expect(navigationItemsMenuBuilder.buildHideMenuItem('Dashboard')).toBeUndefined();
+  });
+
+  test('should not create a menu item for the active item', () => {
+    getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
+
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [{ name: 'Pods', visible: true }],
+      activeItem: 'Pods',
+    });
+
+    const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
+    expect(menu).toBeUndefined();
+  });
+
+  test('should create a menu item for non-active item', () => {
+    getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
+
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'Pods', visible: true },
+        { name: 'Volumes', visible: true },
+      ],
+      activeItem: 'Pods',
+    });
+
+    const menu = navigationItemsMenuBuilder.buildHideMenuItem('Volumes');
+    expect(menu?.label).toBe('Hide Volumes From Navigation Bar');
+  });
+
+  test('click shows confirmation dialog when not dismissed', async () => {
+    getConfigurationMock.mockReturnValue({
+      get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
+    } as unknown as ConfigurationRegistry);
+    vi.mocked(dialog.showMessageBox).mockResolvedValue({ response: 0, checkboxChecked: false });
+    vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
+
+    const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
     menu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
 
-    expect(getConfigurationMock).toBeCalled();
-    // if clicking it should send the item to the configuration as being disabled
-    expect(configurationRegistryMock.updateConfigurationValue).toBeCalledWith(
+    await vi.waitFor(() => {
+      expect(dialog.showMessageBox).toHaveBeenCalled();
+    });
+  });
+
+  test('click hides item when confirmation dialog returns Hide', async () => {
+    getConfigurationMock.mockReturnValue({
+      get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
+    } as unknown as ConfigurationRegistry);
+    vi.mocked(dialog.showMessageBox).mockResolvedValue({ response: 0, checkboxChecked: false });
+    vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
+
+    const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
+    menu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    await vi.waitFor(() => {
+      expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+        'navbar.disabledItems',
+        ['Pods'],
+        'DEFAULT',
+      );
+    });
+  });
+
+  test('click does not hide item when confirmation dialog is cancelled', async () => {
+    getConfigurationMock.mockReturnValue({
+      get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
+    } as unknown as ConfigurationRegistry);
+    vi.mocked(dialog.showMessageBox).mockResolvedValue({ response: 2, checkboxChecked: false });
+
+    const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
+    menu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    await vi.waitFor(() => {
+      expect(dialog.showMessageBox).toHaveBeenCalled();
+    });
+
+    expect(configurationRegistryMock.updateConfigurationValue).not.toHaveBeenCalledWith(
       'navbar.disabledItems',
-      ['Hello'],
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test('click with "Don\'t show again" hides item and dismisses confirmation', async () => {
+    getConfigurationMock.mockReturnValue({
+      get: (key: string) => (key === 'hideConfirmationDismissed' ? false : []),
+    } as unknown as ConfigurationRegistry);
+    vi.mocked(dialog.showMessageBox).mockResolvedValue({ response: 1, checkboxChecked: false });
+    vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
+
+    const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
+    menu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    await vi.waitFor(() => {
+      expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+        'navbar.hideConfirmationDismissed',
+        true,
+        'DEFAULT',
+      );
+    });
+
+    expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+      'navbar.disabledItems',
+      ['Pods'],
       'DEFAULT',
     );
   });
 
-  test('should not create a menu item if in excluded list', async () => {
-    getConfigurationMock.mockReturnValue({ get: () => [] } as unknown as ConfigurationRegistry);
+  test('click skips confirmation dialog when already dismissed', async () => {
+    getConfigurationMock.mockReturnValue({
+      get: (key: string) => (key === 'hideConfirmationDismissed' ? true : []),
+    } as unknown as ConfigurationRegistry);
+    vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
 
-    const menu = navigationItemsMenuBuilder.buildHideMenuItem('Accounts');
-    expect(menu).toBeUndefined();
+    const menu = navigationItemsMenuBuilder.buildHideMenuItem('Pods');
+    menu?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    await vi.waitFor(() => {
+      expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+        'navbar.disabledItems',
+        expect.anything(),
+        'DEFAULT',
+      );
+    });
+
+    expect(dialog.showMessageBox).not.toHaveBeenCalled();
   });
 });
 
-describe('buildNavigationToggleMenuItems', async () => {
-  test('build navigation toggle menu items', async () => {
+describe('buildNavigationToggleMenuItems', () => {
+  test('build navigation toggle menu items', () => {
     getConfigurationMock.mockReturnValue({ get: () => ['existing'] } as unknown as ConfigurationRegistry);
 
-    // send 3 items, two being visible, one being hidden
-    navigationItemsMenuBuilder.receiveNavigationItems([
-      { name: 'A & A', visible: true },
-      { name: 'B', visible: false },
-      { name: 'C', visible: true },
-    ]);
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'A & A', visible: true },
+        { name: 'B', visible: false },
+        { name: 'C', visible: true },
+      ],
+    });
 
     const menu = navigationItemsMenuBuilder.buildNavigationToggleMenuItems();
 
-    // 4 items (first one being a separator)
     expect(menu.length).toBe(4);
-
-    // check the first item is a separator
     expect(menu[0]?.type).toBe('separator');
-
-    // label should be escaped as we have an &
     expect(menu[1]?.label).toBe('A && A');
     expect(menu[1]?.checked).toBe(true);
     expect(menu[2]?.label).toBe('B');
@@ -127,22 +243,17 @@ describe('buildNavigationToggleMenuItems', async () => {
     expect(menu[3]?.label).toBe('C');
     expect(menu[3]?.checked).toBe(true);
 
-    // click on the A item
     menu[1]?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
 
     expect(getConfigurationMock).toBeCalled();
-    // if clicking it should send the item to the configuration as being disabled
     expect(configurationRegistryMock.updateConfigurationValue).toBeCalledWith(
       'navbar.disabledItems',
-      // item A & A should not be escaped
       ['existing', 'A & A'],
       'DEFAULT',
     );
 
-    // reset the calls
     vi.mocked(configurationRegistryMock.updateConfigurationValue).mockClear();
 
-    // click on the B item should unhide it so disabled items should be empty
     menu[2]?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
     expect(configurationRegistryMock.updateConfigurationValue).toBeCalledWith(
       'navbar.disabledItems',
@@ -152,8 +263,65 @@ describe('buildNavigationToggleMenuItems', async () => {
   });
 });
 
-describe('buildNavigationMenu', async () => {
-  test('no items if no linktext', async () => {
+describe('buildShowHiddenItemsSubmenu', () => {
+  test('returns undefined when no items are hidden', () => {
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'A', visible: true },
+        { name: 'B', visible: true },
+      ],
+    });
+
+    expect(navigationItemsMenuBuilder.buildShowHiddenItemsSubmenu()).toBeUndefined();
+  });
+
+  test('returns submenu with hidden items', () => {
+    getConfigurationMock.mockReturnValue({ get: () => ['existing'] } as unknown as ConfigurationRegistry);
+
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'A', visible: true },
+        { name: 'B', visible: false },
+        { name: 'C', visible: false },
+      ],
+    });
+
+    const menu = navigationItemsMenuBuilder.buildShowHiddenItemsSubmenu();
+    expect(menu?.label).toBe('Show Hidden Items');
+    expect(menu?.submenu).toHaveLength(2);
+
+    const submenu = menu?.submenu as MenuItemConstructorOptions[];
+    expect(submenu[0]?.label).toBe('B');
+    expect(submenu[1]?.label).toBe('C');
+
+    submenu[0]?.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+    expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+      'navbar.disabledItems',
+      ['existing'],
+      'DEFAULT',
+    );
+  });
+});
+
+describe('buildResetMenuItem', () => {
+  test('resets all hidden items', () => {
+    vi.mocked(configurationRegistryMock.updateConfigurationValue).mockResolvedValue();
+
+    const menu = navigationItemsMenuBuilder.buildResetMenuItem();
+    expect(menu.label).toBe('Reset Navigation Bar');
+
+    menu.click?.({} as MenuItem, browserWindowMock, {} as unknown as KeyboardEvent);
+
+    expect(configurationRegistryMock.updateConfigurationValue).toHaveBeenCalledWith(
+      'navbar.disabledItems',
+      [],
+      'DEFAULT',
+    );
+  });
+});
+
+describe('buildNavigationMenu', () => {
+  test('no items if no linktext and outside navbar', () => {
     getConfigurationMock.mockReturnValue({ get: () => 160 });
     const parameters = {} as unknown as ContextMenuParams;
 
@@ -162,7 +330,7 @@ describe('buildNavigationMenu', async () => {
     expect(menu).toStrictEqual([]);
   });
 
-  test('no items if outside of range of navbar', async () => {
+  test('no items if outside of range of navbar', () => {
     getConfigurationMock.mockReturnValue({ get: () => 160 });
     const parameters = {
       linkText: 'outside',
@@ -175,10 +343,10 @@ describe('buildNavigationMenu', async () => {
     expect(menu).toStrictEqual([]);
   });
 
-  test('should call the build if inside range of navbar', async () => {
+  test('should include hide item and reset when inside navbar with linkText', () => {
     getConfigurationMock.mockReturnValue({ get: () => 160 });
     const spyMock = vi.spyOn(navigationItemsMenuBuilder, 'buildHideMenuItem');
-    spyMock.mockReturnValue({} as MenuItemConstructorOptions);
+    spyMock.mockReturnValue({ label: 'Hide Test From Navigation Bar' } as MenuItemConstructorOptions);
     const parameters = {
       linkText: 'inside',
       x: 30,
@@ -187,7 +355,45 @@ describe('buildNavigationMenu', async () => {
 
     const menu = navigationItemsMenuBuilder.buildNavigationMenu(parameters);
 
-    expect(menu.length).toBe(1);
     expect(spyMock).toBeCalledWith('inside');
+    const hideItem = menu.find(m => m.label === 'Hide Test From Navigation Bar');
+    expect(hideItem).toBeDefined();
+    const resetItem = menu.find(m => m.label === 'Reset Navigation Bar');
+    expect(resetItem).toBeDefined();
+  });
+
+  test('should include reset when right-clicking empty navbar space', () => {
+    getConfigurationMock.mockReturnValue({ get: () => 160 });
+    const parameters = {
+      x: 30,
+      y: 100,
+    } as unknown as ContextMenuParams;
+
+    const menu = navigationItemsMenuBuilder.buildNavigationMenu(parameters);
+
+    const resetItem = menu.find(m => m.label === 'Reset Navigation Bar');
+    expect(resetItem).toBeDefined();
+  });
+
+  test('should include Show Hidden Items submenu when items are hidden', () => {
+    getConfigurationMock.mockReturnValue({ get: () => 160 });
+
+    navigationItemsMenuBuilder.receiveNavigationItems({
+      items: [
+        { name: 'A', visible: true },
+        { name: 'B', visible: false },
+      ],
+    });
+
+    const parameters = {
+      x: 30,
+      y: 100,
+    } as unknown as ContextMenuParams;
+
+    const menu = navigationItemsMenuBuilder.buildNavigationMenu(parameters);
+
+    const showHidden = menu.find(m => m.label === 'Show Hidden Items');
+    expect(showHidden).toBeDefined();
+    expect(showHidden?.submenu).toHaveLength(1);
   });
 });

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -68,6 +68,12 @@ export class NavigationItemsMenuBuilder {
       items,
       CONFIGURATION_DEFAULT_SCOPE,
     );
+
+    // Optimistic local update to keep state in sync before renderer round-trip
+    const item = this.navigationItems.find(i => i.name === itemName);
+    if (item) {
+      item.visible = visible;
+    }
   }
 
   protected escapeLabel(label: string): string {

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -40,6 +40,11 @@ export class NavigationItemsMenuBuilder {
   }
 
   protected async updateNavbarHiddenItem(itemName: string, visible: boolean): Promise<void> {
+    // defense-in-depth: prevent hiding protected items
+    if (!visible && (EXCLUDED_ITEMS.includes(itemName) || itemName === this.activeItemName)) {
+      return;
+    }
+
     // grab the disabled items, and add the new one
     const configuration = this.configurationRegistry.getConfiguration('navbar');
     let items = configuration.get<string[]>('disabledItems', []);
@@ -143,17 +148,21 @@ export class NavigationItemsMenuBuilder {
     const items: MenuItemConstructorOptions[] = [];
 
     // add all navigation items to be able to show/hide them
-    const menuForNavItems: Electron.MenuItemConstructorOptions[] = this.navigationItems.map(item => ({
-      label: this.escapeLabel(item.name),
-      type: 'checkbox',
-      checked: item.visible,
-      click: (): void => {
-        // send the item to the frontend to show/hide it
-        this.updateNavbarHiddenItem(item.name, !item.visible).catch((e: unknown) =>
-          console.error('error disabling item', e),
-        );
-      },
-    }));
+    const menuForNavItems: Electron.MenuItemConstructorOptions[] = this.navigationItems.map(item => {
+      const isProtected = EXCLUDED_ITEMS.includes(item.name) || item.name === this.activeItemName;
+      return {
+        label: this.escapeLabel(item.name),
+        type: 'checkbox',
+        checked: item.visible,
+        enabled: !isProtected,
+        click: (): void => {
+          // send the item to the frontend to show/hide it
+          this.updateNavbarHiddenItem(item.name, !item.visible).catch((e: unknown) =>
+            console.error('error disabling item', e),
+          );
+        },
+      };
+    });
     if (menuForNavItems.length > 0) {
       // add separator
       items.push({ type: 'separator' });

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -168,6 +168,34 @@ export class NavigationItemsMenuBuilder {
     return items;
   }
 
+  protected buildShowHiddenItemsSubmenu(): MenuItemConstructorOptions | undefined {
+    const hiddenItems = this.navigationItems.filter(item => !item.visible);
+    if (hiddenItems.length === 0) {
+      return undefined;
+    }
+
+    return {
+      label: 'Show Hidden Items',
+      submenu: hiddenItems.map(item => ({
+        label: this.escapeLabel(item.name),
+        click: (): void => {
+          this.updateNavbarHiddenItem(item.name, true).catch((e: unknown) => console.error('error showing item', e));
+        },
+      })),
+    };
+  }
+
+  protected buildResetMenuItem(): MenuItemConstructorOptions {
+    return {
+      label: 'Reset Navigation Bar',
+      click: (): void => {
+        this.configurationRegistry
+          .updateConfigurationValue('navbar.disabledItems', [], CONFIGURATION_DEFAULT_SCOPE)
+          .catch((e: unknown) => console.error('error resetting navigation bar', e));
+      },
+    };
+  }
+
   protected getNavWidth(): number {
     const configuration = this.configurationRegistry.getConfiguration(AppearanceSettings.SectionName);
     return configuration.get<number>(AppearanceSettings.NavigationBarWidth, EXPANDED_WIDTH);
@@ -177,7 +205,6 @@ export class NavigationItemsMenuBuilder {
     const items: MenuItemConstructorOptions[] = [];
     const navWidth = this.getNavWidth();
 
-    // allow to hide the item being selected
     if (parameters.linkText && parameters.x < navWidth && parameters.y > 76) {
       const menu = this.buildHideMenuItem(parameters.linkText);
       if (menu) {
@@ -186,6 +213,15 @@ export class NavigationItemsMenuBuilder {
     }
     if (parameters.x < navWidth) {
       items.push(...this.buildNavigationToggleMenuItems());
+
+      const showHidden = this.buildShowHiddenItemsSubmenu();
+      if (showHidden) {
+        items.push({ type: 'separator' });
+        items.push(showHidden);
+      }
+
+      items.push({ type: 'separator' });
+      items.push(this.buildResetMenuItem());
     }
     return items;
   }

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -113,7 +113,7 @@ export class NavigationItemsMenuBuilder {
       message: `Hide "${itemName}" from the navigation bar?`,
       detail:
         'You can restore hidden items by right-clicking the navigation bar and selecting "Show Hidden Items", or by using "Reset Navigation Bar".',
-      buttons: ['Hide', "Don't show again", 'Cancel'],
+      buttons: ['Hide', `Don't show again`, 'Cancel'],
       defaultId: 0,
       cancelId: 2,
     });
@@ -122,7 +122,7 @@ export class NavigationItemsMenuBuilder {
       return false;
     }
 
-    if (result.response === "Don't show again") {
+    if (result.response === `Don't show again`) {
       await this.dismissHideConfirmation();
     }
 
@@ -148,9 +148,9 @@ export class NavigationItemsMenuBuilder {
       visible: true,
       click: (): void => {
         this.showHideConfirmation(itemName)
-          .then(confirmed => {
+          .then(async confirmed => {
             if (confirmed) {
-              return this.updateNavbarHiddenItem(itemName, false);
+              await this.updateNavbarHiddenItem(itemName, false);
             }
           })
           .catch((e: unknown) => console.error('error hiding item', e));

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -19,23 +19,28 @@
 import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron';
+import { dialog } from 'electron';
 
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
 
-// items that can't be hidden
-const EXCLUDED_ITEMS = ['Accounts', 'Settings'];
+const EXCLUDED_ITEMS = ['Accounts', 'Settings', 'Containers', 'Images', 'Dashboard'];
 
 const EXPANDED_WIDTH = 160;
 
-// This class is responsible of creating the items to hide a given selected item of the left navigation bar
-// and also display a list of all items with the ability to toggle the visibility of each item.
+export interface NavigationItemsPayload {
+  items: { name: string; visible: boolean }[];
+  activeItem?: string;
+}
+
 export class NavigationItemsMenuBuilder {
   private navigationItems: { name: string; visible: boolean }[] = [];
+  private activeItemName: string | undefined;
 
   constructor(private configurationRegistry: ConfigurationRegistry) {}
 
-  receiveNavigationItems(data: { name: string; visible: boolean }[]): void {
-    this.navigationItems = data;
+  receiveNavigationItems(data: NavigationItemsPayload): void {
+    this.navigationItems = data.items;
+    this.activeItemName = data.activeItem;
   }
 
   protected async updateNavbarHiddenItem(itemName: string, visible: boolean): Promise<void> {
@@ -68,26 +73,71 @@ export class NavigationItemsMenuBuilder {
     return itemName.split('\n')[0] ?? itemName;
   }
 
+  protected isHideConfirmationDismissed(): boolean {
+    const configuration = this.configurationRegistry.getConfiguration('navbar');
+    return configuration.get<boolean>('hideConfirmationDismissed', false);
+  }
+
+  protected async dismissHideConfirmation(): Promise<void> {
+    await this.configurationRegistry.updateConfigurationValue(
+      'navbar.hideConfirmationDismissed',
+      true,
+      CONFIGURATION_DEFAULT_SCOPE,
+    );
+  }
+
+  protected async showHideConfirmation(itemName: string): Promise<boolean> {
+    if (this.isHideConfirmationDismissed()) {
+      return true;
+    }
+
+    const result = await dialog.showMessageBox({
+      type: 'question',
+      title: 'Hide From Navigation Bar',
+      message: `Hide "${itemName}" from the navigation bar?`,
+      detail:
+        'You can restore hidden items by right-clicking the navigation bar and selecting "Show Hidden Items", or by using "Reset Navigation Bar".',
+      buttons: ['Hide', "Don't show again", 'Cancel'],
+      defaultId: 0,
+      cancelId: 2,
+    });
+
+    if (result.response === 2) {
+      return false;
+    }
+
+    if (result.response === 1) {
+      await this.dismissHideConfirmation();
+    }
+
+    return true;
+  }
+
   protected buildHideMenuItem(linkText: string): MenuItemConstructorOptions | undefined {
     const rawItemName = linkText;
-
-    // need to filter any counter from the item name
-    // it's at the end with parenthesis like itemName (2)
     const itemName = this.computeItemName(rawItemName);
 
     if (EXCLUDED_ITEMS.includes(itemName)) {
       return undefined;
     }
 
-    // on electron, need to esccape the & character to show it
+    if (itemName === this.activeItemName) {
+      return undefined;
+    }
+
     const itemDisplayName = this.escapeLabel(itemName);
 
     const item: MenuItemConstructorOptions = {
-      label: `Hide ${itemDisplayName}`,
+      label: `Hide ${itemDisplayName} From Navigation Bar`,
       visible: true,
       click: (): void => {
-        // flag the item as being disabled
-        this.updateNavbarHiddenItem(itemName, false).catch((e: unknown) => console.error('error disabling item', e));
+        this.showHideConfirmation(itemName)
+          .then(confirmed => {
+            if (confirmed) {
+              return this.updateNavbarHiddenItem(itemName, false);
+            }
+          })
+          .catch((e: unknown) => console.error('error hiding item', e));
       },
     };
     return item;

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { NavigationItemInfo, NavigationItemsPayload } from '@podman-desktop/core-api';
 import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron';
@@ -27,13 +28,8 @@ const EXCLUDED_ITEMS = ['Accounts', 'Settings', 'Containers', 'Images', 'Dashboa
 
 const EXPANDED_WIDTH = 160;
 
-export interface NavigationItemsPayload {
-  items: { name: string; visible: boolean }[];
-  activeItem?: string;
-}
-
 export class NavigationItemsMenuBuilder {
-  private navigationItems: { name: string; visible: boolean }[] = [];
+  private navigationItems: NavigationItemInfo[] = [];
   private activeItemName: string | undefined;
 
   constructor(private configurationRegistry: ConfigurationRegistry) {}

--- a/packages/main/src/navigation-items-menu-builder.ts
+++ b/packages/main/src/navigation-items-menu-builder.ts
@@ -16,11 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { NavigationItemInfo, NavigationItemsPayload } from '@podman-desktop/core-api';
+import type {
+  MessageBoxOptions,
+  MessageBoxReturnValue,
+  NavigationItemInfo,
+  NavigationItemsPayload,
+} from '@podman-desktop/core-api';
 import { AppearanceSettings } from '@podman-desktop/core-api/appearance';
 import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import type { ContextMenuParams, MenuItemConstructorOptions } from 'electron';
-import { dialog } from 'electron';
 
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
 
@@ -28,11 +32,16 @@ const EXCLUDED_ITEMS = ['Accounts', 'Settings', 'Containers', 'Images', 'Dashboa
 
 const EXPANDED_WIDTH = 160;
 
+export type ShowMessageBoxFn = (options: MessageBoxOptions) => Promise<MessageBoxReturnValue>;
+
 export class NavigationItemsMenuBuilder {
   private navigationItems: NavigationItemInfo[] = [];
   private activeItemName: string | undefined;
 
-  constructor(private configurationRegistry: ConfigurationRegistry) {}
+  constructor(
+    private configurationRegistry: ConfigurationRegistry,
+    private showMessageBox: ShowMessageBoxFn,
+  ) {}
 
   receiveNavigationItems(data: NavigationItemsPayload): void {
     this.navigationItems = data.items;
@@ -92,7 +101,7 @@ export class NavigationItemsMenuBuilder {
       return true;
     }
 
-    const result = await dialog.showMessageBox({
+    const result = await this.showMessageBox({
       type: 'question',
       title: 'Hide From Navigation Bar',
       message: `Hide "${itemName}" from the navigation bar?`,
@@ -103,11 +112,11 @@ export class NavigationItemsMenuBuilder {
       cancelId: 2,
     });
 
-    if (result.response === 2) {
+    if (result.response === 'Cancel') {
       return false;
     }
 
-    if (result.response === 1) {
+    if (result.response === "Don't show again") {
       await this.dismissHideConfirmation();
     }
 

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -835,6 +835,7 @@ export class PluginSystem {
 
     // setup security restrictions on links
     const messageBox = container.get<MessageBox>(MessageBox);
+    ipcMain.emit('message-box', '', messageBox);
     const imageChecker = container.get<ImageCheckerImpl>(ImageCheckerImpl);
     const imageFiles = container.get<ImageFilesRegistry>(ImageFilesRegistry);
     const viewRegistry = container.get<ViewRegistry>(ViewRegistry);

--- a/packages/main/src/plugin/navigation-items-init.spec.ts
+++ b/packages/main/src/plugin/navigation-items-init.spec.ts
@@ -40,11 +40,18 @@ test('should register a configuration', async () => {
   expect(configurationNode?.id).toBe('preferences.navBar');
   expect(configurationNode?.title).toBe('User Confirmation');
   expect(configurationNode?.properties).toBeDefined();
-  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(1);
+  expect(Object.keys(configurationNode?.properties ?? {}).length).toBe(2);
   expect(configurationNode?.properties?.['navbar.disabledItems']).toBeDefined();
   expect(configurationNode?.properties?.['navbar.disabledItems']?.description).toBe(
     'Items being disabled in the navigation bar',
   );
   expect(configurationNode?.properties?.['navbar.disabledItems']?.type).toStrictEqual(['boolean']);
   expect(configurationNode?.properties?.['navbar.disabledItems']?.default).toStrictEqual([]);
+
+  expect(configurationNode?.properties?.['navbar.hideConfirmationDismissed']).toBeDefined();
+  expect(configurationNode?.properties?.['navbar.hideConfirmationDismissed']?.description).toBe(
+    'Whether the hide confirmation dialog has been dismissed',
+  );
+  expect(configurationNode?.properties?.['navbar.hideConfirmationDismissed']?.type).toBe('boolean');
+  expect(configurationNode?.properties?.['navbar.hideConfirmationDismissed']?.default).toBe(false);
 });

--- a/packages/main/src/plugin/navigation-items-init.ts
+++ b/packages/main/src/plugin/navigation-items-init.ts
@@ -35,6 +35,12 @@ export class NavigationItemsInit {
           default: [],
           hidden: true,
         },
+        ['navbar.hideConfirmationDismissed']: {
+          description: 'Whether the hide confirmation dialog has been dismissed',
+          type: 'boolean',
+          default: false,
+          hidden: true,
+        },
       },
     };
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -94,6 +94,7 @@ import type {
   Menu,
   MessageBoxOptions,
   MessageBoxReturnValue,
+  NavigationItemsPayload,
   NavigationRequest,
   NetworkCreateOptions,
   NetworkCreateResult,
@@ -273,12 +274,9 @@ export function initExposure(): void {
     },
   );
 
-  contextBridge.exposeInMainWorld(
-    'sendNavigationItems',
-    async (data: { items: { name: string; visible: boolean }[]; activeItem?: string }): Promise<void> => {
-      return ipcRenderer.invoke('navigation:sendNavigationItems', data);
-    },
-  );
+  contextBridge.exposeInMainWorld('sendNavigationItems', async (data: NavigationItemsPayload): Promise<void> => {
+    return ipcRenderer.invoke('navigation:sendNavigationItems', data);
+  });
 
   contextBridge.exposeInMainWorld('navigateToRoute', async (routeId: string, ...args: unknown[]): Promise<void> => {
     return ipcRenderer.invoke('navigation:navigateToRoute', routeId, ...args);

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -275,8 +275,8 @@ export function initExposure(): void {
 
   contextBridge.exposeInMainWorld(
     'sendNavigationItems',
-    async (items: { name: string; visible: boolean }[]): Promise<void> => {
-      return ipcRenderer.invoke('navigation:sendNavigationItems', items);
+    async (data: { items: { name: string; visible: boolean }[]; activeItem?: string }): Promise<void> => {
+      return ipcRenderer.invoke('navigation:sendNavigationItems', data);
     },
   );
 

--- a/packages/renderer/src/stores/navigation-history.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation-history.svelte.spec.ts
@@ -51,7 +51,6 @@ let routerSubscribeCallback = vi.hoisted(() => {
 vi.mock(import('tinro'));
 
 vi.mock(import('/@/stores/kubernetes-no-current-context'));
-vi.mock(import('/@/stores/navigation/navigation-registry'));
 
 vi.mock(import('/@/PreferencesNavigation'), () => ({
   settingsNavigationEntries: [],

--- a/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
@@ -19,11 +19,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { get } from 'svelte/store';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { configurationProperties } from '/@/stores/configurationProperties';
 
-import { fetchNavigationRegistries, navigationRegistry } from './navigation-registry';
+import {
+  fetchNavigationRegistries,
+  findActiveItem,
+  navigationRegistry,
+  type NavigationRegistryEntry,
+} from './navigation-registry';
 
 const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
 const kubernetesGetCurrentContextGeneralStateMock = vi.fn();
@@ -76,5 +81,52 @@ test('check update properties', async () => {
   const containersAndPods = hidden.filter(item => item.name === 'Containers' || item.name === 'Pods');
   containersAndPods.forEach(item => {
     expect(item.hidden).toBeTruthy();
+  });
+});
+
+describe('findActiveItem', () => {
+  const entries: NavigationRegistryEntry[] = [
+    { name: 'Pods', link: '/pods', icon: {}, tooltip: '', counter: 0, destinations: [], type: 'entry' },
+    { name: 'Volumes', link: '/volumes', icon: {}, tooltip: '', counter: 0, destinations: [], type: 'entry' },
+  ];
+
+  test('should match exact path', () => {
+    expect(findActiveItem(entries, '/pods')).toBe('Pods');
+  });
+
+  test('should match child path with slash delimiter', () => {
+    expect(findActiveItem(entries, '/pods/details')).toBe('Pods');
+  });
+
+  test('should NOT match path that shares a prefix but is a different route', () => {
+    expect(findActiveItem(entries, '/pods-archive')).toBeUndefined();
+  });
+
+  test('should return Dashboard for root path', () => {
+    expect(findActiveItem(entries, '/')).toBe('Dashboard');
+  });
+
+  test('should return undefined for unmatched path', () => {
+    expect(findActiveItem(entries, '/unknown')).toBeUndefined();
+  });
+
+  test('should match submenu items', () => {
+    const withSubmenu: NavigationRegistryEntry[] = [
+      {
+        name: 'Kubernetes',
+        link: '/kubernetes',
+        icon: {},
+        tooltip: '',
+        counter: 0,
+        destinations: [],
+        type: 'submenu',
+        items: [
+          { name: 'Services', link: '/services', icon: {}, tooltip: '', counter: 0, destinations: [], type: 'entry' },
+        ],
+      },
+    ];
+    expect(findActiveItem(withSubmenu, '/services')).toBe('Services');
+    expect(findActiveItem(withSubmenu, '/services/detail')).toBe('Services');
+    expect(findActiveItem(withSubmenu, '/services-other')).toBeUndefined();
   });
 });

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -139,19 +139,38 @@ function hideSingleItem(navigationRegistryEntry: NavigationRegistryEntry): void 
   }
 }
 
+export function findActiveItem(entries: NavigationRegistryEntry[], pathname: string): string | undefined {
+  for (const entry of entries) {
+    if (entry.link && entry.link !== '/' && pathname.startsWith(entry.link)) {
+      return entry.name;
+    }
+    if (entry.items) {
+      for (const sub of entry.items) {
+        if (sub.link && sub.link !== '/' && pathname.startsWith(sub.link)) {
+          return sub.name;
+        }
+      }
+    }
+  }
+  if (pathname === '/') {
+    return 'Dashboard';
+  }
+  return undefined;
+}
+
 async function hideItems(): Promise<void> {
   // for each item, set the hidden property to true
   values.forEach(item => {
     hideSingleItem(item);
   });
 
-  // send to the main side the list of all items, items being displayed or hidden
   const navItems: DisplayItem[] = [];
   values.forEach(item => {
     collecItem(item, navItems);
   });
 
-  await window.sendNavigationItems(navItems);
+  const activeItem = findActiveItem(values, window.location.pathname);
+  await window.sendNavigationItems({ items: navItems, activeItem });
   values = [...values];
   navigationRegistry.set(values);
 }

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -134,14 +134,18 @@ function hideSingleItem(navigationRegistryEntry: NavigationRegistryEntry): void 
   }
 }
 
+function matchesRoute(pathname: string, link: string): boolean {
+  return pathname === link || pathname.startsWith(link + '/');
+}
+
 export function findActiveItem(entries: NavigationRegistryEntry[], pathname: string): string | undefined {
   for (const entry of entries) {
-    if (entry.link && entry.link !== '/' && pathname.startsWith(entry.link)) {
+    if (entry.link && entry.link !== '/' && matchesRoute(pathname, entry.link)) {
       return entry.name;
     }
     if (entry.items) {
       for (const sub of entry.items) {
-        if (sub.link && sub.link !== '/' && pathname.startsWith(sub.link)) {
+        if (sub.link && sub.link !== '/' && matchesRoute(pathname, sub.link)) {
           return sub.name;
         }
       }

--- a/packages/renderer/src/stores/navigation/navigation-registry.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
-import type { GoToInfo } from '@podman-desktop/core-api';
+import type { GoToInfo, NavigationItemInfo } from '@podman-desktop/core-api';
 import type { Component } from 'svelte';
 import { type Writable, writable } from 'svelte/store';
 import type { IconSize } from 'svelte-fa';
@@ -51,11 +51,6 @@ export interface NavigationRegistryEntry {
   hidden?: boolean;
 }
 
-interface DisplayItem {
-  name: string;
-  visible: boolean;
-}
-
 const windowEvents: string[] = [];
 const windowListeners = ['extensions-already-started', 'system-ready'];
 
@@ -78,7 +73,7 @@ const init = (): void => {
   hideItems().catch((err: unknown) => console.error('Error hiding navigation items', err));
 };
 
-function collecItem(navigationRegistryEntry: NavigationRegistryEntry, items: DisplayItem[]): void {
+function collecItem(navigationRegistryEntry: NavigationRegistryEntry, items: NavigationItemInfo[]): void {
   if (navigationRegistryEntry.items && navigationRegistryEntry.type === 'group') {
     navigationRegistryEntry.items.forEach(item => {
       collecItem(item, items);
@@ -164,7 +159,7 @@ async function hideItems(): Promise<void> {
     hideSingleItem(item);
   });
 
-  const navItems: DisplayItem[] = [];
+  const navItems: NavigationItemInfo[] = [];
   values.forEach(item => {
     collecItem(item, navItems);
   });


### PR DESCRIPTION
### What does this PR do?

Implements hide/show guardrails for navigation bar items per #16803.

**Protection rules:**
- Essential items (Containers, Images, Dashboard, Accounts, Settings) cannot be hidden
- The currently active/selected nav item cannot be hidden

**Context menu improvements:**
- Renamed "Hide X" → "Hide X From Navigation Bar"
- Added "Show Hidden Items" submenu listing all hidden items with one-click restore
- Added "Reset Navigation Bar" to restore all items to defaults

**First-time confirmation dialog:**
- On first hide, an Electron native dialog explains how to restore hidden items
- Three buttons: "Hide", "Don't show again", "Cancel"
- "Don't show again" persists via `navbar.hideConfirmationDismissed` config key

**IPC changes:**
- Extended `sendNavigationItems` payload to carry `activeItem` from renderer
- Added `findActiveItem()` to derive the active nav item from the current route
- Exported `NavigationItemsPayload` interface

> **Note — future follow-up (Option B):** The first-time dialog currently uses Electron's native `dialog.showMessageBox`. A richer approach would be to extend `MessageBoxOptions` with `checkboxLabel`/`checkboxChecked` fields across the stack (API types → MessageBox class → MessageBox.svelte), enabling an in-app styled dialog with a "Don't show again" checkbox. A `Checkbox` component already exists in `@podman-desktop/ui-svelte`. This can be tracked as a separate issue if reviewers prefer.

### Screenshot / video of UI

Containers cannot be hidden (example):
<img width="483" height="712" alt="Screenshot From 2026-08-12 01-46-46" src="https://github.com/user-attachments/assets/3dbc0734-309c-4b5b-8491-942f48cc7c5d" />

Hiding pods triggers a dialog that can be permanently dismissed:
<img width="530" height="714" alt="Screenshot From 2026-08-12 01-45-53" src="https://github.com/user-attachments/assets/c9bcd26b-98d0-432e-835c-0f24c27d4a95" />
<img width="578" height="220" alt="Screenshot From 2026-08-12 01-46-10" src="https://github.com/user-attachments/assets/efe89ee5-d006-4b2f-8b80-c77147ac010b" />

Show hidden submenu works, including reset navigation bar to restore all hidden items:
<img width="495" height="895" alt="Screenshot From 2026-08-12 01-47-08" src="https://github.com/user-attachments/assets/47a2498d-db80-49a5-8e72-0d95272b7fb8" />

### What issues does this PR fix or reference?

Closes #16803

- Related: #16804 (More button for hidden items — depends on this)
- Related: #16802 (Pinning — "unpin first, then hide" deferred until pinning lands)
- Epic: #16794

### How to test this PR?

1. Right-click Containers, Images, Dashboard, Accounts, or Settings → no "Hide" option appears
2. Right-click the currently active nav item → no "Hide" option appears
3. Right-click an inactive nav item → "Hide X From Navigation Bar" appears
4. First hide shows confirmation dialog; "Cancel" aborts; "Hide" hides; "Don't show again" hides and suppresses future dialogs
5. Right-click navbar empty space → "Show Hidden Items" submenu lists hidden items, clicking restores them
6. "Reset Navigation Bar" restores all hidden items
7. Unit tests pass: `npx vitest run packages/main/src/navigation-items-menu-builder.spec.ts`

- [x] Tests are covering the bug fix or the new feature