### PR TITLE
fix(Images): unify Push image icon with its modal

### DIFF
--- a/packages/renderer/src/lib/image/ImageActions.svelte
+++ b/packages/renderer/src/lib/image/ImageActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faArrowUp, faDownload, faEdit, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faCircleArrowUp, faDownload, faEdit, faLayerGroup, faPlay, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { Menu } from '@podman-desktop/core-api';
 import { MenuContext, NavigationPage } from '@podman-desktop/core-api';
 import { createEventDispatcher, onMount } from 'svelte';
@@ -130,7 +130,7 @@ function saveImage(): void {
     onClick={(): Promise<void> => pushImage(image)}
     menu={dropdownMenu}
     detailed={detailed}
-    icon={faArrowUp} />
+    icon={faCircleArrowUp} />
 
   <ListItemButtonIcon
     title="Edit Image"


### PR DESCRIPTION
Closes #18850

The Push image entry rendered `faArrowUp`, while `PushImageModal.svelte` uses `faCircleArrowUp` — so the icon changed as you moved from the menu into the modal. Switched the menu entry to the circle variant.

One note on the issue text: it lists `ImagesList.svelte`, but the Push image action actually lives in `ImageActions.svelte` (line 133), which is what this changes. `faArrowUp` had no other use in that file so it is dropped from the import.

Left `ManifestActions.svelte` alone — that is Push manifest, a separate action, and out of scope here. Happy to fold it in if you would rather they move together.

No spec asserts on these icons.