### PR TITLE
fix: adapt CronJob code to V1CronJob.spec being required in @kubernetes/client-node v2.0.0

### DIFF
--- a/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
+++ b/packages/main/src/plugin/kubernetes/kubernetes-client.spec.ts
@@ -2600,6 +2600,10 @@ test('Expect readNamespacedCronJob to return the cronjob', async () => {
     metadata: {
       name: 'foobar',
     },
+    spec: {
+      schedule: '*/5 * * * *',
+      jobTemplate: {},
+    },
   };
   makeApiClientMock.mockReturnValue({
     readNamespacedCronJob: () => Promise.resolve(v1CronJob),

--- a/packages/renderer/src/lib/cronjob/CronJobDetails.spec.ts
+++ b/packages/renderer/src/lib/cronjob/CronJobDetails.spec.ts
@@ -40,6 +40,10 @@ const cronjob: V1CronJob = {
     name: 'my-cronjob',
     namespace: 'default',
   },
+  spec: {
+    schedule: '*/5 * * * *',
+    jobTemplate: {},
+  },
 } as V1CronJob;
 
 vi.mock(import('/@/lib/kube/resources-listen'), async importOriginal => {

--- a/packages/renderer/src/lib/cronjob/CronJobDetails.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobDetails.svelte
@@ -49,6 +49,9 @@ onMount(async () => {
       }
     },
     onResourceUpdated: (resource: KubernetesObject, isExperimental: boolean) => {
+      if (!cronjobUtils.isV1CronJob(resource)) {
+        return;
+      }
       cronjob = cronjobUtils.getCronJobUI(resource);
       if (isExperimental) {
         kubeCronJob = resource;

--- a/packages/renderer/src/lib/cronjob/CronJobList.svelte
+++ b/packages/renderer/src/lib/cronjob/CronJobList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { KubernetesObject } from '@kubernetes/client-node';
 import { TableColumn, TableDurationColumn, TableRow, TableSimpleColumn } from '@podman-desktop/ui-svelte';
 import moment from 'moment';
 
@@ -6,6 +7,7 @@ import CronJobIcon from '/@/lib/images/CronJobIcon.svelte';
 import NameColumn from '/@/lib/kube/column/Name.svelte';
 import StatusColumn from '/@/lib/kube/column/Status.svelte';
 import KubernetesObjectsList from '/@/lib/objects/KubernetesObjectsList.svelte';
+import type { KubernetesObjectUI } from '/@/lib/objects/KubernetesObjectUI';
 import { capitalize } from '/@/lib/ui/Util';
 import { cronJobSearchPattern, kubernetesCurrentContextCronJobsFiltered } from '/@/stores/kubernetes-contexts-state';
 
@@ -85,7 +87,12 @@ const row = new TableRow<CronJobUI>({ selectable: (_cronjob): boolean => true })
 <KubernetesObjectsList
   kinds={[{
     resource: 'cronjobs',
-    transformer: cronjobUtils.getCronJobUI,
+    transformer: (o: KubernetesObject): KubernetesObjectUI => {
+      if (!cronjobUtils.isV1CronJob(o)) {
+        throw new Error('Expected V1CronJob');
+      }
+      return cronjobUtils.getCronJobUI(o);
+    },
     delete: window.kubernetesDeleteCronJob,
     isResource: (): boolean => true,
     legacySearchPatternStore: cronJobSearchPattern,

--- a/packages/renderer/src/lib/cronjob/cronjob-utils.spec.ts
+++ b/packages/renderer/src/lib/cronjob/cronjob-utils.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { V1CronJob } from '@kubernetes/client-node';
+import type { KubernetesObject, V1CronJob } from '@kubernetes/client-node';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { CronJobUtils } from './cronjob-utils';
@@ -35,10 +35,33 @@ test('expect basic UI conversion', async () => {
       name: 'my-cronjob',
       namespace: 'test-namespace',
     },
+    spec: {
+      schedule: '*/5 * * * *',
+      jobTemplate: {},
+    },
     status: {},
   } as V1CronJob;
   const cronjobUI = cronjobUtils.getCronJobUI(cronjob);
   expect(cronjobUI.kind).toEqual('CronJob');
   expect(cronjobUI.name).toEqual('my-cronjob');
   expect(cronjobUI.namespace).toEqual('test-namespace');
+});
+
+test('isV1CronJob returns true for object with spec', () => {
+  const obj = {
+    apiVersion: 'batch/v1',
+    kind: 'CronJob',
+    metadata: { name: 'my-cronjob' },
+    spec: { schedule: '*/5 * * * *', jobTemplate: {} },
+  } as KubernetesObject;
+  expect(cronjobUtils.isV1CronJob(obj)).toBeTruthy();
+});
+
+test('isV1CronJob returns false for object without spec', () => {
+  const obj: KubernetesObject = {
+    apiVersion: 'batch/v1',
+    kind: 'CronJob',
+    metadata: { name: 'my-cronjob' },
+  };
+  expect(cronjobUtils.isV1CronJob(obj)).toBeFalsy();
 });

--- a/packages/renderer/src/lib/cronjob/cronjob-utils.ts
+++ b/packages/renderer/src/lib/cronjob/cronjob-utils.ts
@@ -16,11 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import type { V1CronJob } from '@kubernetes/client-node';
+import type { KubernetesObject, V1CronJob } from '@kubernetes/client-node';
 
 import type { CronJobUI } from './CronJobUI';
 
 export class CronJobUtils {
+  isV1CronJob(o: KubernetesObject): o is V1CronJob {
+    return 'spec' in o && o.spec !== undefined;
+  }
+
   getCronJobUI(cronjob: V1CronJob): CronJobUI {
     return {
       kind: 'CronJob',
@@ -30,8 +34,8 @@ export class CronJobUtils {
       namespace: cronjob.metadata?.namespace ?? '',
       created: cronjob.metadata?.creationTimestamp,
       selected: false,
-      schedule: cronjob.spec?.schedule ?? '',
-      suspended: cronjob.spec?.suspend ?? false,
+      schedule: cronjob.spec.schedule ?? '',
+      suspended: cronjob.spec.suspend ?? false,
       lastScheduleTime: cronjob.status?.lastScheduleTime,
       // Get the number of "active" jobs, we just get the length of the array
       active: cronjob.status?.active?.length ?? 0,


### PR DESCRIPTION
### What does this PR do?

V1CronJob.spec is now a required property. Add isV1CronJob type guard to CronJobUtils, use direct property access instead of optional chaining on spec, and add spec to all test fixtures.

### Screenshot / video of UI

### What issues does this PR fix or reference?

Patch for #18825

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
