### PR TITLE
feat(api): register dynamic search result providers for extension resources

### DIFF
--- a/packages/api/src/api-sender/api-sender-channel-map.ts
+++ b/packages/api/src/api-sender/api-sender-channel-map.ts
@@ -131,6 +131,7 @@ export interface ApiSenderChannelMap {
   'registry-register': unknown;
   'registry-unregister': unknown;
   'registry-update': unknown;
+  'navigation-search-provider-items-changed': never;
   'search-bar-enabled': boolean;
   'show-release-notes': never;
   'showCustomPick:add': unknown;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -80,6 +80,7 @@ export * from './proxy.js';
 export * from './pull-event.js';
 export * from './release-notes-info.js';
 export * from './search-option.js';
+export * from './search-result-item-info.js';
 export * from './secret-info.js';
 export * from './status-bar.js';
 export * from './system-overview-info.js';

--- a/packages/api/src/search-result-item-info.ts
+++ b/packages/api/src/search-result-item-info.ts
@@ -1,0 +1,25 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export interface SearchResultItemInfo {
+  label: string;
+  icon?: string | { light: string; dark: string };
+  command: string;
+  args?: unknown[];
+  providerLabel: string;
+}

--- a/packages/extension-api/src/extension-api.d.ts
+++ b/packages/extension-api/src/extension-api.d.ts
@@ -5121,6 +5121,81 @@ declare module '@podman-desktop/api' {
     icon?: string | { light: string; dark: string };
   }
 
+  /**
+   * A single search result returned by a {@link SearchResultProvider}.
+   */
+  export interface SearchResultItem {
+    /**
+     * Display label for this result in the Command Palette.
+     */
+    label: string;
+
+    /**
+     * Optional icon for this result. Falls back to the extension icon if not provided.
+     */
+    icon?: string | { light: string; dark: string };
+
+    /**
+     * The command to execute when this result is selected.
+     * Must have been registered via {@link commands.registerCommand}.
+     */
+    command: string;
+
+    /**
+     * Optional arguments passed to the command on execution.
+     */
+    args?: unknown[];
+  }
+
+  /**
+   * Options passed to {@link SearchResultProvider.provideItems} by the core.
+   */
+  export interface SearchResultProviderOptions {
+    /**
+     * Maximum number of results the provider should return.
+     */
+    maxResults: number;
+  }
+
+  /**
+   * A dynamic search result provider that is queried when the user types
+   * in the Command Palette.
+   */
+  export interface SearchResultProvider {
+    /**
+     * Called by the core with the current search query. Providers should
+     * return matching items up to {@link SearchResultProviderOptions.maxResults}.
+     *
+     * @param query - The current search text entered by the user.
+     * @param options - Options including the maximum number of results.
+     * @param token - A cancellation token that is cancelled when the user
+     *   types a new character, signalling that results are no longer needed.
+     */
+    provideItems(
+      query: string,
+      options: SearchResultProviderOptions,
+      token?: CancellationToken,
+    ): ProviderResult<SearchResultItem[]>;
+
+    /**
+     * Optional event that fires when the provider's data has changed
+     * (e.g. a new resource was created). While the Command Palette is open
+     * the core subscribes to this event and re-queries the provider.
+     */
+    onDidChangeItems?: Event<void>;
+  }
+
+  /**
+   * Metadata associated with a {@link SearchResultProvider}.
+   */
+  export interface SearchResultProviderMetadata {
+    /**
+     * Label used as the group heading for this provider's results in the
+     * Command Palette. Defaults to the extension's display name.
+     */
+    readonly label?: string;
+  }
+
   export namespace navigation {
     // Navigate to the Dashboard page
     export function navigateToDashboard(): Promise<void>;
@@ -5269,6 +5344,38 @@ declare module '@podman-desktop/api' {
      * restoring its own webview state accordingly (e.g. via `postMessage`).
      */
     export const onDidNavigateToHistoryEntry: Event<NavigateToHistoryEvent>;
+
+    /**
+     * Register a dynamic search result provider for the Command Palette.
+     *
+     * Unlike static routes registered via {@link navigation.register}, dynamic
+     * providers are queried at search time with the user's input and can return
+     * results based on live data (e.g. running containers, Kubernetes resources).
+     *
+     * @example
+     * ```ts
+     * import { navigation, CancellationToken } from '@podman-desktop/api';
+     *
+     * const provider: SearchResultProvider = {
+     *   provideItems(query, options, token) {
+     *     return myResources
+     *       .filter(r => r.name.includes(query))
+     *       .slice(0, options.maxResults)
+     *       .map(r => ({ label: r.name, command: 'myExt.open', args: [r.id] }));
+     *   },
+     * };
+     *
+     * const disposable = navigation.registerSearchResultProvider(provider, { label: 'My Resources' });
+     * ```
+     *
+     * @param provider - The provider that supplies search results.
+     * @param metadata - Optional metadata such as a group label.
+     * @returns A {@link Disposable} that unregisters the provider when disposed.
+     */
+    export function registerSearchResultProvider(
+      provider: SearchResultProvider,
+      metadata?: SearchResultProviderMetadata,
+    ): Disposable;
   }
 
   /**

--- a/packages/main/src/plugin/extension/extension-loader.spec.ts
+++ b/packages/main/src/plugin/extension/extension-loader.spec.ts
@@ -61,6 +61,7 @@ import type { KubernetesClient } from '/@/plugin/kubernetes/kubernetes-client.js
 import type { MenuRegistry } from '/@/plugin/menu-registry.js';
 import type { MessageBox } from '/@/plugin/message-box.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
+import type { SearchResultProviderRegistry } from '/@/plugin/navigation/search-result-provider-registry.js';
 import type { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
 import type { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import type { Proxy } from '/@/plugin/proxy.js';
@@ -289,6 +290,10 @@ const navigationManager: NavigationManager = new NavigationManager(
   onboardingRegistry,
 );
 
+const searchResultProviderRegistry = {
+  registerProvider: vi.fn(),
+} as unknown as SearchResultProviderRegistry;
+
 const colorRegistry = {
   registerExtensionThemes: vi.fn(),
 } as unknown as ColorRegistry;
@@ -394,6 +399,7 @@ beforeEach(() => {
     imageCheckerImpl,
     imageFilesImpl,
     navigationManager,
+    searchResultProviderRegistry,
     webviewRegistry,
     colorRegistry,
     dialogRegistry,

--- a/packages/main/src/plugin/extension/extension-loader.ts
+++ b/packages/main/src/plugin/extension/extension-loader.ts
@@ -69,6 +69,7 @@ import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { MessageBox } from '/@/plugin/message-box.js';
 import { ModuleLoader } from '/@/plugin/module-loader.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
+import { SearchResultProviderRegistry } from '/@/plugin/navigation/search-result-provider-registry.js';
 import { OnboardingRegistry } from '/@/plugin/onboarding-registry.js';
 import { ProviderRegistry } from '/@/plugin/provider-registry.js';
 import { Proxy } from '/@/plugin/proxy.js';
@@ -205,6 +206,8 @@ export class ExtensionLoader implements IAsyncDisposable {
     private imageFilesRegistry: ImageFilesRegistry,
     @inject(NavigationManager)
     private navigationManager: NavigationManager,
+    @inject(SearchResultProviderRegistry)
+    private searchResultProviderRegistry: SearchResultProviderRegistry,
     @inject(WebviewRegistry)
     private webviewRegistry: WebviewRegistry,
     @inject(ColorRegistry)
@@ -1614,6 +1617,20 @@ export class ExtensionLoader implements IAsyncDisposable {
 
         disposables.push(disposable);
 
+        return disposable;
+      },
+      registerSearchResultProvider: (
+        provider: containerDesktopAPI.SearchResultProvider,
+        metadata?: containerDesktopAPI.SearchResultProviderMetadata,
+      ): containerDesktopAPI.Disposable => {
+        const disposable = this.searchResultProviderRegistry.registerProvider(
+          extensionInfo.id,
+          extensionInfo.label,
+          extensionInfo.icon,
+          provider,
+          metadata,
+        );
+        disposables.push(disposable);
         return disposable;
       },
       pushHistoryEntry: (entry: containerDesktopAPI.NavigationHistoryEntry): void => {

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -46,6 +46,7 @@ import { PluginSystem } from './index.js';
 import { LockedConfiguration } from './locked-configuration.js';
 import type { MessageBox } from './message-box.js';
 import { NavigationManager } from './navigation/navigation-manager.js';
+import { SearchResultProviderRegistry } from './navigation/search-result-provider-registry.js';
 import { ProviderRegistry } from './provider-registry.js';
 import { TaskImpl } from './tasks/task-impl.js';
 import { TaskManager } from './tasks/task-manager.js';
@@ -92,6 +93,9 @@ vi.mock(import('./container-registry.js'), importOriginal =>
 vi.mock(import('./tasks/task-manager.js'), importOriginal => mockOriginalClass(importOriginal, 'TaskManager'));
 vi.mock(import('./navigation/navigation-manager.js'), importOriginal =>
   mockOriginalClass(importOriginal, 'NavigationManager'),
+);
+vi.mock(import('./navigation/search-result-provider-registry.js'), importOriginal =>
+  mockOriginalClass(importOriginal, 'SearchResultProviderRegistry'),
 );
 vi.mock(import('./provider-registry.js'), importOriginal => mockOriginalClass(importOriginal, 'ProviderRegistry'));
 vi.mock(import('./image-registry.js'), importOriginal => mockOriginalClass(importOriginal, 'ImageRegistry'));
@@ -1273,4 +1277,17 @@ test('navigation:getSearchableRoutes handler should delegate to navigationManage
 
   expect(NavigationManager.prototype.getSearchableRoutes).toHaveBeenCalled();
   expect(result).toEqual({ result: mockRoutes });
+});
+
+test('navigation:searchDynamicProviders handler should delegate to searchResultProviderRegistry', async () => {
+  const mockResults = [{ label: 'Test', command: 'test.cmd', providerLabel: 'Provider' }];
+  vi.mocked(SearchResultProviderRegistry.prototype.search).mockResolvedValue(mockResults);
+
+  const handle = getHandler<(listener: undefined, query: string, maxResults: number) => Promise<{ result: unknown }>>(
+    'navigation:searchDynamicProviders',
+  );
+  const result = await handle(undefined, 'test query', 10);
+
+  expect(SearchResultProviderRegistry.prototype.search).toHaveBeenCalledWith('test query', 10);
+  expect(result).toEqual({ result: mockResults });
 });

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -112,6 +112,7 @@ import type {
   ReleaseNotesInfo,
   ResourceCount,
   ResourceName,
+  SearchResultItemInfo,
   SecretCreateOptions,
   SecretCreateResult,
   SecretInfo,
@@ -169,6 +170,7 @@ import { KubeGeneratorRegistry } from '/@/plugin/kubernetes/kube-generator-regis
 import { LockedConfiguration } from '/@/plugin/locked-configuration.js';
 import { MenuRegistry } from '/@/plugin/menu-registry.js';
 import { NavigationManager } from '/@/plugin/navigation/navigation-manager.js';
+import { SearchResultProviderRegistry } from '/@/plugin/navigation/search-result-provider-registry.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Uri } from '/@/plugin/types/uri.js';
 import { Updater } from '/@/plugin/updater.js';
@@ -781,6 +783,7 @@ export class PluginSystem {
     dialogRegistry.init();
 
     container.bind<NavigationManager>(NavigationManager).toSelf().inSingletonScope();
+    container.bind<SearchResultProviderRegistry>(SearchResultProviderRegistry).toSelf().inSingletonScope();
     container.bind<CommandsInit>(CommandsInit).toSelf().inSingletonScope();
     const commandsInit = container.get<CommandsInit>(CommandsInit);
     commandsInit.init();
@@ -3272,6 +3275,15 @@ export class PluginSystem {
     this.ipcHandle('navigation:getSearchableRoutes', async () => {
       return navigationManager.getSearchableRoutes();
     });
+
+    const searchResultProviderRegistry = container.get<SearchResultProviderRegistry>(SearchResultProviderRegistry);
+
+    this.ipcHandle(
+      'navigation:searchDynamicProviders',
+      async (_listener, query: string, maxResults: number): Promise<SearchResultItemInfo[]> => {
+        return searchResultProviderRegistry.search(query, maxResults);
+      },
+    );
 
     this.ipcHandle('onboardingRegistry:listOnboarding', async (): Promise<OnboardingInfo[]> => {
       return onboardingRegistry.listOnboarding();

--- a/packages/main/src/plugin/navigation/search-result-provider-registry.spec.ts
+++ b/packages/main/src/plugin/navigation/search-result-provider-registry.spec.ts
@@ -1,0 +1,222 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { SearchResultProvider } from '@podman-desktop/api';
+import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { Emitter } from '/@/plugin/events/emitter.js';
+
+import { SearchResultProviderRegistry } from './search-result-provider-registry.js';
+
+const apiSender: ApiSenderType = {
+  send: vi.fn(),
+  receive: vi.fn(),
+};
+
+let registry: SearchResultProviderRegistry;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  registry = new SearchResultProviderRegistry(apiSender);
+});
+
+function createMockProvider(items: { label: string; command: string }[] = []): SearchResultProvider {
+  return {
+    provideItems: vi.fn().mockResolvedValue(items.map(i => ({ label: i.label, command: i.command }))),
+  };
+}
+
+describe('registerProvider', () => {
+  test('should return a disposable', () => {
+    const provider = createMockProvider();
+    const disposable = registry.registerProvider('ext1', 'Extension 1', undefined, provider);
+    expect(disposable).toBeDefined();
+    expect(disposable.dispose).toBeDefined();
+  });
+
+  test('should subscribe to onDidChangeItems and notify via apiSender', () => {
+    const emitter = new Emitter<void>();
+    const provider: SearchResultProvider = {
+      provideItems: vi.fn().mockResolvedValue([]),
+      onDidChangeItems: emitter.event,
+    };
+
+    registry.registerProvider('ext1', 'Extension 1', undefined, provider);
+    emitter.fire();
+
+    expect(apiSender.send).toHaveBeenCalledWith('navigation-search-provider-items-changed');
+  });
+
+  test('dispose should unsubscribe from onDidChangeItems', () => {
+    const emitter = new Emitter<void>();
+    const provider: SearchResultProvider = {
+      provideItems: vi.fn().mockResolvedValue([]),
+      onDidChangeItems: emitter.event,
+    };
+
+    const disposable = registry.registerProvider('ext1', 'Extension 1', undefined, provider);
+    disposable.dispose();
+    emitter.fire();
+
+    expect(apiSender.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('search', () => {
+  test('should return results from a single provider', async () => {
+    const provider = createMockProvider([
+      { label: 'Pod A', command: 'ext.open' },
+      { label: 'Pod B', command: 'ext.open' },
+    ]);
+
+    registry.registerProvider('ext1', 'Kubernetes', undefined, provider);
+    const results = await registry.search('Pod');
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual(
+      expect.objectContaining({ label: 'Pod A', command: 'ext.open', providerLabel: 'Kubernetes' }),
+    );
+  });
+
+  test('should aggregate results from multiple providers', async () => {
+    const provider1 = createMockProvider([{ label: 'Pod A', command: 'k8s.open' }]);
+    const provider2 = createMockProvider([{ label: 'Model X', command: 'ai.open' }]);
+
+    registry.registerProvider('k8s', 'Kubernetes', undefined, provider1);
+    registry.registerProvider('ai', 'AI Lab', undefined, provider2);
+
+    const results = await registry.search('test');
+    expect(results).toHaveLength(2);
+    expect(results[0]!.providerLabel).toBe('Kubernetes');
+    expect(results[1]!.providerLabel).toBe('AI Lab');
+  });
+
+  test('should use metadata label over extension label', async () => {
+    const provider = createMockProvider([{ label: 'Item', command: 'cmd' }]);
+    registry.registerProvider('ext1', 'Extension 1', undefined, provider, { label: 'Custom Label' });
+
+    const results = await registry.search('Item');
+    expect(results[0]!.providerLabel).toBe('Custom Label');
+  });
+
+  test('should fall back to extension icon when item has no icon', async () => {
+    const provider: SearchResultProvider = {
+      provideItems: vi.fn().mockResolvedValue([{ label: 'Item', command: 'cmd' }]),
+    };
+
+    registry.registerProvider('ext1', 'Ext', 'ext-icon-data', provider);
+    const results = await registry.search('Item');
+    expect(results[0]!.icon).toBe('ext-icon-data');
+  });
+
+  test('should preserve item icon when provided', async () => {
+    const provider: SearchResultProvider = {
+      provideItems: vi.fn().mockResolvedValue([{ label: 'Item', command: 'cmd', icon: 'custom-icon' }]),
+    };
+
+    registry.registerProvider('ext1', 'Ext', 'ext-icon-data', provider);
+    const results = await registry.search('Item');
+    expect(results[0]!.icon).toBe('custom-icon');
+  });
+
+  test('should respect maxResults', async () => {
+    const provider: SearchResultProvider = {
+      provideItems: vi.fn().mockResolvedValue([
+        { label: 'A', command: 'cmd' },
+        { label: 'B', command: 'cmd' },
+        { label: 'C', command: 'cmd' },
+      ]),
+    };
+
+    registry.registerProvider('ext1', 'Ext', undefined, provider);
+    const results = await registry.search('test', 2);
+
+    expect(results).toHaveLength(2);
+    expect(provider.provideItems).toHaveBeenCalledWith('test', { maxResults: 2 }, expect.anything());
+  });
+
+  test('should cancel the previous search while its provider request is still in flight', async () => {
+    const tokens: { isCancellationRequested: boolean }[] = [];
+    const resolvers: ((items: { label: string; command: string }[]) => void)[] = [];
+    const provider: SearchResultProvider = {
+      provideItems: vi.fn().mockImplementation(
+        (_query, _options, token) =>
+          new Promise(resolve => {
+            tokens.push(token);
+            resolvers.push(resolve);
+          }),
+      ),
+    };
+
+    registry.registerProvider('ext1', 'Ext', undefined, provider);
+
+    // start the first search but keep the provider request pending
+    const firstSearch = registry.search('first');
+    const firstToken = tokens[0];
+
+    // start the second search while the first is still in flight
+    const secondSearch = registry.search('second');
+
+    // the second search must cancel the first search's token immediately
+    expect(firstToken!.isCancellationRequested).toBe(true);
+
+    // resolve both pending provider requests
+    resolvers[0]?.([{ label: 'First', command: 'cmd' }]);
+    resolvers[1]?.([{ label: 'Second', command: 'cmd' }]);
+
+    // the cancelled first search yields no results, the second one returns normally
+    await expect(firstSearch).resolves.toEqual([]);
+    const secondResults = await secondSearch;
+    expect(secondResults).toHaveLength(1);
+    expect(secondResults[0]!.label).toBe('Second');
+  });
+
+  test('should handle provider errors gracefully', async () => {
+    const errorProvider: SearchResultProvider = {
+      provideItems: vi.fn().mockRejectedValue(new Error('Provider failed')),
+    };
+    const goodProvider = createMockProvider([{ label: 'Good', command: 'cmd' }]);
+
+    registry.registerProvider('bad', 'Bad', undefined, errorProvider);
+    registry.registerProvider('good', 'Good', undefined, goodProvider);
+
+    const results = await registry.search('test');
+    expect(results).toHaveLength(1);
+    expect(results[0]!.label).toBe('Good');
+  });
+
+  test('should return empty results after provider is disposed', async () => {
+    const provider = createMockProvider([{ label: 'Item', command: 'cmd' }]);
+    const disposable = registry.registerProvider('ext1', 'Ext', undefined, provider);
+
+    disposable.dispose();
+    const results = await registry.search('test');
+    expect(results).toHaveLength(0);
+  });
+
+  test('should pass args through from provider results', async () => {
+    const provider: SearchResultProvider = {
+      provideItems: vi.fn().mockResolvedValue([{ label: 'Item', command: 'cmd', args: ['arg1', 42] }]),
+    };
+
+    registry.registerProvider('ext1', 'Ext', undefined, provider);
+    const results = await registry.search('test');
+    expect(results[0]!.args).toEqual(['arg1', 42]);
+  });
+});

--- a/packages/main/src/plugin/navigation/search-result-provider-registry.ts
+++ b/packages/main/src/plugin/navigation/search-result-provider-registry.ts
@@ -1,0 +1,104 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { SearchResultProvider, SearchResultProviderMetadata } from '@podman-desktop/api';
+import type { IDisposable, SearchResultItemInfo } from '@podman-desktop/core-api';
+import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
+import { inject, injectable } from 'inversify';
+
+import { CancellationTokenSource } from '/@/plugin/cancellation-token.js';
+import { Disposable } from '/@/plugin/types/disposable.js';
+
+interface SearchResultProviderEntry {
+  id: string;
+  label: string;
+  extensionIcon: string | { light: string; dark: string } | undefined;
+  provider: SearchResultProvider;
+}
+
+@injectable()
+export class SearchResultProviderRegistry {
+  #providers = new Map<string, SearchResultProviderEntry>();
+  #currentTokenSource: CancellationTokenSource | undefined;
+  #nextId = 0;
+
+  constructor(
+    @inject(ApiSenderType)
+    private apiSender: ApiSenderType,
+  ) {}
+
+  registerProvider(
+    extensionId: string,
+    extensionLabel: string,
+    extensionIcon: string | { light: string; dark: string } | undefined,
+    provider: SearchResultProvider,
+    metadata?: SearchResultProviderMetadata,
+  ): Disposable {
+    const id = `${extensionId}-${this.#nextId++}`;
+    const label = metadata?.label ?? extensionLabel;
+
+    let changeDisposable: IDisposable | undefined;
+    if (provider.onDidChangeItems) {
+      changeDisposable = provider.onDidChangeItems(() => {
+        this.apiSender.send('navigation-search-provider-items-changed');
+      });
+    }
+
+    this.#providers.set(id, { id, label, extensionIcon, provider });
+
+    return Disposable.create(() => {
+      this.#providers.delete(id);
+      changeDisposable?.dispose();
+    });
+  }
+
+  async search(query: string, maxResults = 10): Promise<SearchResultItemInfo[]> {
+    if (this.#currentTokenSource) {
+      this.#currentTokenSource.cancel();
+      this.#currentTokenSource.dispose();
+    }
+    this.#currentTokenSource = new CancellationTokenSource();
+    const token = this.#currentTokenSource.token;
+
+    const promises = Array.from(this.#providers.values()).map(async entry => {
+      try {
+        const items = await entry.provider.provideItems(query, { maxResults }, token);
+        if (token.isCancellationRequested) return [];
+        return (items ?? []).slice(0, maxResults).map(item => ({
+          label: item.label,
+          icon: item.icon ?? entry.extensionIcon,
+          command: item.command,
+          args: item.args,
+          providerLabel: entry.label,
+        }));
+      } catch (err: unknown) {
+        if (!token.isCancellationRequested) {
+          console.error(`[search-result-provider] Error from provider ${entry.id}:`, err);
+        }
+        return [];
+      }
+    });
+
+    const allResults = await Promise.all(promises);
+    if (token.isCancellationRequested) {
+      return [];
+    }
+
+    return allResults.flat();
+  }
+}

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -263,6 +263,20 @@ describe('collect calls to exposeInMainWorld and ipcRenderer.on and calls initEx
     expect(result).toEqual([{ routeId: 'ext.dashboard', label: 'Dashboard', icon: 'icon.png' }]);
   });
 
+  test('searchDynamicProviders', async () => {
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue({
+      result: [{ label: 'Test Result', command: 'test.command', providerLabel: 'Test Provider' }],
+    });
+
+    const searchDynamicProvidersExposure = getInMainWorld('searchDynamicProviders');
+
+    const result = await searchDynamicProvidersExposure('test query', 10);
+
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith('navigation:searchDynamicProviders', 'test query', 10);
+
+    expect(result).toEqual([{ label: 'Test Result', command: 'test.command', providerLabel: 'Test Provider' }]);
+  });
+
   test('logger passed to createVmProviderConnection is called during provider-registry:taskConnection-onData', async () => {
     vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
     const createVmProviderConnectionExposure = getInMainWorld('createVmProviderConnection');

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -117,6 +117,7 @@ import type {
   ReleaseNotesInfo,
   ResourceCount,
   ResourceName,
+  SearchResultItemInfo,
   SecretCreateOptions,
   SecretCreateResult,
   SecretInfo,
@@ -296,6 +297,13 @@ export function initExposure(): void {
   contextBridge.exposeInMainWorld('getSearchableNavigationRoutes', async (): Promise<NavigationSearchEntryInfo[]> => {
     return ipcInvoke('navigation:getSearchableRoutes');
   });
+
+  contextBridge.exposeInMainWorld(
+    'searchDynamicProviders',
+    async (query: string, maxResults: number): Promise<SearchResultItemInfo[]> => {
+      return ipcInvoke('navigation:searchDynamicProviders', query, maxResults);
+    },
+  );
 
   contextBridge.exposeInMainWorld('listContainers', async (): Promise<ContainerInfo[]> => {
     return ipcInvoke('container-provider-registry:listContainers');

--- a/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { NavigationPage } from '@podman-desktop/core-api';
+import { NavigationPage, type SearchResultItemInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { tick } from 'svelte';
@@ -57,6 +57,7 @@ beforeAll(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   navigationSearchEntries.set([]);
+  vi.mocked(window.searchDynamicProviders).mockResolvedValue([]);
   vi.mocked(window.telemetryTrack).mockResolvedValue(undefined);
   vi.mocked(window.getCommandPaletteSearchOptions).mockResolvedValue([
     { category: 'category 1', text: 'Category 1 text', placeholder: 'Enter category 1 item' },
@@ -835,6 +836,241 @@ describe('Command Palette', () => {
     expect(imgIcon).not.toBeInTheDocument();
     const svgIcon = listItem.querySelector('svg');
     expect(svgIcon).toBeInTheDocument();
+  });
+
+  test('Dynamic search results should appear in Go To tab after typing', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(window.searchDynamicProviders).mockResolvedValue([
+      { label: 'dev-cluster (started)', command: 'navigateToResources', providerLabel: 'Kind Clusters' },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    await userEvent.type(input, 'dev');
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitFor(() => {
+      expect(window.searchDynamicProviders).toHaveBeenCalledWith('dev', 10);
+    });
+
+    const item = await screen.findByRole('listitem', { name: 'Kind Clusters: dev-cluster (started)' });
+    expect(item).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  test('Clicking dynamic search result should execute its command with args', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(window.searchDynamicProviders).mockResolvedValue([
+      {
+        label: 'test-resource',
+        command: 'my.extension.navigate',
+        args: ['arg1', 'arg2'],
+        providerLabel: 'My Extension',
+      },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    await userEvent.type(input, 'test');
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitFor(() => {
+      expect(window.searchDynamicProviders).toHaveBeenCalled();
+    });
+
+    const listItem = await screen.findByRole('listitem', { name: 'My Extension: test-resource' });
+    const button = listItem.querySelector('button')!;
+    await userEvent.click(button);
+
+    expect(vi.mocked(window.executeCommand)).toHaveBeenCalledWith('my.extension.navigate', 'arg1', 'arg2');
+    vi.useRealTimers();
+  });
+
+  test('Dynamic search results should be cleared when palette is reopened', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(window.searchDynamicProviders).mockResolvedValue([
+      { label: 'stale-result', command: 'test.cmd', providerLabel: 'Provider' },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    await userEvent.type(input, 'stale');
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitFor(() => {
+      expect(window.searchDynamicProviders).toHaveBeenCalled();
+    });
+
+    await screen.findByRole('listitem', { name: 'Provider: stale-result' });
+
+    vi.useRealTimers();
+    await userEvent.keyboard('{Escape}');
+    await userEvent.keyboard('{F1}');
+
+    await tick();
+
+    const staleItem = screen.queryByRole('listitem', { name: 'Provider: stale-result' });
+    expect(staleItem).not.toBeInTheDocument();
+  });
+
+  test('Dynamic search result with themed icon should render both variants', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const darkIcon = 'data:image/png;base64,dark';
+    const lightIcon = 'data:image/png;base64,light';
+    vi.mocked(window.searchDynamicProviders).mockResolvedValue([
+      {
+        label: 'themed-item',
+        command: 'test.cmd',
+        providerLabel: 'Themed Provider',
+        icon: { light: lightIcon, dark: darkIcon },
+      },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    await userEvent.type(input, 'themed');
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitFor(() => {
+      expect(window.searchDynamicProviders).toHaveBeenCalled();
+    });
+
+    const listItem = await screen.findByRole('listitem', { name: 'Themed Provider: themed-item' });
+    const icons = listItem.querySelectorAll('img');
+    expect(icons).toHaveLength(2);
+    expect(icons[0]).toHaveAttribute('src', lightIcon);
+    expect(icons[1]).toHaveAttribute('src', darkIcon);
+    vi.useRealTimers();
+  });
+
+  test('Dynamic providers are not queried in Commands or Documentation tabs', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    // Commands tab (index 1) does not render dynamic results
+    const commandsTab = screen.getByRole('button', { name: /Category 2/ });
+    await userEvent.click(commandsTab);
+
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    await userEvent.type(input, 'anything');
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(window.searchDynamicProviders).not.toHaveBeenCalled();
+
+    // Documentation tab (index 2) also does not render dynamic results
+    const docTab = screen.getByRole('button', { name: /Category 3/ });
+    await userEvent.click(docTab);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(window.searchDynamicProviders).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  test('Switching into a dynamic tab with an existing query triggers a provider search', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(window.searchDynamicProviders).mockResolvedValue([
+      { label: 'late-result', command: 'test.cmd', providerLabel: 'Provider' },
+    ]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    // Type while in the Commands tab (no provider query happens)
+    const commandsTab = screen.getByRole('button', { name: /Category 2/ });
+    await userEvent.click(commandsTab);
+
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+    await userEvent.type(input, 'late');
+    await vi.advanceTimersByTimeAsync(250);
+    expect(window.searchDynamicProviders).not.toHaveBeenCalled();
+
+    // Switching to the Go to tab (index 3) should query providers with the existing query
+    const gotoTab = screen.getByRole('button', { name: /Category 4/ });
+    await userEvent.click(gotoTab);
+
+    await waitFor(() => {
+      expect(window.searchDynamicProviders).toHaveBeenCalledWith('late', 10);
+    });
+
+    const item = await screen.findByRole('listitem', { name: 'Provider: late-result' });
+    expect(item).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  test('Stale dynamic-search responses do not overwrite the current query results', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    // First query resolves slowly, second query resolves quickly with different data
+    let resolveFirst: ((value: SearchResultItemInfo[]) => void) | undefined;
+    const slowFirstResponse = new Promise<SearchResultItemInfo[]>(resolve => {
+      resolveFirst = resolve;
+    });
+    vi.mocked(window.searchDynamicProviders)
+      .mockReturnValueOnce(slowFirstResponse)
+      .mockResolvedValueOnce([{ label: 'fresh-result', command: 'test.cmd', providerLabel: 'Provider' }]);
+
+    render(CommandPalette, { display: true });
+
+    await waitFor(() => {
+      expect(window.getCommandPaletteSearchOptions).toHaveBeenCalled();
+    });
+
+    const input = screen.getByRole('textbox', { name: COMMAND_PALETTE_ARIA_LABEL });
+
+    // First keystroke fires the slow (stale) request
+    await userEvent.type(input, 'sta');
+    await vi.advanceTimersByTimeAsync(250);
+
+    // Second keystroke fires the fast request that resolves first
+    await userEvent.type(input, 'le');
+    await vi.advanceTimersByTimeAsync(250);
+
+    await screen.findByRole('listitem', { name: 'Provider: fresh-result' });
+
+    // Now the stale first request resolves — it must be ignored
+    resolveFirst?.([{ label: 'stale-result', command: 'test.cmd', providerLabel: 'Provider' }]);
+    await tick();
+
+    expect(screen.queryByRole('listitem', { name: 'Provider: stale-result' })).not.toBeInTheDocument();
+    expect(screen.getByRole('listitem', { name: 'Provider: fresh-result' })).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   test('Expect hidden navigation entries are excluded from GoTo items', async () => {

--- a/packages/renderer/src/lib/dialogs/CommandPalette.svelte
+++ b/packages/renderer/src/lib/dialogs/CommandPalette.svelte
@@ -12,11 +12,13 @@ import type {
   CommandPaletteSearchOption,
   DocumentationInfo,
   GoToInfo,
+  IDisposable,
   NavigationSearchEntryInfo,
+  SearchResultItemInfo,
 } from '@podman-desktop/core-api';
 import { Button, type IconType, Input } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
-import { onMount, tick } from 'svelte';
+import { onDestroy, onMount, tick, untrack } from 'svelte';
 
 import ArrowDownIcon from '/@/lib/images/ArrowDownIcon.svelte';
 import ArrowUpIcon from '/@/lib/images/ArrowUpIcon.svelte';
@@ -43,7 +45,7 @@ interface Props {
   onclose?: () => void;
 }
 
-type CommandPaletteItem = CommandInfo | DocumentationInfo | GoToInfo | NavigationSearchEntryInfo;
+type CommandPaletteItem = CommandInfo | DocumentationInfo | GoToInfo | NavigationSearchEntryInfo | SearchResultItemInfo;
 
 let { display = false, onclose }: Props = $props();
 
@@ -116,6 +118,34 @@ let filteredExtensionRouteItems: NavigationSearchEntryInfo[] = $derived(
   ),
 );
 
+const SEARCH_DEBOUNCE_MS = 200;
+const DYNAMIC_MAX_RESULTS = 10;
+// Tabs that render dynamic provider results: All (0) and Go to (3)
+const ALL_MODE_INDEX = 0;
+const GO_TO_MODE_INDEX = 3;
+let dynamicSearchResults: SearchResultItemInfo[] = $state([]);
+let searchDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+// Monotonic id used to discard stale dynamic-search responses
+let dynamicSearchRequestId = 0;
+let isDynamicSearchMode = $derived(
+  searchOptionsSelectedIndex === ALL_MODE_INDEX || searchOptionsSelectedIndex === GO_TO_MODE_INDEX,
+);
+
+// Query the dynamic providers and only apply the results if they still match the
+// current request, visible state and query — prevents a slow/earlier response from
+// overwriting newer results or repopulating a closed/reopened palette.
+function refreshDynamicSearch(query: string): void {
+  const requestId = ++dynamicSearchRequestId;
+  window
+    .searchDynamicProviders(query, DYNAMIC_MAX_RESULTS)
+    .then(results => {
+      if (requestId === dynamicSearchRequestId && display && inputValue?.trim() === query) {
+        dynamicSearchResults = results;
+      }
+    })
+    .catch(console.error);
+}
+
 let filteredItems = $derived.by(() => {
   if (searchOptionsSelectedIndex === 1) {
     // Commands mode
@@ -125,23 +155,37 @@ let filteredItems = $derived.by(() => {
     return filteredDocumentationInfoItems;
   } else if (searchOptionsSelectedIndex === 3) {
     // Go to mode
-    return [...filteredGoToItems, ...filteredExtensionRouteItems];
+    return [...filteredGoToItems, ...filteredExtensionRouteItems, ...dynamicSearchResults];
   } else {
     // All mode - combine all
     return [
       ...filteredGoToItems,
       ...filteredExtensionRouteItems,
+      ...dynamicSearchResults,
       ...filteredCommandInfoItems,
       ...filteredDocumentationInfoItems,
     ];
   }
 });
 
+let unsubscribeItemsChanged: IDisposable | undefined;
+
 onMount(async () => {
   const platform = await window.getOsPlatform();
   isMac = platform === 'darwin';
   documentationItems = await window.getDocumentationItems();
   searchOptions = await window.getCommandPaletteSearchOptions();
+
+  unsubscribeItemsChanged = window.events?.receive('navigation-search-provider-items-changed', () => {
+    if (display && isDynamicSearchMode && inputValue && inputValue.trim().length > 0) {
+      refreshDynamicSearch(inputValue.trim());
+    }
+  });
+});
+
+onDestroy(() => {
+  if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+  unsubscribeItemsChanged?.dispose();
 });
 
 // Focus the input when the command palette becomes visible
@@ -159,11 +203,25 @@ $effect(() => {
 
 let selectedFilteredIndex = $state(0);
 
+// Re-run the dynamic search when the user switches into a mode that renders
+// dynamic results while a query is already present. Only depends on the mode
+// (and visibility); the query is read untracked so typing does not trigger this
+// effect — keystrokes go through the debounced onInputChange path instead.
+$effect(() => {
+  if (display && isDynamicSearchMode) {
+    const query = untrack(() => inputValue)?.trim();
+    if (query && query.length > 0) {
+      refreshDynamicSearch(query);
+    }
+  }
+});
+
 function displaySearchBar(): void {
-  // clear the input value
   inputValue = '';
   selectedFilteredIndex = 0;
-  // toggle the display
+  dynamicSearchResults = [];
+  // Invalidate any in-flight dynamic search from a previous open
+  dynamicSearchRequestId++;
   display = true;
   window.telemetryTrack('globalSearch.opened').catch(console.error);
 }
@@ -258,7 +316,14 @@ async function executeAction(index: number): Promise<void> {
   let pageLink: string | undefined = undefined;
   let commandHash: string | undefined = undefined;
 
-  if (isDocItem(item)) {
+  if (isDynamicSearchItem(item)) {
+    try {
+      await window.executeCommand(item.command, ...(item.args ?? []));
+    } catch (error) {
+      console.error('Error executing dynamic search result command', error);
+    }
+    itemType = 'DynamicSearchResult';
+  } else if (isDocItem(item)) {
     // Documentation item
     if (item.url) {
       try {
@@ -316,6 +381,9 @@ function handleMousedown(e: MouseEvent): void {
 
 function hideCommandPallete(): void {
   display = false;
+  if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+  // Invalidate any in-flight dynamic search so late responses cannot repopulate results
+  dynamicSearchRequestId++;
   onclose?.();
 }
 
@@ -329,8 +397,20 @@ async function clickOnItem(index: number): Promise<void> {
 }
 
 async function onInputChange(): Promise<void> {
-  // in case of quick pick, filter the items
   selectedFilteredIndex = 0;
+
+  if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+
+  // Only query providers in modes that render dynamic results (All / Go to) to
+  // avoid expensive provider calls in the Commands / Documentation tabs.
+  if (isDynamicSearchMode && inputValue && inputValue.trim().length > 0) {
+    const query = inputValue.trim();
+    searchDebounceTimer = setTimeout(() => {
+      refreshDynamicSearch(query);
+    }, SEARCH_DEBOUNCE_MS);
+  } else {
+    dynamicSearchResults = [];
+  }
 }
 
 async function onAction(): Promise<void> {
@@ -348,6 +428,10 @@ function isExtensionRouteItem(item: CommandPaletteItem): item is NavigationSearc
   return 'routeId' in item;
 }
 
+function isDynamicSearchItem(item: CommandPaletteItem): item is SearchResultItemInfo {
+  return 'providerLabel' in item;
+}
+
 function isGoToItem(item: CommandPaletteItem): item is GoToInfo {
   return 'page' in item;
 }
@@ -359,6 +443,10 @@ function isDocItem(item: CommandPaletteItem): item is DocumentationInfo {
 function getItemKey(item: CommandPaletteItem, index: number): string {
   if (isExtensionRouteItem(item)) {
     return `route:${item.routeId}`;
+  }
+
+  if (isDynamicSearchItem(item)) {
+    return `dynamic:${item.providerLabel}:${item.label}:${item.command}:${index}`;
   }
 
   if (isGoToItem(item)) {
@@ -375,6 +463,8 @@ function getItemKey(item: CommandPaletteItem, index: number): string {
 function getTextToHighlight(item: CommandPaletteItem): string {
   if (isExtensionRouteItem(item)) {
     return item.label;
+  } else if (isDynamicSearchItem(item)) {
+    return `${item.providerLabel}: ${item.label}`;
   } else if (isDocItem(item)) {
     return `${item.category}: ${item.name}`;
   } else if (isGoToItem(item)) {
@@ -385,7 +475,7 @@ function getTextToHighlight(item: CommandPaletteItem): string {
 }
 
 function getIcon(item: CommandPaletteItem): IconType {
-  if (isExtensionRouteItem(item)) {
+  if (isExtensionRouteItem(item) || isDynamicSearchItem(item)) {
     return item.icon ?? faTerminal;
   } else if (isDocItem(item)) {
     return item.category === 'Tutorial' ? faFilePen : faFileLines;
@@ -452,7 +542,7 @@ function getIcon(item: CommandPaletteItem): IconType {
             {@const goToItem = isGoToItem(item)}
             {@const docItem = isDocItem(item)}
             {@const itemIcon = getIcon(item)}
-            <li class="flex w-full flex-row" bind:this={scrollElements[i]} aria-label={extensionRouteItem ? item.label : goToItem ? item.name : (item.id)}>
+            <li class="flex w-full flex-row" bind:this={scrollElements[i]} aria-label={extensionRouteItem ? item.label : isDynamicSearchItem(item) ? getTextToHighlight(item) : goToItem ? item.name : (item.id)}>
               <button
                 onclick={(): Promise<void> => clickOnItem(i)}
                 class="text-[var(--pd-dropdown-item-text)] text-left relative w-full rounded-sm {i === selectedFilteredIndex


### PR DESCRIPTION
### What does this PR do?

Adds `navigation.registerSearchResultProvider()` to the extension API, allowing extensions to return query-based search results dynamically at search time. When the user types in the Command Palette, registered providers are queried with the current search text and results appear alongside static entries.

**Key features:**
- Extensions register a `SearchResultProvider` with a `provideItems(query, options, token)` method
- Results appear in the "Go to" and "All" tabs of the Command Palette
- 200ms debounce on search queries to avoid excessive provider calls
- `CancellationToken` support — previous searches are cancelled when the user types a new character
- `onDidChangeItems` event for providers to signal data changes (triggers re-query while palette is open)
- Provider results display with `providerLabel: itemLabel` format and support themed (light/dark) icons
- Falls back to the extension icon when no per-item icon is provided

### Screenshot / video of UI

This is example of how it could look like. No UI changes was made

<img width="1406" height="478" alt="CleanShot 2026-08-21 at 14 59 04@2x" src="https://github.com/user-attachments/assets/1bf49bcc-489c-43ba-8925-606dcb452927" />


### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18119

Part of https://github.com/podman-desktop/podman-desktop/issues/15650 (second half — dynamic providers)

### How to test this PR?

1. Register a dynamic search provider in any extension. Example of Kind cluster list from screenshot:
```typescript

  // Register a dynamic search provider for Kind clusters
  const kindClusterSearchEmitter = new extensionApi.EventEmitter<void>();

  extensionContext.subscriptions.push(
    extensionApi.navigation.registerSearchResultProvider(
      {
        provideItems(query, options, token) {
          if (token?.isCancellationRequested) return [];
          const mockClusters = [
            { name: 'kind-dev-cluster', status: 'started' },
            { name: 'kind-staging-cluster', status: 'started' },
            { name: 'kind-test-cluster', status: 'stopped' },
          ];
          const allClusters = [...kindClusters, ...mockClusters];
          return allClusters
            .filter(c => c.name.toLowerCase().includes(query.toLowerCase()))
            .slice(0, options.maxResults)
            .map(c => ({
              label: `${c.name} (${c.status})`,
              command: 'navigateToResources',
            }));
        },
        onDidChangeItems: kindClusterSearchEmitter.event,
      },
      { label: 'Kind Clusters' },
    ),
  );

  extensionContext.subscriptions.push(kindClusterSearchEmitter);

```
2. Open the Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
3. Type a search query — dynamic results should appear in the "Go to" and "All" tabs
4. Click a result — the associated command should execute with the provided args
5. Verify results update when typing new characters (previous query is cancelled)

- [x] Tests are covering the bug fix or the new feature
