### PR TITLE
chore(screenshots): remove the 5M banner when taking screenshots for diff

### DIFF
--- a/website-argos/screenshot.css
+++ b/website-argos/screenshot.css
@@ -31,3 +31,8 @@ video {
 #github-stars-button {
   visibility: hidden;
 }
+
+/* Hide 5M banner */
+#banner-5m {
+  display: none;
+}

--- a/website/src/components/5MBanner/index.tsx
+++ b/website/src/components/5MBanner/index.tsx
@@ -235,7 +235,7 @@ function Banner(): JSX.Element {
   }, [colorMode]);
 
   return (
-    <div ref={containerRef} className="relative w-full h-18 sm:h-21 xl:h-40">
+    <div id="banner-5m" ref={containerRef} className="relative w-full h-18 sm:h-21 xl:h-40">
       <a
         ref={anchorRef}
         href={BLOG_POST_URL}


### PR DESCRIPTION
### What does this PR do?
exclude the banner (to avoid to get animated sprites) as it's producing diff on screenshots

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

fixes https://github.com/podman-desktop/podman-desktop/issues/18999

### How to test this PR?

- run pnpm website:screenshots and look at the captured screenshot for index file, it should not include the banner

- [ ] Tests are covering the bug fix or the new feature
