### PR TITLE
refactor(docker-desktop-installation): replace got dependency by native fetch

### DIFF
--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -74,8 +74,8 @@ class TestDockerDesktopInstallation extends DockerDesktopInstallation {
     return super.isHttpMethod(methodName);
   }
 
-  override asHttpMethod(methodName: string): string {
-    return super.asHttpMethod(methodName);
+  override assertHttpMethod(methodName: string): string {
+    return super.assertHttpMethod(methodName);
   }
 
   override async handleExtensionVMServiceRequest(port: string, config: RequestConfig): Promise<unknown> {
@@ -116,10 +116,10 @@ test('Check isHttpMethod', async () => {
 });
 
 test('Check asHttpMethod', async () => {
-  expect(dockerDesktopInstallation.asHttpMethod('GET')).toBe('GET');
-  expect(dockerDesktopInstallation.asHttpMethod('get')).toBe('get');
+  expect(dockerDesktopInstallation.assertHttpMethod('GET')).toBe('GET');
+  expect(dockerDesktopInstallation.assertHttpMethod('get')).toBe('get');
 
-  expect(() => dockerDesktopInstallation.asHttpMethod('foobar')).toThrowError('Invalid method');
+  expect(() => dockerDesktopInstallation.assertHttpMethod('foobar')).toThrowError('Invalid method');
 });
 
 describe('handleExtensionVMServiceRequest', () => {
@@ -266,7 +266,7 @@ describe('handleExtensionVMServiceRequest', () => {
   });
 
   test('Check unknown error ', async () => {
-    vi.spyOn(dockerDesktopInstallation, 'asHttpMethod').mockImplementation(() => {
+    vi.spyOn(dockerDesktopInstallation, 'assertHttpMethod').mockImplementation(() => {
       throw new Error('foo error');
     });
 

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.spec.ts
@@ -23,7 +23,6 @@ import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type Dockerode from 'dockerode';
 import type { IpcMainEvent } from 'electron';
-import type { Method } from 'got';
 import { http, HttpResponse } from 'msw';
 import { type SetupServer, setupServer } from 'msw/node';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -71,13 +70,12 @@ const apiSender: ApiSenderType = {
 let server: SetupServer | undefined = undefined;
 
 class TestDockerDesktopInstallation extends DockerDesktopInstallation {
-  // transform the method name to a got method
-  override isGotMethod(methodName: string): methodName is Method {
-    return super.isGotMethod(methodName);
+  override isHttpMethod(methodName: string): boolean {
+    return super.isHttpMethod(methodName);
   }
 
-  override asGotMethod(methodName: string): Method {
-    return super.asGotMethod(methodName);
+  override asHttpMethod(methodName: string): string {
+    return super.asHttpMethod(methodName);
   }
 
   override async handleExtensionVMServiceRequest(port: string, config: RequestConfig): Promise<unknown> {
@@ -106,22 +104,22 @@ afterEach(() => {
   server?.close();
 });
 
-test('Check isGotMethod', async () => {
-  expect(dockerDesktopInstallation.isGotMethod('GET')).toBeTruthy();
-  expect(dockerDesktopInstallation.isGotMethod('get')).toBeTruthy();
-  expect(dockerDesktopInstallation.isGotMethod('put')).toBeTruthy();
-  expect(dockerDesktopInstallation.isGotMethod('POST')).toBeTruthy();
-  expect(dockerDesktopInstallation.isGotMethod('delete')).toBeTruthy();
+test('Check isHttpMethod', async () => {
+  expect(dockerDesktopInstallation.isHttpMethod('GET')).toBeTruthy();
+  expect(dockerDesktopInstallation.isHttpMethod('get')).toBeTruthy();
+  expect(dockerDesktopInstallation.isHttpMethod('put')).toBeTruthy();
+  expect(dockerDesktopInstallation.isHttpMethod('POST')).toBeTruthy();
+  expect(dockerDesktopInstallation.isHttpMethod('delete')).toBeTruthy();
 
   // invalid
-  expect(dockerDesktopInstallation.isGotMethod('ff')).toBeFalsy();
+  expect(dockerDesktopInstallation.isHttpMethod('ff')).toBeFalsy();
 });
 
-test('Check asGotMethod', async () => {
-  expect(dockerDesktopInstallation.asGotMethod('GET')).toBe('GET');
-  expect(dockerDesktopInstallation.asGotMethod('get')).toBe('get');
+test('Check asHttpMethod', async () => {
+  expect(dockerDesktopInstallation.asHttpMethod('GET')).toBe('GET');
+  expect(dockerDesktopInstallation.asHttpMethod('get')).toBe('get');
 
-  expect(() => dockerDesktopInstallation.asGotMethod('foobar')).toThrowError('Invalid method');
+  expect(() => dockerDesktopInstallation.asHttpMethod('foobar')).toThrowError('Invalid method');
 });
 
 describe('handleExtensionVMServiceRequest', () => {
@@ -268,7 +266,7 @@ describe('handleExtensionVMServiceRequest', () => {
   });
 
   test('Check unknown error ', async () => {
-    vi.spyOn(dockerDesktopInstallation, 'asGotMethod').mockImplementation(() => {
+    vi.spyOn(dockerDesktopInstallation, 'asHttpMethod').mockImplementation(() => {
       throw new Error('foo error');
     });
 

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -252,7 +252,7 @@ export class DockerDesktopInstallation {
     return allMethods.includes(methodName);
   }
 
-  protected asHttpMethod(methodName: string): string {
+  protected assertHttpMethod(methodName: string): string {
     if (!this.isHttpMethod(methodName)) {
       throw Error('Invalid method');
     }
@@ -260,7 +260,7 @@ export class DockerDesktopInstallation {
   }
 
   protected async handleExtensionVMServiceRequest(port: string, config: v1.RequestConfig): Promise<unknown> {
-    const method = this.asHttpMethod(config.method);
+    const method = this.assertHttpMethod(config.method);
 
     const headers: Record<string, string> = { ...config.headers };
     let body: string | undefined;

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installation.ts
@@ -27,8 +27,6 @@ import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type Dockerode from 'dockerode';
 import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron';
 import { ipcMain } from 'electron';
-import type { Method, OptionsOfTextResponseBody } from 'got';
-import got, { RequestError } from 'got';
 import * as tarFs from 'tar-fs';
 
 import type { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
@@ -232,8 +230,7 @@ export class DockerDesktopInstallation {
     );
   }
 
-  // transform the method name to a got method
-  protected isGotMethod(methodName: string): methodName is Method {
+  protected isHttpMethod(methodName: string): boolean {
     const allMethods = [
       'GET',
       'POST',
@@ -255,48 +252,37 @@ export class DockerDesktopInstallation {
     return allMethods.includes(methodName);
   }
 
-  protected asGotMethod(methodName: string): Method {
-    if (!this.isGotMethod(methodName)) {
+  protected asHttpMethod(methodName: string): string {
+    if (!this.isHttpMethod(methodName)) {
       throw Error('Invalid method');
     }
-    return methodName as Method;
+    return methodName;
   }
 
   protected async handleExtensionVMServiceRequest(port: string, config: v1.RequestConfig): Promise<unknown> {
-    // use got library
+    const method = this.asHttpMethod(config.method);
+
+    const headers: Record<string, string> = { ...config.headers };
+    let body: string | undefined;
+    if (config.data) {
+      body = JSON.stringify(config.data);
+      headers['Content-Type'] = 'application/json';
+    }
+
+    const response = await fetch(`http://localhost:${port}${config.url}`, { method, headers, body });
+
+    if (response.status === 401 || response.status === 403) {
+      throw Error('Unable to get access');
+    }
+    if (!response.ok) {
+      throw Error(response.statusText);
+    }
+
+    const text = await response.text();
     try {
-      const method: Method = this.asGotMethod(config.method);
-
-      const options: OptionsOfTextResponseBody = {
-        method,
-      };
-
-      if (config.data) {
-        options.json = config.data;
-      }
-
-      options.headers = config.headers;
-
-      const response = await got(`http://localhost:${port}${config.url}`, options);
-
-      // try to see if response is json
-      try {
-        return JSON.parse(response.body);
-      } catch (error) {
-        // provides the body as is
-        return response.body;
-      }
-    } catch (requestErr) {
-      if (
-        requestErr instanceof RequestError &&
-        (requestErr.response?.statusCode === 401 || requestErr.response?.statusCode === 403)
-      ) {
-        throw Error('Unable to get access');
-      } else if (requestErr instanceof Error) {
-        throw Error(requestErr.message);
-      } else {
-        throw Error('Unknown error: ' + requestErr);
-      }
+      return JSON.parse(text);
+    } catch {
+      return text;
     }
   }
 


### PR DESCRIPTION
### What does this PR do?

We are using `got` dependency in 2 places.

- `packages/main/src/plugin/docker-extension/docker-desktop-installation.ts`
- `packages/main/src/plugin/image-registry.ts`

got was nice when fetch on node was lacking feature, but now fetch is capable of doing everything got was providing. It is even causing some issues with the proxy (https://github.com/podman-desktop/podman-desktop/issues/18356), having a single http client will help us avoid maintaining two clients.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Required for https://github.com/podman-desktop/podman-desktop/issues/18134

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

I really tried to find a way to test this, but we don't really have coverage. Moreover, HeadLamp Docker Extension is not using the HttpService, so we can't do things like

```
await ddClient.extension.vm.service.get('/config')
Uncaught Error: Error invoking remote method 'docker-desktop-adapter:extensionVMServiceRequest': TypeError: fetch failed
```

