### PR TITLE
refactor(renderer): migrate Route to Svelte 5

### DIFF
--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -7,20 +7,30 @@ import type { NavigationHint } from './navigation';
 import { currentPage, history, lastPage } from './stores/breadcrumb';
 import { TelemetryService } from './TelemetryService';
 
-export let path = '/*';
-export let fallback = false;
-export let redirect = false;
-export let firstmatch = false;
-export let breadcrumb: string | undefined = undefined;
-export let navigationHint: NavigationHint | undefined = undefined;
-export let requestParser:
-  | ((request: { query: Record<string, string>; params: Record<string, string> }) => T)
-  | undefined = undefined;
+interface Props {
+  path?: string;
+  fallback?: boolean;
+  redirect?: boolean;
+  firstmatch?: boolean;
+  breadcrumb?: string;
+  navigationHint?: NavigationHint;
+  requestParser?: (request: { query: Record<string, string>; params: Record<string, string> }) => T;
+}
 
-let showContent = false;
-let params: Record<string, string> = {};
-let meta: TinroRouteMeta = { url: '' } as TinroRouteMeta;
-let request: T | undefined;
+let {
+  path = '/*',
+  fallback = false,
+  redirect = false,
+  firstmatch = false,
+  breadcrumb,
+  navigationHint,
+  requestParser,
+}: Props = $props();
+
+let showContent = $state(false);
+let params = $state<Record<string, string>>({});
+let meta = $state<TinroRouteMeta>({ url: '' } as TinroRouteMeta);
+let request: T | undefined = $derived(requestParser && meta ? requestParser(meta) : undefined);
 
 const route = createRouteObject({
   fallback,
@@ -71,14 +81,14 @@ function processMetaBreadcrumbs(breadcrumbs?: Array<TinroBreadcrumb>): void {
   }
 }
 
-$: route.update({
-  path,
-  redirect,
-  firstmatch,
-  breadcrumb,
+$effect(() => {
+  route.update({
+    path,
+    redirect,
+    firstmatch,
+    breadcrumb,
+  });
 });
-
-$: request = requestParser && meta ? requestParser(meta) : undefined;
 
 onDestroy(() => {
   TelemetryService.getService().handlePageClose();

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" generics="T">
-import { onDestroy } from 'svelte';
+import { onDestroy, untrack } from 'svelte';
 import type { TinroBreadcrumb, TinroRouteMeta } from 'tinro';
 import { createRouteObject } from 'tinro/dist/tinro_lib';
 
@@ -82,12 +82,10 @@ function processMetaBreadcrumbs(breadcrumbs?: Array<TinroBreadcrumb>): void {
 }
 
 $effect(() => {
-  route.update({
-    path,
-    redirect,
-    firstmatch,
-    breadcrumb,
-  });
+  const args = { path, redirect, firstmatch, breadcrumb };
+
+  // untrack to prevent route.update() internal store reads/writes from being tracked as dependencies
+  untrack(() => route.update(args));
 });
 
 onDestroy(() => {

--- a/packages/renderer/src/Route.svelte
+++ b/packages/renderer/src/Route.svelte
@@ -81,7 +81,7 @@ function processMetaBreadcrumbs(breadcrumbs?: Array<TinroBreadcrumb>): void {
   }
 }
 
-$effect(() => {
+$effect.pre(() => {
   const args = { path, redirect, firstmatch, breadcrumb };
 
   // untrack to prevent route.update() internal store reads/writes from being tracked as dependencies


### PR DESCRIPTION
### What does this PR do?
Migrates Route.svelte to Svelte 5 syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature