### PR TITLE
refactor(extension-loader): extract extensions external logic

### DIFF
--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -84,6 +84,7 @@ import type { ActivatedExtension, AnalyzedExtensionWithApi, RequireCacheDict } f
 import { ExtensionLoader } from './extension-loader.js';
 import type { ExtensionManifest } from './extension-manifest-schema.js';
 import type { ExtensionWatcher } from './extension-watcher.js';
+import type { ExtensionsExternal } from './local/extensions-external.js';
 
 vi.mock(import('node:fs'));
 
@@ -329,6 +330,10 @@ const extensionsBundle = {
   all: vi.fn(),
 } as unknown as ExtensionsBundle;
 
+const extensionsExternal = {
+  all: vi.fn(),
+} as unknown as ExtensionsExternal;
+
 const createApi = (disposables?: { dispose(): unknown }[]): typeof containerDesktopAPI => {
   const analyzedExtension = {
     path: '/path',
@@ -400,6 +405,7 @@ beforeEach(() => {
     extensionApiVersion,
     featureRegistry,
     extensionsBundle,
+    extensionsExternal,
   );
 });
 
@@ -410,6 +416,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 
   vi.mocked(extensionsBundle.all).mockReturnValue([]);
+  vi.mocked(extensionsExternal.all).mockReturnValue([]);
 
   configurationRegistryGetConfigurationMock.mockReturnValue({
     get: vi.fn().mockImplementation((key: string, defaultValue?: unknown) => {

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -48,6 +48,7 @@ import { Directories } from '/@/plugin/directories.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
 import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.js';
 import { ExtensionsBundle } from '/@/plugin/extension/local/extensions-bundle.js';
+import { ExtensionsExternal } from '/@/plugin/extension/local/extensions-external.js';
 import { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import { FilesystemMonitoring } from '/@/plugin/filesystem-monitoring.js';
 import { IconRegistry } from '/@/plugin/icon-registry.js';
@@ -109,8 +110,6 @@ export interface ActivatedExtension {
   extensionContext: containerDesktopAPI.ExtensionContext;
   packageJSON: unknown;
 }
-
-const EXTENSION_OPTION = '--extension-folder';
 
 export interface RequireCacheDict {
   [key: string]: NodeModule | undefined;
@@ -228,6 +227,8 @@ export class ExtensionLoader implements IAsyncDisposable {
     private featureRegistry: FeatureRegistry,
     @inject(ExtensionsBundle)
     private extensionsBundle: ExtensionsBundle,
+    @inject(ExtensionsExternal)
+    private extensionsExternal: ExtensionsExternal,
   ) {
     this.pluginsDirectory = directories.getPluginsDirectory();
     this.pluginsScanDirectory = directories.getPluginsScanDirectory();
@@ -486,22 +487,10 @@ export class ExtensionLoader implements IAsyncDisposable {
     }
 
     // Get the bundled extensions
-    const analyzedExtensions: AnalyzedExtension[] = this.extensionsBundle.all().filter(extension => !extension.error);
-
-    // Get the external foldr extensions
-    const externalExtensions = await this.readExternalFolders();
-    const analyzedExternalExtensions = (
-      await Promise.all(
-        externalExtensions.map(folder =>
-          this.analyzeExtension({
-            extensionPath: folder,
-            removable: false,
-            devMode: true,
-          }),
-        ),
-      )
-    ).filter(extension => !extension.error);
-    analyzedExtensions.push(...analyzedExternalExtensions);
+    const analyzedExtensions: AnalyzedExtension[] = [
+      ...this.extensionsBundle.all(),
+      ...this.extensionsExternal.all(),
+    ].filter(extension => !extension.error);
 
     // also load extensions from the plugins directory
     if (fs.existsSync(this.pluginsDirectory)) {
@@ -650,17 +639,6 @@ export class ExtensionLoader implements IAsyncDisposable {
     });
 
     return sorted;
-  }
-
-  async readExternalFolders(): Promise<string[]> {
-    const pathes = [];
-    for (let index = 0; index < process.argv.length; index++) {
-      if (process.argv[index] === EXTENSION_OPTION && index < process.argv.length - 1) {
-        pathes.push(process.argv[++index]);
-      }
-    }
-    // filter all undefined values
-    return pathes.filter(path => path !== undefined);
   }
 
   /**

--- a/packages/main/src/plugin/extension/local/extensions-external.spec.ts
+++ b/packages/main/src/plugin/extension/local/extensions-external.spec.ts
@@ -1,0 +1,109 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { AnalyzedExtension, ExtensionAnalyzer } from '/@/plugin/extension/extension-analyzer.js';
+import { ExtensionsExternal } from '/@/plugin/extension/local/extensions-external.js';
+
+const EXTENSION_ANALYZER = {
+  analyzeExtension: vi.fn(),
+} as unknown as ExtensionAnalyzer;
+
+let extensionsExternal: ExtensionsExternal;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  extensionsExternal = new ExtensionsExternal(EXTENSION_ANALYZER);
+});
+
+describe('readExternalFolders', () => {
+  test('should return empty array when no --extension-folder args', async () => {
+    vi.stubGlobal('process', { argv: ['electron', 'main.js'] });
+
+    const folders = await extensionsExternal.readExternalFolders();
+
+    expect(folders).toEqual([]);
+  });
+
+  test('should return folder path when --extension-folder is provided', async () => {
+    vi.stubGlobal('process', { argv: ['electron', 'main.js', '--extension-folder', '/path/to/ext'] });
+
+    const folders = await extensionsExternal.readExternalFolders();
+
+    expect(folders).toEqual(['/path/to/ext']);
+  });
+
+  test('should return multiple folder paths for multiple --extension-folder args', async () => {
+    vi.stubGlobal('process', {
+      argv: ['electron', 'main.js', '--extension-folder', '/ext1', '--extension-folder', '/ext2'],
+    });
+
+    const folders = await extensionsExternal.readExternalFolders();
+
+    expect(folders).toEqual(['/ext1', '/ext2']);
+  });
+
+  test('should ignore --extension-folder at the end without a value', async () => {
+    vi.stubGlobal('process', { argv: ['electron', 'main.js', '--extension-folder'] });
+
+    const folders = await extensionsExternal.readExternalFolders();
+
+    expect(folders).toEqual([]);
+  });
+});
+
+describe('init', () => {
+  test('should analyze each external folder extension', async () => {
+    vi.stubGlobal('process', {
+      argv: ['electron', 'main.js', '--extension-folder', '/ext1', '--extension-folder', '/ext2'],
+    });
+
+    const fakeExtension1 = { id: 'ext1' } as unknown as AnalyzedExtension;
+    const fakeExtension2 = { id: 'ext2' } as unknown as AnalyzedExtension;
+
+    vi.mocked(EXTENSION_ANALYZER.analyzeExtension)
+      .mockResolvedValueOnce(fakeExtension1)
+      .mockResolvedValueOnce(fakeExtension2);
+
+    await extensionsExternal.init();
+
+    expect(EXTENSION_ANALYZER.analyzeExtension).toHaveBeenCalledTimes(2);
+    expect(EXTENSION_ANALYZER.analyzeExtension).toHaveBeenCalledWith({
+      extensionPath: '/ext1',
+      removable: false,
+      devMode: true,
+    });
+    expect(EXTENSION_ANALYZER.analyzeExtension).toHaveBeenCalledWith({
+      extensionPath: '/ext2',
+      removable: false,
+      devMode: true,
+    });
+
+    expect(extensionsExternal.all()).toEqual([fakeExtension1, fakeExtension2]);
+  });
+
+  test('should set empty extensions when no --extension-folder args', async () => {
+    vi.stubGlobal('process', { argv: ['electron', 'main.js'] });
+
+    await extensionsExternal.init();
+
+    expect(EXTENSION_ANALYZER.analyzeExtension).not.toHaveBeenCalled();
+    expect(extensionsExternal.all()).toEqual([]);
+  });
+});

--- a/packages/main/src/plugin/extension/local/extensions-external.ts
+++ b/packages/main/src/plugin/extension/local/extensions-external.ts
@@ -1,0 +1,63 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { inject, injectable, postConstruct } from 'inversify';
+
+import { AnalyzedExtension, ExtensionAnalyzer } from '/@/plugin/extension/extension-analyzer.js';
+
+const EXTENSION_OPTION = '--extension-folder';
+
+@injectable()
+export class ExtensionsExternal {
+  #extensions: Array<AnalyzedExtension> = [];
+
+  constructor(
+    @inject(ExtensionAnalyzer)
+    private extensionAnalyzer: ExtensionAnalyzer,
+  ) {}
+
+  all(): ReadonlyArray<AnalyzedExtension> {
+    return this.#extensions;
+  }
+
+  @postConstruct()
+  async init(): Promise<void> {
+    // Get the external foldr extensions
+    const externalExtensions = await this.readExternalFolders();
+    this.#extensions = await Promise.all(
+      externalExtensions.map(folder =>
+        this.extensionAnalyzer.analyzeExtension({
+          extensionPath: folder,
+          removable: false,
+          devMode: true,
+        }),
+      ),
+    );
+  }
+
+  async readExternalFolders(): Promise<string[]> {
+    const pathes = [];
+    for (let index = 0; index < process.argv.length; index++) {
+      if (process.argv[index] === EXTENSION_OPTION && index < process.argv.length - 1) {
+        pathes.push(process.argv[++index]);
+      }
+    }
+    // filter all undefined values
+    return pathes.filter(path => path !== undefined);
+  }
+}

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -162,6 +162,7 @@ import { ExtensionApiVersion } from '/@/plugin/extension/extension-api-version.j
 import { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
 import { ExtensionWatcher } from '/@/plugin/extension/extension-watcher.js';
 import { ExtensionsBundle } from '/@/plugin/extension/local/extensions-bundle.js';
+import { ExtensionsExternal } from '/@/plugin/extension/local/extensions-external.js';
 import { FeatureRegistry } from '/@/plugin/feature-registry.js';
 import { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-registry.js';
 import { LockedConfiguration } from '/@/plugin/locked-configuration.js';
@@ -804,6 +805,7 @@ export class PluginSystem {
 
     container.bind<ExtensionApiVersion>(ExtensionApiVersion).toSelf().inSingletonScope();
     container.bind<ExtensionsBundle>(ExtensionsBundle).toSelf().inSingletonScope();
+    container.bind<ExtensionsExternal>(ExtensionsExternal).toSelf().inSingletonScope();
 
     container.bind<ExtensionLoader>(ExtensionLoader).toSelf().inSingletonScope();
     this.extensionLoader = await container.getAsync<ExtensionLoader>(ExtensionLoader);


### PR DESCRIPTION
### What does this PR do?

Extracting the logic of loading extensions from the `--extensions-folder` cli argument to a dedicated class. (Similar as https://github.com/podman-desktop/podman-desktop/pull/18749)

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/18748

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

I added new tests, as nothing in `packages/main/src/plugin/extension/extension-loader.spec.ts` was testing the logic of extensions external