### PR TITLE
fix: detect registry credentials created after startup

### DIFF
--- a/extensions/podman/packages/extension/src/extension.ts
+++ b/extensions/podman/packages/extension/src/extension.ts
@@ -1841,7 +1841,7 @@ export async function start(
 
   // register the registries
   const registrySetup = new RegistrySetup(podmanConfiguration.registryConfiguration);
-  await registrySetup.setup();
+  extensionContext.subscriptions.push(await registrySetup.setup());
 
   await calcPodmanMachineSetting();
 }

--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -226,6 +226,59 @@ test('should clean up the watcher and registry subscriptions when initial setup 
   }
 });
 
+test('should unregister registries added before initial setup fails', async () => {
+  const authJsonLocation = '/containers/auth.json';
+  vi.spyOn(registrySetup, 'getAuthFileLocation').mockReturnValue(authJsonLocation);
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(readFile).mockResolvedValue(
+    JSON.stringify({
+      auths: {
+        'first.io': { auth: Buffer.from('user:password').toString('base64') },
+        'second.io': { auth: Buffer.from('user:password').toString('base64') },
+      },
+    }),
+  );
+  const setupError = new Error('Failed to register second registry');
+  vi.mocked(extensionApi.registry.registerRegistry).mockImplementation(registry => {
+    if (registry.serverUrl === 'second.io') {
+      throw setupError;
+    }
+    return extensionApi.Disposable.create(() => undefined);
+  });
+
+  await expect(registrySetup.setup()).rejects.toThrow(setupError);
+
+  expect(extensionApi.registry.unregisterRegistry).toHaveBeenCalledOnce();
+  expect(extensionApi.registry.unregisterRegistry).toHaveBeenCalledWith(
+    expect.objectContaining({ serverUrl: 'first.io' }),
+  );
+});
+
+test('should retain and retry a registry when auth-file removal fails', async () => {
+  const authJsonLocation = '/containers/auth.json';
+  vi.spyOn(registrySetup, 'getAuthFileLocation').mockReturnValue(authJsonLocation);
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(readFile).mockResolvedValueOnce(
+    JSON.stringify({ auths: { 'first.io': { auth: Buffer.from('user:password').toString('base64') } } }),
+  );
+  await registrySetup.updateRegistries();
+
+  const unregisterError = new Error('Failed to unregister registry');
+  vi.mocked(extensionApi.registry.unregisterRegistry).mockImplementationOnce(() => {
+    throw unregisterError;
+  });
+  vi.mocked(readFile).mockResolvedValue(JSON.stringify({ auths: {} }));
+
+  await expect(registrySetup.updateRegistries()).resolves.toBeUndefined();
+  expect(consoleErroMock).toHaveBeenCalledWith('Error unregistering registry', 'first.io', unregisterError);
+
+  await registrySetup.updateRegistries();
+  expect(extensionApi.registry.unregisterRegistry).toHaveBeenCalledTimes(2);
+  expect(extensionApi.registry.unregisterRegistry).toHaveBeenLastCalledWith(
+    expect.objectContaining({ serverUrl: 'first.io' }),
+  );
+});
+
 test('should unregister registries when auth file is deleted and reload them when it is recreated', async () => {
   const authJsonLocation = '/containers/auth.json';
   vi.spyOn(registrySetup, 'getAuthFileLocation').mockReturnValue(authJsonLocation);

--- a/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.spec.ts
@@ -20,7 +20,7 @@ import * as fs from 'node:fs';
 import { chmod, readFile, writeFile } from 'node:fs/promises';
 
 import * as extensionApi from '@podman-desktop/api';
-import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import type { RegistryConfiguration, RegistryConfigurationFile } from '/@/configuration/registry-configuration';
 
@@ -55,6 +55,8 @@ export class TestRegistrySetup extends RegistrySetup {
 }
 
 let registrySetup: TestRegistrySetup;
+let registryProviderDisposable: extensionApi.Disposable;
+let registryEventDisposables: extensionApi.Disposable[];
 
 // mock the fs module
 vi.mock(import('node:fs'));
@@ -72,12 +74,16 @@ const mockRegistryConfiguration: RegistryConfiguration = {
   saveRegistriesConfContent: vi.fn(),
 };
 
-beforeAll(() => {
-  registrySetup = new TestRegistrySetup(mockRegistryConfiguration);
-});
-
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(extensionApi.Disposable.create).mockImplementation(dispose => ({ dispose }) as extensionApi.Disposable);
+  registryProviderDisposable = { dispose: vi.fn() };
+  registryEventDisposables = [{ dispose: vi.fn() }, { dispose: vi.fn() }, { dispose: vi.fn() }];
+  vi.mocked(extensionApi.registry.registerRegistryProvider).mockReturnValue(registryProviderDisposable);
+  vi.mocked(extensionApi.registry.onDidRegisterRegistry).mockReturnValue(registryEventDisposables[0]);
+  vi.mocked(extensionApi.registry.onDidUnregisterRegistry).mockReturnValue(registryEventDisposables[1]);
+  vi.mocked(extensionApi.registry.onDidUpdateRegistry).mockReturnValue(registryEventDisposables[2]);
+  registrySetup = new TestRegistrySetup(mockRegistryConfiguration);
   console.error = consoleErroMock;
   console.warn = consoleWarnMock;
 });
