### PR TITLE
fix: remove usage of requestAnimationFrame when updating settings navigation width

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -627,10 +627,13 @@ describe('Navigation width measurement and calculation', () => {
   test('should update navigation width when the document becomes visible', async () => {
     const addEventListener = vi.spyOn(document, 'addEventListener');
     const removeEventListener = vi.spyOn(document, 'removeEventListener');
-    const titleWidths: Record<string, number> = {};
     mockNavigationMeasurements({
-      titleWidths,
+      withRequestAnimationFrame: true,
+      titleWidths: {
+        Resources: 260,
+      },
     });
+    setDocumentHidden(true);
 
     const { unmount } = render(PreferencesNavigation, {
       meta: {
@@ -639,8 +642,10 @@ describe('Navigation width measurement and calculation', () => {
     });
 
     await vi.waitFor(() => expect(addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function)));
+    await tick();
 
-    titleWidths.Resources = 260;
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+
     setDocumentHidden(false);
     document.dispatchEvent(new Event('visibilitychange'));
 

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2026 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,19 +123,11 @@ function mockNavigationMeasurements(options: {
   });
 }
 
-function setDocumentHidden(hidden: boolean): void {
-  Object.defineProperty(document, 'hidden', {
-    configurable: true,
-    get: () => hidden,
-  });
-}
-
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.resetAllMocks();
   registeredFeatures.set([]);
   configurationProperties.set([]);
-  setDocumentHidden(false);
   Object.defineProperty(global, 'ResizeObserver', {
     configurable: true,
     value: undefined,
@@ -538,23 +530,6 @@ describe('Navigation width measurement and calculation', () => {
     });
   });
 
-  test('should measure after requestAnimationFrame when it is available', async () => {
-    mockNavigationMeasurements({
-      withRequestAnimationFrame: true,
-      titleWidths: {
-        'A Very Long Preference Entry': 260,
-      },
-    });
-    configurationProperties.set([LONG_CONFIG]);
-
-    renderPreferencesNavigation();
-
-    await fireEvent.click(await screen.findByRole('link', { name: 'preferences' }));
-
-    await waitForNavigationWidth('292px');
-    expect(window.requestAnimationFrame).toHaveBeenCalled();
-  });
-
   test('should update navigation width when the window is resized', async () => {
     const addEventListener = vi.fn();
     const removeEventListener = vi.fn();
@@ -587,72 +562,6 @@ describe('Navigation width measurement and calculation', () => {
 
     unmount();
     expect(removeEventListener).toHaveBeenCalledWith('resize', resizeListener);
-  });
-
-  test('should skip navigation width measurement when the document is hidden', async () => {
-    mockNavigationMeasurements({
-      withRequestAnimationFrame: true,
-      titleWidths: {
-        Resources: 260,
-      },
-    });
-    setDocumentHidden(true);
-
-    renderPreferencesNavigation();
-    await tick();
-
-    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
-  });
-
-  test('should skip requestAnimationFrame when the document becomes hidden after tick', async () => {
-    let hidden = false;
-    Object.defineProperty(document, 'hidden', {
-      configurable: true,
-      get: () => hidden,
-    });
-    mockNavigationMeasurements({
-      withRequestAnimationFrame: true,
-      titleWidths: {
-        Resources: 260,
-      },
-    });
-
-    renderPreferencesNavigation();
-    hidden = true;
-    await tick();
-
-    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
-  });
-
-  test('should update navigation width when the document becomes visible', async () => {
-    const addEventListener = vi.spyOn(document, 'addEventListener');
-    const removeEventListener = vi.spyOn(document, 'removeEventListener');
-    mockNavigationMeasurements({
-      withRequestAnimationFrame: true,
-      titleWidths: {
-        Resources: 260,
-      },
-    });
-    setDocumentHidden(true);
-
-    const { unmount } = render(PreferencesNavigation, {
-      meta: {
-        url: '/preferences/docker',
-      } as unknown as TinroRouteMeta,
-    });
-
-    await vi.waitFor(() => expect(addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function)));
-    await tick();
-
-    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
-
-    setDocumentHidden(false);
-    document.dispatchEvent(new Event('visibilitychange'));
-
-    await waitForNavigationWidth('292px');
-
-    unmount();
-    expect(removeEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
   });
 
   test('should observe parent resize and disconnect observer on unmount', async () => {

--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2023-2025 Red Hat, Inc.
+ * Copyright (C) 2023-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,11 +123,19 @@ function mockNavigationMeasurements(options: {
   });
 }
 
+function setDocumentHidden(hidden: boolean): void {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => hidden,
+  });
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.resetAllMocks();
   registeredFeatures.set([]);
   configurationProperties.set([]);
+  setDocumentHidden(false);
   Object.defineProperty(global, 'ResizeObserver', {
     configurable: true,
     value: undefined,
@@ -579,6 +587,67 @@ describe('Navigation width measurement and calculation', () => {
 
     unmount();
     expect(removeEventListener).toHaveBeenCalledWith('resize', resizeListener);
+  });
+
+  test('should skip navigation width measurement when the document is hidden', async () => {
+    mockNavigationMeasurements({
+      withRequestAnimationFrame: true,
+      titleWidths: {
+        Resources: 260,
+      },
+    });
+    setDocumentHidden(true);
+
+    renderPreferencesNavigation();
+    await tick();
+
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  test('should skip requestAnimationFrame when the document becomes hidden after tick', async () => {
+    let hidden = false;
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => hidden,
+    });
+    mockNavigationMeasurements({
+      withRequestAnimationFrame: true,
+      titleWidths: {
+        Resources: 260,
+      },
+    });
+
+    renderPreferencesNavigation();
+    hidden = true;
+    await tick();
+
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  test('should update navigation width when the document becomes visible', async () => {
+    const addEventListener = vi.spyOn(document, 'addEventListener');
+    const removeEventListener = vi.spyOn(document, 'removeEventListener');
+    const titleWidths: Record<string, number> = {};
+    mockNavigationMeasurements({
+      titleWidths,
+    });
+
+    const { unmount } = render(PreferencesNavigation, {
+      meta: {
+        url: '/preferences/docker',
+      } as unknown as TinroRouteMeta,
+    });
+
+    await vi.waitFor(() => expect(addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function)));
+
+    titleWidths.Resources = 260;
+    setDocumentHidden(false);
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await waitForNavigationWidth('292px');
+
+    unmount();
+    expect(removeEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
   });
 
   test('should observe parent resize and disconnect observer on unmount', async () => {

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -134,6 +134,7 @@ function updateNavigationWidth(): void {
 function scheduleNavigationWidthUpdate(): void {
   void tick()
     .then(() => {
+      if (document.hidden) return;
       // Measure after next paint so newly-shown items have final layout metrics.
       if (typeof window.requestAnimationFrame === 'function') {
         window.requestAnimationFrame(() => {
@@ -190,6 +191,11 @@ onMount(() => {
   const resizeListener = (): void => {
     scheduleNavigationWidthUpdate();
   };
+  const visibilityListener = (): void => {
+    if (!document.hidden) {
+      scheduleNavigationWidthUpdate();
+    }
+  };
 
   let resizeObserver: ResizeObserver | undefined;
   if (navigationElement && typeof ResizeObserver !== 'undefined') {
@@ -203,6 +209,7 @@ onMount(() => {
   if (typeof window.addEventListener === 'function') {
     window.addEventListener('resize', resizeListener);
   }
+  document.addEventListener('visibilitychange', visibilityListener);
 
   onDidChangeRegisteredFeatures.addEventListener(kubernetesContextsManagerFeature, featureListener);
 
@@ -256,6 +263,7 @@ onMount(() => {
     if (typeof window.removeEventListener === 'function') {
       window.removeEventListener('resize', resizeListener);
     }
+    document.removeEventListener('visibilitychange', visibilityListener);
     resizeObserver?.disconnect();
     unsubConfig();
     unsubFeatures();

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -132,21 +132,8 @@ function updateNavigationWidth(): void {
 }
 
 function scheduleNavigationWidthUpdate(): void {
-  void tick()
-    .then(() => {
-      if (document.hidden) return;
-      // Measure after next paint so newly-shown items have final layout metrics.
-      if (typeof window.requestAnimationFrame === 'function') {
-        window.requestAnimationFrame(() => {
-          updateNavigationWidth();
-        });
-      } else {
-        updateNavigationWidth();
-      }
-    })
-    .catch(() => {
-      updateNavigationWidth();
-    });
+  // Measure after next paint so newly-shown items have final layout metrics.
+  void tick().then(updateNavigationWidth).catch(updateNavigationWidth);
 }
 
 function updateDockerCompatibility(): void {
@@ -191,11 +178,6 @@ onMount(() => {
   const resizeListener = (): void => {
     scheduleNavigationWidthUpdate();
   };
-  const visibilityListener = (): void => {
-    if (!document.hidden) {
-      scheduleNavigationWidthUpdate();
-    }
-  };
 
   let resizeObserver: ResizeObserver | undefined;
   if (navigationElement && typeof ResizeObserver !== 'undefined') {
@@ -209,7 +191,6 @@ onMount(() => {
   if (typeof window.addEventListener === 'function') {
     window.addEventListener('resize', resizeListener);
   }
-  document.addEventListener('visibilitychange', visibilityListener);
 
   onDidChangeRegisteredFeatures.addEventListener(kubernetesContextsManagerFeature, featureListener);
 
@@ -263,7 +244,6 @@ onMount(() => {
     if (typeof window.removeEventListener === 'function') {
       window.removeEventListener('resize', resizeListener);
     }
-    document.removeEventListener('visibilitychange', visibilityListener);
     resizeObserver?.disconnect();
     unsubConfig();
     unsubFeatures();

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -133,7 +133,7 @@ function updateNavigationWidth(): void {
 
 function scheduleNavigationWidthUpdate(): void {
   // Measure after next paint so newly-shown items have final layout metrics.
-  void tick().then(updateNavigationWidth).catch(updateNavigationWidth);
+  tick().then(updateNavigationWidth).catch(updateNavigationWidth);
 }
 
 function updateDockerCompatibility(): void {


### PR DESCRIPTION
### What does this PR do?

Removes usage rAF callback for recalculating settings navigation width. It is not required, because calculation involves calling getComputedStyle() which makes the browser flush style and layout immediately. 

Callbacks added twice every 5 seconds because of configuration change listener fires every five seconds and schedule update for navigation in the end. It also call function to detect docker compatibility status change which also triggers navigation update.

When window is minimized chromium throttle calls for registered callbacks and accumulates them (memory usage goes up because of that when PD window is minimized). When window is restored throttled callbacks are executed and that freezes UI. 

### Screenshot / video of UI

Before the change


https://github.com/user-attachments/assets/c34cca96-79ee-42bd-ae23-c02b85df7bca



After the change


https://github.com/user-attachments/assets/c58e072c-57ec-4f06-95e5-2d706e5a226b



### What issues does this PR fix or reference?

Closes #18548.

### How to test this PR?

1. Pull the branch
2. Make sure using nodejs v24.15+
3. Run `pnpm install && pnpm build && ./node_modules/.bin/electron .`
2. Open Settings on any page (Resources is opened by default)
3. minimize it and wait for 10 minutes
4. Restore window
5. Make sure UI is still responsive