### PR TITLE
fix(renderer): compact factory property descriptions 

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -98,34 +98,6 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('Expect Markdown factory property descriptions to use compact spacing', async () => {
-  render(PreferencesConnectionCreationOrEditRendering, {
-    properties: [
-      {
-        title: 'Import host trusted CA certs',
-        parentId: '',
-        scope: 'ContainerProviderConnectionFactory',
-        id: 'test.importHostCerts',
-        type: 'boolean',
-        markdownDescription: 'Import host trusted CA certs',
-      },
-    ],
-    providerInfo,
-    connectionInfo: undefined,
-    propertyScope,
-    callback: vi.fn(),
-    pageIsLoading: false,
-  });
-
-  const markdown = await screen.findByLabelText('markdown-content');
-  const description = screen.getByText('Import host trusted CA certs');
-
-  expect(markdown.parentElement).toHaveClass('factory-property-markdown-description');
-  expect(Number.parseFloat(getComputedStyle(markdown).paddingBottom)).toBe(0);
-  expect(Number.parseFloat(getComputedStyle(description).marginBottom)).toBe(0);
-  expect(screen.getByRole('checkbox', { name: 'Import host trusted CA certs' })).toBeInTheDocument();
-});
-
 describe.each([
   {
     action: 'creation',

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -98,6 +98,34 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
+test('Expect Markdown factory property descriptions to use compact spacing', async () => {
+  render(PreferencesConnectionCreationOrEditRendering, {
+    properties: [
+      {
+        title: 'Import host trusted CA certs',
+        parentId: '',
+        scope: 'ContainerProviderConnectionFactory',
+        id: 'test.importHostCerts',
+        type: 'boolean',
+        markdownDescription: 'Import host trusted CA certs',
+      },
+    ],
+    providerInfo,
+    connectionInfo: undefined,
+    propertyScope,
+    callback: vi.fn(),
+    pageIsLoading: false,
+  });
+
+  const markdown = await screen.findByLabelText('markdown-content');
+  const description = screen.getByText('Import host trusted CA certs');
+
+  expect(markdown.parentElement).toHaveClass('factory-property-markdown-description');
+  expect(Number.parseFloat(getComputedStyle(markdown).paddingBottom)).toBe(0);
+  expect(Number.parseFloat(getComputedStyle(description).marginBottom)).toBe(0);
+  expect(screen.getByRole('checkbox', { name: 'Import host trusted CA certs' })).toBeInTheDocument();
+});
+
 describe.each([
   {
     action: 'creation',

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -582,7 +582,7 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
                   {#if configurationKey.description}
                     {configurationKey.description}:
                   {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}
-                    <div class="factory-property-markdown-description">
+                    <div class="[&>section]:pb-0 [&_p:last-child]:mb-0">
                       <Markdown markdown={configurationKey.markdownDescription} />
                     </div>
                   {/if}
@@ -622,13 +622,3 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
     </div>
   {/if}
 </div>
-
-<style>
-  .factory-property-markdown-description :global(section) {
-    padding-bottom: 0;
-  }
-
-  .factory-property-markdown-description :global(p:last-child) {
-    margin-bottom: 0;
-  }
-</style>

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -582,7 +582,9 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
                   {#if configurationKey.description}
                     {configurationKey.description}:
                   {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}
-                    <Markdown markdown={configurationKey.markdownDescription} />
+                    <div class="factory-property-markdown-description">
+                      <Markdown markdown={configurationKey.markdownDescription} />
+                    </div>
                   {/if}
                   {#if configurationKey.format === 'memory' || configurationKey.format === 'diskSize' || configurationKey.format === 'cpu'}
                     <div class="text-[var(--pd-content-text)]">
@@ -620,3 +622,13 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
     </div>
   {/if}
 </div>
+
+<style>
+  .factory-property-markdown-description :global(section) {
+    padding-bottom: 0;
+  }
+
+  .factory-property-markdown-description :global(p:last-child) {
+    margin-bottom: 0;
+  }
+</style>

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.svelte
@@ -582,7 +582,7 @@ function preventDefault(handler: (e: SubmitEvent) => Promise<void>): (e: SubmitE
                   {#if configurationKey.description}
                     {configurationKey.description}:
                   {:else if configurationKey.markdownDescription && configurationKey.type !== 'markdown'}
-                    <div class="[&>section]:pb-0 [&_p:last-child]:mb-0">
+                    <div class="[&>section]:pb-0 [&_p]:text-inherit">
                       <Markdown markdown={configurationKey.markdownDescription} />
                     </div>
                   {/if}


### PR DESCRIPTION
### What does this PR do?

- Removes the excess space between Markdown factory-property descriptions and their controls in `PreferencesConnectionCreationOrEditRendering`.
- Keeps the spacing override scoped to this form by applying Tailwind utilities to a local wrapper.
- Leaves behavior and wording unchanged.

The earlier CSS-specific computed-style test was removed following review feedback. AI assistance from OpenAI Codex (GPT-5) was used to investigate, implement, and verify this change; I reviewed the scoped diff and validation results. The latest review-fix commit also includes a GitHub-recognized Codex `Co-authored-by` trailer.

### Screenshot / video of UI

These are unedited full-window captures from the actual Podman Desktop development app. Both use the same isolated local profile and viewport with telemetry disabled. A no-op Podman 6 CLI stub was used only to expose the machine creation form without installing Podman on the host.

Before (PR base):

![Full Podman Desktop window before the fix](https://raw.githubusercontent.com/taljeon/podman-desktop/920e6a746cd89dc5b8d8f94e99873061e4d9b768/pr-assets/18897/actual-app-before.png)

After (this PR):

![Full Podman Desktop window after the fix](https://raw.githubusercontent.com/taljeon/podman-desktop/920e6a746cd89dc5b8d8f94e99873061e4d9b768/pr-assets/18897/actual-app-after.png)

The base capture shows the extra vertical gap between the Markdown description and its `Enabled` control. The PR capture removes that gap by changing the Markdown section's bottom padding from 24 px to 0 px.

### What issues does this PR fix or reference?

Fixes #18544.

The earlier #18557 was closed unmerged by its author. This change was prepared and verified independently against current `main`.

### How to test this PR?

1. Open **Settings → Resources → Podman**.
2. Start the **Create Podman machine** flow.
3. Locate **Import host trusted CA certificates into the machine during startup**.
4. Verify that the Markdown description no longer adds excess space above its `Enabled` control.
5. Confirm that other Markdown rendering remains unchanged.

Validation completed:

- `pnpm exec vitest run packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts` — 21 tests passed
- ESLint and Biome formatting on the changed Svelte file
- `pnpm run typecheck:renderer` — 0 errors
- `pnpm --filter renderer build`
- `git diff --check`

- [ ] Tests are covering the bug fix or the new feature

No new CSS-specific test is included; it was removed per review because this is a small visual spacing change. The existing component suite remains green.
