### PR TITLE
fix: suspend processing events in event-store when document is hidden

### DIFF
--- a/packages/renderer/src/stores/event-store.spec.ts
+++ b/packages/renderer/src/stores/event-store.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { get, type Writable, writable } from 'svelte/store';
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, assert, beforeEach, expect, test, vi } from 'vitest';
 
 import { EventStore, type EventStoreInfo, fineGrainedEvents } from './event-store';
 
@@ -510,6 +510,54 @@ test('should flush pending update when document becomes visible', async () => {
   await vi.waitFor(() => {
     expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
   });
+});
+
+test('should defer debounced update when document becomes hidden before timer fires', async () => {
+  vi.useFakeTimers({ shouldAdvanceTime: false });
+
+  try {
+    const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
+    const checkForUpdateMock = vi.fn().mockResolvedValue(true);
+    const windowEventName = 'my-custom-event';
+    const updater = vi.fn();
+
+    const myCustomTypeInfo: MyCustomTypeInfo = { name: 'deferred-item' };
+    updater.mockResolvedValue([myCustomTypeInfo]);
+
+    const eventStore = new TestEventStore('my-test', myStoreInfo, checkForUpdateMock, [windowEventName], [], updater);
+    eventStore.setupWithDebounce(500, 0);
+
+    const callback = callbacks.get(windowEventName);
+    assert(callback);
+
+    // fire the event while visible — this schedules a 500ms debounce timer
+    await callback?.();
+    expect(updater).not.toHaveBeenCalled();
+
+    // hide the document before the debounce timer fires
+    Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+
+    // advance past the debounce timeout — doUpdate should see document.hidden and skip
+    await vi.advanceTimersByTimeAsync(600);
+    expect(updater).not.toHaveBeenCalled();
+    expect(get(myStoreInfo)).toStrictEqual([]);
+
+    // restore visibility and fire the visibilitychange event
+    Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+    const visibilityCallback = documentCallbacks.get('visibilitychange');
+    assert(visibilityCallback);
+    visibilityCallback(new Event('visibilitychange'));
+
+    // the pending update should now flush
+    await vi.waitFor(() => {
+      expect(updater).toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+    });
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test('should not flush on visibility change if no events were received while hidden', async () => {

--- a/packages/renderer/src/stores/event-store.spec.ts
+++ b/packages/renderer/src/stores/event-store.spec.ts
@@ -17,14 +17,17 @@
  ***********************************************************************/
 
 import { get, type Writable, writable } from 'svelte/store';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { EventStore, type EventStoreInfo, fineGrainedEvents } from './event-store';
 
 const callbacks = new Map<string, (arg?: unknown) => Promise<void> | void>();
 
+const documentCallbacks = new Map<string, EventListener>();
+
 beforeEach(() => {
   callbacks.clear();
+  documentCallbacks.clear();
   vi.resetAllMocks();
   vi.mocked(window.events.receive).mockImplementation((message, callback) => {
     callbacks.set(message, callback);
@@ -33,6 +36,14 @@ beforeEach(() => {
   vi.spyOn(window, 'addEventListener').mockImplementation((event, callback) => {
     callbacks.set(event, callback as (arg?: unknown) => void);
   });
+  vi.spyOn(document, 'addEventListener').mockImplementation((event, callback) => {
+    documentCallbacks.set(event, callback as EventListener);
+  });
+  Object.defineProperty(document, 'hidden', { value: false, writable: true, configurable: true });
+});
+
+afterEach(() => {
+  Object.defineProperty(document, 'hidden', { value: false, writable: true, configurable: true });
 });
 
 interface MyCustomTypeInfo {
@@ -436,4 +447,88 @@ test('Check debounce+delay', async () => {
 
   // check buffer events
   expect(eventStoreInfo.bufferEvents.length).toBeGreaterThan(1);
+});
+
+test('should skip updates when document is hidden', async () => {
+  const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
+  const checkForUpdateMock = vi.fn();
+  const windowEventName = 'my-custom-event';
+  const updater = vi.fn();
+
+  checkForUpdateMock.mockResolvedValue(true);
+
+  const eventStore = new TestEventStore('my-test', myStoreInfo, checkForUpdateMock, [windowEventName], [], updater);
+  eventStore.setup();
+
+  const callback = callbacks.get(windowEventName);
+  expect(callback).toBeDefined();
+
+  updater.mockResolvedValue([{ name: 'item' }]);
+
+  // simulate the window being hidden
+  Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+
+  await callback?.();
+
+  // updater should not have been called while hidden
+  expect(updater).not.toHaveBeenCalled();
+  expect(get(myStoreInfo)).toStrictEqual([]);
+});
+
+test('should flush pending update when document becomes visible', async () => {
+  const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
+  const checkForUpdateMock = vi.fn();
+  const windowEventName = 'my-custom-event';
+  const updater = vi.fn();
+
+  checkForUpdateMock.mockResolvedValue(true);
+
+  const myCustomTypeInfo: MyCustomTypeInfo = { name: 'my-custom-type' };
+  updater.mockResolvedValue([myCustomTypeInfo]);
+
+  const eventStore = new TestEventStore('my-test', myStoreInfo, checkForUpdateMock, [windowEventName], [], updater);
+  eventStore.setup();
+
+  const callback = callbacks.get(windowEventName);
+  expect(callback).toBeDefined();
+
+  // simulate the window being hidden and receiving an event
+  Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+  await callback?.();
+  expect(updater).not.toHaveBeenCalled();
+
+  // simulate the window becoming visible again
+  Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+  const visibilityCallback = documentCallbacks.get('visibilitychange');
+  expect(visibilityCallback).toBeDefined();
+  visibilityCallback?.(new Event('visibilitychange'));
+
+  // the store should be refreshed
+  await vi.waitFor(() => {
+    expect(updater).toHaveBeenCalled();
+  });
+  await vi.waitFor(() => {
+    expect(get(myStoreInfo)).toStrictEqual([myCustomTypeInfo]);
+  });
+});
+
+test('should not flush on visibility change if no events were received while hidden', async () => {
+  const myStoreInfo: Writable<MyCustomTypeInfo[]> = writable([]);
+  const checkForUpdateMock = vi.fn();
+  const updater = vi.fn();
+
+  checkForUpdateMock.mockResolvedValue(true);
+
+  const eventStore = new TestEventStore('my-test', myStoreInfo, checkForUpdateMock, ['my-event'], [], updater);
+  eventStore.setup();
+
+  // go hidden and come back without any events firing
+  Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+  Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+  const visibilityCallback = documentCallbacks.get('visibilitychange');
+  visibilityCallback?.(new Event('visibilitychange'));
+
+  // small delay to ensure nothing fires
+  await new Promise(resolve => setTimeout(resolve, 100));
+  expect(updater).not.toHaveBeenCalled();
 });

--- a/packages/renderer/src/stores/event-store.ts
+++ b/packages/renderer/src/stores/event-store.ts
@@ -226,6 +226,11 @@ export class EventStore<T> {
 
       // method that do the update
       const doUpdate = async (): Promise<void> => {
+        // re-check visibility: the timer may fire after the document became hidden
+        if (document.hidden) {
+          pendingUpdateWhileHidden = true;
+          return;
+        }
         await this.performUpdate(needUpdate, eventStoreInfo, eventName, args);
       };
 

--- a/packages/renderer/src/stores/event-store.ts
+++ b/packages/renderer/src/stores/event-store.ts
@@ -212,7 +212,16 @@ export class EventStore<T> {
     // for throttling every 5s if not already done
     let timeoutThrottle: NodeJS.Timeout | undefined;
 
+    // track whether an update was skipped while the window was hidden
+    let pendingUpdateWhileHidden = false;
+
     const update = async (eventName: string, args?: unknown[]): Promise<void> => {
+      // when the window is hidden, skip IPC calls and mark a pending update
+      if (document.hidden) {
+        pendingUpdateWhileHidden = true;
+        return;
+      }
+
       const needUpdate = await this.checkForUpdate(eventName, args);
 
       // method that do the update
@@ -272,6 +281,15 @@ export class EventStore<T> {
         }, this.debounceThrottleTimeoutDelay);
       }
     };
+
+    document.addEventListener('visibilitychange', () => {
+      if (!document.hidden && pendingUpdateWhileHidden) {
+        pendingUpdateWhileHidden = false;
+        eventStoreInfo.fetch().catch((error: unknown) => {
+          console.error(`Failed to refresh ${this.name} on visibility change`, error);
+        });
+      }
+    });
 
     this.windowEvents.forEach(eventNameWithOptionalKeys => {
       const [eventName, keysList] = eventNameWithOptionalKeys.split(EVENT_SEPARATOR);


### PR DESCRIPTION
### What does this PR do?

Currently when Podman Desktop window gets from minimized to visible state UI freezes for seveal seconds (depends on how long it was minimized). This is happening not for all pages but for those getting to many update events from event-store. The examples are:
1. Resources page with running podman VM
2. Details page for running podman VM
3. Preferences page

This change fixes all of them

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Closes #18548.

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

### For manual testing

Run command below from terminal to see cpu, memory and disk usage changes or resources page.

```
podman run --rm --name disk-stress ghcr.io/alexei-led/stress-ng --hdd 4 --hdd-bytes 10G --timeout 60s --metrics-brief
```