### PR TITLE
refactor(renderer): use state runes in KubeObjectMetaArtifact to enable reactivity of dropdowns

### DIFF
--- a/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
+++ b/packages/renderer/src/lib/kube/details/KubeObjectMetaArtifact.svelte
@@ -17,8 +17,8 @@ if (artifact?.creationTimestamp) {
   artifact.creationTimestamp = new Date(artifact.creationTimestamp);
 }
 
-let internalLabelsDropdownOpen: boolean = false;
-let internalAnnotationsDropdownOpen: boolean = false;
+let internalLabelsDropdownOpen = $state(false);
+let internalAnnotationsDropdownOpen = $state(false);
 
 let labels: [string, string][] = [];
 let internalLabels: [string, string][] = [];


### PR DESCRIPTION
### What does this PR do?
Changes 2 plain let variables that were not reactive, to state runes which are reactive in `KubeObjectMetaArtifact.svelte` file. They need to be reactive, because they both manage dropdown state.

### What issues does this PR fix or reference?

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
