### PR TITLE
chore(redhat-actions/podman-install): bump to v1.0.0

### DIFF
--- a/.github/workflows/argos-podman-desktop.yaml
+++ b/.github/workflows/argos-podman-desktop.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d
+        uses: redhat-actions/podman-install@42d2db54fedf8b6eecbd104b77f21d13761602b2 # v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d
+        uses: redhat-actions/podman-install@42d2db54fedf8b6eecbd104b77f21d13761602b2 # v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d
+        uses: redhat-actions/podman-install@42d2db54fedf8b6eecbd104b77f21d13761602b2 # v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -322,7 +322,7 @@ jobs:
 
       - name: Install Podman v5 using external action
         # Use the action from the other repository
-        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d
+        uses: redhat-actions/podman-install@42d2db54fedf8b6eecbd104b77f21d13761602b2 # v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -390,7 +390,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install latest Podman version using external action
-        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d
+        uses: redhat-actions/podman-install@42d2db54fedf8b6eecbd104b77f21d13761602b2 # v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -428,7 +428,7 @@ jobs:
           path: |
             ./tests/**/output/
             !./tests/**/traces/raw
-  
+
   macos-sanity-check-e2e-tests:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'area/ci') || !github.event.pull_request.draft }}
     name: macos sanity check e2e tests
@@ -489,7 +489,7 @@ jobs:
           echo "KIND_PROVIDER=${{ env.DEFAULT_KIND_PROVIDER }}" >> $GITHUB_ENV
 
       - name: Install Podman v5 using external action
-        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d
+        uses: redhat-actions/podman-install@42d2db54fedf8b6eecbd104b77f21d13761602b2 # v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### What does this PR do?

~~The action seems to be failing, trying to bump to https://github.com/redhat-actions/podman-install/releases/tag/v1.0.0~~

The failing action is not caused by the action, this seems to be a problem on ubuntu mirror side, so hopefully should be resolved soon.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle: 
