### PR TITLE
fix(Images): match Load/Import/Save modal icons to toolbar

### DIFF
--- a/packages/renderer/src/lib/image/ImportContainersImages.svelte
+++ b/packages/renderer/src/lib/image/ImportContainersImages.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
-import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCircleArrowDown, faMinusCircle, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
@@ -144,7 +144,7 @@ async function importContainers(): Promise<void> {
         on:click={importContainers}
         inProgress={inProgress}
         class="w-full"
-        icon={faPlay}
+        icon={faCircleArrowDown}
         aria-label="Import containers"
         disabled={importDisabled}>
         Import Containers

--- a/packages/renderer/src/lib/image/LoadImages.svelte
+++ b/packages/renderer/src/lib/image/LoadImages.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 /* eslint-disable import/no-duplicates */
 // https://github.com/import-js/eslint-plugin-import/issues/1479
-import { faMinusCircle, faPlay, faPlusCircle } from '@fortawesome/free-solid-svg-icons';
+import { faMinusCircle, faPlusCircle, faUpload } from '@fortawesome/free-solid-svg-icons';
 import type { ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
@@ -114,7 +114,7 @@ async function loadImages(): Promise<void> {
         on:click={loadImages}
         inProgress={inProgress}
         class="w-full"
-        icon={faPlay}
+        icon={faUpload}
         aria-label="Load images"
         disabled={loadDisabled}>
         Load Images

--- a/packages/renderer/src/lib/image/SaveImages.svelte
+++ b/packages/renderer/src/lib/image/SaveImages.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faMinusCircle, faPlay } from '@fortawesome/free-solid-svg-icons';
+import { faDownload, faMinusCircle } from '@fortawesome/free-solid-svg-icons';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
@@ -167,7 +167,7 @@ async function saveImages(): Promise<void> {
           on:click={saveImages}
           inProgress={inProgress}
           class="w-full"
-          icon={faPlay}
+          icon={faDownload}
           aria-label="Save images"
           disabled={saveDisabled}>
           Save Images


### PR DESCRIPTION
Closes #18849

The Load, Import and Save modals all shipped `faPlay` on their primary button, which reads as "run" and does not match what the toolbar shows for those actions.

- `LoadImages.svelte` → `faUpload` (matches the Load button in `ImagesList.svelte`)
- `ImportContainersImages.svelte` → `faCircleArrowDown`
- `SaveImages.svelte` → `faDownload`

`RunImage.svelte` and the Run action in `ImageActions.svelte` keep `faPlay`, which is correct there.

The Import icon here is the one #18848 settles on; I opened #18852 for that, so if the choice changes there this should follow it. Stacking-wise the two touch different files, so they can merge in either order.

No spec asserts on these icons.