### PR TITLE
refactor(renderer): store ContainerInfoUI instead of ContainerInfo

### DIFF
--- a/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetails.spec.ts
@@ -264,3 +264,72 @@ test('Test that compose kube tab is clickable and loadable', async () => {
   const kubeHref = screen.getByRole('link', { name: 'Kube' });
   await fireEvent.click(kubeHref);
 });
+
+test('Expect compose status RUNNING when every container of the project runs', async () => {
+  // ContainerUtils.getState uppercases, so comparing the UI state against 'running'
+  // would silently make allRunning false and show the project as STOPPED forever
+  vi.mocked(window.listContainers).mockResolvedValue([
+    {
+      Id: 'sha256:compose1',
+      Image: 'sha256:123',
+      Names: ['/foobar-web-1'],
+      State: 'running',
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'sha256:dummy-image-id',
+      Labels: { 'com.docker.compose.project': 'foobar' },
+    },
+    {
+      Id: 'sha256:compose2',
+      Image: 'sha256:123',
+      Names: ['/foobar-db-1'],
+      State: 'running',
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'sha256:dummy-image-id',
+      Labels: { 'com.docker.compose.project': 'foobar' },
+    },
+  ] as unknown as ContainerInfo[]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+  // wait for the store to actually be populated
+  await vi.waitUntil(() => get(containersInfos).length === 2);
+
+  await waitRender('foobar', 'podman');
+
+  expect(screen.getByRole('status', { name: 'RUNNING' })).toBeInTheDocument();
+});
+
+test('Expect compose status STOPPED when one container of the project is stopped', async () => {
+  vi.mocked(window.listContainers).mockResolvedValue([
+    {
+      Id: 'sha256:compose1',
+      Image: 'sha256:123',
+      Names: ['/foobar-web-1'],
+      State: 'running',
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'sha256:dummy-image-id',
+      Labels: { 'com.docker.compose.project': 'foobar' },
+    },
+    {
+      Id: 'sha256:compose2',
+      Image: 'sha256:123',
+      Names: ['/foobar-db-1'],
+      State: 'exited',
+      engineId: 'podman',
+      engineName: 'podman',
+      ImageID: 'sha256:dummy-image-id',
+      Labels: { 'com.docker.compose.project': 'foobar' },
+    },
+  ] as unknown as ContainerInfo[]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+
+  await vi.waitUntil(() => get(containersInfos).length === 2);
+
+  await waitRender('foobar', 'podman');
+
+  expect(screen.getByRole('status', { name: 'STOPPED' })).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/compose/ComposeDetails.svelte
+++ b/packages/renderer/src/lib/compose/ComposeDetails.svelte
@@ -4,7 +4,6 @@ import { onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
-import { ContainerUtils } from '/@/lib/container/container-utils';
 import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import ComposeIcon from '/@/lib/images/PodIcon.svelte';
 import DetailsPage from '/@/lib/ui/DetailsPage.svelte';
@@ -22,7 +21,6 @@ import type { ComposeInfoUI } from './ComposeInfoUI';
 export let composeName: string;
 export let engineId: string;
 
-const containerUtils = new ContainerUtils();
 let composeUnsubscribe: Unsubscriber;
 
 let compose: ComposeInfoUI;
@@ -41,7 +39,7 @@ onMount(() => {
 
     // Get all containers that match the composeName we are looking at
     const containersMatchingProject = containers.filter(container => {
-      return container?.Labels['com.docker.compose.project'] === composeName;
+      return container?.labels['com.docker.compose.project'] === composeName;
     });
 
     // Update our current status
@@ -49,7 +47,8 @@ onMount(() => {
       status = 'STOPPED';
     } else {
       const allRunning = containersMatchingProject.every(container => {
-        return container?.State === 'running';
+        // the UI state is uppercased by ContainerUtils.getState, unlike the raw backend value
+        return container?.state === 'RUNNING';
       });
       if (allRunning) {
         status = 'RUNNING';
@@ -58,9 +57,10 @@ onMount(() => {
       }
     }
 
-    // Convert each matching container to the ComposeInfoContainerUI type and add it to compose.containers
+    // the store already holds ContainerInfoUI; copy so ComposeActions, which writes
+    // actionInProgress, actionError and state, never touches the store's own elements
     convertedContainers = containersMatchingProject.map(container => {
-      return containerUtils.getContainerInfoUI(container);
+      return { ...container };
     });
 
     // Get the engine type from the first container in the list (if it exists)

--- a/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsLogs.spec.ts
@@ -69,6 +69,8 @@ const containerInfoUIMock: ContainerInfoUI = {
   created: 0,
   labels: {},
   imageBase64RepoTag: '',
+  imageId: 'foobar',
+  names: ['/foobar'],
 };
 
 const composeInfoUIMock: ComposeInfoUI = {

--- a/packages/renderer/src/lib/compose/ComposeDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/compose/ComposeDetailsSummary.spec.ts
@@ -54,6 +54,8 @@ const fakeContainer1: ContainerInfoUI = {
   created: 1234,
   labels: {},
   imageBase64RepoTag: 'fakeRepoTag',
+  imageId: 'fakeImageID1',
+  names: ['/fakeContainer1'],
 };
 
 const fakeContainer2: ContainerInfoUI = {
@@ -84,6 +86,8 @@ const fakeContainer2: ContainerInfoUI = {
   created: 1234,
   labels: {},
   imageBase64RepoTag: 'fakeRepoTag',
+  imageId: 'fakeImageID2',
+  names: ['/fakeContainer2'],
 };
 
 const fakeCompose: ComposeInfoUI = {

--- a/packages/renderer/src/lib/container/ContainerColumnName.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnName.spec.ts
@@ -54,6 +54,8 @@ const container: ContainerInfoUI = {
   created: 0,
   labels: {},
   imageBase64RepoTag: '',
+  imageId: 'sha256:123',
+  names: ['/my-container'],
 };
 
 const pod: ContainerGroupInfoUI = {

--- a/packages/renderer/src/lib/container/ContainerColumnStatus.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerColumnStatus.spec.ts
@@ -47,6 +47,8 @@ test('Expect simple column styling - container', async () => {
     created: 0,
     labels: {},
     imageBase64RepoTag: '',
+    imageId: '',
+    names: [''],
   };
   render(ContainerColumnStatus, { object: container });
 

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -19,7 +19,9 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { ContainerInfo, ContainerInspectInfo } from '@podman-desktop/core-api';
+import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
@@ -28,6 +30,8 @@ import { lastPage } from '/@/stores/breadcrumb';
 import { containersInfos } from '/@/stores/containers';
 
 import ContainerDetails from './ContainerDetails.svelte';
+import type { ContainerInfoUI } from './ContainerInfoUI';
+import { ContainerGroupInfoTypeUI } from './ContainerInfoUI';
 
 const myContainer: ContainerInfo = {
   Id: 'myContainer',
@@ -47,11 +51,56 @@ const myContainer: ContainerInfo = {
   ImageBase64RepoTag: '',
 };
 
-const myInfraContainer: ContainerInfo = {
-  ...myContainer,
-  Id: 'myInfraContainer',
-  Names: ['infra0'],
-  IsInfra: true,
+// myContainer above is the raw backend shape returned by window.listContainers.
+// myContainerUI is the same container already shaped the way the store holds it.
+// They describe the same container and must be kept in sync by hand.
+const myContainerUI: ContainerInfoUI = {
+  id: 'myContainer',
+  shortId: 'myContai',
+  name: 'name0',
+  image: '',
+  shortImage: '',
+  engineId: 'engine0',
+  engineName: 'podman',
+  engineType: 'podman',
+  state: '',
+  uptime: '',
+  startedAt: '',
+  ports: [],
+  portsAsString: '',
+  displayPort: '',
+  command: '',
+  hasPublicPort: false,
+  openingUrl: '',
+  groupInfo: {
+    name: 'name0',
+    type: ContainerGroupInfoTypeUI.STANDALONE,
+    status: 'RUNNING',
+    engineId: 'engine0',
+    engineType: 'podman',
+    id: 'myContainer',
+    engineName: 'podman',
+  },
+  selected: false,
+  created: 0,
+  labels: {},
+  icon: ContainerIcon,
+  imageBase64RepoTag: '',
+  imageHref: '/images//engine0',
+  imageId: '',
+  names: ['name0'],
+};
+
+// The store holds ContainerInfoUI, so the infra fixture is a UI object too. Upstream added
+// it as a raw ContainerInfo back when the store still carried the backend shape.
+const myInfraContainerUI: ContainerInfoUI = {
+  ...myContainerUI,
+  id: 'myInfraContainer',
+  shortId: 'myInfraC',
+  name: 'infra0',
+  names: ['infra0'],
+  isInfra: true,
+  groupInfo: { ...myContainerUI.groupInfo, name: 'infra0', id: 'myInfraContainer' },
 };
 
 vi.mock(import('@xterm/xterm'));
@@ -68,7 +117,7 @@ beforeEach(() => {
 test('Expect logs when tty is not enabled', async () => {
   router.goto('/');
 
-  containersInfos.set([myContainer]);
+  containersInfos.set([myContainerUI]);
 
   // spy router.goto
   const routerGotoSpy = vi.spyOn(router, 'goto');
@@ -97,7 +146,7 @@ test('Expect logs when tty is not enabled', async () => {
 test('Expect show tty if container has tty enabled', async () => {
   router.goto('/');
 
-  containersInfos.set([myContainer]);
+  containersInfos.set([myContainerUI]);
 
   // spy router.goto
   const routerGotoSpy = vi.spyOn(router, 'goto');
@@ -140,7 +189,7 @@ test('Expect redirect to previous page if container is deleted', async () => {
   // remove myContainer from the store when we call 'deleteContainer'
   // it will then refresh the store and update ContainerDetails page
   vi.mocked(window.deleteContainer).mockImplementation(async (): Promise<void> => {
-    containersInfos.update(containers => containers.filter(container => container.Id !== myContainer.Id));
+    containersInfos.update(containers => containers.filter(container => container.id !== myContainerUI.id));
   });
 
   // defines a fake lastPage so we can check where we will be redirected
@@ -180,7 +229,7 @@ test('Expect redirect to previous page if container is deleted', async () => {
 test('Expect Terminal tab to be hidden for infra containers', async () => {
   router.goto('/');
 
-  containersInfos.set([myInfraContainer]);
+  containersInfos.set([myInfraContainerUI]);
 
   vi.mocked(window.getContainerInspect).mockResolvedValue({
     Config: {
@@ -202,7 +251,7 @@ test('Expect Terminal tab to be hidden for infra containers', async () => {
 test('Expect Terminal tab to be visible for non-infra containers', async () => {
   router.goto('/');
 
-  containersInfos.set([myContainer]);
+  containersInfos.set([myContainerUI]);
 
   vi.mocked(window.getContainerInspect).mockResolvedValue({
     Config: {
@@ -218,4 +267,34 @@ test('Expect Terminal tab to be visible for non-infra containers', async () => {
     expect(screen.getByText('Inspect')).toBeInTheDocument();
     expect(screen.getByText('Terminal')).toBeInTheDocument();
   });
+});
+
+test('Expect a failed action not to write through to the store element', async () => {
+  // R13: ContainerActions.handleError writes actionError and state = 'ERROR' straight onto
+  // the container it was given. Before the store held ContainerInfoUI every screen built a
+  // fresh object, so a failed action stayed on screen. Now the screen must copy, or the
+  // failure sticks in the store until the next backend refresh and leaks into the list.
+  router.goto('/');
+  const stopped: ContainerInfoUI = { ...myContainerUI, state: 'STOPPED' };
+  containersInfos.set([stopped]);
+
+  vi.mocked(window.getContainerInspect).mockResolvedValue({
+    Config: {},
+  } as unknown as ContainerInspectInfo);
+  vi.mocked(window.startContainer).mockRejectedValue('cannot bind port');
+
+  render(ContainerDetails, { containerID: 'myContainer' });
+
+  const startButton = await screen.findByRole('button', { name: 'Start Container' });
+  await fireEvent.click(startButton);
+
+  // let the rejected action settle
+  await vi.waitFor(() => expect(window.startContainer).toHaveBeenCalled());
+  await tick();
+  await tick();
+
+  // ...and the store element is untouched by it
+  const inStore = get(containersInfos)[0];
+  expect(inStore.actionError).toBeUndefined();
+  expect(inStore.state).toBe('STOPPED');
 });

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import '@xterm/xterm/css/xterm.css';
 
-import type { ContainerInfo } from '@podman-desktop/core-api';
 import { ErrorMessage, Link, StatusIcon, Tab } from '@podman-desktop/ui-svelte';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { router } from 'tinro';
@@ -13,7 +12,6 @@ import Route from '/@/Route.svelte';
 import { lastPage } from '/@/stores/breadcrumb';
 import { containersInfos } from '/@/stores/containers';
 
-import { ContainerUtils } from './container-utils';
 import ContainerActions from './ContainerActions.svelte';
 import ContainerDetailsInspect from './ContainerDetailsInspect.svelte';
 import ContainerDetailsKube from './ContainerDetailsKube.svelte';
@@ -30,14 +28,12 @@ interface Props {
 
 let { containerID }: Props = $props();
 
-const containerUtils = new ContainerUtils();
-
 let displayTty: boolean = $state(false);
 let hadContainer = false;
 
-let container: ContainerInfoUI | undefined = $derived(
-  getContainerInfoUI($containersInfos.find(c => c.Id === containerID)),
-);
+// copy rather than hand the store's own element to ContainerActions, which writes
+// actionInProgress, actionError and state onto the container it is given
+let container: ContainerInfoUI | undefined = $derived(copyOf($containersInfos.find(c => c.id === containerID)));
 
 $effect(() => {
   if (container) {
@@ -62,8 +58,8 @@ $effect(() => {
   }
 });
 
-function getContainerInfoUI(cont: ContainerInfo | undefined): ContainerInfoUI | undefined {
-  return cont ? containerUtils.getContainerInfoUI(cont) : undefined;
+function copyOf(cont: ContainerInfoUI | undefined): ContainerInfoUI | undefined {
+  return cont ? { ...cont } : undefined;
 }
 </script>
 

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
@@ -60,6 +60,8 @@ const fakePodContainer: ContainerInfoUI = {
   created: 1234,
   labels: { label1: 'label1' },
   imageBase64RepoTag: 'fakeRepoTag',
+  imageId: 'fakeImageID1',
+  names: ['/fakePodContainer'],
 };
 
 const fakeStandaloneContainer: ContainerInfoUI = {
@@ -90,6 +92,8 @@ const fakeStandaloneContainer: ContainerInfoUI = {
   created: 1234,
   labels: {},
   imageBase64RepoTag: 'fakeRepoTag',
+  imageId: 'fakeImageID2',
+  names: ['/fakeStandaloneContainer'],
 };
 
 // Test render ContainerDetailsSummary with ContainerInfoUI object with a pod group

--- a/packages/renderer/src/lib/container/ContainerExport.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerExport.spec.ts
@@ -19,7 +19,6 @@
 import '@testing-library/jest-dom/vitest';
 
 import type { Uri } from '@podman-desktop/api';
-import type { ContainerInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -29,14 +28,17 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import { containersInfos } from '/@/stores/containers';
 
 import ContainerExport from './ContainerExport.svelte';
+import type { ContainerInfoUI } from './ContainerInfoUI';
 
-const container: ContainerInfo = {
+// the store holds ContainerInfoUI now
+const container: ContainerInfoUI = {
   engineId: 'engine',
-  Id: 'container-id',
-  Names: ['test'],
-  Image: 'test-image',
-  ImageID: 'test-image-id',
-} as unknown as ContainerInfo;
+  id: 'container-id',
+  name: 'test',
+  names: ['test'],
+  image: 'test-image',
+  imageId: 'test-image-id',
+} as unknown as ContainerInfoUI;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -86,7 +88,7 @@ test('Expect export function called when export button is clicked', async () => 
   await userEvent.click(btnExportcontainer);
 
   expect(window.exportContainer).toBeCalledWith(container.engineId, {
-    id: container.Id,
+    id: container.id,
     outputTarget: '/tmp/my/path',
   });
   expect(goToMock).toBeCalledWith('/containers');
@@ -109,7 +111,7 @@ test('Expect error shown if export function fails', async () => {
   const errorDiv = screen.getByLabelText('Error Message Content');
 
   expect(window.exportContainer).toBeCalledWith(container.engineId, {
-    id: container.Id,
+    id: container.id,
     outputTarget: '/tmp/my/path',
   });
   expect(goToMock).not.toBeCalled();

--- a/packages/renderer/src/lib/container/ContainerExport.svelte
+++ b/packages/renderer/src/lib/container/ContainerExport.svelte
@@ -4,7 +4,6 @@ import { NavigationPage } from '@podman-desktop/core-api';
 import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 
-import { ContainerUtils } from '/@/lib/container/container-utils';
 import EngineFormPage from '/@/lib/ui/EngineFormPage.svelte';
 import { Uri } from '/@/lib/uri/Uri';
 import { handleNavigation } from '/@/navigation';
@@ -28,13 +27,12 @@ let inProgress = $state(false);
 let invalidFields = $derived(invalidName || invalidFolder);
 
 onMount(() => {
-  const containerUtils = new ContainerUtils();
-
   // loading container info
   return containersInfos.subscribe(containers => {
-    const matchingContainer = containers.find(c => c.Id === containerID);
+    const matchingContainer = containers.find(c => c.id === containerID);
     if (matchingContainer) {
-      container = containerUtils.getContainerInfoUI(matchingContainer);
+      // copy: this object is local to the screen and must not alias the store's element
+      container = { ...matchingContainer };
     } else {
       handleNavigation({
         page: NavigationPage.CONTAINERS,

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -74,6 +74,15 @@ export interface ContainerInfoUI {
   icon?: string | IconDefinition | Component;
   imageBase64RepoTag: string;
   imageHref?: string;
+  // Raw ContainerInfo.ImageID, always set by the converter since ContainerInfo.ImageID
+  // is non-optional upstream. Kept because image-utils.getInUse() matches an image
+  // against the containers using it, and no other field carries the plain image id.
+  imageId: string;
+  // Raw, unprocessed ContainerInfo.Names, always set by the converter since
+  // ContainerInfo.Names is non-optional upstream: the leading '/' is kept and the
+  // compose project prefix is not stripped, unlike `name` above. Consumers that match
+  // a container by any of its aliases need this rather than `name`.
+  names: string[];
 }
 
 export interface ContainerGroupInfoUI extends ContainerGroupPartInfoUI {

--- a/packages/renderer/src/lib/container/ContainerList.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerList.spec.ts
@@ -28,8 +28,10 @@ import { get } from 'svelte/store';
 import { router } from 'tinro';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import { CONTAINER_LIST_VIEW } from '/@/lib/view/views';
 import { containersInfos } from '/@/stores/containers';
 import { providerInfos } from '/@/stores/providers';
+import { viewsContributions } from '/@/stores/views';
 
 import ContainerList from './ContainerList.svelte';
 
@@ -37,6 +39,9 @@ vi.mock(import('tinro'));
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // vi.resetAllMocks does not touch Svelte stores; a test that sets one would
+  // otherwise leak its contributions into every test declared after it
+  viewsContributions.set([]);
   vi.mocked(window.listPods).mockResolvedValue([]);
   vi.mocked(window.listViewsContributions).mockResolvedValue([]);
   vi.mocked(window.getContributedMenus).mockResolvedValue([]);
@@ -1278,4 +1283,79 @@ test('Expect clicking Existing image button closes dialog', async () => {
   await waitFor(() => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
+});
+
+test('Expect contributed icon to be applied to the container row', async () => {
+  // the containers store converts without the context and the view contributions, so this
+  // icon can only appear if ContainerList overlays it after reading the store
+  vi.mocked(window.listContainers).mockResolvedValue([
+    {
+      Id: 'sha256:iconcontainer',
+      Image: 'sha256:123',
+      Names: ['/icon-container'],
+      State: 'RUNNING',
+      ImageID: 'sha256:image-id',
+      engineId: 'podman',
+      engineName: 'podman',
+      Labels: { 'podman-desktop.label': 'true' },
+    } as unknown as ContainerInfo,
+  ]);
+
+  const contribs = [
+    {
+      extensionId: 'foo.bar',
+      viewId: CONTAINER_LIST_VIEW,
+      value: {
+        icon: '${my-custom-icon}',
+        when: 'podman-desktop.label in containerLabelKeys',
+      },
+    },
+  ];
+  vi.mocked(window.listViewsContributions).mockResolvedValue(contribs);
+  viewsContributions.set(contribs);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('tray:update-provider'));
+
+  await waitFor(() => expect(get(containersInfos)).not.toHaveLength(0));
+  await waitFor(() => expect(get(providerInfos)).not.toHaveLength(0));
+  await waitRender({});
+
+  const statusElement = screen.getByRole('status', { name: 'RUNNING' });
+  expect(statusElement.getElementsByClassName('podman-desktop-icon-my-custom-icon')).toHaveLength(1);
+});
+
+test('Expect search not to match the raw compose-prefixed container name', async () => {
+  // `names` carries the raw '/myproject-web-1'; `name` is the compose-stripped 'web-1'.
+  // Search has always matched on `name`, and adding `names` to the object must not
+  // silently widen it — findMatchInLeaves recurses into arrays.
+  vi.mocked(window.listContainers).mockResolvedValue([
+    {
+      Id: 'sha256:composecontainer',
+      Image: 'sha256:123',
+      Names: ['/myproject-web-1'],
+      State: 'RUNNING',
+      ImageID: 'sha256:image-id',
+      engineId: 'podman',
+      engineName: 'podman',
+      Labels: { 'com.docker.compose.project': 'myproject' },
+    } as unknown as ContainerInfo,
+  ]);
+
+  window.dispatchEvent(new CustomEvent('extensions-already-started'));
+  window.dispatchEvent(new CustomEvent('provider-lifecycle-change'));
+  window.dispatchEvent(new CustomEvent('tray:update-provider'));
+
+  await waitFor(() => expect(get(containersInfos)).not.toHaveLength(0));
+  await waitFor(() => expect(get(providerInfos)).not.toHaveLength(0));
+
+  // the stripped name still matches, as it did before the store held ContainerInfoUI
+  const { unmount } = await waitRender({ searchTerm: 'web-1' });
+  expect(screen.queryByText('web-1')).toBeInTheDocument();
+  unmount();
+
+  // the raw prefixed name must not
+  await waitRender({ searchTerm: 'myproject-web-1' });
+  expect(screen.queryByText('web-1')).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/container/ContainerList.svelte
+++ b/packages/renderer/src/lib/container/ContainerList.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { faPlay, faPlusCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
-import type { ContainerInfo } from '@podman-desktop/core-api';
 import { NavigationPage } from '@podman-desktop/core-api';
 import {
   Button,
@@ -217,8 +216,14 @@ function createPodFromContainers(): void {
 let currentContainers = $derived.by(() => {
   const viewContributions = $viewsContributions.filter(view => view.viewId === CONTAINER_LIST_VIEW);
 
-  return $containersInfos.map((containerInfo: ContainerInfo) => {
-    return containerUtils.getContainerInfoUI(containerInfo, $context, viewContributions);
+  // the store already holds ContainerInfoUI; only the extension-contributed icon is left
+  // to resolve, because it needs the context and the view contributions, which are
+  // component-level stores the containers store deliberately does not subscribe to
+  return $containersInfos.map((containerInfo: ContainerInfoUI) => {
+    return {
+      ...containerInfo,
+      icon: containerUtils.iconClass(containerInfo, $context, viewContributions) ?? ContainerIcon,
+    };
   });
 });
 
@@ -243,7 +248,13 @@ let containerGroups = $derived.by(() => {
   computedContainerGroups.forEach(group => {
     group.containers = group.containers
       .filter(containerInfo =>
-        findMatchInLeaves(containerInfo, containerUtils.filterSearchTerm(searchTerm).toLowerCase()),
+        // `names` is excluded on purpose: findMatchInLeaves recurses into arrays, so the raw
+        // names would newly make the leading '/', the compose project prefix and every alias
+        // searchable. Search matches on `name` as it always has.
+        findMatchInLeaves(
+          { ...containerInfo, names: undefined },
+          containerUtils.filterSearchTerm(searchTerm).toLowerCase(),
+        ),
       )
       .filter(containerInfo => {
         if (containerUtils.filterIsRunning(searchTerm)) {

--- a/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerStatistics.spec.ts
@@ -54,6 +54,8 @@ const myContainer: ContainerInfoUI = {
   created: 0,
   labels: {},
   imageBase64RepoTag: '',
+  imageId: 'foobar',
+  names: ['/foobar'],
 };
 
 const stats: ContainerStatsInfo = {

--- a/packages/renderer/src/lib/container/container-utils.spec.ts
+++ b/packages/renderer/src/lib/container/container-utils.spec.ts
@@ -17,6 +17,7 @@
  ***********************************************************************/
 
 import type { ContainerInfo, ViewInfoUI } from '@podman-desktop/core-api';
+import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { ContextUI } from '/@/lib/context/context';
@@ -280,8 +281,8 @@ test('containers in same named compose project on two different engine should ha
 });
 
 test('should expect icon to be undefined if no context/view is passed', async () => {
-  const containerInfo = {
-    Image: 'docker.io/kindest/node:foobar',
+  const containerInfoUI = {
+    image: 'docker.io/kindest/node:foobar',
     Ports: [
       {
         PublicPort: 80,
@@ -290,8 +291,8 @@ test('should expect icon to be undefined if no context/view is passed', async ()
         PublicPort: 8022,
       },
     ],
-  } as unknown as ContainerInfo;
-  const icon = containerUtils.iconClass(containerInfo);
+  } as unknown as ContainerInfoUI;
+  const icon = containerUtils.iconClass(containerInfoUI);
   expect(icon).toBe(undefined);
 });
 
@@ -305,13 +306,13 @@ test('should expect icon to be valid value with context/view set', async () => {
       when: 'io.x-k8s.kind.cluster in containerLabelKeys',
     },
   };
-  const containerInfo = {
-    Image: 'docker.io/kindest/node:foobar',
-    Labels: {
+  const containerInfoUI = {
+    image: 'docker.io/kindest/node:foobar',
+    labels: {
       'io.x-k8s.kind.cluster': 'ok',
     },
-  } as unknown as ContainerInfo;
-  const icon = containerUtils.iconClass(containerInfo, context, [view]);
+  } as unknown as ContainerInfoUI;
+  const icon = containerUtils.iconClass(containerInfoUI, context, [view]);
   expect(icon).toBe('podman-desktop-icon-kind-icon');
 });
 
@@ -325,10 +326,10 @@ test('should expect icon to be valid value with context/view set with containerI
       when: 'containerImageName == docker.io/kindest/node:foobar',
     },
   };
-  const containerInfo = {
-    Image: 'docker.io/kindest/node:foobar',
-  } as unknown as ContainerInfo;
-  const icon = containerUtils.iconClass(containerInfo, context, [view]);
+  const containerInfoUI = {
+    image: 'docker.io/kindest/node:foobar',
+  } as unknown as ContainerInfoUI;
+  const icon = containerUtils.iconClass(containerInfoUI, context, [view]);
   expect(icon).toBe('podman-desktop-icon-kind-icon');
 });
 
@@ -392,14 +393,14 @@ test('test that if a container is part of compose, and that container_name has b
 
 test('check parsing of container info without labels', async () => {
   const context = new ContextUI();
-  const containerInfo = {
-    Id: 'container1',
-    Image: 'registry.k8s.io/pause:3.7',
-    Labels: '',
-    Names: ['container1'],
-    State: 'RUNNING',
-  } as unknown as ContainerInfo;
-  containerUtils.adaptContextOnContainer(context, containerInfo);
+  const containerInfoUI = {
+    id: 'container1',
+    image: 'registry.k8s.io/pause:3.7',
+    labels: '',
+    name: 'container1',
+    state: 'RUNNING',
+  } as unknown as ContainerInfoUI;
+  containerUtils.adaptContextOnContainer(context, containerInfoUI);
 });
 
 test('should expect imageHref to use image tag', async () => {
@@ -461,4 +462,45 @@ test('should be able to identify containers', async () => {
   } as unknown as ContainerInfoUI;
   expect(containerUtils.isContainerInfoUI(containerInfo)).toBe(true);
   expect(containerUtils.isContainerGroupInfoUI(containerInfo)).toBe(false);
+});
+
+test('should expect getContainerInfoUI to carry the raw image id and names', async () => {
+  const containerInfo = {
+    Id: 'id123',
+    Names: ['/myproject-web-1', '/web-alias'],
+    Image: 'docker.io/library/nginx:latest',
+    ImageID: 'sha256:abcdef0123456789',
+    State: 'running',
+    Labels: {
+      'com.docker.compose.project': 'myproject',
+    },
+    engineId: 'engine',
+    engineName: 'podman',
+  } as unknown as ContainerInfo;
+
+  const containerUI = containerUtils.getContainerInfoUI(containerInfo);
+
+  // both fields are optional on the type, but the converter always populates them
+  expect(containerUI.imageId).toBe('sha256:abcdef0123456789');
+  expect(containerUI.names).toStrictEqual(['/myproject-web-1', '/web-alias']);
+
+  // names stays raw where name does not: the leading slash and the compose project
+  // prefix survive, which is what alias matching and the navigation label rely on
+  expect(containerUI.name).toBe('web-1');
+});
+
+test('should expect getContainerInfoUI to default the icon, leaving contributions to the caller', async () => {
+  const containerInfo = {
+    Id: 'id123',
+    Names: ['/container'],
+    Image: 'docker.io/kindest/node:foobar',
+    State: 'running',
+    Labels: {
+      'io.x-k8s.kind.cluster': 'ok',
+    },
+  } as unknown as ContainerInfo;
+
+  // the converter takes one argument now: it cannot see the context or the view
+  // contributions, so an extension icon is never resolved here
+  expect(containerUtils.getContainerInfoUI(containerInfo).icon).toBe(ContainerIcon);
 });

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -149,11 +149,10 @@ export class ContainerUtils {
     }
   }
 
-  getContainerInfoUI(
-    containerInfo: ContainerInfo,
-    context?: ContextUI,
-    viewContributions?: ViewInfoUI[],
-  ): ContainerInfoUI {
+  // The icon is deliberately not resolved here: extension-contributed icons need the
+  // context and the view contributions, which are component-level stores. The containers
+  // store calls this converter, so the icon is overlaid by ContainerList instead.
+  getContainerInfoUI(containerInfo: ContainerInfo): ContainerInfoUI {
     return {
       id: containerInfo.Id,
       shortId: containerInfo.Id.substring(0, 8),
@@ -177,9 +176,11 @@ export class ContainerUtils {
       created: containerInfo.Created,
       labels: containerInfo.Labels,
       isInfra: containerInfo.IsInfra,
-      icon: this.iconClass(containerInfo, context, viewContributions) ?? ContainerIcon,
+      icon: ContainerIcon,
       imageBase64RepoTag: containerInfo.ImageBase64RepoTag,
       imageHref: this.getImageHref(containerInfo),
+      imageId: containerInfo.ImageID,
+      names: containerInfo.Names,
     };
   }
 
@@ -284,7 +285,7 @@ export class ContainerUtils {
     }
   }
 
-  iconClass(container: ContainerInfo, context?: ContextUI, viewContributions?: ViewInfoUI[]): string | undefined {
+  iconClass(container: ContainerInfoUI, context?: ContextUI, viewContributions?: ViewInfoUI[]): string | undefined {
     if (!context || !viewContributions) {
       return undefined;
     }
@@ -313,9 +314,9 @@ export class ContainerUtils {
     return icon;
   }
 
-  adaptContextOnContainer(context: ContextUI, container: ContainerInfo): void {
-    context.setValue('containerLabelKeys', container.Labels ? Object.keys(container.Labels) : []);
-    context.setValue('containerImageName', container.Image);
+  adaptContextOnContainer(context: ContextUI, container: ContainerInfoUI): void {
+    context.setValue('containerLabelKeys', container.labels ? Object.keys(container.labels) : []);
+    context.setValue('containerImageName', container.image);
   }
 
   filterResetRunning(f: string): string {

--- a/packages/renderer/src/lib/dashboard/SystemOverviewContent.svelte
+++ b/packages/renderer/src/lib/dashboard/SystemOverviewContent.svelte
@@ -61,7 +61,7 @@ onMount(async () => {
 
 // Go through all containers and find the matching label to a connection name.
 function resolveKubernetesOwnerEngineId(connectionName: string): string | undefined {
-  return $containersInfos.find(c => c.Labels && Object.values(c.Labels).includes(connectionName))?.engineId;
+  return $containersInfos.find(c => c.labels && Object.values(c.labels).includes(connectionName))?.engineId;
 }
 
 // Go through all containers and find the matching engineName to a connection name.

--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -18,12 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { type ContainerInfo, NavigationPage } from '@podman-desktop/core-api';
+import { NavigationPage } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import { commandsInfos } from '/@/stores/commands';
 import { containersInfos } from '/@/stores/containers';
 import { context } from '/@/stores/context';
@@ -37,9 +38,10 @@ const COMMAND_PALETTE_ARIA_LABEL = 'Command palette command input';
 vi.mock(import('tinro'));
 
 const mockContainerInfo = {
-  Id: 'test-container-id',
-  Names: ['test-container'],
-} as unknown as ContainerInfo;
+  id: 'test-container-id',
+  name: 'test-container',
+  names: ['/test-container'],
+} as unknown as ContainerInfoUI;
 
 beforeAll(() => {
   vi.mocked(window.executeCommand).mockResolvedValue(undefined);

--- a/packages/renderer/src/lib/image/ImageDetails.spec.ts
+++ b/packages/renderer/src/lib/image/ImageDetails.spec.ts
@@ -18,12 +18,13 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { ContainerInfo, ImageInfo } from '@podman-desktop/core-api';
+import type { ImageInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { router } from 'tinro';
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import {
   IMAGE_DETAILS_VIEW_BADGES,
   IMAGE_DETAILS_VIEW_ICONS,
@@ -169,8 +170,8 @@ describe('expect display usage of an image', () => {
     const imageID = 'abcd12345';
 
     const containerInfo = {
-      ImageID: imageID,
-    } as unknown as ContainerInfo;
+      imageId: imageID,
+    } as unknown as ContainerInfoUI;
     containersInfos.set([containerInfo]);
 
     const myImage = {
@@ -199,8 +200,8 @@ describe('expect display usage of an image', () => {
 
     // containers but not using the image
     const containerInfo = {
-      ImageID: 'anotherID',
-    } as unknown as ContainerInfo;
+      imageId: 'anotherID',
+    } as unknown as ContainerInfoUI;
     containersInfos.set([containerInfo]);
 
     const myImage = {

--- a/packages/renderer/src/lib/image/ImagesList.svelte
+++ b/packages/renderer/src/lib/image/ImagesList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { faArrowCircleDown, faCube, faDownload, faTrash, faUpload } from '@fortawesome/free-solid-svg-icons';
-import type { ContainerInfo, ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
+import type { ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
 import {
   Button,
   FilteredEmptyScreen,
@@ -17,6 +17,7 @@ import type { Unsubscriber } from 'svelte/store';
 import { router } from 'tinro';
 
 import { withBulkConfirmation } from '/@/lib/actions/BulkActions';
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import type { ContextUI } from '/@/lib/context/context';
 import type { EngineInfoUI } from '/@/lib/engine/EngineInfoUI';
 import Prune from '/@/lib/engine/Prune.svelte';
@@ -125,7 +126,7 @@ let imagesUnsubscribe: Unsubscriber;
 let containersUnsubscribe: Unsubscriber;
 let contextsUnsubscribe: Unsubscriber;
 let viewsUnsubscribe: Unsubscriber;
-let storeContainers: ContainerInfo[] = [];
+let storeContainers: ContainerInfoUI[] = [];
 let storeImages: ImageInfo[] = [];
 
 onMount(async () => {

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -20,14 +20,16 @@ import '@testing-library/jest-dom/vitest';
 
 import type { ImageInfo } from '@podman-desktop/api';
 import type { ImageInspectInfo, SecretInfo } from '@podman-desktop/core-api';
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
 import { router } from 'tinro';
 import { afterEach, beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vitest';
 
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import RunImage from '/@/lib/image/RunImage.svelte';
 import { mockBreadcrumb } from '/@/stores/breadcrumb.spec';
+import { containersInfos } from '/@/stores/containers';
 import { imagesInfos } from '/@/stores/images';
 import { secretsInfo } from '/@/stores/secrets';
 
@@ -692,5 +694,28 @@ describe('RunImage', () => {
         }),
       }),
     );
+  });
+});
+
+describe('RunImage container name collision', () => {
+  test('Expect an error when the name matches one of an existing container aliases', async () => {
+    // the store holds ContainerInfoUI, whose `name` is compose-stripped and slash-free.
+    // The collision check compares against the raw `/name` form, so it needs `names`.
+    containersInfos.set([
+      {
+        id: 'existing',
+        engineId: 'engineid',
+        name: 'web-1',
+        names: ['/myproject-web-1', '/existing-container'],
+      } as unknown as ContainerInfoUI,
+    ]);
+
+    await createRunImage(undefined, []);
+
+    const nameInput = screen.getByRole('textbox', { name: 'Container Name' });
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'existing-container');
+
+    await waitFor(() => expect(screen.getByText(/The name existing-container already exists/)).toBeInTheDocument());
   });
 });

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -94,7 +94,9 @@ let containerNameError: string | undefined = $derived.by(() => {
   const containerAlreadyExists = $containersInfos.find(
     container =>
       container.engineId === imageInspectInfo.engineId &&
-      container.Names.some(iteratingContainerName => iteratingContainerName === `/${options.basic.containerName}`),
+      // `names` keeps the raw aliases with their leading slash; `name` is a single
+      // compose-stripped string and cannot answer a multi-alias match
+      container.names.some(iteratingContainerName => iteratingContainerName === `/${options.basic.containerName}`),
   );
   if (containerAlreadyExists) {
     return `The name ${options.basic.containerName} already exists. Please choose another name or leave blank to generate a name.`;

--- a/packages/renderer/src/lib/image/image-utils.spec.ts
+++ b/packages/renderer/src/lib/image/image-utils.spec.ts
@@ -16,9 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ContainerInfo, ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
+import type { ImageInfo, ViewInfoUI } from '@podman-desktop/core-api';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import { ContextUI } from '/@/lib/context/context';
 
 import { ImageUtils } from './image-utils';
@@ -151,16 +152,16 @@ describe('inUse', () => {
 
   const containerInfo = {
     Id: 'container1',
-    Image: 'quay.io/podman/hello:latest',
-    ImageID: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
-  } as unknown as ContainerInfo;
+    image: 'quay.io/podman/hello:latest',
+    imageId: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
+  } as unknown as ContainerInfoUI;
 
   test('should expect inUse with an untagged image', async () => {
     const containerInfo = {
       Id: 'container1',
-      Image: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
-      ImageID: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
-    } as unknown as ContainerInfo;
+      image: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
+      imageId: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
+    } as unknown as ContainerInfoUI;
 
     const isUsed = imageUtils.getInUse(untaggedImageInfo, undefined, [containerInfo]);
     expect(isUsed).toBeTruthy();
@@ -183,9 +184,9 @@ describe('inUse', () => {
   test('should expect inUse for untagged image when container references it by original tag name', async () => {
     const containerWithTag = {
       Id: 'container1',
-      Image: 'quay.io/podman/hello:latest',
-      ImageID: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
-    } as unknown as ContainerInfo;
+      image: 'quay.io/podman/hello:latest',
+      imageId: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
+    } as unknown as ContainerInfoUI;
 
     const isUsed = imageUtils.getInUse(untaggedImageInfo, undefined, [containerWithTag]);
     expect(isUsed).toBeTruthy();
@@ -204,9 +205,9 @@ describe('inUse', () => {
   test('should not expect inUse when no container matches the ImageID', async () => {
     const differentContainer = {
       Id: 'container2',
-      Image: 'quay.io/podman/hello:latest',
-      ImageID: 'sha256:different_image_id',
-    } as unknown as ContainerInfo;
+      image: 'quay.io/podman/hello:latest',
+      imageId: 'sha256:different_image_id',
+    } as unknown as ContainerInfoUI;
 
     const isUsed = imageUtils.getInUse(imageInfoHello, 'quay.io/podman/hello:latest', [differentContainer]);
     expect(isUsed).toBeFalsy();
@@ -223,7 +224,7 @@ describe('getImagesFromManifest and construct ImageInfoUI', () => {
   let imageUtils: ImageUtils;
   let manifestImage: ImageInfo;
   let imageList: ImageInfo[];
-  let containerInfoList: ContainerInfo[];
+  let containerInfoList: ContainerInfoUI[];
   let contextUI: ContextUI;
   let viewContributions: ViewInfoUI[];
 
@@ -250,8 +251,8 @@ describe('getImagesFromManifest and construct ImageInfoUI', () => {
     ] as unknown as ImageInfo[];
 
     containerInfoList = [
-      { Id: 'container1', Image: 'my.registry:1234/manifest:latest', ImageID: 'manifest1' },
-    ] as unknown as ContainerInfo[];
+      { id: 'container1', image: 'my.registry:1234/manifest:latest', imageId: 'manifest1' },
+    ] as unknown as ContainerInfoUI[];
 
     contextUI = new ContextUI();
     viewContributions = [{ extensionId: 'extension', viewId: 'id', value: {} }] as unknown as ViewInfoUI[];
@@ -279,4 +280,21 @@ describe('getImagesFromManifest and construct ImageInfoUI', () => {
     expect(imageInfoUIs.length).toBe(1);
     expect(imageInfoUIs[0].id).toBe('manifest1');
   });
+});
+
+test('should not expect inUse when the container carries no imageId', async () => {
+  // imageId is required on ContainerInfoUI, but this fixture is hand-built and omits it:
+  // a container without one must never be reported as using an image, rather than
+  // falling back to some other field
+  const imageInfo = {
+    Id: 'sha256:1b10fa0fd8d184d9de22a553688af8f9f8adbabb11f5dfc15f1a0fdd21873db2',
+    RepoTags: ['quay.io/podman/hello:latest'],
+  } as unknown as ImageInfo;
+
+  const containerWithoutImageId = {
+    id: 'container1',
+    image: 'quay.io/podman/hello:latest',
+  } as unknown as ContainerInfoUI;
+
+  expect(imageUtils.getInUse(imageInfo, 'quay.io/podman/hello:latest', [containerWithoutImageId])).toBeFalsy();
 });

--- a/packages/renderer/src/lib/image/image-utils.ts
+++ b/packages/renderer/src/lib/image/image-utils.ts
@@ -17,7 +17,6 @@
  ***********************************************************************/
 
 import {
-  type ContainerInfo,
   type ImageInfo,
   isViewContributionBadge,
   isViewContributionIcon,
@@ -30,6 +29,7 @@ import { filesize } from 'filesize';
 import humanizeDuration from 'humanize-duration';
 import moment from 'moment';
 
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import type { ContextUI } from '/@/lib/context/context';
 import { ContextKeyExpr } from '/@/lib/context/contextKey';
 import ImageIcon from '/@/lib/images/ImageIcon.svelte';
@@ -92,23 +92,26 @@ export class ImageUtils {
     return Buffer.from(name, 'binary').toString('base64');
   }
 
-  getInUse(imageInfo: ImageInfo, repositoryTag?: string, containersInfo?: ContainerInfo[]): boolean {
+  getInUse(imageInfo: ImageInfo, repositoryTag?: string, containersInfo?: ContainerInfoUI[]): boolean {
     if (!containersInfo) {
       return false;
     }
 
     return containersInfo.some(container => {
-      if (container.ImageID !== imageInfo.Id) {
+      // imageId is required on ContainerInfoUI, but a hand-built fixture (e.g. in tests)
+      // may still omit it; an undefined one simply never matches. Falling back to another
+      // field here would report the wrong image as in-use
+      if (container.imageId !== imageInfo.Id) {
         return false;
       }
       if (repositoryTag) {
-        if (container.Image === repositoryTag) {
+        if (container.image === repositoryTag) {
           return true;
         }
         // The container's original tag no longer exists on the image (e.g. image was retagged).
         // All remaining tags should be considered in-use since the underlying image data is referenced.
         const repoTags = imageInfo.RepoTags ?? [];
-        return !repoTags.includes(container.Image);
+        return !repoTags.includes(container.image);
       }
       return (imageInfo.RepoTags ?? []).length === 0;
     });
@@ -171,7 +174,7 @@ export class ImageUtils {
 
   getImagesInfoUI(
     imageInfo: ImageInfo,
-    containersInfo: ContainerInfo[],
+    containersInfo: ContainerInfoUI[],
     context?: ContextUI,
     viewContributions?: ViewInfoUI[],
     imageList?: ImageInfo[],
@@ -255,7 +258,7 @@ export class ImageUtils {
   getImageInfoUI(
     imageInfo: ImageInfo,
     base64RepoTag: string,
-    containersInfo: ContainerInfo[],
+    containersInfo: ContainerInfoUI[],
     context?: ContextUI,
     viewContributions?: ViewInfoUI[],
   ): ImageInfoUI | undefined {

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.spec.ts
@@ -25,7 +25,9 @@ import userEvent from '@testing-library/user-event';
 import { readable, writable } from 'svelte/store';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import { listenActiveResourcesCount } from '/@/lib/kube/active-resources-count-listen';
+import { containersInfos } from '/@/stores/containers';
 import * as kubernetesPermissions from '/@/stores/kubernetes-context-permission';
 import { kubernetesContexts } from '/@/stores/kubernetes-contexts';
 import * as kubeContextStore from '/@/stores/kubernetes-contexts-state';
@@ -430,6 +432,46 @@ describe('with current context', () => {
         expect.objectContaining({
           activeCount: 0,
           count: 2,
+          kind: 'Node',
+          type: 'Nodes',
+        }),
+      );
+    });
+
+    test('active node count reads the uppercased UI state and the raw container names', async () => {
+      // regression guard: the containers store holds ContainerInfoUI, whose `state` is
+      // uppercased and whose aliases live on `names`. Comparing against 'running', or
+      // reaching for `name`, makes this count silently zero with no type error.
+      vi.mocked(kubeContextStore).kubernetesCurrentContextDeployments = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextNodes = readable<KubernetesObject[]>([
+        { metadata: { name: 'node-1' } },
+        { metadata: { name: 'node-2' } },
+      ]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextPods = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextServices = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextIngresses = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextRoutes = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextJobs = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextCronJobs = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextConfigMaps = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextSecrets = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextPersistentVolumeClaims = readable<KubernetesObject[]>([]);
+      vi.mocked(kubeContextStore).kubernetesCurrentContextState = readable<ContextGeneralState>(
+        {} as ContextGeneralState,
+      );
+
+      containersInfos.set([
+        { id: 'c1', name: 'node-1', names: ['/node-1'], state: 'RUNNING' } as unknown as ContainerInfoUI,
+        { id: 'c2', name: 'node-2', names: ['/node-2'], state: 'EXITED' } as unknown as ContainerInfoUI,
+      ]);
+
+      render(KubernetesDashboard);
+
+      expect(KubernetesDashboardResourceCard).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          count: 2,
+          activeCount: 1,
           kind: 'Node',
           type: 'Nodes',
         }),

--- a/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
+++ b/packages/renderer/src/lib/kube/KubernetesDashboard.svelte
@@ -47,8 +47,10 @@ let nodeCount = $derived($kubernetesCurrentContextNodes.length);
 let activeNodeCount = $derived(
   $containersInfos.filter(
     container =>
-      container.State === 'running' &&
-      container.Names?.some(name => $kubernetesCurrentContextNodes.some(node => name === `/${node.metadata?.name}`)),
+      // the UI state is uppercased by ContainerUtils.getState; comparing against the raw
+      // lowercase value would make this count silently zero
+      container.state === 'RUNNING' &&
+      container.names.some(name => $kubernetesCurrentContextNodes.some(node => name === `/${node.metadata?.name}`)),
   ).length,
 );
 let deploymentCount = $derived($kubernetesCurrentContextDeployments.length);

--- a/packages/renderer/src/stores/container-terminal-store.ts
+++ b/packages/renderer/src/stores/container-terminal-store.ts
@@ -46,7 +46,7 @@ containersInfos.subscribe(containers => {
   const toRemove: TerminalOfContainer[] = [];
   terminals.forEach(terminal => {
     const found = containers.find(
-      container => container.Id === terminal.containerId && container.engineId === terminal.engineId,
+      container => container.id === terminal.containerId && container.engineId === terminal.engineId,
     );
     if (!found) {
       toRemove.push(terminal);

--- a/packages/renderer/src/stores/containers.spec.ts
+++ b/packages/renderer/src/stores/containers.spec.ts
@@ -56,9 +56,19 @@ test.each([
   vi.mocked(window.listContainers).mockClear();
 
   // now, setup at least one container
+  // the store converts through ContainerUtils, so the mocked backend object has to be
+  // complete enough for the conversion: getName reads Names, getState reads State, and
+  // an absent field throws inside the updater rather than failing an assertion
   vi.mocked(window.listContainers).mockResolvedValue([
     {
       Id: 'id123',
+      Names: ['/container'],
+      Image: 'docker.io/library/nginx:latest',
+      ImageID: 'sha256:abcdef0123456789',
+      State: 'running',
+      Labels: {},
+      engineId: 'engine',
+      engineName: 'podman',
     } as unknown as ContainerInfo,
   ]);
 
@@ -75,5 +85,5 @@ test.each([
   // now get list
   const containerListResult = get(containersInfos);
   expect(containerListResult.length).toBe(1);
-  expect(containerListResult[0].Id).toEqual('id123');
+  expect(containerListResult[0].id).toEqual('id123');
 });

--- a/packages/renderer/src/stores/containers.ts
+++ b/packages/renderer/src/stores/containers.ts
@@ -16,9 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ContainerInfo } from '@podman-desktop/core-api';
 import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 import { type Writable, writable } from 'svelte/store';
+
+import { ContainerUtils } from '/@/lib/container/container-utils';
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 
 import { EventStore } from './event-store';
 
@@ -51,14 +53,16 @@ async function checkForUpdate(eventName: string): Promise<boolean> {
   return readyToUpdate;
 }
 
-export const containersInfos: Writable<ContainerInfo[]> = writable([]);
+export const containersInfos: Writable<ContainerInfoUI[]> = writable([]);
+
+const containerUtils = new ContainerUtils();
 
 // use helper here as window methods are initialized after the store in tests
-const listContainers = (): Promise<ContainerInfo[]> => {
-  return window.listContainers();
+const listContainers = async (): Promise<ContainerInfoUI[]> => {
+  return (await window.listContainers()).map(containerInfo => containerUtils.getContainerInfoUI(containerInfo));
 };
 
-export const containersEventStore = new EventStore<ContainerInfo[]>(
+export const containersEventStore = new EventStore<ContainerInfoUI[]>(
   'containers',
   containersInfos,
   checkForUpdate,

--- a/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.spec.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { ContainerInfo } from '@podman-desktop/core-api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { ContainerInfoUI } from '/@/lib/container/ContainerInfoUI';
 import { containersInfos } from '/@/stores/containers';
 
 import { createNavigationContainerEntry } from './navigation-registry-container.svelte';
@@ -33,15 +33,17 @@ test('createNavigationContainerEntry', async () => {
   const entry = createNavigationContainerEntry();
   containersInfos.set([
     {
-      Id: '1234',
-      Names: ['/web-app'],
+      id: '1234',
+      name: 'web-app',
+      names: ['/web-app'],
       engineId: 'podman',
-    } as unknown as ContainerInfo,
+    } as unknown as ContainerInfoUI,
     {
-      Id: '3456',
-      Names: ['database'],
+      id: '3456',
+      name: 'database',
+      names: ['database'],
       engineId: 'docker',
-    } as unknown as ContainerInfo,
+    } as unknown as ContainerInfoUI,
   ]);
 
   expect(entry).toBeDefined();
@@ -65,4 +67,42 @@ test('createNavigationContainerEntry', async () => {
 
   expect(listEntry.page).toBe('containers');
   expect(listEntry.name).toBe('Containers (2)');
+});
+
+test('compose container keeps its project prefix in the navigation label', async () => {
+  // ContainerInfoUI.name is compose-stripped ('web-1'), while the navigation entry has
+  // always shown the raw name. Switching this to `name` would silently relabel every
+  // compose container in the navigation tree.
+  const entry = createNavigationContainerEntry();
+  containersInfos.set([
+    {
+      id: '9999',
+      name: 'web-1',
+      names: ['/myproject-web-1'],
+      engineId: 'podman',
+    } as unknown as ContainerInfoUI,
+  ]);
+
+  await vi.waitFor(() => expect(entry.destinations).toHaveLength(2));
+
+  const [first] = entry.destinations;
+  expect(first.name).toBe('Container: myproject-web-1');
+});
+
+test('falls back to the UI name when names is absent', async () => {
+  // `names` is required on ContainerInfoUI, but a container built by hand for this test
+  // may still not carry it
+  const entry = createNavigationContainerEntry();
+  containersInfos.set([
+    {
+      id: '8888',
+      name: 'no-names',
+      engineId: 'podman',
+    } as unknown as ContainerInfoUI,
+  ]);
+
+  await vi.waitFor(() => expect(entry.destinations).toHaveLength(2));
+
+  const [first] = entry.destinations;
+  expect(first.name).toBe('Container: no-names');
 });

--- a/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.ts
+++ b/packages/renderer/src/stores/navigation/navigation-registry-container.svelte.ts
@@ -32,9 +32,11 @@ export function createNavigationContainerEntry(): NavigationRegistryEntry {
     destinations = [
       ...containers.map(container => ({
         page: NavigationPage.CONTAINER_SUMMARY as const,
-        parameters: { id: container.Id },
+        parameters: { id: container.id },
         icon: { iconComponent: ContainerIcon },
-        name: `Container: ${container.Names[0].replace(/^\//, '')}`,
+        // deliberately not `container.name`: getName also strips the compose project
+        // prefix, which would relabel navigation entries for every compose container
+        name: `Container: ${container.names?.[0]?.replace(/^\//, '') ?? container.name}`,
       })),
       {
         page: NavigationPage.CONTAINERS as const,


### PR DESCRIPTION
### What does this PR do?

The containers store held raw `ContainerInfo` and every consumer converted it to `ContainerInfoUI` on its own. This moves the conversion into the store, so all downstream components receive ready-to-use UI objects — the pattern #18319 already established for pods.

First resource of the epic #18831; images (#18833), networks (#18834) and volumes (#18835) follow the same shape.

Two things this had to solve that pods did not:

- **The conversion drops fields other domains still read.** `image-utils.getInUse()` matches an image against its containers by the plain image id, and `RunImage`, `KubernetesDashboard` and the navigation registry match containers by their raw aliases. `ContainerInfoUI` therefore gains required `imageId` and `names` — the converter always fills both, since `ContainerInfo.ImageID` and `ContainerInfo.Names` are non-optional upstream. Eight hand-written fixture literals across six spec files gained the two fields to match.
- **The icon needs stores the containers store cannot see.** Extension-contributed icons resolve against the context and view-contribution stores, which are component-level. `getContainerInfoUI` loses its optional arguments and always returns the default icon; `ContainerList` overlays the contributed one after reading the store. Making the store a `derived` over those inputs would re-convert the whole list on every extension `setContext`, even with no container screen mounted.

**Where to look**
**The logic is about 40 lines.** The store itself (`stores/containers.ts:56-65`), the icon overlay and search guard in `ContainerList.svelte:220-256`, and the three copies at `ContainerDetails.svelte:62`, `ContainerExport.svelte:35`, `ComposeDetails.svelte:63`.

**Three conversions change a value, not just a field name** — these are the lines worth real attention, and each has a test that fails without the fix:

- `getState` uppercases (`container-utils.ts:58-60`), so `ComposeDetails.svelte:52` and `KubernetesDashboard.svelte:50` had to move to `'RUNNING'`. A mechanical rename compiles and silently makes both filters always false.
- `getName` strips the compose project prefix (`container-utils.ts:52-53`), while `navigation-registry-container.svelte.ts:37` has always shown the raw name. It uses `names[0]` on purpose — `name` would relabel every compose container in the navigation tree.
- `findMatchInLeaves` recurses into arrays (`search-util.ts:38-41`), so the new `names` array would have made the leading `/`, the compose prefix and every alias searchable. `ContainerList.svelte:255` excludes it.

**Everything else is mechanical**: `Id` → `id`, `Labels` → `labels`, `Names` → `names`, and spec fixtures reshaped to the UI type.

**Not in this PR**
- **The pods follow-up shape** (`01e4af6e793`): replacing prop mutation in `ContainerActions` with store setters. `ContainerActions.svelte` is untouched here because #18785 is rewriting it. This PR handles the aliasing with a copy at the three assignment sites instead; the setters deserve their own issue.
- **Grouping stays in `ContainerList`.** The issue asks the store to hold `ContainerInfoUI`, not `ContainerGroupInfoUI`, and `getContainerGroups` carries screen state (`selected`, `expanded`).
- **The sibling resources** — images #18833, networks #18834, volumes #18835. Note that #18833 will come back to `image-utils.ts`, whose `containersInfo` parameters this PR retypes.

### Screenshot / video of UI

n/a — no UI change is intended. This is a behaviour-preserving refactor, and the parts most at risk of changing the UI silently are the three value traps above, each pinned by a test.

Verified manually on macOS against a local build: container list with compose, pod and kind groups; compose project status; extension icon on a kind container; search; container details actions; image in-use; run-image name collision; Kubernetes node count; navigation labels.

### What issues does this PR fix or reference?

Closes #18832

Part of #18831.

| R-ID | Requirement | Where | Test |
|------|-------------|-------|------|
| R1 | Convert `ContainerInfo` to `ContainerInfoUI` at the store level | `stores/containers.ts:60-63` | `stores/containers.spec.ts:88` |
| R2 | Use `ContainerUtils` for the transformation | `stores/containers.ts:62` | `stores/containers.spec.ts:88` |
| R3 | Follow the pattern established by #18319 (pods) | `stores/containers.ts:58-63` | mirrors `stores/pods.ts:85-90` |
| R4 | All consumers receive ready-to-use UI objects | 11 consumer files, see *Where to look* | `container-smoke.spec.ts` — 14/14 green |
| R5 | `Writable<ContainerInfoUI[]>` and `EventStore<ContainerInfoUI[]>` | `stores/containers.ts:56,65` | `pnpm typecheck:renderer` |
| R6 | No user-visible behaviour change | the three value traps below | `ComposeDetails.spec.ts:268`, `KubernetesDashboard.spec.ts:441`, `navigation-registry-container.svelte.spec.ts:72` |
| R7 | Consumers of the dropped `ImageID` / `Names` keep working | `ContainerInfoUI.ts:78,82`, `image-utils.ts:103` | `image-utils.spec.ts`, `RunImage.spec.ts:701`, `KubernetesDashboard.spec.ts:441` |
| R8 | Extension-contributed icons survive the move | `ContainerList.svelte:225` | `ContainerList.spec.ts:1282` |
| R9 | Group aggregation still runs as a batch over the list | `ContainerList.svelte:245` | `ContainerList.spec.ts` |
| R10 | Specs seeding the store migrated to `ContainerInfoUI` | 12 spec files | `pnpm test:renderer` |
| R11 | Store spec asserts the UI `id` | `stores/containers.spec.ts:88` | itself |
| R12 | Container list search results unchanged | `ContainerList.svelte:255` | `ContainerList.spec.ts:1323` |
| R13 | Screens copy before handing the element to mutating components | `ContainerDetails.svelte:62`, `ContainerExport.svelte:35`, `ComposeDetails.svelte:63` | `ContainerDetails.spec.ts:180` |

### How to test this PR?

1. **Create the fixtures.** The steps below refer to these names; create them before launching the app so the first store load is exercised too. → `podman ps -a` lists `web`, `idle`, two `myproject-*` containers, `inpod` and `pdcheck-control-plane`.

   ```bash
   # a running and a stopped standalone container
   podman run -d --name web -p 8080:80 docker.io/library/nginx:alpine
   podman run -d --name idle docker.io/library/nginx:alpine
   podman stop idle

   # a compose project named myproject — this is what produces the
   # compose-prefixed names that two of the three traps are about
   mkdir -p /tmp/pd-18832 && cd /tmp/pd-18832
   cat > compose.yaml <<'YAML'
   services:
     web:
       image: docker.io/library/nginx:alpine
     db:
       image: docker.io/library/redis:alpine
   YAML
   podman compose -p myproject up -d

   # a pod, for the other grouping branch
   podman pod create --name mypod
   podman run -d --pod mypod --name inpod docker.io/library/nginx:alpine

   # a kind cluster covers two steps at once: the kind extension contributes a
   # container-list icon on the io.x-k8s.kind.cluster label, and its node is
   # what the Kubernetes dashboard counts
   kind create cluster --name pdcheck
   ```

2. **Run the app from this branch.** `pnpm watch` → Podman Desktop launches.
3. **Container list renders and groups.** Open Containers. → `web`, `idle`, a `myproject` group, a `mypod` group and the kind container all appear; compose containers show short names (`web`, `db`), not `myproject-web-1`.
4. **Extension icon.** Look at the row for `pdcheck-control-plane`. → It shows the kind icon, not the default container icon. This is the one thing the store no longer does for you, so it is the first thing to check.
5. **Search did not widen.** Type `web` in the container search, then `myproject-web`. → `web` matches the compose service; `myproject-web` matches nothing, as before.
6. **Compose status flips.** Open the `myproject` details, then stop one service with `podman stop $(podman ps -q --filter label=com.docker.compose.project=myproject | head -1)`. → Status reads RUNNING first, then STOPPED. Not STOPPED from the start.
7. **A failed action does not stick.** Take the port so the start fails, press Start on `web` in the UI, then leave Containers and come back. → The error shows, and `web` is not left permanently in ERROR with a stale message.

   ```bash
   podman stop web
   podman run -d --name porthog -p 8080:80 docker.io/library/nginx:alpine
   ```

8. **Image in use.** Open Images with `nginx:alpine` in use, and try to delete it. → The image reads as used and deletion warns.
9. **Duplicate container name.** Images → `nginx:alpine` → Run, and type `web` as the container name. → "The name web already exists…" appears.
10. **Kubernetes node count.** Select the `kind-pdcheck` context, open Kubernetes → Dashboard. → The Nodes card reads 1 total, 1 active — not 1 of 0.
11. **Navigation labels.** Expand Containers in the left navigation. → Compose entries read `Container: myproject-web-1`, keeping the project prefix.

Cleanup:

```bash
podman compose -p myproject down
podman pod rm -f mypod
podman rm -f web idle porthog
kind delete cluster --name pdcheck
rm -rf /tmp/pd-18832
```

**Notes for reviewers**
**Checked manually on macOS 15 (darwin 25.4.0)** against a local `pnpm watch` build, because the risk in this refactor sits in screens rather than in logic: container list with compose, pod and kind groups, compose project status, the extension icon on a kind container, search, container details actions, image in-use, the run-image name collision, the Kubernetes node count and the navigation labels. That pass is my word rather than a captured run — everything below it is captured.

`pnpm typecheck:renderer` reports 0 errors, matching the baseline on `main` exactly (2788 files, 40 warnings). The renderer unit suite is 3012 tests green. `container-smoke.spec.ts` is 14/14 in 4.5m.

**About the local smoke run.** `pnpm test:e2e:smoke` reported `197 passed, 2 failed, 6 did not run` on my machine. Neither failure touches this diff, and both are environmental:

- `compose-onboarding-smoke.spec.ts:66` asserts the compose **Setup** button is visible, which only holds when compose is not installed. Its own failure message says as much ("perhaps compose is already installed"). The block is `.serial`, so its remaining 5 tests did not run.
- `volume-smoke.spec.ts:176` fails pulling `ghcr.io/osbuild/bootc-image-builder:latest` from the registry, in `waitForPullCompletion`. Also `.serial`, accounting for the 6th non-run.

`container-smoke.spec.ts` is not among either, and I re-ran it alone to be sure rather than concluding it by elimination: 14 passed.

**Two consequences of converting inside the store, both inherited from the pods precedent and called out rather than left to be discovered.** The conversion now runs inside the `EventStore` updater (`stores/containers.ts:61-63`), which has no `catch` (`stores/event-store.ts:145-166`): a container the converter cannot read would drop the whole store update rather than break one screen. `ContainerInfo` types `Id`, `Names` and `Image` as required and the podman registry always maps them, so I could not construct such a container — but the failure mode is wider than it was. Second, the per-container cost (`moment`, `humanizeDuration`, a base64 decode) now runs on every debounced container event instead of only for a mounted screen. Both match `stores/pods.ts:87-89`; say the word if you would rather this store guarded the mapping.

**Two exported symbols added** (`imageId`, `names` on `ContainerInfoUI`), neither in the public extension API surface.

- [ ] Tests are covering the bug fix or the new feature

<sub>Prepared with podman-desktop-kit (Claude Code Plugin), reviewed by @vzhukovs</sub>
