### PR TITLE
feat(renderer): add OnboardingWelcomeTelemetry component 

### DIFF
--- a/packages/renderer/src/lib/onboarding/OnboardingWelcomeTelemetry.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingWelcomeTelemetry.spec.ts
@@ -1,0 +1,148 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import OnboardingWelcomeTelemetry from './OnboardingWelcomeTelemetry.svelte';
+
+const mockSetTelemetry = vi.fn();
+const mockHavePromptedForTelemetry = vi.fn();
+
+vi.mock(import('/@/lib/welcome/welcome-utils'), async importOriginal => {
+  const orig = await importOriginal();
+  class MockWelcomeUtils extends orig.WelcomeUtils {
+    override setTelemetry = mockSetTelemetry;
+    override havePromptedForTelemetry = mockHavePromptedForTelemetry;
+  }
+  return { WelcomeUtils: MockWelcomeUtils };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockHavePromptedForTelemetry.mockResolvedValue(false);
+  (window as unknown as Record<string, unknown>).getTelemetryMessages = vi.fn().mockResolvedValue({
+    acceptMessage: 'Help us improve',
+    info: { url: 'https://example.com/privacy', link: 'Privacy statement' },
+  });
+  (window as unknown as Record<string, unknown>).openExternal = vi.fn();
+});
+
+describe('OnboardingWelcomeTelemetry', () => {
+  test('shows telemetry checkbox when not previously prompted', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Telemetry' })).toBeInTheDocument();
+    });
+  });
+
+  test('persists default telemetry value (true) on mount when not previously prompted', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(mockSetTelemetry).toHaveBeenCalledWith(true);
+    });
+  });
+
+  test('hides telemetry when already prompted', async () => {
+    mockHavePromptedForTelemetry.mockResolvedValue(true);
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(mockHavePromptedForTelemetry).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole('checkbox', { name: 'Telemetry' })).not.toBeInTheDocument();
+  });
+
+  test('displays telemetry accept message and privacy link', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Help us improve')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Privacy statement')).toBeInTheDocument();
+  });
+
+  test('checkbox is checked by default', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Telemetry' })).toBeChecked();
+    });
+  });
+
+  test('persists telemetry as false immediately when unchecked', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Telemetry' })).toBeInTheDocument();
+    });
+
+    mockSetTelemetry.mockClear();
+    const checkbox = screen.getByRole('checkbox', { name: 'Telemetry' });
+    await fireEvent.click(checkbox);
+
+    expect(checkbox).not.toBeChecked();
+    expect(mockSetTelemetry).toHaveBeenCalledWith(false);
+  });
+
+  test('persists telemetry as true immediately when re-checked', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Telemetry' })).toBeInTheDocument();
+    });
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Telemetry' });
+    await fireEvent.click(checkbox);
+    mockSetTelemetry.mockClear();
+    await fireEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+    expect(mockSetTelemetry).toHaveBeenCalledWith(true);
+  });
+
+  test('clicking the visible Telemetry label toggles the checkbox', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Telemetry' })).toBeChecked();
+    });
+
+    mockSetTelemetry.mockClear();
+    await fireEvent.click(screen.getByText('Telemetry'));
+
+    expect(screen.getByRole('checkbox', { name: 'Telemetry' })).not.toBeChecked();
+    expect(mockSetTelemetry).toHaveBeenCalledWith(false);
+  });
+
+  test('does not show or persist telemetry when already prompted', async () => {
+    mockHavePromptedForTelemetry.mockResolvedValue(true);
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(mockHavePromptedForTelemetry).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole('checkbox', { name: 'Telemetry' })).not.toBeInTheDocument();
+    expect(mockSetTelemetry).not.toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/onboarding/OnboardingWelcomeTelemetry.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingWelcomeTelemetry.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+import type { TelemetryMessages } from '@podman-desktop/core-api';
+import { Checkbox, Link } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+
+import { WelcomeUtils } from '/@/lib/welcome/welcome-utils';
+
+const welcomeUtils = new WelcomeUtils();
+let telemetry = $state(true);
+let showTelemetry = $state(false);
+let telemetryMessages: TelemetryMessages | undefined = $state(undefined);
+
+onMount(async () => {
+  const alreadyPrompted = await welcomeUtils.havePromptedForTelemetry();
+  if (!alreadyPrompted) {
+    telemetryMessages = await window.getTelemetryMessages();
+    showTelemetry = true;
+    await welcomeUtils.setTelemetry(telemetry);
+  }
+});
+
+async function toggleTelemetry(): Promise<void> {
+  telemetry = !telemetry;
+  await welcomeUtils.setTelemetry(telemetry);
+}
+</script>
+
+{#if showTelemetry}
+  <div class="flex items-start gap-2">
+    <Checkbox
+      id="onboarding-telemetry"
+      checked={telemetry}
+      title="Telemetry"
+      onclick={toggleTelemetry} />
+    <div>
+      <label for="onboarding-telemetry" class="text-sm font-medium text-(--pd-content-header) cursor-pointer">Telemetry</label>
+      <p class="text-xs leading-relaxed text-(--pd-content-card-text)">
+        {#if telemetryMessages}
+          {telemetryMessages.acceptMessage}
+          {#if telemetryMessages.info}
+            <Link
+              onclick={async (): Promise<void> => { await window.openExternal(telemetryMessages?.info?.url ?? ''); }}>
+              {telemetryMessages.info.link}
+            </Link>
+          {/if}
+        {:else}
+          Help us improve Podman Desktop by allowing anonymous usage data to be collected.
+        {/if}
+      </p>
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
## What does this PR do?

Adds a standalone `OnboardingWelcomeTelemetry` component for the new onboarding wizard sidebar. It displays a telemetry opt-in/opt-out checkbox that persists the choice immediately on toggle.

- Checks if telemetry has already been prompted via `WelcomeUtils.havePromptedForTelemetry()`
- If not yet prompted, displays the accept message and privacy statement link from IPC
- Persists the telemetry choice immediately when the checkbox is toggled (visible in console as `Telemetry enablement: true/false`)
- Hidden when telemetry has already been prompted

> **Note:** This PR only contains the telemetry component and its unit tests. The surrounding page layout and demo route are on the [`feat/onboarding-welcome-page`](https://github.com/simonrey1/podman-desktop/tree/feat/onboarding-welcome-page) branch which builds on top of this PR.

## Screenshot / video of UI

Integration on feat/onboarding-welcome-page branch:

<img width="1191" height="860" alt="Screenshot 2026-08-27 at 09 48 57" src="https://github.com/user-attachments/assets/7f07f33a-a6a6-48e6-8764-dca28edd4835" />

## What issues does this PR fix or reference?

Part of the onboarding wizard redesign (#17465).

## How to test this PR?

The component is not wired into any route in this PR. To see it in action, use the demo branch `feat/onboarding-welcome-page`:

1. `git fetch origin feat/onboarding-welcome-page && git checkout feat/onboarding-welcome-page`
2. `pnpm install && pnpm watch`
3. Open DevTools console, reset telemetry prompt: `window.updateConfigurationValue('telemetry.check', false, 'DEFAULT')`
4. Navigate to the demo: `window.__pdGoto('/onboarding-welcome-demo')`
5. Toggle the telemetry checkbox — observe console logs: `Telemetry enablement: true` / `Telemetry enablement: false`

* 6 unit tests covering the new component

Made with Cursor

Made with [Cursor](https://cursor.com)