### PR TITLE
fix(renderer): keep resize handle below welcome overlay

### DIFF
--- a/packages/renderer/src/AppNavigation.svelte
+++ b/packages/renderer/src/AppNavigation.svelte
@@ -294,7 +294,7 @@ function onDidChangeConfigurationCallback(e: Event): void {
 
   <!-- Resize handle -->
   <div
-    class="absolute top-0 right-0 w-1.5 h-full cursor-col-resize z-50 hover:bg-[var(--pd-global-nav-icon-selected-highlight)] transition-colors duration-150"
+    class="absolute top-0 right-0 w-1.5 h-full cursor-col-resize z-40 hover:bg-[var(--pd-global-nav-icon-selected-highlight)] transition-colors duration-150"
     class:bg-[var(--pd-global-nav-icon-selected-highlight)]={isDragging}
     role="separator"
     aria-orientation="vertical"

--- a/tests/playwright/src/specs/welcome-page-smoke.spec.ts
+++ b/tests/playwright/src/specs/welcome-page-smoke.spec.ts
@@ -38,6 +38,18 @@ test.describe
           await playExpect(welcomePage.welcomeMessage).toBeVisible();
         });
 
+        test('Welcome page overlays the navigation resize handle', async ({ page, welcomePage }) => {
+          await playExpect(welcomePage.welcomeMessage).toBeVisible();
+
+          const resizeHandle = page.getByRole('separator', { name: 'Resize navigation bar' });
+          const resizeHandleIsTopmost = await resizeHandle.evaluate(element => {
+            const { left, top, width, height } = element.getBoundingClientRect();
+            return document.elementFromPoint(left + width / 2, top + height / 2) === element;
+          });
+
+          playExpect(resizeHandleIsTopmost).toBeFalsy();
+        });
+
         test('Telemetry checkbox is present, set to true, consent can be changed', async ({ welcomePage }) => {
           await playExpect(welcomePage.telemetryConsent).toBeVisible();
           await playExpect(welcomePage.telemetryConsent).toBeChecked();


### PR DESCRIPTION
### What does this PR do?

- Keeps the left-navigation resize handle below full-screen onboarding overlays by lowering its stacking level from `z-50` to `z-40`.
- Adds a Playwright regression test that hit-tests the center of the resize handle while the welcome page is visible and verifies that the handle is not the topmost element.

### Screenshot / video of UI

**Before**

Hovering at the left-navigation boundary reveals the purple resize handle above the welcome page:

![Resize handle visible above the welcome page](https://github.com/user-attachments/assets/6a6ad0a0-35db-4894-bb80-db82277477db)

**After**

With the pointer at the same boundary, the welcome page remains above the resize handle and the purple hover state is no longer exposed:

<img width="2100" height="1400" alt="welcome-after" src="https://github.com/user-attachments/assets/5eaad682-7f7b-4c21-acce-8d3b009829e1" />

### What issues does this PR fix or reference?

Closes #18959

### How to test this PR?

- `pnpm exec biome format packages/renderer/src/AppNavigation.svelte tests/playwright/src/specs/welcome-page-smoke.spec.ts`
- `pnpm exec vitest --run packages/renderer/src/AppNavigation.spec.ts --reporter=dot` — 6 tests passed
- `pnpm run typecheck:renderer` — 0 errors
- `pnpm exec playwright test tests/playwright/src/specs/welcome-page-smoke.spec.ts -g "Welcome page overlays the navigation resize handle"` — 1 test passed
- Regression proof: the new E2E assertion fails with the original `z-50` value (`resizeHandleIsTopmost === true`) and passes with `z-40`.

- [x] Tests are covering the bug fix or the new feature

AI assistance: Codex helped with codebase navigation, implementation review, and test drafting.