### PR TITLE
refactor(renderer): migrate Prune to Svelte 5 

### DIFF
--- a/packages/renderer/src/lib/engine/Prune.svelte
+++ b/packages/renderer/src/lib/engine/Prune.svelte
@@ -4,11 +4,12 @@ import { Button } from '@podman-desktop/ui-svelte';
 
 import type { EngineInfoUI } from './EngineInfoUI';
 
-// Imported type for prune (containers, images, pods, volumes)
-export let type: 'containers' | 'images' | 'pods' | 'volumes';
+interface Props {
+  type: 'containers' | 'images' | 'pods' | 'volumes'; // Imported type for prune (containers, images, pods, volumes)
+  engines: EngineInfoUI[]; // List of engines that the prune will work on
+}
 
-// List of engines that the prune will work on
-export let engines: EngineInfoUI[];
+let { type, engines }: Props = $props();
 
 const LABEL_IMAGE_UNUSED = 'All unused images';
 const LABEL_IMAGE_UNTAGGED = 'All untagged images';


### PR DESCRIPTION
### What does this PR do?
Migrates Prune.svelte to Svelte 5 syntax.

### Screenshot / video of UI

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18613

### How to test this PR?

- [X] Tests are covering the bug fix or the new feature