### PR TITLE
fix(renderer): show network name before ID 

### DIFF
--- a/packages/renderer/src/lib/network/NetworksList.spec.ts
+++ b/packages/renderer/src/lib/network/NetworksList.spec.ts
@@ -174,12 +174,13 @@ test('Expect network name before ID in the table', async () => {
   await init();
 
   const headers = screen.getAllByRole('columnheader');
-  const nameIndex = headers.findIndex(header => header.textContent?.includes('Name'));
-  const idIndex = headers.findIndex(header => header.textContent?.includes('Id'));
-
-  expect(nameIndex).toBeGreaterThan(-1);
-  expect(idIndex).toBeGreaterThan(-1);
-  expect(nameIndex).toBeLessThan(idIndex);
+  expect(headers.map(({ textContent }) => textContent.trim()).filter(header => !!header)).toStrictEqual([
+    'Name',
+    'Id',
+    'Environment',
+    'Driver',
+    'Actions',
+  ]);
 });
 
 test('Expect to have edit action for Podman networks', async () => {

--- a/packages/renderer/src/lib/network/NetworksList.spec.ts
+++ b/packages/renderer/src/lib/network/NetworksList.spec.ts
@@ -170,6 +170,18 @@ test('Expect networks to be order by name by default', async () => {
   expect(network1Name.compareDocumentPosition(network2Name)).toBe(4);
 });
 
+test('Expect network name before ID in the table', async () => {
+  await init();
+
+  const headers = screen.getAllByRole('columnheader');
+  const nameIndex = headers.findIndex(header => header.textContent?.includes('Name'));
+  const idIndex = headers.findIndex(header => header.textContent?.includes('Id'));
+
+  expect(nameIndex).toBeGreaterThan(-1);
+  expect(idIndex).toBeGreaterThan(-1);
+  expect(nameIndex).toBeLessThan(idIndex);
+});
+
 test('Expect to have edit action for Podman networks', async () => {
   await init();
 

--- a/packages/renderer/src/lib/network/NetworksList.spec.ts
+++ b/packages/renderer/src/lib/network/NetworksList.spec.ts
@@ -170,7 +170,7 @@ test('Expect networks to be order by name by default', async () => {
   expect(network1Name.compareDocumentPosition(network2Name)).toBe(4);
 });
 
-test('Expect network name before ID in the table', async () => {
+test('Expect network name before ID and match resource table width', async () => {
   await init();
 
   const headers = screen.getAllByRole('columnheader');
@@ -181,6 +181,10 @@ test('Expect network name before ID in the table', async () => {
     'Driver',
     'Actions',
   ]);
+
+  expect(screen.getByRole('table', { name: 'network' })).toHaveStyle({
+    '--table-grid-table-columns': '20px 32px 2fr 100px 1fr 1fr 1fr 32px',
+  });
 });
 
 test('Expect to have edit action for Podman networks', async () => {

--- a/packages/renderer/src/lib/network/NetworksList.spec.ts
+++ b/packages/renderer/src/lib/network/NetworksList.spec.ts
@@ -174,7 +174,7 @@ test('Expect network name before ID and match resource table width', async () =>
   await init();
 
   const headers = screen.getAllByRole('columnheader');
-  expect(headers.map(({ textContent }) => textContent.trim()).filter(header => !!header)).toStrictEqual([
+  expect(headers.map(({ textContent }) => textContent?.trim() ?? '').filter(header => !!header)).toStrictEqual([
     'Name',
     'Id',
     'Environment',

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -104,8 +104,8 @@ let envColumn = new TableColumn<NetworkInfoUI>('Environment', {
 });
 
 const columns = [
-  idColumn,
   nameColumn,
+  idColumn,
   envColumn,
   driverColumn,
   new TableColumn<NetworkInfoUI>('Actions', { align: 'right', renderer: NetworkActions, overflow: true }),

--- a/packages/renderer/src/lib/network/NetworksList.svelte
+++ b/packages/renderer/src/lib/network/NetworksList.svelte
@@ -88,7 +88,7 @@ let idColumn = new TableColumn<NetworkInfoUI>('Id', {
 });
 
 let nameColumn = new TableColumn<NetworkInfoUI>('Name', {
-  width: '3fr',
+  width: '2fr',
   renderer: NetworkColumnName,
   comparator: (a, b): number => a.name.localeCompare(b.name),
 });


### PR DESCRIPTION
### What does this PR do?

- Places the Name column before ID on the Networks page, matching the other resource tables.
- Adds a focused regression test that verifies Name appears before ID.

### Screenshot / video of UI

Before (from #18916):

<img width="1377" height="784" alt="Networks page before the change, showing ID before Name" src="https://github.com/user-attachments/assets/145ec200-3ade-4407-8e3a-aa61a119c683" />

After (local development build connected to Docker 29.1.2):

<img width="1050" height="700" alt="Networks page after the change, showing Name before ID" src="https://raw.githubusercontent.com/hamedrabah/podman-desktop/ca158b140da42789244f21c93322deed64afcad9/pr-assets/podman-networks-after-2fr-v2.png" />

The updated column order is **Name → ID → Environment → Driver → Actions**.

### What issues does this PR fix or reference?

Fixes #18916

### How to test this PR?

1. Open the Networks page.
2. Confirm that Name appears before ID.
3. Run `pnpm exec vitest --run --project=renderer packages/renderer/src/lib/network/NetworksList.spec.ts`.

- [x] Tests are covering the bug fix or the new feature
