### PR TITLE
test(e2e): update serial declaration - part 5

### DIFF
--- a/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-push-to-registry-smoke.spec.ts
@@ -63,86 +63,86 @@ test.afterAll(async ({ runner, page }) => {
 
 test.skip(!canTestRegistry(), 'Registry tests are disabled');
 
-test.describe
-  .serial('Push image to container registry', { tag: '@smoke' }, () => {
-    test('Add registry', async ({ page }) => {
-      await createRegistryAndVerify(page, registryUrl, registryUsername, registryPswdSecret, 'GitHub');
-    });
-
-    test('Pull image', async ({ navigationBar }) => {
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const pullImagePage = await imagesPage.openPullImage();
-      imagesPage = await pullImagePage.pullImage(helloContainer);
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => imagesPage.waitForRowToExists(helloContainer, 30_000), { timeout: 0 })
-        .toBeTruthy();
-    });
-
-    test('Rename image', async ({ page }) => {
-      let imagesPage = new ImagesPage(page);
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      fullName = `${registryUrl}/${registryUsername}/test-image`;
-
-      imagesPage = await imagesPage.renameImage(helloContainer, fullName, 'latest');
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => imagesPage.waitForRowToExists(fullName, 30_000), {
-          timeout: 0,
-        })
-        .toBeTruthy();
-    });
-
-    test('Push image to registry', async ({ page }) => {
-      const imagesPage = new ImagesPage(page);
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const imageDetailsPage = await imagesPage.openImageDetails(fullName);
-      await playExpect(imageDetailsPage.heading).toBeVisible();
-
-      await imageDetailsPage.pushImage();
-    });
-
-    test('Delete image', async ({ navigationBar }) => {
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => imagesPage.waitForRowToExists(fullName, 30_000), {
-          timeout: 0,
-        })
-        .toBeTruthy();
-
-      const imageDetailPage = await imagesPage.openImageDetails(fullName);
-      await playExpect(imageDetailPage.heading).toBeVisible();
-
-      imagesPage = await imageDetailPage.deleteImage();
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
-
-      await playExpect
-        .poll(async () => await imagesPage.waitForRowToBeDelete(fullName, 60_000), { timeout: 0 })
-        .toBeTruthy();
-    });
-
-    test('Pull image from github repo under new name', async ({ navigationBar }) => {
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const pullImagePage = await imagesPage.openPullImage();
-      imagesPage = await pullImagePage.pullImage(fullName, 'latest');
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => await imagesPage.waitForRowToExists(fullName, 15_000), { timeout: 0 })
-        .toBeTruthy();
-    });
-
-    test('Registry removal verification', async ({ page }) => {
-      await removeRegistryAndVerify(page, registryName, registryUsername);
-    });
+test.describe('Push image to container registry', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Add registry', async ({ page }) => {
+    await createRegistryAndVerify(page, registryUrl, registryUsername, registryPswdSecret, 'GitHub');
   });
+
+  test('Pull image', async ({ navigationBar }) => {
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const pullImagePage = await imagesPage.openPullImage();
+    imagesPage = await pullImagePage.pullImage(helloContainer);
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => imagesPage.waitForRowToExists(helloContainer, 30_000), { timeout: 0 })
+      .toBeTruthy();
+  });
+
+  test('Rename image', async ({ page }) => {
+    let imagesPage = new ImagesPage(page);
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    fullName = `${registryUrl}/${registryUsername}/test-image`;
+
+    imagesPage = await imagesPage.renameImage(helloContainer, fullName, 'latest');
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => imagesPage.waitForRowToExists(fullName, 30_000), {
+        timeout: 0,
+      })
+      .toBeTruthy();
+  });
+
+  test('Push image to registry', async ({ page }) => {
+    const imagesPage = new ImagesPage(page);
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const imageDetailsPage = await imagesPage.openImageDetails(fullName);
+    await playExpect(imageDetailsPage.heading).toBeVisible();
+
+    await imageDetailsPage.pushImage();
+  });
+
+  test('Delete image', async ({ navigationBar }) => {
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => imagesPage.waitForRowToExists(fullName, 30_000), {
+        timeout: 0,
+      })
+      .toBeTruthy();
+
+    const imageDetailPage = await imagesPage.openImageDetails(fullName);
+    await playExpect(imageDetailPage.heading).toBeVisible();
+
+    imagesPage = await imageDetailPage.deleteImage();
+    await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
+
+    await playExpect
+      .poll(async () => await imagesPage.waitForRowToBeDelete(fullName, 60_000), { timeout: 0 })
+      .toBeTruthy();
+  });
+
+  test('Pull image from github repo under new name', async ({ navigationBar }) => {
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const pullImagePage = await imagesPage.openPullImage();
+    imagesPage = await pullImagePage.pullImage(fullName, 'latest');
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await imagesPage.waitForRowToExists(fullName, 15_000), { timeout: 0 })
+      .toBeTruthy();
+  });
+
+  test('Registry removal verification', async ({ page }) => {
+    await removeRegistryAndVerify(page, registryName, registryUsername);
+  });
+});

