### PR TITLE
feat: detecting infra container

### DIFF
--- a/packages/api/src/container-info.ts
+++ b/packages/api/src/container-info.ts
@@ -42,6 +42,7 @@ export interface ContainerInfo {
   Names: string[];
   Image: string;
   ImageID: string;
+  IsInfra?: boolean;
   ImageBase64RepoTag: string;
   Command?: string;
   Created: number;

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -629,6 +629,7 @@ export class ContainerProviderRegistry {
             Names: string[];
             Image: string;
             ImageID: string;
+            IsInfra?: boolean;
             Command?: string;
             Created: number;
             Ports: ContainerPortInfo[];
@@ -677,6 +678,7 @@ export class ContainerProviderRegistry {
                 Names: podmanContainer.Names.map(name => `/${name}`),
                 ImageID: `sha256:${podmanContainer.ImageID}`,
                 Image: podmanContainer.Image,
+                IsInfra: podmanContainer.IsInfra,
                 // convert to unix timestamp
                 Created: moment(podmanContainer.Created).unix(),
                 State: podmanContainer.State,
@@ -738,6 +740,7 @@ export class ContainerProviderRegistry {
                 engineType: provider.connection.type,
                 StartedAt: container.StartedAt ?? '',
                 Status: container.Status,
+                IsInfra: container.IsInfra,
                 ImageBase64RepoTag: Buffer.from(container.Image, 'binary').toString('base64'),
               };
               return containerInfo;

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -51,6 +51,7 @@ export interface PodmanContainerInfo {
   Names: string[];
   ImageID: string;
   Image: string;
+  IsInfra: boolean;
   Created: string;
   State: string;
   StartedAt: number;

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -182,8 +182,6 @@ test('Expect Terminal tab to be hidden for infra containers', async () => {
 
   containersInfos.set([myInfraContainer]);
 
-  const routerGotoSpy = vi.spyOn(router, 'goto');
-
   vi.mocked(window.getContainerInspect).mockResolvedValue({
     Config: {
       Tty: false,
@@ -192,23 +190,19 @@ test('Expect Terminal tab to be hidden for infra containers', async () => {
 
   render(ContainerDetails, { containerID: 'myInfraContainer' });
 
-  while (routerGotoSpy.mock.calls.length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-
-  expect(screen.getByText('Summary')).toBeInTheDocument();
-  expect(screen.getByText('Logs')).toBeInTheDocument();
-  expect(screen.getByText('Inspect')).toBeInTheDocument();
-  expect(screen.queryByText('Terminal')).not.toBeInTheDocument();
-  expect(screen.queryByText('Tty')).not.toBeInTheDocument();
+  await vi.waitFor(() => {
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('Logs')).toBeInTheDocument();
+    expect(screen.getByText('Inspect')).toBeInTheDocument();
+    expect(screen.queryByText('Terminal')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tty')).not.toBeInTheDocument();
+  });
 });
 
 test('Expect Terminal tab to be visible for non-infra containers', async () => {
   router.goto('/');
 
   containersInfos.set([myContainer]);
-
-  const routerGotoSpy = vi.spyOn(router, 'goto');
 
   vi.mocked(window.getContainerInspect).mockResolvedValue({
     Config: {
@@ -218,12 +212,10 @@ test('Expect Terminal tab to be visible for non-infra containers', async () => {
 
   render(ContainerDetails, { containerID: 'myContainer' });
 
-  while (routerGotoSpy.mock.calls.length === 0) {
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-
-  expect(screen.getByText('Summary')).toBeInTheDocument();
-  expect(screen.getByText('Logs')).toBeInTheDocument();
-  expect(screen.getByText('Inspect')).toBeInTheDocument();
-  expect(screen.getByText('Terminal')).toBeInTheDocument();
+  await vi.waitFor(() => {
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('Logs')).toBeInTheDocument();
+    expect(screen.getByText('Inspect')).toBeInTheDocument();
+    expect(screen.getByText('Terminal')).toBeInTheDocument();
+  });
 });

--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -47,6 +47,13 @@ const myContainer: ContainerInfo = {
   ImageBase64RepoTag: '',
 };
 
+const myInfraContainer: ContainerInfo = {
+  ...myContainer,
+  Id: 'myInfraContainer',
+  Names: ['infra0'],
+  IsInfra: true,
+};
+
 vi.mock(import('@xterm/xterm'));
 vi.mock(import('@xterm/addon-search'));
 
@@ -168,4 +175,55 @@ test('Expect redirect to previous page if container is deleted', async () => {
   // grab updated route
   const afterRoute = window.location;
   expect(afterRoute.href).toBe('http://localhost:3000/last');
+});
+
+test('Expect Terminal tab to be hidden for infra containers', async () => {
+  router.goto('/');
+
+  containersInfos.set([myInfraContainer]);
+
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  vi.mocked(window.getContainerInspect).mockResolvedValue({
+    Config: {
+      Tty: false,
+    },
+  } as unknown as ContainerInspectInfo);
+
+  render(ContainerDetails, { containerID: 'myInfraContainer' });
+
+  while (routerGotoSpy.mock.calls.length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  expect(screen.getByText('Summary')).toBeInTheDocument();
+  expect(screen.getByText('Logs')).toBeInTheDocument();
+  expect(screen.getByText('Inspect')).toBeInTheDocument();
+  expect(screen.queryByText('Terminal')).not.toBeInTheDocument();
+  expect(screen.queryByText('Tty')).not.toBeInTheDocument();
+});
+
+test('Expect Terminal tab to be visible for non-infra containers', async () => {
+  router.goto('/');
+
+  containersInfos.set([myContainer]);
+
+  const routerGotoSpy = vi.spyOn(router, 'goto');
+
+  vi.mocked(window.getContainerInspect).mockResolvedValue({
+    Config: {
+      Tty: false,
+    },
+  } as unknown as ContainerInspectInfo);
+
+  render(ContainerDetails, { containerID: 'myContainer' });
+
+  while (routerGotoSpy.mock.calls.length === 0) {
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  expect(screen.getByText('Summary')).toBeInTheDocument();
+  expect(screen.getByText('Logs')).toBeInTheDocument();
+  expect(screen.getByText('Inspect')).toBeInTheDocument();
+  expect(screen.getByText('Terminal')).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -105,12 +105,14 @@ function getContainerInfoUI(cont: ContainerInfo | undefined): ContainerInfoUI | 
       {#if container.engineType === 'podman' && container.groupInfo.type === ContainerGroupInfoTypeUI.STANDALONE}
         <Tab title="Kube" selected={isTabSelected($router.path, 'kube')} url={getTabUrl($router.path, 'kube')} />
       {/if}
-      <Tab
-        title="Terminal"
-        selected={isTabSelected($router.path, 'terminal')}
-        url={getTabUrl($router.path, 'terminal')} />
-      {#if displayTty}
-        <Tab title="Tty" selected={isTabSelected($router.path, 'tty')} url={getTabUrl($router.path, 'tty')} />
+      {#if !container.isInfra}
+        <Tab
+          title="Terminal"
+          selected={isTabSelected($router.path, 'terminal')}
+          url={getTabUrl($router.path, 'terminal')} />
+        {#if displayTty}
+          <Tab title="Tty" selected={isTabSelected($router.path, 'tty')} url={getTabUrl($router.path, 'tty')} />
+        {/if}
       {/if}
     {/snippet}
     {#snippet contentSnippet()}
@@ -126,12 +128,14 @@ function getContainerInfoUI(cont: ContainerInfo | undefined): ContainerInfoUI | 
       <Route path="/kube" breadcrumb="Kube" navigationHint="tab">
         <ContainerDetailsKube container={container} />
       </Route>
-      <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
-        <ContainerDetailsTerminal container={container} />
-      </Route>
-      <Route path="/tty" breadcrumb="Tty" navigationHint="tab">
-        <ContainerDetailsTtyTerminal container={container} />
-      </Route>
+      {#if !container.isInfra}
+        <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
+          <ContainerDetailsTerminal container={container} />
+        </Route>
+        <Route path="/tty" breadcrumb="Tty" navigationHint="tab">
+          <ContainerDetailsTtyTerminal container={container} />
+        </Route>
+      {/if}
     {/snippet}
   </DetailsPage>
 {/if}

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.spec.ts
@@ -158,6 +158,31 @@ test('port link shows tooltip with full URL and external link icon', async () =>
   expect(tooltipTrigger).toBeInTheDocument();
 });
 
+test('should display infra container banner when isInfra is true', async () => {
+  const infraContainer: ContainerInfoUI = {
+    ...fakePodContainer,
+    isInfra: true,
+  };
+
+  render(ContainerDetailsSummary, { container: infraContainer });
+
+  expect(screen.getByText(/This is an infra container that manages the pod's shared namespaces./)).toBeInTheDocument();
+  expect(screen.getByText('Learn more')).toBeInTheDocument();
+});
+
+test('should not display infra container banner when isInfra is false', async () => {
+  const nonInfraContainer: ContainerInfoUI = {
+    ...fakePodContainer,
+    isInfra: false,
+  };
+
+  render(ContainerDetailsSummary, { container: nonInfraContainer });
+
+  expect(
+    screen.queryByText(/This is an infra container that manages the pod's shared namespaces./),
+  ).not.toBeInTheDocument();
+});
+
 test('renders duplicate public ports on different host IPs without key collision', async () => {
   const containerWithDuplicatedPublicPorts: ContainerInfoUI = {
     ...fakeStandaloneContainer,

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -41,7 +41,7 @@ function openPort(port: number): void {
       <Link
         class="inline-flex flex-row items-center"
         onclick={(): void => {
-          window.openExternal('https://docs.podman.io/en/v5.4.1/markdown/podman-pod-create.1.html').catch((err: unknown) => console.error('Error opening link', err));
+          window.openExternal('https://docs.podman.io/en/stable/markdown/podman-pod-create.1.html').catch(console.warn);
         }}>
         Learn more <Icon class="ml-1 self-center" icon={faUpRightFromSquare} />
       </Link>

--- a/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsSummary.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-import { faExternalLink } from '@fortawesome/free-solid-svg-icons';
+import { faCircleInfo, faExternalLink, faUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
 import { ChevronExpander, Link, Tooltip } from '@podman-desktop/ui-svelte';
+import { Icon } from '@podman-desktop/ui-svelte/icons';
 import Fa from 'svelte-fa';
 import { router } from 'tinro';
 
@@ -31,130 +32,148 @@ function openPort(port: number): void {
 }
 </script>
 
-<DetailsTable>
-  <tr>
-    <DetailsTitle>Details</DetailsTitle>
-  </tr>
-  <tr>
-    <DetailsCell>Name</DetailsCell>
-    <DetailsCell>{container.name}</DetailsCell>
-  </tr>
-  <tr>
-    <DetailsCell>ID</DetailsCell>
-    <DetailsCell>{container.id}</DetailsCell>
-  </tr>
-  <tr>
-    <DetailsCell>Engine type</DetailsCell>
-    <DetailsCell>{container.engineType}</DetailsCell>
-  </tr>
-  <tr>
-    <DetailsCell>Engine ID</DetailsCell>
-    <DetailsCell>{container.engineId}</DetailsCell>
-  </tr>
-  <tr>
-    <DetailsCell>Image</DetailsCell>
-    <DetailsCell>
-      <Link on:click={(): void => router.goto(container.imageHref ?? $router.path)}>{container.image}</Link>
-    </DetailsCell>
-  </tr>
-  {#if container.command}
-    <tr>
-      <DetailsCell>Command</DetailsCell>
-      <DetailsCell>{container.command}</DetailsCell>
-    </tr>
+<div class="pt-4">
+  {#if container.isInfra}
+    <div class="mx-5 p-3 flex flex-row items-center gap-2 rounded-md border border-[var(--pd-state-info)] bg-[var(--pd-content-card-bg)] text-[var(--pd-content-text)]">
+      <Icon icon={faCircleInfo} class="text-[var(--pd-state-info)]" />
+      <span>
+      This is an infra container that manages the pod's shared namespaces.
+      <Link
+        class="inline-flex flex-row items-center"
+        onclick={(): void => {
+          window.openExternal('https://docs.podman.io/en/v5.4.1/markdown/podman-pod-create.1.html').catch((err: unknown) => console.error('Error opening link', err));
+        }}>
+        Learn more <Icon class="ml-1 self-center" icon={faUpRightFromSquare} />
+      </Link>
+    </span>
+    </div>
   {/if}
-  <tr>
-    <DetailsCell>Ports</DetailsCell>
-    {#if container.hasPublicPort}
-      <DetailsCell>
-        {#each container.ports as port, i (`${port.IP ?? ''}-${port.PublicPort}-${port.Type}`)}
-          {#if i > 0},&nbsp;{/if}
-          <Tooltip tip={portUrl(port.PublicPort)} bottom>
-            <Link on:click={(): void => openPort(port.PublicPort)}>
-              <span class="inline-flex items-center">{port.PublicPort}<Fa icon={faExternalLink} class="ml-1" size="0.7x" /></span>
-            </Link>
-          </Tooltip>
-        {/each}
-      </DetailsCell>
-    {:else}
-      <DetailsCell>N/A</DetailsCell>
-    {/if}
-  </tr>
-  <tr>
-    <DetailsCell>State</DetailsCell>
-    <DetailsCell>{container.state.toLowerCase()}</DetailsCell>
-  </tr>
-  <tr>
-    <DetailsCell>Uptime</DetailsCell>
-    <DetailsCell>{container.uptime === '' ? 'N/A' : container.uptime}</DetailsCell>
-  </tr>
-  <tr>
-    <DetailsCell>Started at</DetailsCell>
-    <DetailsCell>{startedTime}</DetailsCell>
-  </tr>
-  {#if Object.entries(container.labels).length > 0}
+
+  <DetailsTable>
     <tr>
-      <DetailsCell style="cursor-pointer flex items-center" onClick={(): boolean => (labelsDropdownOpen = !labelsDropdownOpen)}>
-        Labels
-        <ChevronExpander expanded={labelsDropdownOpen} size="0.9x" class="ml-1" />
-      </DetailsCell>
-      <DetailsCell>
-        {#if labelsDropdownOpen}
-          {#each Object.entries(container.labels) as [key, value] (key)}
-            {key}: {value}
-            <br />
-          {/each}
-        {:else}
-          ...
-        {/if}
-      </DetailsCell>
+      <DetailsTitle>Details</DetailsTitle>
     </tr>
-  {/if}
-  <tr>
-    <DetailsTitle>Group</DetailsTitle>
-  </tr>
-  <tr>
-    <DetailsCell>Name</DetailsCell>
-    <DetailsCell>{container.groupInfo.name}</DetailsCell>
-  </tr>
-  <tr>
-    <DetailsCell>Type</DetailsCell>
-    <DetailsCell>{container.groupInfo.type}</DetailsCell>
-  </tr>
-  {#if container.groupInfo.id}
     <tr>
-      <DetailsCell>Id</DetailsCell>
-      <DetailsCell>{container.groupInfo.id}</DetailsCell>
+      <DetailsCell>Name</DetailsCell>
+      <DetailsCell>{container.name}</DetailsCell>
     </tr>
-  {/if}
-  {#if container.groupInfo.engineName}
     <tr>
-      <DetailsCell>Engine name</DetailsCell>
-      <DetailsCell>{container.groupInfo.engineName}</DetailsCell>
+      <DetailsCell>ID</DetailsCell>
+      <DetailsCell>{container.id}</DetailsCell>
     </tr>
-  {/if}
-  {#if container.groupInfo.engineType}
     <tr>
       <DetailsCell>Engine type</DetailsCell>
-      <DetailsCell>{container.groupInfo.engineType}</DetailsCell>
+      <DetailsCell>{container.engineType}</DetailsCell>
     </tr>
-  {/if}
-  {#if container.groupInfo.engineId}
     <tr>
-      <DetailsCell>Engine Id</DetailsCell>
-      <DetailsCell>{container.groupInfo.engineId}</DetailsCell>
+      <DetailsCell>Engine ID</DetailsCell>
+      <DetailsCell>{container.engineId}</DetailsCell>
     </tr>
-  {/if}
-  {#if container.groupInfo.status}
     <tr>
-      <DetailsCell>status</DetailsCell>
-      <DetailsCell>{container.groupInfo.status.toLowerCase()}</DetailsCell>
+      <DetailsCell>Image</DetailsCell>
+      <DetailsCell>
+        <Link on:click={(): void => router.goto(container.imageHref ?? $router.path)}>{container.image}</Link>
+      </DetailsCell>
     </tr>
-  {/if}
-  {#if createdTime}
+    {#if container.command}
+      <tr>
+        <DetailsCell>Command</DetailsCell>
+        <DetailsCell>{container.command}</DetailsCell>
+      </tr>
+    {/if}
     <tr>
-      <DetailsCell>Created</DetailsCell>
-      <DetailsCell>{createdTime}</DetailsCell>
+      <DetailsCell>Ports</DetailsCell>
+      {#if container.hasPublicPort}
+        <DetailsCell>
+          {#each container.ports as port, i (`${port.IP ?? ''}-${port.PublicPort}-${port.Type}`)}
+            {#if i > 0},&nbsp;{/if}
+            <Tooltip tip={portUrl(port.PublicPort)} bottom>
+              <Link on:click={(): void => openPort(port.PublicPort)}>
+                <span class="inline-flex items-center">{port.PublicPort}<Fa icon={faExternalLink} class="ml-1" size="0.7x" /></span>
+              </Link>
+            </Tooltip>
+          {/each}
+        </DetailsCell>
+      {:else}
+        <DetailsCell>N/A</DetailsCell>
+      {/if}
     </tr>
-  {/if}
-</DetailsTable>
+    <tr>
+      <DetailsCell>State</DetailsCell>
+      <DetailsCell>{container.state.toLowerCase()}</DetailsCell>
+    </tr>
+    <tr>
+      <DetailsCell>Uptime</DetailsCell>
+      <DetailsCell>{container.uptime === '' ? 'N/A' : container.uptime}</DetailsCell>
+    </tr>
+    <tr>
+      <DetailsCell>Started at</DetailsCell>
+      <DetailsCell>{startedTime}</DetailsCell>
+    </tr>
+    {#if Object.entries(container.labels).length > 0}
+      <tr>
+        <DetailsCell style="cursor-pointer flex items-center" onClick={(): boolean => (labelsDropdownOpen = !labelsDropdownOpen)}>
+          Labels
+          <ChevronExpander expanded={labelsDropdownOpen} size="0.9x" class="ml-1" />
+        </DetailsCell>
+        <DetailsCell>
+          {#if labelsDropdownOpen}
+            {#each Object.entries(container.labels) as [key, value] (key)}
+              {key}: {value}
+              <br />
+            {/each}
+          {:else}
+            ...
+          {/if}
+        </DetailsCell>
+      </tr>
+    {/if}
+    <tr>
+      <DetailsTitle>Group</DetailsTitle>
+    </tr>
+    <tr>
+      <DetailsCell>Name</DetailsCell>
+      <DetailsCell>{container.groupInfo.name}</DetailsCell>
+    </tr>
+    <tr>
+      <DetailsCell>Type</DetailsCell>
+      <DetailsCell>{container.groupInfo.type}</DetailsCell>
+    </tr>
+    {#if container.groupInfo.id}
+      <tr>
+        <DetailsCell>Id</DetailsCell>
+        <DetailsCell>{container.groupInfo.id}</DetailsCell>
+      </tr>
+    {/if}
+    {#if container.groupInfo.engineName}
+      <tr>
+        <DetailsCell>Engine name</DetailsCell>
+        <DetailsCell>{container.groupInfo.engineName}</DetailsCell>
+      </tr>
+    {/if}
+    {#if container.groupInfo.engineType}
+      <tr>
+        <DetailsCell>Engine type</DetailsCell>
+        <DetailsCell>{container.groupInfo.engineType}</DetailsCell>
+      </tr>
+    {/if}
+    {#if container.groupInfo.engineId}
+      <tr>
+        <DetailsCell>Engine Id</DetailsCell>
+        <DetailsCell>{container.groupInfo.engineId}</DetailsCell>
+      </tr>
+    {/if}
+    {#if container.groupInfo.status}
+      <tr>
+        <DetailsCell>status</DetailsCell>
+        <DetailsCell>{container.groupInfo.status.toLowerCase()}</DetailsCell>
+      </tr>
+    {/if}
+    {#if createdTime}
+      <tr>
+        <DetailsCell>Created</DetailsCell>
+        <DetailsCell>{createdTime}</DetailsCell>
+      </tr>
+    {/if}
+  </DetailsTable>
+</div>

--- a/packages/renderer/src/lib/container/ContainerInfoUI.ts
+++ b/packages/renderer/src/lib/container/ContainerInfoUI.ts
@@ -70,6 +70,7 @@ export interface ContainerInfoUI {
   actionInProgress?: boolean;
   actionError?: string;
   labels: { [label: string]: string };
+  isInfra?: boolean;
   icon?: string | IconDefinition | Component;
   imageBase64RepoTag: string;
   imageHref?: string;

--- a/packages/renderer/src/lib/container/container-utils.ts
+++ b/packages/renderer/src/lib/container/container-utils.ts
@@ -176,6 +176,7 @@ export class ContainerUtils {
       selected: false,
       created: containerInfo.Created,
       labels: containerInfo.Labels,
+      isInfra: containerInfo.IsInfra,
       icon: this.iconClass(containerInfo, context, viewContributions) ?? ContainerIcon,
       imageBase64RepoTag: containerInfo.ImageBase64RepoTag,
       imageHref: this.getImageHref(containerInfo),


### PR DESCRIPTION
### What does this PR do?

To allow containers in a pod to share the network, podman create an infra container. This container is not really made to run stuff in it, leading to undefined behavior.

When listing containers, podman specify through a `IsInfra` property if a container is an infra container or not. We can propagate this property to the frontend, and conditionally show the `terminal` tab.

I added a small banner as visible bellow, to help the user understand what this container is, and a link to the podman pod documentation. 

### Screenshot / video of UI

<img width="959" height="356" alt="image" src="https://github.com/user-attachments/assets/538360f3-4fff-437c-a734-4f062d37c54a" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/11997

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature

**Testing manually**

1. Go to `Pods > Kube Play`
2. Paste the following content

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: nginx
spec:
  containers:
    - name: nginx
      image: nginx
    - name: nginx-2
      image: nginx
```

3. Go to `Containers` page
4. Open the infra container
5. Assert you don't see the terminal tab
6. Assert you see the banner in the details page
