### PR TITLE
chore(test): add long press navigation history e2e tests

### DIFF
--- a/.agents/skills/playwright-testing/SKILL.md
+++ b/.agents/skills/playwright-testing/SKILL.md
@@ -64,10 +64,23 @@ tests/playwright/
 
 ## Imports and Fixtures
 
-**Always** import `test` and `expect` from the project fixtures, not from `@playwright/test`:
+**Spec files** must import `test` and `expect` from the project fixtures:
 
 ```typescript
 import { expect as playExpect, test } from '/@/utility/fixtures';
+```
+
+**Model/POM files** must import from `@playwright/test` directly — **never** from
+`/@/utility/fixtures`. The fixtures module imports `NavigationBar`, which imports
+page models, which extend base classes like `DetailsPage` and `MainPage`. If any
+of those base classes import from fixtures, it creates a circular dependency that
+causes `ReferenceError: Cannot access '<ClassName>' before initialization` at
+runtime. This is a hard crash with no tests running.
+
+```typescript
+// In model/pages/*.ts and model/workbench/*.ts:
+import type { Locator, Page } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
 ```
 
 All source imports use the `/@/` path alias, which Vite resolves to `src/`.
@@ -201,7 +214,7 @@ async pullImage(image: string): Promise<ImagesPage> {
 
 4. **Navigation methods return POM instances** — e.g. `openPullImage()` returns `PullImagePage`
 5. **Use `playExpect`** (aliased from `@playwright/test`) inside POM files for assertions
-6. **Import `test` from `@playwright/test`** in POM files (for `test.step`), but from `/@/utility/fixtures` in spec files
+6. **Import `test` and `playExpect` from `@playwright/test`** in POM files (for `test.step` and assertions). **Never import from `/@/utility/fixtures` in model files** — this creates a circular dependency (fixtures -> NavigationBar -> page models -> fixtures) that crashes at runtime with `ReferenceError: Cannot access '<ClassName>' before initialization`. Only spec files import from fixtures.
 
 ### NavigationBar
 

--- a/tests/playwright/src/model/pages/details-page.ts
+++ b/tests/playwright/src/model/pages/details-page.ts
@@ -19,7 +19,6 @@
 import test, { expect as playExpect, type Locator, type Page } from '@playwright/test';
 
 import { isMac } from '/@/utility/platform';
-import { waitUntil } from '/@/utility/wait';
 
 import { BasePage } from './base-page';
 
@@ -57,9 +56,7 @@ export abstract class DetailsPage extends BasePage {
   async activateTab(tabName: string): Promise<this> {
     return test.step(`Activate tab: ${tabName}`, async () => {
       const tabItem = this.tabs.getByRole('link', { name: tabName, exact: true });
-      await waitUntil(async () => await tabItem.isVisible(), {
-        message: `Tab ${tabName} does not exist currently, maybe entry was deleted!`,
-      });
+      await playExpect(tabItem).toBeVisible({ timeout: 5_000 });
       await tabItem.click();
       return this;
     });

--- a/tests/playwright/src/model/workbench/navigation.ts
+++ b/tests/playwright/src/model/workbench/navigation.ts
@@ -163,7 +163,7 @@ export class NavigationBar {
   async longPressBack(): Promise<Locator> {
     return test.step('Long press back button to open history dropdown', async () => {
       await playExpect(this.backButton).toBeEnabled({ timeout: 5_000 });
-      await this.backButton.click({ delay: 600 });
+      await this.backButton.click({ delay: 1_000 });
       const dropdown = this.page.getByLabel('Back history');
       await playExpect(dropdown).toBeVisible({ timeout: 5_000 });
       return dropdown;
@@ -173,7 +173,7 @@ export class NavigationBar {
   async longPressForward(): Promise<Locator> {
     return test.step('Long press forward button to open history dropdown', async () => {
       await playExpect(this.forwardButton).toBeEnabled({ timeout: 5_000 });
-      await this.forwardButton.click({ delay: 600 });
+      await this.forwardButton.click({ delay: 1_000 });
       const dropdown = this.page.getByLabel('Forward history');
       await playExpect(dropdown).toBeVisible({ timeout: 5_000 });
       return dropdown;

--- a/tests/playwright/src/model/workbench/navigation.ts
+++ b/tests/playwright/src/model/workbench/navigation.ts
@@ -159,4 +159,32 @@ export class NavigationBar {
       await this.forwardButton.click();
     });
   }
+
+  async longPressBack(): Promise<Locator> {
+    return test.step('Long press back button to open history dropdown', async () => {
+      await playExpect(this.backButton).toBeEnabled({ timeout: 5_000 });
+      await this.backButton.click({ delay: 600 });
+      const dropdown = this.page.getByLabel('Back history');
+      await playExpect(dropdown).toBeVisible({ timeout: 5_000 });
+      return dropdown;
+    });
+  }
+
+  async longPressForward(): Promise<Locator> {
+    return test.step('Long press forward button to open history dropdown', async () => {
+      await playExpect(this.forwardButton).toBeEnabled({ timeout: 5_000 });
+      await this.forwardButton.click({ delay: 600 });
+      const dropdown = this.page.getByLabel('Forward history');
+      await playExpect(dropdown).toBeVisible({ timeout: 5_000 });
+      return dropdown;
+    });
+  }
+
+  async selectHistoryEntry(dropdown: Locator, name: string): Promise<void> {
+    return test.step(`Select history entry: ${name}`, async () => {
+      const entry = dropdown.getByRole('button', { name, exact: true });
+      await playExpect(entry).toBeVisible({ timeout: 5_000 });
+      await entry.click();
+    });
+  }
 }

--- a/tests/playwright/src/specs/navigation-history-smoke.spec.ts
+++ b/tests/playwright/src/specs/navigation-history-smoke.spec.ts
@@ -155,8 +155,10 @@ test.describe
       await page.reload();
 
       await navigationBar.openDashboard();
-      await navigationBar.openContainers();
-      await navigationBar.openImages();
+      const containersPage = await navigationBar.openContainers();
+      await playExpect(containersPage.heading).toBeVisible();
+      const imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
 
       const dropdown = await navigationBar.longPressBack();
 
@@ -169,8 +171,10 @@ test.describe
       await page.reload();
 
       await navigationBar.openDashboard();
-      await navigationBar.openContainers();
-      await navigationBar.openImages();
+      const containersPage = await navigationBar.openContainers();
+      await playExpect(containersPage.heading).toBeVisible();
+      const imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
 
       const dropdown = await navigationBar.longPressBack();
       await navigationBar.selectHistoryEntry(dropdown, 'Dashboard');
@@ -183,12 +187,17 @@ test.describe
       await page.evaluate(() => sessionStorage.clear());
       await page.reload();
 
+      const dashboardPage = new DashboardPage(page);
       await navigationBar.openDashboard();
-      await navigationBar.openContainers();
-      await navigationBar.openImages();
+      const containersPage = await navigationBar.openContainers();
+      await playExpect(containersPage.heading).toBeVisible();
+      const imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
 
       await navigationBar.goBack();
+      await playExpect(containersPage.heading).toBeVisible();
       await navigationBar.goBack();
+      await playExpect(dashboardPage.heading).toBeVisible();
 
       const dropdown = await navigationBar.longPressForward();
 
@@ -200,17 +209,21 @@ test.describe
       await page.evaluate(() => sessionStorage.clear());
       await page.reload();
 
+      const dashboardPage = new DashboardPage(page);
       await navigationBar.openDashboard();
-      await navigationBar.openContainers();
-      await navigationBar.openImages();
+      const containersPage = await navigationBar.openContainers();
+      await playExpect(containersPage.heading).toBeVisible();
+      const imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
 
       await navigationBar.goBack();
+      await playExpect(containersPage.heading).toBeVisible();
       await navigationBar.goBack();
+      await playExpect(dashboardPage.heading).toBeVisible();
 
       const dropdown = await navigationBar.longPressForward();
       await navigationBar.selectHistoryEntry(dropdown, 'Images');
 
-      const imagesPage = new ImagesPage(page);
       await playExpect(imagesPage.heading).toBeVisible({ timeout: 5_000 });
     });
   });

--- a/tests/playwright/src/specs/navigation-history-smoke.spec.ts
+++ b/tests/playwright/src/specs/navigation-history-smoke.spec.ts
@@ -149,4 +149,68 @@ test.describe
       const dashboardPage = new DashboardPage(page);
       await playExpect(dashboardPage.heading).toBeVisible({ timeout: 5_000 });
     });
+
+    test('Long press on back button shows history dropdown', async ({ navigationBar, page }) => {
+      await page.evaluate(() => sessionStorage.clear());
+      await page.reload();
+
+      await navigationBar.openDashboard();
+      await navigationBar.openContainers();
+      await navigationBar.openImages();
+
+      const dropdown = await navigationBar.longPressBack();
+
+      await playExpect(dropdown.getByRole('button', { name: 'Containers' })).toBeVisible();
+      await playExpect(dropdown.getByRole('button', { name: 'Dashboard' })).toBeVisible();
+    });
+
+    test('Selecting entry from back history dropdown navigates to that page', async ({ navigationBar, page }) => {
+      await page.evaluate(() => sessionStorage.clear());
+      await page.reload();
+
+      await navigationBar.openDashboard();
+      await navigationBar.openContainers();
+      await navigationBar.openImages();
+
+      const dropdown = await navigationBar.longPressBack();
+      await navigationBar.selectHistoryEntry(dropdown, 'Dashboard');
+
+      const dashboardPage = new DashboardPage(page);
+      await playExpect(dashboardPage.heading).toBeVisible({ timeout: 5_000 });
+    });
+
+    test('Long press on forward button shows forward history dropdown', async ({ navigationBar, page }) => {
+      await page.evaluate(() => sessionStorage.clear());
+      await page.reload();
+
+      await navigationBar.openDashboard();
+      await navigationBar.openContainers();
+      await navigationBar.openImages();
+
+      await navigationBar.goBack();
+      await navigationBar.goBack();
+
+      const dropdown = await navigationBar.longPressForward();
+
+      await playExpect(dropdown.getByRole('button', { name: 'Containers' })).toBeVisible();
+      await playExpect(dropdown.getByRole('button', { name: 'Images' })).toBeVisible();
+    });
+
+    test('Selecting entry from forward history dropdown navigates to that page', async ({ navigationBar, page }) => {
+      await page.evaluate(() => sessionStorage.clear());
+      await page.reload();
+
+      await navigationBar.openDashboard();
+      await navigationBar.openContainers();
+      await navigationBar.openImages();
+
+      await navigationBar.goBack();
+      await navigationBar.goBack();
+
+      const dropdown = await navigationBar.longPressForward();
+      await navigationBar.selectHistoryEntry(dropdown, 'Images');
+
+      const imagesPage = new ImagesPage(page);
+      await playExpect(imagesPage.heading).toBeVisible({ timeout: 5_000 });
+    });
   });


### PR DESCRIPTION
### What does this PR do?
Adds e2e tests to validate navigation history long press functionality.

### What issues does this PR fix or reference?
https://github.com/podman-desktop/podman-desktop/issues/18512
