### PR TITLE
feat(main): support declarative env:/file: configuration defaults

### DIFF
--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -17,8 +17,10 @@
  ***********************************************************************/
 
 // Import to access mocked functionionalities such as using vi.mock (we don't want to actually call node:fs methods)
-import { cpSync, readFileSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { access, copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
 
 import type { IDisposable } from '@podman-desktop/core-api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
@@ -42,7 +44,16 @@ vi.mock(import('node:fs'), () => ({
   readFileSync: vi.fn(),
   writeFileSync: vi.fn(),
   cpSync: vi.fn(),
+  existsSync: vi.fn(),
 }));
+
+vi.mock(import('node:os'), async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    homedir: vi.fn(),
+  };
+});
 
 vi.mock(import('node:fs/promises'), () => ({
   access: vi.fn(),
@@ -105,6 +116,7 @@ beforeEach(async () => {
   const writeFileMock = vi.mocked(writeFile);
   const readFileMock = vi.mocked(readFile);
   const cpSyncMock = vi.mocked(cpSync);
+  const existsSyncMock = vi.mocked(existsSync);
 
   readFileSyncMock.mockReturnValue(JSON.stringify({}));
   accessMock.mockResolvedValue(undefined);
@@ -112,6 +124,8 @@ beforeEach(async () => {
   writeFileMock.mockResolvedValue(undefined);
   readFileMock.mockResolvedValue(JSON.stringify({}));
   cpSyncMock.mockReturnValue(undefined);
+  existsSyncMock.mockReturnValue(false);
+  vi.mocked(homedir).mockReturnValue('/home/testuser');
 
   // Setup DefaultConfiguration mock for the new functionality
   getContentMock.mockResolvedValue({});
@@ -1064,5 +1078,157 @@ describe('configuration.override from product.json', () => {
     expect(property?.type).toBe('string');
     expect(property?.default).toBe('myDefault');
     expect(property?.experimental).toBeUndefined();
+  });
+});
+
+describe('declarative env:/file: defaults', () => {
+  const ENV_VAR = 'PD_TEST_CREDENTIALS_PATH';
+  const APPDATA_VAR = 'PD_TEST_APPDATA';
+
+  beforeEach(() => {
+    delete process.env[ENV_VAR];
+    delete process.env[APPDATA_VAR];
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(homedir).mockReturnValue('/home/testuser');
+  });
+
+  function registerWithDefault(defaultValue: unknown): IConfigurationPropertySchema | undefined {
+    const node: IConfigurationNode = {
+      id: 'my-extension',
+      title: 'My Extension',
+      type: 'object',
+      properties: {
+        'my-extension.credentialsFile': {
+          description: 'Path to credentials file',
+          type: 'string',
+          format: 'file',
+          default: defaultValue,
+        },
+      },
+    };
+    configurationRegistry.registerConfigurations([node]);
+    return configurationRegistry.getConfigurationProperties()['my-extension.credentialsFile'];
+  }
+
+  test('should resolve env: entry when environment variable is set', () => {
+    process.env[ENV_VAR] = '/custom/credentials.json';
+
+    const property = registerWithDefault([
+      `env:${ENV_VAR}`,
+      'file:~/.config/my-tool/credentials.json',
+      `file:$${APPDATA_VAR}/my-tool/credentials.json`,
+    ]);
+
+    expect(property?.default).toBe('/custom/credentials.json');
+    expect(configurationRegistry.getConfiguration('my-extension').get('credentialsFile')).toBe(
+      '/custom/credentials.json',
+    );
+  });
+
+  test('should skip empty env: value and fall through to file:', () => {
+    process.env[ENV_VAR] = '';
+    const expectedPath = path.join('/home/testuser', '.config/my-tool/credentials.json');
+    vi.mocked(existsSync).mockImplementation((p: Parameters<typeof existsSync>[0]) => p === expectedPath);
+
+    const property = registerWithDefault([`env:${ENV_VAR}`, 'file:~/.config/my-tool/credentials.json']);
+
+    expect(property?.default).toBe(expectedPath);
+  });
+
+  test('should resolve file: with ~ expansion when file exists', () => {
+    const expectedPath = path.join('/home/testuser', '.config/my-tool/credentials.json');
+    vi.mocked(existsSync).mockImplementation((p: Parameters<typeof existsSync>[0]) => p === expectedPath);
+
+    const property = registerWithDefault([
+      `env:${ENV_VAR}`,
+      'file:~/.config/my-tool/credentials.json',
+      `file:$${APPDATA_VAR}/my-tool/credentials.json`,
+    ]);
+
+    expect(property?.default).toBe(expectedPath);
+  });
+
+  test('should resolve file: with $VAR expansion when file exists', () => {
+    process.env[APPDATA_VAR] = 'C:\\Users\\test\\AppData\\Roaming';
+    const expectedPath = 'C:\\Users\\test\\AppData\\Roaming/my-tool/credentials.json';
+    vi.mocked(existsSync).mockImplementation((p: Parameters<typeof existsSync>[0]) => p === expectedPath);
+
+    const property = registerWithDefault([
+      `env:${ENV_VAR}`,
+      'file:~/.config/my-tool/credentials.json',
+      `file:$${APPDATA_VAR}/my-tool/credentials.json`,
+    ]);
+
+    expect(property?.default).toBe(expectedPath);
+  });
+
+  test('should skip file: entry when $VAR is unset instead of checking a truncated path', () => {
+    const existsSyncMock = vi.mocked(existsSync);
+    // If expandPath incorrectly replaced $VAR with '', this path would be checked
+    existsSyncMock.mockImplementation((p: Parameters<typeof existsSync>[0]) => p === '/my-tool/credentials.json');
+
+    const property = registerWithDefault([`file:$${APPDATA_VAR}/my-tool/credentials.json`]);
+
+    expect(property?.default).toBeUndefined();
+    expect(existsSyncMock).not.toHaveBeenCalled();
+  });
+
+  test('should leave default undefined when no entry resolves', () => {
+    const property = registerWithDefault([
+      `env:${ENV_VAR}`,
+      'file:~/.config/my-tool/credentials.json',
+      `file:$${APPDATA_VAR}/my-tool/credentials.json`,
+    ]);
+
+    expect(property?.default).toBeUndefined();
+    expect(configurationRegistry.getConfiguration('my-extension').get('credentialsFile')).toBeUndefined();
+  });
+
+  test('should not treat literal array defaults as declarative', () => {
+    const literalDefault = [
+      { label: 'foo', value: 1 },
+      { label: 'bar', value: 2 },
+    ];
+    const node: IConfigurationNode = {
+      id: 'custom',
+      title: 'Test Object Property',
+      properties: {
+        'test.literalArray': {
+          description: 'test property',
+          type: 'array',
+          default: literalDefault,
+        },
+      },
+    };
+
+    configurationRegistry.registerConfigurations([node]);
+    const property = configurationRegistry.getConfigurationProperties()['test.literalArray'];
+
+    expect(property?.default).toEqual(literalDefault);
+  });
+
+  test('should not treat string array defaults without env:/file: prefixes as declarative', () => {
+    const literalDefault = ['alpha', 'beta'];
+    const node: IConfigurationNode = {
+      id: 'custom',
+      title: 'Test String Array',
+      properties: {
+        'test.stringArray': {
+          description: 'test property',
+          type: 'array',
+          default: literalDefault,
+        },
+      },
+    };
+
+    configurationRegistry.registerConfigurations([node]);
+    const property = configurationRegistry.getConfigurationProperties()['test.stringArray'];
+
+    expect(property?.default).toEqual(literalDefault);
+  });
+
+  test('should leave scalar defaults unchanged', () => {
+    const property = registerWithDefault('/already/set/path.json');
+    expect(property?.default).toBe('/already/set/path.json');
   });
 });

--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -1231,4 +1231,33 @@ describe('declarative env:/file: defaults', () => {
     const property = registerWithDefault('/already/set/path.json');
     expect(property?.default).toBe('/already/set/path.json');
   });
+
+  test('should resolve single env: string default when variable is set', () => {
+    process.env[ENV_VAR] = '/from/env/creds.json';
+
+    const property = registerWithDefault(`env:${ENV_VAR}`);
+
+    expect(property?.default).toBe('/from/env/creds.json');
+  });
+
+  test('should resolve single env: string default to undefined when variable is unset', () => {
+    const property = registerWithDefault(`env:${ENV_VAR}`);
+
+    expect(property?.default).toBeUndefined();
+  });
+
+  test('should resolve single file: string default when file exists', () => {
+    const expectedPath = path.join('/home/testuser', '.config/my-tool/credentials.json');
+    vi.mocked(existsSync).mockImplementation((p: Parameters<typeof existsSync>[0]) => p === expectedPath);
+
+    const property = registerWithDefault('file:~/.config/my-tool/credentials.json');
+
+    expect(property?.default).toBe(expectedPath);
+  });
+
+  test('should resolve single file: string default to undefined when file does not exist', () => {
+    const property = registerWithDefault('file:~/.config/my-tool/credentials.json');
+
+    expect(property?.default).toBeUndefined();
+  });
 });

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2022-2025 Red Hat, Inc.
+ * Copyright (C) 2022-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
+import { homedir } from 'node:os';
 import * as path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 
@@ -226,6 +227,9 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
           configProperty.extension = { id: configuration.extension?.id };
         }
 
+        // Resolve declarative defaults (env:/file: arrays) at registration time
+        configProperty.default = this.resolveDeclarativeDefault(configProperty.default);
+
         // register default if not yet set
         const configurationValue = this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE);
         if (configurationValue !== undefined) {
@@ -256,6 +260,94 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
       return true;
     }
     return scope === CONFIGURATION_DEFAULT_SCOPE;
+  }
+
+  /**
+   * Resolve declarative default values declared as an ordered list of `env:` / `file:` entries.
+   * Returns the first matching value, or `undefined` if none resolve.
+   * Non-declarative defaults (literals, object arrays, etc.) are returned unchanged.
+   */
+  protected resolveDeclarativeDefault(defaultValue: unknown): unknown {
+    if (!Array.isArray(defaultValue) || defaultValue.length === 0) {
+      return defaultValue;
+    }
+
+    // Only treat as declarative when every entry is an env: or file: string
+    if (
+      !defaultValue.every(
+        (entry): entry is string =>
+          typeof entry === 'string' && (entry.startsWith('env:') || entry.startsWith('file:')),
+      )
+    ) {
+      return defaultValue;
+    }
+
+    for (const entry of defaultValue) {
+      const resolved = this.resolveDeclarativeDefaultEntry(entry);
+      if (resolved !== undefined) {
+        return resolved;
+      }
+    }
+    return undefined;
+  }
+
+  protected resolveDeclarativeDefaultEntry(entry: string): string | undefined {
+    if (entry.startsWith('env:')) {
+      const varName = entry.slice('env:'.length);
+      if (!varName) {
+        return undefined;
+      }
+      const value = process.env[varName];
+      if (value !== undefined && value !== '') {
+        return value;
+      }
+      return undefined;
+    }
+
+    if (entry.startsWith('file:')) {
+      const pathSpec = entry.slice('file:'.length);
+      if (!pathSpec) {
+        return undefined;
+      }
+      const expanded = this.expandPath(pathSpec);
+      if (expanded && fs.existsSync(expanded)) {
+        return expanded;
+      }
+      return undefined;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Expand `~` (home directory) and `$VAR` environment variables in a path string.
+   * Returns `undefined` if any referenced `$VAR` is unset or empty, so we never
+   * check a truncated path like `/gcloud/creds.json` when `$APPDATA` is missing.
+   */
+  protected expandPath(pathSpec: string): string | undefined {
+    let result = pathSpec;
+
+    if (result === '~') {
+      result = homedir();
+    } else if (result.startsWith('~/') || result.startsWith('~\\')) {
+      result = path.join(homedir(), result.slice(2));
+    }
+
+    let unsetVariable = false;
+    result = result.replace(/\$([A-Za-z_]\w*)/g, (_match, name: string) => {
+      const value = process.env[name];
+      if (value === undefined || value === '') {
+        unsetVariable = true;
+        return '';
+      }
+      return value;
+    });
+
+    if (unsetVariable) {
+      return undefined;
+    }
+
+    return result;
   }
 
   /**

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -263,11 +263,18 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   }
 
   /**
-   * Resolve declarative default values declared as an ordered list of `env:` / `file:` entries.
+   * Resolve declarative default values declared as `env:` / `file:` entries.
+   * Supports both a single string (`"default": "env:VAR"`) and an ordered
+   * array (`"default": ["env:VAR", "file:~/.path"]`).
    * Returns the first matching value, or `undefined` if none resolve.
    * Non-declarative defaults (literals, object arrays, etc.) are returned unchanged.
    */
   protected resolveDeclarativeDefault(defaultValue: unknown): unknown {
+    // Single string form: "default": "env:VAR" or "default": "file:~/.path"
+    if (typeof defaultValue === 'string' && (defaultValue.startsWith('env:') || defaultValue.startsWith('file:'))) {
+      return this.resolveDeclarativeDefaultEntry(defaultValue);
+    }
+
     if (!Array.isArray(defaultValue) || defaultValue.length === 0) {
       return defaultValue;
     }


### PR DESCRIPTION

### What does this PR do?
Allow extensions to declare an ordered array of env: and file: entries as a property default. ConfigurationRegistry resolves the first match at registration time (~ and $VAR expansion for file paths; unset $VAR skips the entry), leaving the field empty when nothing resolves.

### What issues does this PR fix or reference?

Fixes #18788

### How to test this PR?

## Test plan

### Automated
- [x] Unit tests pass (`npx vitest run packages/main/src/plugin/configuration-registry.spec.ts`) — 41 tests covering:
  - `env:VAR` resolves when set, skips when empty/unset
  - `file:~/.path` resolves with home expansion when file exists
  - `file:$VAR/path` resolves with env expansion when file exists
  - `file:$VAR/path` is skipped (not checked) when `$VAR` is unset
  - Falls back to `undefined` when no entry resolves
  - Literal array defaults (objects, plain strings) are left untouched

### Manual verification
1. Create a test extension (or modify an existing one) with a `package.json` property using a declarative default:
   ```json
   {
     "contributes": {
       "configuration": {
         "title": "Test",
         "properties": {
           "test.credFile": {
             "type": "string",
             "format": "file",
             "description": "Credentials file",
             "default": [
               "env:TEST_CRED_PATH",
               "file:~/.config/test/credentials.json"
             ]
           }
         }
       }
     }
   }
   ```
2. **With env set:** run `TEST_CRED_PATH=/tmp/creds.json pnpm watch`, open Settings → verify the field shows `/tmp/creds.json`
3. **With file existing:** unset `TEST_CRED_PATH`, create `~/.config/test/credentials.json`, restart → verify the field shows the expanded path
4. **With neither:** unset env and remove the file, restart → verify the field is empty
5. **Existing extensions unaffected:** confirm Podman, Docker, Compose settings still show their normal defaults (no regressions from literal array/scalar defaults)

- [ ] Tests are covering the bug fix or the new feature
