### PR TITLE
test(e2e): update serial declaration - part 4

### DIFF
--- a/tests/playwright/src/specs/extension-installation-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-installation-smoke.spec.ts
@@ -278,72 +278,72 @@ for (const { extensionLabel, extensionFullLabel, extensionName, extensionFullNam
   });
 }
 
-test.describe
-  .serial('Install extension via SHA digest', { tag: '@smoke' }, () => {
-    const ext = openshiftDockerExtension;
-    const config: ExtensionInstallConfig | undefined = extensionInstallConfigs[ext.extensionName];
-    const shaDigestUrl = config?.shaDigestImageUrl;
+test.describe('Install extension via SHA digest', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  const ext = openshiftDockerExtension;
+  const config: ExtensionInstallConfig | undefined = extensionInstallConfigs[ext.extensionName];
+  const shaDigestUrl = config?.shaDigestImageUrl;
 
-    test.skip(!shaDigestUrl, 'No SHA digest URL configured');
-    test.skip(!!isWindows, 'OpenShift Docker extension times out on Windows');
+  test.skip(!shaDigestUrl, 'No SHA digest URL configured');
+  test.skip(!!isWindows, 'OpenShift Docker extension times out on Windows');
 
-    test.beforeAll(async () => {
-      await _startup(ext.extensionLabel);
-    });
-
-    test.afterAll(async () => {
-      await pdRunner.close();
-    });
-
-    test('Install extension from OCI image using SHA digest', async () => {
-      test.setTimeout(200_000);
-
-      const extensionsPage = await navigationBar.openExtensions();
-      await playExpect(extensionsPage.heading).toBeVisible();
-
-      if (!shaDigestUrl) throw new Error('shaDigestUrl is required');
-      await extensionsPage.installExtensionFromOCIImage(shaDigestUrl, 180_000);
-
-      await extensionsPage.openInstalledTab();
-      await playExpect
-        .poll(async () => await extensionsPage.extensionIsInstalled(ext.extensionFullLabel), { timeout: 15_000 })
-        .toBeTruthy();
-    });
-
-    test('Extension installed via digest is active with no errors', async () => {
-      const extensionsPage = await navigationBar.openExtensions();
-      const extensionPage = await extensionsPage.openExtensionDetails(
-        ext.extensionLabel,
-        ext.extensionFullLabel,
-        ext.extensionFullName,
-      );
-      await playExpect(extensionPage.heading).toBeVisible();
-      await playExpect(extensionPage.status).toHaveText(ExtensionState.Active, { timeout: 15_000 });
-
-      const errorTab = extensionPage.tabs.getByRole('button', { name: 'Error' });
-      let stackTrace = '';
-      if ((await errorTab.count()) > 0) {
-        stackTrace = await errorTab.innerText();
-      }
-      await playExpect(errorTab, `Error Tab was present with stackTrace: ${stackTrace}`).not.toBeVisible();
-    });
-
-    test('Remove extension installed via digest', async () => {
-      const extensionsPage = await navigationBar.openExtensions();
-      const extensionDetails = await extensionsPage.openExtensionDetails(
-        ext.extensionLabel,
-        ext.extensionFullLabel,
-        ext.extensionFullName,
-      );
-      await extensionDetails.removeExtension(false);
-
-      await goToDashboard();
-      const extensionsPageAfter = await navigationBar.openExtensions();
-      await playExpect
-        .poll(async () => extensionsPageAfter.extensionIsInstalled(ext.extensionFullLabel), { timeout: 15_000 })
-        .toBeFalsy();
-    });
+  test.beforeAll(async () => {
+    await _startup(ext.extensionLabel);
   });
+
+  test.afterAll(async () => {
+    await pdRunner.close();
+  });
+
+  test('Install extension from OCI image using SHA digest', async () => {
+    test.setTimeout(200_000);
+
+    const extensionsPage = await navigationBar.openExtensions();
+    await playExpect(extensionsPage.heading).toBeVisible();
+
+    if (!shaDigestUrl) throw new Error('shaDigestUrl is required');
+    await extensionsPage.installExtensionFromOCIImage(shaDigestUrl, 180_000);
+
+    await extensionsPage.openInstalledTab();
+    await playExpect
+      .poll(async () => await extensionsPage.extensionIsInstalled(ext.extensionFullLabel), { timeout: 15_000 })
+      .toBeTruthy();
+  });
+
+  test('Extension installed via digest is active with no errors', async () => {
+    const extensionsPage = await navigationBar.openExtensions();
+    const extensionPage = await extensionsPage.openExtensionDetails(
+      ext.extensionLabel,
+      ext.extensionFullLabel,
+      ext.extensionFullName,
+    );
+    await playExpect(extensionPage.heading).toBeVisible();
+    await playExpect(extensionPage.status).toHaveText(ExtensionState.Active, { timeout: 15_000 });
+
+    const errorTab = extensionPage.tabs.getByRole('button', { name: 'Error' });
+    let stackTrace = '';
+    if ((await errorTab.count()) > 0) {
+      stackTrace = await errorTab.innerText();
+    }
+    await playExpect(errorTab, `Error Tab was present with stackTrace: ${stackTrace}`).not.toBeVisible();
+  });
+
+  test('Remove extension installed via digest', async () => {
+    const extensionsPage = await navigationBar.openExtensions();
+    const extensionDetails = await extensionsPage.openExtensionDetails(
+      ext.extensionLabel,
+      ext.extensionFullLabel,
+      ext.extensionFullName,
+    );
+    await extensionDetails.removeExtension(false);
+
+    await goToDashboard();
+    const extensionsPageAfter = await navigationBar.openExtensions();
+    await playExpect
+      .poll(async () => extensionsPageAfter.extensionIsInstalled(ext.extensionFullLabel), { timeout: 15_000 })
+      .toBeFalsy();
+  });
+});
 
 function initializeLocators(extensionName: string): void {
   const nav = new NavigationBar(page);

--- a/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
+++ b/tests/playwright/src/specs/extension-onboarding-smoke.spec.ts
@@ -48,151 +48,151 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Verify onboarding experience for compose versioning', { tag: '@smoke' }, () => {
-    test('Welcome message available and handle telemetry', async ({ welcomePage }) => {
-      await playExpect(welcomePage.welcomeMessage).toBeVisible();
-      await playExpect(welcomePage.telemetryConsent).toBeVisible();
-      await playExpect(welcomePage.telemetryConsent).toBeChecked();
-      await welcomePage.turnOffTelemetry();
-    });
-
-    test('Check podman installation', async ({ welcomePage }) => {
-      await playExpect(welcomePage.startOnboarding).toBeEnabled({ timeout: 10_000 });
-      await welcomePage.startOnboarding.click();
-
-      await playExpect(welcomePage.onboardingMessageStatus).toBeVisible({ timeout: 10_000 });
-      await playExpect(welcomePage.onboardingMessageStatus).toContainText('Podman has been set up correctly', {
-        timeout: 10_000,
-      });
-      await playExpect(welcomePage.nextStepButton).toBeEnabled();
-      await welcomePage.nextStepButton.click();
-
-      const podmanInstalledMessage = welcomePage.onboardingMessageStatus.filter({
-        hasText: 'Podman installed',
-      });
-      const noMachineMessage = welcomePage.onboardingMessageStatus.filter({
-        hasText: 'We could not find any Podman machine',
-      });
-
-      await playExpect(podmanInstalledMessage.or(noMachineMessage)).toBeVisible({ timeout: 10_000 });
-
-      if (await noMachineMessage.isVisible()) {
-        await playExpect(welcomePage.nextStepButton).toBeEnabled();
-        await welcomePage.nextStepButton.click();
-      }
-
-      await playExpect(welcomePage.onboardingMessageStatus).toContainText('Podman installed', {
-        timeout: 10_000,
-      });
-      await playExpect(welcomePage.nextStepButton).toBeEnabled();
-      await welcomePage.nextStepButton.click();
-    });
-
-    test('Check k8s step (kubectl installed or download)', async ({ welcomePage }) => {
-      await playExpect(welcomePage.onboardingMessageStatus).toBeVisible({ timeout: 10_000 });
-      await playExpect(welcomePage.onboardingMessageStatus).toContainText(/kubectl (installed|download)/, {
-        timeout: 10_000,
-      });
-      kubectlOnboardingStatusText = await welcomePage.onboardingMessageStatus.innerText();
-
-      if (kubectlOnboardingStatusText?.toLowerCase().includes('kubectl installed')) {
-        await playExpect(welcomePage.nextStepButton).toBeEnabled();
-        await welcomePage.nextStepButton.click();
-        return;
-      }
-
-      await playExpect(welcomePage.onboardingMessageStatus).toContainText('kubectl download', { timeout: 10_000 });
-      await playExpect(welcomePage.nextStepButton).toBeEnabled();
-      await welcomePage.nextStepButton.click();
-    });
-
-    test('Download and install kubectl', async ({ welcomePage }) => {
-      test.setTimeout(130_000);
-
-      if (!kubectlOnboardingStatusText?.toLowerCase().includes('kubectl download')) {
-        test.skip(true, 'kubectl already installed; see "Check k8s step" test');
-        return;
-      }
-
-      // Wait for either success or failure (download can fail in CI)
-      await playExpect(welcomePage.onboardingMessageStatus).toContainText(
-        /kubectl successfully downloaded|Failed downloading kubectl/,
-        { timeout: 120_000 },
-      );
-      const statusText = await welcomePage.onboardingMessageStatus.innerText();
-
-      if (statusText.includes('Failed downloading kubectl')) {
-        await playExpect(welcomePage.skipOnBoarding).toBeEnabled();
-        await welcomePage.skipOnBoarding.click();
-        return;
-      }
-
-      await playExpect(welcomePage.nextStepButton).toBeEnabled();
-      await welcomePage.nextStepButton.click();
-
-      await playExpect(welcomePage.onboardingMessageStatus).toContainText('kubectl installed', { timeout: 60_000 });
-      await playExpect(welcomePage.nextStepButton).toBeEnabled();
-      await welcomePage.nextStepButton.click();
-    });
-
-    test('Check other versions for compose', async ({ welcomePage }) => {
-      await playExpect(welcomePage.onboardingMessageStatus).toBeVisible({ timeout: 10_000 });
-
-      await playExpect(welcomePage.onboardingMessageStatus).toContainText(
-        /Compose (installed|download)|Unable to retrieve Compose version/,
-        { timeout: 10_000 },
-      );
-      composeOnboardingStatusText = await welcomePage.onboardingMessageStatus.innerText();
-
-      if (composeOnboardingStatusText?.includes('Unable to retrieve Compose version') || rateLimitReachedFlag) {
-        test.skip(true, 'Unable to retrieve Compose version; likely GitHub API rate limit or network issue');
-        return;
-      }
-
-      if (composeOnboardingStatusText?.toLowerCase().includes('compose installed')) {
-        test.skip(true, 'Compose already installed; see "Compose already installed" test');
-        return;
-      }
-
-      await playExpect(welcomePage.onboardingMessageStatus).toContainText('Compose download', { timeout: 10_000 });
-      await playExpect(welcomePage.otherVersionButton).toBeVisible();
-
-      if (rateLimitReachedFlag) {
-        test.skip(true, 'Rate limit exceeded; skipping compose onboarding checks');
-      }
-
-      await welcomePage.otherVersionButton.click();
-
-      const appeared = await welcomePage.dropDownDialog
-        .waitFor({ state: 'visible', timeout: 5_000 })
-        .then(() => true)
-        .catch(() => false);
-      if (!appeared) {
-        if (rateLimitReachedFlag) {
-          test.skip(true, 'Rate limit exceeded after clicking version selector; skipping');
-        }
-        await welcomePage.otherVersionButton.click();
-      }
-
-      if (rateLimitReachedFlag) {
-        test.skip(true, 'Rate limit exceeded while loading version dropdown; skipping');
-      }
-
-      await playExpect(welcomePage.dropDownDialog).toBeVisible({ timeout: 10_000 });
-      await playExpect(welcomePage.latestVersionFromDropDown).toBeEnabled();
-      await welcomePage.latestVersionFromDropDown.click();
-    });
-
-    test('Compose already installed', async ({ welcomePage, page }) => {
-      if (!composeOnboardingStatusText?.toLowerCase().includes('compose installed')) {
-        test.skip(true, 'Compose download path; handled by "Check other versions for compose" test');
-      }
-
-      await playExpect(welcomePage.nextStepButton).toBeEnabled({ timeout: 10_000 });
-      await welcomePage.nextStepButton.click();
-
-      const dashboardPage = new DashboardPage(page);
-      await playExpect(dashboardPage.heading).toBeVisible({ timeout: 10_000 });
-    });
+test.describe('Verify onboarding experience for compose versioning', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Welcome message available and handle telemetry', async ({ welcomePage }) => {
+    await playExpect(welcomePage.welcomeMessage).toBeVisible();
+    await playExpect(welcomePage.telemetryConsent).toBeVisible();
+    await playExpect(welcomePage.telemetryConsent).toBeChecked();
+    await welcomePage.turnOffTelemetry();
   });
+
+  test('Check podman installation', async ({ welcomePage }) => {
+    await playExpect(welcomePage.startOnboarding).toBeEnabled({ timeout: 10_000 });
+    await welcomePage.startOnboarding.click();
+
+    await playExpect(welcomePage.onboardingMessageStatus).toBeVisible({ timeout: 10_000 });
+    await playExpect(welcomePage.onboardingMessageStatus).toContainText('Podman has been set up correctly', {
+      timeout: 10_000,
+    });
+    await playExpect(welcomePage.nextStepButton).toBeEnabled();
+    await welcomePage.nextStepButton.click();
+
+    const podmanInstalledMessage = welcomePage.onboardingMessageStatus.filter({
+      hasText: 'Podman installed',
+    });
+    const noMachineMessage = welcomePage.onboardingMessageStatus.filter({
+      hasText: 'We could not find any Podman machine',
+    });
+
+    await playExpect(podmanInstalledMessage.or(noMachineMessage)).toBeVisible({ timeout: 10_000 });
+
+    if (await noMachineMessage.isVisible()) {
+      await playExpect(welcomePage.nextStepButton).toBeEnabled();
+      await welcomePage.nextStepButton.click();
+    }
+
+    await playExpect(welcomePage.onboardingMessageStatus).toContainText('Podman installed', {
+      timeout: 10_000,
+    });
+    await playExpect(welcomePage.nextStepButton).toBeEnabled();
+    await welcomePage.nextStepButton.click();
+  });
+
+  test('Check k8s step (kubectl installed or download)', async ({ welcomePage }) => {
+    await playExpect(welcomePage.onboardingMessageStatus).toBeVisible({ timeout: 10_000 });
+    await playExpect(welcomePage.onboardingMessageStatus).toContainText(/kubectl (installed|download)/, {
+      timeout: 10_000,
+    });
+    kubectlOnboardingStatusText = await welcomePage.onboardingMessageStatus.innerText();
+
+    if (kubectlOnboardingStatusText?.toLowerCase().includes('kubectl installed')) {
+      await playExpect(welcomePage.nextStepButton).toBeEnabled();
+      await welcomePage.nextStepButton.click();
+      return;
+    }
+
+    await playExpect(welcomePage.onboardingMessageStatus).toContainText('kubectl download', { timeout: 10_000 });
+    await playExpect(welcomePage.nextStepButton).toBeEnabled();
+    await welcomePage.nextStepButton.click();
+  });
+
+  test('Download and install kubectl', async ({ welcomePage }) => {
+    test.setTimeout(130_000);
+
+    if (!kubectlOnboardingStatusText?.toLowerCase().includes('kubectl download')) {
+      test.skip(true, 'kubectl already installed; see "Check k8s step" test');
+      return;
+    }
+
+    // Wait for either success or failure (download can fail in CI)
+    await playExpect(welcomePage.onboardingMessageStatus).toContainText(
+      /kubectl successfully downloaded|Failed downloading kubectl/,
+      { timeout: 120_000 },
+    );
+    const statusText = await welcomePage.onboardingMessageStatus.innerText();
+
+    if (statusText.includes('Failed downloading kubectl')) {
+      await playExpect(welcomePage.skipOnBoarding).toBeEnabled();
+      await welcomePage.skipOnBoarding.click();
+      return;
+    }
+
+    await playExpect(welcomePage.nextStepButton).toBeEnabled();
+    await welcomePage.nextStepButton.click();
+
+    await playExpect(welcomePage.onboardingMessageStatus).toContainText('kubectl installed', { timeout: 60_000 });
+    await playExpect(welcomePage.nextStepButton).toBeEnabled();
+    await welcomePage.nextStepButton.click();
+  });
+
+  test('Check other versions for compose', async ({ welcomePage }) => {
+    await playExpect(welcomePage.onboardingMessageStatus).toBeVisible({ timeout: 10_000 });
+
+    await playExpect(welcomePage.onboardingMessageStatus).toContainText(
+      /Compose (installed|download)|Unable to retrieve Compose version/,
+      { timeout: 10_000 },
+    );
+    composeOnboardingStatusText = await welcomePage.onboardingMessageStatus.innerText();
+
+    if (composeOnboardingStatusText?.includes('Unable to retrieve Compose version') || rateLimitReachedFlag) {
+      test.skip(true, 'Unable to retrieve Compose version; likely GitHub API rate limit or network issue');
+      return;
+    }
+
+    if (composeOnboardingStatusText?.toLowerCase().includes('compose installed')) {
+      test.skip(true, 'Compose already installed; see "Compose already installed" test');
+      return;
+    }
+
+    await playExpect(welcomePage.onboardingMessageStatus).toContainText('Compose download', { timeout: 10_000 });
+    await playExpect(welcomePage.otherVersionButton).toBeVisible();
+
+    if (rateLimitReachedFlag) {
+      test.skip(true, 'Rate limit exceeded; skipping compose onboarding checks');
+    }
+
+    await welcomePage.otherVersionButton.click();
+
+    const appeared = await welcomePage.dropDownDialog
+      .waitFor({ state: 'visible', timeout: 5_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!appeared) {
+      if (rateLimitReachedFlag) {
+        test.skip(true, 'Rate limit exceeded after clicking version selector; skipping');
+      }
+      await welcomePage.otherVersionButton.click();
+    }
+
+    if (rateLimitReachedFlag) {
+      test.skip(true, 'Rate limit exceeded while loading version dropdown; skipping');
+    }
+
+    await playExpect(welcomePage.dropDownDialog).toBeVisible({ timeout: 10_000 });
+    await playExpect(welcomePage.latestVersionFromDropDown).toBeEnabled();
+    await welcomePage.latestVersionFromDropDown.click();
+  });
+
+  test('Compose already installed', async ({ welcomePage, page }) => {
+    if (!composeOnboardingStatusText?.toLowerCase().includes('compose installed')) {
+      test.skip(true, 'Compose download path; handled by "Check other versions for compose" test');
+    }
+
+    await playExpect(welcomePage.nextStepButton).toBeEnabled({ timeout: 10_000 });
+    await welcomePage.nextStepButton.click();
+
+    const dashboardPage = new DashboardPage(page);
+    await playExpect(dashboardPage.heading).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/tests/playwright/src/specs/image-manifest-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-manifest-smoke.spec.ts
@@ -93,185 +93,185 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe
-  .serial('Image Manifest E2E Validation', { tag: '@smoke' }, () => {
-    test.describe
-      .serial('Image Manifest Validation - Simple Containerfile', () => {
-        test('Build the image using cross-arch build (simple)', async ({ navigationBar }) => {
-          test.setTimeout(120_000);
+test.describe('Image Manifest E2E Validation', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test.describe('Image Manifest Validation - Simple Containerfile', () => {
+    test.describe.configure({ mode: 'serial' });
+    test('Build the image using cross-arch build (simple)', async ({ navigationBar }) => {
+      test.setTimeout(120_000);
 
-          imagesPage = await navigationBar.openImages();
-          await playExpect(imagesPage.heading).toBeVisible();
-          const alreadyPresentImagesCount = await imagesPage.countRowsFromTable();
+      imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+      const alreadyPresentImagesCount = await imagesPage.countRowsFromTable();
 
-          const buildImagePage = await imagesPage.openBuildImage();
-          await playExpect(buildImagePage.heading).toBeVisible();
-          const dockerfilePath = path.resolve(__dirname, '..', '..', 'resources', 'test-containerfile');
-          const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
+      const buildImagePage = await imagesPage.openBuildImage();
+      await playExpect(buildImagePage.heading).toBeVisible();
+      const dockerfilePath = path.resolve(__dirname, '..', '..', 'resources', 'test-containerfile');
+      const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
 
-          imagesPage = await buildImagePage.buildImage(
-            manifestLabelSimple,
-            dockerfilePath,
-            contextDirectory,
-            architectures,
-          );
-          await playExpect
-            .poll(async () => await imagesPage.waitForImageExists(manifestLabelSimple, 60_000), { timeout: 0 })
-            .toBeTruthy();
-          await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 4);
-          await imagesPage.toggleImageManifest(manifestLabelSimple);
-          await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 2);
-        });
+      imagesPage = await buildImagePage.buildImage(
+        manifestLabelSimple,
+        dockerfilePath,
+        contextDirectory,
+        architectures,
+      );
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(manifestLabelSimple, 60_000), { timeout: 0 })
+        .toBeTruthy();
+      await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 4);
+      await imagesPage.toggleImageManifest(manifestLabelSimple);
+      await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 2);
+    });
 
-        test('Check Manifest details', async () => {
-          const imageDetailsPage = await imagesPage.openImageDetails(manifestLabelSimple);
+    test('Check Manifest details', async () => {
+      const imageDetailsPage = await imagesPage.openImageDetails(manifestLabelSimple);
 
-          await Promise.all(
-            architectures.map(async architecture => {
-              await playExpect(imageDetailsPage.tabContent).toContainText(architecture);
-            }),
-          );
-          await playExpect(imageDetailsPage.backLink).toBeVisible();
-          await imageDetailsPage.backLink.click();
-        });
+      await Promise.all(
+        architectures.map(async architecture => {
+          await playExpect(imageDetailsPage.tabContent).toContainText(architecture);
+        }),
+      );
+      await playExpect(imageDetailsPage.backLink).toBeVisible();
+      await imageDetailsPage.backLink.click();
+    });
 
-        test('Add registry for manifest push', async ({ navigationBar, page }) => {
-          test.skip(!canTestRegistry(), 'Registry tests are disabled');
+    test('Add registry for manifest push', async ({ navigationBar, page }) => {
+      test.skip(!canTestRegistry(), 'Registry tests are disabled');
 
-          await navigationBar.openSettings();
-          const settingsBar = new SettingsBar(page);
-          const registryPage = await settingsBar.openTabPage(RegistriesPage);
-          await playExpect(registryPage.heading).toBeVisible();
+      await navigationBar.openSettings();
+      const settingsBar = new SettingsBar(page);
+      const registryPage = await settingsBar.openTabPage(RegistriesPage);
+      await playExpect(registryPage.heading).toBeVisible();
 
-          await registryPage.createRegistry(registryUrl, registryUsername, registryPswdSecret);
+      await registryPage.createRegistry(registryUrl, registryUsername, registryPswdSecret);
 
-          const registryBox = await registryPage.getRegistryRowByName('GitHub');
-          const username = registryBox.getByText(registryUsername);
-          await playExpect(username).toBeVisible({ timeout: 10_000 });
-        });
+      const registryBox = await registryPage.getRegistryRowByName('GitHub');
+      const username = registryBox.getByText(registryUsername);
+      await playExpect(username).toBeVisible({ timeout: 10_000 });
+    });
 
-        test('Push manifest to registry', async ({ navigationBar }) => {
-          test.skip(!canTestRegistry(), 'Registry tests are disabled');
-          test.setTimeout(120_000);
+    test('Push manifest to registry', async ({ navigationBar }) => {
+      test.skip(!canTestRegistry(), 'Registry tests are disabled');
+      test.setTimeout(120_000);
 
-          imagesPage = await navigationBar.openImages();
-          await playExpect(imagesPage.heading).toBeVisible();
-          try {
-            await imagesPage.pushManifest(manifestLabelSimple, 60_000);
-          } catch (error: unknown) {
-            // On CI, the push dialog interaction can fail for small images.
-            // Push still completes; next test verifies by pulling from registry.
-            console.log('Push manifest dialog interaction failed:', error);
-          }
-        });
+      imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+      try {
+        await imagesPage.pushManifest(manifestLabelSimple, 60_000);
+      } catch (error: unknown) {
+        // On CI, the push dialog interaction can fail for small images.
+        // Push still completes; next test verifies by pulling from registry.
+        console.log('Push manifest dialog interaction failed:', error);
+      }
+    });
 
-        test('Verify manifest was pushed to registry', async ({ page, navigationBar }) => {
-          test.skip(!canTestRegistry(), 'Registry tests are disabled');
-          test.setTimeout(120_000);
+    test('Verify manifest was pushed to registry', async ({ page, navigationBar }) => {
+      test.skip(!canTestRegistry(), 'Registry tests are disabled');
+      test.setTimeout(120_000);
 
-          await deleteImageManifest(page, manifestLabelSimple);
+      await deleteImageManifest(page, manifestLabelSimple);
 
-          imagesPage = await navigationBar.openImages();
-          await playExpect(imagesPage.heading).toBeVisible();
+      imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
 
-          const pullImagePage = await imagesPage.openPullImage();
-          imagesPage = await pullImagePage.pullImage(manifestLabelSimple);
-          await playExpect(imagesPage.heading).toBeVisible();
-          await playExpect
-            .poll(async () => await imagesPage.waitForImageExists(manifestLabelSimple, 15_000), { timeout: 0 })
-            .toBeTruthy();
+      const pullImagePage = await imagesPage.openPullImage();
+      imagesPage = await pullImagePage.pullImage(manifestLabelSimple);
+      await playExpect(imagesPage.heading).toBeVisible();
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(manifestLabelSimple, 15_000), { timeout: 0 })
+        .toBeTruthy();
 
-          // Pull resolves the manifest to the host platform — verify via the ARCH column
-          const expectedArch = archType === 'arm64' ? ArchitectureType.ARM64 : ArchitectureType.AMD64;
-          await playExpect.poll(async () => await imagesPage.getImageArch(manifestLabelSimple)).toBe(expectedArch);
-        });
+      // Pull resolves the manifest to the host platform — verify via the ARCH column
+      const expectedArch = archType === 'arm64' ? ArchitectureType.ARM64 : ArchitectureType.AMD64;
+      await playExpect.poll(async () => await imagesPage.getImageArch(manifestLabelSimple)).toBe(expectedArch);
+    });
 
-        test('Remove registry after manifest push', async ({ page, navigationBar }) => {
-          test.skip(!canTestRegistry(), 'Registry tests are disabled');
+    test('Remove registry after manifest push', async ({ page, navigationBar }) => {
+      test.skip(!canTestRegistry(), 'Registry tests are disabled');
 
-          await navigationBar.openSettings();
-          const settingsBar = new SettingsBar(page);
-          const registryPage = await settingsBar.openTabPage(RegistriesPage);
-          await playExpect(registryPage.heading).toBeVisible();
+      await navigationBar.openSettings();
+      const settingsBar = new SettingsBar(page);
+      const registryPage = await settingsBar.openTabPage(RegistriesPage);
+      await playExpect(registryPage.heading).toBeVisible();
 
-          await registryPage.removeRegistry('GitHub');
-          const registryBox = await registryPage.getRegistryRowByName('GitHub');
-          const username = registryBox.getByText(registryUsername);
-          await playExpect(username).toBeHidden();
-        });
+      await registryPage.removeRegistry('GitHub');
+      const registryBox = await registryPage.getRegistryRowByName('GitHub');
+      const username = registryBox.getByText(registryUsername);
+      await playExpect(username).toBeHidden();
+    });
 
-        test('Delete Manifest', async ({ page }) => {
-          test.setTimeout(120_000);
-          if (canTestRegistry()) {
-            // Verify test pulled the manifest back as a single-platform image,
-            // so it's a regular image now — not a manifest.
-            await deleteImage(page, manifestLabelSimple);
-          } else {
-            await deleteImageManifest(page, manifestLabelSimple);
-          }
-        });
-      });
-    test.describe
-      .serial('Image Manifest Validation - Complex Containerfile', () => {
-        test.skip(
-          () => isWindows && provider?.toLocaleLowerCase().trim() === 'wsl',
-          'Complex Containerfile uses RUN steps that require executing foreign-arch binaries, which fails on WSL without QEMU emulation. Simple Containerfile only defines CMD metadata and succeeds.',
-        );
-        test('Build the image using cross-arch build (complex)', async ({ navigationBar }) => {
-          test.setTimeout(180_000);
-
-          imagesPage = await navigationBar.openImages();
-          await playExpect(imagesPage.heading).toBeVisible();
-          const alreadyPresentImagesCount = await imagesPage.countRowsFromTable();
-
-          const buildImagePage = await imagesPage.openBuildImage();
-          await playExpect(buildImagePage.heading).toBeVisible();
-
-          const dockerfilePath = path.resolve(
-            __dirname,
-            '..',
-            '..',
-            'resources',
-            'alphine-hello',
-            'alphine-hello.containerfile',
-          );
-          const contextDirectory = path.resolve(__dirname, '..', '..', 'resources', 'alphine-hello');
-
-          imagesPage = await buildImagePage.buildImage(
-            manifestLabelComplex,
-            dockerfilePath,
-            contextDirectory,
-            architectures,
-          );
-
-          await playExpect
-            .poll(async () => await imagesPage.waitForImageExists(manifestLabelComplex, 60_000), { timeout: 0 })
-            .toBeTruthy();
-          await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 4);
-          await imagesPage.toggleImageManifest(manifestLabelComplex);
-          await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 2);
-        });
-
-        test('Check Manifest details', async ({ navigationBar }) => {
-          imagesPage = await navigationBar.openImages();
-          await playExpect(imagesPage.heading).toBeVisible();
-
-          const imageDetailsPage = await imagesPage.openImageDetails(manifestLabelComplex);
-          await Promise.all(
-            architectures.map(async architecture => {
-              await playExpect(imageDetailsPage.tabContent).toContainText(architecture);
-            }),
-          );
-          await playExpect(imageDetailsPage.backLink).toBeVisible();
-          await imageDetailsPage.backLink.click();
-        });
-
-        test('Delete Manifest', async ({ page }) => {
-          test.setTimeout(180_000);
-          await deleteImageManifest(page, manifestLabelComplex);
-        });
-      });
+    test('Delete Manifest', async ({ page }) => {
+      test.setTimeout(120_000);
+      if (canTestRegistry()) {
+        // Verify test pulled the manifest back as a single-platform image,
+        // so it's a regular image now — not a manifest.
+        await deleteImage(page, manifestLabelSimple);
+      } else {
+        await deleteImageManifest(page, manifestLabelSimple);
+      }
+    });
   });
