### PR TITLE
chore: use constant env vars names as fallback to download remote extensions

### DIFF
--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -130,6 +130,52 @@ describe('findAuthEnvironment', () => {
     });
   });
 
+  test('should fallback to AUTH_REGISTRY_USER and AUTH_REGISTRY_SECRET when registry-specific env vars are not set', () => {
+    vi.stubEnv('AUTH_REGISTRY_USER', 'fallback-user');
+    vi.stubEnv('AUTH_REGISTRY_SECRET', 'fallback-secret');
+
+    const result = findAuthEnvironment('quay.io');
+    expect(result).toStrictEqual({
+      username: 'fallback-user',
+      secret: 'fallback-secret',
+    });
+  });
+
+  test('registry-specific env vars should take precedence over fallback env vars', () => {
+    vi.stubEnv('AUTH_QUAY_IO_USER', 'specific-user');
+    vi.stubEnv('AUTH_QUAY_IO_SECRET', 'specific-secret');
+    vi.stubEnv('AUTH_REGISTRY_USER', 'fallback-user');
+    vi.stubEnv('AUTH_REGISTRY_SECRET', 'fallback-secret');
+
+    const result = findAuthEnvironment('quay.io');
+    expect(result).toStrictEqual({
+      username: 'specific-user',
+      secret: 'specific-secret',
+    });
+  });
+
+  test('should mix registry-specific user with fallback secret', () => {
+    vi.stubEnv('AUTH_QUAY_IO_USER', 'specific-user');
+    vi.stubEnv('AUTH_REGISTRY_SECRET', 'fallback-secret');
+
+    const result = findAuthEnvironment('quay.io');
+    expect(result).toStrictEqual({
+      username: 'specific-user',
+      secret: 'fallback-secret',
+    });
+  });
+
+  test('should mix fallback user with registry-specific secret', () => {
+    vi.stubEnv('AUTH_REGISTRY_USER', 'fallback-user');
+    vi.stubEnv('AUTH_QUAY_IO_SECRET', 'specific-secret');
+
+    const result = findAuthEnvironment('quay.io');
+    expect(result).toStrictEqual({
+      username: 'fallback-user',
+      secret: 'specific-secret',
+    });
+  });
+
   test.each<string>(['AUTH_QUAY_IO_USER', 'AUTH_QUAY_IO_SECRET'])(
     'should throw an error if %s is the only env defined',
     env => {
@@ -137,9 +183,31 @@ describe('findAuthEnvironment', () => {
 
       expect(() => {
         findAuthEnvironment('quay.io');
-      }).toThrowError('if one of AUTH_QUAY_IO_USER and AUTH_QUAY_IO_SECRET is specified, both need to be defined.');
+      }).toThrowError(
+        'if one of AUTH_QUAY_IO_USER/AUTH_REGISTRY_USER and AUTH_QUAY_IO_SECRET/AUTH_REGISTRY_SECRET is specified, both need to be defined.',
+      );
     },
   );
+
+  test('should throw an error if only AUTH_REGISTRY_USER fallback is defined', () => {
+    vi.stubEnv('AUTH_REGISTRY_USER', 'fallback-user');
+
+    expect(() => {
+      findAuthEnvironment('quay.io');
+    }).toThrow(
+      'if one of AUTH_QUAY_IO_USER/AUTH_REGISTRY_USER and AUTH_QUAY_IO_SECRET/AUTH_REGISTRY_SECRET is specified, both need to be defined.',
+    );
+  });
+
+  test('should throw an error if only AUTH_REGISTRY_SECRET fallback is defined', () => {
+    vi.stubEnv('AUTH_REGISTRY_SECRET', 'fallback-secret');
+
+    expect(() => {
+      findAuthEnvironment('quay.io');
+    }).toThrow(
+      'if one of AUTH_QUAY_IO_USER/AUTH_REGISTRY_USER and AUTH_QUAY_IO_SECRET/AUTH_REGISTRY_SECRET is specified, both need to be defined.',
+    );
+  });
 });
 
 describe('downloadExtension', () => {

--- a/packages/main/scripts/download-remote-extensions.spec.ts
+++ b/packages/main/scripts/download-remote-extensions.spec.ts
@@ -130,9 +130,9 @@ describe('findAuthEnvironment', () => {
     });
   });
 
