### PR TITLE
fix(podman): quote the registries.conf path in the symlink playbook

### DIFF
--- a/extensions/podman/packages/extension/src/configuration/playbook-setup-registry-conf-file.mustache
+++ b/extensions/podman/packages/extension/src/configuration/playbook-setup-registry-conf-file.mustache
@@ -4,4 +4,8 @@
   become: true
   tasks:
     - name: Create symbolic link with sudo from the host
-      command: sudo ln -s {{{configurationFileInsideVmPath}}} /etc/containers/registries.conf.d/{{{configurationFileName}}}
+      ansible.builtin.file:
+        src: "{{{configurationFileInsideVmPath}}}"
+        dest: "/etc/containers/registries.conf.d/{{{configurationFileName}}}"
+        state: link
+        force: true

--- a/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
+++ b/extensions/podman/packages/extension/src/configuration/registry-configuration.spec.ts
@@ -105,12 +105,37 @@ describe('getPlaybookScriptPath', () => {
     // expect the path to be inside the extension storage path
     expect(playbookPath).toContain(os.tmpdir());
 
-    // we should have written content
+    // we should have written content using the `file` module (state: link) rather than a raw
+    // `command: ln -s ...` string: Ansible's `command` module splits its argument on whitespace,
+    // so any path containing a space (e.g. a Windows username with a space) breaks `ln -s` into
+    // more positional arguments than it expects. `src`/`dest` as separate, quoted module
+    // parameters are not subject to that splitting - see the mustache template's comment.
     expect(vi.mocked(writeFile)).toBeCalledWith(
       expect.stringContaining('playbook-setup-registry-conf-file.yml'),
-      expect.stringContaining(
-        'sudo ln -s /fake/path/inside/vm /etc/containers/registries.conf.d/999-podman-desktop-registries-from-host.conf',
-      ),
+      expect.stringContaining('src: "/fake/path/inside/vm"'),
+      'utf-8',
+    );
+    expect(vi.mocked(writeFile)).toBeCalledWith(
+      expect.stringContaining('playbook-setup-registry-conf-file.yml'),
+      expect.stringContaining('dest: "/etc/containers/registries.conf.d/999-podman-desktop-registries-from-host.conf"'),
+      'utf-8',
+    );
+  });
+
+  test('expect a path containing a space to be quoted rather than split into two ln arguments', async () => {
+    vi.mocked(env).isWindows = true;
+
+    // A Windows username containing a space (e.g. "Ondrej Novak") is a real, reported case:
+    // https://github.com/podman-desktop/podman-desktop/issues/14881
+    vi.spyOn(registryConfiguration, 'getPathToRegistriesConfInsideVM').mockReturnValue(
+      '/mnt/c/Users/Ondrej Novak/.config/containers/registries.conf',
+    );
+
+    await registryConfiguration.getPlaybookScriptPath();
+
+    expect(vi.mocked(writeFile)).toBeCalledWith(
+      expect.stringContaining('playbook-setup-registry-conf-file.yml'),
+      expect.stringContaining('src: "/mnt/c/Users/Ondrej Novak/.config/containers/registries.conf"'),
       'utf-8',
     );
   });


### PR DESCRIPTION
## What does this PR do?

Fixes registries.conf sync being silently broken when the host username contains a space (e.g. a Windows account named "Ondrej Novak" or set up from a full-name Microsoft account, as reported in #14881).

### Root cause

`getPlaybookScriptPath()` renders an Ansible playbook that links the host's `registries.conf` into the Podman machine using a raw shell-style command:

```yaml
command: sudo ln -s {{{configurationFileInsideVmPath}}} /etc/containers/registries.conf.d/{{{configurationFileName}}}
```

Ansible's `command` module parses its argument the same way a shell would tokenize an unquoted string: it splits on whitespace. When the host path contains a space, it gets split into more positional arguments than `ln -s` expects, so the symlink is never created and `registries.conf.d/999-podman-desktop-registries-from-host.conf` ends up missing — exactly the symptom in the issue.

I verified this against a real `ansible-core` install rather than by inspection alone:

```
$ ansible-playbook test-playbook.yml   # command: ln -s "/mnt/c/Users/Ondrej Novak/.config/containers/registries.conf" ./dest
fatal: [localhost]: FAILED! => {"cmd": ["ln", "-s", "/mnt/c/Users/Ondrej", "Novak/.config/containers/registries.conf", "./dest"], ...}
```

### Fix

Switches the task to the `ansible.builtin.file` module (`state: link`), passing `src`/`dest` as separate, quoted module parameters instead of a parsed command line. Structured module parameters aren't tokenized the way a `command:` string is, so no argument-splitting can happen regardless of what characters the path contains. Re-ran the same path through the fixed template and confirmed it creates the correct symlink with the space intact.

## Screenshot / video

Not applicable — this is a backend/Ansible-template fix with no visible UI change, verified via unit tests and a real `ansible-playbook` run (see above).

Closes #14881