### PR TITLE
chore: update troubleshooting/purge labels

### DIFF
--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -36,12 +36,12 @@ test('displays what the cleanup action will and will not delete', () => {
 });
 
 test('Check cleanupProviders is called and button is in progress', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean / purge data' });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clear / Purge Data' });
 
   render(TroubleshootingRepairCleanup);
 
   // expect to have the cleanup button
-  const cleanupButton = screen.getByRole('button', { name: 'Cleanup' });
+  const cleanupButton = screen.getByRole('button', { name: 'Clear / Purge Data' });
   expect(cleanupButton).toBeInTheDocument();
 
   // mock the cleanup as waiting for 10ms
@@ -67,10 +67,10 @@ test('Check cleanupProviders is called and button is in progress', async () => {
 
   // check that we asked for confirmation
   expect(window.showMessageBox).toBeCalledWith({
-    buttons: ['Clean / purge data', 'Cancel'],
+    buttons: ['Clear / Purge Data', 'Cancel'],
     type: 'danger',
     message: 'This action will delete data and cannot be undone. Proceed?',
-    title: 'Clean / purge data?',
+    title: 'Clear / Purge Data?',
   });
 
   // check that we're calling the vi.mocked(window.cleanupProviders)
@@ -78,12 +78,12 @@ test('Check cleanupProviders is called and button is in progress', async () => {
 });
 
 test('Check errors are displayed with clipboard button', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean / purge data' });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clear / Purge Data' });
 
   render(TroubleshootingRepairCleanup);
 
   // expect to have the cleanup button
-  const cleanupButton = screen.getByRole('button', { name: 'Cleanup' });
+  const cleanupButton = screen.getByRole('button', { name: 'Clear / Purge Data' });
   expect(cleanupButton).toBeInTheDocument();
 
   // mock the cleanup as waiting for 2 seconds
@@ -95,10 +95,10 @@ test('Check errors are displayed with clipboard button', async () => {
 
   // check that we asked for confirmation
   expect(window.showMessageBox).toBeCalledWith({
-    buttons: ['Clean / purge data', 'Cancel'],
+    buttons: ['Clear / Purge Data', 'Cancel'],
     type: 'danger',
     message: 'This action will delete data and cannot be undone. Proceed?',
-    title: 'Clean / purge data?',
+    title: 'Clear / Purge Data?',
   });
 
   // check that we're calling the vi.mocked(window.cleanupProviders)

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,8 +23,20 @@ import { expect, test, vi } from 'vitest';
 
 import TroubleshootingRepairCleanup from './TroubleshootingRepairCleanup.svelte';
 
+test('displays what the cleanup action will and will not delete', () => {
+  render(TroubleshootingRepairCleanup);
+
+  expect(screen.getByText('Proceeding with this action will result in data loss.')).toBeInTheDocument();
+  expect(screen.getByText('It will delete:')).toBeInTheDocument();
+  expect(screen.getByText('The current Podman machine')).toBeInTheDocument();
+  expect(screen.getByText('Containers, images, volumes, configuration files')).toBeInTheDocument();
+  expect(screen.getByText('SSH keys')).toBeInTheDocument();
+  expect(screen.getByText('It will not delete:')).toBeInTheDocument();
+  expect(screen.getByText('Podman logs')).toBeInTheDocument();
+});
+
 test('Check cleanupProviders is called and button is in progress', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean Up' });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean / purge data' });
 
   render(TroubleshootingRepairCleanup);
 
@@ -55,10 +67,10 @@ test('Check cleanupProviders is called and button is in progress', async () => {
 
   // check that we asked for confirmation
   expect(window.showMessageBox).toBeCalledWith({
-    buttons: ['Clean Up', 'Cancel'],
+    buttons: ['Clean / purge data', 'Cancel'],
     type: 'danger',
-    message: 'This action may delete data. Proceed?',
-    title: 'Clean Up Data?',
+    message: 'This action will delete data and cannot be undone. Proceed?',
+    title: 'Clean / purge data?',
   });
 
   // check that we're calling the vi.mocked(window.cleanupProviders)
@@ -66,7 +78,7 @@ test('Check cleanupProviders is called and button is in progress', async () => {
 });
 
 test('Check errors are displayed with clipboard button', async () => {
-  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean Up' });
+  vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Clean / purge data' });
 
   render(TroubleshootingRepairCleanup);
 
@@ -83,10 +95,10 @@ test('Check errors are displayed with clipboard button', async () => {
 
   // check that we asked for confirmation
   expect(window.showMessageBox).toBeCalledWith({
-    buttons: ['Clean Up', 'Cancel'],
+    buttons: ['Clean / purge data', 'Cancel'],
     type: 'danger',
-    message: 'This action may delete data. Proceed?',
-    title: 'Clean Up Data?',
+    message: 'This action will delete data and cannot be undone. Proceed?',
+    title: 'Clean / purge data?',
   });
 
   // check that we're calling the vi.mocked(window.cleanupProviders)

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
@@ -21,13 +21,13 @@ async function openCleanupDialog(): Promise<void> {
   let message = 'This action will delete data and cannot be undone. Proceed?';
 
   const result = await window.showMessageBox({
-    title: 'Clean / purge data?',
+    title: 'Clear / Purge Data?',
     type: 'danger',
     message: message,
-    buttons: ['Clean / purge data', 'Cancel'],
+    buttons: ['Clear / Purge Data', 'Cancel'],
   });
 
-  if (result?.response === 'Clean / purge data') {
+  if (result?.response === 'Clear / Purge Data') {
     await cleanup();
   }
 }
@@ -50,9 +50,9 @@ async function cleanup(): Promise<void> {
 }
 </script>
 
-<div class="flex flex-row items-start">
+<div class="flex flex-row items-end">
   <div>
-    <div class="text-[var(--pd-content-header)] flex flex-row items-center">Clean / purge data</div>
+    <div class="text-[var(--pd-content-header)] flex flex-row items-center">Clear / purge data</div>
     <div class="text-sm pt-1">
       <div class="flex flex-row items-center">
         <Icon class="pr-1" size="0.8x" icon={faWarning} />Proceeding with this action will result in data loss.
@@ -75,8 +75,7 @@ async function cleanup(): Promise<void> {
       type="danger"
       on:click={openCleanupDialog}
       inProgress={cleanupInProgress}
-      aria-label="Cleanup"
-      icon={faBroom}>Clean / purge data</Button>
+      icon={faBroom}>Clear / Purge Data</Button>
   </div>
 
   <div>

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingRepairCleanup.svelte
@@ -18,16 +18,16 @@ let cleanupInProgress = $state(false);
 let cleanupFailures = $state<string[]>([]);
 
 async function openCleanupDialog(): Promise<void> {
-  let message = 'This action may delete data. Proceed?';
+  let message = 'This action will delete data and cannot be undone. Proceed?';
 
   const result = await window.showMessageBox({
-    title: 'Clean Up Data?',
+    title: 'Clean / purge data?',
     type: 'danger',
     message: message,
-    buttons: ['Clean Up', 'Cancel'],
+    buttons: ['Clean / purge data', 'Cancel'],
   });
 
-  if (result?.response === 'Clean Up') {
+  if (result?.response === 'Clean / purge data') {
     await cleanup();
   }
 }
@@ -50,12 +50,23 @@ async function cleanup(): Promise<void> {
 }
 </script>
 
-<div class="flex flex-row items-center">
+<div class="flex flex-row items-start">
   <div>
-    <div class="text-[var(--pd-content-header)] flex flex-row items-center">Clean / Purge data</div>
-    <div class="text-sm flex flex-row items-center pt-1">
-      <Icon class="pr-1" size="0.8x" icon={faWarning} />Proceeding with this action may result in data loss, including
-      existing volumes, containers, images, etc.
+    <div class="text-[var(--pd-content-header)] flex flex-row items-center">Clean / purge data</div>
+    <div class="text-sm pt-1">
+      <div class="flex flex-row items-center">
+        <Icon class="pr-1" size="0.8x" icon={faWarning} />Proceeding with this action will result in data loss.
+      </div>
+      <p class="pt-2">It will delete:</p>
+      <ul class="list-disc ml-5">
+        <li>The current Podman machine</li>
+        <li>Containers, images, volumes, configuration files</li>
+        <li>SSH keys</li>
+      </ul>
+      <p class="pt-2">It will not delete:</p>
+      <ul class="list-disc ml-5">
+        <li>Podman logs</li>
+      </ul>
     </div>
   </div>
 
@@ -65,7 +76,7 @@ async function cleanup(): Promise<void> {
       on:click={openCleanupDialog}
       inProgress={cleanupInProgress}
       aria-label="Cleanup"
-      icon={faBroom}>Cleanup / Purge data</Button>
+      icon={faBroom}>Clean / purge data</Button>
   </div>
 
   <div>


### PR DESCRIPTION
### What does this PR do?

Updates the Troubleshooting Repair **Clean / purge data** copy so it is clear this action **will** delete data, not that it might.

- Uses sentence case: `Clean / purge data`
- Explains what the action will delete (current Podman machine, containers/images/volumes/configuration files, SSH keys) and what it will not delete (Podman logs)
- Strengthens the confirmation dialog: `This action will delete data and cannot be undone. Proceed?`
- Aligns the button with the top of the card

### Screenshot / video of UI

<!-- Please attach a screenshot of Troubleshooting → Repair & Connections showing the updated copy and top-aligned button -->

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18760

### How to test this PR?

1. Start Podman Desktop and open **Troubleshooting** from the status bar.
2. Open the **Repair & Connections** tab.
3. Check that the heading and button say **Clean / purge data**, the warning uses **will result in data loss**, and the will / will not lists are visible.
4. Click **Clean / purge data** and confirm the dialog says **This action will delete data and cannot be undone. Proceed?**
5. Cancel the dialog and check that no cleanup runs.

- [x] Tests are covering the bug fix or the new feature

### Before
<img width="1920" height="1012" alt="Screenshot From 2026-08-19 13-51-09" src="https://github.com/user-attachments/assets/41ef26f9-c95e-4eb0-8fab-0b23834c2199" />

<img width="1920" height="1012" alt="Screenshot From 2026-08-19 13-51-14" src="https://github.com/user-attachments/assets/4bd6401c-0aa2-4e0b-991b-c63cf5e6d586" />

### After
<img width="1920" height="1012" alt="Screenshot From 2026-08-19 14-11-32" src="https://github.com/user-attachments/assets/1e9645aa-0e75-4043-b959-8ed477ed1719" />

<img width="1920" height="1012" alt="Screenshot From 2026-08-19 14-11-37" src="https://github.com/user-attachments/assets/cc6c4d11-5995-457d-bb9f-c9c732bad439" />
