### PR TITLE
fix(ci): install script dependencies for schemastore sync

### DIFF
--- a/.github/workflows/schemastore-sync-extension-schema.yaml
+++ b/.github/workflows/schemastore-sync-extension-schema.yaml
@@ -87,6 +87,8 @@ jobs:
           path: schemastore
           ref: master
 
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.nvmrc'

--- a/scripts/schemastore-sync-extension-schema.sh
+++ b/scripts/schemastore-sync-extension-schema.sh
@@ -48,6 +48,10 @@ if [[ -z "$versioned_schema_file_name" ]]; then
   exit 1
 fi
 
+# Install dependencies needed by the sync TypeScript script
+(cd "${REPO_ROOT}" && pnpm install --frozen-lockfile)
+
+# Install SchemaStore dependencies (prettier, etc.)
 npm install --no-audit --no-fund --ignore-scripts
 
 node --experimental-strip-types "${REPO_ROOT}/scripts/schemastore-sync-extension-schema.ts" \


### PR DESCRIPTION
### What does this PR do?

Fixes the schemastore sync CI job by ensuring the podman-desktop repo dependencies are installed before running the sync TypeScript script.

The script (`scripts/schemastore-sync-extension-schema.ts`) imports `jsonc-parser` and `minimist`, which are declared in the repo's root `package.json`. However, the workflow never installed them — it only ran `npm install` inside the SchemaStore checkout directory. This PR adds `pnpm/action-setup` to the workflow and runs `pnpm install --frozen-lockfile` in the repo root within the shell script.

### Screenshot / video of UI

N/A — CI-only change.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18539

### How to test this PR?

Validated with a push-triggered test workflow on a fork: https://github.com/simonrey1/podman-desktop/actions/runs/31815875338

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)