### PR TITLE
test(e2e): add managed configuration test for appUpdate setting

### DIFF
--- a/tests/playwright/resources/managed-configuration/default-settings.json
+++ b/tests/playwright/resources/managed-configuration/default-settings.json
@@ -22,5 +22,6 @@
   "proxy.no": "localhost,127.0.0.1,.example.com",
   "extensions.catalog.enabled": false,
   "extensions.localExtensions.enabled": false,
-  "extensions.customExtensions.enabled": false
+  "extensions.customExtensions.enabled": false,
+  "preferences.update.appUpdate": false
 }

--- a/tests/playwright/resources/managed-configuration/locked.json
+++ b/tests/playwright/resources/managed-configuration/locked.json
@@ -8,6 +8,7 @@
     "proxy.https",
     "extensions.catalog.enabled",
     "extensions.localExtensions.enabled",
-    "extensions.customExtensions.enabled"
+    "extensions.customExtensions.enabled",
+    "preferences.update.appUpdate"
   ]
 }

--- a/tests/playwright/src/model/core/settings/preferences.ts
+++ b/tests/playwright/src/model/core/settings/preferences.ts
@@ -23,6 +23,7 @@ enum PreferenceLabels {
   ZOOM_LEVEL = 'Zoom Level',
   EXIT_ON_CLOSE = ' Exit On Close',
   LINE_HEIGHT = 'Line Height',
+  APP_UPDATE = 'App Update',
 }
 
 export class Preferences {
@@ -33,4 +34,5 @@ export class Preferences {
     'Quit the app when the close button is clicked instead of minimizing to the tray.';
   static readonly ZOOM_LEVEL_NUMBER_INPUT_LABEL = 'preferences.zoomLevel';
   static readonly TERMINAL_LINE_HEIGHT_INPUT_LABEL = 'terminal.integrated.lineHeight';
+  static readonly APP_UPDATE_TOGGLE_BUTTON_LABEL = 'Check for application updates';
 }

--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-combined.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-combined.spec.ts
@@ -237,6 +237,33 @@ test.describe
       });
 
     test.describe
+      .serial('Defaults + Locked preference: App Update', () => {
+        let appUpdateRow: Locator;
+        let value: boolean;
+        test('Expected settings value', async () => {
+          appUpdateRow = preferencesPage.getPreferenceRowByName(Preferences.Labels.APP_UPDATE);
+          await playExpect(appUpdateRow).toBeAttached();
+
+          const isManaged = await preferencesPage.isPreferenceManaged(Preferences.Labels.APP_UPDATE);
+          playExpect(isManaged).toBeTruthy();
+
+          value = await preferencesPage.getPreferenceCheckboxValue(
+            Preferences.Labels.APP_UPDATE,
+            Preferences.APP_UPDATE_TOGGLE_BUTTON_LABEL,
+          );
+          playExpect(value).toBeFalsy();
+        });
+        test('Preference can not be changed', async () => {
+          const selectionToggle = appUpdateRow.getByLabel(Preferences.APP_UPDATE_TOGGLE_BUTTON_LABEL);
+          await playExpect(selectionToggle).toBeDisabled();
+        });
+        test('Preference can not be reset', async () => {
+          const resetButton = appUpdateRow.getByRole('button', { name: 'Reset to default value' });
+          await playExpect(resetButton).not.toBeAttached();
+        });
+      });
+
+    test.describe
       .serial('Locked preference: Line Height', () => {
         let lineHeightRow: Locator;
         let value: string;


### PR DESCRIPTION
## Summary

- Adds E2E test for `preferences.update.appUpdate` managed configuration (merged in #17682)
- Verifies the setting shows the Managed badge, is locked (disabled), and cannot be reset when configured via `default-settings.json` + `locked.json`
- Follows the existing "Defaults + Locked" pattern in `managed-configuration-combined.spec.ts`

## Changes

- `tests/playwright/resources/managed-configuration/default-settings.json` — added `preferences.update.appUpdate: false`
- `tests/playwright/resources/managed-configuration/locked.json` — added `preferences.update.appUpdate` to locked array
- `tests/playwright/src/model/core/settings/preferences.ts` — added `APP_UPDATE` label and toggle button constants
- `tests/playwright/src/special-specs/managed-configuration/managed-configuration-combined.spec.ts` — added "Defaults + Locked preference: App Update" test block

## What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/18024

**Follow-up:** https://github.com/podman-desktop/podman-desktop/issues/18763 tracks E2E test for `providers.allowUpdate` (blocked on PR #17878)

## How to test this PR?

1. Copy managed config files to OS-level directory:
   ```bash
   sudo cp tests/playwright/resources/managed-configuration/default-settings.json /usr/share/podman-desktop/
   sudo cp tests/playwright/resources/managed-configuration/locked.json /usr/share/podman-desktop/
   ```
2. Run managed configuration E2E tests:
   ```bash
   pnpm test:e2e:managed-configuration
   ```
3. Verify the "App Update" preference row shows "Managed" badge, is disabled, and has no reset button

## Test plan

- [x] Manually verified against running Podman Desktop binary with managed config applied
- [x] Manually verified without managed config (setting is enabled, no Managed badge)
- [x] Lint passes
- [ ] CI managed-configuration pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)