### PR TITLE
fix(e2e): wait for Electron process exit before relaunching 

### DIFF
--- a/tests/playwright/src/runner/electron-runner.ts
+++ b/tests/playwright/src/runner/electron-runner.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { ChildProcess } from 'node:child_process';
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
 
@@ -170,7 +171,8 @@ export class ElectronRunner extends Runner {
       throw Error('Podman Desktop is not running');
     }
 
-    const pid = this._app?.process()?.pid;
+    const proc = this._app?.process();
+    const pid = proc?.pid;
     console.log(`Closing Podman Desktop with a timeout of ${timeout} ms, PID: ${pid}`);
     try {
       await this.raceWithTimeout(
@@ -182,6 +184,8 @@ export class ElectronRunner extends Runner {
       console.log(`Caught exception in closing: ${err}`);
       this.ensureElectronProcessesStopped(pid);
     }
+
+    await this.waitForProcessExit(proc, pid, 5_000);
 
     this._running = false;
     RunnerFactory.dispose();
@@ -206,6 +210,30 @@ export class ElectronRunner extends Runner {
    * all Electron processes by image name. This prevents a stale
    * single-instance lock from blocking subsequent test launches.
    */
+  protected async waitForProcessExit(
+    proc: ChildProcess | undefined | null,
+    pid: number | undefined,
+    timeout: number,
+  ): Promise<void> {
+    if (proc?.exitCode !== null || proc?.signalCode !== null) {
+      return;
+    }
+    console.log(`Waiting up to ${timeout}ms for PID ${pid} to exit...`);
+    try {
+      await this.raceWithTimeout(
+        new Promise<void>(resolve => {
+          proc.on('exit', resolve);
+        }),
+        timeout,
+        `Process ${pid} did not exit within ${timeout}ms`,
+      );
+      console.log(`Process ${pid} exited`);
+    } catch {
+      console.log(`Process ${pid} still alive after ${timeout}ms, force-killing`);
+      this.ensureElectronProcessesStopped(pid);
+    }
+  }
+
   protected ensureElectronProcessesStopped(pid: number | undefined): void {
     if (pid) {
       this.forceKillByPid(pid);


### PR DESCRIPTION
### What does this PR do?

The windows-11-arm update e2e tests fail intermittently because the second Electron launch starts before the first process has fully exited.

Investigation of CI run 32020589944 (job 95359312907) showed:
- The renderer crashes 91ms after launch with: TypeError: Cannot read properties of undefined (reading 'receive')
- The Playwright trace confirms a completely blank DOM (<div id="app"/> is empty) — the Svelte app never mounts.
- window.events (set by the preload via contextBridge.exposeInMainWorld) is undefined, meaning the preload script silently failed to initialize.
- The first launch works fine; only the second launch crashes.
- Zero preload/main-process console output is captured during the second launch, unlike the first which shows MaxListenersExceededWarning, IPC handler errors, and PluginSystem messages.

Root cause: the before-quit handler in packages/main/src/index.ts calls event.preventDefault() and runs extensionLoader.asyncDispose() before allowing the process to exit. On Win11-ARM, only 380ms elapsed between the first process's CDP debugger disconnecting and the second electron .launch() call — not enough time for the OS to fully release the first process's resources (single-instance lock mutex, ASAR file handles, IPC named pipes). The second process creates a window but the preload fails to set up contextBridge, leaving window.events undefined.

In successful runs on the same platform, the gap is ~2-3 seconds, giving the OS enough time to clean up. Other platforms (x86 Windows, macOS) are faster at process teardown and don't hit this race.

The fix adds waitForProcessExit() after electronApp.close() returns. It checks whether the child process has actually exited; if not, it waits up to 5 seconds for the exit event, then force-kills as a fallback. On platforms where the process exits promptly, the early-return check (exitCode !== null || killed) adds zero overhead.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #18225 

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
