### PR TITLE
fix(podman): clean up Hyper-V VMs during migration data reset

### DIFF
--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.spec.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.spec.ts
@@ -47,9 +47,11 @@ test('check stopPodmanProcesses', async () => {
     stderr: '',
   });
 
-  // mock stopProcessesPids
+  // mock stopProcessesPids and removeHyperVMachines
   const getProcessesToStopMock = vi.spyOn(podmanCleanupWindows, 'stopProcessesPids');
   getProcessesToStopMock.mockResolvedValue();
+  const removeHyperVMock = vi.spyOn(podmanCleanupWindows, 'removeHyperVMachines');
+  removeHyperVMock.mockResolvedValue();
 
   await podmanCleanupWindows.stopPodmanProcesses({ logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn() } });
 
@@ -69,6 +71,7 @@ test('check stopPodmanProcesses', async () => {
   expect(process.exec).toHaveBeenNthCalledWith(6, 'wsl', ['--unregister', 'podman-my-machine2'], {
     env: { WSL_UTF8: '1' },
   });
+  expect(removeHyperVMock).toHaveBeenCalled();
 });
 
 test('check stopPodmanProcesses with error', async () => {
@@ -77,6 +80,8 @@ test('check stopPodmanProcesses with error', async () => {
 
   const getProcessesToStopMock = vi.spyOn(podmanCleanupWindows, 'stopProcessesPids');
   getProcessesToStopMock.mockResolvedValue();
+  const removeHyperVMock = vi.spyOn(podmanCleanupWindows, 'removeHyperVMachines');
+  removeHyperVMock.mockResolvedValue();
 
   await podmanCleanupWindows.stopPodmanProcesses({ logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn() } });
 
@@ -84,6 +89,78 @@ test('check stopPodmanProcesses with error', async () => {
 
   // only one call, no call to terminate
   expect(vi.mocked(process.exec).call.length).toBe(1);
+});
+
+test('check removeHyperVMachines removes VMs', async () => {
+  vi.mocked(process.exec)
+    .mockResolvedValueOnce({
+      stdout: 'podman-machine-default\r\npodman-my-machine',
+      command: 'powershell.exe',
+      stderr: '',
+    })
+    .mockResolvedValue({ stdout: '', command: 'powershell.exe', stderr: '' });
+
+  const logger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
+  await podmanCleanupWindows.removeHyperVMachines({ logger });
+
+  expect(process.exec).toHaveBeenNthCalledWith(
+    1,
+    'powershell.exe',
+    expect.arrayContaining([expect.stringContaining('Get-VM -Name "podman-*"')]),
+  );
+  expect(process.exec).toHaveBeenCalledWith(
+    'powershell.exe',
+    expect.arrayContaining([expect.stringContaining('Remove-VM -Name "podman-machine-default"')]),
+  );
+  expect(process.exec).toHaveBeenCalledWith(
+    'powershell.exe',
+    expect.arrayContaining([expect.stringContaining('Remove-VM -Name "podman-my-machine"')]),
+  );
+});
+
+test('check removeHyperVMachines with no VMs found', async () => {
+  vi.mocked(process.exec).mockResolvedValueOnce({
+    stdout: '',
+    command: 'powershell.exe',
+    stderr: '',
+  });
+
+  const logger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
+  await podmanCleanupWindows.removeHyperVMachines({ logger });
+
+  expect(process.exec).toHaveBeenCalledTimes(1);
+});
+
+test('check removeHyperVMachines handles Get-VM error gracefully', async () => {
+  vi.mocked(process.exec).mockRejectedValueOnce(new Error('powershell not available'));
+
+  const logger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
+  await podmanCleanupWindows.removeHyperVMachines({ logger });
+
+  expect(logger.error).toHaveBeenCalledWith('error while listing Hyper-V machines', expect.any(Error));
+});
+
+test('check removeHyperVMachines handles removal failure gracefully', async () => {
+  vi.mocked(process.exec)
+    .mockResolvedValueOnce({
+      stdout: 'podman-machine-default\r\npodman-my-machine',
+      command: 'powershell.exe',
+      stderr: '',
+    })
+    .mockRejectedValueOnce(new Error('remove failed'))
+    .mockResolvedValueOnce({ stdout: '', command: 'powershell.exe', stderr: '' });
+
+  const logger = { log: vi.fn(), error: vi.fn(), warn: vi.fn() };
+  await podmanCleanupWindows.removeHyperVMachines({ logger });
+
+  expect(logger.error).toHaveBeenCalledWith(
+    'unable to remove Hyper-V machine podman-machine-default',
+    expect.any(Error),
+  );
+  expect(process.exec).toHaveBeenCalledWith(
+    'powershell.exe',
+    expect.arrayContaining([expect.stringContaining('Remove-VM -Name "podman-my-machine"')]),
+  );
 });
 
 test('check getContainersConfPath', async () => {

--- a/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.ts
+++ b/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2024 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,8 +78,44 @@ export class PodmanCleanupWindows extends AbsPodmanCleanup {
       options.logger.error('error while listing wsl machines', error);
     }
 
+    // stop and remove Hyper-V podman machines
+    await this.removeHyperVMachines(options);
+
     // stop processes
     await this.stopProcessesPids(options);
+  }
+
+  async removeHyperVMachines(options: ProviderCleanupExecuteOptions): Promise<void> {
+    try {
+      const { stdout } = await process.exec('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        'Get-VM -Name "podman-*" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name',
+      ]);
+
+      if (!stdout.trim()) {
+        return;
+      }
+
+      const machines = stdout.trim().split(/\r?\n/).filter(Boolean);
+
+      for (const machine of machines) {
+        options.logger.log(`Removing Hyper-V machine ${machine}...`);
+        try {
+          await process.exec('powershell.exe', [
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            `Remove-VM -Name "${machine}" -Force`,
+          ]);
+        } catch (error) {
+          options.logger.error(`unable to remove Hyper-V machine ${machine}`, error);
+        }
+      }
+    } catch (error) {
+      options.logger.error('error while listing Hyper-V machines', error);
+    }
   }
 
   async getPidProcesses(processNames: string[]): Promise<{ pid: number; name: string }[]> {


### PR DESCRIPTION
### What does this PR do?

Adds Hyper-V VM cleanup during the Podman 5→6 migration data reset on Windows. When the user confirms "reset all data" during the update flow, any `podman-*` Hyper-V VMs are now discovered via `Get-VM` and removed via `Remove-VM`, preventing stale VMs from being left behind in Hyper-V Manager.

This follows the same pattern already used for WSL machines — enumerate by `podman-` prefix via the platform tool, then remove directly:

https://github.com/podman-desktop/podman-desktop/blob/fc492d3d76dce0a590d1d2496e0778d085f003a9/extensions/podman/packages/extension/src/cleanup/podman-cleanup-windows.ts#L58-L79

### Screenshot / video of UI

N/A — no UI changes.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18497

### How to test this PR?

Download the built artifacts from the CI checks and install on a Windows machine.

1. Have Podman 5.8.5 installed.
2. In Podman Desktop, create a Hyper-V Podman machine and confirm it is running (e.g. run a pod).
3. On the Resources page, click **Update** to Podman 6.
4. When prompted to stop machines, click **Yes** (clicking No cancels the update). Verify in Hyper-V Manager that the machine is stopped.
5. When prompted to reset all data, click **Yes**. Verify in Hyper-V Manager that the machine is now deleted.
6. Complete the update wizard.
7. Create a new Podman machine (select Hyper-V), and verify it works correctly (e.g. run a pod).

- [x] Tests are covering the bug fix or the new feature


Made with [Cursor](https://cursor.com)