### PR TITLE
fix: show provider warnings for configured and installed states

### DIFF
--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { beforeAll, test, vi } from 'vitest';
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import { render, screen } from '@testing-library/svelte';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import ProviderConfigured from '/@/lib/dashboard/ProviderConfigured.svelte';
+import { InitializeOnlyMode } from '/@/lib/dashboard/ProviderInitUtils';
+import { providerInfos } from '/@/stores/providers';
 
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 
@@ -32,10 +36,56 @@ beforeAll(() => {
   });
 });
 
+beforeEach(() => {
+  providerInfos.set([]);
+});
+
 test('Expect configured provider shows update button', async () => {
   await verifyStatus(ProviderConfigured, 'configured', false);
 });
 
 test('Expect configured provider does not show update button if version same', async () => {
   await verifyStatus(ProviderConfigured, 'configured', true);
+});
+
+test('Expect configured provider shows multiple installation warnings', async () => {
+  const provider: ProviderInfo = {
+    containerConnections: [],
+    containerProviderConnectionCreation: false,
+    containerProviderConnectionInitialization: false,
+    detectionChecks: [],
+    id: 'podman',
+    images: {},
+    installationSupport: false,
+    internalId: 'podman-internal',
+    kubernetesConnections: [],
+    kubernetesProviderConnectionCreation: false,
+    kubernetesProviderConnectionInitialization: false,
+    vmConnections: [],
+    vmProviderConnectionCreation: false,
+    vmProviderConnectionInitialization: false,
+    links: [],
+    name: 'Podman',
+    status: 'configured',
+    warnings: [
+      {
+        name: 'Multiple Podman installations detected',
+        details: 'You have multiple Podman instances in your PATH.',
+      },
+    ],
+    version: '5.0.0',
+    extensionId: '',
+    cleanupSupport: false,
+    canStart: false,
+    canStop: false,
+  };
+
+  providerInfos.set([provider]);
+  render(ProviderConfigured, {
+    provider,
+    initializationContext: { mode: InitializeOnlyMode },
+  });
+
+  expect(screen.getByRole('list', { name: 'Provider Warnings' })).toBeInTheDocument();
+  expect(screen.getByRole('listitem', { name: 'Multiple Podman installations detected' })).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderConfigured.svelte
@@ -14,6 +14,7 @@ import {
   InitializeOnlyMode,
 } from './ProviderInitUtils';
 import ProviderUpdateButton from './ProviderUpdateButton.svelte';
+import ProviderWarnings from './ProviderWarnings.svelte';
 
 interface Props {
   provider: ProviderInfo;
@@ -64,6 +65,7 @@ onMount(async () => {
           v{provider.version}
         {/if} needs to be started.
       </p>
+      <ProviderWarnings provider={provider} />
       <div class="w-1/3 flex justify-center">
         <Button on:click={runProvider}>
           Run {provider.name}

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderInfo } from '@podman-desktop/core-api';
-import { render } from '@testing-library/svelte';
+import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import { type InitializationContext, InitializeAndStartMode } from '/@/lib/dashboard/ProviderInitUtils';
 import ProviderInstalled from '/@/lib/dashboard/ProviderInstalled.svelte';
+import { providerInfos } from '/@/stores/providers';
 
 import { verifyStatus } from './ProviderStatusTestHelper.spec';
 
@@ -59,6 +60,10 @@ beforeAll(() => {
     func();
     return { dispose: vi.fn() };
   });
+});
+
+beforeEach(() => {
+  providerInfos.set([]);
 });
 
 test('Expect installed provider shows button', async () => {
@@ -170,4 +175,46 @@ test('Expect to see the initialize context error if provider installation fails'
 
   expect((initializationContext as InitializationContextImpl).promise).toBeDefined();
   expect((initializationContext as InitializationContextImpl).error).toBeDefined();
+});
+
+test('Expect installed provider shows multiple installation warnings', async () => {
+  const provider: ProviderInfo = {
+    containerConnections: [],
+    containerProviderConnectionCreation: false,
+    containerProviderConnectionInitialization: false,
+    detectionChecks: [],
+    id: 'podman',
+    images: {},
+    installationSupport: false,
+    internalId: 'podman-internal',
+    kubernetesConnections: [],
+    kubernetesProviderConnectionCreation: false,
+    kubernetesProviderConnectionInitialization: false,
+    vmConnections: [],
+    vmProviderConnectionCreation: false,
+    vmProviderConnectionInitialization: false,
+    links: [],
+    name: 'Podman',
+    status: 'installed',
+    warnings: [
+      {
+        name: 'Multiple Podman installations detected',
+        details: 'You have multiple Podman instances in your PATH.',
+      },
+    ],
+    version: '5.0.0',
+    extensionId: '',
+    cleanupSupport: false,
+    canStart: false,
+    canStop: false,
+  };
+
+  providerInfos.set([provider]);
+  render(ProviderInstalled, {
+    provider,
+    initializationContext: { mode: InitializeAndStartMode },
+  });
+
+  expect(screen.getByRole('list', { name: 'Provider Warnings' })).toBeInTheDocument();
+  expect(screen.getByRole('listitem', { name: 'Multiple Podman installations detected' })).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
+++ b/packages/renderer/src/lib/dashboard/ProviderInstalled.svelte
@@ -22,6 +22,7 @@ import {
   InitializeOnlyMode,
 } from './ProviderInitUtils';
 import ProviderUpdateButton from './ProviderUpdateButton.svelte';
+import ProviderWarnings from './ProviderWarnings.svelte';
 
 export let provider: ProviderInfo;
 export let initializationContext: InitializationContext;
@@ -167,6 +168,8 @@ async function onInstallationClick(): Promise<void> {
     <p class="text-sm text-[var(--pd-content-text)] w-2/3 text-center" aria-label="Suggested Actions">
       To start working with containers, {provider.name} needs to be initialized.
     </p>
+
+    <ProviderWarnings provider={provider} />
 
     <div class="flex space-x-2 mb-2">
       {#if provider.installationSupport}


### PR DESCRIPTION
### What does this PR do?

Fix adds `<ProviderWarnings provider={provider} />` component to ProviderConfigured and ProviderInstalled components.

### Screenshot / video of UI

https://github.com/user-attachments/assets/5a0fbd46-102e-4c56-a27d-c79196db45d5


### What issues does this PR fix or reference?

This fix closes #14942.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