@@ -85,6 +91,202 @@ beforeEach(() => {
 afterEach(() => {
   console.error = originalConsoleError;
   console.warn = originalConsoleWarn;
+});
+
+test('should watch auth file when it does not exist at startup', async () => {
+  const authJsonLocation = '/containers/auth.json';
+  vi.spyOn(registrySetup, 'getAuthFileLocation').mockReturnValue(authJsonLocation);
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+  vi.mocked(readFile).mockResolvedValue(
+    JSON.stringify({ auths: { 'myregistry.io': { auth: Buffer.from('user:password').toString('base64') } } }),
+  );
+  let authFileListener: fs.StatsListener | undefined;
+  vi.mocked(fs.watchFile).mockImplementation((_path, listener) => {
+    authFileListener = listener;
+    return {} as fs.StatWatcher;
+  });
+
+  const disposable = await registrySetup.setup();
+
+  expect(fs.watchFile).toHaveBeenCalledWith(authJsonLocation, expect.any(Function));
+  expect(readFile).not.toHaveBeenCalled();
+
+  expect(authFileListener).toBeDefined();
+  authFileListener?.({ nlink: 0 } as fs.Stats, {} as fs.Stats);
+  expect(readFile).not.toHaveBeenCalled();
+  expect(extensionApi.registry.unregisterRegistry).not.toHaveBeenCalled();
+
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  authFileListener?.({ nlink: 1 } as fs.Stats, {} as fs.Stats);
+
+  await vi.waitFor(() => expect(extensionApi.registry.registerRegistry).toHaveBeenCalledTimes(1));
+
+  disposable.dispose();
+  expect(fs.unwatchFile).toHaveBeenCalledWith(authJsonLocation, authFileListener);
+});
+
+test('should ignore a stale auth file read when the file is deleted during creation handling', async () => {
+  const authJsonLocation = '/containers/auth.json';
+  vi.spyOn(registrySetup, 'getAuthFileLocation').mockReturnValue(authJsonLocation);
+  let authFileExists = false;
+  vi.mocked(fs.existsSync).mockImplementation(() => authFileExists);
+  let authFileListener: fs.StatsListener | undefined;
+  vi.mocked(fs.watchFile).mockImplementation((_path, listener) => {
+    authFileListener = listener;
+    return {} as fs.StatWatcher;
+  });
+  let resolveReadFile: ((value: string) => void) | undefined;
+  vi.mocked(readFile).mockReturnValue(
+    new Promise(resolve => {
+      resolveReadFile = resolve;
+    }),
+  );
+
+  await registrySetup.setup();
+
+  authFileExists = true;
+  authFileListener?.({ nlink: 1 } as fs.Stats, {} as fs.Stats);
+  await vi.waitFor(() => expect(readFile).toHaveBeenCalledOnce());
+
+  authFileExists = false;
+  authFileListener?.({ nlink: 0 } as fs.Stats, {} as fs.Stats);
+  resolveReadFile?.(
+    JSON.stringify({ auths: { 'stale.io': { auth: Buffer.from('user:password').toString('base64') } } }),
+  );
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  expect(extensionApi.registry.registerRegistry).not.toHaveBeenCalled();
+});
+
+test('should dispose registry subscriptions and ignore events after disposal', async () => {
+  const authJsonLocation = '/containers/auth.json';
+  vi.spyOn(registrySetup, 'getAuthFileLocation').mockReturnValue(authJsonLocation);
+  vi.mocked(fs.existsSync).mockReturnValue(false);
+  let onRegisterRegistry: ((registry: extensionApi.Registry) => unknown) | undefined;
+  let onUnregisterRegistry: ((registry: extensionApi.Registry) => unknown) | undefined;
+  let onUpdateRegistry: ((registry: extensionApi.Registry) => unknown) | undefined;
+  vi.mocked(extensionApi.registry.onDidRegisterRegistry).mockImplementation(callback => {
+    onRegisterRegistry = callback;
+    return registryEventDisposables[0];
+  });
+  vi.mocked(extensionApi.registry.onDidUnregisterRegistry).mockImplementation(callback => {
+    onUnregisterRegistry = callback;
+    return registryEventDisposables[1];
+  });
+  vi.mocked(extensionApi.registry.onDidUpdateRegistry).mockImplementation(callback => {
+    onUpdateRegistry = callback;
+    return registryEventDisposables[2];
+  });
+
+  const disposable = await registrySetup.setup();
+  disposable.dispose();
+
+  expect(registryProviderDisposable.dispose).toHaveBeenCalledOnce();
+  for (const eventDisposable of registryEventDisposables) {
+    expect(eventDisposable.dispose).toHaveBeenCalledOnce();
+  }
+  expect(fs.unwatchFile).toHaveBeenCalledWith(authJsonLocation, expect.any(Function));
+
+  const registry: extensionApi.Registry = {
+    source: 'external',
+    serverUrl: 'example.io',
+    username: 'user',
+    secret: 'password',
+  };
+  await Promise.all([onRegisterRegistry?.(registry), onUnregisterRegistry?.(registry), onUpdateRegistry?.(registry)]);
+
+  expect(readFile).not.toHaveBeenCalled();
+  expect(writeFile).not.toHaveBeenCalled();
+  expect(mockRegistryConfiguration.saveRegistriesConfContent).not.toHaveBeenCalled();
+});
+
+test('should clean up the watcher and registry subscriptions when initial setup fails', async () => {
+  const authJsonLocation = '/containers/auth.json';
+  vi.spyOn(registrySetup, 'getAuthFileLocation').mockReturnValue(authJsonLocation);
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(readFile).mockResolvedValue(
+    JSON.stringify({ auths: { 'myregistry.io': { auth: Buffer.from('user:password').toString('base64') } } }),
+  );
+  const setupError = new Error('Failed to register registry');
+  vi.mocked(extensionApi.registry.registerRegistry).mockImplementation(() => {
+    throw setupError;
+  });
+  let authFileListener: fs.StatsListener | undefined;
+  vi.mocked(fs.watchFile).mockImplementation((_path, listener) => {
+    authFileListener = listener;
+    return {} as fs.StatWatcher;
+  });
+
+  await expect(registrySetup.setup()).rejects.toThrow(setupError);
+
+  expect(fs.unwatchFile).toHaveBeenCalledWith(authJsonLocation, authFileListener);
+  expect(registryProviderDisposable.dispose).toHaveBeenCalledOnce();
+  for (const eventDisposable of registryEventDisposables) {
+    expect(eventDisposable.dispose).toHaveBeenCalledOnce();
+  }
+});
+
+test('should unregister registries when auth file is deleted and reload them when it is recreated', async () => {
+  const authJsonLocation = '/containers/auth.json';
+  vi.spyOn(registrySetup, 'getAuthFileLocation').mockReturnValue(authJsonLocation);
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(readFile).mockResolvedValue(
+    JSON.stringify({ auths: { 'first.io': { auth: Buffer.from('user:password').toString('base64') } } }),
+  );
+  let authFileListener: fs.StatsListener | undefined;
+  vi.mocked(fs.watchFile).mockImplementation((_path, listener) => {
+    authFileListener = listener;
+    return {} as fs.StatWatcher;
+  });
+
+  await registrySetup.setup();
+  expect(extensionApi.registry.registerRegistry).toHaveBeenCalledWith(
+    expect.objectContaining({ serverUrl: 'first.io' }),
+  );
+
+  authFileListener?.({ nlink: 0 } as fs.Stats, {} as fs.Stats);
+  expect(extensionApi.registry.unregisterRegistry).toHaveBeenCalledWith(
+    expect.objectContaining({ serverUrl: 'first.io' }),
+  );
+
+  vi.mocked(readFile).mockResolvedValue(
+    JSON.stringify({
+      auths: {
+        'second.io': { auth: Buffer.from('user:password').toString('base64') },
+        'third.io': { auth: Buffer.from('user:password').toString('base64') },
+      },
+    }),
+  );
+  authFileListener?.({ nlink: 1 } as fs.Stats, {} as fs.Stats);
+
+  await vi.waitFor(() => expect(extensionApi.registry.registerRegistry).toHaveBeenCalledTimes(3));
+
+  const unregisterError = new Error('Failed to unregister registry');
+  vi.mocked(extensionApi.registry.unregisterRegistry).mockImplementation(registry => {
+    if (registry.serverUrl === 'second.io') {
+      throw unregisterError;
+    }
+  });
+  expect(() => authFileListener?.({ nlink: 0 } as fs.Stats, {} as fs.Stats)).not.toThrow();
+  expect(extensionApi.registry.unregisterRegistry).toHaveBeenCalledWith(
+    expect.objectContaining({ serverUrl: 'second.io' }),
+  );
+  expect(extensionApi.registry.unregisterRegistry).toHaveBeenCalledWith(
+    expect.objectContaining({ serverUrl: 'third.io' }),
+  );
+  expect(consoleErroMock).toHaveBeenCalledWith('Error unregistering registry', 'second.io', unregisterError);
+
+  vi.mocked(extensionApi.registry.unregisterRegistry).mockReturnValue(undefined);
+  vi.mocked(readFile).mockResolvedValue(JSON.stringify({ auths: {} }));
+  authFileListener?.({ nlink: 1 } as fs.Stats, {} as fs.Stats);
+
+  await vi.waitFor(() => {
+    const unregisterAttempts = vi.mocked(extensionApi.registry.unregisterRegistry).mock.calls;
+    const secondRegistryAttempts = unregisterAttempts.filter(([registry]) => registry.serverUrl === 'second.io');
+    const thirdRegistryAttempts = unregisterAttempts.filter(([registry]) => registry.serverUrl === 'third.io');
+    expect(secondRegistryAttempts).toHaveLength(2);
+    expect(thirdRegistryAttempts).toHaveLength(1);
+  });
 });
 
 test('should work with invalid JSON auth file', async () => {

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -61,6 +61,23 @@ export class RegistrySetup {
   protected async updateRegistries(): Promise<void> {
     // read the file
     const authFile = await this.readAuthFile();
+    this.updateRegistriesFromAuthFile(authFile);
+  }
+
+  private async updateRegistriesIfCurrent(isCurrent: () => boolean): Promise<void> {
+    if (!isCurrent()) {
+      return;
+    }
+
+    const authFile = await this.readAuthFile();
+    if (!isCurrent()) {
+      return;
+    }
+
+    this.updateRegistriesFromAuthFile(authFile);
+  }
+
+  private updateRegistriesFromAuthFile(authFile: ContainersAuthConfigFile): void {
     const inFileRegistries: extensionApi.Registry[] = [];
     const source = 'podman';
     if (authFile.auths) {
@@ -106,103 +123,207 @@ export class RegistrySetup {
     });
   }
 
-  public async setup(): Promise<void> {
-    extensionApi.registry.registerRegistryProvider({
-      name: 'podman',
-      create: function (registryCreateOptions: extensionApi.RegistryCreateOptions): extensionApi.Registry {
-        const registry: extensionApi.Registry = {
-          source: '',
-          ...registryCreateOptions,
-        };
-        return registry;
-      },
-    });
-    // handle addition of the registry in the file
-    extensionApi.registry.onDidRegisterRegistry(async registry => {
-      // external change, update the local registries
-      if (!this.localRegistries.has(registry.serverUrl)) {
-        let encode = true;
+  private unregisterLocalRegistries(): void {
+    for (const registry of Array.from(this.localRegistries.values())) {
+      this.localRegistries.delete(registry.serverUrl);
+      try {
+        extensionApi.registry.unregisterRegistry(registry);
+      } catch (error: unknown) {
         this.localRegistries.set(registry.serverUrl, registry);
-        // read the file
-        const authFile = await this.readAuthFile();
-        authFile.auths ??= {};
+        console.error('Error unregistering registry', registry.serverUrl, error);
+      }
+    }
+  }
 
-        // if the registry already exists in the file, check if it has the same value as the registered registry
-        if (authFile.auths[registry.serverUrl]) {
-          const decoded = Buffer.from(authFile.auths[registry.serverUrl].auth, 'base64').toString();
+  public async setup(): Promise<extensionApi.Disposable> {
+    let disposed = false;
+    let authFileGeneration = 0;
+    let authFileLocation: string | undefined;
+    let authFileListener: fs.StatsListener | undefined;
+    const subscriptions: extensionApi.Disposable[] = [];
+    const dispose = (): void => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      authFileGeneration++;
+      if (authFileLocation && authFileListener) {
+        fs.unwatchFile(authFileLocation, authFileListener);
+      }
+      for (const subscription of subscriptions) {
+        try {
+          subscription.dispose();
+        } catch (error: unknown) {
+          console.error('Error disposing registry setup subscription', error);
+        }
+      }
+    };
 
-          // split the decoded string into username and password separated by :
-          const [username, secret] = decoded.split(':');
+    try {
+      subscriptions.push(
+        extensionApi.registry.registerRegistryProvider({
+          name: 'podman',
+          create: function (registryCreateOptions: extensionApi.RegistryCreateOptions): extensionApi.Registry {
+            const registry: extensionApi.Registry = {
+              source: '',
+              ...registryCreateOptions,
+            };
+            return registry;
+          },
+        }),
+      );
+      // handle addition of the registry in the file
+      subscriptions.push(
+        extensionApi.registry.onDidRegisterRegistry(async registry => {
+          if (disposed) {
+            return;
+          }
+          // external change, update the local registries
+          if (!this.localRegistries.has(registry.serverUrl)) {
+            let encode = true;
+            this.localRegistries.set(registry.serverUrl, registry);
+            // read the file
+            const authFile = await this.readAuthFile();
+            if (disposed) {
+              return;
+            }
+            authFile.auths ??= {};
 
-          // only encode if values have changed from what's stored in the auth file
-          encode = !(username === registry.username && secret === registry.secret);
+            // if the registry already exists in the file, check if it has the same value as the registered registry
+            if (authFile.auths[registry.serverUrl]) {
+              const decoded = Buffer.from(authFile.auths[registry.serverUrl].auth, 'base64').toString();
+
+              // split the decoded string into username and password separated by :
+              const [username, secret] = decoded.split(':');
+
+              // only encode if values have changed from what's stored in the auth file
+              encode = !(username === registry.username && secret === registry.secret);
+            }
+
+            if (encode) {
+              authFile.auths[registry.serverUrl] = {
+                auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
+                podmanDesktopAlias: registry.alias,
+              };
+
+              await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
+              if (disposed) {
+                return;
+              }
+            }
+
+            // Update registries.conf with the registry configuration
+            await this.updateRegistriesConf(registry, true);
+          }
+        }),
+      );
+
+      // handle removal of the registry in the file
+      subscriptions.push(
+        extensionApi.registry.onDidUnregisterRegistry(async registry => {
+          if (disposed) {
+            return;
+          }
+          // external change, update the local registries
+          if (this.localRegistries.has(registry.serverUrl)) {
+            this.localRegistries.delete(registry.serverUrl);
+            // update the file
+            const authFile = await this.readAuthFile();
+            if (disposed) {
+              return;
+            }
+            if (authFile.auths) {
+              delete authFile.auths[registry.serverUrl];
+            }
+            await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
+            if (disposed) {
+              return;
+            }
+
+            // Remove from registries.conf
+            await this.removeFromRegistriesConf(registry);
+          }
+        }),
+      );
+
+      // handle update of the registry in the file
+      subscriptions.push(
+        extensionApi.registry.onDidUpdateRegistry(async registry => {
+          if (disposed) {
+            return;
+          }
+          // external change, update the local registries
+          if (this.localRegistries.has(registry.serverUrl)) {
+            this.localRegistries.set(registry.serverUrl, registry);
+            // update the file
+            const authFile = await this.readAuthFile();
+            if (disposed) {
+              return;
+            }
+            authFile.auths ??= {};
+            authFile.auths[registry.serverUrl] = {
+              auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
+              podmanDesktopAlias: registry.alias,
+            };
+
+            await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
+            if (disposed) {
+              return;
+            }
+
+            // Update registries.conf with the updated registry configuration
+            await this.updateRegistriesConf(registry, false);
+          }
+        }),
+      );
+
+      authFileLocation = this.getAuthFileLocation();
+      let authFileExists = fs.existsSync(authFileLocation);
+      authFileListener = (current): void => {
+        if (disposed) {
+          return;
+        }
+        if (current.nlink === 0) {
+          authFileGeneration++;
+          if (authFileExists) {
+            this.unregisterLocalRegistries();
+          }
+          authFileExists = false;
+          return;
         }
 
-        if (encode) {
-          authFile.auths[registry.serverUrl] = {
-            auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
-            podmanDesktopAlias: registry.alias,
-          };
+        authFileExists = true;
+        const generation = ++authFileGeneration;
+        this.updateRegistriesIfCurrent(
+          () =>
+            !disposed &&
+            authFileExists &&
+            generation === authFileGeneration &&
+            fs.existsSync(authFileLocation as string),
+        ).catch((error: unknown) => {
+          console.error('Error updating registries', error);
+        });
+      };
 
-          await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
-        }
+      // fs.watchFile also monitors files that do not exist yet.
+      fs.watchFile(authFileLocation, authFileListener);
 
-        // Update registries.conf with the registry configuration
-        await this.updateRegistriesConf(registry, true);
+      if (authFileExists) {
+        const generation = ++authFileGeneration;
+        await this.updateRegistriesIfCurrent(
+          () =>
+            !disposed &&
+            authFileExists &&
+            generation === authFileGeneration &&
+            fs.existsSync(authFileLocation as string),
+        );
       }
-    });
-
-    // handle removal of the registry in the file
-    extensionApi.registry.onDidUnregisterRegistry(async registry => {
-      // external change, update the local registries
-      if (this.localRegistries.has(registry.serverUrl)) {
-        this.localRegistries.delete(registry.serverUrl);
-        // update the file
-        const authFile = await this.readAuthFile();
-        if (authFile.auths) {
-          delete authFile.auths[registry.serverUrl];
-        }
-        await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
-
-        // Remove from registries.conf
-        await this.removeFromRegistriesConf(registry);
-      }
-    });
-
-    // handle update of the registry in the file
-    extensionApi.registry.onDidUpdateRegistry(async registry => {
-      // external change, update the local registries
-      if (this.localRegistries.has(registry.serverUrl)) {
-        this.localRegistries.set(registry.serverUrl, registry);
-        // update the file
-        const authFile = await this.readAuthFile();
-        authFile.auths ??= {};
-        authFile.auths[registry.serverUrl] = {
-          auth: Buffer.from(`${registry.username}:${registry.secret}`).toString('base64'),
-          podmanDesktopAlias: registry.alias,
-        };
-
-        await this.writeAuthFile(JSON.stringify(authFile, undefined, 8));
-
-        // Update registries.conf with the updated registry configuration
-        await this.updateRegistriesConf(registry, false);
-      }
-    });
-
-    // check if the file exists
-    if (!fs.existsSync(this.getAuthFileLocation())) {
-      return;
+    } catch (error: unknown) {
+      dispose();
+      throw error;
     }
 
-    // need to monitor this file
-    fs.watchFile(this.getAuthFileLocation(), () => {
-      this.updateRegistries().catch((error: unknown) => {
-        console.error('Error updating registries', error);
-      });
-    });
-
-    // else init with the content of this file
-    await this.updateRegistries();
+    return extensionApi.Disposable.create(dispose);
   }
 
   protected async readAuthFile(): Promise<ContainersAuthConfigFile> {

--- a/extensions/podman/packages/extension/src/utils/registry-setup.ts
+++ b/extensions/podman/packages/extension/src/utils/registry-setup.ts
@@ -118,8 +118,12 @@ export class RegistrySetup {
         !inFileRegistries.find(inFileLocalRegistry => inFileLocalRegistry.serverUrl === localRegistry.serverUrl),
     );
     toBeRemoved.forEach(registry => {
-      this.localRegistries.delete(registry.serverUrl);
-      extensionApi.registry.unregisterRegistry(registry);
+      try {
+        extensionApi.registry.unregisterRegistry(registry);
+        this.localRegistries.delete(registry.serverUrl);
+      } catch (error: unknown) {
+        console.error('Error unregistering registry', registry.serverUrl, error);
+      }
     });
   }
 
@@ -320,6 +324,7 @@ export class RegistrySetup {
       }
     } catch (error: unknown) {
       dispose();
+      this.unregisterLocalRegistries();
       throw error;
     }
 


### PR DESCRIPTION
### What does this PR do?

- starts watching the Podman authentication file even when it does not exist at extension startup
- imports registry credentials when the file is created later
- handles deletion and recreation without allowing an older in-flight read to restore stale credentials
- disposes the file watcher, registry provider, and registry event subscriptions with the extension

### Screenshot / video of UI

Not applicable. This changes registry credential synchronization and does not add or modify UI elements.

### What issues does this PR fix or reference?

Closes #17610

### How to test this PR?

1. Back up and remove `~/.config/containers/auth.json`.
2. Start Podman Desktop and open **Settings > Registries**.
3. Run `podman login quay.io` in a terminal.
4. Verify the new credentials appear without restarting Podman Desktop.
5. Remove the authentication file and verify its imported credentials are removed.
6. Recreate the file and verify its credentials are imported again.

Automated coverage includes startup with a missing file, later creation, deletion and recreation, stale asynchronous reads, independent unregister failures, setup-failure cleanup, and disposal. The focused registry setup tests pass (18), along with the Podman extension type check and production build. The broader extension run passed 703 of 704 tests; the unrelated socket-status failure passed immediately in an isolated rerun.

- [x] Tests are covering the bug fix or the new feature

Disclosure: AI was used to understand the codebase and review the fix.