--- a/tests/playwright/src/specs/image-smoke.spec.ts
+++ b/tests/playwright/src/specs/image-smoke.spec.ts
@@ -48,318 +48,315 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Image workflow verification', { tag: '@smoke' }, () => {
-    test.describe.configure({ retries: 1 });
+test.describe('Image workflow verification', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial', retries: 1 });
 
-    test('Pull image', async ({ navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
+  test('Pull image', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
 
-      const pullImagePage = await imagesPage.openPullImage();
-      const updatedImages = await pullImagePage.pullImage(helloContainer);
-      await playExpect(updatedImages.heading).toBeVisible({ timeout: 10_000 });
+    const pullImagePage = await imagesPage.openPullImage();
+    const updatedImages = await pullImagePage.pullImage(helloContainer);
+    await playExpect(updatedImages.heading).toBeVisible({ timeout: 10_000 });
 
-      await playExpect
-        .poll(async () => updatedImages.waitForImageExists(helloContainer, 30_000), { timeout: 0 })
-        .toBeTruthy();
+    await playExpect
+      .poll(async () => updatedImages.waitForImageExists(helloContainer, 30_000), { timeout: 0 })
+      .toBeTruthy();
 
-      playExpect(await updatedImages.getCurrentStatusOfImage(helloContainer)).toBe(ImageState.Unused);
-    });
+    playExpect(await updatedImages.getCurrentStatusOfImage(helloContainer)).toBe(ImageState.Unused);
+  });
 
-    test('Pull image from search results', async ({ navigationBar }) => {
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
+  test('Pull image from search results', async ({ navigationBar }) => {
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
 
-      const pullImagePage = await imagesPage.openPullImage();
-      await playExpect(pullImagePage.heading).toBeVisible();
+    const pullImagePage = await imagesPage.openPullImage();
+    await playExpect(pullImagePage.heading).toBeVisible();
 
-      const searchResults = await pullImagePage.getAllSearchResultsFor(imageToSearch, true);
-      playExpect(searchResults.length).toBeGreaterThan(0);
+    const searchResults = await pullImagePage.getAllSearchResultsFor(imageToSearch, true);
+    playExpect(searchResults.length).toBeGreaterThan(0);
 
-      imagesPage = await pullImagePage.pullImageFromSearchResults(`${imageToSearch}:${imageTagToSearch}`);
-      await playExpect(imagesPage.heading).toBeVisible();
-      await playExpect.poll(async () => await imagesPage.waitForImageExists(imageToSearch)).toBeTruthy();
+    imagesPage = await pullImagePage.pullImageFromSearchResults(`${imageToSearch}:${imageTagToSearch}`);
+    await playExpect(imagesPage.heading).toBeVisible();
+    await playExpect.poll(async () => await imagesPage.waitForImageExists(imageToSearch)).toBeTruthy();
 
-      const imageDetailPage = await imagesPage.openImageDetails(imageToSearch);
-      await playExpect(imageDetailPage.heading).toBeVisible();
+    const imageDetailPage = await imagesPage.openImageDetails(imageToSearch);
+    await playExpect(imageDetailPage.heading).toBeVisible();
 
-      imagesPage = await imageDetailPage.deleteImage();
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
+    imagesPage = await imageDetailPage.deleteImage();
+    await playExpect(imagesPage.heading).toBeVisible({ timeout: 30_000 });
 
-      await playExpect
-        .poll(async () => await imagesPage.waitForImageDelete(imageToSearch, 60_000), { timeout: 0 })
-        .toBeTruthy();
-    });
+    await playExpect
+      .poll(async () => await imagesPage.waitForImageDelete(imageToSearch, 60_000), { timeout: 0 })
+      .toBeTruthy();
+  });
 
-    test('Cancel pull image', async ({ navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
+  test('Cancel pull image', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
 
-      const pullImagePage = await imagesPage.openPullImage();
-      await playExpect(pullImagePage.heading).toBeVisible();
+    const pullImagePage = await imagesPage.openPullImage();
+    await playExpect(pullImagePage.heading).toBeVisible();
 
-      await pullImagePage.cancelPullImage(imageToSearch);
-      await playExpect(pullImagePage.heading).toBeVisible();
-    });
+    await pullImagePage.cancelPullImage(imageToSearch);
+    await playExpect(pullImagePage.heading).toBeVisible();
+  });
 
-    test('Pull image and view details', async ({ navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
+  test('Pull image and view details', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
 
-      const pullImagePage = await imagesPage.openPullImage();
-      await playExpect(pullImagePage.heading).toBeVisible();
+    const pullImagePage = await imagesPage.openPullImage();
+    await playExpect(pullImagePage.heading).toBeVisible();
 
-      const imageDetailsPage = await pullImagePage.pullImageAndViewDetails(helloContainer);
-      await playExpect(imageDetailsPage.heading).toBeVisible();
-    });
+    const imageDetailsPage = await pullImagePage.pullImageAndViewDetails(helloContainer);
+    await playExpect(imageDetailsPage.heading).toBeVisible();
+  });
 
-    test('Test navigation between pages', async ({ navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      const imageDetailPage = await imagesPage.openImageDetails(helloContainer);
-      await playExpect(imageDetailPage.heading).toBeVisible();
-      await imageDetailPage.backLink.click();
-      await playExpect(imagesPage.heading).toBeVisible();
+  test('Test navigation between pages', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    const imageDetailPage = await imagesPage.openImageDetails(helloContainer);
+    await playExpect(imageDetailPage.heading).toBeVisible();
+    await imageDetailPage.backLink.click();
+    await playExpect(imagesPage.heading).toBeVisible();
 
-      await imagesPage.openImageDetails(helloContainer);
-      await playExpect(imageDetailPage.heading).toBeVisible();
-      await imageDetailPage.closeButton.click();
-      await playExpect(imagesPage.heading).toBeVisible();
-    });
+    await imagesPage.openImageDetails(helloContainer);
+    await playExpect(imageDetailPage.heading).toBeVisible();
+    await imageDetailPage.closeButton.click();
+    await playExpect(imagesPage.heading).toBeVisible();
+  });
 
-    test('Check image details', async ({ navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      const imageDetailPage = await imagesPage.openImageDetails(helloContainer);
+  test('Check image details', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    const imageDetailPage = await imagesPage.openImageDetails(helloContainer);
 
-      await playExpect(imageDetailPage.summaryTab).toBeVisible();
-      await playExpect(imageDetailPage.historyTab).toBeVisible();
-      await playExpect(imageDetailPage.inspectTab).toBeVisible();
-    });
+    await playExpect(imageDetailPage.summaryTab).toBeVisible();
+    await playExpect(imageDetailPage.historyTab).toBeVisible();
+    await playExpect(imageDetailPage.inspectTab).toBeVisible();
+  });
 
-    test('Rename image', async ({ page }) => {
-      const imageDetailsPage = new ImageDetailsPage(page, helloContainer);
-      const editPage = await imageDetailsPage.openEditImage();
-      const imagesPage = await editPage.renameImage('quay.io/podman/hi');
-      playExpect(await imagesPage.waitForImageExists('quay.io/podman/hi')).toBe(true);
-    });
+  test('Rename image', async ({ page }) => {
+    const imageDetailsPage = new ImageDetailsPage(page, helloContainer);
+    const editPage = await imageDetailsPage.openEditImage();
+    const imagesPage = await editPage.renameImage('quay.io/podman/hi');
+    playExpect(await imagesPage.waitForImageExists('quay.io/podman/hi')).toBe(true);
+  });
 
-    test('Delete image', async ({ navigationBar }) => {
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
+  test('Delete image', async ({ navigationBar }) => {
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
 
+    await imagesPage.pullImage(helloContainer);
+    await playExpect(imagesPage.heading).toBeVisible();
+    await playExpect.poll(async () => await imagesPage.waitForImageExists(helloContainer)).toBeTruthy();
+
+    const imageDetailPage = await imagesPage.openImageDetails(helloContainer);
+    imagesPage = await imageDetailPage.deleteImage();
+
+    await playExpect
+      .poll(async () => await imagesPage.waitForImageDelete(helloContainer, 60_000), { timeout: 0 })
+      .toBeTruthy();
+    playExpect(await imagesPage.waitForImageExists('quay.io/podman/hi')).toBe(true);
+  });
+
+  test('Cancel build image', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const buildImagePage = await imagesPage.openBuildImage();
+    await playExpect(buildImagePage.heading).toBeVisible();
+    const dockerfilePath = path.resolve(__dirname, '..', '..', 'resources', 'test-containerfile');
+    const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
+
+    await buildImagePage.cancelBuild(
+      'cancel-build-image-test',
+      dockerfilePath,
+      contextDirectory,
+      [ArchitectureType.Default],
+      { cancelAfterTimeout: 20 },
+    );
+  });
+
+  test('Build image', async ({ navigationBar }) => {
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const buildImagePage = await imagesPage.openBuildImage();
+    await playExpect(buildImagePage.heading).toBeVisible();
+    const dockerfilePath = path.resolve(__dirname, '..', '..', 'resources', 'test-containerfile');
+    const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
+
+    imagesPage = await buildImagePage.buildImage('build-image-test', dockerfilePath, contextDirectory);
+    playExpect(await imagesPage.waitForImageExists('docker.io/library/build-image-test')).toBeTruthy();
+
+    const imageDetailsPage = await imagesPage.openImageDetails('docker.io/library/build-image-test');
+    await playExpect(imageDetailsPage.heading).toBeVisible();
+    imagesPage = await imageDetailsPage.deleteImage();
+    playExpect(await imagesPage.waitForImageDelete('docker.io/library/build-image-test')).toBeTruthy();
+  });
+
+  test('Build image with stage2 target from staged Containerfile', async ({ navigationBar }) => {
+    test.setTimeout(420_000);
+
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const buildImagePage = await imagesPage.openBuildImage();
+    await playExpect(buildImagePage.heading).toBeVisible();
+    const containerfilePath = path.resolve(__dirname, '..', '..', 'resources', 'staged_build.yaml');
+    const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
+
+    imagesPage = await buildImagePage.buildImage(
+      'staged-build-stage2-test',
+      containerfilePath,
+      contextDirectory,
+      [ArchitectureType.Default],
+      300_000,
+      'stage2',
+    );
+    playExpect(await imagesPage.waitForImageExists('docker.io/library/staged-build-stage2-test')).toBeTruthy();
+
+    const imageDetailsPage = await imagesPage.openImageDetails('docker.io/library/staged-build-stage2-test');
+    await playExpect(imageDetailsPage.heading).toBeVisible();
+    imagesPage = await imageDetailsPage.deleteImage();
+    playExpect(await imagesPage.waitForImageDelete('docker.io/library/staged-build-stage2-test')).toBeTruthy();
+  });
+
+  test('Filter and prune all images', async ({ navigationBar }) => {
+    test.setTimeout(240_000);
+
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    for (const image of imageList) {
       await imagesPage.pullImage(helloContainer);
       await playExpect(imagesPage.heading).toBeVisible();
-      await playExpect.poll(async () => await imagesPage.waitForImageExists(helloContainer)).toBeTruthy();
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(helloContainer, 15_000), { timeout: 0 })
+        .toBeTruthy();
 
-      const imageDetailPage = await imagesPage.openImageDetails(helloContainer);
-      imagesPage = await imageDetailPage.deleteImage();
+      await imagesPage.renameImage(helloContainer, image);
+      await playExpect(imagesPage.heading).toBeVisible();
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(image, 10_000), { timeout: 0 })
+        .toBeTruthy();
+    }
 
+    await test.step('Verify search filtering works for each image', async () => {
+      for (const image of imageList) {
+        await imagesPage.filterByName(image);
+        await playExpect
+          .poll(async () => await imagesPage.countRowsFromTable(), { timeout: 10_000 })
+          .toBeGreaterThanOrEqual(1);
+        await playExpect.poll(async () => await imagesPage.getImageRowByName(image), { timeout: 5_000 }).toBeDefined();
+      }
+      await imagesPage.clearFilterByName();
+      await playExpect
+        .poll(async () => await imagesPage.countRowsFromTable(), { timeout: 10_000 })
+        .toBeGreaterThanOrEqual(imageList.length);
+    });
+
+    await imagesPage.pruneImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    for (const image of imageList) {
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageDelete(image, 180_000), { timeout: 0 })
+        .toBeTruthy();
+    }
+  });
+
+  test('Prune untagged images', async ({ navigationBar }) => {
+    test.setTimeout(240_000);
+
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const baselineNoneCount = await imagesPage.countImagesByName('<none>');
+
+    for (const image of imageList) {
+      await imagesPage.pullImage(helloContainer);
+      await playExpect(imagesPage.heading).toBeVisible();
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(helloContainer, 15_000), { timeout: 0 })
+        .toBeTruthy();
+
+      await imagesPage.renameImage(helloContainer, image);
+      await playExpect(imagesPage.heading).toBeVisible();
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(image, 10_000), { timeout: 0 })
+        .toBeTruthy();
+    }
+
+    await imagesPage.pullImage(imageToSearch);
+    await playExpect(imagesPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => await imagesPage.waitForImageExists(imageToSearch, 120_000), { timeout: 0 })
+      .toBeTruthy();
+
+    await untagImagesFromPodman(imageList[0]);
+    await playExpect
+      .poll(async () => await imagesPage.countImagesByName('<none>'), { timeout: 60_000 })
+      .toBeGreaterThan(baselineNoneCount);
+
+    await imagesPage.pruneUntaggedImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => await imagesPage.countImagesByName('<none>'), { timeout: 60_000 })
+      .toBeLessThanOrEqual(baselineNoneCount);
+    await playExpect
+      .poll(async () => await imagesPage.waitForImageExists(imageToSearch, 60_000), { timeout: 0 })
+      .toBeTruthy();
+
+    await imagesPage.deleteAllUnusedImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await imagesPage.waitForImageDelete(imageToSearch, 60_000), { timeout: 0 })
+      .toBeTruthy();
+  });
+
+  test('Save image as tar, delete, load from tar', async ({ navigationBar }) => {
+    test.skip(
+      process.env.DEBUGGING_PORT !== undefined && process.env.PODMAN_DESKTOP_BINARY !== undefined,
+      'Test is not runnig with CDP runner',
+    );
+    test.setTimeout(180_000);
+
+    const tarFilePath = path.join(tmpdir(), 'podman-desktop-e2e-hello.tar');
+
+    try {
+      let imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      imagesPage = await imagesPage.pullImage(helloContainer);
+      await playExpect(imagesPage.heading).toBeVisible();
+
+      await playExpect
+        .poll(async () => await imagesPage.waitForImageExists(helloContainer, 15_000), { timeout: 0 })
+        .toBeTruthy();
+
+      const imageDetailsPage = await imagesPage.openImageDetails(helloContainer);
+      await playExpect(imageDetailsPage.heading).toBeVisible();
+
+      imagesPage = await imageDetailsPage.saveImage(tarFilePath);
+      await playExpect(imagesPage.heading).toBeVisible({ timeout: 60_000 });
+
+      const imageDetailsPageForDelete = await imagesPage.openImageDetails(helloContainer);
+      await playExpect(imageDetailsPageForDelete.heading).toBeVisible();
+
+      imagesPage = await imageDetailsPageForDelete.deleteImage();
       await playExpect
         .poll(async () => await imagesPage.waitForImageDelete(helloContainer, 60_000), { timeout: 0 })
         .toBeTruthy();
-      playExpect(await imagesPage.waitForImageExists('quay.io/podman/hi')).toBe(true);
-    });
 
-    test('Cancel build image', async ({ navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const buildImagePage = await imagesPage.openBuildImage();
-      await playExpect(buildImagePage.heading).toBeVisible();
-      const dockerfilePath = path.resolve(__dirname, '..', '..', 'resources', 'test-containerfile');
-      const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
-
-      await buildImagePage.cancelBuild(
-        'cancel-build-image-test',
-        dockerfilePath,
-        contextDirectory,
-        [ArchitectureType.Default],
-        { cancelAfterTimeout: 20 },
-      );
-    });
-
-    test('Build image', async ({ navigationBar }) => {
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const buildImagePage = await imagesPage.openBuildImage();
-      await playExpect(buildImagePage.heading).toBeVisible();
-      const dockerfilePath = path.resolve(__dirname, '..', '..', 'resources', 'test-containerfile');
-      const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
-
-      imagesPage = await buildImagePage.buildImage('build-image-test', dockerfilePath, contextDirectory);
-      playExpect(await imagesPage.waitForImageExists('docker.io/library/build-image-test')).toBeTruthy();
-
-      const imageDetailsPage = await imagesPage.openImageDetails('docker.io/library/build-image-test');
-      await playExpect(imageDetailsPage.heading).toBeVisible();
-      imagesPage = await imageDetailsPage.deleteImage();
-      playExpect(await imagesPage.waitForImageDelete('docker.io/library/build-image-test')).toBeTruthy();
-    });
-
-    test('Build image with stage2 target from staged Containerfile', async ({ navigationBar }) => {
-      test.setTimeout(420_000);
-
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const buildImagePage = await imagesPage.openBuildImage();
-      await playExpect(buildImagePage.heading).toBeVisible();
-      const containerfilePath = path.resolve(__dirname, '..', '..', 'resources', 'staged_build.yaml');
-      const contextDirectory = path.resolve(__dirname, '..', '..', 'resources');
-
-      imagesPage = await buildImagePage.buildImage(
-        'staged-build-stage2-test',
-        containerfilePath,
-        contextDirectory,
-        [ArchitectureType.Default],
-        300_000,
-        'stage2',
-      );
-      playExpect(await imagesPage.waitForImageExists('docker.io/library/staged-build-stage2-test')).toBeTruthy();
-
-      const imageDetailsPage = await imagesPage.openImageDetails('docker.io/library/staged-build-stage2-test');
-      await playExpect(imageDetailsPage.heading).toBeVisible();
-      imagesPage = await imageDetailsPage.deleteImage();
-      playExpect(await imagesPage.waitForImageDelete('docker.io/library/staged-build-stage2-test')).toBeTruthy();
-    });
-
-    test('Filter and prune all images', async ({ navigationBar }) => {
-      test.setTimeout(240_000);
-
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      for (const image of imageList) {
-        await imagesPage.pullImage(helloContainer);
-        await playExpect(imagesPage.heading).toBeVisible();
-        await playExpect
-          .poll(async () => await imagesPage.waitForImageExists(helloContainer, 15_000), { timeout: 0 })
-          .toBeTruthy();
-
-        await imagesPage.renameImage(helloContainer, image);
-        await playExpect(imagesPage.heading).toBeVisible();
-        await playExpect
-          .poll(async () => await imagesPage.waitForImageExists(image, 10_000), { timeout: 0 })
-          .toBeTruthy();
-      }
-
-      await test.step('Verify search filtering works for each image', async () => {
-        for (const image of imageList) {
-          await imagesPage.filterByName(image);
-          await playExpect
-            .poll(async () => await imagesPage.countRowsFromTable(), { timeout: 10_000 })
-            .toBeGreaterThanOrEqual(1);
-          await playExpect
-            .poll(async () => await imagesPage.getImageRowByName(image), { timeout: 5_000 })
-            .toBeDefined();
-        }
-        await imagesPage.clearFilterByName();
-        await playExpect
-          .poll(async () => await imagesPage.countRowsFromTable(), { timeout: 10_000 })
-          .toBeGreaterThanOrEqual(imageList.length);
-      });
-
-      await imagesPage.pruneImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      for (const image of imageList) {
-        await playExpect
-          .poll(async () => await imagesPage.waitForImageDelete(image, 180_000), { timeout: 0 })
-          .toBeTruthy();
-      }
-    });
-
-    test('Prune untagged images', async ({ navigationBar }) => {
-      test.setTimeout(240_000);
-
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const baselineNoneCount = await imagesPage.countImagesByName('<none>');
-
-      for (const image of imageList) {
-        await imagesPage.pullImage(helloContainer);
-        await playExpect(imagesPage.heading).toBeVisible();
-        await playExpect
-          .poll(async () => await imagesPage.waitForImageExists(helloContainer, 15_000), { timeout: 0 })
-          .toBeTruthy();
-
-        await imagesPage.renameImage(helloContainer, image);
-        await playExpect(imagesPage.heading).toBeVisible();
-        await playExpect
-          .poll(async () => await imagesPage.waitForImageExists(image, 10_000), { timeout: 0 })
-          .toBeTruthy();
-      }
-
-      await imagesPage.pullImage(imageToSearch);
-      await playExpect(imagesPage.heading).toBeVisible();
+      await imagesPage.loadImages(tarFilePath);
       await playExpect
-        .poll(async () => await imagesPage.waitForImageExists(imageToSearch, 120_000), { timeout: 0 })
+        .poll(async () => await imagesPage.waitForImageExists(helloContainer, 30_000), { timeout: 0 })
         .toBeTruthy();
-
-      await untagImagesFromPodman(imageList[0]);
-      await playExpect
-        .poll(async () => await imagesPage.countImagesByName('<none>'), { timeout: 60_000 })
-        .toBeGreaterThan(baselineNoneCount);
-
-      await imagesPage.pruneUntaggedImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-      await playExpect
-        .poll(async () => await imagesPage.countImagesByName('<none>'), { timeout: 60_000 })
-        .toBeLessThanOrEqual(baselineNoneCount);
-      await playExpect
-        .poll(async () => await imagesPage.waitForImageExists(imageToSearch, 60_000), { timeout: 0 })
-        .toBeTruthy();
-
-      await imagesPage.deleteAllUnusedImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => await imagesPage.waitForImageDelete(imageToSearch, 60_000), { timeout: 0 })
-        .toBeTruthy();
-    });
-
-    test('Save image as tar, delete, load from tar', async ({ navigationBar }) => {
-      test.skip(
-        process.env.DEBUGGING_PORT !== undefined && process.env.PODMAN_DESKTOP_BINARY !== undefined,
-        'Test is not runnig with CDP runner',
-      );
-      test.setTimeout(180_000);
-
-      const tarFilePath = path.join(tmpdir(), 'podman-desktop-e2e-hello.tar');
-
-      try {
-        let imagesPage = await navigationBar.openImages();
-        await playExpect(imagesPage.heading).toBeVisible();
-
-        imagesPage = await imagesPage.pullImage(helloContainer);
-        await playExpect(imagesPage.heading).toBeVisible();
-
-        await playExpect
-          .poll(async () => await imagesPage.waitForImageExists(helloContainer, 15_000), { timeout: 0 })
-          .toBeTruthy();
-
-        const imageDetailsPage = await imagesPage.openImageDetails(helloContainer);
-        await playExpect(imageDetailsPage.heading).toBeVisible();
-
-        imagesPage = await imageDetailsPage.saveImage(tarFilePath);
-        await playExpect(imagesPage.heading).toBeVisible({ timeout: 60_000 });
-
-        const imageDetailsPageForDelete = await imagesPage.openImageDetails(helloContainer);
-        await playExpect(imageDetailsPageForDelete.heading).toBeVisible();
-
-        imagesPage = await imageDetailsPageForDelete.deleteImage();
-        await playExpect
-          .poll(async () => await imagesPage.waitForImageDelete(helloContainer, 60_000), { timeout: 0 })
-          .toBeTruthy();
-
-        await imagesPage.loadImages(tarFilePath);
-        await playExpect
-          .poll(async () => await imagesPage.waitForImageExists(helloContainer, 30_000), { timeout: 0 })
-          .toBeTruthy();
-      } finally {
-        // eslint-disable-next-line n/no-sync
-        rmSync(tarFilePath, { force: true });
-      }
-    });
+    } finally {
+      // eslint-disable-next-line n/no-sync
+      rmSync(tarFilePath, { force: true });
+    }
   });
