### PR TITLE
refactor(renderer/tests): replace `(window as any)` with proper mock access

### DIFF
--- a/packages/renderer/src/lib/context/contextKey.spec.ts
+++ b/packages/renderer/src/lib/context/contextKey.spec.ts
@@ -167,9 +167,7 @@ suite('ContextKeyExpr', () => {
   });
 
   test('false, true', async () => {
-    const getOsPlatformMock = vi.fn();
-    (window as any).getOsPlatform = getOsPlatformMock;
-    getOsPlatformMock.mockResolvedValue('darwin');
+    vi.mocked(window.getOsPlatform).mockResolvedValue('darwin');
     await initContextKeysPlatform();
 
     function testNormalize(expr: string, expected: string): void {

--- a/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
+++ b/packages/renderer/src/lib/pod/PodCreateFromContainers.spec.ts
@@ -18,8 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { ContainerInspectInfo } from '@podman-desktop/api';
-import type { ProviderInfo } from '@podman-desktop/core-api';
+import type { ContainerInspectInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { expect, test, vi } from 'vitest';
 
@@ -243,10 +242,8 @@ test('Expect to see name input, containers and exposed ports list', async () => 
 });
 
 test('Show error if pod creation fails', async () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).getContainerInspect = vi.fn().mockResolvedValue(containerInspectInfo);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (window as any).createPod = vi.fn().mockRejectedValue('error create pod');
+  vi.mocked(window.getContainerInspect).mockResolvedValue(containerInspectInfo);
+  vi.mocked(window.createPod).mockRejectedValue('error create pod');
   providerInfos.set([providerInfo]);
   podCreationHolder.set(podCreation);
 

--- a/packages/renderer/src/lib/pod/PodsList.spec.ts
+++ b/packages/renderer/src/lib/pod/PodsList.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type {
@@ -38,12 +36,6 @@ import { beforeAll, expect, test, vi } from 'vitest';
 import PodsList from '/@/lib/pod/PodsList.svelte';
 import { filtered, podsInfos } from '/@/stores/pods';
 import { providerInfos } from '/@/stores/providers';
-
-const getProvidersInfoMock = vi.fn();
-const listPodsMock = vi.fn();
-const listContainersMock = vi.fn();
-const getContributedMenusMock = vi.fn();
-const kubernetesGetCurrentNamespaceMock = vi.fn();
 
 const provider: ProviderInfo = {
   canStart: false,
@@ -238,15 +230,9 @@ const ocppod: PodInfo = {
 beforeAll(() => {
   vi.mocked(window.kubernetesGetContextsGeneralState).mockResolvedValue(new Map());
   vi.mocked(window.kubernetesGetCurrentContextGeneralState).mockResolvedValue({} as ContextGeneralState);
-  (window as any).getProviderInfos = getProvidersInfoMock;
-  (window as any).listPods = listPodsMock;
-  (window as any).listContainers = listContainersMock.mockResolvedValue([]);
-  (window as any).kubernetesGetCurrentNamespace = kubernetesGetCurrentNamespaceMock;
-  (window as any).onDidUpdateProviderStatus = vi.fn().mockResolvedValue(undefined);
-  (window as any).removePod = vi.fn();
-  (window as any).kubernetesGetDetailedContexts = vi.fn().mockResolvedValue([]);
-  vi.mocked(window.removePod);
-  (window as any).getConfigurationValue = vi.fn();
+  vi.mocked(window.listContainers).mockResolvedValue([]);
+  vi.mocked(window.onDidUpdateProviderStatus).mockResolvedValue(undefined);
+  vi.mocked(window.kubernetesGetDetailedContexts).mockResolvedValue([]);
   vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
 
   vi.mocked(window.events.receive).mockImplementation((_channel, func) => {
@@ -254,8 +240,7 @@ beforeAll(() => {
     return { dispose: vi.fn() };
   });
 
-  (window as any).getContributedMenus = getContributedMenusMock;
-  getContributedMenusMock.mockResolvedValue([]);
+  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
 });
 
 async function waitRender(customProperties: object): Promise<void> {
@@ -264,7 +249,7 @@ async function waitRender(customProperties: object): Promise<void> {
 }
 
 test('Expect no pods being displayed', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
 
   await vi.waitUntil(() => get(providerInfos).length !== 0);
@@ -275,8 +260,8 @@ test('Expect no pods being displayed', async () => {
 });
 
 test('Expect single podman pod being displayed', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([pod1]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([pod1]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -297,8 +282,8 @@ test('Expect single podman pod being displayed', async () => {
 });
 
 test('Expect 2 podman pods being displayed', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([pod1, pod2]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([pod1, pod2]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -318,8 +303,8 @@ test('Expect 2 podman pods being displayed', async () => {
 });
 
 test('Expect filter empty screen', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([pod1]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([pod1]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -331,8 +316,8 @@ test('Expect filter empty screen', async () => {
 });
 
 test('Expect the route to a pod details page is correctly encoded with an engineId containing / characters', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([ocppod]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([ocppod]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -363,8 +348,8 @@ test('Expect the route to a pod details page is correctly encoded with an engine
 });
 
 test('Expect the pod1 row to have 3 status dots with the correct colors and the pod2 row to have 1 status dot', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([pod1, pod2]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([pod1, pod2]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -385,8 +370,8 @@ test('Expect the pod1 row to have 3 status dots with the correct colors and the 
 });
 
 test('Expect the manyPod row to show 9 dots representing every status', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([manyPod]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([manyPod]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -458,8 +443,8 @@ const stoppedPod: PodInfo = {
 };
 
 test('Expect All tab to show all pods running and stopped (not running)', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([stoppedPod, runningPod]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([stoppedPod, runningPod]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -476,8 +461,8 @@ test('Expect All tab to show all pods running and stopped (not running)', async 
 });
 
 test('Expect Running tab to show running pods only', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([stoppedPod, runningPod]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([stoppedPod, runningPod]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -498,8 +483,8 @@ test('Expect Running tab to show running pods only', async () => {
 });
 
 test('Expect Stopped tab to show stopped (not running) pods only', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([stoppedPod, runningPod]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([stoppedPod, runningPod]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -520,8 +505,8 @@ test('Expect Stopped tab to show stopped (not running) pods only', async () => {
 });
 
 test('Expect tab filtering to not duplicate filter condition in the search bar', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([stoppedPod, runningPod]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([stoppedPod, runningPod]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -541,8 +526,8 @@ test('Expect tab filtering to not duplicate filter condition in the search bar',
 });
 
 test('Expect user confirmation to pop up when preferences require', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
-  listPodsMock.mockResolvedValue([pod1]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
+  vi.mocked(window.listPods).mockResolvedValue([pod1]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -554,8 +539,6 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   await fireEvent.click(checkboxes[0]);
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
-
-  (window as any).showMessageBox = vi.fn();
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });
@@ -570,7 +553,7 @@ test('Expect user confirmation to pop up when preferences require', async () => 
 });
 
 test('Expect to see empty page and no table when no container engine is running', async () => {
-  getProvidersInfoMock.mockResolvedValue([
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
     {
       name: 'podman',
       status: 'started',
@@ -587,7 +570,7 @@ test('Expect to see empty page and no table when no container engine is running'
       ],
     } as unknown as ProviderInfo,
   ]);
-  listPodsMock.mockResolvedValue([pod1]);
+  vi.mocked(window.listPods).mockResolvedValue([pod1]);
 
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
@@ -605,12 +588,12 @@ test('Expect to see empty page and no table when no container engine is running'
 });
 
 test('Expect environment column sorted by engineId', async () => {
-  getProvidersInfoMock.mockResolvedValue([provider]);
+  vi.mocked(window.getProviderInfos).mockResolvedValue([provider]);
 
   const podA = { ...pod1, Name: 'pod-aaa', engineId: 'engine-zzz', engineName: 'name-aaa' };
   const podB = { ...pod2, Name: 'pod-bbb', engineId: 'engine-aaa', engineName: 'name-zzz' };
 
-  listPodsMock.mockResolvedValue([podA, podB]);
+  vi.mocked(window.listPods).mockResolvedValue([podA, podB]);
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 
@@ -630,7 +613,7 @@ test('Expect environment column sorted by engineId', async () => {
 });
 
 test('Expect environment dropdown to appear with multiple running connections', async () => {
-  getProvidersInfoMock.mockResolvedValue([
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
     {
       ...provider,
       id: 'podman',
@@ -675,7 +658,7 @@ test('Expect environment dropdown to appear with multiple running connections', 
   };
   const dockerPod = { ...pod2, Name: 'docker-pod', engineId: 'docker.docker-context', engineName: 'Docker Desktop' };
 
-  listPodsMock.mockResolvedValue([podmanPod, dockerPod]);
+  vi.mocked(window.listPods).mockResolvedValue([podmanPod, dockerPod]);
 
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
@@ -694,7 +677,7 @@ test('Expect environment dropdown to appear with multiple running connections', 
 });
 
 test('Expect environment dropdown to filter pods by selected environment', async () => {
-  getProvidersInfoMock.mockResolvedValue([
+  vi.mocked(window.getProviderInfos).mockResolvedValue([
     {
       ...provider,
       id: 'podman',
@@ -739,7 +722,7 @@ test('Expect environment dropdown to filter pods by selected environment', async
   };
   const dockerPod = { ...pod2, Name: 'docker-pod', engineId: 'docker.docker-context', engineName: 'Docker Desktop' };
 
-  listPodsMock.mockResolvedValue([podmanPod, dockerPod]);
+  vi.mocked(window.listPods).mockResolvedValue([podmanPod, dockerPod]);
 
   window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
   window.dispatchEvent(new CustomEvent('extensions-already-started'));

--- a/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
+++ b/packages/renderer/src/lib/preferences/ExtensionIcon.spec.ts
@@ -21,16 +21,9 @@ import '@testing-library/jest-dom/vitest';
 import type { ExtensionInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import ExtensionIcon from './ExtensionIcon.svelte';
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-empty-function */
-
-beforeAll(() => {
-  (window as any).getConfigurationValue = vi.fn();
-});
 
 test('Expect started icon', async () => {
   const extension: ExtensionInfo = {

--- a/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesAuthenticationProvidersRendering.spec.ts
@@ -16,37 +16,22 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { AppearanceUtil } from '/@/lib/appearance/appearance-util';
 import { authenticationProviders } from '/@/stores/authenticationProviders';
 
 import PreferencesAuthenticationProvidersRendering from './PreferencesAuthenticationProvidersRendering.svelte';
 
-class ResizeObserver {
-  observe = vi.fn();
-  disconnect = vi.fn();
-  unobserve = vi.fn();
-}
-
-const configMock = vi.fn();
-
 vi.mock(import('/@/lib/appearance/appearance-util'));
 
-beforeAll(() => {
-  (window as any).ResizeObserver = ResizeObserver;
-  (window as any).getConfigurationValue = configMock;
-});
-
 beforeEach(() => {
+  vi.resetAllMocks();
   // ensure we mock the config to not block rendering of the component (individual tests can override)
-  configMock.mockResolvedValue(undefined);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -115,10 +100,8 @@ test('Expect Sign Out button click calls window.requestAuthenticationProviderSig
   const signoutButton = await waitFor(() =>
     screen.getByRole('button', { name: `Sign out of ${testProvidersInfo[0].accounts[0].label}` }),
   );
-  const requestSignOutMock = vi.fn().mockImplementation(() => {});
-  (window as any).requestAuthenticationProviderSignOut = requestSignOutMock;
   await fireEvent.click(signoutButton);
-  expect(requestSignOutMock).toBeCalledWith('test', 'test-account');
+  expect(vi.mocked(window.requestAuthenticationProviderSignOut)).toBeCalledWith('test', 'test-account');
 });
 
 const testProvidersInfoWithoutSessionRequests = [
@@ -157,8 +140,6 @@ const testProvidersInfoWithSessionRequests = [
 
 test('Expect Sign In button to be visible when there is only one session request', async () => {
   authenticationProviders.set(testProvidersInfoWithSessionRequests);
-  const requestSignInMock = vi.fn();
-  (window as any).requestAuthenticationProviderSignIn = requestSignInMock;
   render(PreferencesAuthenticationProvidersRendering, {});
   const menuButton = await waitFor(() => screen.getByRole('button', { name: 'Sign in' }));
 
@@ -168,7 +149,7 @@ test('Expect Sign In button to be visible when there is only one session request
   const tooltip = await screen.findByText('Sign in to use Extension Label');
   expect(tooltip).toBeInTheDocument();
   await fireEvent.click(menuButton);
-  expect(requestSignInMock).toBeCalled();
+  expect(vi.mocked(window.requestAuthenticationProviderSignIn)).toBeCalled();
 });
 
 const testProvidersInfoWithMultipleSessionRequests = [
@@ -197,22 +178,19 @@ const testProvidersInfoWithMultipleSessionRequests = [
 
 test('Expect Sign In popup menu to be visible when there is more than one session request', async () => {
   authenticationProviders.set(testProvidersInfoWithMultipleSessionRequests);
-  (window as any).requestAuthenticationProviderSignIn = vi.fn();
   render(PreferencesAuthenticationProvidersRendering, {});
   const menuButton = await waitFor(() => screen.getByRole('button', { name: 'kebab menu' }));
   await fireEvent.click(menuButton);
   // test sign in with extension1
   const menuItem1 = screen.getByText('Sign in to use Extension1 Label');
-  const requestSignInMock = vi.fn();
-  (window as any).requestAuthenticationProviderSignIn = requestSignInMock;
   await fireEvent.click(menuItem1);
-  expect(requestSignInMock).toBeCalledWith('ext:test1');
+  expect(vi.mocked(window.requestAuthenticationProviderSignIn)).toBeCalledWith('ext:test1');
   // test sign in with extension2
-  requestSignInMock.mockReset();
+  vi.mocked(window.requestAuthenticationProviderSignIn).mockReset();
   await fireEvent.click(menuButton);
   const menuItem2 = screen.getByText('Sign in to use Extension2 Label');
   await fireEvent.click(menuItem2);
-  expect(requestSignInMock).toBeCalledWith('ext:test2');
+  expect(vi.mocked(window.requestAuthenticationProviderSignIn)).toBeCalledWith('ext:test2');
 });
 
 test('Expects default icon to be used when provider has no images option', async () => {
@@ -267,7 +245,7 @@ test('Expects images.icon.dark option to be used when theme is dark', async () =
   vi.mocked(AppearanceUtil.prototype.getImage).mockReturnValue('./icon-dark.png');
   authenticationProviders.set(providerWithImageIcon);
 
-  configMock.mockReturnValue('dark');
+  vi.mocked(window.getConfigurationValue).mockResolvedValue('dark');
   render(PreferencesAuthenticationProvidersRendering, {});
 
   const icon = await waitFor(() => {

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -251,8 +251,7 @@ describe('CLI Tool item', () => {
   });
 
   test('check version is sent to updateCliTool', async () => {
-    const selectCliToolVersionToUpdateMock = vi.fn().mockResolvedValue('1.1.1');
-    (window as any).selectCliToolVersionToUpdate = selectCliToolVersionToUpdateMock;
+    vi.mocked(window.selectCliToolVersionToUpdate).mockResolvedValue('1.1.1');
     render(PreferencesCliTool, {
       cliTool: cliToolInfoItem4,
     });
@@ -262,7 +261,7 @@ describe('CLI Tool item', () => {
 
     await userEvent.click(updateAvailableElement);
 
-    expect(selectCliToolVersionToUpdateMock).toBeCalledWith(cliToolInfoItem4.id);
+    expect(vi.mocked(window.selectCliToolVersionToUpdate)).toBeCalledWith(cliToolInfoItem4.id);
     expect(vi.mocked(window.updateCliTool)).toBeCalledWith(
       cliToolInfoItem4.id,
       expect.any(Symbol),

--- a/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesCliTool.spec.ts
@@ -143,6 +143,7 @@ beforeAll(() => {
       showMessageBox: vi.fn(),
       executeCommand: vi.fn(),
       getUrlProtocol: vi.fn().mockResolvedValue('podman-desktop'),
+      selectCliToolVersionToUpdate: vi.fn(),
       navigator: {
         clipboard: {
           writeText: vi.fn(),

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -16,7 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -67,15 +66,7 @@ const connectionInfo = {
 const propertyScope = 'ContainerProviderConnectionFactory';
 
 beforeAll(() => {
-  (window as any).getConfigurationValue = vi.fn();
-  (window as any).updateConfigurationValue = vi.fn();
-  (window as any).getOsMemory = vi.fn();
-  (window as any).getOsCpu = vi.fn();
-  (window as any).getOsFreeDiskSize = vi.fn();
-  (window as any).getCancellableTokenSource = vi.fn();
-  (window as any).auditConnectionParameters = vi.fn();
-  (window as any).telemetryTrack = vi.fn();
-  (window as any).openDialog = vi.fn();
+  vi.resetAllMocks();
 });
 
 function mockCallback(
@@ -248,7 +239,7 @@ describe.each([
       // keep reference
       providedKeyLogger = keyLogger;
     });
-    (window as any).getCancellableTokenSource.mockReturnValue(Date.now());
+    vi.mocked(window.getCancellableTokenSource).mockResolvedValue(Date.now());
     render(PreferencesConnectionCreationOrEditRendering, {
       properties,
       providerInfo,
@@ -286,8 +277,7 @@ describe.each([
     expect(callback).toHaveBeenCalled();
     expect(providedKeyLogger).toBeDefined();
 
-    const cancelTokenMock = vi.fn().mockImplementation(() => {});
-    (window as any).cancelToken = cancelTokenMock;
+    const cancelTokenMock = vi.mocked(window.cancelToken).mockImplementation(async () => {});
     await fireEvent.click(cancelButton);
 
     // simulate end of the create operation
@@ -348,12 +338,12 @@ describe.each([
 
   test(`Expect ${label} button to be disabled if itemsAudit returns errors or enabled otherwise`, async () => {
     const callback = vi.fn();
-    let auditSpy = vi.spyOn(window as any, 'auditConnectionParameters');
+    let auditSpy = vi.spyOn(window, 'auditConnectionParameters');
     if (!connectionInfo) {
-      auditSpy = vi.spyOn(window as any, 'auditConnectionParameters').mockReturnValueOnce({ records: [] });
+      auditSpy = vi.spyOn(window, 'auditConnectionParameters').mockResolvedValueOnce({ records: [] });
     }
     auditSpy
-      .mockReturnValueOnce({
+      .mockResolvedValueOnce({
         records: [
           {
             type: 'error',
@@ -361,7 +351,7 @@ describe.each([
           },
         ],
       })
-      .mockReturnValueOnce({
+      .mockResolvedValueOnce({
         records: [
           {
             type: 'info',
@@ -392,21 +382,21 @@ describe.each([
     const inputElement = screen.queryByRole('textbox', { name: 'test.factoryProperty' });
     expect(inputElement).toBeDefined();
     await fireEvent.input(inputElement!, { target: { value: '1' } });
-    await vi.waitFor(() => expect(vi.mocked(window as any).auditConnectionParameters).toBeCalled());
+    await vi.waitFor(() => expect(vi.mocked(window.auditConnectionParameters)).toBeCalled());
     const createButton = screen.getByRole('button', { name: `${label}` });
     expect(createButton).toBeInTheDocument();
     await vi.waitFor(() => expect(createButton).toBeDisabled());
 
     await fireEvent.input(inputElement as Element, { target: { value: '2' } });
-    await vi.waitFor(() => expect(vi.mocked(window as any).auditConnectionParameters).toBeCalledTimes(2));
+    await vi.waitFor(() => expect(vi.mocked(window.auditConnectionParameters)).toBeCalledTimes(2));
     await vi.waitFor(() => expect(createButton).toBeEnabled());
   });
 });
 
 test(`Check itemsAudit receive updated values`, async () => {
   const callback = mockCallback(async () => {});
-  const auditSpy = vi.spyOn(window as any, 'auditConnectionParameters').mockResolvedValue({ records: [] });
-  vi.spyOn(window as any, 'openDialog').mockResolvedValue(['somefile']);
+  const auditSpy = vi.spyOn(window, 'auditConnectionParameters').mockResolvedValue({ records: [] });
+  vi.spyOn(window, 'openDialog').mockResolvedValue(['somefile']);
   // eslint-disable-next-line @typescript-eslint/await-thenable
   render(PreferencesConnectionCreationOrEditRendering, {
     properties: [
@@ -595,7 +585,7 @@ test(`Expect create with unchecked and checked checkboxes having multiple scopes
   ];
 
   // mock getConfigurationValue to return true if property is 'test.checked'
-  (window as any).getConfigurationValue = vi.fn().mockImplementation((property: string) => {
+  vi.mocked(window.getConfigurationValue).mockImplementation(async (property: string) => {
     return property === 'test.checked';
   });
 

--- a/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesContainerConnectionRendering.spec.ts
@@ -16,10 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderInfo } from '@podman-desktop/core-api';
@@ -150,9 +146,6 @@ test('Expect that removing the connection is going back to the previous page', a
 
   const routerGotoSpy = vi.spyOn(router, 'goto');
 
-  const deleteMock = vi.fn();
-  (window as any).deleteProviderConnectionLifecycle = deleteMock;
-
   const providerInfo: ProviderInfo = {
     ...EMPTY_PROVIDER_MOCK,
     containerConnections: [
@@ -214,7 +207,7 @@ test('Expect that removing the connection is going back to the previous page', a
   lastPage.set({ name: 'Fake Previous', path: '/last' });
 
   // delete current machine 2 from the provider info
-  deleteMock.mockImplementation(() => {
+  vi.mocked(window.deleteProviderConnectionLifecycle).mockImplementation(async () => {
     providerInfos.update(providerInfos =>
       providerInfos.map(provider => {
         provider.containerConnections = provider.containerConnections.filter(
@@ -258,9 +251,6 @@ test('Expect to see error message if action fails', async () => {
   const socketPath = '/my/common-socket-path';
   const podmanMachineName = 'podman machine';
 
-  const deleteMock = vi.fn();
-  (window as any).deleteProviderConnectionLifecycle = deleteMock;
-
   const providerInfo: ProviderInfo = {
     ...EMPTY_PROVIDER_MOCK,
     containerConnections: [
@@ -290,7 +280,7 @@ test('Expect to see error message if action fails', async () => {
   const connection = Buffer.from(socketPath).toString('base64');
 
   // simulate that the delete action fails
-  deleteMock.mockRejectedValue('failed to delete machine');
+  vi.mocked(window.deleteProviderConnectionLifecycle).mockRejectedValue('failed to delete machine');
 
   render(PreferencesContainerConnectionRendering, {
     name,
@@ -322,11 +312,6 @@ test('Expect to see error message if action fails', async () => {
 test('Expect startContainerProvider to only be called once when restarting', async () => {
   const socketPath = '/my/common-socket-path';
   const podmanMachineName = 'podman machine';
-
-  const stopConnectionMock = vi.fn();
-  const startConnectionMock = vi.fn();
-  (window as any).stopProviderConnectionLifecycle = stopConnectionMock;
-  (window as any).startProviderConnectionLifecycle = startConnectionMock;
 
   const providerInfo: ProviderInfo = {
     ...EMPTY_PROVIDER_MOCK,
@@ -376,18 +361,13 @@ test('Expect startContainerProvider to only be called once when restarting', asy
   providerInfo.containerConnections[0].status = 'started';
   providerInfos.set([providerInfo]);
 
-  expect(startConnectionMock).toBeCalledTimes(1);
+  expect(window.startProviderConnectionLifecycle).toBeCalledTimes(1);
 });
 
 test('Expect display name to be used in favor of name for page title', async () => {
   const socketPath = '/my/common-socket-path';
   const podmanMachineName = 'podman-machine-default';
   const podmanMachineDisplayName = 'Dummy Podman Display Name';
-
-  const stopConnectionMock = vi.fn();
-  const startConnectionMock = vi.fn();
-  (window as any).stopProviderConnectionLifecycle = stopConnectionMock;
-  (window as any).startProviderConnectionLifecycle = startConnectionMock;
 
   const providerInfo: ProviderInfo = {
     ...EMPTY_PROVIDER_MOCK,

--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesConnectionRendering.spec.ts
@@ -16,10 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderInfo } from '@podman-desktop/core-api';
@@ -46,9 +42,6 @@ test('Expect that removing the connection is going back to the previous page', a
   const kindCluster3 = 'kind cluster 3';
 
   const routerGotoSpy = vi.spyOn(router, 'goto');
-
-  const deleteMock = vi.fn();
-  (window as any).deleteProviderConnectionLifecycle = deleteMock;
 
   const providerInfo: ProviderInfo = {
     id: 'kind',
@@ -123,7 +116,7 @@ test('Expect that removing the connection is going back to the previous page', a
   const apiUrlBase64 = Buffer.from('http://localhost:8181').toString('base64');
 
   // delete current cluster 2 from the provider info
-  deleteMock.mockImplementation(() => {
+  vi.mocked(window.deleteProviderConnectionLifecycle).mockImplementation(async () => {
     providerInfos.update(providerInfos =>
       providerInfos.map(provider => {
         provider.kubernetesConnections = provider.kubernetesConnections.filter(
@@ -165,9 +158,6 @@ test('Expect that removing the connection is going back to the previous page', a
 test('Expect to see error message if action fails', async () => {
   const apiURL = 'http://localhost:8081';
   const kindCluster = 'kind cluster';
-
-  const deleteMock = vi.fn();
-  (window as any).deleteProviderConnectionLifecycle = deleteMock;
 
   const providerInfo: ProviderInfo = {
     id: 'kind',
@@ -217,7 +207,7 @@ test('Expect to see error message if action fails', async () => {
   const apiUrlBase64 = Buffer.from(apiURL).toString('base64');
 
   // simulate that the delete action fails
-  deleteMock.mockRejectedValue('failed to delete machine');
+  vi.mocked(window.deleteProviderConnectionLifecycle).mockRejectedValue('failed to delete machine');
 
   render(PreferencesKubernetesConnectionRendering, {
     apiUrlBase64,

--- a/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRendering.spec.ts
@@ -17,8 +17,6 @@
  ***********************************************************************/
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-empty-function */
 
 import '@testing-library/jest-dom/vitest';
 
@@ -39,8 +37,8 @@ async function waitRender(customProperties: any): Promise<void> {
 }
 
 beforeAll(() => {
-  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(true);
-  (window as any).telemetryPage = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
+  vi.mocked(window.telemetryPage).mockResolvedValue(undefined);
 });
 
 const record: IConfigurationPropertyRecordedSchema = {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -17,8 +17,6 @@
  ***********************************************************************/
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-empty-function */
 
 import '@testing-library/jest-dom/vitest';
 
@@ -429,7 +427,7 @@ test('Expect value is updated from an external change', async () => {
   expect(inputField.value).toBe('1');
 
   // change getConfigurationValue to return 5
-  (window as any).getConfigurationValue = vi.fn().mockResolvedValue(5);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(5);
 
   // now update the configuration value
   onDidChangeConfiguration.dispatchEvent(

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -519,12 +519,8 @@ describe.each<{
     });
 
     test('Expect to display the dialog if missing requirements for installation', async () => {
-      const installPreflightMock = vi.fn().mockResolvedValue(false);
-      const installProviderMock = vi.fn().mockResolvedValue(undefined);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).runInstallPreflightChecks = installPreflightMock;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).installProvider = installProviderMock;
+      vi.mocked(window.runInstallPreflightChecks).mockResolvedValue(false);
+      vi.mocked(window.installProvider).mockResolvedValue([]);
       // clone providerInfo and change id and status
       const customProviderInfo: ProviderInfo = { ...providerInfo };
       // remove display name
@@ -538,19 +534,15 @@ describe.each<{
       expect(button).toBeInTheDocument();
       await userEvent.click(button);
       // provider is not installed, it checks the requirements, something fails and the dialog about missing reqs is shown
-      expect(installPreflightMock).toBeCalled();
-      expect(installProviderMock).not.toHaveBeenCalled();
+      expect(window.runInstallPreflightChecks).toBeCalled();
+      expect(window.installProvider).not.toHaveBeenCalled();
       const modal = screen.getByLabelText('install provider');
       expect(modal).toBeInTheDocument();
     });
 
     test('Expect to directly install the provider if requirements are met', async () => {
-      const installPreflightMock = vi.fn().mockResolvedValue(true);
-      const installProviderMock = vi.fn().mockResolvedValue(undefined);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).runInstallPreflightChecks = installPreflightMock;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).installProvider = installProviderMock;
+      vi.mocked(window.runInstallPreflightChecks).mockResolvedValue(true);
+      vi.mocked(window.installProvider).mockResolvedValue([]);
       // clone providerInfo and change id and status
       const customProviderInfo: ProviderInfo = { ...providerInfo };
       // remove display name
@@ -564,8 +556,8 @@ describe.each<{
       expect(button).toBeInTheDocument();
       await userEvent.click(button);
       // all requirements are met so the installProvider function is called
-      expect(installPreflightMock).toBeCalled();
-      expect(installProviderMock).toBeCalled();
+      expect(window.runInstallPreflightChecks).toBeCalled();
+      expect(window.installProvider).toBeCalled();
     });
 
     test('Expect to redirect to onboarding page if setup button is clicked', async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesResourcesRendering.spec.ts
@@ -121,6 +121,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  vi.clearAllMocks();
   onboardingList.set([]);
 });
 

--- a/packages/renderer/src/lib/style/ColorsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/ColorsStyle.spec.ts
@@ -16,24 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { ColorInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { colorsInfos, darkContextColorsInfos, hcDarkContextColorsInfos } from '/@/stores/colors';
 
 import ColorsStyle from './ColorsStyle.svelte';
-
-const listColorsMock = vi.fn();
-
-// fake the window object
-beforeAll(() => {
-  (window as any).listColors = listColorsMock;
-});
 
 test('Check colors are added in the css style', async () => {
   const color: ColorInfo = {

--- a/packages/renderer/src/lib/style/IconsStyle.spec.ts
+++ b/packages/renderer/src/lib/style/IconsStyle.spec.ts
@@ -16,25 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { IconInfo } from '@podman-desktop/core-api';
 import { render } from '@testing-library/svelte';
 import { get } from 'svelte/store';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { iconsInfos } from '/@/stores/icons';
 
 import IconsStyle from './IconsStyle.svelte';
-
-const listIconsMock = vi.fn();
-
-// fake the window object
-beforeAll(() => {
-  (window as any).listIcons = listIconsMock;
-});
 
 test('Check containers button is available and click on it', async () => {
   const file = 'file://my-font.woff';
@@ -56,7 +47,7 @@ test('Check containers button is available and click on it', async () => {
     },
   };
 
-  listIconsMock.mockResolvedValue([icon]);
+  vi.mocked(window.listIcons).mockResolvedValue([icon]);
 
   window.dispatchEvent(new CustomEvent('extensions-already-started'));
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngine.spec.ts
@@ -16,22 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import TroubleshootingContainerEngine from './TroubleshootingContainerEngine.svelte';
-
-const listContainersFromEngineMock = vi.fn();
-
-// fake the window object
-beforeAll(() => {
-  (window as any).listContainersFromEngine = listContainersFromEngineMock;
-});
 
 test('Check containers button is available and click on it', async () => {
   const socketPath = '/foo/socket.path';

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineGrabContainers.spec.ts
@@ -16,25 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import TroubleshootingContainerEngineGrabContainers from './TroubleshootingContainerEngineGrabContainers.svelte';
 
-const listContainersFromEngineMock = vi.fn();
-
-// fake the window object
-beforeAll(() => {
-  (window as any).listContainersFromEngine = listContainersFromEngineMock;
-});
-
 test('Check containers button is available and click on it', async () => {
-  listContainersFromEngineMock.mockReturnValue([{}]);
+  vi.mocked(window.listContainersFromEngine).mockResolvedValue([{ Id: '', Names: [] }]);
 
   const providerContainerEngine = {} as unknown as ProviderContainerConnectionInfo;
   render(TroubleshootingContainerEngineGrabContainers, { providerContainerEngine });
@@ -57,7 +48,7 @@ test('Check containers button is available and click on it', async () => {
 });
 
 test('Check containers button is available and get error', async () => {
-  listContainersFromEngineMock.mockImplementation(() => {
+  vi.mocked(window.listContainersFromEngine).mockImplementation(() => {
     throw new Error('Unable to ping container engine');
   });
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEnginePing.spec.ts
@@ -16,25 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderContainerConnectionInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import TroubleshootingContainerEnginePing from './TroubleshootingContainerEnginePing.svelte';
 
-const pingContainerEngineMock = vi.fn();
-
-// fake the window object
-beforeAll(() => {
-  (window as any).pingContainerEngine = pingContainerEngineMock;
-});
-
 test('Check ping button is available and click on it', async () => {
-  pingContainerEngineMock.mockReturnValue('OK');
+  vi.mocked(window.pingContainerEngine).mockResolvedValue('OK');
 
   const providerContainerEngine = {} as unknown as ProviderContainerConnectionInfo;
   render(TroubleshootingContainerEnginePing, { providerContainerEngine });
@@ -57,7 +48,7 @@ test('Check ping button is available and click on it', async () => {
 });
 
 test('Check ping button is available and get error', async () => {
-  pingContainerEngineMock.mockImplementation(() => {
+  vi.mocked(window.pingContainerEngine).mockImplementation(() => {
     throw new Error('Unable to ping container engine');
   });
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingContainerEngineReconnect.spec.ts
@@ -16,21 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import TroubleshootingContainerEngineReconnect from './TroubleshootingContainerEngineReconnect.svelte';
-
-const reconnectContainerProvidersMock = vi.fn();
-
-// fake the window object
-beforeAll(() => {
-  (window as any).reconnectContainerProviders = reconnectContainerProvidersMock;
-});
 
 test('Check reconnect button is available and click on it', async () => {
   render(TroubleshootingContainerEngineReconnect, {});
@@ -53,7 +44,7 @@ test('Check reconnect button is available and click on it', async () => {
 });
 
 test('Check reconnect button is available and get error', async () => {
-  reconnectContainerProvidersMock.mockImplementation(() => {
+  vi.mocked(window.reconnectContainerProviders).mockImplementation(() => {
     throw new Error('Unable to ping container engine');
   });
   render(TroubleshootingContainerEngineReconnect);

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingDevToolsConsoleLogs.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
@@ -26,18 +24,9 @@ import { beforeAll, expect, test, vi } from 'vitest';
 
 import TroubleshootingDevToolsConsoleLogs from './TroubleshootingDevToolsConsoleLogs.svelte';
 
-const getDevtoolsConsoleLogsMock = vi.fn();
-const clipboardWriteTextMock = vi.fn();
-const getConfigurationValueMock = vi.fn();
-const updateConfigurationValueMock = vi.fn();
-
 beforeAll(() => {
-  (window as any).getDevtoolsConsoleLogs = getDevtoolsConsoleLogsMock;
-  (window as any).clipboardWriteText = clipboardWriteTextMock;
-  (window as any).getConfigurationValue = getConfigurationValueMock;
-  (window as any).updateConfigurationValue = updateConfigurationValueMock;
-  getConfigurationValueMock.mockResolvedValue(false);
-  updateConfigurationValueMock.mockResolvedValue(undefined);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(false);
+  vi.mocked(window.updateConfigurationValue).mockResolvedValue(undefined);
 });
 
 async function waitRender(customProperties: object): Promise<void> {
@@ -47,7 +36,7 @@ async function waitRender(customProperties: object): Promise<void> {
 
 test('Check logs are displayed with clipboard button', async () => {
   const fixedDate = new Date('2026-04-29T14:30:45');
-  getDevtoolsConsoleLogsMock.mockReturnValue([
+  vi.mocked(window.getDevtoolsConsoleLogs).mockResolvedValue([
     {
       logType: 'log',
       message: 'test1',
@@ -78,12 +67,12 @@ test('Check logs are displayed with clipboard button', async () => {
   await fireEvent.click(clipboardButton);
 
   // timestamps are hidden by default, so clipboard should not include them
-  expect(clipboardWriteTextMock).toHaveBeenCalledWith('log : test1\nerror : test2');
+  expect(window.clipboardWriteText).toHaveBeenCalledWith('log : test1\nerror : test2');
 });
 
 test('Timestamps are hidden by default and shown after toggle', async () => {
   const fixedDate = new Date('2026-04-29T14:30:45');
-  getDevtoolsConsoleLogsMock.mockReturnValue([{ logType: 'log', message: 'hello', date: fixedDate }]);
+  vi.mocked(window.getDevtoolsConsoleLogs).mockResolvedValue([{ logType: 'log', message: 'hello', date: fixedDate }]);
 
   await waitRender({});
 
@@ -107,23 +96,23 @@ test('Timestamps are hidden by default and shown after toggle', async () => {
 });
 
 test('Toggle persists the setting via updateConfigurationValue', async () => {
-  getDevtoolsConsoleLogsMock.mockReturnValue([{ logType: 'log', message: 'hello', date: new Date() }]);
+  vi.mocked(window.getDevtoolsConsoleLogs).mockResolvedValue([{ logType: 'log', message: 'hello', date: new Date() }]);
 
   await waitRender({});
 
   const toggleButton = screen.getByRole('button', { name: 'Toggle Timestamps' });
   await fireEvent.click(toggleButton);
 
-  expect(updateConfigurationValueMock).toHaveBeenCalledWith('troubleshooting.logsTimestamps', true);
+  expect(vi.mocked(window.updateConfigurationValue)).toHaveBeenCalledWith('troubleshooting.logsTimestamps', true);
 
   await fireEvent.click(toggleButton);
 
-  expect(updateConfigurationValueMock).toHaveBeenCalledWith('troubleshooting.logsTimestamps', false);
+  expect(vi.mocked(window.updateConfigurationValue)).toHaveBeenCalledWith('troubleshooting.logsTimestamps', false);
 });
 
 test('Clipboard includes timestamps when toggle is enabled', async () => {
   const fixedDate = new Date('2026-04-29T14:30:45');
-  getDevtoolsConsoleLogsMock.mockReturnValue([
+  vi.mocked(window.getDevtoolsConsoleLogs).mockResolvedValue([
     { logType: 'log', message: 'test1', date: fixedDate },
     { logType: 'error', message: 'test2', date: fixedDate },
   ]);
@@ -138,5 +127,5 @@ test('Clipboard includes timestamps when toggle is enabled', async () => {
   const clipboardButton = screen.getByRole('button', { name: 'Copy To Clipboard' });
   await fireEvent.click(clipboardButton);
 
-  expect(clipboardWriteTextMock).toHaveBeenCalledWith('14:30:45 log : test1\n14:30:45 error : test2');
+  expect(window.clipboardWriteText).toHaveBeenCalledWith('14:30:45 log : test1\n14:30:45 error : test2');
 });

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.spec.ts
@@ -16,23 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import TroubleshootingPage from './TroubleshootingPage.svelte';
 
-const getDevtoolsConsoleLogsMock = vi.fn();
-// fake the window object
-beforeAll(() => {
-  (window as any).getDevtoolsConsoleLogs = getDevtoolsConsoleLogsMock;
-});
-
 test('Check Troubleshooting Page', async () => {
-  getDevtoolsConsoleLogsMock.mockReturnValue([]);
+  vi.mocked(window.getDevtoolsConsoleLogs).mockResolvedValue([]);
   render(TroubleshootingPage, {});
 
   // click on the first tab

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -16,20 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte';
-
-const cleanupProvidersMock = vi.fn();
-
-beforeAll(() => {
-  (window as any).window.cleanupProviders = cleanupProvidersMock;
-});
 
 test('Check cleanupProviders is called and button is in progress', async () => {
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean Up' });
@@ -41,7 +33,7 @@ test('Check cleanupProviders is called and button is in progress', async () => {
   expect(cleanupButton).toBeInTheDocument();
 
   // mock the cleanup as waiting for 10ms
-  cleanupProvidersMock.mockResolvedValue(new Promise(resolve => setTimeout(resolve, 10)));
+  vi.mocked(window.cleanupProviders).mockReturnValue(new Promise(resolve => setTimeout(resolve, 10)));
 
   // click on the cleanup button
   expect(cleanupButton).toBeEnabled();
@@ -69,8 +61,8 @@ test('Check cleanupProviders is called and button is in progress', async () => {
     title: 'Clean Up Data?',
   });
 
-  // check that we're calling the cleanupProvidersMock
-  expect(cleanupProvidersMock).toBeCalled();
+  // check that we're calling the vi.mocked(window.cleanupProviders)
+  expect(vi.mocked(window.cleanupProviders)).toBeCalled();
 });
 
 test('Check errors are displayed with clipboard button', async () => {
@@ -83,7 +75,7 @@ test('Check errors are displayed with clipboard button', async () => {
   expect(cleanupButton).toBeInTheDocument();
 
   // mock the cleanup as waiting for 2 seconds
-  cleanupProvidersMock.mockRejectedValue(new Error('test error'));
+  vi.mocked(window.cleanupProviders).mockRejectedValue(new Error('test error'));
 
   // click on the cleanup button
   expect(cleanupButton).toBeEnabled();
@@ -97,8 +89,8 @@ test('Check errors are displayed with clipboard button', async () => {
     title: 'Clean Up Data?',
   });
 
-  // check that we're calling the cleanupProvidersMock
-  expect(cleanupProvidersMock).toBeCalled();
+  // check that we're calling the vi.mocked(window.cleanupProviders)
+  expect(vi.mocked(window.cleanupProviders)).toBeCalled();
 
   // check errors are displayed
   const alterSection = screen.getByRole('alert');

--- a/packages/renderer/src/lib/ui/Steps.spec.ts
+++ b/packages/renderer/src/lib/ui/Steps.spec.ts
@@ -16,24 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { render, screen } from '@testing-library/svelte';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { expect, test } from 'vitest';
 
 import Steps from './Steps.svelte';
-
-class ResizeObserver {
-  observe = vi.fn();
-  disconnect = vi.fn();
-  unobserve = vi.fn();
-}
-
-beforeEach(() => {
-  (window as any).ResizeObserver = ResizeObserver;
-});
 
 test('Check step styling', async () => {
   render(Steps, { steps: ['One', 'Two'] });

--- a/packages/renderer/src/lib/volume/CreateVolume.spec.ts
+++ b/packages/renderer/src/lib/volume/CreateVolume.spec.ts
@@ -16,25 +16,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import type { ProviderInfo, VolumeListInfo } from '@podman-desktop/core-api';
 import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { providerInfos } from '/@/stores/providers';
 import { volumeListInfos } from '/@/stores/volumes';
 
 import CreateVolume from './CreateVolume.svelte';
-
-const createVolumeMock = vi.fn();
-
-beforeAll(() => {
-  (window as any).createVolume = createVolumeMock;
-});
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -57,7 +49,7 @@ test('Expect no create button with no providers', async () => {
   expect(emptyScreen).toBeInTheDocument();
 
   // expect that we never call
-  expect(createVolumeMock).not.toBeCalled();
+  expect(window.createVolume).not.toBeCalled();
 });
 
 test('Expect Create button is working', async () => {
@@ -86,7 +78,7 @@ test('Expect Create button is working', async () => {
   await userEvent.click(createButton);
 
   // expect that we called createVolume API
-  expect(createVolumeMock).toHaveBeenCalledWith(expect.anything(), { Name: '' });
+  expect(window.createVolume).toHaveBeenCalledWith(expect.anything(), { Name: '' });
 });
 
 test('Expect Create with a custom name', async () => {
@@ -129,14 +121,14 @@ test('Expect Create with a custom name', async () => {
   await userEvent.click(createButton);
 
   // expect that we called createVolume API
-  expect(createVolumeMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'podman-machine-default' }), {
+  expect(window.createVolume).toHaveBeenCalledWith(expect.objectContaining({ name: 'podman-machine-default' }), {
     Name: customVolumeName,
   });
 });
 
 test('Expect error message when volume creation fails', async () => {
   const errorMessage = 'volume name "bad/name" includes invalid characters';
-  createVolumeMock.mockRejectedValueOnce(new Error(errorMessage));
+  vi.mocked(window.createVolume).mockRejectedValueOnce(new Error(errorMessage));
 
   providerInfos.set([
     {
@@ -225,7 +217,7 @@ test('Expect Create with a custom name and multiple providers', async () => {
   await userEvent.click(createButton);
 
   // expect that we called createVolume API with the docker provider as we changed the toggle
-  expect(createVolumeMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'docker' }), {
+  expect(window.createVolume).toHaveBeenCalledWith(expect.objectContaining({ name: 'docker' }), {
     Name: customVolumeName,
   });
 });
@@ -498,7 +490,7 @@ test('Expect no duplicate error after successful creation when store updates', a
     } as unknown as VolumeListInfo,
   ]);
 
-  createVolumeMock.mockResolvedValue(undefined);
+  vi.mocked(window.createVolume).mockResolvedValue(undefined);
 
   render(CreateVolume, {});
 

--- a/packages/renderer/src/lib/volume/VolumesList.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumesList.spec.ts
@@ -375,7 +375,6 @@ test('Expect user confirmation to pop up when preferences require', async () => 
   await fireEvent.click(checkboxes[0]);
 
   vi.mocked(window.getConfigurationValue).mockResolvedValue(true);
-  (window as any).showMessageBox = vi.fn();
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Cancel' });
 
   const deleteButton = screen.getByRole('button', { name: 'Delete 1 selected items' });

--- a/packages/renderer/src/lib/webview/Webview.spec.ts
+++ b/packages/renderer/src/lib/webview/Webview.spec.ts
@@ -29,9 +29,6 @@ import { webviews } from '/@/stores/webviews';
 
 import Webview from './Webview.svelte';
 
-const makeDefaultWebviewVisibleMock = vi.fn();
-const getWebviewPreloadPathMock = vi.fn();
-const getWebviewRegistryHttpPortMock = vi.fn();
 const messages = new Map<string, (args: any) => void>();
 
 // webviews for the store
@@ -60,9 +57,7 @@ const webviewTestList: WebviewInfo[] = [
 
 beforeEach(() => {
   vi.resetAllMocks();
-  (window as any).makeDefaultWebviewVisible = makeDefaultWebviewVisibleMock.mockResolvedValue(undefined);
-  (window as any).getWebviewPreloadPath = getWebviewPreloadPathMock;
-  (window as any).getWebviewRegistryHttpPort = getWebviewRegistryHttpPortMock;
+  vi.mocked(window.makeDefaultWebviewVisible).mockResolvedValue(undefined);
 
   vi.mocked(window.events.receive).mockImplementation((channel, func) => {
     messages.set(channel, func);
@@ -72,10 +67,10 @@ beforeEach(() => {
   });
 
   // provide preload path
-  getWebviewPreloadPathMock.mockResolvedValue('/path/to/preload');
+  vi.mocked(window.getWebviewPreloadPath).mockResolvedValue('/path/to/preload');
 
   // provide registry port
-  getWebviewRegistryHttpPortMock.mockResolvedValue(5678);
+  vi.mocked(window.getWebviewRegistryHttpPort).mockResolvedValue(5678);
 
   webviews.set(webviewTestList);
 });

--- a/packages/renderer/src/lib/welcome/welcome-utils.spec.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { WelcomeSettings } from '@podman-desktop/core-api/welcome';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -25,25 +23,25 @@ import { WelcomeUtils } from './welcome-utils';
 
 let welcomeUtils: WelcomeUtils;
 
-// mock window.getConfigurationValue
-const getConfigurationValueMock = vi.fn();
-(window as any).getConfigurationValue = getConfigurationValueMock;
-
 beforeEach(() => {
   vi.clearAllMocks();
   welcomeUtils = new WelcomeUtils();
 });
 
 test('should expect no value by default', async () => {
-  getConfigurationValueMock.mockResolvedValue(undefined);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
   const version = await welcomeUtils.getVersion();
   expect(version).toBeUndefined();
-  expect(getConfigurationValueMock).toHaveBeenCalledWith(WelcomeSettings.SectionName + '.' + WelcomeSettings.Version);
+  expect(vi.mocked(window.getConfigurationValue)).toHaveBeenCalledWith(
+    WelcomeSettings.SectionName + '.' + WelcomeSettings.Version,
+  );
 });
 
 test('should expect value', async () => {
-  getConfigurationValueMock.mockResolvedValue('foo');
+  vi.mocked(window.getConfigurationValue).mockResolvedValue('foo');
   const version = await welcomeUtils.getVersion();
   expect(version).toBe('foo');
-  expect(getConfigurationValueMock).toHaveBeenCalledWith(WelcomeSettings.SectionName + '.' + WelcomeSettings.Version);
+  expect(vi.mocked(window.getConfigurationValue)).toHaveBeenCalledWith(
+    WelcomeSettings.SectionName + '.' + WelcomeSettings.Version,
+  );
 });

--- a/packages/renderer/src/lib/window-control-buttons/ControlButtons.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/ControlButtons.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
@@ -46,33 +44,24 @@ describe.each([{ platform: 'linux' }, { platform: 'win32' }])('Platform($platfor
   test('Expect minimize is called', async () => {
     render(ControlButtons, { platform });
 
-    const minimizeMock = vi.fn();
-    (window as any).windowMinimize = minimizeMock;
-
     const minimizeButton = screen.getByRole('button', { name: 'Minimize' });
     await fireEvent.click(minimizeButton);
-    expect(minimizeMock).toBeCalled();
+    expect(vi.mocked(window.windowMinimize)).toBeCalled();
   });
 
   test('Expect maximize is called', async () => {
     render(ControlButtons, { platform });
 
-    const maximizeMock = vi.fn().mockResolvedValue(undefined);
-    (window as any).windowMaximize = maximizeMock;
-
     const maximizeButton = screen.getByRole('button', { name: 'Maximize' });
     await fireEvent.click(maximizeButton);
-    expect(maximizeMock).toBeCalled();
+    expect(vi.mocked(window.windowMaximize)).toBeCalled();
   });
 
   test('Expect close is called', async () => {
     render(ControlButtons, { platform });
 
-    const closeMock = vi.fn().mockResolvedValue(undefined);
-    (window as any).windowClose = closeMock;
-
     const closeButton = screen.getByRole('button', { name: 'Close' });
     await fireEvent.click(closeButton);
-    expect(closeMock).toBeCalled();
+    expect(vi.mocked(window.windowClose)).toBeCalled();
   });
 });

--- a/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
+++ b/packages/renderer/src/lib/window-control-buttons/WindowsControlButton.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
@@ -27,7 +25,6 @@ import WindowsControlButton from './WindowsControlButton.svelte';
 
 beforeEach(() => {
   vi.resetAllMocks();
-  (window as any).windowClose = vi.fn().mockResolvedValue(undefined);
 });
 
 test('Check Maximize/Restore', async () => {

--- a/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry.spec.ts
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { get } from 'svelte/store';
 import { beforeEach, expect, test, vi } from 'vitest';
 
@@ -25,24 +23,17 @@ import { configurationProperties } from '/@/stores/configurationProperties';
 
 import { fetchNavigationRegistries, navigationRegistry } from './navigation-registry';
 
-const kubernetesRegisterGetCurrentContextResourcesMock = vi.fn();
-const kubernetesGetCurrentContextGeneralStateMock = vi.fn();
-
-const getConfigurationValueMock = vi.fn();
 beforeEach(() => {
   vi.resetAllMocks();
-  (window as any).kubernetesRegisterGetCurrentContextResources = kubernetesRegisterGetCurrentContextResourcesMock;
-  (window as any).getKubernetesPortForwards = vi.fn();
-  (window as any).window.kubernetesGetCurrentContextGeneralState = kubernetesGetCurrentContextGeneralStateMock;
-  (window as any).getConfigurationValue = getConfigurationValueMock;
-  (window as any).sendNavigationItems = vi.fn();
-
   vi.mocked(window.getKubernetesPortForwards).mockResolvedValue([]);
 });
 
 test('check navigation registry items', async () => {
-  kubernetesRegisterGetCurrentContextResourcesMock.mockResolvedValue([]);
-  kubernetesGetCurrentContextGeneralStateMock.mockResolvedValue({});
+  vi.mocked(window.kubernetesRegisterGetCurrentContextResources).mockResolvedValue([]);
+  vi.mocked(window.kubernetesGetCurrentContextGeneralState).mockResolvedValue({
+    reachable: true,
+    resources: { pods: 0, deployments: 0 },
+  });
   await fetchNavigationRegistries();
   const registries = get(navigationRegistry);
   // expect 8 items in the registry
@@ -57,7 +48,7 @@ test('check update properties', async () => {
   });
 
   // Say that Containers and Pods are hidden by the configuration
-  getConfigurationValueMock.mockResolvedValue(['Containers', 'Pods']);
+  vi.mocked(window.getConfigurationValue).mockResolvedValue(['Containers', 'Pods']);
 
   // do an update to force the update
   configurationProperties.set([]);

--- a/packages/renderer/src/stores/update-store.spec.ts
+++ b/packages/renderer/src/stores/update-store.spec.ts
@@ -25,8 +25,6 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { updateAvailable, updateEventStore } from './update-store';
 
 const messages = new Map<string, any>();
-const eventListenerMock = vi.fn();
-const podmanDesktopUpdateAvailableMock = vi.fn();
 const eventEmitter = {
   receive: (message: string, callback: any): void => {
     messages.set(message, callback);
@@ -35,12 +33,11 @@ const eventEmitter = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  (window as any).podmanDesktopUpdateAvailable = podmanDesktopUpdateAvailableMock.mockResolvedValue(false);
+  vi.mocked(window.podmanDesktopUpdateAvailable).mockResolvedValue(false);
   vi.mocked(window.events.receive).mockImplementation((message, callback) => {
     eventEmitter.receive(message, callback);
     return { dispose: vi.fn() };
   });
-  (window as any).addEventListener = eventListenerMock.mockImplementation(eventEmitter.receive);
 });
 
 test('updateAvailable starts as podmanDesktopUpdateAvailable value or false if undefined', async () => {

--- a/packages/renderer/src/stores/update-store.spec.ts
+++ b/packages/renderer/src/stores/update-store.spec.ts
@@ -33,11 +33,13 @@ const eventEmitter = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  messages.clear();
   vi.mocked(window.podmanDesktopUpdateAvailable).mockResolvedValue(false);
   vi.mocked(window.events.receive).mockImplementation((message, callback) => {
     eventEmitter.receive(message, callback);
     return { dispose: vi.fn() };
   });
+  vi.spyOn(window, 'addEventListener').mockImplementation(eventEmitter.receive as any);
 });
 
 test('updateAvailable starts as podmanDesktopUpdateAvailable value or false if undefined', async () => {


### PR DESCRIPTION
### What does this PR do?

We have many many cast to any to access mocks function, this prevent type safety, does not allow refactoring, and requires search and query.

This PR is only targetting `.spec` file in the `renderer`. This PR has been made in pair with Claude I asked to split each file in a commit. The goal is to ease review.

### Suggestion to review

Click on `Commits` select the first one, and then review the commit, then the next one, then the next one. Or review all the 30 changes, but those are very small so I made a single PR

<img width="1031" height="588" alt="image" src="https://github.com/user-attachments/assets/bdec7810-96f7-4e8f-be48-80906ec7c596" />

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18790

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle: 
