### PR TITLE
fix(main): always schedule a reconnect when event subscription fails

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3755,8 +3755,13 @@ test('setupConnectionAPI with errors', async () => {
   expect(allCalls).toBeDefined();
 
   // filter calls to find the one with container-started-event
+  //
+  // The reconnect chain keeps retrying through the intermediate failures until it
+  // reaches stream2, so the buffered event is delivered. This used to assert 0,
+  // because the chain stopped retrying and never got there.
   const containerStartedEventCalls = allCalls.filter(call => call[0] === 'container-started-event');
-  expect(containerStartedEventCalls).toHaveLength(0);
+  expect(containerStartedEventCalls).toHaveLength(1);
+  expect(containerStartedEventCalls[0]).toEqual(['container-started-event', fakeId]);
 
   stream2.end();
 
@@ -4113,6 +4118,273 @@ test('check handleEvents calls errorCallback and destroys pipeline on parse erro
   expect(errorCallback).toHaveBeenCalledWith(expect.objectContaining({ message: 'Error while parsing events' }));
 
   consoleErrorSpy.mockRestore();
+});
+
+test('check handleEvents calls errorCallback for every consecutive getEvents failure (no notify latch)', () => {
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((err: Error | null, stream?: PassThrough) => void) | undefined;
+  // keep the function passed in parameter of getEventsMock
+  getEventsMock.mockImplementation((options: (err: Error | null, stream?: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  expect(eventsMockCallback).toBeDefined();
+
+  // three consecutive failures to subscribe to the event stream must each
+  // reach errorCallback: nothing should latch after the first one.
+  eventsMockCallback?.(new Error('connection error 1'));
+  eventsMockCallback?.(new Error('connection error 2'));
+  eventsMockCallback?.(new Error('connection error 3'));
+
+  expect(errorCallback).toHaveBeenCalledTimes(3);
+});
+
+test('setupConnectionAPI reconnect chain via msw continues past the second attempt', async () => {
+  const stream1 = new PassThrough();
+  server = setupServer(
+    http.get('http://localhost/events', () => new HttpResponse(stream1 as unknown as ReadableStream)),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const internalContainerProvider: InternalContainerProvider = {
+    name: 'podman',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+      displayName: 'podman',
+      name: 'podman',
+      endpoint: {
+        socketPath: 'http://localhost',
+      },
+      status: () => 'started',
+    },
+  };
+
+  const providerConnectionInfo: podmanDesktopAPI.ContainerProviderConnection = {
+    name: 'podman',
+    displayName: 'podman',
+    type: 'podman',
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    status: () => 'started',
+  };
+
+  containerRegistry.setupConnectionAPI(internalContainerProvider, providerConnectionInfo);
+  containerRegistry.setRetryDelayEvents(200);
+
+  // wait for the first connection to be established
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internalContainerProvider.api).toBeDefined();
+
+  // first failure
+  stream1.emit('error', new Error('first error'));
+  stream1.end();
+  await vi.waitFor(() => expect(internalContainerProvider.api).toBeUndefined());
+
+  // mock the second attempt: this is the retry a latched notify would have
+  // swallowed (see 'setupConnectionAPI with errors')
+  const stream2 = new PassThrough();
+  server.use(http.get('http://localhost/events', () => new HttpResponse(stream2 as unknown as ReadableStream)));
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internalContainerProvider.api).toBeDefined();
+
+  // second failure
+  stream2.emit('error', new Error('second error'));
+  stream2.end();
+  await vi.waitFor(() => expect(internalContainerProvider.api).toBeUndefined());
+
+  // a third attempt must still happen: the chain has not latched
+  const stream3 = new PassThrough();
+  server.use(http.get('http://localhost/events', () => new HttpResponse(stream3 as unknown as ReadableStream)));
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internalContainerProvider.api).toBeDefined();
+
+  // terminate the chain: no further error is emitted on stream3, so no more
+  // reconnects get scheduled and this test does not leak a running chain.
+  stream3.end();
+});
+
+test('two errors close together schedule exactly one reconnect', () => {
+  vi.useFakeTimers();
+
+  try {
+    const providerConnectionInfo: podmanDesktopAPI.ContainerProviderConnection = {
+      name: 'podman',
+      displayName: 'podman',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/endpoint1.sock',
+      },
+      status: () => 'started',
+    };
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      connection: providerConnectionInfo,
+    };
+
+    // mock handleEvents itself so this test controls exactly when and how
+    // many times the connection reports an error, without depending on real
+    // network timing: it captures the errorHandler closure that
+    // setupConnectionAPI builds for each connection attempt.
+    let capturedErrorCallback: ((error: Error) => void) | undefined;
+    const handleEventsSpy = vi.spyOn(containerRegistry, 'handleEvents').mockImplementation((_api, errorCallback) => {
+      capturedErrorCallback = errorCallback;
+    });
+
+    containerRegistry.setupConnectionAPI(internalContainerProvider, providerConnectionInfo);
+    containerRegistry.setRetryDelayEvents(200);
+
+    expect(handleEventsSpy).toHaveBeenCalledTimes(1);
+    expect(capturedErrorCallback).toBeDefined();
+    handleEventsSpy.mockClear();
+
+    // two errors in close succession must schedule exactly one pending reconnect
+    capturedErrorCallback?.(new Error('first close error'));
+    capturedErrorCallback?.(new Error('second close error'));
+
+    expect(internalContainerProvider.api).toBeUndefined();
+    expect(internalContainerProvider.reconnectTimer).toBeDefined();
+
+    // let the single scheduled reconnect fire
+    vi.advanceTimersByTime(200);
+
+    // exactly one reconnect happened, not two
+    expect(handleEventsSpy).toHaveBeenCalledTimes(1);
+    expect(internalContainerProvider.api).toBeDefined();
+    expect(internalContainerProvider.reconnectTimer).toBeUndefined();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('disposing a connection cancels its pending reconnect, and a chain whose status went unknown stops', async () => {
+  const stream1 = new PassThrough();
+  server = setupServer(
+    http.get('http://localhost/events', () => new HttpResponse(stream1 as unknown as ReadableStream)),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const providerRegistry: ProviderRegistry = {
+    onBeforeDidUpdateContainerConnection: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  } as unknown as ProviderRegistry;
+
+  containerRegistry.setRetryDelayEvents(300);
+
+  // Part 1: disposing a connection cancels its pending reconnect
+  const statusMock = vi.fn().mockReturnValue('started');
+  const containerProviderConnection: podmanDesktopAPI.ContainerProviderConnection = {
+    name: 'podman',
+    type: 'podman',
+    displayName: 'podman',
+    endpoint: {
+      socketPath: 'http://localhost',
+    },
+    status: statusMock,
+  } as unknown as podmanDesktopAPI.ContainerProviderConnection;
+
+  const podmanProvider = { name: 'podman', id: 'podman' } as unknown as podmanDesktopAPI.Provider;
+
+  const disposable = containerRegistry.registerContainerConnection(
+    podmanProvider,
+    containerProviderConnection,
+    providerRegistry,
+  );
+  const internal = containerRegistry.getMatchingPodmanEngine('podman.podman');
+  expect(internal.api).toBeDefined();
+
+  // wait for the events stream to be attached
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  // an error schedules a pending reconnect
+  stream1.emit('error', new Error('boom'));
+  stream1.end();
+
+  await vi.waitFor(() => expect(internal.reconnectTimer).toBeDefined());
+
+  // dispose while the reconnect is pending
+  disposable.dispose();
+  expect(internal.reconnectTimer).toBeUndefined();
+
+  // wait past the retry delay: the disposed provider must not reconnect
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internal.api).toBeUndefined();
+
+  // Part 2: a chain whose status went 'unknown' stops on its own
+  const stream2 = new PassThrough();
+  server.use(http.get('http://localhost/events', () => new HttpResponse(stream2 as unknown as ReadableStream)));
+
+  const chainStatusMock = vi.fn().mockReturnValue('started');
+  const chainConnection: podmanDesktopAPI.ContainerProviderConnection = {
+    name: 'podman-chain',
+    type: 'podman',
+    displayName: 'podman-chain',
+    endpoint: {
+      socketPath: 'http://localhost',
+    },
+    status: chainStatusMock,
+  } as unknown as podmanDesktopAPI.ContainerProviderConnection;
+
+  const chainProvider = { name: 'podman-chain', id: 'podman-chain' } as unknown as podmanDesktopAPI.Provider;
+  const chainDisposable = containerRegistry.registerContainerConnection(
+    chainProvider,
+    chainConnection,
+    providerRegistry,
+  );
+  const chainInternal = containerRegistry.getMatchingPodmanEngine('podman-chain.podman-chain');
+  expect(chainInternal.api).toBeDefined();
+
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  // the connection's status is now unknown, e.g. the podman machine was removed
+  chainStatusMock.mockReturnValue('unknown');
+
+  stream2.emit('error', new Error('boom'));
+  stream2.end();
+
+  // wait past the retry delay: the chain must terminate rather than keep
+  // firing a reconnect every 5s against a provider that is not coming back
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(chainInternal.api).toBeUndefined();
+  expect(chainInternal.reconnectTimer).toBeUndefined();
+
+  chainDisposable.dispose();
+});
+
+test('reconnectContainerProviders re-establishes a provider whose api is undefined', () => {
+  const setupConnectionAPISpy = vi.spyOn(containerRegistry, 'setupConnectionAPI').mockImplementation(() => {});
+
+  const connection = {
+    type: 'podman',
+    name: 'podman',
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    status: () => 'started',
+  } as unknown as podmanDesktopAPI.ContainerProviderConnection;
+
+  const provider: InternalContainerProvider = {
+    id: 'podman.podman',
+    name: 'podman',
+    connection,
+    api: undefined,
+  };
+
+  containerRegistry.addInternalProvider('podman.podman', provider);
+
+  containerRegistry.reconnectContainerProviders();
+
+  expect(setupConnectionAPISpy).toHaveBeenCalledWith(provider, connection);
 });
 
 test('check volume mounted is replicated when executing replicatePodmanContainer with named volume', async () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -110,6 +110,11 @@ export interface InternalContainerProvider {
   // api not there if status is stopped
   api?: Dockerode;
   libpodApi?: LibPod;
+  // the pending reconnect for this provider, or undefined when none is
+  // scheduled. Cleared at the top of setupConnectionAPI, before anything
+  // that can throw, so a throw never leaves this set forever (which would
+  // otherwise suppress every future reconnect for the provider).
+  reconnectTimer?: ReturnType<typeof setTimeout>;
 }
 
 interface JSONEvent {
@@ -266,11 +271,14 @@ export class ContainerProviderRegistry {
 
     api.getEvents((err, stream) => {
       if (err) {
+        // always notify the caller so a retry gets scheduled; `notify` only
+        // gates the console.log below so we do not repeat it on every
+        // subsequent failure until we successfully reconnect.
         if (this.notify) {
           console.log('error is', err);
-          errorCallback(new Error('Error in handling events', err));
           this.notify = false;
         }
+        errorCallback(new Error('Error in handling events', err));
       }
 
       stream?.on('error', error => {
@@ -323,9 +331,8 @@ export class ContainerProviderRegistry {
   }
 
   reconnectContainerProviders(): void {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const provider of this.internalProviders.values()) {
-      if (provider.api) this.setupConnectionAPI(provider, provider.connection);
+      this.setupConnectionAPI(provider, provider.connection);
     }
   }
 
@@ -333,14 +340,25 @@ export class ContainerProviderRegistry {
     internalProvider: InternalContainerProvider,
     containerProviderConnection: containerDesktopAPI.ContainerProviderConnection,
   ): void {
+    // clear any pending reconnect for this provider first, before anything
+    // below can throw (status() is extension-supplied). Otherwise a throw
+    // would leave the handle set forever and no future reconnect would ever
+    // be scheduled again for this provider (see InternalContainerProvider).
+    clearTimeout(internalProvider.reconnectTimer);
+    internalProvider.reconnectTimer = undefined;
+
+    const status = containerProviderConnection.status();
+
     // abort if connection is stopped
-    if (containerProviderConnection.status() === 'stopped') {
+    if (status === 'stopped') {
       console.log('Aborting reconnect due to error as connection is now stopped');
       return;
     }
 
-    // abort if connection has been removed
-    if (containerProviderConnection.status() === undefined) {
+    // proceed only if the connection is started or starting; abort for
+    // everything else, including a removed connection (undefined) and an
+    // 'unknown' status, which is what a removed podman machine reports.
+    if (status !== 'started' && status !== 'starting') {
       console.log('Aborting reconnect due to error as connection has been removed (probably machine has been removed)');
       return;
     }
@@ -357,10 +375,15 @@ export class ContainerProviderRegistry {
       internalProvider.api = undefined;
       internalProvider.libpodApi = undefined;
 
+      // at most one reconnect is pending per provider
+      if (internalProvider.reconnectTimer) {
+        return;
+      }
+
       // ok we had some errors so we need to reconnect the provider
       // delay the reconnection to avoid too many reconnections
       // retry in 5 seconds
-      setTimeout(() => {
+      internalProvider.reconnectTimer = setTimeout(() => {
         this.setupConnectionAPI(internalProvider, containerProviderConnection);
       }, this.retryDelayEvents);
     };
@@ -433,6 +456,8 @@ export class ContainerProviderRegistry {
 
     return Disposable.create(() => {
       clearInterval(timer);
+      clearTimeout(internalProvider.reconnectTimer);
+      internalProvider.reconnectTimer = undefined;
       onBeforeUpdateDisposable.dispose();
       this.internalProviders.delete(id);
       this.containerProviders.delete(id);


### PR DESCRIPTION
### What does this PR do?

Editing a Podman machine's CPU or memory left the Containers page frozen: status stopped updating, the log filled with `socket hang up`, and only restarting the app recovered it — while `podman ps` showed everything healthy the whole time.

`ContainerProviderRegistry.notify` is a singleton-wide one-way latch. It is cleared in the `getEvents` failure branch and set back to `true` only inside the `eventEmitter.on('event')` handler, so it could only reset once an event arrived over a working stream. After two consecutive subscription failures `errorCallback` was never reached again and no reconnect was ever scheduled. Because `setupConnectionAPI` assigns a fresh `Dockerode` *before* subscribing, `api` was left set with no stream — so the 2s status poll, which requires `!api`, could not recover it either.

Reproduced on 1.29.0 by editing a machine's memory: the stream aborted, two reconnects were scheduled, and nothing further happened. The machine came back 22 seconds after the last attempt and the UI stayed frozen indefinitely.

`notify` now gates only the console message it was meant for. `errorCallback` always fires, matching the ungated `stream.on('error')` path.

**Removing the latch removes the only thing that bounded a retry chain**, so this also adds what has to replace it — these are load-bearing, not scope creep:

- at most one reconnect pending per provider, tracked by `reconnectTimer`, cleared at the top of `setupConnectionAPI` before anything that can throw
- `setupConnectionAPI` proceeds only for `started`/`starting`. A removed Podman machine reports `unknown` (`podmanMachinesStatuses.get(name) ?? 'unknown'`), which passed both previous guards
- the connection `Disposable` clears a pending reconnect, so deleting a machine cannot leave a chain retrying forever

**This restores a guard rather than inventing one.** `1b0dd7e00bd` ("chore: suggestions", 2025-01-06) removed `activeTimeouts` — a per-connection single-flight reconnect guard — and added `notify` in the same commit. `b910fad262b` ("test: fixed tests", 2025-01-13, same author) then weakened the assertion in `setupConnectionAPI with errors` from `toHaveLength(1)` plus an id check down to `toHaveLength(0)`. That assertion contradicted its own surviving comments ("emit a container start event, we should proceed it as expected"). This PR flips it back to `1`. Without that history the change reads as papering over a failure, which is why it is spelled out here.

**Where to look**
The behavioural change is small and concentrated:

- `container-registry.ts:281` — `errorCallback` now called unconditionally; `notify` guards only the `console.log` above it. **This one line is the reported bug.**
- `container-registry.ts:347-348, 379-381, 386` — the single-flight reconnect guard.
- `container-registry.ts:361` — the `started`/`starting` allow-list.
- `container-registry.ts:459-460` — pending reconnect cleared on dispose.
- `container-registry.ts:333-337` — the inverted `if (provider.api)` guard removed from `reconnectContainerProviders`, which skipped exactly the providers that had lost their api. Independent of the rest; happy to drop it if you would rather see it separately.

The remaining ~270 lines are tests.

**Not in this PR**
The Playwright end-to-end test for this scenario is a separate PR, stacked on this one. It is kept apart because it is `tests/playwright` rather than `packages/main`, and because a user-facing freeze should not wait on review of a spec that no CI job in this repository executes.

Also deliberately excluded, having been investigated and ruled out as causes of this bug: event-stream disposal on re-subscribe, and any liveness/ping check on the connection. Both are real latent issues and are written up for a follow-up issue; neither causes the freeze reported here, and bundling them would have turned a ten-line fix into a subsystem redesign.

### Screenshot / video of UI

n/a — no UI change. The user-visible effect is that the Containers page keeps updating after a machine edit; there is nothing new to show, only something that stops going stale. Manual before/after evidence is described under *How to test*.

### What issues does this PR fix or reference?

Closes #18967

| R-ID | Requirement | Where | Test |
|------|-------------|-------|------|
| R1 | After editing CPU/RAM and clicking Update, the Containers page resumes reflecting real container state without restarting Podman Desktop | `packages/main/src/plugin/container-registry.ts:281` | verified manually, see *How to test*; end-to-end coverage in the stacked test PR |
| R2 | Starting and stopping containers from the UI after such an edit updates their status, matching `podman ps` | `packages/main/src/plugin/container-registry.ts:281` | verified manually, see *How to test*; end-to-end coverage in the stacked test PR |
| R3 | `socket hang up` errors from image and network listing stop once the machine is running again | `packages/main/src/plugin/container-registry.ts:281` | verified manually, see *How to test* |
| R4 | The engine API client and its event stream recover automatically after an edit-triggered restart | `packages/main/src/plugin/container-registry.ts:281` | `container-registry.spec.ts:4150` |
| R7 | Recovery does not depend on the timing coincidence of the extension's 5s status poll and the registry's 2s poll | `packages/main/src/plugin/container-registry.ts:281, :361` | `container-registry.spec.ts:4150` |
| R8 | Unit tests cover repeated event-subscription failures continuing to schedule reconnects | `packages/main/src/plugin/container-registry.spec.ts:4123` | `container-registry.spec.ts:4123` |
| R9 | `reconnectContainerProviders()` no longer skips providers that lost their api | `packages/main/src/plugin/container-registry.ts:333-337` | `container-registry.spec.ts:4364` |
| R11 | A failure to subscribe the event stream always schedules a reconnect; console-noise suppression never suppresses recovery | `packages/main/src/plugin/container-registry.ts:281` | `container-registry.spec.ts:4123` |

Note on the closing line: this PR closes the issue because it is what fixes the reported behaviour. The stacked test PR references the issue without closing it, so that dropping the test PR does not leave a fixed bug open.

### How to test this PR?

Reproducing the bug needs the released build; confirming the fix needs this branch. Both were done on macOS with an `applehv` machine. No Kind cluster is needed despite what the issue says — two plain containers are enough.

1. Start a machine and give it something to watch:
   `podman machine start podman-machine-default`
   `podman run -d --name probe-a docker.io/library/alpine:latest sleep 7200`
   `podman run -d --name probe-b docker.io/library/alpine:latest sleep 7200`
   → both containers show as `RUNNING` on the Containers page.

2. Launch the released 1.29.0 from a terminal so the main-process log is visible:
   `"/Applications/Podman Desktop.app/Contents/MacOS/Podman Desktop" 2>&1 | tee /tmp/pd.log`
   → the app starts and lists both containers.

3. In the app go to Settings → Resources → Edit on the machine, move the Memory slider, and click Update.
   → the machine stops and restarts, and all containers stop. That much is expected.

4. With the machine back up, start a container from outside the app:
   `podman start probe-a`
   → broken behaviour: the Containers page still shows `EXITED` while `podman ps` shows `running`, and it never recovers. Only restarting the app fixes it.

5. Read the log from step 2 to see why:
   `grep -c 'Will reconnect in 5s' /tmp/pd.log`
   `grep -c 'error is' /tmp/pd.log`
   `grep -c 'Aborting reconnect' /tmp/pd.log`
   → shows 2, 1 and 0. Two reconnects are scheduled and then nothing, although the machine only returned about twenty seconds later. `Aborting reconnect` at 0 rules out the chain having ended legitimately.

6. Build and run this branch, then repeat steps 3 to 5.
   → fixed behaviour: the Containers page reflects `podman start` and `podman stop` within a second or two. `Will reconnect in 5s` continues past the second attempt for as long as the machine is down, at roughly one attempt per 2s poll tick rather than a flood, and stops once it is back. No `socket hang up` appears after recovery.

7. Run the unit tests:
   `npx vitest run packages/main/src/plugin/container-registry.spec.ts`
   → passes. The interesting case is `check handleEvents calls errorCallback for every consecutive getEvents failure (no notify latch)`, which against `main` fails with `expected "vi.fn()" to be called 3 times, but got 1 times`.

8. Clean up, since editing through the UI really does change the machine configuration:
   `podman rm -f probe-a probe-b`
   `podman machine set --memory <original> podman-machine-default`
   → the machine is back to its original size.

**Notes for reviewers**
**Manually verified on macOS only** (`applehv`, podman 5.8.1). The reproduction and the fix were both driven through the real application there. Windows/WSL and Linux were not exercised by hand. The change itself is platform-independent — it is connection-lifecycle logic in `packages/main` with no platform branches — but CI does not exercise a machine restart on any platform, so the before/after evidence above is manual by necessity.

**The end-to-end test is not in this PR** and has never been executed. It is in the stacked test PR, where that is stated plainly. Nothing here rests on it.

**Not covered by a test:** the orphan-chain case that the `Disposable` cleanup guards — deleting a machine within 5s of its last stream error — is covered by a unit test but was not driven through the real application.

**On the issue's `area/podman-upstream` label:** the cause is in `packages/main`, not upstream Podman. `podman ps` stays healthy throughout the failure; only Podman Desktop's own client stops recovering. The label is worth changing.

- [x] Tests are covering the bug fix or the new feature

<sub>Prepared with podman-desktop-kit (Claude Code Plugin), reviewed by @vzhukovs</sub>
