### PR TITLE
refactor(renderer): use state runes in KubeObjectMetaArtifact to enable reactivity

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -94,7 +94,7 @@ function openPort(port: number): void {
   </tr>
   {#if Object.entries(container.labels).length > 0}
     <tr>
-      <DetailsCell style="cursor-pointer flex items-center" onClick={(): boolean => (labelsDropdownOpen = !labelsDropdownOpen)}>
+      <DetailsCell class="cursor-pointer flex items-center" onclick={(): boolean => (labelsDropdownOpen = !labelsDropdownOpen)}>
         Labels
         <ChevronExpander expanded={labelsDropdownOpen} size="0.9x" class="ml-1" />
       </DetailsCell>

--- a/packages/renderer/src/lib/details/DetailsCell.spec.ts
+++ b/packages/renderer/src/lib/details/DetailsCell.spec.ts
@@ -34,7 +34,7 @@ test('a details cell can wrap a value with nothing to wrap at', async () => {
 });
 
 test('the caller can still add classes of its own', async () => {
-  render(DetailsCell, { style: 'text-right' });
+  render(DetailsCell, { class: 'text-right' });
 
   const cell = screen.getByRole('cell');
   expect(cell).toHaveClass('text-right');

--- a/packages/renderer/src/lib/details/DetailsCell.svelte
+++ b/packages/renderer/src/lib/details/DetailsCell.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
-export let style: string = '';
-export let onClick: () => void = () => {};
+interface Props {
+  style?: string;
+  onClick?: () => void;
+  class?: string;
+}
+
+let { style = '', onClick = (): void => {}, class: className = '' }: Props = $props();
 </script>
 
 <!-- wrap-anywhere, because a details cell holds values nobody chose the length
@@ -12,6 +17,6 @@ export let onClick: () => void = () => {};
      Not break-all: that breaks ordinary words too, so prose and hyphenated names
      get chopped mid-word even when they would have fitted. overflow-wrap:
      anywhere breaks only what would otherwise overflow. -->
-<td class="pt-1 pl-3 wrap-anywhere {style} {$$props.class}" on:click={onClick}>
+<td class="pt-1 pl-3 wrap-anywhere {style} {className}" onclick={onClick}>
   <slot />
 </td>

--- a/packages/renderer/src/lib/details/DetailsCell.svelte
+++ b/packages/renderer/src/lib/details/DetailsCell.svelte
@@ -18,6 +18,6 @@ let { class: className, children, ...restProps }: Props = $props();
      Not break-all: that breaks ordinary words too, so prose and hyphenated names
      get chopped mid-word even when they would have fitted. overflow-wrap:
      anywhere breaks only what would otherwise overflow. -->
-<td class="{['pt-1', 'pl-3', 'wrap-anywhere', className]}" {...restProps}>
+<td class="{['pt-1 pl-3 wrap-anywhere', className]}" {...restProps}>
   {@render children?.()}
 </td>

--- a/packages/renderer/src/lib/details/DetailsCell.svelte
+++ b/packages/renderer/src/lib/details/DetailsCell.svelte
@@ -18,6 +18,6 @@ let { class: className, children, ...restProps }: Props = $props();
      Not break-all: that breaks ordinary words too, so prose and hyphenated names
      get chopped mid-word even when they would have fitted. overflow-wrap:
      anywhere breaks only what would otherwise overflow. -->
-<td class="pt-1 pl-3 wrap-anywhere {className}" {...restProps}>
+<td class="{['pt-1', 'pl-3', 'wrap-anywhere', className]}" {...restProps}>
   {@render children?.()}
 </td>

--- a/packages/renderer/src/lib/details/DetailsCell.svelte
+++ b/packages/renderer/src/lib/details/DetailsCell.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-interface Props {
-  style?: string;
-  onClick?: () => void;
-  class?: string;
+import type { Snippet } from 'svelte';
+import type { HTMLTdAttributes } from 'svelte/elements';
+
+interface Props extends HTMLTdAttributes {
+  children?: Snippet;
 }
 
-let { style = '', onClick = (): void => {}, class: className = '' }: Props = $props();
+let { class: className, children, ...restProps }: Props = $props();
 </script>
 
 <!-- wrap-anywhere, because a details cell holds values nobody chose the length
@@ -17,6 +18,6 @@ let { style = '', onClick = (): void => {}, class: className = '' }: Props = $pr
      Not break-all: that breaks ordinary words too, so prose and hyphenated names
      get chopped mid-word even when they would have fitted. overflow-wrap:
      anywhere breaks only what would otherwise overflow. -->
-<td class="pt-1 pl-3 wrap-anywhere {style} {className}" onclick={onClick}>
-  <slot />
+<td class="pt-1 pl-3 wrap-anywhere {className}" {...restProps}>
+  {@render children?.()}
 </td>

--- a/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
@@ -17,8 +17,8 @@ if (artifact?.creationTimestamp) {
   artifact.creationTimestamp = new Date(artifact.creationTimestamp);
 }
 
-let internalLabelsDropdownOpen: boolean = false;
-let internalAnnotationsDropdownOpen: boolean = false;
+let internalLabelsDropdownOpen = $state(false);
+let internalAnnotationsDropdownOpen = $state(false);
 
 let labels: [string, string][] = [];
 let internalLabels: [string, string][] = [];

--- a/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
@@ -81,7 +81,7 @@ if (artifact?.annotations) {
     <tr>
       <Cell
         style="cursor-pointer flex items-center"
-        onClick={(): boolean => (internalLabelsDropdownOpen = !internalLabelsDropdownOpen)}>
+        onclick={(): boolean => (internalLabelsDropdownOpen = !internalLabelsDropdownOpen)}>
         Internal Labels
         <ChevronExpander expanded={internalLabelsDropdownOpen} size="0.9x" class="ml-1" />
       </Cell>
@@ -113,7 +113,7 @@ if (artifact?.annotations) {
     <tr>
       <Cell
         style="cursor-pointer flex items-center"
-        onClick={(): boolean => (internalAnnotationsDropdownOpen = !internalAnnotationsDropdownOpen)}>
+        onclick={(): boolean => (internalAnnotationsDropdownOpen = !internalAnnotationsDropdownOpen)}>
         Internal Annotations
         <ChevronExpander expanded={internalAnnotationsDropdownOpen} size="0.9x" class="ml-1" />
       </Cell>

--- a/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
@@ -80,7 +80,7 @@ if (artifact?.annotations) {
   {#if internalLabels.length > 0}
     <tr>
       <Cell
-        style="cursor-pointer flex items-center"
+        class="cursor-pointer flex items-center"
         onclick={(): boolean => (internalLabelsDropdownOpen = !internalLabelsDropdownOpen)}>
         Internal Labels
         <ChevronExpander expanded={internalLabelsDropdownOpen} size="0.9x" class="ml-1" />
@@ -112,7 +112,7 @@ if (artifact?.annotations) {
   {#if internalAnnotations.length > 0}
     <tr>
       <Cell
-        style="cursor-pointer flex items-center"
+        class="cursor-pointer flex items-center"
         onclick={(): boolean => (internalAnnotationsDropdownOpen = !internalAnnotationsDropdownOpen)}>
         Internal Annotations
         <ChevronExpander expanded={internalAnnotationsDropdownOpen} size="0.9x" class="ml-1" />


### PR DESCRIPTION
### What does this PR do?
Changes 2 plain let variables that were not reactive, to state runes which are reactive in `KubeObjectMetaArtifact.svelte` file. They need to be reactive, because they both manage dropdown state.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/pull/18772/changes/BASE..a79e03043d7a157fa7d410b283565ca3982f9571#r3810417133

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
