### PR TITLE
chore: add bundled property

### DIFF
--- a/packages/main/src/plugin/extension/extension-analyzer.ts
+++ b/packages/main/src/plugin/extension/extension-analyzer.ts
@@ -36,6 +36,7 @@ export interface AnalyzedExtension {
   mainPath?: string;
   api?: typeof containerDesktopAPI;
   removable: boolean;
+  bundled: boolean;
 
   // true if the extension is running in development mode
   // it means we're using a separate development folder
@@ -62,11 +63,17 @@ export interface ExtensionAnalyzerOptions {
   extensionPath: string;
   removable: boolean;
   devMode?: boolean;
+  bundled?: boolean;
 }
 
 @injectable()
 export class ExtensionAnalyzer {
-  async analyzeExtension({ extensionPath, removable, devMode }: ExtensionAnalyzerOptions): Promise<AnalyzedExtension> {
+  async analyzeExtension({
+    extensionPath,
+    removable,
+    devMode,
+    bundled,
+  }: ExtensionAnalyzerOptions): Promise<AnalyzedExtension> {
     const resolvedExtensionPath = await realpath(extensionPath);
     // do nothing if there is no package.json file
     let error = undefined;
@@ -82,6 +89,7 @@ export class ExtensionAnalyzer {
         api: <typeof containerDesktopAPI>{},
         removable: removable,
         devMode: devMode ?? false,
+        bundled: bundled ?? false,
         subscriptions: [],
         dispose(): void {},
         error,
@@ -114,6 +122,7 @@ export class ExtensionAnalyzer {
       readme,
       removable,
       devMode: devMode ?? false,
+      bundled: bundled ?? false,
       subscriptions: disposables,
       dispose(): void {
         for (const disposable of disposables) {

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -610,6 +610,7 @@ test('Verify extension error leads to failed state', async () => {
       mainPath: '',
       removable: false,
       devMode: false,
+      bundled: false,
       manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
@@ -641,6 +642,7 @@ test('Verify extension subscriptions are disposed when failed state reached', as
       mainPath: '',
       removable: false,
       devMode: false,
+      bundled: false,
       manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
@@ -676,6 +678,7 @@ test('Verify extension activate with a long timeout is flagged as error', async 
       mainPath: '',
       removable: false,
       devMode: false,
+      bundled: false,
       manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
@@ -708,6 +711,7 @@ test('Verify extension load triggers an onDidChange event', async () => {
     mainPath: '',
     removable: false,
     devMode: false,
+    bundled: false,
     manifest: {} as unknown as ExtensionManifest,
     subscriptions: [],
     readme: '',
@@ -729,6 +733,7 @@ test('Verify extension load', async () => {
     mainPath: '',
     removable: true,
     devMode: false,
+    bundled: false,
     manifest: {
       version: '1.1',
     } as unknown as ExtensionManifest,
@@ -768,6 +773,7 @@ test('Verify disabled extension skips registering contributions and runtime acti
     mainPath: 'main.js',
     removable: true,
     devMode: false,
+    bundled: false,
     manifest: {
       version: '1.0',
       contributes: {
@@ -815,6 +821,7 @@ test('Verify enabled extension registers contributions and activates runtime', a
     mainPath: '',
     removable: true,
     devMode: false,
+    bundled: false,
     manifest: {
       version: '1.0',
       contributes: {
@@ -862,6 +869,7 @@ test('Verify extension do not add configuration to subscriptions', async () => {
     mainPath: '',
     removable: false,
     devMode: false,
+    bundled: false,
     manifest: {
       version: '1.1',
       contributes: {
@@ -897,6 +905,7 @@ test('Verify extension activate registers extension features and the disposable 
     mainPath: '',
     removable: false,
     devMode: false,
+    bundled: false,
     manifest: {
       contributes: {
         features: ['feature1', 'feature2'],
@@ -1475,6 +1484,7 @@ test('Verify extension uri', async () => {
       mainPath: '',
       removable: false,
       devMode: false,
+      bundled: false,
       manifest: {} as unknown as ExtensionManifest,
       subscriptions: [],
       readme: '',
@@ -1509,6 +1519,7 @@ test('Verify exports and packageJSON', async () => {
       mainPath: '',
       removable: false,
       devMode: false,
+      bundled: false,
       manifest: {
         foo: 'bar',
       } as unknown as ExtensionManifest,
@@ -2903,6 +2914,7 @@ test('ExtensionLoader async dispose should stop all extensions', async () => {
       subscriptions: [],
       readme: '',
       dispose: vi.fn(),
+      bundled: false,
     },
     {
       activate: activateMock,

--- a/packages/main/src/plugin/extension/local/extension-bundle.spec.ts
+++ b/packages/main/src/plugin/extension/local/extension-bundle.spec.ts
@@ -77,6 +77,24 @@ test('should load extensions & extensions-extra', async () => {
   expect(devFolder).toEqual(path.join(process.resourcesPath, 'extensions-extra'));
 });
 
+test('should call ExtensionAnalyzer#analyzeExtension with builtin true', async () => {
+  vi.stubEnv('PROD', true);
+
+  const readProductionFoldersMock = vi.spyOn(extensionBundle, 'readProductionFolders');
+  readProductionFoldersMock.mockResolvedValue(['foo-bar']);
+  const readDevelopmentFoldersMock = vi.spyOn(extensionBundle, 'readDevelopmentFolders');
+  readDevelopmentFoldersMock.mockResolvedValue([]);
+
+  await extensionBundle.init();
+
+  expect(EXTENSION_ANALYZER.analyzeExtension).toHaveBeenCalledExactlyOnceWith({
+    builtin: true,
+    devMode: false,
+    extensionPath: 'foo-bar',
+    removable: false,
+  });
+});
+
 describe('loading extension folders', () => {
   const fileEntry = {
     isDirectory: () => false,

--- a/packages/main/src/plugin/extension/local/extension-bundle.spec.ts
+++ b/packages/main/src/plugin/extension/local/extension-bundle.spec.ts
@@ -77,7 +77,7 @@ test('should load extensions & extensions-extra', async () => {
   expect(devFolder).toEqual(path.join(process.resourcesPath, 'extensions-extra'));
 });
 
-test('should call ExtensionAnalyzer#analyzeExtension with builtin true', async () => {
+test('should call ExtensionAnalyzer#analyzeExtension with bundled true', async () => {
   vi.stubEnv('PROD', true);
 
   const readProductionFoldersMock = vi.spyOn(extensionBundle, 'readProductionFolders');
@@ -88,7 +88,7 @@ test('should call ExtensionAnalyzer#analyzeExtension with builtin true', async (
   await extensionBundle.init();
 
   expect(EXTENSION_ANALYZER.analyzeExtension).toHaveBeenCalledExactlyOnceWith({
-    builtin: true,
+    bundled: true,
     devMode: false,
     extensionPath: 'foo-bar',
     removable: false,

--- a/packages/main/src/plugin/extension/local/extensions-bundle.ts
+++ b/packages/main/src/plugin/extension/local/extensions-bundle.ts
@@ -59,6 +59,7 @@ export class ExtensionsBundle {
           extensionPath: folder,
           removable: false,
           devMode: false,
+          bundled: true,
         }),
       ),
     );


### PR DESCRIPTION
### What does this PR do?

Add `bundled` property to ExtensionInfo, to clearly distinct the extensions, without having to derive the property from others.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/15999

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
