### PR TITLE
refactor(renderer): migrate DetailsSubtitle to Svelte 5

### DIFF
--- a/packages/renderer/src/lib/details/DetailsSubtitle.svelte
+++ b/packages/renderer/src/lib/details/DetailsSubtitle.svelte
@@ -1,14 +1,9 @@
 <script lang="ts">
-import type { Snippet } from 'svelte';
 import type { HTMLTdAttributes } from 'svelte/elements';
 
-interface Props extends HTMLTdAttributes {
-  children?: Snippet;
-}
-
-let { children, ...props }: Props = $props();
+let { class: className, children, ...restProps }: HTMLTdAttributes = $props();
 </script>
 
-<td class="pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)]" {...props}>
+<td class={['pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)]', className]} {...restProps}>
   {@render children?.()}
 </td>

--- a/packages/renderer/src/lib/details/DetailsSubtitle.svelte
+++ b/packages/renderer/src/lib/details/DetailsSubtitle.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-export let style: string = '';
+interface Props {
+  style?: string;
+}
+
+let { style = '' }: Props = $props();
 </script>
 
 <td class="pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)] {style}">

--- a/packages/renderer/src/lib/details/DetailsSubtitle.svelte
+++ b/packages/renderer/src/lib/details/DetailsSubtitle.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-interface Props {
-  style?: string;
-}
+import type { HTMLAttributes } from 'svelte/elements';
 
-let { style = '' }: Props = $props();
+let { ...props }: HTMLAttributes<HTMLTableCellElement> = $props();
 </script>
 
-<td class="pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)] {style}">
+<td class="pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)]" {...props}>
   <slot />
 </td>

--- a/packages/renderer/src/lib/details/DetailsSubtitle.svelte
+++ b/packages/renderer/src/lib/details/DetailsSubtitle.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
+import type { Snippet } from 'svelte';
 import type { HTMLTdAttributes } from 'svelte/elements';
 
-let { class: className, children, ...restProps }: HTMLTdAttributes = $props();
+interface Props extends HTMLTdAttributes {
+  children?: Snippet;
+}
+
+let { class: className, children, ...restProps }: Props = $props();
 </script>
 
 <td class={['pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)]', className]} {...restProps}>

--- a/packages/renderer/src/lib/details/DetailsSubtitle.svelte
+++ b/packages/renderer/src/lib/details/DetailsSubtitle.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
-import type { HTMLAttributes } from 'svelte/elements';
+import type { Snippet } from 'svelte';
+import type { HTMLTdAttributes } from 'svelte/elements';
 
-let { ...props }: HTMLAttributes<HTMLTableCellElement> = $props();
+interface Props extends HTMLTdAttributes {
+  children?: Snippet;
+}
+
+let { children, ...props }: Props = $props();
 </script>
 
 <td class="pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)]" {...props}>
-  <slot />
+  {@render children?.()}
 </td>

--- a/packages/renderer/src/lib/details/DetailsSubtitle.svelte
+++ b/packages/renderer/src/lib/details/DetailsSubtitle.svelte
@@ -9,6 +9,6 @@ interface Props extends HTMLTdAttributes {
 let { class: className, children, ...restProps }: Props = $props();
 </script>
 
-<td class={['pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)]', className]} {...restProps}>
+<td class="pl-2 text-md font-semibold text-[var(--pd-table-body-text-sub-secondary)] {className}" {...restProps}>
   {@render children?.()}
 </td>


### PR DESCRIPTION
### What does this PR do?
Migrates DetailsSubtitle.svelte to Svelte 5 syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature