### PR TITLE
test(e2e): cover container status recovery after editing machine resources

### DIFF
--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -3755,8 +3755,13 @@ test('setupConnectionAPI with errors', async () => {
   expect(allCalls).toBeDefined();
 
   // filter calls to find the one with container-started-event
+  //
+  // The reconnect chain keeps retrying through the intermediate failures until it
+  // reaches stream2, so the buffered event is delivered. This used to assert 0,
+  // because the chain stopped retrying and never got there.
   const containerStartedEventCalls = allCalls.filter(call => call[0] === 'container-started-event');
-  expect(containerStartedEventCalls).toHaveLength(0);
+  expect(containerStartedEventCalls).toHaveLength(1);
+  expect(containerStartedEventCalls[0]).toEqual(['container-started-event', fakeId]);
 
   stream2.end();
 
@@ -4113,6 +4118,273 @@ test('check handleEvents calls errorCallback and destroys pipeline on parse erro
   expect(errorCallback).toHaveBeenCalledWith(expect.objectContaining({ message: 'Error while parsing events' }));
 
   consoleErrorSpy.mockRestore();
+});
+
+test('check handleEvents calls errorCallback for every consecutive getEvents failure (no notify latch)', () => {
+  const getEventsMock = vi.fn();
+  let eventsMockCallback: ((err: Error | null, stream?: PassThrough) => void) | undefined;
+  // keep the function passed in parameter of getEventsMock
+  getEventsMock.mockImplementation((options: (err: Error | null, stream?: PassThrough) => void) => {
+    eventsMockCallback = options;
+  });
+
+  const fakeDockerode = {
+    getEvents: getEventsMock,
+  } as unknown as Dockerode;
+
+  const errorCallback = vi.fn();
+
+  containerRegistry.handleEvents(fakeDockerode, errorCallback);
+
+  expect(eventsMockCallback).toBeDefined();
+
+  // three consecutive failures to subscribe to the event stream must each
+  // reach errorCallback: nothing should latch after the first one.
+  eventsMockCallback?.(new Error('connection error 1'));
+  eventsMockCallback?.(new Error('connection error 2'));
+  eventsMockCallback?.(new Error('connection error 3'));
+
+  expect(errorCallback).toHaveBeenCalledTimes(3);
+});
+
+test('setupConnectionAPI reconnect chain via msw continues past the second attempt', async () => {
+  const stream1 = new PassThrough();
+  server = setupServer(
+    http.get('http://localhost/events', () => new HttpResponse(stream1 as unknown as ReadableStream)),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const internalContainerProvider: InternalContainerProvider = {
+    name: 'podman',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+      displayName: 'podman',
+      name: 'podman',
+      endpoint: {
+        socketPath: 'http://localhost',
+      },
+      status: () => 'started',
+    },
+  };
+
+  const providerConnectionInfo: podmanDesktopAPI.ContainerProviderConnection = {
+    name: 'podman',
+    displayName: 'podman',
+    type: 'podman',
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    status: () => 'started',
+  };
+
+  containerRegistry.setupConnectionAPI(internalContainerProvider, providerConnectionInfo);
+  containerRegistry.setRetryDelayEvents(200);
+
+  // wait for the first connection to be established
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internalContainerProvider.api).toBeDefined();
+
+  // first failure
+  stream1.emit('error', new Error('first error'));
+  stream1.end();
+  await vi.waitFor(() => expect(internalContainerProvider.api).toBeUndefined());
+
+  // mock the second attempt: this is the retry a latched notify would have
+  // swallowed (see 'setupConnectionAPI with errors')
+  const stream2 = new PassThrough();
+  server.use(http.get('http://localhost/events', () => new HttpResponse(stream2 as unknown as ReadableStream)));
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internalContainerProvider.api).toBeDefined();
+
+  // second failure
+  stream2.emit('error', new Error('second error'));
+  stream2.end();
+  await vi.waitFor(() => expect(internalContainerProvider.api).toBeUndefined());
+
+  // a third attempt must still happen: the chain has not latched
+  const stream3 = new PassThrough();
+  server.use(http.get('http://localhost/events', () => new HttpResponse(stream3 as unknown as ReadableStream)));
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internalContainerProvider.api).toBeDefined();
+
+  // terminate the chain: no further error is emitted on stream3, so no more
+  // reconnects get scheduled and this test does not leak a running chain.
+  stream3.end();
+});
+
+test('two errors close together schedule exactly one reconnect', () => {
+  vi.useFakeTimers();
+
+  try {
+    const providerConnectionInfo: podmanDesktopAPI.ContainerProviderConnection = {
+      name: 'podman',
+      displayName: 'podman',
+      type: 'podman',
+      endpoint: {
+        socketPath: '/endpoint1.sock',
+      },
+      status: () => 'started',
+    };
+
+    const internalContainerProvider: InternalContainerProvider = {
+      name: 'podman',
+      id: 'podman1',
+      connection: providerConnectionInfo,
+    };
+
+    // mock handleEvents itself so this test controls exactly when and how
+    // many times the connection reports an error, without depending on real
+    // network timing: it captures the errorHandler closure that
+    // setupConnectionAPI builds for each connection attempt.
+    let capturedErrorCallback: ((error: Error) => void) | undefined;
+    const handleEventsSpy = vi.spyOn(containerRegistry, 'handleEvents').mockImplementation((_api, errorCallback) => {
+      capturedErrorCallback = errorCallback;
+    });
+
+    containerRegistry.setupConnectionAPI(internalContainerProvider, providerConnectionInfo);
+    containerRegistry.setRetryDelayEvents(200);
+
+    expect(handleEventsSpy).toHaveBeenCalledTimes(1);
+    expect(capturedErrorCallback).toBeDefined();
+    handleEventsSpy.mockClear();
+
+    // two errors in close succession must schedule exactly one pending reconnect
+    capturedErrorCallback?.(new Error('first close error'));
+    capturedErrorCallback?.(new Error('second close error'));
+
+    expect(internalContainerProvider.api).toBeUndefined();
+    expect(internalContainerProvider.reconnectTimer).toBeDefined();
+
+    // let the single scheduled reconnect fire
+    vi.advanceTimersByTime(200);
+
+    // exactly one reconnect happened, not two
+    expect(handleEventsSpy).toHaveBeenCalledTimes(1);
+    expect(internalContainerProvider.api).toBeDefined();
+    expect(internalContainerProvider.reconnectTimer).toBeUndefined();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('disposing a connection cancels its pending reconnect, and a chain whose status went unknown stops', async () => {
+  const stream1 = new PassThrough();
+  server = setupServer(
+    http.get('http://localhost/events', () => new HttpResponse(stream1 as unknown as ReadableStream)),
+  );
+  server.listen({ onUnhandledRequest: 'error' });
+
+  const providerRegistry: ProviderRegistry = {
+    onBeforeDidUpdateContainerConnection: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  } as unknown as ProviderRegistry;
+
+  containerRegistry.setRetryDelayEvents(300);
+
+  // Part 1: disposing a connection cancels its pending reconnect
+  const statusMock = vi.fn().mockReturnValue('started');
+  const containerProviderConnection: podmanDesktopAPI.ContainerProviderConnection = {
+    name: 'podman',
+    type: 'podman',
+    displayName: 'podman',
+    endpoint: {
+      socketPath: 'http://localhost',
+    },
+    status: statusMock,
+  } as unknown as podmanDesktopAPI.ContainerProviderConnection;
+
+  const podmanProvider = { name: 'podman', id: 'podman' } as unknown as podmanDesktopAPI.Provider;
+
+  const disposable = containerRegistry.registerContainerConnection(
+    podmanProvider,
+    containerProviderConnection,
+    providerRegistry,
+  );
+  const internal = containerRegistry.getMatchingPodmanEngine('podman.podman');
+  expect(internal.api).toBeDefined();
+
+  // wait for the events stream to be attached
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  // an error schedules a pending reconnect
+  stream1.emit('error', new Error('boom'));
+  stream1.end();
+
+  await vi.waitFor(() => expect(internal.reconnectTimer).toBeDefined());
+
+  // dispose while the reconnect is pending
+  disposable.dispose();
+  expect(internal.reconnectTimer).toBeUndefined();
+
+  // wait past the retry delay: the disposed provider must not reconnect
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(internal.api).toBeUndefined();
+
+  // Part 2: a chain whose status went 'unknown' stops on its own
+  const stream2 = new PassThrough();
+  server.use(http.get('http://localhost/events', () => new HttpResponse(stream2 as unknown as ReadableStream)));
+
+  const chainStatusMock = vi.fn().mockReturnValue('started');
+  const chainConnection: podmanDesktopAPI.ContainerProviderConnection = {
+    name: 'podman-chain',
+    type: 'podman',
+    displayName: 'podman-chain',
+    endpoint: {
+      socketPath: 'http://localhost',
+    },
+    status: chainStatusMock,
+  } as unknown as podmanDesktopAPI.ContainerProviderConnection;
+
+  const chainProvider = { name: 'podman-chain', id: 'podman-chain' } as unknown as podmanDesktopAPI.Provider;
+  const chainDisposable = containerRegistry.registerContainerConnection(
+    chainProvider,
+    chainConnection,
+    providerRegistry,
+  );
+  const chainInternal = containerRegistry.getMatchingPodmanEngine('podman-chain.podman-chain');
+  expect(chainInternal.api).toBeDefined();
+
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  // the connection's status is now unknown, e.g. the podman machine was removed
+  chainStatusMock.mockReturnValue('unknown');
+
+  stream2.emit('error', new Error('boom'));
+  stream2.end();
+
+  // wait past the retry delay: the chain must terminate rather than keep
+  // firing a reconnect every 5s against a provider that is not coming back
+  await new Promise(resolve => setTimeout(resolve, 500));
+  expect(chainInternal.api).toBeUndefined();
+  expect(chainInternal.reconnectTimer).toBeUndefined();
+
+  chainDisposable.dispose();
+});
+
+test('reconnectContainerProviders re-establishes a provider whose api is undefined', () => {
+  const setupConnectionAPISpy = vi.spyOn(containerRegistry, 'setupConnectionAPI').mockImplementation(() => {});
+
+  const connection = {
+    type: 'podman',
+    name: 'podman',
+    endpoint: {
+      socketPath: '/endpoint1.sock',
+    },
+    status: () => 'started',
+  } as unknown as podmanDesktopAPI.ContainerProviderConnection;
+
+  const provider: InternalContainerProvider = {
+    id: 'podman.podman',
+    name: 'podman',
+    connection,
+    api: undefined,
+  };
+
+  containerRegistry.addInternalProvider('podman.podman', provider);
+
+  containerRegistry.reconnectContainerProviders();
+
+  expect(setupConnectionAPISpy).toHaveBeenCalledWith(provider, connection);
 });
 
 test('check volume mounted is replicated when executing replicatePodmanContainer with named volume', async () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -110,6 +110,11 @@ export interface InternalContainerProvider {
   // api not there if status is stopped
   api?: Dockerode;
   libpodApi?: LibPod;
+  // the pending reconnect for this provider, or undefined when none is
+  // scheduled. Cleared at the top of setupConnectionAPI, before anything
+  // that can throw, so a throw never leaves this set forever (which would
+  // otherwise suppress every future reconnect for the provider).
+  reconnectTimer?: ReturnType<typeof setTimeout>;
 }
 
 interface JSONEvent {
@@ -266,11 +271,14 @@ export class ContainerProviderRegistry {
 
     api.getEvents((err, stream) => {
       if (err) {
+        // always notify the caller so a retry gets scheduled; `notify` only
+        // gates the console.log below so we do not repeat it on every
+        // subsequent failure until we successfully reconnect.
         if (this.notify) {
           console.log('error is', err);
-          errorCallback(new Error('Error in handling events', err));
           this.notify = false;
         }
+        errorCallback(new Error('Error in handling events', err));
       }
 
       stream?.on('error', error => {
@@ -323,9 +331,8 @@ export class ContainerProviderRegistry {
   }
 
   reconnectContainerProviders(): void {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const provider of this.internalProviders.values()) {
-      if (provider.api) this.setupConnectionAPI(provider, provider.connection);
+      this.setupConnectionAPI(provider, provider.connection);
     }
   }
 
@@ -333,14 +340,25 @@ export class ContainerProviderRegistry {
     internalProvider: InternalContainerProvider,
     containerProviderConnection: containerDesktopAPI.ContainerProviderConnection,
   ): void {
+    // clear any pending reconnect for this provider first, before anything
+    // below can throw (status() is extension-supplied). Otherwise a throw
+    // would leave the handle set forever and no future reconnect would ever
+    // be scheduled again for this provider (see InternalContainerProvider).
+    clearTimeout(internalProvider.reconnectTimer);
+    internalProvider.reconnectTimer = undefined;
+
+    const status = containerProviderConnection.status();
+
     // abort if connection is stopped
-    if (containerProviderConnection.status() === 'stopped') {
+    if (status === 'stopped') {
       console.log('Aborting reconnect due to error as connection is now stopped');
       return;
     }
 
-    // abort if connection has been removed
-    if (containerProviderConnection.status() === undefined) {
+    // proceed only if the connection is started or starting; abort for
+    // everything else, including a removed connection (undefined) and an
+    // 'unknown' status, which is what a removed podman machine reports.
+    if (status !== 'started' && status !== 'starting') {
       console.log('Aborting reconnect due to error as connection has been removed (probably machine has been removed)');
       return;
     }
@@ -357,10 +375,15 @@ export class ContainerProviderRegistry {
       internalProvider.api = undefined;
       internalProvider.libpodApi = undefined;
 
+      // at most one reconnect is pending per provider
+      if (internalProvider.reconnectTimer) {
+        return;
+      }
+
       // ok we had some errors so we need to reconnect the provider
       // delay the reconnection to avoid too many reconnections
       // retry in 5 seconds
-      setTimeout(() => {
+      internalProvider.reconnectTimer = setTimeout(() => {
         this.setupConnectionAPI(internalProvider, containerProviderConnection);
       }, this.retryDelayEvents);
     };
@@ -433,6 +456,8 @@ export class ContainerProviderRegistry {
 
     return Disposable.create(() => {
       clearInterval(timer);
+      clearTimeout(internalProvider.reconnectTimer);
+      internalProvider.reconnectTimer = undefined;
       onBeforeUpdateDisposable.dispose();
       this.internalProviders.delete(id);
       this.containerProviders.delete(id);

--- a/tests/playwright/src/model/pages/podman-machine-details-page.ts
+++ b/tests/playwright/src/model/pages/podman-machine-details-page.ts
@@ -17,7 +17,9 @@
  ***********************************************************************/
 
 import type { Locator, Page } from '@playwright/test';
+import test, { expect as playExpect } from '@playwright/test';
 
+import { MachineCreationForm } from './forms/machine-creation-form';
 import { ResourcesPage } from './resources-page';
 
 export class PodmanMachineDetails extends ResourcesPage {
@@ -28,6 +30,8 @@ export class PodmanMachineDetails extends ResourcesPage {
   readonly podmanMachineRestartButton: Locator;
   readonly podmanMachineStopButton: Locator;
   readonly podmanMachineDeleteButton: Locator;
+  readonly podmanMachineUpdateButton: Locator;
+  readonly podmanMachineGoBackToResourcesButton: Locator;
 
   readonly tabs: Locator;
   readonly summaryTab: Locator;
@@ -49,6 +53,10 @@ export class PodmanMachineDetails extends ResourcesPage {
     this.podmanMachineRestartButton = this.podmanMachineConnectionActions.getByRole('button', { name: 'Restart' });
     this.podmanMachineStopButton = this.podmanMachineConnectionActions.getByRole('button', { name: 'Stop' });
     this.podmanMachineDeleteButton = this.podmanMachineConnectionActions.getByRole('button', { name: 'Delete' });
+    this.podmanMachineUpdateButton = page
+      .getByRole('form', { name: 'Properties Information' })
+      .getByRole('button', { name: 'Update' });
+    this.podmanMachineGoBackToResourcesButton = page.getByRole('button', { name: 'Go back to resources' });
 
     this.tabs = page.getByRole('region', { name: 'Tabs' });
     this.summaryTab = this.tabs.getByText('Summary');
@@ -57,5 +65,37 @@ export class PodmanMachineDetails extends ResourcesPage {
     this.tabContent = page.getByRole('region', { name: 'Tab Content' });
     this.terminalInput = this.tabContent.getByLabel('Terminal input');
     this.terminalContent = this.tabContent.locator('.xterm-rows');
+  }
+
+  // Edits the Memory slider on the machine edit form (reusing MachineCreationForm, whose
+  // submit button is named 'Create' and therefore cannot be used to submit an edit) and
+  // submits it, then waits for the update (including the machine stop/start cycle it
+  // triggers) to finish and navigates back to the Resources page.
+  async editMachineMemory(): Promise<void> {
+    return test.step('Edit Podman Machine memory', async () => {
+      const machineCreationForm = new MachineCreationForm(this.page);
+      await playExpect(machineCreationForm.podmanMachineMemory).toBeVisible({ timeout: 10_000 });
+
+      const currentValue = await machineCreationForm.podmanMachineMemory.inputValue();
+      const min = await machineCreationForm.podmanMachineMemory.getAttribute('min');
+      const max = await machineCreationForm.podmanMachineMemory.getAttribute('max');
+      const step = await machineCreationForm.podmanMachineMemory.getAttribute('step');
+
+      const current = Number(currentValue);
+      const stepValue = Number(step) || 500_000_000;
+      const maxValue = Number(max);
+      const minValue = Number(min);
+      const increasedValue = current + stepValue;
+      const newValue = increasedValue <= maxValue ? increasedValue : Math.max(minValue, current - stepValue);
+
+      await machineCreationForm.podmanMachineMemory.fill(newValue.toString());
+      await playExpect(machineCreationForm.podmanMachineMemory).toHaveValue(newValue.toString());
+
+      await playExpect(this.podmanMachineUpdateButton).toBeEnabled();
+      await this.podmanMachineUpdateButton.click();
+
+      await playExpect(this.podmanMachineGoBackToResourcesButton).toBeEnabled({ timeout: 180_000 });
+      await this.podmanMachineGoBackToResourcesButton.click();
+    });
   }
 }

--- a/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
+++ b/tests/playwright/src/specs/z-podman-machine-resources.spec.ts
@@ -19,26 +19,32 @@
 import type { Locator } from '@playwright/test';
 
 import { ResourceElementActions } from '/@/model/core/operations';
-import { ResourceElementState } from '/@/model/core/states';
+import { ContainerState, ResourceElementState } from '/@/model/core/states';
+import type { ContainerInteractiveParams } from '/@/model/core/types';
 import { PodmanMachinePrivileges, PodmanVirtualizationProviders } from '/@/model/core/types';
 import { CreateMachinePage } from '/@/model/pages/create-machine-page';
+import { PodmanMachineDetails } from '/@/model/pages/podman-machine-details-page';
 import { ResourceConnectionCardPage } from '/@/model/pages/resource-connection-card-page';
 import { ResourcesPage } from '/@/model/pages/resources-page';
 import { expect as playExpect, test } from '/@/utility/fixtures';
 import {
   createPodmanMachineFromCLI,
+  deleteContainer,
   deletePodmanMachine,
   handlePodmanConfirmationDialogs,
   resetPodmanMachinesFromCLI,
   verifyMachinePrivileges,
   verifyVirtualizationProvider,
 } from '/@/utility/operations';
-import { isCI, isLinux, isWindows } from '/@/utility/platform';
+import { isCI, isLinux, isMac, isWindows } from '/@/utility/platform';
 import { getDefaultVirtualizationProvider, getVirtualizationProvider } from '/@/utility/provider';
 import { waitForPodmanMachineStartup, waitUntil } from '/@/utility/wait';
 
 const DEFAULT_PODMAN_MACHINE_NAME = 'podman-machine-default';
 const RESOURCE_NAME = 'podman';
+const IMAGE_TO_PULL = 'ghcr.io/linuxcontainers/alpine';
+const IMAGE_TAG = 'latest';
+const CONTAINER_START_PARAMS: ContainerInteractiveParams = { attachTerminal: true, interactive: true };
 
 // Timeout constants
 const TIMEOUT_SHORT = 30_000;
@@ -206,6 +212,88 @@ for (const { PODMAN_MACHINE_NAME, MACHINE_VISIBLE_NAME, isRoot, userNet } of mac
             (await machineCard.resourceElementConnectionStatus.innerText()).includes(ResourceElementState.Running),
           { timeout: TIMEOUT_SHORT, sendError: true },
         );
+      });
+
+      test('container status recovers after editing machine resources', async ({ page, navigationBar }) => {
+        test.setTimeout(TIMEOUT_MACHINE_CREATION);
+        // Editing machine memory is only offered on macOS and Hyper-V: the property carries
+        // `when: podman.podmanMachineEditMemorySupported`, set from `isMac || isHyperVMachine`.
+        // On WSL the Edit form opens but never renders the Memory slider.
+        test.skip(
+          !isMac && getVirtualizationProvider() !== PodmanVirtualizationProviders.HyperV,
+          'Editing machine memory requires macOS or Hyper-V',
+        );
+
+        const containerName = `${PODMAN_MACHINE_NAME}-resource-edit`;
+
+        // The previous test only asserted the machine card reads Running; the container
+        // engine connection attaches asynchronously after that, and pulling before it is
+        // ready fails with "no running provider".
+        await waitForPodmanMachineStartup(page);
+
+        // Start a container so there is something running before the machine is edited.
+        // Pull and run are kept separate, with a wait for the image to register in
+        // between: pullImageAndRun clicks Run as soon as the pull reports done, and on a
+        // machine created seconds ago the Run form is not ready for it yet.
+        let images = await navigationBar.openImages();
+        const pullImagePage = await images.openPullImage();
+        images = await pullImagePage.pullImage(IMAGE_TO_PULL, IMAGE_TAG);
+        await playExpect
+          .poll(async () => await images.waitForImageExists(IMAGE_TO_PULL), { timeout: TIMEOUT_MEDIUM })
+          .toBeTruthy();
+
+        const imageDetails = await images.openImageDetails(IMAGE_TO_PULL);
+        const runImagePage = await imageDetails.openRunImage();
+        await runImagePage.startContainer(containerName, CONTAINER_START_PARAMS);
+
+        let containers = await navigationBar.openContainers();
+        await playExpect(containers.heading).toBeVisible({ timeout: TIMEOUT_SHORT });
+        await playExpect
+          .poll(async () => await containers.containerExists(containerName), { timeout: TIMEOUT_MEDIUM })
+          .toBeTruthy();
+
+        let containerDetails = await containers.openContainersDetails(containerName);
+        await playExpect
+          .poll(async () => await containerDetails.getState(), { timeout: TIMEOUT_SHORT })
+          .toContain(ContainerState.Running);
+
+        // Edit the machine's memory through Settings > Resources > Edit, which restarts the machine
+        const settingsBar = await navigationBar.openSettings();
+        await settingsBar.resourcesTab.click();
+
+        const machineCard = new ResourceConnectionCardPage(page, RESOURCE_NAME, PODMAN_MACHINE_NAME);
+        await playExpect(machineCard.resourceElement).toBeVisible({ timeout: TIMEOUT_SHORT });
+        await machineCard.performConnectionAction(ResourceElementActions.Edit);
+
+        const podmanMachineDetails = new PodmanMachineDetails(page, PODMAN_MACHINE_NAME);
+        await podmanMachineDetails.editMachineMemory();
+
+        // Wait for the machine to stop and restart
+        await waitUntil(
+          async () =>
+            (await machineCard.resourceElementConnectionStatus.innerText()).includes(ResourceElementState.Running),
+          { timeout: TIMEOUT_LONG, sendError: true },
+        );
+
+        // Start a container and check the Containers page reflects it
+        containers = await navigationBar.openContainers();
+        await playExpect(containers.heading).toBeVisible({ timeout: TIMEOUT_SHORT });
+        await containers.startContainer(containerName);
+
+        containerDetails = await containers.openContainersDetails(containerName);
+        await playExpect
+          .poll(async () => await containerDetails.getState(), { timeout: TIMEOUT_MEDIUM })
+          .toContain(ContainerState.Running);
+
+        // Leave the machine quiet: the next test in this serial block restarts it and
+        // allows TIMEOUT_SHORT to reach Off, which a running container does not fit into.
+        await deleteContainer(page, containerName);
+
+        // Leave the app where this test found it. The tests in this serial block do not
+        // navigate: they build a ResourceConnectionCardPage and act on it, so they only
+        // work while Settings > Resources is still open.
+        const resourcesBar = await navigationBar.openSettings();
+        await resourcesBar.resourcesTab.click();
       });
 
       test('Restart the machine', async ({ page }) => {


### PR DESCRIPTION
### What does this PR do?

Adds end-to-end coverage for the freeze fixed in the base PR of this stack: with a container running, edit the Podman machine's memory from Settings > Resources, wait for the machine to come back, then start a container and assert the Containers page reflects it.

No existing test edits a running machine's resources — `z-podman-machine-resources.spec.ts` covers create, start, restart, stop and delete only.

**Where to look**
- `podman-machine-details-page.ts` — an `Update` submit locator and an `editMachineMemory()` helper. The page object had locators and no methods before this.
- `z-podman-machine-resources.spec.ts` — the new test, inside the existing serial `@pdmachine` block after "Start the machine", so it runs once per machine type.

The edit form reuses the machine *creation* form, so the sliders come from `MachineCreationForm` unchanged. Only the submit button differs: that form's is named `Create`, the edit form renders `Update` — hence the separate locator here rather than a change to the shared form.

The new memory value is computed from the slider's own min/max/step, because the maximum depends on host memory.

**Not in this PR**
**This PR is stacked on #19001 and, until that merges, the diff below includes its commit.** GitHub requires a pull request's base to be a branch of the target repository, and both branches here live in a fork, so this cannot be opened against #19001's branch directly — `main` is the only base available. Once #19001 merges, this diff collapses to the two files this PR actually adds:

- `tests/playwright/src/model/pages/podman-machine-details-page.ts`
- `tests/playwright/src/specs/z-podman-machine-resources.spec.ts`

Everything under `packages/main/` that you see here belongs to #19001 and should be reviewed there, not in this PR.

The fix itself is therefore not in this PR — see `Closes` on #19001. This PR is coverage only and adds no product code of its own.

### Screenshot / video of UI

n/a — no UI change. This PR only adds a test and a page-object helper.

### What issues does this PR fix or reference?

Part of #18967

| R-ID | Requirement | Where | Test |
|------|-------------|-------|------|
| R10 | A Playwright e2e edits a machine's resources and asserts container status recovers afterwards | `tests/playwright/src/specs/z-podman-machine-resources.spec.ts` | the test added here |
| R1 | The Containers page resumes reflecting real container state after a machine edit | — | the test added here |
| R2 | Starting and stopping containers after such an edit updates their status | — | the test added here |

### How to test this PR?

This spec is skipped unless `TEST_PODMAN_MACHINE=true`, and the new test additionally requires macOS or Hyper-V (see Notes). On an AppleHV host also export `CONTAINERS_MACHINE_PROVIDER=applehv`, or the suite creates LibKrun machines regardless of `containers.conf`.

1. Build the application for e2e:
   `pnpm run test:e2e:build`
   → completes without error.

2. Confirm the new test is registered for every machine type:
   `npx playwright test tests/playwright/src/specs/z-podman-machine-resources.spec.ts --list --reporter=line | grep 'container status recovers'`
   → lists the test once per machine type.

3. Have a running `podman-machine-default` before starting, which the suite's `beforeAll` requires and then stops:
   `podman machine init podman-machine-default && podman machine start podman-machine-default`
   → the machine reaches Running and `podman ps` responds.

4. Run the spec:
   `TEST_PODMAN_MACHINE=true npx playwright test tests/playwright/src/specs/z-podman-machine-resources.spec.ts`
   → the new test passes alongside the existing ones.

5. Check the test actually exercises the regression rather than passing vacuously: revert the base commit of this stack and run step 4 again.
   → the new test should fail, because the Containers page no longer updates after the machine restart.

**Notes for reviewers**
**Stability.** Three consecutive green runs of this spec were recorded before opening this PR (`pdkit e2e stability`, macOS / AppleHV, both machine types). Getting there took four fixes to this test, all of the same shape — it did not wait for what it was about to use, and did not leave the world as it found it:

- it pulled an image before the container engine connection had attached (`no running provider for the matching container`); `Start the machine` only asserts the machine card reads Running, and the engine attaches after that
- it clicked Run as soon as the pull reported done, before the Run form had rendered its Basic tab; it now polls `waitForImageExists` first, the idiom `container-smoke.spec.ts` already uses
- it left a running container behind, which does not fit inside the `TIMEOUT_SHORT` that `Restart the machine` allows for the machine to reach Off
- it ended on the Containers page. The tests in this serial block do not navigate — they construct a `ResourceConnectionCardPage` and act on it — so the next test could not find the machine card at all

None of these were visible by reading; each surfaced only in a run.

**Platform-gated.** Editing machine memory carries `when: podman.podmanMachineEditMemorySupported`, set from `isMac || isHyperVMachine`. On WSL the Edit form opens but never renders the Memory slider, so the test skips there. The `.skip` in the diff is that guard, not a leftover.

**Skipped in this repository's CI.** The three jobs that set `TEST_PODMAN_MACHINE=true` are `ubuntu-24.04`, and the spec skips Linux. So this test does not run on any pull request here; it is for maintainers running the suite locally on macOS or Hyper-V.

**On running this suite locally: it is destructive.** `tests/playwright/src/utility/operations.ts:570` runs `podman machine reset -f` on failure, which removes every machine and resets podman's configuration, and the machine-creation form defaults to the name `podman-machine-default`. It cost a working four-month-old machine while validating this test. Pre-existing behaviour, not introduced here, but worth stating and worth fixing separately.

Also found while validating and not changed here: `tests/playwright/src/utility/provider.ts` hardcodes LibKrun as the macOS default rather than reading `containers.conf`, so the suite cannot run on an AppleHV host unless `CONTAINERS_MACHINE_PROVIDER` is set.

- [ ] Tests are covering the bug fix or the new feature

<sub>Prepared with podman-desktop-kit (Claude Code Plugin), reviewed by @vzhukovs</sub>