+  test.describe('Image Manifest Validation - Complex Containerfile', () => {
+    test.describe.configure({ mode: 'serial' });
+    test.skip(
+      () => isWindows && provider?.toLocaleLowerCase().trim() === 'wsl',
+      'Complex Containerfile uses RUN steps that require executing foreign-arch binaries, which fails on WSL without QEMU emulation. Simple Containerfile only defines CMD metadata and succeeds.',
+    );
+    test('Build the image using cross-arch build (complex)', async ({ navigationBar }) => {
+      test.setTimeout(180_000);
+
+      imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+      const alreadyPresentImagesCount = await imagesPage.countRowsFromTable();
+
+      const buildImagePage = await imagesPage.openBuildImage();
+      await playExpect(buildImagePage.heading).toBeVisible();
+
+      const dockerfilePath = path.resolve(
+        __dirname,
+        '..',
+        '..',
+        'resources',
+        'alphine-hello',
+        'alphine-hello.containerfile',
+      );
+      const contextDirectory = path.resolve(__dirname, '..', '..', 'resources', 'alphine-hello');
+
+      imagesPage = await buildImagePage.buildImage(
+        manifestLabelComplex,
+        dockerfilePath,
+        contextDirectory,
+        architectures,
+      );
+
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(manifestLabelComplex, 60_000), { timeout: 0 })
+        .toBeTruthy();
+      await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 4);
+      await imagesPage.toggleImageManifest(manifestLabelComplex);
+      await playExpect.poll(async () => await imagesPage.countRowsFromTable()).toBe(alreadyPresentImagesCount + 2);
+    });
+
+    test('Check Manifest details', async ({ navigationBar }) => {
+      imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      const imageDetailsPage = await imagesPage.openImageDetails(manifestLabelComplex);
+      await Promise.all(
+        architectures.map(async architecture => {
+          await playExpect(imageDetailsPage.tabContent).toContainText(architecture);
+        }),
+      );
+      await playExpect(imageDetailsPage.backLink).toBeVisible();
+      await imageDetailsPage.backLink.click();
+    });
+
+    test('Delete Manifest', async ({ page }) => {
+      test.setTimeout(180_000);
+      await deleteImageManifest(page, manifestLabelComplex);
+    });
+  });
+});
 
 async function deleteImageManifest(page: Page, manifestName: string): Promise<void> {
   const navigationBar = new NavigationBar(page);


### PR DESCRIPTION
Continues the migration away from the deprecated `test.describe.serial(...)` API (discouraged by the Playwright team) towards
`test.describe.configure({ mode: 'serial' })`, following the same pattern used in parts 1-3.

Converts the next 3 spec files from the tracking checklist in #15697:
- extension-installation-smoke.spec.ts (remaining "Install extension via SHA digest" suite)
- extension-onboarding-smoke.spec.ts
- image-manifest-smoke.spec.ts (outer suite + 2 nested suites)

No behavioral changes; test names, counts, and execution order are unchanged (verified with `playwright test --list`).

Assisted-by: claude-sonnet-5

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
