### PR TITLE
refactor(renderer): migrate MonacoEditor to Svelte 5  

### DIFF
--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -9,14 +9,18 @@ import type { Unsubscriber } from 'svelte/store';
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 import { isDark } from '/@/stores/appearance';
 
+interface Props {
+  content?: string;
+  language?: string;
+  readOnly?: boolean;
+}
+
+let { content = '', language = 'json', readOnly = true }: Props = $props();
+
 let divEl: HTMLDivElement;
 let editor: monaco.editor.IStandaloneCodeEditor;
 let Monaco;
 let isDarkUnsubscribe: Unsubscriber;
-
-export let content = '';
-export let language = 'json';
-export let readOnly = true;
 
 const dispatch = createEventDispatcher<{ contentChange: string }>();
 
@@ -84,7 +88,9 @@ onDestroy(() => {
   }
 });
 
-$: content, editor?.getModel()?.setValue(content);
+$effect(() => {
+  editor?.getModel()?.setValue(content);
+});
 </script>
 
 <div bind:this={divEl} class="h-full"></div>


### PR DESCRIPTION
### What does this PR do?
Migrates MonacoEditor.svelte to Svelte 5 syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature