### PR TITLE
fix(ui): use sentence case for tab labels

### DIFF
--- a/.agents/skills/mcp-testing/examples.md
+++ b/.agents/skills/mcp-testing/examples.md
@@ -531,7 +531,7 @@ document.querySelector('[aria-label="Find"]');
 // Extension page tabs
 document.querySelector('button[aria-label="Installed"]');
 document.querySelector('button[aria-label="Catalog"]');
-document.querySelector('button[aria-label="Local Extensions"]');
+document.querySelector('button[aria-label="Local extensions"]');
 
 // Featured extensions region
 document.querySelector('[role="region"][aria-label="FeaturedExtensions"]');

--- a/.agents/skills/mcp-testing/references/operations/extensions.md
+++ b/.agents/skills/mcp-testing/references/operations/extensions.md
@@ -16,7 +16,7 @@
 │   ├── [role="heading"]                        ← "Extensions"
 │   └── button:has-text("Installed")          ← tab buttons
 │       button:has-text("Catalog")
-│       button:has-text("Local Extensions")
+│       button:has-text("Local extensions")
 ├── [role="region"][aria-label="content"]
 │   └── [role="region"][aria-label="{extensionId}"]     ← extension cards
 ```
@@ -30,7 +30,7 @@
 | Page heading          | `[aria-label="header"] [role="heading"]:has-text("extensions")` |
 | Installed tab         | `button:has-text("Installed")`                                  |
 | Catalog tab           | `button:has-text("Catalog")`                                    |
-| Local Extensions tab  | `button:has-text("Local Extensions")`                           |
+| Local extensions tab  | `button:has-text("Local extensions")`                           |
 | Install custom button | `[aria-label="Install custom"]`                                 |
 
 ### Install Custom Extension Dialog

--- a/.agents/skills/new-extension/SKILL.md
+++ b/.agents/skills/new-extension/SKILL.md
@@ -468,7 +468,7 @@ After building, verify:
 
 1. Open Podman Desktop
 2. Go to **Settings > Preferences > Extensions** and enable **Development mode**
-3. Go to **Extensions > Local Extensions** tab
+3. Go to **Extensions > Local extensions** tab
 4. Click **Add a local folder extension...** and select the folder containing the extension `package.json`:
    - **Multi-package layout:** select `packages/backend/` (not the root)
    - **Minimal layout:** select the repository root
@@ -541,9 +541,7 @@ if (infos.length === 0) {
 }
 const engineId = infos[0].engineId;
 
-await extensionApi.containerEngine.createContainer(engineId, {
-  /* ... */
-});
+await extensionApi.containerEngine.createContainer(engineId, {/* ... */});
 ```
 
 Alternatively, if you already have containers or images from `listContainers()` or `listImages()`, their `engineId` field can be reused directly.

--- a/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionList.spec.ts
@@ -250,11 +250,11 @@ test('Expect to see local extensions tab content', async () => {
   render(ExtensionList);
 
   await vi.waitFor(() => {
-    expect(screen.getByRole('button', { name: 'Local Extensions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Local extensions' })).toBeInTheDocument();
   });
 
   // select the local extensions tab
-  const localModeTab = screen.getByRole('button', { name: 'Local Extensions' });
+  const localModeTab = screen.getByRole('button', { name: 'Local extensions' });
   await fireEvent.click(localModeTab);
 
   // expect to see empty screen
@@ -312,7 +312,7 @@ test('Expect local extensions tab is visible', async () => {
   render(ExtensionList);
 
   await vi.waitFor(() => {
-    expect(screen.getByRole('button', { name: 'Local Extensions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Local extensions' })).toBeInTheDocument();
   });
 });
 
@@ -327,7 +327,7 @@ test('Expect local extensions tab to not be visible if extensions.localExtension
     expect(window.getConfigurationValue).toHaveBeenCalled();
   });
 
-  const localExtensionsTab = screen.queryByRole('button', { name: 'Local Extensions' });
+  const localExtensionsTab = screen.queryByRole('button', { name: 'Local extensions' });
   expect(localExtensionsTab).not.toBeInTheDocument();
 });
 

--- a/packages/renderer/src/lib/extensions/ExtensionList.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionList.svelte
@@ -119,7 +119,7 @@ function changeScreen(newScreen: 'installed' | 'catalog' | 'development'): void 
         on:click={(): void => {
           changeScreen('development');
         }}
-        selected={screen === 'development'}>Local Extensions</Button>
+        selected={screen === 'development'}>Local extensions</Button>
     {/if}
  {/snippet}
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.spec.ts
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.spec.ts
@@ -28,7 +28,7 @@ test('Check Troubleshooting Page', async () => {
   render(TroubleshootingPage, {});
 
   // click on the first tab
-  const repairConnectionsLink = screen.getByRole('link', { name: 'Repair & Connections' });
+  const repairConnectionsLink = screen.getByRole('link', { name: 'Repair & connections' });
   expect(repairConnectionsLink).toBeInTheDocument();
   await fireEvent.click(repairConnectionsLink);
 

--- a/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
+++ b/packages/renderer/src/lib/troubleshooting/TroubleshootingPage.svelte
@@ -33,12 +33,12 @@ onMount(async () => {
   {#snippet tabs()}
   <div class="flex flex-row px-2 border-b border-[var(--pd-content-divider)]">
     <Tab
-      title="Repair & Connections"
+      title="Repair & connections"
       selected={isTabSelected($router.path, 'repair-connections')}
       url={getTabUrl($router.path, 'repair-connections')} />
     <Tab title="Logs" selected={isTabSelected($router.path, 'logs')} url={getTabUrl($router.path, 'logs')} />
     <Tab
-      title="Gather Logs"
+      title="Gather logs"
       selected={isTabSelected($router.path, 'gatherlogs')}
       url={getTabUrl($router.path, 'gatherlogs')} />
     <Tab title="Stores" selected={isTabSelected($router.path, 'stores')} url={getTabUrl($router.path, 'stores')} />
@@ -49,7 +49,7 @@ onMount(async () => {
   {/snippet}
   {#snippet content()}
   <div class="flex w-full h-full overflow-auto">
-    <Route path="/repair-connections" breadcrumb="Repair & Connections" navigationHint="tab">
+    <Route path="/repair-connections" breadcrumb="Repair & connections" navigationHint="tab">
       <TroubleshootingPageProviders />
     </Route>
 
@@ -57,7 +57,7 @@ onMount(async () => {
       <TroubleshootingDevToolsConsoleLogs />
     </Route>
 
-    <Route path="/gatherlogs" breadcrumb="GatherLogs" navigationHint="tab">
+    <Route path="/gatherlogs" breadcrumb="Gather logs" navigationHint="tab">
       <TroubleshootingGatherLogs />
     </Route>
 

--- a/tests/playwright/src/model/pages/extensions-page.ts
+++ b/tests/playwright/src/model/pages/extensions-page.ts
@@ -46,7 +46,7 @@ export class ExtensionsPage {
     });
     this.installedTab = this.page.getByRole('button', { name: 'Installed' });
     this.catalogTab = this.page.getByRole('button', { name: 'Catalog', exact: true });
-    this.localExtensionsTab = this.page.getByRole('button', { name: 'Local Extensions' });
+    this.localExtensionsTab = this.page.getByRole('button', { name: 'Local extensions' });
     this.installExtensionFromOCIImageButton = this.additionalActions.getByLabel('Install custom');
     this.searchInput = this.search.getByLabel('search extensions');
   }

--- a/tests/playwright/src/model/pages/troubleshooting-page.ts
+++ b/tests/playwright/src/model/pages/troubleshooting-page.ts
@@ -53,7 +53,7 @@ export class TroubleshootingPage extends BasePage {
   }
 
   public async openRepairConnections(): Promise<void> {
-    await this.openTab('Repair & Connections');
+    await this.openTab('Repair & connections');
     await playExpect(this.containerConnectionsStatus).toBeVisible();
   }
 
@@ -68,7 +68,7 @@ export class TroubleshootingPage extends BasePage {
   }
 
   public async openGatherLogs(): Promise<void> {
-    await this.openTab('Gather Logs');
+    await this.openTab('Gather logs');
     await playExpect(this.gatherLogsText).toBeVisible();
   }
 

--- a/tests/playwright/src/special-specs/managed-configuration/managed-configuration-extensions.spec.ts
+++ b/tests/playwright/src/special-specs/managed-configuration/managed-configuration-extensions.spec.ts
@@ -58,9 +58,9 @@ test.describe
       });
 
     test.describe
-      .serial('Defaults + Locked setting: Local Extensions disabled', () => {
-        test('Local Extensions tab is not rendered when extensions.localExtensions.enabled is false', async () => {
-          // ExtensionList.svelte conditionally renders the Local Extensions tab
+      .serial('Defaults + Locked setting: Local extensions disabled', () => {
+        test('Local extensions tab is not rendered when extensions.localExtensions.enabled is false', async () => {
+          // ExtensionList.svelte conditionally renders the Local extensions tab
           // with {#if enableLocalExtensions}, so the button should not exist in the DOM
           await playExpect(extensionsPage.localExtensionsTab).not.toBeAttached();
         });

--- a/website/docs/extensions/debugging-an-extension.md
+++ b/website/docs/extensions/debugging-an-extension.md
@@ -19,7 +19,7 @@ After developing an extension, you can start and debug the extension from the UI
 
 1. Go to **Settings > Preferences > Extensions**.
 1. Click the toggle button to enable the development mode.
-1. Go to **Extensions** and select the **Local Extensions** tab.
+1. Go to **Extensions** and select the **Local extensions** tab.
 1. Click **Add a local folder extension...**.
 1. Select the folder that contains your extension.
 1. Check the extension is in the `started` state on the same page.

--- a/website/docs/troubleshooting/access-logs.md
+++ b/website/docs/troubleshooting/access-logs.md
@@ -8,7 +8,7 @@ tags: [accessing-podman-desktop-logs, troubleshooting-podman-desktop]
 
 # Access Podman Desktop logs
 
-When you face any connection issues or any other problems with your task execution, you can access the Podman Desktop logs to troubleshoot. In addition, you can also resolve those issues using the **Repair & Connections** and **Stores** tabs.
+When you face any connection issues or any other problems with your task execution, you can access the Podman Desktop logs to troubleshoot. In addition, you can also resolve those issues using the **Repair & connections** and **Stores** tabs.
 
 Stores denote the front-end objects that capture the event logs from the back-end side. For example, if a container is missing from the **Containers** component page, click the **containers** store link to check the event that triggered the last refresh. After comparing the number of containers in the store with those on the **Containers** page, you can identify whether a recent event is captured. If not, use the **Refresh** button to refresh the store data.
 
@@ -19,7 +19,7 @@ If you do not want to track the previous event logs, you can remove them from th
 1. Click the **Troubleshooting** icon in the status bar.
 1. Select the **Logs** tab to view the logs.
    ![accessing logs](img/access-logs.png)
-1. Optional: Select the **Gather Logs** tab to save all the logs into a .zip file.
+1. Optional: Select the **Gather logs** tab to save all the logs into a .zip file.
    1. Click **collect and save logs as .zip**.
    1. Browse the location where you want to save the logs.
    1. Click **Save**. You get a successful operation notification.
@@ -28,7 +28,7 @@ If you do not want to track the previous event logs, you can remove them from th
 
 1. Click the **Troubleshooting** icon in the status bar.
 1. Optional: Click **Cleanup/Purge data** to delete all resources from the engine.
-   ![Repair & Connections tab](img/repair-and-connections-tab.png)
+   ![Repair & connections tab](img/repair-and-connections-tab.png)
 1. Optional: Check container connections:
    1. Click **Ping** to view the response time of the container engine.
    1. Click **Check containers** to view the response time of the available containers.


### PR DESCRIPTION



### What does this PR do?
Tab labels should capitalize only the first word, matching the existing sentence-case UI copy guidelines. Update Extensions and Troubleshooting tabs, breadcrumbs, tests, and docs.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Fixes #18761

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
