### PR TITLE
feat: add Podman volume rename

### DIFF
--- a/packages/api/src/volume-info.ts
+++ b/packages/api/src/volume-info.ts
@@ -22,6 +22,12 @@ export interface VolumeInfo extends Dockerode.VolumeInspectInfo {
   engineId: string;
   engineName: string;
   engineType: 'podman' | 'docker';
+  /**
+   * Whether this volume meets the eligibility checks Podman Desktop can determine
+   * before asking Podman to rename it. Podman remains authoritative for transient
+   * conditions such as a volume mounted with `podman volume mount`.
+   */
+  canRename?: boolean;
   CreatedAt: string;
   containersUsage: { id: string; names: string[] }[];
 }

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2719,13 +2719,78 @@ test('renameVolume', async () => {
     connection: {
       type: 'podman',
     },
-    api: {} as Dockerode,
+    api: {
+      getVolume: vi.fn().mockReturnValue({ inspect: vi.fn().mockResolvedValue({ Driver: 'local' }) }),
+      listContainers: vi.fn().mockResolvedValue([]),
+    } as unknown as Dockerode,
     libpodApi: libPodApi,
+    volumeRenameSupported: true,
   } as InternalContainerProvider);
 
   await containerRegistry.renameVolume('podman1', 'old-volume', 'new-volume');
 
   expect(libPodApi.renameVolume).toHaveBeenCalledWith('old-volume', 'new-volume');
