### PR TITLE
fix(renderer): use sticky positioning for onboarding step buttons

### DIFF
--- a/packages/renderer/src/lib/onboarding/Onboarding.svelte
+++ b/packages/renderer/src/lib/onboarding/Onboarding.svelte
@@ -455,10 +455,6 @@ let globalOnboarding = $derived(global);
       {/if}
 
       {#if !activeStep.step.completionEvents || activeStep.step.completionEvents.length === 0}
-        <!-- fake div used to hide scrollbar shadow  -->
-        {#if !globalOnboarding}
-          <div class="fixed bg-[var(--pd-details-bg)] right-0 bottom-0 h-[70px] w-[30px] z-10 mb-6"></div>
-        {/if}
         <div class="grow"></div>
         {#if activeStep.step.state !== 'failed'}
           <div class="mt-10 mx-auto text-sm min-h-[120px]" aria-label="Next Info Message">
@@ -471,9 +467,7 @@ let globalOnboarding = $derived(global);
           </div>
         {/if}
         <div
-          class="flex flex-row-reverse p-6 bg-[var(--pd-content-bg)] fixed {globalOnboarding
-            ? 'w-full'
-            : 'w-[calc(100%-(var(--spacing-leftnavbar))-(var(--spacing-leftsidebar)))] mb-5'} bottom-0 pr-10 max-h-20 bg-opacity-90 z-20"
+          class="flex flex-row-reverse p-6 bg-[var(--pd-content-bg)] sticky bottom-0 w-full pr-10 max-h-20 bg-opacity-90 z-20"
           role="group"
           aria-label="Step Buttons">
           <Button


### PR DESCRIPTION
### What does this PR do?

Fixes the onboarding Next/Cancel buttons being pushed outside the visible area when the navigation bar width is customized.

The buttons previously used `fixed` positioning with a fragile `calc()` width that subtracted CSS custom properties for navbar and sidebar widths. When the navbar width changed, this computation broke and the buttons overflowed.

This PR replaces `fixed` with `sticky bottom-0 w-full`, which anchors the button bar to the bottom of its scroll container and automatically inherits the correct width — no `calc()` needed. The workaround div that hid the scrollbar shadow behind the fixed bar is also removed.

Follow-up of https://github.com/podman-desktop/podman-desktop/pull/4054.

Fixes https://github.com/podman-desktop/podman-desktop/issues/18402

### Screenshot / video of UI changes

The change should be minimal in the buttons positioning

#### Extension onboarding

Before:
<img width="1127" height="712" alt="Screenshot 2026-08-26 at 15 49 31" src="https://github.com/user-attachments/assets/9603a7bf-1560-4771-80e5-f79371cc2ce7" />


After:
<img width="1127" height="712" alt="Screenshot 2026-08-26 at 15 49 11" src="https://github.com/user-attachments/assets/26ac7f89-d88a-49b3-90cd-52541c35b7df" />

<!-- Add screenshot here -->

#### Global onboarding



Before:
<img width="1253" height="964" alt="Screenshot 2026-08-26 at 11 53 11" src="https://github.com/user-attachments/assets/63fc3e40-8b8e-4a55-a03f-6ee8337fa5dc" />


After:

<img width="1253" height="964" alt="Screenshot 2026-08-26 at 11 50 43" src="https://github.com/user-attachments/assets/034deaa2-c94b-4563-9441-712ec4c572f5" />


<!-- Add screenshot here -->

### How to reproduce

**Extension onboarding:**
1. Uninstall Podman
2. Launch Podman Desktop in dev mode (`pnpm watch`)
3. Go to Settings
4. Go to Preferences > Apparence
5. Go to Resources
6. Click the "Set up…" button
7. Check that Cancel and Next buttons are visible
8. Change the navigation bar width in Settings > Appearance and verify buttons remain visible

**Global onboarding:**
1. In the DevTools console, run:
   ```js
   await resetOnboarding(['podman-desktop.podman']);
   await updateConfigurationValue('welcome.version', '');
   location.reload();
   ```
2. Check that buttons are visible and well aligned

### What issues does this PR fix or address?

Fixes https://github.com/podman-desktop/podman-desktop/issues/18402

### Are there any particular things to be aware of?

- Uses `sticky` instead of `fixed` positioning, which is simpler and more robust against layout changes
- Removed the fake scrollbar-shadow-hiding div that was only needed with fixed positioning

Made with [Cursor](https://cursor.com)