### PR TITLE
fix: prevent tooltip from reappearing after menu closes

### DIFF
--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -20,6 +20,7 @@ import '@testing-library/jest-dom/vitest';
 
 import { autoUpdate, computePosition } from '@floating-ui/dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { resetTooltipHideCount } from './tooltip-store';
@@ -49,7 +50,7 @@ describe('Tooltip', () => {
     vi.clearAllMocks();
   });
 
-  test('tooltip is hidden when tooltipHidden is true', async () => {
+  test('tooltip remains hidden after tooltipHidden resets until pointer re-enters', async () => {
     render(TooltipTestComponent, { tip: 'test 1' });
 
     const slot = screen.getByTestId('tooltip-trigger');
@@ -69,6 +70,9 @@ describe('Tooltip', () => {
 
     // Simulate dropdown closing (shows tooltips)
     window.dispatchEvent(new Event('tooltip-show'));
+    await tick();
+    expect(screen.queryByText('test 1')).not.toBeInTheDocument();
+
     await fireEvent.mouseEnter(slot);
 
     await waitFor(() => {

--- a/packages/ui/src/lib/tooltip/Tooltip.spec.ts
+++ b/packages/ui/src/lib/tooltip/Tooltip.spec.ts
@@ -20,7 +20,6 @@ import '@testing-library/jest-dom/vitest';
 
 import { autoUpdate, computePosition } from '@floating-ui/dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { tick } from 'svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { resetTooltipHideCount } from './tooltip-store';
@@ -70,8 +69,10 @@ describe('Tooltip', () => {
 
     // Simulate dropdown closing (shows tooltips)
     window.dispatchEvent(new Event('tooltip-show'));
-    await tick();
-    expect(screen.queryByText('test 1')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByText('test 1')).not.toBeInTheDocument();
+    });
 
     await fireEvent.mouseEnter(slot);
 

--- a/packages/ui/src/lib/tooltip/Tooltip.svelte
+++ b/packages/ui/src/lib/tooltip/Tooltip.svelte
@@ -160,6 +160,12 @@ function handleFocusOut(event: FocusEvent): void {
   handleMouseLeave();
 }
 
+$effect(() => {
+  if ($tooltipHidden) {
+    handleMouseLeave();
+  }
+});
+
 $effect((): (() => void) => {
   if (isVisible && referenceElement && tooltipElement) {
     // Initial positioning


### PR DESCRIPTION
### What does this PR do?

Prevents a tooltip from reappearing after a dropdown or context menu closes.
The global tooltip state hid tooltips while a menu was open, but the tooltip kept
its local visible state - so when the menu closed, the old tooltip could reappear
without a new pointer or focus event. This clears the local visibility and
requires a new hover or keyboard focus before the tooltip is shown again.

### Screenshot / video of UI

_To be added - screen recording demonstrating the fix._

### What issues does this PR fix or reference?

Closes #14879. Supersedes #18501 by @oozan.

### How to test this PR?

1. Find a component with a tooltip trigger that also opens a dropdown / context menu.
2. Hover to show the tooltip, then open the menu (the tooltip hides).
3. Close the menu.
4. Verify the tooltip does **not** reappear until a new hover or keyboard focus.

Run the focused suite: `npx vitest run packages/ui/src/lib/tooltip/Tooltip.spec.ts` (26 tests pass).

- [x] Tests are covering the bug fix or the new feature

---

Supersedes #18501 by @oozan — the original commits are preserved with **@oozan as
author**, so full credit for the fix goes to them. I reached out via PR comment and
email to have them re-sign the DCO, but received no response, so I opened this
superseding PR and signed the previously unsigned commit as committer to unblock it.
