### PR TITLE
fix(tests): increase managed-configuration beforeAll timeout to 120s

### DIFF
--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-combined.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-combined.spec.ts
@@ -38,7 +38,7 @@ test.use({
 });
 
 test.beforeAll(async ({ runner, welcomePage, navigationBar }) => {
-  test.setTimeout(60_000);
+  test.setTimeout(120_000);
   runner.setVideoAndTraceName('managed-configuration-combined-e2e');
   await welcomePage.handleWelcomePage(true);
   const settingsBar = await navigationBar.openSettings();

--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-extensions.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-extensions.spec.ts
@@ -31,7 +31,7 @@ test.use({
 });
 
 test.beforeAll(async ({ runner, welcomePage, navigationBar }) => {
-  test.setTimeout(60_000);
+  test.setTimeout(120_000);
   runner.setVideoAndTraceName('managed-configuration-extensions-e2e');
   await welcomePage.handleWelcomePage(true);
   extensionsPage = await navigationBar.openExtensions();

--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-proxy.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-proxy.spec.ts
@@ -36,7 +36,7 @@ test.use({
 });
 
 test.beforeAll(async ({ runner, welcomePage, navigationBar }) => {
-  test.setTimeout(60_000);
+  test.setTimeout(120_000);
   runner.setVideoAndTraceName('managed-configuration-proxy-e2e');
   await welcomePage.handleWelcomePage(true);
   const settingsBar = await navigationBar.openSettings();

--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-registries.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-registries.spec.ts
@@ -36,7 +36,7 @@ test.use({
 });
 
 test.beforeAll(async ({ runner, welcomePage, navigationBar }) => {
-  test.setTimeout(60_000);
+  test.setTimeout(120_000);
   runner.setVideoAndTraceName('managed-configuration-registries-e2e');
   await welcomePage.handleWelcomePage(true);
   const settingsBar = await navigationBar.openSettings();


### PR DESCRIPTION
### What does this PR do?

The beforeAll hook in managed-configuration specs was flaky on Windows CI runners due to slow extension loading consuming the entire 60s timeout budget.

The beforeAll calls handleWelcomePage → turnOffTelemetry, which waits for the "Start onboarding" button to be enabled. This button is conditionally rendered only after the `extensions-already-started` event fires, gating it behind all extensions finishing activation.

On slow Windows runners, extension loading times vary significantly:
- Passing run: kind=3.2s, kubectl-cli=3.3s, podman=12.3s → total ~19s
- Failing run: kind=19.3s, kubectl-cli=13.4s, podman=19.3s → total ~52s

With 60s beforeAll timeout and ~23s of setup before the wait begins, the test only has ~37s for extensions — not enough when they take 52s.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Fixes #18874

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
