### PR TITLE
docs: align prerequisites with pinned tool versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ You can develop on either: `Windows`, `macOS` or `Linux`.
 Requirements:
 
 - [Node.js 24+](https://nodejs.org/en/)
-- [pnpm v10.x](https://pnpm.io/installation) (`corepack enable pnpm`)
+- [pnpm](https://pnpm.io/installation), using the version pinned in `package.json` (`corepack enable pnpm`)
 
 Optional Linux requirements:
 

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -5,9 +5,9 @@ This is particularly useful if you want to execute the tests from a Podman Deskt
 
 Prerequisites:
 
-- Have Node.js 22 installed (ideally using `nvm`)
-- Uses pnpm v10, can be installed via `npm install -g pnpm@10` or you can get it [here](https://pnpm.io/installation)
-- Have a clone of the Podman Desktop repo (you can get it [here](https://github.com/containers/podman-desktop/tree/main))
+- Have Node.js 24 or newer installed (ideally using `nvm`)
+- Enable pnpm with `corepack enable`; the required version is pinned in the [root `package.json`](../../package.json)
+- Have a clone of the [Podman Desktop repository](https://github.com/podman-desktop/podman-desktop)
 
 ## Core functionality how the E2E tests works
 


### PR DESCRIPTION
### What does this PR do?

- Stops hard-coding pnpm 10 in contributor docs and points contributors to the version pinned by the root `package.json`.
- Updates the Playwright guide from Node.js 22 to the repository's Node.js 24 requirement.
- Corrects the Playwright guide's stale repository URL.

This keeps both setup guides aligned with the authoritative `engines` and `packageManager` fields and avoids another version drift when pnpm is upgraded.

### Screenshot / video of UI

Not applicable; this is a documentation-only change.

### What issues does this PR fix or reference?

Fixes #18923

### How to test this PR?

- Review both edited setup guides against the root `package.json`.
- `markdownlint-cli2 CONTRIBUTING.md tests/playwright/README.md`
- Run `git diff --check`.

- [x] Tests are covering the bug fix or the new feature (documentation-only validation)