+});
+
+test('renameVolume rejects an unsupported Podman version', async () => {
+  const libPodApi = { renameVolume: vi.fn() } as unknown as LibPod;
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: { type: 'podman' },
+    api: { version: vi.fn().mockResolvedValue({ Version: '6.0.3' }) } as unknown as Dockerode,
+    libpodApi: libPodApi,
+  } as InternalContainerProvider);
+
+  await expect(containerRegistry.renameVolume('podman1', 'old-volume', 'new-volume')).rejects.toThrow(
+    'Renaming volumes requires Podman 6.1 or later.',
+  );
+  expect(libPodApi.renameVolume).not.toHaveBeenCalled();
+});
+
+test('renameVolume rejects non-local and in-use volumes', async () => {
+  const libPodApi = { renameVolume: vi.fn() } as unknown as LibPod;
+  const inspect = vi.fn().mockResolvedValueOnce({ Driver: 'custom' }).mockResolvedValue({ Driver: 'local' });
+  const listContainers = vi.fn().mockResolvedValue([{ Id: 'container1', Mounts: [{ Name: 'old-volume' }] }]);
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: { type: 'podman' },
+    api: {
+      getVolume: vi.fn().mockReturnValue({ inspect }),
+      listContainers,
+    } as unknown as Dockerode,
+    libpodApi: libPodApi,
+    volumeRenameSupported: true,
+  } as InternalContainerProvider);
+
+  await expect(containerRegistry.renameVolume('podman1', 'old-volume', 'new-volume')).rejects.toThrow(
+    'Volume old-volume cannot be renamed because it does not use the local driver.',
+  );
+  await expect(containerRegistry.renameVolume('podman1', 'old-volume', 'new-volume')).rejects.toThrow(
+    'Volume old-volume cannot be renamed while it is used by a container.',
+  );
+  expect(libPodApi.renameVolume).not.toHaveBeenCalled();
+});
+
+test('renameVolume rejects invalid names before calling Podman', async () => {
+  const libPodApi = { renameVolume: vi.fn() } as unknown as LibPod;
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: { type: 'podman' },
+    api: {} as Dockerode,
+    libpodApi: libPodApi,
+    volumeRenameSupported: true,
+  } as InternalContainerProvider);
+
+  await expect(containerRegistry.renameVolume('podman1', 'old-volume', '   ')).rejects.toThrow(
+    'The new volume name cannot be empty.',
+  );
+  await expect(containerRegistry.renameVolume('podman1', 'old-volume', 'old-volume')).rejects.toThrow(
+    'The new volume name must be different from the current name.',
+  );
+  expect(libPodApi.renameVolume).not.toHaveBeenCalled();
 });
 
 test('renameVolume reports Podman errors through telemetry', async () => {
@@ -2739,8 +2804,12 @@ test('renameVolume reports Podman errors through telemetry', async () => {
     name: 'podman1',
     id: 'podman1',
     connection: { type: 'podman' },
-    api: {} as Dockerode,
+    api: {
+      getVolume: vi.fn().mockReturnValue({ inspect: vi.fn().mockResolvedValue({ Driver: 'local' }) }),
+      listContainers: vi.fn().mockResolvedValue([]),
+    } as unknown as Dockerode,
     libpodApi: libPodApi,
+    volumeRenameSupported: true,
   } as InternalContainerProvider);
 
   await expect(containerRegistry.renameVolume('podman1', 'old-volume', 'new-volume')).rejects.toThrow(renameError);

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -2036,6 +2036,92 @@ describe('buildImage', () => {
 });
 
 describe('listVolumes', () => {
+  test('marks only eligible Podman 6.1 local volumes as renameable and caches engine support', async () => {
+    const podman61Version = vi.fn().mockResolvedValue({ Version: '6.1.0' });
+    const podman60Version = vi.fn().mockResolvedValue({ Version: '6.0.3' });
+    const listContainers = vi.fn().mockResolvedValue([
+      {
+        Id: 'container1',
+        Names: ['/container1'],
+        Mounts: [{ Name: 'used-local' }],
+      },
+    ]);
+    const listVolumes = vi.fn().mockResolvedValue({
+      Volumes: [
+        { Name: 'unused-local', Driver: 'local' },
+        { Name: 'used-local', Driver: 'local' },
+        { Name: 'plugin-volume', Driver: 'custom' },
+      ],
+      Warnings: [],
+    });
+
+    containerRegistry.addInternalProvider('podman61', {
+      name: 'Podman 6.1',
+      id: 'podman61',
+      api: { version: podman61Version, listContainers, listVolumes } as unknown as Dockerode,
+      libpodApi: {} as LibPod,
+      connection: { type: 'podman' },
+    } as InternalContainerProvider);
+    containerRegistry.addInternalProvider('podman60', {
+      name: 'Podman 6.0',
+      id: 'podman60',
+      api: {
+        version: podman60Version,
+        listContainers: vi.fn().mockResolvedValue([]),
+        listVolumes: vi.fn().mockResolvedValue({
+          Volumes: [{ Name: 'old-podman-volume', Driver: 'local' }],
+          Warnings: [],
+        }),
+      } as unknown as Dockerode,
+      libpodApi: {} as LibPod,
+      connection: { type: 'podman' },
+    } as InternalContainerProvider);
+
+    const firstResult = await containerRegistry.listVolumes(false);
+    const podman61Volumes = firstResult.find(result => result.engineId === 'podman61')?.Volumes;
+    const podman60Volumes = firstResult.find(result => result.engineId === 'podman60')?.Volumes;
+
+    expect(podman61Volumes?.find(volume => volume.Name === 'unused-local')?.canRename).toBeTruthy();
+    expect(podman61Volumes?.find(volume => volume.Name === 'used-local')?.canRename).toBeFalsy();
+    expect(podman61Volumes?.find(volume => volume.Name === 'plugin-volume')?.canRename).toBeFalsy();
+    expect(podman61Volumes?.every(volume => volume.engineType === 'podman')).toBeTruthy();
+    expect(podman60Volumes?.[0]?.canRename).toBeFalsy();
+
+    await containerRegistry.listVolumes(false);
+    expect(podman61Version).toHaveBeenCalledOnce();
+    expect(podman60Version).toHaveBeenCalledOnce();
+  });
+
+  test('retries a transient Podman version check failure', async () => {
+    const version = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary connection failure'))
+      .mockResolvedValue({ Version: '6.1.0' });
+    const api = {
+      version,
+      listContainers: vi.fn().mockResolvedValue([]),
+      listVolumes: vi.fn().mockResolvedValue({
+        Volumes: [{ Name: 'local-volume', Driver: 'local' }],
+        Warnings: [],
+      }),
+    } as unknown as Dockerode;
+
+    containerRegistry.addInternalProvider('podman61', {
+      name: 'Podman 6.1',
+      id: 'podman61',
+      api,
+      libpodApi: {} as LibPod,
+      connection: { type: 'podman' },
+    } as InternalContainerProvider);
+
+    const firstResult = await containerRegistry.listVolumes(false);
+    expect(firstResult[0]?.Volumes[0]?.canRename).toBeFalsy();
+
+    const secondResult = await containerRegistry.listVolumes(false);
+    expect(secondResult[0]?.Volumes[0]?.canRename).toBeTruthy();
+    expect(version).toHaveBeenCalledTimes(2);
+  });
+
   test('with fetching the volumes size', async () => {
     const volumesDataMock = {
       Volumes: [
@@ -2620,6 +2706,46 @@ test('updateNetwork', async () => {
   await containerRegistry.updateNetwork('podman1', 'network1', ['1.1.1.1'], []);
 
   expect(libPodApi.updateNetwork).toHaveBeenCalledWith('network1', ['1.1.1.1'], []);
+});
+
+test('renameVolume', async () => {
+  const libPodApi = {
+    renameVolume: vi.fn(),
+  } as unknown as LibPod;
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: {
+      type: 'podman',
+    },
+    api: {} as Dockerode,
+    libpodApi: libPodApi,
+  } as InternalContainerProvider);
+
+  await containerRegistry.renameVolume('podman1', 'old-volume', 'new-volume');
+
+  expect(libPodApi.renameVolume).toHaveBeenCalledWith('old-volume', 'new-volume');
+});
+
+test('renameVolume reports Podman errors through telemetry', async () => {
+  const renameError = new Error('volume is currently mounted');
+  const libPodApi = {
+    renameVolume: vi.fn().mockRejectedValue(renameError),
+  } as unknown as LibPod;
+  telemetryTrackMock.mockClear();
+
+  containerRegistry.addInternalProvider('podman1', {
+    name: 'podman1',
+    id: 'podman1',
+    connection: { type: 'podman' },
+    api: {} as Dockerode,
+    libpodApi: libPodApi,
+  } as InternalContainerProvider);
+
+  await expect(containerRegistry.renameVolume('podman1', 'old-volume', 'new-volume')).rejects.toThrow(renameError);
+
+  expect(telemetryTrackMock).toHaveBeenCalledWith('renameVolume', { error: renameError });
 });
 
 describe('info', () => {

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -82,7 +82,7 @@ import type { ContainerAttachOptions, ImageBuildOptions } from 'dockerode';
 import Dockerode from 'dockerode';
 import { inject, injectable } from 'inversify';
 import moment from 'moment';
-import { coerce, gtr, lt } from 'semver';
+import { coerce, gte, gtr, lt } from 'semver';
 import { withParserAsStream } from 'stream-json/streamers/stream-values.js';
 import type { Headers, Pack, PackOptions } from 'tar-fs';
 
@@ -113,6 +113,7 @@ export interface InternalContainerProvider {
   // api not there if status is stopped
   api?: Dockerode;
   libpodApi?: LibPod;
+  volumeRenameSupported?: boolean;
 }
 
 interface JSONEvent {
@@ -349,6 +350,7 @@ export class ContainerProviderRegistry {
     }
 
     internalProvider.api = new Dockerode({ socketPath: containerProviderConnection.endpoint.socketPath });
+    internalProvider.volumeRenameSupported = undefined;
     if (containerProviderConnection.type === 'podman') {
       internalProvider.libpodApi = internalProvider.api as unknown as LibPod;
     }
@@ -1027,6 +1029,22 @@ export class ContainerProviderRegistry {
           // grab containers
           const containers = await provider.api.listContainers({ all: true });
 
+          let volumeRenameSupported = provider.volumeRenameSupported ?? false;
+          if (provider.volumeRenameSupported === undefined) {
+            if (provider.libpodApi) {
+              try {
+                const version = await provider.api.version();
+                const coercedVersion = coerce(version.Version);
+                provider.volumeRenameSupported = !!coercedVersion && gte(coercedVersion, '6.1.0');
+              } catch (error) {
+                this.notifyConsole(`error checking volume rename support in engine ${provider.name} ${error}`);
+              }
+            } else {
+              provider.volumeRenameSupported = false;
+            }
+            volumeRenameSupported = provider.volumeRenameSupported ?? false;
+          }
+
           // any as there is a CreatedAt field missing in the type
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const volumeListInfo: any = await provider.api.listVolumes();
@@ -1044,7 +1062,12 @@ export class ContainerProviderRegistry {
           const engineId = provider.id;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const volumeInfos = volumeListInfo.Volumes.map((volumeList: any) => {
-            const volumeInfo: VolumeInfo = { ...volumeList, engineName, engineId };
+            const volumeInfo: VolumeInfo = {
+              ...volumeList,
+              engineName,
+              engineId,
+              engineType: provider.connection.type,
+            };
 
             // compute containers using this volume
             const containersUsingThisVolume = containers
@@ -1053,6 +1076,10 @@ export class ContainerProviderRegistry {
                 return { id: container.Id, names: container.Names };
               });
             volumeInfo.containersUsage = containersUsingThisVolume;
+            volumeInfo.canRename =
+              volumeRenameSupported &&
+              (volumeInfo.Driver === '' || volumeInfo.Driver === 'local') &&
+              volumeInfo.containersUsage.length === 0;
 
             // no usage data, set to -1 for size and 0 for refCount
             volumeInfo.UsageData ??= {
@@ -1146,6 +1173,18 @@ export class ContainerProviderRegistry {
       throw error;
     } finally {
       this.telemetryService.track('removeVolume', telemetryOptions);
+    }
+  }
+
+  async renameVolume(engineId: string, volumeName: string, newName: string): Promise<void> {
+    let telemetryOptions = {};
+    try {
+      await this.getMatchingPodmanEngineLibPod(engineId).renameVolume(volumeName, newName);
+    } catch (error) {
+      telemetryOptions = { error };
+      throw error;
+    } finally {
+      this.telemetryService.track('renameVolume', telemetryOptions);
     }
   }
 

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1029,21 +1029,7 @@ export class ContainerProviderRegistry {
           // grab containers
           const containers = await provider.api.listContainers({ all: true });
 
-          let volumeRenameSupported = provider.volumeRenameSupported ?? false;
-          if (provider.volumeRenameSupported === undefined) {
-            if (provider.libpodApi) {
-              try {
-                const version = await provider.api.version();
-                const coercedVersion = coerce(version.Version);
-                provider.volumeRenameSupported = !!coercedVersion && gte(coercedVersion, '6.1.0');
-              } catch (error) {
-                this.notifyConsole(`error checking volume rename support in engine ${provider.name} ${error}`);
-              }
-            } else {
-              provider.volumeRenameSupported = false;
-            }
-            volumeRenameSupported = provider.volumeRenameSupported ?? false;
-          }
+          const volumeRenameSupported = await this.isVolumeRenameSupported(provider);
 
           // any as there is a CreatedAt field missing in the type
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1179,7 +1165,36 @@ export class ContainerProviderRegistry {
   async renameVolume(engineId: string, volumeName: string, newName: string): Promise<void> {
     let telemetryOptions = {};
     try {
-      await this.getMatchingPodmanEngineLibPod(engineId).renameVolume(volumeName, newName);
+      const normalizedNewName = newName.trim();
+      if (!normalizedNewName) {
+        throw new Error('The new volume name cannot be empty.');
+      }
+      if (normalizedNewName === volumeName) {
+        throw new Error('The new volume name must be different from the current name.');
+      }
+
+      const provider = this.getMatchingPodmanEngine(engineId);
+      const api = provider.api;
+      const libpodApi = provider.libpodApi;
+      if (!api || !libpodApi) {
+        throw new Error('no running Podman provider for the matching engine');
+      }
+      if (!(await this.isVolumeRenameSupported(provider))) {
+        throw new Error('Renaming volumes requires Podman 6.1 or later.');
+      }
+
+      const volumeInspect = await api.getVolume(volumeName).inspect();
+      if (volumeInspect.Driver !== '' && volumeInspect.Driver !== 'local') {
+        throw new Error(`Volume ${volumeName} cannot be renamed because it does not use the local driver.`);
+      }
+
+      const containers = await api.listContainers({ all: true });
+      const volumeInUse = containers.some(container => container.Mounts?.some(mount => mount.Name === volumeName));
+      if (volumeInUse) {
+        throw new Error(`Volume ${volumeName} cannot be renamed while it is used by a container.`);
+      }
+
+      await libpodApi.renameVolume(volumeName, normalizedNewName);
     } catch (error) {
       telemetryOptions = { error };
       throw error;
@@ -1198,6 +1213,24 @@ export class ContainerProviderRegistry {
       throw new Error('no running provider for the matching engine');
     }
     return engine.api;
+  }
+
+  private async isVolumeRenameSupported(provider: InternalContainerProvider): Promise<boolean> {
+    if (provider.volumeRenameSupported !== undefined) {
+      return provider.volumeRenameSupported;
+    }
+    if (!provider.libpodApi || !provider.api) {
+      provider.volumeRenameSupported = false;
+      return false;
+    }
+    try {
+      const version = await provider.api.version();
+      const coercedVersion = coerce(version.Version);
+      provider.volumeRenameSupported = !!coercedVersion && gte(coercedVersion, '6.1.0');
+    } catch (error) {
+      this.notifyConsole(`error checking volume rename support in engine ${provider.name} ${error}`);
+    }
+    return provider.volumeRenameSupported ?? false;
   }
 
   protected getMatchingPodmanEngine(engineId: string): InternalContainerProvider {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.spec.ts
@@ -477,6 +477,34 @@ test('Check update network', async () => {
   await (api as unknown as LibPod).updateNetwork('network1', ['1.1.1.1'], []);
 });
 
+describe('volume rename', () => {
+  test('calls the Libpod endpoint with encoded names', async () => {
+    const renameHandler = vi.fn().mockReturnValue(HttpResponse.text('', { status: 204 }));
+    server = setupServer(http.post('http://localhost/v4.2.0/libpod/volumes/old%20name/rename', renameHandler));
+    server.listen({ onUnhandledRequest: 'error' });
+
+    const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+    await (api as unknown as LibPod).renameVolume('old name', 'new name');
+
+    expect(renameHandler).toHaveBeenCalledOnce();
+    const request = vi.mocked(renameHandler).mock.calls[0]?.[0]?.request;
+    assert(request);
+    expect(new URL(request.url).searchParams.get('newName')).toBe('new name');
+  });
+
+  test('rejects errors returned by Podman', async () => {
+    server = setupServer(
+      http.post('http://localhost/v4.2.0/libpod/volumes/current/rename', () =>
+        HttpResponse.json({ message: 'volume is currently mounted' }, { status: 409 }),
+      ),
+    );
+    server.listen({ onUnhandledRequest: 'error' });
+
+    const api = new Dockerode({ protocol: 'http', host: 'localhost' });
+    await expect((api as unknown as LibPod).renameVolume('current', 'renamed')).rejects.toThrow();
+  });
+});
+
 describe('kube play', () => {
   let tmpDirectory: string;
   beforeAll(async () => {

--- a/packages/main/src/plugin/dockerode/libpod-dockerode.ts
+++ b/packages/main/src/plugin/dockerode/libpod-dockerode.ts
@@ -261,6 +261,7 @@ export interface LibPod {
   podmanPushManifest(manifestOptions: ManifestPushOptions, authInfo?: Dockerode.AuthConfig): Promise<void>;
   podmanRemoveManifest(manifestName: string): Promise<void>;
   updateNetwork(networkId: string, addDNSServer: string[], removeDNSServer: string[]): Promise<void>;
+  renameVolume(volumeName: string, newName: string): Promise<void>;
   /**
    * The compatibility endpoint to delete a secret on the podman service has an issue where the path is not recognised;
    * Therefore, we need to use the official libpod api to be able to remove a secret
@@ -981,6 +982,30 @@ export class LibpodDockerode {
           200: true,
           204: true,
           400: 'bad parameter',
+          500: 'server error',
+        },
+      };
+      return new Promise((resolve, reject) => {
+        this.modem.dial(optsf, (err: unknown, data: unknown) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(wrapAs<void>(data));
+        });
+      });
+    };
+
+    prototypeOfDockerode.renameVolume = function (volumeName: string, newName: string): Promise<void> {
+      const encodedVolumeName = encodeURIComponent(volumeName);
+      const optsf = {
+        path: `/v4.2.0/libpod/volumes/${encodedVolumeName}/rename?`,
+        method: 'POST',
+        options: { newName },
+        statusCodes: {
+          204: true,
+          400: 'bad parameter',
+          404: 'no such volume',
+          409: 'volume is in use or new name already exists',
           500: 'server error',
         },
       };

--- a/packages/main/src/plugin/index.spec.ts
+++ b/packages/main/src/plugin/index.spec.ts
@@ -178,6 +178,16 @@ afterEach(async () => {
   await inversifyContainer.unbindAllAsync();
 });
 
+test('rename volume IPC delegates to the container provider registry', async () => {
+  const handle = getHandler<(_event: unknown, engine: string, volumeName: string, newName: string) => Promise<void>>(
+    'container-provider-registry:renameVolume',
+  );
+
+  await handle(undefined, 'podman1', 'old-volume', 'new-volume');
+
+  expect(ContainerProviderRegistry.prototype.renameVolume).toHaveBeenCalledWith('podman1', 'old-volume', 'new-volume');
+});
+
 test('Should queue events until we are ready', async () => {
   const apiSender = pluginSystem.getApiSender(webContents);
   expect(apiSender).toBeDefined();

--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1014,6 +1014,12 @@ export class PluginSystem {
         return containerProviderRegistry.removeVolume(engine, volumeName);
       },
     );
+    this.ipcHandle(
+      'container-provider-registry:renameVolume',
+      async (_listener, engine: string, volumeName: string, newName: string): Promise<void> => {
+        return containerProviderRegistry.renameVolume(engine, volumeName, newName);
+      },
+    );
 
     this.ipcHandle(
       'container-provider-registry:replicatePodmanContainer',

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -249,6 +249,20 @@ describe('collect calls to exposeInMainWorld and ipcRenderer.on and calls initEx
     expect(result).toEqual(undefined);
   });
 
+  test('renameVolume', async () => {
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue({ result: undefined });
+
+    const renameVolumeExposure = getInMainWorld('renameVolume');
+    await renameVolumeExposure('podman1', 'old-volume', 'new-volume');
+
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+      'container-provider-registry:renameVolume',
+      'podman1',
+      'old-volume',
+      'new-volume',
+    );
+  });
+
   test('getSearchableNavigationRoutes', async () => {
     vi.mocked(ipcRenderer.invoke).mockResolvedValue({
       result: [{ routeId: 'ext.dashboard', label: 'Dashboard', icon: 'icon.png' }],

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -335,6 +335,12 @@ export function initExposure(): void {
     return ipcInvoke('container-provider-registry:removeVolume', engine, volumeName);
   });
   contextBridge.exposeInMainWorld(
+    'renameVolume',
+    async (engine: string, volumeName: string, newName: string): Promise<void> => {
+      return ipcInvoke('container-provider-registry:renameVolume', engine, volumeName, newName);
+    },
+  );
+  contextBridge.exposeInMainWorld(
     'getVolumeInspect',
     async (engine: string, volumeName: string): Promise<VolumeInspectInfo> => {
       return ipcInvoke('container-provider-registry:getVolumeInspect', engine, volumeName);

--- a/packages/renderer/src/lib/volume/RenameVolumeDialog.spec.ts
+++ b/packages/renderer/src/lib/volume/RenameVolumeDialog.spec.ts
@@ -1,0 +1,72 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import RenameVolumeDialog from './RenameVolumeDialog.svelte';
+import type { VolumeInfoUI } from './VolumeInfoUI';
+
+const volume = {
+  name: 'current-volume',
+  engineId: 'podman1',
+} as VolumeInfoUI;
+
+const onClose = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test('requires a changed non-empty name and submits the normalized value', async () => {
+  render(RenameVolumeDialog, { volume, onClose });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  const renameButton = screen.getByRole('button', { name: 'Rename' });
+  expect(nameInput).toHaveValue('current-volume');
+  expect(renameButton).toBeDisabled();
+
+  await userEvent.clear(nameInput);
+  expect(renameButton).toBeDisabled();
+
+  await userEvent.type(nameInput, ' renamed-volume ');
+  expect(renameButton).toBeEnabled();
+  await fireEvent.click(renameButton);
+
+  await waitFor(() => {
+    expect(window.renameVolume).toHaveBeenCalledWith('podman1', 'current-volume', 'renamed-volume');
+  });
+  expect(onClose).toHaveBeenCalledOnce();
+});
+
+test('keeps the dialog open and displays Podman errors', async () => {
+  vi.mocked(window.renameVolume).mockRejectedValue(new Error('volume is currently mounted'));
+  render(RenameVolumeDialog, { volume, onClose });
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.clear(nameInput);
+  await userEvent.type(nameInput, 'renamed-volume');
+  await fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+  expect(await screen.findByText('volume is currently mounted')).toBeInTheDocument();
+  expect(onClose).not.toHaveBeenCalled();
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+});

--- a/packages/renderer/src/lib/volume/RenameVolumeDialog.svelte
+++ b/packages/renderer/src/lib/volume/RenameVolumeDialog.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { Button, ErrorMessage, Input } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+
+import Dialog from '/@/lib/dialogs/Dialog.svelte';
+
+import type { VolumeInfoUI } from './VolumeInfoUI';
+
+interface Props {
+  volume: VolumeInfoUI;
+  onClose: () => void;
+}
+
+let { volume, onClose }: Props = $props();
+
+let newName = $state('');
+let renameInProgress = $state(false);
+let renameError: string | undefined = $state();
+
+let normalizedName = $derived(newName.trim());
+let renameDisabled = $derived(renameInProgress || normalizedName.length === 0 || normalizedName === volume.name);
+
+onMount(() => {
+  newName = volume.name;
+});
+
+async function renameVolume(): Promise<void> {
+  renameError = undefined;
+  renameInProgress = true;
+  try {
+    await window.renameVolume(volume.engineId, volume.name, normalizedName);
+    onClose();
+  } catch (error: unknown) {
+    renameError = error instanceof Error ? error.message : String(error);
+  } finally {
+    renameInProgress = false;
+  }
+}
+</script>
+
+<Dialog title="Rename Volume" onclose={onClose}>
+  {#snippet content()}
+    <div class="w-full">
+      <label for="volumeName" class="block my-2 text-sm font-bold text-[var(--pd-modal-text)]">Volume name</label>
+      <Input
+        bind:value={newName}
+        name="volumeName"
+        id="volumeName"
+        aria-label="Volume Name"
+        disabled={renameInProgress}
+        required />
+      {#if renameError}
+        <ErrorMessage class="text-sm mt-2" error={renameError} />
+      {/if}
+    </div>
+  {/snippet}
+  {#snippet buttons()}
+    <Button type="link" onclick={onClose} disabled={renameInProgress}>Cancel</Button>
+    <Button type="primary" onclick={renameVolume} disabled={renameDisabled} inProgress={renameInProgress}>Rename</Button>
+  {/snippet}
+</Dialog>

--- a/packages/renderer/src/lib/volume/VolumeActions.spec.ts
+++ b/packages/renderer/src/lib/volume/VolumeActions.spec.ts
@@ -19,18 +19,21 @@
 import '@testing-library/jest-dom/vitest';
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { beforeAll, expect, test, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
 import VolumeActions from './VolumeActions.svelte';
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
 const removeVolumeMock = vi.fn();
+const renameVolumeMock = vi.fn();
 
 class VolumeInfoUIImpl {
   #status: string;
   constructor(
     public name: string,
     initialStatus: string,
+    public canRename = false,
   ) {
     this.#status = initialStatus;
   }
@@ -41,14 +44,21 @@ class VolumeInfoUIImpl {
   set status(status: string) {
     this.#status = status;
   }
+
+  engineId = 'podman1';
 }
 
 beforeAll(() => {
   Object.defineProperty(window, 'removeVolume', { value: removeVolumeMock });
+  Object.defineProperty(window, 'renameVolume', { value: renameVolumeMock });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
 });
 
 test('Expect prompt dialog and deletion', async () => {
-  vi.mocked(window.getContributedMenus).mockResolvedValue([]);
   // Mock the showMessageBox to return 0 (yes)
   vi.mocked(window.showMessageBox).mockResolvedValue({ response: 'Delete' });
 
@@ -67,4 +77,28 @@ test('Expect prompt dialog and deletion', async () => {
 
   expect(volume.status).toBe('DELETING');
   expect(removeVolumeMock).toHaveBeenCalled();
+});
+
+test('Expect eligible volume to have a rename action', async () => {
+  const volume: VolumeInfoUI = new VolumeInfoUIImpl('dummy', 'UNUSED', true) as unknown as VolumeInfoUI;
+
+  render(VolumeActions, { volume });
+  await fireEvent.click(screen.getByRole('button', { name: 'Rename Volume' }));
+
+  const nameInput = screen.getByRole('textbox', { name: 'Volume Name' });
+  await userEvent.clear(nameInput);
+  await userEvent.type(nameInput, 'renamed-volume');
+  await fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+
+  await waitFor(() => {
+    expect(renameVolumeMock).toHaveBeenCalledWith('podman1', 'dummy', 'renamed-volume');
+  });
+});
+
+test('Expect ineligible volume not to have a rename action', () => {
+  const volume: VolumeInfoUI = new VolumeInfoUIImpl('dummy', 'UNUSED') as unknown as VolumeInfoUI;
+
+  render(VolumeActions, { volume });
+
+  expect(screen.queryByRole('button', { name: 'Rename Volume' })).not.toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/volume/VolumeActions.svelte
+++ b/packages/renderer/src/lib/volume/VolumeActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
 import type { Menu } from '@podman-desktop/core-api';
 import { MenuContext } from '@podman-desktop/core-api';
 import { DropdownMenu } from '@podman-desktop/ui-svelte';
@@ -10,6 +10,7 @@ import { withConfirmation } from '/@/lib/dialogs/messagebox-utils';
 import FlatMenu from '/@/lib/ui/FlatMenu.svelte';
 import ListItemButtonIcon from '/@/lib/ui/ListItemButtonIcon.svelte';
 
+import RenameVolumeDialog from './RenameVolumeDialog.svelte';
 import type { VolumeInfoUI } from './VolumeInfoUI';
 
 interface Props {
@@ -23,6 +24,7 @@ let { volume, dropdownMenu = false, detailed = false }: Props = $props();
 const dispatch = createEventDispatcher<{ update: VolumeInfoUI }>();
 
 let contributions: Menu[] = $state([]);
+let showRenameDialog = $state(false);
 onMount(async () => {
   try {
     contributions = await window.getContributedMenus(MenuContext.DASHBOARD_VOLUME);
@@ -38,17 +40,40 @@ async function removeVolume(): Promise<void> {
   await window.removeVolume(volume.engineId, volume.name);
 }
 
+function confirmRemoveVolume(): void {
+  withConfirmation(removeVolume, `delete volume ${volume.name}`, { title: 'Delete Volume?', variant: 'delete' });
+}
+
+function openRenameDialog(): void {
+  showRenameDialog = true;
+}
+
+function closeRenameDialog(): void {
+  showRenameDialog = false;
+}
+
 // If dropdownMenu = true, we'll change style to the imported dropdownMenu style
 // otherwise, leave blank.
 let MenuComponent = $derived(dropdownMenu ? DropdownMenu : FlatMenu);
 </script>
 
 {#if volume.status === 'UNUSED'}
+  {#if volume.canRename}
+    <ListItemButtonIcon
+      title="Rename Volume"
+      onClick={openRenameDialog}
+      detailed={detailed}
+      icon={faEdit} />
+  {/if}
   <ListItemButtonIcon
     title="Delete Volume"
-    onClick={(): void => withConfirmation(removeVolume, `delete volume ${volume.name}`, { title: 'Delete Volume?', variant: 'delete' })}
+    onClick={confirmRemoveVolume}
     detailed={detailed}
     icon={faTrash} />
+{/if}
+
+{#if showRenameDialog}
+  <RenameVolumeDialog {volume} onClose={closeRenameDialog} />
 {/if}
 
 <MenuComponent>

--- a/packages/renderer/src/lib/volume/VolumeInfoUI.ts
+++ b/packages/renderer/src/lib/volume/VolumeInfoUI.ts
@@ -28,6 +28,7 @@ export interface VolumeInfoUI {
   humanSize: string;
   engineId: string;
   engineName: string;
+  canRename?: boolean;
   selected: boolean;
   status: 'USED' | 'UNUSED' | 'DELETING';
   containersUsage: { id: string; names: string[] }[];

--- a/packages/renderer/src/lib/volume/volume-utils.ts
+++ b/packages/renderer/src/lib/volume/volume-utils.ts
@@ -75,6 +75,7 @@ export class VolumeUtils {
       humanSize: this.getSize(volumeInfo),
       engineId: volumeInfo.engineId,
       engineName: volumeInfo.engineName,
+      canRename: volumeInfo.canRename ?? false,
       selected: false,
       status: (volumeInfo.UsageData?.RefCount ?? 0) > 0 ? 'USED' : 'UNUSED',
       containersUsage: volumeInfo.containersUsage,


### PR DESCRIPTION
### What does this PR do?

- adds volume rename support through Podman's Libpod API
- enables the action only for Podman 6.1+ local volumes with no known container usage
- adds a rename dialog that validates the new name, prevents duplicate submissions, and keeps Podman errors visible
- refreshes volume data through the existing Podman volume-event flow

Podman remains authoritative for transient conditions that are not available in the volume list response, such as a volume mounted with `podman volume mount`.

### Screenshot / video of UI

Podman Desktop v1.30.0-next connected to Podman client/server 6.1.0:

<img width="1482" height="768" alt="volume-rename" src="https://github.com/user-attachments/assets/9ab5c8b9-d25c-4e15-9511-0ef0a14d32e4" />


### What issues does this PR fix or reference?

Closes #18795

### How to test this PR?

1. Connect Podman Desktop to Podman 6.1 or newer.
2. Create an unused local volume.
3. Select **Rename Volume**, enter a different valid name, and select **Rename**.
4. Verify the old name disappears and the renamed volume appears.
5. Verify volumes used by a container and volumes using a non-local driver do not show the rename action.
6. Mount an otherwise unused volume with `podman volume mount`, attempt to rename it, and verify Podman's error remains visible in the dialog.

Automated coverage includes the Libpod request and error path, Podman version and eligibility checks, telemetry, IPC/preload forwarding, action visibility, dialog validation, success, and server-error handling.

The affected main tests passed (255), renderer volume tests passed (35), preload tests passed (13), and the focused main IPC test passed. Core API, main, preload, and renderer type checks also passed.

A manual UI smoke test also passed with Podman client/server 6.1.0: an unused local volume exposed the rename action, the dialog accepted a valid new name, the rename completed, and the refreshed list showed the destination name.

- [x] Tests are covering the bug fix or the new feature

Disclosure: AI was used to understand the codebase and review the fix.