-  test('should fallback to AUTH_REGISTRY_USER and AUTH_REGISTRY_SECRET when registry-specific env vars are not set', () => {
-    vi.stubEnv('AUTH_REGISTRY_USER', 'fallback-user');
-    vi.stubEnv('AUTH_REGISTRY_SECRET', 'fallback-secret');
+  test('should fallback to REMOTE_EXTENSIONS_AUTH_USER and REMOTE_EXTENSIONS_AUTH_SECRET when registry-specific env vars are not set', () => {
+    vi.stubEnv('REMOTE_EXTENSIONS_AUTH_USER', 'fallback-user');
+    vi.stubEnv('REMOTE_EXTENSIONS_AUTH_SECRET', 'fallback-secret');
 
     const result = findAuthEnvironment('quay.io');
     expect(result).toStrictEqual({
@@ -144,8 +144,8 @@ describe('findAuthEnvironment', () => {
   test('registry-specific env vars should take precedence over fallback env vars', () => {
     vi.stubEnv('AUTH_QUAY_IO_USER', 'specific-user');
     vi.stubEnv('AUTH_QUAY_IO_SECRET', 'specific-secret');
-    vi.stubEnv('AUTH_REGISTRY_USER', 'fallback-user');
-    vi.stubEnv('AUTH_REGISTRY_SECRET', 'fallback-secret');
+    vi.stubEnv('REMOTE_EXTENSIONS_AUTH_USER', 'fallback-user');
+    vi.stubEnv('REMOTE_EXTENSIONS_AUTH_SECRET', 'fallback-secret');
 
     const result = findAuthEnvironment('quay.io');
     expect(result).toStrictEqual({
@@ -156,7 +156,7 @@ describe('findAuthEnvironment', () => {
 
   test('should mix registry-specific user with fallback secret', () => {
     vi.stubEnv('AUTH_QUAY_IO_USER', 'specific-user');
-    vi.stubEnv('AUTH_REGISTRY_SECRET', 'fallback-secret');
+    vi.stubEnv('REMOTE_EXTENSIONS_AUTH_SECRET', 'fallback-secret');
 
     const result = findAuthEnvironment('quay.io');
     expect(result).toStrictEqual({
@@ -166,7 +166,7 @@ describe('findAuthEnvironment', () => {
   });
 
   test('should mix fallback user with registry-specific secret', () => {
-    vi.stubEnv('AUTH_REGISTRY_USER', 'fallback-user');
+    vi.stubEnv('REMOTE_EXTENSIONS_AUTH_USER', 'fallback-user');
     vi.stubEnv('AUTH_QUAY_IO_SECRET', 'specific-secret');
 
     const result = findAuthEnvironment('quay.io');
@@ -184,28 +184,28 @@ describe('findAuthEnvironment', () => {
       expect(() => {
         findAuthEnvironment('quay.io');
       }).toThrowError(
-        'if one of AUTH_QUAY_IO_USER/AUTH_REGISTRY_USER and AUTH_QUAY_IO_SECRET/AUTH_REGISTRY_SECRET is specified, both need to be defined.',
+        'if one of AUTH_QUAY_IO_USER/REMOTE_EXTENSIONS_AUTH_USER and AUTH_QUAY_IO_SECRET/REMOTE_EXTENSIONS_AUTH_SECRET is specified, both need to be defined.',
       );
     },
   );
 
-  test('should throw an error if only AUTH_REGISTRY_USER fallback is defined', () => {
-    vi.stubEnv('AUTH_REGISTRY_USER', 'fallback-user');
+  test('should throw an error if only REMOTE_EXTENSIONS_AUTH_USER fallback is defined', () => {
+    vi.stubEnv('REMOTE_EXTENSIONS_AUTH_USER', 'fallback-user');
 
     expect(() => {
       findAuthEnvironment('quay.io');
     }).toThrow(
-      'if one of AUTH_QUAY_IO_USER/AUTH_REGISTRY_USER and AUTH_QUAY_IO_SECRET/AUTH_REGISTRY_SECRET is specified, both need to be defined.',
+      'if one of AUTH_QUAY_IO_USER/REMOTE_EXTENSIONS_AUTH_USER and AUTH_QUAY_IO_SECRET/REMOTE_EXTENSIONS_AUTH_SECRET is specified, both need to be defined.',
     );
   });
 
-  test('should throw an error if only AUTH_REGISTRY_SECRET fallback is defined', () => {
-    vi.stubEnv('AUTH_REGISTRY_SECRET', 'fallback-secret');
+  test('should throw an error if only REMOTE_EXTENSIONS_AUTH_SECRET fallback is defined', () => {
+    vi.stubEnv('REMOTE_EXTENSIONS_AUTH_SECRET', 'fallback-secret');
 
     expect(() => {
       findAuthEnvironment('quay.io');
     }).toThrow(
-      'if one of AUTH_QUAY_IO_USER/AUTH_REGISTRY_USER and AUTH_QUAY_IO_SECRET/AUTH_REGISTRY_SECRET is specified, both need to be defined.',
+      'if one of AUTH_QUAY_IO_USER/REMOTE_EXTENSIONS_AUTH_USER and AUTH_QUAY_IO_SECRET/REMOTE_EXTENSIONS_AUTH_SECRET is specified, both need to be defined.',
     );
   });
 });

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -89,8 +89,8 @@ export function findAuthEnvironment(registry: string): RegistryAuth | undefined 
   const secretKey = `${prefix}_SECRET`;
   console.debug(`Lookup environment variable ${usernameKey} & ${secretKey}`);
 
-  const usernameValue = process.env[usernameKey] ?? process.env['AUTH_REGISTRY_USER'];
-  const secretValue = process.env[secretKey] ?? process.env['AUTH_REGISTRY_SECRET'];
+  const usernameValue = process.env[usernameKey] ?? process.env['REMOTE_EXTENSIONS_AUTH_USER'];
+  const secretValue = process.env[secretKey] ?? process.env['REMOTE_EXTENSIONS_AUTH_SECRET'];
 
   // if both undefined => ignore
   if (!usernameValue && !secretValue) return undefined;
@@ -98,7 +98,7 @@ export function findAuthEnvironment(registry: string): RegistryAuth | undefined 
   // if only one is defined => raise error
   if (!usernameValue || !secretValue) {
     throw new Error(
-      `if one of ${usernameKey}/AUTH_REGISTRY_USER and ${secretKey}/AUTH_REGISTRY_SECRET is specified, both need to be defined.`,
+      `if one of ${usernameKey}/REMOTE_EXTENSIONS_AUTH_USER and ${secretKey}/REMOTE_EXTENSIONS_AUTH_SECRET is specified, both need to be defined.`,
     );
   }
 

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -97,7 +97,9 @@ export function findAuthEnvironment(registry: string): RegistryAuth | undefined 
 
   // if only one is defined => raise error
   if (!usernameValue || !secretValue) {
-    throw new Error(`if one of ${usernameKey} and ${secretKey} is specified, both need to be defined.`);
+    throw new Error(
+      `if one of ${usernameKey}/AUTH_REGISTRY_USER and ${secretKey}/AUTH_REGISTRY_SECRET is specified, both need to be defined.`,
+    );
   }
 
   return {

--- a/packages/main/scripts/download-remote-extensions.ts
+++ b/packages/main/scripts/download-remote-extensions.ts
@@ -89,8 +89,8 @@ export function findAuthEnvironment(registry: string): RegistryAuth | undefined 
   const secretKey = `${prefix}_SECRET`;
   console.debug(`Lookup environment variable ${usernameKey} & ${secretKey}`);
 
-  const usernameValue = process.env[usernameKey];
-  const secretValue = process.env[secretKey];
+  const usernameValue = process.env[usernameKey] ?? process.env['AUTH_REGISTRY_USER'];
+  const secretValue = process.env[secretKey] ?? process.env['AUTH_REGISTRY_SECRET'];
 
   // if both undefined => ignore
   if (!usernameValue && !secretValue) return undefined;


### PR DESCRIPTION
### What does this PR do?
This PR adds constant env var names as fallback to download remote extensions - `REMOTE_EXTENSIONS_AUTH_USER` and `REMOTE_EXTENSIONS_AUTH_SECRET`

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Closes https://github.com/podman-desktop/podman-desktop/issues/18325

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [X] Tests are covering the bug fix or the new feature
