### PR TITLE
fix: resolve GHSA-mh99-v99m-4gvg in brace-expansion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,9 @@ overrides:
   tar: ^7.5.3
   cheerio>undici: ^7.18.2
   minimatch>@isaacs/brace-expansion: ^5.0.1
-  brace-expansion@^1: ^1.1.14
+  brace-expansion@^1: ^1.1.17
+  brace-expansion@^2: ^2.1.4
+  brace-expansion@^5: ^5.0.9
   lodash-es: ^4.18.1
   lodash: ^4.18.1
   '@docusaurus/types>webpack': ^5.105.0
@@ -6050,15 +6052,11 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -18499,18 +18497,14 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.9:
     dependencies:
@@ -22638,7 +22632,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
@@ -22646,15 +22640,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,9 @@ overrides:
   tar: ^7.5.3
   cheerio>undici: ^7.18.2
   minimatch>@isaacs/brace-expansion: ^5.0.1
-  brace-expansion@^1: ^1.1.14
+  brace-expansion@^1: ^1.1.17
+  brace-expansion@^2: ^2.1.4
+  brace-expansion@^5: ^5.0.9
   lodash-es: ^4.18.1
   lodash: ^4.18.1
   '@docusaurus/types>webpack': ^5.105.0


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-mh99-v99m-4gvg in `brace-expansion`.

**Advisory**: brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash
**Vulnerable versions**: <1.1.17
**Patched versions**: >=1.1.17
**Advisory URL**: https://github.com/advisories/GHSA-mh99-v99m-4gvg

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-mh99-v99m-4gvg: _brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash_

### How to test this PR?

Run `pnpm audit` and verify GHSA-mh99-v99m-4gvg is no longer reported