### PR TITLE
fix(Images): distinguish Pull and Import toolbar icons

### DIFF
--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-import { faCircleArrowDown, faCloudDownload, faCube, faDownload, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCircleArrowDown,
+  faCloudDownload,
+  faCube,
+  faDownload,
+  faTrash,
+  faUpload,
+} from '@fortawesome/free-solid-svg-icons';
 import type { ContainerInfo, ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
 import {
   Button,

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowCircleDown, faCube, faDownload, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
+import { faCircleArrowDown, faCloudDownload, faCube, faDownload, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
 import type { ContainerInfo, ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
 import {
   Button,
@@ -320,11 +320,11 @@ function label(item: ImageInfoUI): string {
       type="secondary"
       on:click={importImage}
       title="Import Containers From Filesystem"
-      icon={faArrowCircleDown}
+      icon={faCircleArrowDown}
       aria-label="Import Image">
       Import
     </Button>
-    <Button type="secondary" on:click={gotoPullImage} title="Pull Image From a Registry" icon={faArrowCircleDown}>Pull</Button>
+    <Button type="secondary" on:click={gotoPullImage} title="Pull Image From a Registry" icon={faCloudDownload}>Pull</Button>
     <Button type="primary" on:click={gotoBuildImage} title="Build Image From Containerfile" icon={faCube}>Build</Button>
   {/snippet}
 


### PR DESCRIPTION
Closes #18848

Pull and Import sat next to each other in the Images toolbar both rendering `faArrowCircleDown`, so the two buttons were visually identical.

- Pull → `faCloudDownload`, matching "Install extension" in `ExtensionList.svelte` / `InstallManuallyExtensionModal.svelte` — same "fetch a remote resource into the app" meaning.
- Import → `faCircleArrowDown`, keeping the plain-circle arrow for the local filesystem action.

Both identifiers are already imported from `@fortawesome/free-solid-svg-icons` elsewhere in the renderer. No spec asserts on these icons, so nothing in `ImagesList.spec.ts` needed updating.