### PR TITLE
fix(ui): use TTY label for container tab

### DIFF
--- a/packages/renderer/src/lib/container/ContainerDetails.spec.ts
+++ b/packages/renderer/src/lib/container/ContainerDetails.spec.ts
@@ -249,7 +249,7 @@ test('Expect Terminal tab to be hidden for infra containers', async () => {
     expect(screen.getByText('Logs')).toBeInTheDocument();
     expect(screen.getByText('Inspect')).toBeInTheDocument();
     expect(screen.queryByText('Terminal')).not.toBeInTheDocument();
-    expect(screen.queryByText('Tty')).not.toBeInTheDocument();
+    expect(screen.queryByText('TTY')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/renderer/src/lib/container/ContainerDetails.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetails.svelte
@@ -108,7 +108,7 @@ function copyOf(cont: ContainerInfoUI | undefined): ContainerInfoUI | undefined 
           selected={isTabSelected($router.path, 'terminal')}
           url={getTabUrl($router.path, 'terminal')} />
         {#if displayTty}
-          <Tab title="Tty" selected={isTabSelected($router.path, 'tty')} url={getTabUrl($router.path, 'tty')} />
+          <Tab title="TTY" selected={isTabSelected($router.path, 'tty')} url={getTabUrl($router.path, 'tty')} />
         {/if}
       {/if}
     {/snippet}
@@ -129,7 +129,7 @@ function copyOf(cont: ContainerInfoUI | undefined): ContainerInfoUI | undefined 
         <Route path="/terminal" breadcrumb="Terminal" navigationHint="tab">
           <ContainerDetailsTerminal container={container} />
         </Route>
-        <Route path="/tty" breadcrumb="Tty" navigationHint="tab">
+        <Route path="/tty" breadcrumb="TTY" navigationHint="tab">
           <ContainerDetailsTtyTerminal container={container} />
         </Route>
       {/if}

--- a/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
+++ b/packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte
@@ -92,7 +92,7 @@ onMount(async () => {
   hidden={!closed && container.state !== 'RUNNING'}
   icon={NoLogIcon}
   title="No TTY"
-  message="Tty has stopped" />
+  message="TTY has stopped" />
 
 <EmptyScreen
   hidden={container.state === 'RUNNING'}

--- a/tests/playwright/src/model/pages/container-details-page.ts
+++ b/tests/playwright/src/model/pages/container-details-page.ts
@@ -48,7 +48,7 @@ export class ContainerDetailsPage extends DetailsPage {
   static readonly KUBE_TAB = 'Kube';
   static readonly TERMINAL_TAB = 'Terminal';
   static readonly INSPECT_TAB = 'Inspect';
-  static readonly Tty_TAB = 'Tty';
+  static readonly TTY_TAB = 'TTY';
 
   constructor(page: Page, name: string) {
     super(page, name);
@@ -135,7 +135,7 @@ export class ContainerDetailsPage extends DetailsPage {
 
   async executeCommandInTty(command: string): Promise<void> {
     return test.step('Execute command in TTY terminal', async () => {
-      await this.activateTab(ContainerDetailsPage.Tty_TAB);
+      await this.activateTab(ContainerDetailsPage.TTY_TAB);
 
       await this.terminalInput.pressSequentially(command, { delay: 10 });
       await this.terminalInput.press('Enter');


### PR DESCRIPTION
## What does this PR do?

Renders the container details tab, its route breadcrumb, and its empty-state
message as `TTY` (the correct casing for the acronym) instead of `Tty`.

Two prior attempts at this exact fix (#16224, #16229) stalled/closed. The
second one hit a real e2e failure:

```
Error: Tab Tty does not exist currently, maybe entry was deleted!
```

`tests/playwright/src/model/pages/container-details-page.ts` has a page-object
constant (`Tty_TAB`) that asserts the tab's accessible name by **exact** text
match (`getByRole('link', { name: tabName, exact: true })`). Renaming the
label without updating this constant breaks the e2e suite. This PR updates
both together:

- `packages/renderer/src/lib/container/ContainerDetails.svelte`: `Tab title`
  and `Route breadcrumb` for the tty tab
- `packages/renderer/src/lib/container/ContainerDetailsTtyTerminal.svelte`:
  the "has stopped" empty-state message (the sibling `title="No TTY"` on the
  same component was already using the correct casing, just the message
  wasn't)
- `tests/playwright/src/model/pages/container-details-page.ts`: renamed the
  constant to `TTY_TAB` (matching the existing `SUMMARY_TAB`/`LOGS_TAB`/etc.
  naming convention — the old `Tty_TAB` was inconsistently cased even before
  this fix) and updated its 2 use sites

The route path itself (`/tty`) and the `aria-controls`/`id` DOM attributes
(derived from `title.toLowerCase()`) are unaffected by the casing change.

## Screenshot / video of UI change

Not applicable — this is a plain-text label change verified by the existing
component tests and the Playwright page-object constant that asserts the
label by exact text match, not a screenshot-provable layout/visual change.

## What issues does this PR fix or reference

Fixes #15663

## How to test this PR?

- `packages/renderer/src/lib/container/ContainerDetails.spec.ts` and
  `ContainerDetailsTtyTerminal.spec.ts`: 4/4 passing
- `node --max-old-space-size=8192 node_modules/eslint/bin/eslint.js` on the 3
  changed files: clean
- `pnpm run typecheck:renderer`: identical baseline to `main` (1 pre-existing,
  unrelated error in `CommandPalette.svelte`, confirmed present on `main`
  before this change) — no new errors introduced
- `grep`-swept the whole repo for any remaining `Tty` label/constant
  reference: none left