### PR TITLE
fix(renderer): a details value with nothing to wrap at no longer widens the card

### DIFF
--- a/packages/renderer/src/lib/details/DetailsCell.spec.ts
+++ b/packages/renderer/src/lib/details/DetailsCell.spec.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import DetailsCell from './DetailsCell.svelte';
+
+test('a details cell can wrap a value with nothing to wrap at', async () => {
+  render(DetailsCell);
+
+  // The defect this guards: a details cell holds values nobody chose the length
+  // of — a container command, an image digest, a secret. One with no spaces
+  // cannot wrap, so the table takes its width from that value and the card
+  // scrolls sideways, putting the labels and every other field off-screen.
+  expect(screen.getByRole('cell')).toHaveClass('wrap-anywhere');
+});
+
+test('the caller can still add classes of its own', async () => {
+  render(DetailsCell, { style: 'text-right' });
+
+  const cell = screen.getByRole('cell');
+  expect(cell).toHaveClass('text-right');
+  expect(cell).toHaveClass('wrap-anywhere');
+});

--- a/packages/renderer/src/lib/details/DetailsCell.svelte
+++ b/packages/renderer/src/lib/details/DetailsCell.svelte
@@ -3,6 +3,15 @@ export let style: string = '';
 export let onClick: () => void = () => {};
 </script>
 
-<td class="pt-1 pl-3 {style} {$$props.class}" on:click={onClick}>
+<!-- wrap-anywhere, because a details cell holds values nobody chose the length
+     of: a container command, an image digest, a secret, a config map entry. A
+     value with no spaces in it cannot wrap, so without this the table takes its
+     width from that one value and the whole card scrolls sideways — at which
+     point the label column and every other field are off-screen.
+
+     Not break-all: that breaks ordinary words too, so prose and hyphenated names
+     get chopped mid-word even when they would have fitted. overflow-wrap:
+     anywhere breaks only what would otherwise overflow. -->
+<td class="pt-1 pl-3 wrap-anywhere {style} {$$props.class}" on:click={onClick}>
   <slot />
 </td>


### PR DESCRIPTION
### What does this PR do?

A details cell holds values nobody chose the length of: a container command, an image digest, a secret, a config map entry. A value with no spaces in it cannot wrap, so the table takes its width from that one value and the whole card scrolls sideways — and while it is scrolled the label column and every other field are off-screen.

Measured on a build of `main` with a container whose command carries a 420-character run of no spaces: the details pane went from 949px of visible width to 2768px of content. Nothing was corrupted — `document.body` does not scroll and the app chrome is untouched — but reading the command meant losing everything else.

`wrap-anywhere` rather than `break-all`: `break-all` breaks ordinary words too, so prose and hyphenated names get chopped mid-word even when they would have fitted, while `overflow-wrap: anywhere` breaks only what would otherwise overflow. With it the pane comes back to exactly 949px and every field stays visible.

**Where to look**
One declaration in `DetailsCell.svelte`; the other 42 lines are its spec.

The fix is on `DetailsCell` rather than on the container summary because the same cell renders in 157 places, and image digests, secret values and kube config map entries are unbreakable for the same reason — they fit today only because they happen to be shorter. The whole renderer suite (543 files, 2991 tests) is green, which is the evidence that widening it changed nothing at those call sites.

**Not in this PR**
No truncation and no tooltip. Both were discussed on #18561; wrapping shows the whole value, and a tooltip hides behind a hover the one thing the reader opened the card for.

### Screenshot / video of UI

Before — the command runs past the right edge, and scrolled fully right the labels and every other field are gone:

<img width="1109" height="840" alt="details card with the command overflowing" src="https://github.com/user-attachments/assets/1d03c163-3872-4b08-bb18-b25f4d98e41d" />
<img width="1109" height="840" alt="scrolled right: only the tail of one value is visible" src="https://github.com/user-attachments/assets/159d8b8f-808e-4ef4-b286-910ade71fe76" />

After — the command wraps and every field stays in view:

<img width="1109" height="840" alt="details card with the command wrapped" src="https://github.com/user-attachments/assets/4f892a76-ad16-479d-bbba-d4ac39ef6a8e" />

### What issues does this PR fix or reference?

Fixes #18778

### How to test this PR?

1. Start a container whose command carries a long run with no spaces:
   `podman run -d --name long-cmd alpine sh -c "echo $(python3 -c "print('x'*420)"); sleep 3600"`
   Expected: the container starts.
2. Open **Containers**, click `long-cmd`, open the **Summary** tab.
   Expected: the Command row wraps across several lines and stays inside the pane.
   Before this change: the value runs past the right edge.
3. Look at the rest of the card without scrolling sideways.
   Expected: Name, ID, Image, Ports, State, Uptime and the Group section are all visible, with their labels.
4. Open the Summary tab of an image and a secret.
   Expected: unchanged — digests and values already fitted, and wrapping only takes effect where a value would otherwise overflow.

**Notes for reviewers**
n/a — nothing here is outside what CI checks. The change is one CSS utility and a unit test; `test:renderer` covers the component and every one of the 157 call sites.

- [ ] Tests are covering the bug fix or the new feature

<sub>Prepared with podman-desktop-kit (Claude Code Plugin), reviewed by @vzhukovs</sub>
