### PR TITLE
fix(kind): select container connection for cluster creation

### DIFF
--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -34,15 +34,11 @@
           "scope": "KubernetesProviderConnectionFactory",
           "description": "Name"
         },
-        "kind.cluster.creation.provider": {
+        "kind.cluster.creation.containerConnection": {
           "type": "string",
-          "default": "podman",
-          "enum": [
-            "podman",
-            "docker"
-          ],
+          "format": "containerConnection",
           "scope": "KubernetesProviderConnectionFactory",
-          "description": "Provider Type"
+          "description": "Container Connection"
         },
         "kind.cluster.creation.http.port": {
           "type": "number",

--- a/extensions/kind/package.json
+++ b/extensions/kind/package.json
@@ -34,7 +34,7 @@
           "scope": "KubernetesProviderConnectionFactory",
           "description": "Name"
         },
-        "kind.cluster.creation.containerConnection": {
+        "kind.cluster.creation.provider": {
           "type": "string",
           "format": "containerConnection",
           "scope": "KubernetesProviderConnectionFactory",

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -19,7 +19,7 @@
 import * as fs from 'node:fs';
 
 import { KubeConfig, loadAllYaml } from '@kubernetes/client-node';
-import type { AuditRecord, TelemetryLogger } from '@podman-desktop/api';
+import type { AuditRecord, AuditRequestItems, TelemetryLogger } from '@podman-desktop/api';
 import * as extensionApi from '@podman-desktop/api';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -35,6 +35,7 @@ vi.mock(import('node:fs'));
 
 beforeEach(() => {
   vi.resetAllMocks();
+  (extensionApi.env.isWindows as unknown as boolean) = false;
   vi.mocked(extensionApi.kubernetes.getKubeconfig).mockReturnValue({
     path: '/some/path',
   } as unknown as extensionApi.Uri);
@@ -71,11 +72,34 @@ const telemetryLoggerMock = {
   logError: telemetryLogErrorMock,
 } as unknown as TelemetryLogger;
 
+function connectionSelection(providerId: string, connectionName: string): string {
+  return JSON.stringify({ providerId, connectionName });
+}
+
+function withConnection(
+  params: Record<string, unknown> = {},
+  providerId = 'docker',
+  connectionName = 'docker-connection',
+): Record<string, unknown> {
+  return {
+    'kind.cluster.creation.containerConnection': connectionSelection(providerId, connectionName),
+    ...params,
+  };
+}
+
+async function auditConnection(
+  items: AuditRequestItems,
+  providerId = 'docker',
+  connectionName = 'docker-connection',
+): Promise<extensionApi.AuditResult> {
+  return connectionAuditor(withConnection(items, providerId, connectionName));
+}
+
 test('expect error is cli returns non zero exit code', async () => {
   const error = { exitCode: -1, message: 'error' } as extensionApi.RunError;
   try {
     (extensionApi.process.exec as Mock).mockRejectedValue(error);
-    await createCluster({}, '', telemetryLoggerMock);
+    await createCluster(withConnection(), '', telemetryLoggerMock);
   } catch (err) {
     expect(err).to.be.a('Error');
     expect((err as Error).message).equal('Failed to create kind cluster. error');
@@ -87,7 +111,7 @@ test('expect error is cli returns non zero exit code', async () => {
 test('expect cluster to be created', async () => {
   vi.mocked(getKindPath).mockReturnValue('/kind/path');
   vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
-  await createCluster({}, '', telemetryLoggerMock);
+  await createCluster(withConnection(), '', telemetryLoggerMock);
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
     1,
     'createCluster',
@@ -98,7 +122,142 @@ test('expect cluster to be created', async () => {
   const props = (extensionApi.process.exec as Mock).mock.calls[0][2];
   expect(props).to.have.property('env');
   const env = props.env;
-  expect(env).toStrictEqual({ PATH: '/kind/path' });
+  expect(env).toStrictEqual({ DOCKER_HOST: 'unix://socket', PATH: '/kind/path' });
+});
+
+test('expect selected Podman connection and cancellation token in Kind command environment', async () => {
+  vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([
+    {
+      providerId: 'podman',
+      connection: {
+        name: 'podman-machine-remote',
+        type: 'podman',
+        endpoint: { socketPath: 'remote-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+  ]);
+  vi.mocked(getKindPath).mockReturnValue('/kind/path');
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
+  const token = {} as extensionApi.CancellationToken;
+
+  await createCluster(
+    withConnection({}, 'podman', 'podman-machine-remote'),
+    '/kind',
+    telemetryLoggerMock,
+    undefined,
+    token,
+  );
+
+  expect(extensionApi.process.exec).toHaveBeenCalledWith(
+    '/kind',
+    expect.any(Array),
+    expect.objectContaining({
+      env: {
+        CONTAINER_CONNECTION: 'podman-machine-remote',
+        KIND_EXPERIMENTAL_PROVIDER: 'podman',
+        PATH: '/kind/path',
+      },
+      token,
+    }),
+  );
+  expect(telemetryLogUsageMock).toHaveBeenCalledWith('createCluster', expect.objectContaining({ provider: 'podman' }));
+  expect(telemetryLogUsageMock.mock.calls[0][1]).not.toHaveProperty('containerConnection');
+});
+
+test('expect selected Docker connection to configure its Unix socket', async () => {
+  vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([
+    {
+      providerId: 'podman',
+      connection: {
+        name: 'shared-name',
+        type: 'podman',
+        endpoint: { socketPath: 'podman-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+    {
+      providerId: 'docker',
+      connection: {
+        name: 'shared-name',
+        type: 'docker',
+        endpoint: { socketPath: 'docker-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+  ]);
+  vi.mocked(getKindPath).mockReturnValue('/kind/path');
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
+
+  await createCluster(withConnection({}, 'docker', 'shared-name'), '/kind', telemetryLoggerMock);
+
+  expect(extensionApi.process.exec).toHaveBeenCalledWith(
+    '/kind',
+    expect.any(Array),
+    expect.objectContaining({ env: { DOCKER_HOST: 'unix://docker-socket', PATH: '/kind/path' } }),
+  );
+  expect(telemetryLogUsageMock).toHaveBeenCalledWith('createCluster', expect.objectContaining({ provider: 'docker' }));
+  expect(telemetryLogUsageMock.mock.calls[0][1]).not.toHaveProperty('containerConnection');
+});
+
+test('expect selected Docker connection to configure its Windows named pipe', async () => {
+  (extensionApi.env.isWindows as unknown as boolean) = true;
+  vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([
+    {
+      providerId: 'docker',
+      connection: {
+        name: 'docker-desktop',
+        type: 'docker',
+        endpoint: { socketPath: '\\\\.\\pipe\\docker_engine' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+  ]);
+  vi.mocked(getKindPath).mockReturnValue('C:\\kind');
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
+
+  await createCluster(withConnection({}, 'docker', 'docker-desktop'), 'C:\\kind\\kind.exe', telemetryLoggerMock);
+
+  expect(extensionApi.process.exec).toHaveBeenCalledWith(
+    'C:\\kind\\kind.exe',
+    expect.any(Array),
+    expect.objectContaining({
+      env: {
+        DOCKER_HOST: 'npipe:////./pipe/docker_engine',
+        PATH: 'C:\\kind',
+      },
+    }),
+  );
+});
+
+test('expect cluster creation to fail if the selected connection disappears', async () => {
+  vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([]);
+
+  await expect(createCluster(withConnection(), '/kind', telemetryLoggerMock)).rejects.toThrow(
+    'The selected container connection "docker-connection" is no longer available. Select another connection.',
+  );
+  expect(extensionApi.process.exec).not.toHaveBeenCalled();
+});
+
+test('expect cluster creation to reject an unsupported connection type', async () => {
+  vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([
+    {
+      providerId: 'custom',
+      connection: {
+        name: 'custom-connection',
+        type: 'custom',
+        endpoint: { socketPath: 'custom-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    } as unknown as extensionApi.ProviderContainerConnection,
+  ]);
+
+  await expect(
+    createCluster(withConnection({}, 'custom', 'custom-connection'), '/kind', telemetryLoggerMock),
+  ).rejects.toThrow(
+    'The selected container connection "custom-connection" uses an unsupported provider type "custom". Select a Podman or Docker connection.',
+  );
+  expect(extensionApi.process.exec).not.toHaveBeenCalled();
 });
 
 describe('fake timers', () => {
@@ -122,7 +281,7 @@ describe('fake timers', () => {
       };
     });
 
-    createCluster({}, '', telemetryLoggerMock).catch((error: unknown) => {
+    createCluster(withConnection(), '', telemetryLoggerMock).catch((error: unknown) => {
       console.error('Error creating cluster', error);
     });
 
@@ -148,7 +307,7 @@ test('expect cluster to be created using config file', async () => {
     error: vi.fn(),
     warn: vi.fn(),
   };
-  await createCluster({ 'kind.cluster.creation.configFile': '/path' }, '', telemetryLoggerMock, logger);
+  await createCluster(withConnection({ 'kind.cluster.creation.configFile': '/path' }), '', telemetryLoggerMock, logger);
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
     1,
     'createCluster',
@@ -167,7 +326,7 @@ test('expect cluster to not call setupIngressController function when supplying 
   };
 
   // Supply the configuration file
-  await createCluster({ 'kind.cluster.creation.configFile': '/path' }, '', telemetryLoggerMock, logger);
+  await createCluster(withConnection({ 'kind.cluster.creation.configFile': '/path' }), '', telemetryLoggerMock, logger);
 
   // Expect us to call the exec function as normal
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
@@ -191,7 +350,7 @@ test('expect cluster to call ingress controller setup when ingress is set to yes
 
   // Supply the configuration file
   await createCluster(
-    { 'kind.cluster.creation.configFile': '/path', 'kind.cluster.creation.ingress': 'on' },
+    withConnection({ 'kind.cluster.creation.configFile': '/path', 'kind.cluster.creation.ingress': 'on' }),
     '',
     telemetryLoggerMock,
     logger,
@@ -235,7 +394,7 @@ test('expect cluster to use "name: foobar" within the yaml file when supplying a
 
   // Supply the configuration file
   await createCluster(
-    { 'kind.cluster.creation.configFile': '/path', 'kind.cluster.creation.ingress': 'on' },
+    withConnection({ 'kind.cluster.creation.configFile': '/path', 'kind.cluster.creation.ingress': 'on' }),
     '',
     telemetryLoggerMock,
     logger,
@@ -264,7 +423,7 @@ test('expect cluster to be created with ingress', async () => {
     error: vi.fn(),
     warn: vi.fn(),
   };
-  await createCluster({ 'kind.cluster.creation.ingress': 'on' }, '', telemetryLoggerMock, logger);
+  await createCluster(withConnection({ 'kind.cluster.creation.ingress': 'on' }), '', telemetryLoggerMock, logger);
   expect(telemetryLogUsageMock).toHaveBeenNthCalledWith(
     1,
     'createCluster',
@@ -281,10 +440,10 @@ test('expect cluster to be created with ports as strings', async () => {
     warn: vi.fn(),
   };
   await createCluster(
-    {
+    withConnection({
       'kind.cluster.creation.http.port': '9091',
       'kind.cluster.creation.https.port': '9444',
-    },
+    }),
     '',
     telemetryLoggerMock,
     logger,
@@ -318,10 +477,10 @@ test('expect cluster to be created with ports as numbers', async () => {
     warn: vi.fn(),
   };
   await createCluster(
-    {
+    withConnection({
       'kind.cluster.creation.http.port': 9091,
       'kind.cluster.creation.https.port': 9444,
-    },
+    }),
     '',
     telemetryLoggerMock,
     logger,
@@ -357,7 +516,7 @@ test('expect error if Kubernetes reports error', async () => {
       warn: vi.fn(),
     };
     (extensionApi.kubernetes.createResources as Mock).mockRejectedValue(error);
-    await createCluster({ 'kind.cluster.creation.ingress': 'on' }, '', telemetryLoggerMock, logger);
+    await createCluster(withConnection({ 'kind.cluster.creation.ingress': 'on' }), '', telemetryLoggerMock, logger);
   } catch (err) {
     expect(extensionApi.kubernetes.createResources).toBeCalled();
     expect(err).to.be.a('Error');
@@ -388,7 +547,7 @@ test('check cluster configuration null string image', async () => {
 test('check that consilience check returns warning message', async () => {
   vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
   (getMemTotalInfo as Mock).mockReturnValue(3000000000);
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9443,
   });
@@ -405,7 +564,7 @@ test('check that consilience check returns warning message', async () => {
 test('check that consilience check returns no warning messages', async () => {
   vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
   (getMemTotalInfo as Mock).mockReturnValue(6000000001);
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9443,
   });
@@ -417,7 +576,7 @@ test('check that consilience check returns no warning messages', async () => {
 
 test('check that consilience check returns warning message when image has no sha256 digest', async () => {
   vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9443);
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.controlPlaneImage': 'image:tag',
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9443,
@@ -432,7 +591,7 @@ test('check that consilience check returns warning message when image has no sha
 
 test('check that consilience check returns warning message when config file is specified', async () => {
   vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.configFile': '/path',
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9443,
@@ -447,7 +606,7 @@ test('check that consilience check returns warning message when config file is s
 
 test('check that auditItems returns error message when HTTP port is not available', async () => {
   vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9091).mockResolvedValueOnce(9443);
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9443,
   });
@@ -461,7 +620,7 @@ test('check that auditItems returns error message when HTTP port is not availabl
 
 test('check that auditItems returns error message when HTTPS port is not available', async () => {
   vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9090).mockResolvedValueOnce(9444);
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9443,
   });
@@ -471,6 +630,88 @@ test('check that auditItems returns error message when HTTPS port is not availab
   expect(checks.records.length).toBe(1);
   expect(checks.records[0]).toHaveProperty('type');
   expect(checks.records[0].type).toBe('error');
+});
+
+test('check that auditItems requires a selected connection', async () => {
+  vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
+
+  const checks = await connectionAuditor({
+    'kind.cluster.creation.http.port': 9090,
+    'kind.cluster.creation.https.port': 9443,
+  });
+
+  expect(checks.records).toContainEqual({
+    type: 'error',
+    record: 'Select a running container connection to create a Kind cluster.',
+  });
+});
+
+test('check that selected provider identity disambiguates duplicate connection names', async () => {
+  vi.spyOn(extensionApi.provider, 'getContainerConnections').mockReturnValue([
+    {
+      providerId: 'podman',
+      connection: {
+        name: 'shared-name',
+        type: 'podman',
+        endpoint: { socketPath: 'podman-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+    {
+      providerId: 'docker',
+      connection: {
+        name: 'shared-name',
+        type: 'docker',
+        endpoint: { socketPath: 'docker-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+  ]);
+  vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
+  vi.mocked(getMemTotalInfo).mockResolvedValue(8000000000);
+
+  const checks = await auditConnection(
+    {
+      'kind.cluster.creation.http.port': 9090,
+      'kind.cluster.creation.https.port': 9443,
+    },
+    'docker',
+    'shared-name',
+  );
+
+  expect(checks.records.filter(record => record.type === 'error')).toHaveLength(0);
+  expect(getMemTotalInfo).toHaveBeenCalledWith('docker-socket');
+});
+
+test('check that auditItems rejects an unsupported connection type', async () => {
+  vi.spyOn(extensionApi.provider, 'getContainerConnections').mockReturnValue([
+    {
+      providerId: 'custom',
+      connection: {
+        name: 'custom-connection',
+        type: 'custom',
+        endpoint: { socketPath: 'custom-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    } as unknown as extensionApi.ProviderContainerConnection,
+  ]);
+  vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
+
+  const checks = await auditConnection(
+    {
+      'kind.cluster.creation.http.port': 9090,
+      'kind.cluster.creation.https.port': 9443,
+    },
+    'custom',
+    'custom-connection',
+  );
+
+  expect(checks.records).toContainEqual({
+    type: 'error',
+    record:
+      'The selected container connection "custom-connection" uses an unsupported provider type "custom". Select a Podman or Docker connection.',
+  });
+  expect(getMemTotalInfo).not.toHaveBeenCalled();
 });
 
 test('check that auditItems returns error message when no provider connections are running', async () => {
@@ -488,22 +729,28 @@ test('check that auditItems returns error message when no provider connections a
   ]);
   vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
 
-  const checks = await connectionAuditor('podman', {
-    'kind.cluster.creation.http.port': 9090,
-    'kind.cluster.creation.https.port': 9443,
-  });
+  const checks = await auditConnection(
+    {
+      'kind.cluster.creation.http.port': 9090,
+      'kind.cluster.creation.https.port': 9443,
+    },
+    'podman',
+    'podman-machine-default',
+  );
 
   expect(checks).toBeDefined();
   expect(checks).toHaveProperty('records');
   expect(checks.records.length).toBe(1);
   expect(checks.records[0]).toHaveProperty('type');
   expect(checks.records[0].type).toBe('error');
-  expect(checks.records[0].record).toContain('The podman provider is not running');
+  expect(checks.records[0].record).toContain(
+    'The selected container connection "podman-machine-default" is not running',
+  );
 });
 
 test('check that auditItems returns error message when HTTP and HTTPS ports are the same', async () => {
   vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.http.port': 9090,
     'kind.cluster.creation.https.port': 9090,
   });
@@ -522,7 +769,7 @@ test('check that auditItems returns error message when port is invalid (> 65535)
   );
   vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9443);
 
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.http.port': 999999,
     'kind.cluster.creation.https.port': 9443,
   });
@@ -540,7 +787,7 @@ test('check that auditItems returns error message when port is invalid (< 1024)'
   vi.spyOn(extensionApi.net, 'getFreePort').mockRejectedValueOnce(new Error('The port must be greater than 1024.'));
   vi.spyOn(extensionApi.net, 'getFreePort').mockResolvedValueOnce(9443);
 
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.http.port': 500,
     'kind.cluster.creation.https.port': 9443,
   });
@@ -562,7 +809,7 @@ test('check that auditItems returns multiple error messages when both ports are 
     new Error('Please enter a port number between 0 and 65535.'),
   );
 
-  const checks = await connectionAuditor('docker', {
+  const checks = await auditConnection({
     'kind.cluster.creation.http.port': 999999,
     'kind.cluster.creation.https.port': 888888,
   });
@@ -606,17 +853,23 @@ test('check that auditItems returns error message when multiple VMs exist but al
   ]);
   vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
 
-  const checks = await connectionAuditor('podman', {
-    'kind.cluster.creation.http.port': 9090,
-    'kind.cluster.creation.https.port': 9443,
-  });
+  const checks = await auditConnection(
+    {
+      'kind.cluster.creation.http.port': 9090,
+      'kind.cluster.creation.https.port': 9443,
+    },
+    'podman',
+    'podman-machine-default',
+  );
 
   expect(checks).toBeDefined();
   expect(checks).toHaveProperty('records');
   expect(checks.records.length).toBe(1);
   expect(checks.records[0]).toHaveProperty('type');
   expect(checks.records[0].type).toBe('error');
-  expect(checks.records[0].record).toContain('The podman provider is not running');
+  expect(checks.records[0].record).toContain(
+    'The selected container connection "podman-machine-default" is not running',
+  );
 });
 
 test('check that auditItems does not return error when multiple VMs exist and one is running', async () => {
@@ -644,10 +897,14 @@ test('check that auditItems does not return error when multiple VMs exist and on
   vi.spyOn(extensionApi.net, 'getFreePort').mockImplementation((port: number) => Promise.resolve(port));
   vi.mocked(getMemTotalInfo).mockResolvedValue(8000000000); // 8GB
 
-  const checks = await connectionAuditor('podman', {
-    'kind.cluster.creation.http.port': 9090,
-    'kind.cluster.creation.https.port': 9443,
-  });
+  const checks = await auditConnection(
+    {
+      'kind.cluster.creation.http.port': 9090,
+      'kind.cluster.creation.https.port': 9443,
+    },
+    'podman',
+    'podman-machine-custom',
+  );
 
   expect(checks).toBeDefined();
   expect(checks).toHaveProperty('records');

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -82,7 +82,7 @@ function withConnection(
   connectionName = 'docker-connection',
 ): Record<string, unknown> {
   return {
-    'kind.cluster.creation.containerConnection': connectionSelection(providerId, connectionName),
+    'kind.cluster.creation.provider': connectionSelection(providerId, connectionName),
     ...params,
   };
 }
@@ -163,6 +163,45 @@ test('expect selected Podman connection and cancellation token in Kind command e
   );
   expect(telemetryLogUsageMock).toHaveBeenCalledWith('createCluster', expect.objectContaining({ provider: 'podman' }));
   expect(telemetryLogUsageMock.mock.calls[0][1]).not.toHaveProperty('containerConnection');
+});
+
+test('expect a legacy provider value to use a running connection of the same type', async () => {
+  vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([
+    {
+      providerId: 'docker',
+      connection: {
+        name: 'docker-desktop',
+        type: 'docker',
+        endpoint: { socketPath: 'docker-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+    {
+      providerId: 'podman',
+      connection: {
+        name: 'podman-machine-default',
+        type: 'podman',
+        endpoint: { socketPath: 'podman-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'started',
+      },
+    },
+  ]);
+  vi.mocked(getKindPath).mockReturnValue('/kind/path');
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({} as extensionApi.RunResult);
+
+  await createCluster({ 'kind.cluster.creation.provider': 'podman' }, '/kind', telemetryLoggerMock);
+
+  expect(extensionApi.process.exec).toHaveBeenCalledWith(
+    '/kind',
+    expect.any(Array),
+    expect.objectContaining({
+      env: {
+        CONTAINER_CONNECTION: 'podman-machine-default',
+        KIND_EXPERIMENTAL_PROVIDER: 'podman',
+        PATH: '/kind/path',
+      },
+    }),
+  );
 });
 
 test('expect selected Docker connection to configure its Unix socket', async () => {

--- a/extensions/kind/src/create-cluster.spec.ts
+++ b/extensions/kind/src/create-cluster.spec.ts
@@ -204,6 +204,27 @@ test('expect a legacy provider value to use a running connection of the same typ
   );
 });
 
+test('expect a legacy provider value to reject stopped connections', async () => {
+  vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([
+    {
+      providerId: 'podman',
+      connection: {
+        name: 'podman-machine-default',
+        type: 'podman',
+        endpoint: { socketPath: 'podman-socket' },
+        status: (): extensionApi.ProviderConnectionStatus => 'stopped',
+      },
+    },
+  ]);
+
+  await expect(
+    createCluster({ 'kind.cluster.creation.provider': 'podman' }, '/kind', telemetryLoggerMock),
+  ).rejects.toThrow(
+    'The previously selected Podman provider has no running container connection. Start one or select another connection.',
+  );
+  expect(extensionApi.process.exec).not.toHaveBeenCalled();
+});
+
 test('expect selected Docker connection to configure its Unix socket', async () => {
   vi.mocked(extensionApi.provider.getContainerConnections).mockReturnValue([
     {

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -153,7 +153,73 @@ async function validateAndCheckPort(portName: string, port: number, records: Aud
   }
 }
 
-export async function connectionAuditor(provider: string, items: AuditRequestItems): Promise<AuditResult> {
+interface ContainerConnectionSelection {
+  providerId: string;
+  connectionName: string;
+}
+
+type ContainerConnectionResolution = { connection: extensionApi.ProviderContainerConnection } | { error: string };
+
+function parseContainerConnectionSelection(value: unknown): ContainerConnectionSelection | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  try {
+    const selection: unknown = JSON.parse(value);
+    if (
+      selection &&
+      typeof selection === 'object' &&
+      'providerId' in selection &&
+      typeof selection.providerId === 'string' &&
+      'connectionName' in selection &&
+      typeof selection.connectionName === 'string'
+    ) {
+      return {
+        providerId: selection.providerId,
+        connectionName: selection.connectionName,
+      };
+    }
+  } catch {
+    // The validation error below explains how to recover from malformed input.
+  }
+
+  return undefined;
+}
+
+function resolveContainerConnection(items: AuditRequestItems): ContainerConnectionResolution {
+  const selection = parseContainerConnectionSelection(items['kind.cluster.creation.containerConnection']);
+  if (!selection) {
+    return { error: 'Select a running container connection to create a Kind cluster.' };
+  }
+
+  const selectedConnection = extensionApi.provider
+    .getContainerConnections()
+    .find(
+      connection =>
+        connection.providerId === selection.providerId && connection.connection.name === selection.connectionName,
+    );
+
+  if (!selectedConnection) {
+    return {
+      error: `The selected container connection "${selection.connectionName}" is no longer available. Select another connection.`,
+    };
+  }
+
+  if (selectedConnection.connection.type !== 'podman' && selectedConnection.connection.type !== 'docker') {
+    return {
+      error: `The selected container connection "${selection.connectionName}" uses an unsupported provider type "${selectedConnection.connection.type}". Select a Podman or Docker connection.`,
+    };
+  }
+
+  if (selectedConnection.connection.status() !== 'started') {
+    return {
+      error: `The selected container connection "${selection.connectionName}" is not running. Start it or select another connection.`,
+    };
+  }
+
+  return { connection: selectedConnection };
+}
+
+export async function connectionAuditor(items: AuditRequestItems): Promise<AuditResult> {
   const records: AuditRecord[] = [];
   const auditResult = {
     records: records,
@@ -189,23 +255,14 @@ export async function connectionAuditor(provider: string, items: AuditRequestIte
     });
   }
 
-  const providerSockets = extensionApi.provider
-    .getContainerConnections()
-    .filter(connection => connection.connection.type === provider);
-
-  if (providerSockets.length === 0) return auditResult;
-
-  // Check if any connection from the list is running
-  const runningConnection = providerSockets.find(connection => connection.connection.status() === 'started');
-
-  if (!runningConnection) {
+  const selectedConnection = resolveContainerConnection(items);
+  if ('error' in selectedConnection) {
     records.push({
       type: 'error',
-      record: `The ${provider} provider is not running. Please start the ${provider} provider to create a Kind cluster.`,
+      record: selectedConnection.error,
     });
   } else {
-    // Only check memory if provider is running
-    const memTotal = await getMemTotalInfo(runningConnection.connection.endpoint.socketPath);
+    const memTotal = await getMemTotalInfo(selectedConnection.connection.connection.endpoint.socketPath);
     // check if configured memory is less than 6GB
     if (memTotal < 6000000000) {
       records.push({
@@ -235,16 +292,22 @@ export async function createCluster(
     clusterName = String(params['kind.cluster.creation.name']);
   }
 
-  // grab provider
-  let provider = 'docker';
-  if (params['kind.cluster.creation.provider']) {
-    provider = String(params['kind.cluster.creation.provider']);
-  }
+  const selectedConnection = resolveContainerConnection(params);
+  if ('error' in selectedConnection) throw new Error(selectedConnection.error);
+
+  const connection = selectedConnection.connection.connection;
+  const provider = connection.type;
 
   const env: { [key: string]: string } = {};
   // add KIND_EXPERIMENTAL_PROVIDER env variable if needed
   if (provider === 'podman') {
     env['KIND_EXPERIMENTAL_PROVIDER'] = 'podman';
+    env['CONTAINER_CONNECTION'] = connection.name;
+  } else {
+    const socketPath = connection.endpoint.socketPath;
+    env['DOCKER_HOST'] = extensionApi.env.isWindows
+      ? socketPath.replace('\\\\.\\pipe\\', 'npipe:////./pipe/')
+      : `unix://${socketPath}`;
   }
 
   // grab http host port

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -196,14 +196,18 @@ function resolveContainerConnection(items: AuditRequestItems): ContainerConnecti
   const connections = extensionApi.provider.getContainerConnections();
 
   if (isLegacyProviderSelection(configuredValue)) {
-    const legacyConnection =
-      connections.find(
-        connection => connection.connection.type === configuredValue && connection.connection.status() === 'started',
-      ) ?? connections.find(connection => connection.connection.type === configuredValue);
+    const legacyConnections = connections.filter(connection => connection.connection.type === configuredValue);
+    const legacyConnection = legacyConnections.find(connection => connection.connection.status() === 'started');
 
     if (!legacyConnection) {
+      const providerName = configuredValue === 'podman' ? 'Podman' : 'Docker';
+      if (legacyConnections.length > 0) {
+        return {
+          error: `The previously selected ${providerName} provider has no running container connection. Start one or select another connection.`,
+        };
+      }
       return {
-        error: `The previously selected ${configuredValue === 'podman' ? 'Podman' : 'Docker'} provider is no longer available. Select a running container connection.`,
+        error: `The previously selected ${providerName} provider is no longer available. Select a running container connection.`,
       };
     }
 

--- a/extensions/kind/src/create-cluster.ts
+++ b/extensions/kind/src/create-cluster.ts
@@ -160,6 +160,12 @@ interface ContainerConnectionSelection {
 
 type ContainerConnectionResolution = { connection: extensionApi.ProviderContainerConnection } | { error: string };
 
+const CONTAINER_CONNECTION_CONFIGURATION_KEY = 'kind.cluster.creation.provider';
+
+function isLegacyProviderSelection(value: unknown): value is 'podman' | 'docker' {
+  return value === 'podman' || value === 'docker';
+}
+
 function parseContainerConnectionSelection(value: unknown): ContainerConnectionSelection | undefined {
   if (typeof value !== 'string') return undefined;
 
@@ -186,17 +192,33 @@ function parseContainerConnectionSelection(value: unknown): ContainerConnectionS
 }
 
 function resolveContainerConnection(items: AuditRequestItems): ContainerConnectionResolution {
-  const selection = parseContainerConnectionSelection(items['kind.cluster.creation.containerConnection']);
+  const configuredValue = items[CONTAINER_CONNECTION_CONFIGURATION_KEY];
+  const connections = extensionApi.provider.getContainerConnections();
+
+  if (isLegacyProviderSelection(configuredValue)) {
+    const legacyConnection =
+      connections.find(
+        connection => connection.connection.type === configuredValue && connection.connection.status() === 'started',
+      ) ?? connections.find(connection => connection.connection.type === configuredValue);
+
+    if (!legacyConnection) {
+      return {
+        error: `The previously selected ${configuredValue === 'podman' ? 'Podman' : 'Docker'} provider is no longer available. Select a running container connection.`,
+      };
+    }
+
+    return { connection: legacyConnection };
+  }
+
+  const selection = parseContainerConnectionSelection(configuredValue);
   if (!selection) {
     return { error: 'Select a running container connection to create a Kind cluster.' };
   }
 
-  const selectedConnection = extensionApi.provider
-    .getContainerConnections()
-    .find(
-      connection =>
-        connection.providerId === selection.providerId && connection.connection.name === selection.connectionName,
-    );
+  const selectedConnection = connections.find(
+    connection =>
+      connection.providerId === selection.providerId && connection.connection.name === selection.connectionName,
+  );
 
   if (!selectedConnection) {
     return {

--- a/extensions/kind/src/extension.spec.ts
+++ b/extensions/kind/src/extension.spec.ts
@@ -535,6 +535,28 @@ describe('kubernetes create factory', () => {
     expect(PROVIDER_MOCK.setKubernetesProviderConnectionFactory).not.toHaveBeenCalled();
   });
 
+  test('activate should NOT register factory when only unsupported running connections exist', async () => {
+    vi.mocked(podmanDesktopApi.provider.getContainerConnections).mockReturnValue([
+      {
+        connection: {
+          name: 'unsupported-connection',
+          status: () => 'started',
+          type: 'unsupported',
+        },
+      } as unknown as extensionApi.ProviderContainerConnection,
+    ]);
+
+    await extension.activate(
+      vi.mocked<extensionApi.ExtensionContext>({
+        subscriptions: {
+          push: vi.fn(),
+        },
+      } as unknown as extensionApi.ExtensionContext),
+    );
+
+    expect(PROVIDER_MOCK.setKubernetesProviderConnectionFactory).not.toHaveBeenCalled();
+  });
+
   test('expect info message to be displayed when no binary installed and cluster created called', async () => {
     vi.mocked(podmanDesktopApi.provider.getContainerConnections).mockReturnValue([
       {

--- a/extensions/kind/src/extension.ts
+++ b/extensions/kind/src/extension.ts
@@ -122,7 +122,7 @@ function registerKubernetesFactory(
     },
     {
       auditItems: async (items: AuditRequestItems) => {
-        return await connectionAuditor(new ProviderNameExtractor(items).getProviderName(), items);
+        return await connectionAuditor(items);
       },
     },
   );
@@ -137,7 +137,11 @@ function updateKubernetesFactoryRegistration(
   telemetryLogger: extensionApi.TelemetryLogger,
 ): void {
   const containerConnections = extensionApi.provider.getContainerConnections();
-  const runningConnections = containerConnections.filter(conn => conn.connection.status() === 'started');
+  const runningConnections = containerConnections.filter(
+    conn =>
+      conn.connection.status() === 'started' &&
+      (conn.connection.type === 'podman' || conn.connection.type === 'docker'),
+  );
 
   if (runningConnections.length > 0) {
     kubernetesFactoryDisposable ??= registerKubernetesFactory(provider, telemetryLogger);
@@ -165,18 +169,6 @@ async function registerProvider(
   updateKubernetesFactoryRegistration(provider, telemetryLogger);
   await searchKindClusters(provider);
   console.log('kind extension is active');
-}
-
-class ProviderNameExtractor {
-  constructor(private items: AuditRequestItems) {}
-
-  getProviderName(): string {
-    if (this.items['kind.cluster.creation.provider']) {
-      return this.items['kind.cluster.creation.provider'];
-    }
-
-    return 'docker';
-  }
 }
 
 // search for clusters

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -497,7 +497,7 @@ test('selected container connection is submitted to the provider factory', async
         title: 'Kind',
         parentId: 'kind',
         scope: 'KubernetesProviderConnectionFactory',
-        id: 'kind.cluster.creation.containerConnection',
+        id: 'kind.cluster.creation.provider',
         type: 'string',
         format: 'containerConnection',
         description: 'Container Connection',
@@ -518,7 +518,7 @@ test('selected container connection is submitted to the provider factory', async
   expect(callback).toHaveBeenCalledWith(
     kindProviderInfo.internalId,
     {
-      'kind.cluster.creation.containerConnection': JSON.stringify({
+      'kind.cluster.creation.provider': JSON.stringify({
         providerId: 'docker',
         connectionName: 'shared-name',
       }),

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
@@ -31,6 +31,7 @@ import { beforeAll, beforeEach, describe, expect, type Mock, test, vi } from 'vi
 
 import { eventCollect, reconnectUI } from '/@/lib/preferences/preferences-connection-rendering-task';
 import { operationConnectionsInfo } from '/@/stores/operation-connections';
+import { providerInfos } from '/@/stores/providers';
 
 import PreferencesConnectionCreationOrEditRendering from './PreferencesConnectionCreationOrEditRendering.svelte';
 
@@ -95,6 +96,7 @@ function mockCallback(
 
 beforeEach(() => {
   operationConnectionsInfo.set(new Map());
+  providerInfos.set([]);
   vi.resetAllMocks();
 });
 
@@ -444,6 +446,88 @@ test(`Check itemsAudit receive updated values`, async () => {
     'test.factoryProperty': '2',
     'test.fileProperty': 'somefile',
   });
+});
+
+test('selected container connection is submitted to the provider factory', async () => {
+  providerInfos.set([
+    {
+      id: 'podman',
+      name: 'Podman',
+      containerConnections: [
+        {
+          name: 'shared-name',
+          displayName: 'Local',
+          status: 'started',
+          type: 'podman',
+          endpoint: { socketPath: 'podman-socket' },
+        },
+      ],
+      kubernetesConnections: [],
+      vmConnections: [],
+    } as unknown as ProviderInfo,
+    {
+      id: 'docker',
+      name: 'Docker',
+      containerConnections: [
+        {
+          name: 'shared-name',
+          displayName: 'Local',
+          status: 'started',
+          type: 'docker',
+          endpoint: { socketPath: 'docker-socket' },
+        },
+      ],
+      kubernetesConnections: [],
+      vmConnections: [],
+    } as unknown as ProviderInfo,
+  ]);
+  vi.mocked(window.auditConnectionParameters).mockResolvedValue({ records: [] });
+  const callback = mockCallback(async () => {});
+  const taskId = 5;
+  const kindProviderInfo = {
+    ...providerInfo,
+    id: 'kind',
+    internalId: 'kind',
+    name: 'Kind',
+  } as ProviderInfo;
+
+  render(PreferencesConnectionCreationOrEditRendering, {
+    properties: [
+      {
+        title: 'Kind',
+        parentId: 'kind',
+        scope: 'KubernetesProviderConnectionFactory',
+        id: 'kind.cluster.creation.containerConnection',
+        type: 'string',
+        format: 'containerConnection',
+        description: 'Container Connection',
+      },
+    ],
+    providerInfo: kindProviderInfo,
+    propertyScope: 'KubernetesProviderConnectionFactory',
+    callback,
+    pageIsLoading: false,
+    taskId,
+  });
+
+  await vi.waitFor(() => expect(screen.getByLabelText('Container Connection')).toHaveTextContent('Local (Podman)'));
+  await fireEvent.click(screen.getByRole('button', { name: /Local \(Podman\)/ }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Local (Docker)' }));
+  await fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+  expect(callback).toHaveBeenCalledWith(
+    kindProviderInfo.internalId,
+    {
+      'kind.cluster.creation.containerConnection': JSON.stringify({
+        providerId: 'docker',
+        connectionName: 'shared-name',
+      }),
+    },
+    expect.anything(),
+    eventCollect,
+    undefined,
+    taskId,
+  );
 });
 
 test(`Expect create with unchecked and checked checkboxes`, async () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -579,6 +579,46 @@ test('waits for the saved container connection before selecting a default', asyn
   expect(setRecordValue).not.toHaveBeenCalledWith('kind.cluster.creation.provider', podmanSelection);
 });
 
+test('does not select a default container connection when the saved value cannot be loaded', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'kind.cluster.creation.provider',
+    title: 'Kind',
+    parentId: 'kind',
+    description: 'Container Connection',
+    type: 'string',
+    format: 'containerConnection',
+  };
+  providerInfos.set([
+    {
+      id: 'podman',
+      name: 'Podman',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          displayName: 'Podman Machine',
+          status: 'started',
+          type: 'podman',
+        },
+      ],
+      kubernetesConnections: [],
+      vmConnections: [],
+    } as unknown as ProviderInfo,
+  ]);
+  const setRecordValue = vi.fn();
+  const consoleError = vi.spyOn(console, 'error').mockReturnValue(undefined);
+
+  render(PreferencesRenderingItemFormat, {
+    record,
+    initialValue: Promise.reject(new Error('settings unavailable')),
+    setRecordValue,
+  });
+
+  await vi.waitFor(() => expect(consoleError).toHaveBeenCalledWith('Error getting initial value', expect.any(Error)));
+  expect(screen.getByTestId('tooltip-trigger')).toBeInTheDocument();
+  expect(screen.queryByLabelText('Container Connection')).not.toBeInTheDocument();
+  expect(setRecordValue).not.toHaveBeenCalled();
+});
+
 describe('experimental configuration update', () => {
   test('Expect updateExperimentalConfigurationValue to be called for experimental records', async () => {
     const record: IConfigurationPropertyRecordedSchema = {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -20,6 +20,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
@@ -28,11 +29,13 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { getInitialValue } from '/@/lib/preferences/Util';
 import { onDidChangeConfiguration } from '/@/stores/configurationProperties';
+import { providerInfos } from '/@/stores/providers';
 
 import PreferencesRenderingItemFormat from './PreferencesRenderingItemFormat.svelte';
 
 beforeEach(() => {
   vi.resetAllMocks();
+  providerInfos.set([]);
 });
 
 async function awaitRender(record: IConfigurationPropertyRecordedSchema, customProperties: any): Promise<void> {
@@ -509,6 +512,71 @@ test('Expect a password input when record is type string and format is password'
   // check that the name is properly set and the value too
   expect(passwordInput).toHaveAttribute('name', 'record');
   expect(passwordInput).toHaveValue('foobar');
+});
+
+test('waits for the saved container connection before selecting a default', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'kind.cluster.creation.provider',
+    title: 'Kind',
+    parentId: 'kind',
+    description: 'Container Connection',
+    type: 'string',
+    format: 'containerConnection',
+  };
+  const podmanSelection = JSON.stringify({ providerId: 'podman', connectionName: 'podman-machine-default' });
+  const dockerSelection = JSON.stringify({ providerId: 'docker', connectionName: 'docker-desktop' });
+  providerInfos.set([
+    {
+      id: 'podman',
+      name: 'Podman',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          displayName: 'Podman Machine',
+          status: 'started',
+          type: 'podman',
+        },
+      ],
+      kubernetesConnections: [],
+      vmConnections: [],
+    } as unknown as ProviderInfo,
+    {
+      id: 'docker',
+      name: 'Docker',
+      containerConnections: [
+        {
+          name: 'docker-desktop',
+          displayName: 'Docker Desktop',
+          status: 'started',
+          type: 'docker',
+        },
+      ],
+      kubernetesConnections: [],
+      vmConnections: [],
+    } as unknown as ProviderInfo,
+  ]);
+
+  let resolveInitialValue: (value: unknown) => void = (): void => {};
+  const initialValue = new Promise<unknown>(resolve => {
+    resolveInitialValue = resolve;
+  });
+  const setRecordValue = vi.fn();
+
+  render(PreferencesRenderingItemFormat, { record, initialValue, setRecordValue });
+  await tick();
+
+  expect(screen.queryByLabelText('Container Connection')).not.toBeInTheDocument();
+  expect(setRecordValue).not.toHaveBeenCalled();
+
+  resolveInitialValue(dockerSelection);
+
+  await vi.waitFor(() =>
+    expect(screen.getByLabelText('Container Connection')).toHaveTextContent('Docker Desktop (Docker)'),
+  );
+  await vi.waitFor(() =>
+    expect(setRecordValue).toHaveBeenCalledWith('kind.cluster.creation.provider', dockerSelection),
+  );
+  expect(setRecordValue).not.toHaveBeenCalledWith('kind.cluster.creation.provider', podmanSelection);
 });
 
 describe('experimental configuration update', () => {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.spec.ts
@@ -619,6 +619,60 @@ test('does not select a default container connection when the saved value cannot
   expect(setRecordValue).not.toHaveBeenCalled();
 });
 
+test('ignores a stale initial-value rejection after the record changes', async () => {
+  const firstRecord: IConfigurationPropertyRecordedSchema = {
+    id: 'first.connection',
+    title: 'First',
+    parentId: 'kind',
+    description: 'First Connection',
+    type: 'string',
+    format: 'containerConnection',
+  };
+  const secondRecord: IConfigurationPropertyRecordedSchema = {
+    ...firstRecord,
+    id: 'second.connection',
+    title: 'Second',
+    description: 'Second Connection',
+  };
+  const selection = JSON.stringify({ providerId: 'podman', connectionName: 'podman-machine-default' });
+  providerInfos.set([
+    {
+      id: 'podman',
+      name: 'Podman',
+      containerConnections: [
+        {
+          name: 'podman-machine-default',
+          displayName: 'Podman Machine',
+          status: 'started',
+          type: 'podman',
+        },
+      ],
+      kubernetesConnections: [],
+      vmConnections: [],
+    } as unknown as ProviderInfo,
+  ]);
+  let rejectFirst: (reason: Error) => void = (): void => {};
+  const firstInitialValue = new Promise<unknown>((_resolve, reject) => {
+    rejectFirst = reject;
+  });
+  const setRecordValue = vi.fn();
+  const consoleError = vi.spyOn(console, 'error').mockReturnValue(undefined);
+  const { rerender } = render(PreferencesRenderingItemFormat, {
+    record: firstRecord,
+    initialValue: firstInitialValue,
+    setRecordValue,
+  });
+
+  await rerender({ record: secondRecord, initialValue: Promise.resolve(selection), setRecordValue });
+  await vi.waitFor(() => expect(screen.getByLabelText('Second Connection')).toBeInTheDocument());
+
+  rejectFirst(new Error('stale settings failure'));
+  await tick();
+
+  expect(screen.getByLabelText('Second Connection')).toBeInTheDocument();
+  expect(consoleError).not.toHaveBeenCalled();
+});
+
 describe('experimental configuration update', () => {
   test('Expect updateExperimentalConfigurationValue to be called for experimental records', async () => {
     const record: IConfigurationPropertyRecordedSchema = {

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -48,6 +48,7 @@ let recordUpdateTimeout: NodeJS.Timeout;
 let invalidText: string | undefined = $state(undefined);
 let recordValue: unknown = $state(undefined);
 let initialValueResolved = $state(false);
+let initialValueError: string | undefined = $state(undefined);
 
 $effect(() => {
   updateResetButtonVisibility?.(recordValue);
@@ -89,6 +90,7 @@ $effect(() => {
 $effect(() => {
   if (!isEqual(currentRecord, record)) {
     initialValueResolved = false;
+    initialValueError = undefined;
     initialValue
       .then(value => {
         recordValue = value;
@@ -96,7 +98,10 @@ $effect(() => {
           recordValue = !!value;
         }
       })
-      .catch((err: unknown) => console.error('Error getting initial value', err))
+      .catch((err: unknown) => {
+        console.error('Error getting initial value', err);
+        initialValueError = 'Unable to load the current configuration value.';
+      })
       .finally(() => {
         initialValueResolved = true;
       });
@@ -214,6 +219,9 @@ function containerConnectionValue(): string | undefined {
   {#if invalidText}
     <ErrorMessage error="{invalidText}." icon={true} class="mr-2" />
   {/if}
+  {#if initialValueError}
+    <ErrorMessage error={initialValueError} icon={true} class="mr-2" />
+  {/if}
   {#if record.type === 'boolean'}
     <BooleanItem
       record={record}
@@ -239,7 +247,7 @@ function containerConnectionValue(): string | undefined {
     {/if}
   {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
     {#if record.format === 'containerConnection'}
-      {#if initialValueResolved}
+      {#if initialValueResolved && !initialValueError}
         <ContainerConnectionItem
           record={record}
           value={containerConnectionValue()}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -49,6 +49,7 @@ let invalidText: string | undefined = $state(undefined);
 let recordValue: unknown = $state(undefined);
 let initialValueResolved = $state(false);
 let initialValueError: string | undefined = $state(undefined);
+let initialValueRequest = 0;
 
 $effect(() => {
   updateResetButtonVisibility?.(recordValue);
@@ -89,21 +90,31 @@ $effect(() => {
 
 $effect(() => {
   if (!isEqual(currentRecord, record)) {
+    const request = ++initialValueRequest;
+    const requestedRecord = record;
     initialValueResolved = false;
     initialValueError = undefined;
     initialValue
       .then(value => {
+        if (request !== initialValueRequest) {
+          return;
+        }
         recordValue = value;
-        if (record.type === 'boolean' || record.type === 'object') {
+        if (requestedRecord.type === 'boolean' || requestedRecord.type === 'object') {
           recordValue = !!value;
         }
       })
       .catch((err: unknown) => {
+        if (request !== initialValueRequest) {
+          return;
+        }
         console.error('Error getting initial value', err);
         initialValueError = 'Unable to load the current configuration value.';
       })
       .finally(() => {
-        initialValueResolved = true;
+        if (request === initialValueRequest) {
+          initialValueResolved = true;
+        }
       });
 
     invalidText = undefined;

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -5,6 +5,7 @@ import { onDestroy, onMount } from 'svelte';
 
 import Markdown from '/@/lib/markdown/Markdown.svelte';
 import BooleanItem from '/@/lib/preferences/item-formats/BooleanItem.svelte';
+import ContainerConnectionItem from '/@/lib/preferences/item-formats/ContainerConnectionItem.svelte';
 import EnumItem from '/@/lib/preferences/item-formats/EnumItem.svelte';
 import FileItem from '/@/lib/preferences/item-formats/FileItem.svelte';
 import NumberItem from '/@/lib/preferences/item-formats/NumberItem.svelte';
@@ -225,7 +226,12 @@ function numberItemValue(): number {
         invalidRecord={invalidRecord} />
     {/if}
   {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
-    {#if record.format === 'file' || record.format === 'folder'}
+    {#if record.format === 'containerConnection'}
+      <ContainerConnectionItem
+        record={record}
+        value={typeof givenValue === 'string' ? givenValue : undefined}
+        onChange={onChange} />
+    {:else if record.format === 'file' || record.format === 'folder'}
       <FileItem
         record={record}
         value={typeof givenValue === 'string' ? givenValue : (recordValue ?? '')}

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItemFormat.svelte
@@ -47,6 +47,7 @@ let recordUpdateTimeout: NodeJS.Timeout;
 
 let invalidText: string | undefined = $state(undefined);
 let recordValue: unknown = $state(undefined);
+let initialValueResolved = $state(false);
 
 $effect(() => {
   updateResetButtonVisibility?.(recordValue);
@@ -87,6 +88,7 @@ $effect(() => {
 
 $effect(() => {
   if (!isEqual(currentRecord, record)) {
+    initialValueResolved = false;
     initialValue
       .then(value => {
         recordValue = value;
@@ -94,7 +96,10 @@ $effect(() => {
           recordValue = !!value;
         }
       })
-      .catch((err: unknown) => console.error('Error getting initial value', err));
+      .catch((err: unknown) => console.error('Error getting initial value', err))
+      .finally(() => {
+        initialValueResolved = true;
+      });
 
     invalidText = undefined;
     currentRecord = record;
@@ -196,6 +201,13 @@ function numberItemValue(): number {
   }
   return getNormalizedDefaultNumberValue(record);
 }
+
+function containerConnectionValue(): string | undefined {
+  if (typeof givenValue === 'string') {
+    return givenValue;
+  }
+  return typeof recordValue === 'string' ? recordValue : undefined;
+}
 </script>
 
 <div class="flex flex-row mb-1 pt-2 text-start items-center justify-start">
@@ -227,10 +239,12 @@ function numberItemValue(): number {
     {/if}
   {:else if record.type === 'string' && (typeof recordValue === 'string' || recordValue === undefined)}
     {#if record.format === 'containerConnection'}
-      <ContainerConnectionItem
-        record={record}
-        value={typeof givenValue === 'string' ? givenValue : undefined}
-        onChange={onChange} />
+      {#if initialValueResolved}
+        <ContainerConnectionItem
+          record={record}
+          value={containerConnectionValue()}
+          onChange={onChange} />
+      {/if}
     {:else if record.format === 'file' || record.format === 'folder'}
       <FileItem
         record={record}

--- a/packages/renderer/src/lib/preferences/item-formats/ContainerConnectionItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/ContainerConnectionItem.spec.ts
@@ -31,7 +31,7 @@ import ContainerConnectionItem from './ContainerConnectionItem.svelte';
 vi.mock(import('/@/stores/providers'));
 
 const RECORD: IConfigurationPropertyRecordedSchema = {
-  id: 'kind.cluster.creation.containerConnection',
+  id: 'kind.cluster.creation.provider',
   title: 'Kind',
   parentId: 'kind',
   type: 'string',
@@ -83,10 +83,29 @@ test('selects the only running connection by default', async () => {
   expect(dropdown).toHaveTextContent('Podman Machine (Podman)');
   await vi.waitFor(() =>
     expect(onChange).toHaveBeenCalledWith(
-      'kind.cluster.creation.containerConnection',
+      'kind.cluster.creation.provider',
       selection('podman', 'podman-machine-default'),
     ),
   );
+});
+
+test('migrates a legacy provider value to a running connection of the same type', async () => {
+  vi.mocked(providers).providerInfos = writable([
+    provider('docker', 'docker', 'docker-desktop', 'Docker Desktop'),
+    provider('podman', 'podman', 'podman-machine-default', 'Podman Machine'),
+  ]);
+  const onChange = vi.fn().mockResolvedValue(undefined);
+
+  render(ContainerConnectionItem, { record: RECORD, value: 'podman', onChange });
+
+  expect(screen.getByLabelText('Container Connection')).toHaveTextContent('Podman Machine (Podman)');
+  await vi.waitFor(() =>
+    expect(onChange).toHaveBeenCalledWith(
+      'kind.cluster.creation.provider',
+      selection('podman', 'podman-machine-default'),
+    ),
+  );
+  expect(onChange).not.toHaveBeenCalledWith('kind.cluster.creation.provider', selection('docker', 'docker-desktop'));
 });
 
 test('lists running connections and excludes stopped connections', async () => {
@@ -117,10 +136,7 @@ test('duplicate display names select the connection from the chosen provider', a
   await fireEvent.click(screen.getByRole('button'));
   await fireEvent.click(screen.getByRole('button', { name: 'Local (Docker)' }));
 
-  expect(onChange).toHaveBeenLastCalledWith(
-    'kind.cluster.creation.containerConnection',
-    selection('docker', 'shared-name'),
-  );
+  expect(onChange).toHaveBeenLastCalledWith('kind.cluster.creation.provider', selection('docker', 'shared-name'));
 });
 
 test('keeps and revalidates a connection that disappears and recovers', async () => {
@@ -135,13 +151,13 @@ test('keeps and revalidates a connection that disappears and recovers', async ()
   providerStore.set([]);
 
   await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
-  expect(onChange).toHaveBeenLastCalledWith('kind.cluster.creation.containerConnection', selection('podman', 'remote'));
+  expect(onChange).toHaveBeenLastCalledWith('kind.cluster.creation.provider', selection('podman', 'remote'));
   expect(screen.getByLabelText('Container Connection')).toHaveTextContent('Selected connection is unavailable');
 
   providerStore.set([remoteProvider]);
 
   await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(3));
-  expect(onChange).toHaveBeenLastCalledWith('kind.cluster.creation.containerConnection', selection('podman', 'remote'));
+  expect(onChange).toHaveBeenLastCalledWith('kind.cluster.creation.provider', selection('podman', 'remote'));
   expect(screen.getByLabelText('Container Connection')).toHaveTextContent('Remote (Podman)');
 });
 

--- a/packages/renderer/src/lib/preferences/item-formats/ContainerConnectionItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/ContainerConnectionItem.spec.ts
@@ -1,0 +1,155 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import type { ProviderInfo } from '@podman-desktop/core-api';
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import * as providers from '/@/stores/providers';
+
+import ContainerConnectionItem from './ContainerConnectionItem.svelte';
+
+vi.mock(import('/@/stores/providers'));
+
+const RECORD: IConfigurationPropertyRecordedSchema = {
+  id: 'kind.cluster.creation.containerConnection',
+  title: 'Kind',
+  parentId: 'kind',
+  type: 'string',
+  format: 'containerConnection',
+  description: 'Container Connection',
+};
+
+function provider(
+  id: string,
+  type: 'podman' | 'docker' | 'unsupported',
+  name: string,
+  displayName: string,
+  status: 'started' | 'stopped' = 'started',
+): ProviderInfo {
+  return {
+    id,
+    name: id,
+    containerConnections: [
+      {
+        name,
+        displayName,
+        status,
+        type,
+        endpoint: { socketPath: `${name}.sock` },
+      },
+    ],
+    kubernetesConnections: [],
+    vmConnections: [],
+  } as unknown as ProviderInfo;
+}
+
+function selection(providerId: string, connectionName: string): string {
+  return JSON.stringify({ providerId, connectionName });
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('selects the only running connection by default', async () => {
+  vi.mocked(providers).providerInfos = writable([
+    provider('podman', 'podman', 'podman-machine-default', 'Podman Machine'),
+  ]);
+  const onChange = vi.fn().mockResolvedValue(undefined);
+
+  render(ContainerConnectionItem, { record: RECORD, onChange });
+
+  const dropdown = screen.getByLabelText('Container Connection');
+  expect(dropdown).toHaveTextContent('Podman Machine (Podman)');
+  await vi.waitFor(() =>
+    expect(onChange).toHaveBeenCalledWith(
+      'kind.cluster.creation.containerConnection',
+      selection('podman', 'podman-machine-default'),
+    ),
+  );
+});
+
+test('lists running connections and excludes stopped connections', async () => {
+  vi.mocked(providers).providerInfos = writable([
+    provider('podman', 'podman', 'running-podman', 'Running Podman'),
+    provider('docker', 'docker', 'running-docker', 'Running Docker'),
+    provider('stopped', 'podman', 'stopped-podman', 'Stopped Podman', 'stopped'),
+    provider('unsupported', 'unsupported', 'running-unsupported', 'Running Unsupported'),
+  ]);
+
+  render(ContainerConnectionItem, { record: RECORD, onChange: vi.fn().mockResolvedValue(undefined) });
+  await fireEvent.click(screen.getByRole('button'));
+
+  expect(screen.getAllByRole('button', { name: 'Running Podman (Podman)' })).toHaveLength(2);
+  expect(screen.getByRole('button', { name: 'Running Docker (Docker)' })).toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'Stopped Podman (Podman)' })).not.toBeInTheDocument();
+  expect(screen.queryByText('Running Unsupported')).not.toBeInTheDocument();
+});
+
+test('duplicate display names select the connection from the chosen provider', async () => {
+  vi.mocked(providers).providerInfos = writable([
+    provider('podman', 'podman', 'shared-name', 'Local'),
+    provider('docker', 'docker', 'shared-name', 'Local'),
+  ]);
+  const onChange = vi.fn().mockResolvedValue(undefined);
+
+  render(ContainerConnectionItem, { record: RECORD, onChange });
+  await fireEvent.click(screen.getByRole('button'));
+  await fireEvent.click(screen.getByRole('button', { name: 'Local (Docker)' }));
+
+  expect(onChange).toHaveBeenLastCalledWith(
+    'kind.cluster.creation.containerConnection',
+    selection('docker', 'shared-name'),
+  );
+});
+
+test('keeps and revalidates a connection that disappears and recovers', async () => {
+  const remoteProvider = provider('podman', 'podman', 'remote', 'Remote');
+  const providerStore = writable([remoteProvider]);
+  vi.mocked(providers).providerInfos = providerStore;
+  const onChange = vi.fn().mockResolvedValue(undefined);
+
+  render(ContainerConnectionItem, { record: RECORD, onChange });
+  await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+
+  providerStore.set([]);
+
+  await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(2));
+  expect(onChange).toHaveBeenLastCalledWith('kind.cluster.creation.containerConnection', selection('podman', 'remote'));
+  expect(screen.getByLabelText('Container Connection')).toHaveTextContent('Selected connection is unavailable');
+
+  providerStore.set([remoteProvider]);
+
+  await vi.waitFor(() => expect(onChange).toHaveBeenCalledTimes(3));
+  expect(onChange).toHaveBeenLastCalledWith('kind.cluster.creation.containerConnection', selection('podman', 'remote'));
+  expect(screen.getByLabelText('Container Connection')).toHaveTextContent('Remote (Podman)');
+});
+
+test('disables the selector when no running connections are available', () => {
+  vi.mocked(providers).providerInfos = writable([provider('podman', 'podman', 'stopped', 'Stopped', 'stopped')]);
+
+  render(ContainerConnectionItem, { record: RECORD, onChange: vi.fn().mockResolvedValue(undefined) });
+
+  expect(screen.getByRole('button')).toBeDisabled();
+  expect(screen.getByLabelText('Container Connection')).toHaveTextContent('No running container connections');
+});

--- a/packages/renderer/src/lib/preferences/item-formats/ContainerConnectionItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/ContainerConnectionItem.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
+import { Dropdown } from '@podman-desktop/ui-svelte';
+
+import { providerInfos } from '/@/stores/providers';
+
+interface Props {
+  record: IConfigurationPropertyRecordedSchema;
+  value?: string;
+  onChange?: (_id: string, _value: string) => Promise<void>;
+}
+
+let {
+  record,
+  value = $bindable(),
+  onChange = async (_id: string, _value: string): Promise<void> => {},
+}: Props = $props();
+
+let invalidEntry = $state(false);
+let lastNotifiedValue: string | undefined = $state(undefined);
+let wasSelectedConnectionAvailable: boolean | undefined = $state(undefined);
+
+const connectionOptions = $derived(
+  $providerInfos.flatMap(provider =>
+    provider.containerConnections
+      .filter(
+        connection => connection.status === 'started' && (connection.type === 'podman' || connection.type === 'docker'),
+      )
+      .map(connection => ({
+        label: `${connection.displayName} (${connection.type === 'podman' ? 'Podman' : 'Docker'})`,
+        value: JSON.stringify({
+          providerId: provider.id,
+          connectionName: connection.name,
+        }),
+      })),
+  ),
+);
+
+const selectedConnectionAvailable = $derived(!!value && connectionOptions.some(option => option.value === value));
+
+const displayedOptions = $derived.by(() => {
+  if (value && !selectedConnectionAvailable) {
+    return [{ label: 'Selected connection is unavailable', value }, ...connectionOptions];
+  }
+  if (connectionOptions.length === 0) {
+    return [{ label: 'No running container connections', value: '' }];
+  }
+  return connectionOptions;
+});
+
+$effect(() => {
+  if (!value && connectionOptions.length > 0) {
+    value = connectionOptions[0].value;
+  } else if (value && value !== lastNotifiedValue) {
+    lastNotifiedValue = value;
+    notifyChange(value);
+  } else if (
+    value &&
+    wasSelectedConnectionAvailable !== undefined &&
+    wasSelectedConnectionAvailable !== selectedConnectionAvailable
+  ) {
+    // Re-audit the unchanged selection when it stops, disappears, or becomes available again.
+    notifyChange(value);
+  }
+  wasSelectedConnectionAvailable = selectedConnectionAvailable;
+});
+
+function notifyChange(newValue: string): void {
+  invalidEntry = false;
+  if (record.id) {
+    onChange(record.id, newValue).catch(() => (invalidEntry = true));
+  }
+}
+
+function onChangeHandler(newValue: unknown): void {
+  if (typeof newValue === 'string' && newValue !== value) {
+    value = newValue;
+    lastNotifiedValue = newValue;
+    notifyChange(newValue);
+  }
+}
+</script>
+
+<Dropdown
+  name={record.id}
+  id="input-standard-{record.id}"
+  onChange={onChangeHandler}
+  bind:value
+  ariaInvalid={invalidEntry}
+  ariaLabel={record.description}
+  disabled={!!record.readonly || !!record.locked || connectionOptions.length === 0}
+  options={displayedOptions}>
+</Dropdown>

--- a/packages/renderer/src/lib/preferences/item-formats/ContainerConnectionItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/ContainerConnectionItem.svelte
@@ -20,6 +20,12 @@ let invalidEntry = $state(false);
 let lastNotifiedValue: string | undefined = $state(undefined);
 let wasSelectedConnectionAvailable: boolean | undefined = $state(undefined);
 
+type ContainerProviderType = 'podman' | 'docker';
+
+function isLegacyProviderValue(value: string | undefined): value is ContainerProviderType {
+  return value === 'podman' || value === 'docker';
+}
+
 const connectionOptions = $derived(
   $providerInfos.flatMap(provider =>
     provider.containerConnections
@@ -28,6 +34,7 @@ const connectionOptions = $derived(
       )
       .map(connection => ({
         label: `${connection.displayName} (${connection.type === 'podman' ? 'Podman' : 'Docker'})`,
+        providerType: connection.type as ContainerProviderType,
         value: JSON.stringify({
           providerId: provider.id,
           connectionName: connection.name,
@@ -49,6 +56,13 @@ const displayedOptions = $derived.by(() => {
 });
 
 $effect(() => {
+  if (isLegacyProviderValue(value)) {
+    const migratedOption = connectionOptions.find(option => option.providerType === value);
+    if (migratedOption) {
+      value = migratedOption.value;
+    }
+  }
+
   if (!value && connectionOptions.length > 0) {
     value = connectionOptions[0].value;
   } else if (value && value !== lastNotifiedValue) {


### PR DESCRIPTION
### What does this PR do?

Adds a container-connection selector to the Kind cluster creation form so users can choose the running Podman or Docker connection that Kind should use.

The selected connection now:

- determines whether Kind uses Podman or Docker;
- sets `CONTAINER_CONNECTION` and `KIND_EXPERIMENTAL_PROVIDER` for Podman;
- sets `DOCKER_HOST` from the selected Docker socket, including Windows named-pipe conversion;
- supplies the socket used by the creation auditor for resource validation.

The selector uses provider ID and connection name as its stable identity, so duplicate display names cannot select the wrong provider. It retains and revalidates a selection when its connection becomes unavailable or recovers, rejects stopped, missing, or unsupported connections with actionable errors, and defaults to the first suitable running connection.

Kind creation is only advertised when at least one started Podman or Docker connection is available.

### Screenshot / video of UI
<img width="1689" height="897" alt="Kind container connection selector" src="https://github.com/user-attachments/assets/54c42fd9-785d-46ca-81fa-c447484f1cf9" />


### What issues does this PR fix or reference?

Fixes #15080

### How to test this PR?

1. Start Podman Desktop with at least one running Podman or Docker connection.
2. Open the Kind cluster creation form.
3. Confirm the **Container Connection** selector lists the suitable running connections.
4. Select a connection and create the cluster.
5. Confirm the cluster is created with the selected container engine connection.
6. Stop or remove the selected connection and confirm the form reports that it is unavailable.
7. Restore the connection and confirm the selection is revalidated.

Automated validation:

```bash
pnpm run test:extensions:kind
pnpm --dir packages/renderer exec vitest run src/lib/preferences/item-formats/ContainerConnectionItem.spec.ts src/lib/preferences/PreferencesConnectionCreationOrEditRendering.spec.ts
pnpm run typecheck:extensions:kind
pnpm run typecheck:renderer
```

- [x] Tests are covering the bug fix or the new feature

Disclosure: AI was used to understand the codebase and review the fix.