### PR TITLE
fix(e2e): expect log terminal instead of 'No Log' for interactive container

### DIFF
--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -126,10 +126,9 @@ test.describe('Verification of container creation workflow', { tag: ['@smoke'] }
     // test state of container in summary tab
     const containerState = await containersDetails.getState();
     playExpect(containerState).toContain(ContainerState.Running);
-    // check Logs output
+    // check Logs output — interactive TTY container produces log data (shell prompt)
     await containersDetails.activateTab('Logs');
-    const helloWorldMessage = containersDetails.getPage().getByText('No Log');
-    await playExpect(helloWorldMessage).toBeVisible();
+    await playExpect(containersDetails.terminalContent).toBeVisible();
     // Switch between various other tabs, no checking of the content
     await containersDetails.activateTab('Inspect');
     await containersDetails.activateTab('Kube');


### PR DESCRIPTION

### What does this PR do?

Interactive TTY containers produce log data (shell prompt), so the Logs tab shows the xterm terminal rather than the empty screen.

### Screenshot / video of UI

### What issues does this PR fix or reference?

Fixes #18826 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