+});

--- a/tests/playwright/src/specs/insecure-registry-smoke.spec.ts
+++ b/tests/playwright/src/specs/insecure-registry-smoke.spec.ts
@@ -70,98 +70,98 @@ test.afterAll(async ({ runner, page }) => {
 
 test.skip(true, 'Temporarily disabled: investigating HTTPS cert bundle failures blocking e2e-main (#17384)');
 
-test.describe
-  .serial('Push image to insecure registry with self-signed certificate', { tag: '@smoke' }, () => {
-    test('Add insecure registry', async ({ page }) => {
-      await createRegistryAndVerify(page, registryUrl, registryUsername, registryPassword, registryUrl, true);
-    });
-
-    test('Pull source image', async ({ navigationBar }) => {
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const pullImagePage = await imagesPage.openPullImage();
-      imagesPage = await pullImagePage.pullImage(sourceImage);
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await imagesPage.waitForRowToExists(sourceImage, 30_000);
-    });
-
-    test('Tag image for insecure registry', async ({ page }) => {
-      let imagesPage = new ImagesPage(page);
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      fullImageName = `${registryUrl}/${registryUsername}/test-image`;
-
-      imagesPage = await imagesPage.renameImage(sourceImage, fullImageName, 'latest');
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await imagesPage.waitForRowToExists(fullImageName, 30_000);
-    });
-
-    test('Push image to insecure registry', async ({ navigationBar, page, statusBar }) => {
-      test.setTimeout(SYNC_TIMEOUT + 60_000);
-
-      const imagesPage = new ImagesPage(page);
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const imageDetailsPage = await imagesPage.openImageDetails(fullImageName);
-      await playExpect(imageDetailsPage.heading).toBeVisible();
-
-      if (isLinux) {
-        await imageDetailsPage.pushImage();
-      } else {
-        const errorText = (await pushImageExpectFailure(page, imageDetailsPage.pushButton)).toLowerCase();
-        playExpect(
-          errorText.includes('x509') || errorText.includes('certificate') || errorText.includes('tls'),
-          `Expected TLS/certificate error in push output, got: ${errorText.substring(0, 200)}`,
-        ).toBeTruthy();
-
-        const tasksPage = await statusBar.openTasksPage();
-        await playExpect(tasksPage.heading).toBeVisible();
-
-        const commandPalette = new CommandPalette(page);
-        await commandPalette.executeCommand('Podman: Synchronize certificates to all VMs');
-
-        await playExpect
-          .poll(
-            async () => {
-              try {
-                const status = await tasksPage.getStatusForLatestTask();
-                if (status && !status.includes(TaskState.Success)) {
-                  console.log(`Poll: certificate sync task status = "${status}"`);
-                }
-                return status;
-              } catch (error: unknown) {
-                console.log('Poll: task status not yet available —', error instanceof Error ? error.message : error);
-                return '';
-              }
-            },
-            { timeout: SYNC_TIMEOUT, intervals: [POLL_INTERVAL] },
-          )
-          .toContain(TaskState.Success);
-
-        const imagesPageAfterSync = await navigationBar.openImages();
-        const imageDetailsAfterSync = await imagesPageAfterSync.openImageDetails(fullImageName);
-        await playExpect(imageDetailsAfterSync.heading).toBeVisible();
-        await imageDetailsAfterSync.pushImage();
-      }
-    });
-
-    test('Verify push by re-pulling from insecure registry', async ({ navigationBar, page }) => {
-      await deleteImage(page, fullImageName);
-
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const pullImagePage = await imagesPage.openPullImage();
-      imagesPage = await pullImagePage.pullImage(fullImageName, 'latest');
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await imagesPage.waitForRowToExists(fullImageName, 30_000);
-    });
-
-    test('Remove insecure registry', async ({ page }) => {
-      await deleteRegistry(page, registryUrl);
-    });
+test.describe('Push image to insecure registry with self-signed certificate', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Add insecure registry', async ({ page }) => {
+    await createRegistryAndVerify(page, registryUrl, registryUsername, registryPassword, registryUrl, true);
   });
+
+  test('Pull source image', async ({ navigationBar }) => {
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const pullImagePage = await imagesPage.openPullImage();
+    imagesPage = await pullImagePage.pullImage(sourceImage);
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await imagesPage.waitForRowToExists(sourceImage, 30_000);
+  });
+
+  test('Tag image for insecure registry', async ({ page }) => {
+    let imagesPage = new ImagesPage(page);
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    fullImageName = `${registryUrl}/${registryUsername}/test-image`;
+
+    imagesPage = await imagesPage.renameImage(sourceImage, fullImageName, 'latest');
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await imagesPage.waitForRowToExists(fullImageName, 30_000);
+  });
+
+  test('Push image to insecure registry', async ({ navigationBar, page, statusBar }) => {
+    test.setTimeout(SYNC_TIMEOUT + 60_000);
+
+    const imagesPage = new ImagesPage(page);
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const imageDetailsPage = await imagesPage.openImageDetails(fullImageName);
+    await playExpect(imageDetailsPage.heading).toBeVisible();
+
+    if (isLinux) {
+      await imageDetailsPage.pushImage();
+    } else {
+      const errorText = (await pushImageExpectFailure(page, imageDetailsPage.pushButton)).toLowerCase();
+      playExpect(
+        errorText.includes('x509') || errorText.includes('certificate') || errorText.includes('tls'),
+        `Expected TLS/certificate error in push output, got: ${errorText.substring(0, 200)}`,
+      ).toBeTruthy();
+
+      const tasksPage = await statusBar.openTasksPage();
+      await playExpect(tasksPage.heading).toBeVisible();
+
+      const commandPalette = new CommandPalette(page);
+      await commandPalette.executeCommand('Podman: Synchronize certificates to all VMs');
+
+      await playExpect
+        .poll(
+          async () => {
+            try {
+              const status = await tasksPage.getStatusForLatestTask();
+              if (status && !status.includes(TaskState.Success)) {
+                console.log(`Poll: certificate sync task status = "${status}"`);
+              }
+              return status;
+            } catch (error: unknown) {
+              console.log('Poll: task status not yet available —', error instanceof Error ? error.message : error);
+              return '';
+            }
+          },
+          { timeout: SYNC_TIMEOUT, intervals: [POLL_INTERVAL] },
+        )
+        .toContain(TaskState.Success);
+
+      const imagesPageAfterSync = await navigationBar.openImages();
+      const imageDetailsAfterSync = await imagesPageAfterSync.openImageDetails(fullImageName);
+      await playExpect(imageDetailsAfterSync.heading).toBeVisible();
+      await imageDetailsAfterSync.pushImage();
+    }
+  });
+
+  test('Verify push by re-pulling from insecure registry', async ({ navigationBar, page }) => {
+    await deleteImage(page, fullImageName);
+
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const pullImagePage = await imagesPage.openPullImage();
+    imagesPage = await pullImagePage.pullImage(fullImageName, 'latest');
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await imagesPage.waitForRowToExists(fullImageName, 30_000);
+  });
+
+  test('Remove insecure registry', async ({ page }) => {
+    await deleteRegistry(page, registryUrl);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Updates the old, to be deprecated, serial declaration of the e2e tests to the current standard. Only 3 test cases at a time to make it feasible to review.

Most of the diff is indentation/whitespace from unwrapping `test.describe.serial(...)` into `test.describe(...)` + `test.describe.configure({ mode: 'serial' })`. **Reviewing with the "Hide whitespace" option enabled in the PR "Files changed" view makes it much easier to see the actual logic changes** (there are none in this PR — pure mechanical conversion).

### Screenshot / video of UI


### What issues does this PR fix or reference?
Partially https://github.com/podman-desktop/podman-desktop/issues/15697

### How to test this PR?


- [ ] Tests are covering the bug fix or the new feature