### PR TITLE
feat(renderer): add OnboardingExtensionCard component

### DIFF
--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingExtensionCard.spec.ts
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingExtensionCard.spec.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, test, vi } from 'vitest';
+
+import OnboardingExtensionCard from './OnboardingExtensionCard.svelte';
+
+describe('OnboardingExtensionCard', () => {
+  const onToggle = vi.fn();
+
+  test('renders display name and description', () => {
+    render(OnboardingExtensionCard, {
+      displayName: 'Podman',
+      description: 'Integration for Podman and Podman Machines',
+      checked: true,
+      onToggle,
+    });
+
+    expect(screen.getByText('Podman')).toBeInTheDocument();
+    expect(screen.getByText('Integration for Podman and Podman Machines')).toBeInTheDocument();
+  });
+
+  test('exposes a single checkbox role with a descriptive label', () => {
+    render(OnboardingExtensionCard, {
+      displayName: 'Podman',
+      description: 'Integration for Podman and Podman Machines',
+      checked: true,
+      onToggle,
+    });
+
+    const card = screen.getByRole('checkbox', { name: 'Podman: Integration for Podman and Podman Machines' });
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveAttribute('aria-checked', 'true');
+  });
+
+  test('reflects unchecked state via aria-checked', () => {
+    render(OnboardingExtensionCard, {
+      displayName: 'Podman',
+      checked: false,
+      onToggle,
+    });
+
+    const card = screen.getByRole('checkbox');
+    expect(card).toHaveAttribute('aria-checked', 'false');
+  });
+
+  test('calls onToggle with new state on click', async () => {
+    const toggle = vi.fn();
+    render(OnboardingExtensionCard, {
+      displayName: 'Podman',
+      checked: true,
+      onToggle: toggle,
+    });
+
+    const card = screen.getByRole('checkbox');
+    await fireEvent.click(card);
+
+    expect(toggle).toHaveBeenCalledWith(false);
+  });
+
+  test('applies selected border style when checked', () => {
+    render(OnboardingExtensionCard, {
+      displayName: 'Podman',
+      checked: true,
+      onToggle,
+    });
+
+    const card = screen.getByRole('checkbox');
+    expect(card.className).toContain('border-(--pd-content-card-border-selected)');
+  });
+
+  test('applies default border style when not checked', () => {
+    render(OnboardingExtensionCard, {
+      displayName: 'Podman',
+      checked: false,
+      onToggle,
+    });
+
+    const card = screen.getByRole('checkbox');
+    expect(card.className).not.toContain('border-(--pd-content-card-border-selected)');
+    expect(card.className).toContain('border-(--pd-content-card-border)');
+  });
+
+  test('toggles on Space keydown', async () => {
+    const toggle = vi.fn();
+    render(OnboardingExtensionCard, {
+      displayName: 'Podman',
+      checked: true,
+      onToggle: toggle,
+    });
+
+    const card = screen.getByRole('checkbox');
+    await fireEvent.keyDown(card, { key: ' ' });
+
+    expect(toggle).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingExtensionCard.svelte
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingExtensionCard.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+import { faSquare as faOutlineSquare } from '@fortawesome/free-regular-svg-icons';
+import { faCheckSquare } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+
+import IconImage from '/@/lib/appearance/IconImage.svelte';
+
+interface Props {
+  icon?: string | { readonly light: string; readonly dark: string };
+  displayName: string;
+  description?: string;
+  checked: boolean;
+  onToggle: (checked: boolean) => void;
+}
+
+let { icon, displayName, description = '', checked = $bindable(), onToggle }: Props = $props();
+
+function handleToggle(): void {
+  checked = !checked;
+  onToggle(checked);
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  if (event.key === ' ' || event.key === 'Enter') {
+    event.preventDefault();
+    handleToggle();
+  }
+}
+</script>
+
+<div
+  role="checkbox"
+  aria-checked={checked}
+  aria-label="{displayName}: {description}"
+  tabindex="0"
+  class={[
+    'flex w-full cursor-pointer items-center gap-4 rounded-lg border px-5 py-4 text-left outline-none transition-colors',
+    checked
+      ? 'border-(--pd-content-card-border-selected) bg-(--pd-content-card-inset-bg)'
+      : 'border-(--pd-content-card-border) bg-(--pd-content-card-inset-bg) opacity-75',
+  ]}
+  onclick={handleToggle}
+  onkeydown={handleKeydown}>
+  <Icon
+    size="1.33x"
+    icon={checked ? faCheckSquare : faOutlineSquare}
+    class={checked
+      ? 'text-[var(--pd-input-checkbox-checked)]'
+      : 'text-[var(--pd-input-checkbox-unchecked)]'} />
+
+  {#if icon}
+    <div aria-hidden="true" class="shrink-0">
+      <IconImage image={icon} class="h-10 w-10" alt="" />
+    </div>
+  {/if}
+
+  <div class="min-w-0 flex-1" aria-hidden="true">
+    <div class="text-sm font-semibold text-(--pd-content-header)">{displayName}</div>
+    {#if description}
+      <div class="mt-0.5 text-xs text-(--pd-content-card-text)">{description}</div>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
### What does this PR do?

Adds a reusable `OnboardingExtensionCard` component for the new onboarding wizard welcome page. Each card displays an extension with a checkbox, icon, display name, and description.

> **Note:** This PR only contains the card component and its unit tests. Please review just the card — the surrounding page layout, sidebar, steps, and footer are **not** part of this PR.

### Screenshot / video of UI

#### Light mode — all checked

<img width="1162" height="812" alt="Screenshot 2026-08-14 at 11 47 51" src="https://github.com/user-attachments/assets/d4cec8f9-2984-4e8b-ac62-2c54e0980551" />


#### Light mode — one unchecked

<img width="1162" height="812" alt="Screenshot 2026-08-14 at 11 47 58" src="https://github.com/user-attachments/assets/c1161572-db9b-432f-bfed-cd998107cc7e" />

#### Dark mode — all checked
<img width="1162" height="812" alt="Screenshot 2026-08-14 at 11 48 14" src="https://github.com/user-attachments/assets/08001872-36ce-4178-835a-d1bea3632801" />


#### Dark mode — one unchecked
<img width="1162" height="812" alt="Screenshot 2026-08-14 at 11 48 21" src="https://github.com/user-attachments/assets/4002692b-d6fb-40dd-b1e4-cabfab266080" />


### What issues does this PR fix or reference?

Part of the onboarding wizard redesign (#17465).

### How to test this PR?

The card component is not wired into any route in this PR. To see it in action, use the demo branch [`feat/onboarding-welcome-demo`](https://github.com/simonrey1/podman-desktop/tree/feat/onboarding-welcome-demo) which builds on top of this PR:

1. Check out the demo branch: `git fetch origin feat/onboarding-welcome-demo && git checkout feat/onboarding-welcome-demo`
2. `pnpm install && pnpm watch`
3. Open DevTools console and run: `window.__pdGoto('/onboarding-welcome-demo')`
4. Verify cards display with icons, names, descriptions
5. Click cards to toggle checked/unchecked state — border and opacity should change

- [x] Tests are covering the new feature (6 unit tests)


Made with [Cursor](https://cursor.com)