### PR TITLE
fix: install extensions from local images

### DIFF
--- a/packages/main/src/plugin/contribution-manager.spec.ts
+++ b/packages/main/src/plugin/contribution-manager.spec.ts
@@ -464,6 +464,24 @@ describe('startVM', () => {
 
     expect(waitForRunningStateSpy).toBeCalled();
   });
+
+  test('clears the started marker when compose startup fails', async () => {
+    vi.spyOn(contributionManager, 'execComposeCommand').mockRejectedValueOnce(new Error('compose failed'));
+
+    await expect(contributionManager.startVM('contrib1', '/path/to/compose.yaml')).rejects.toThrow('compose failed');
+
+    expect(contributionManager.hasStartedContribution('contrib1')).toBeFalsy();
+  });
+
+  test('stops a VM and clears its started marker', async () => {
+    const execComposeCommand = vi.spyOn(contributionManager, 'execComposeCommand').mockResolvedValue({} as RunResult);
+    contributionManager.setStartedContribution('contrib1', true);
+
+    await contributionManager.stopVM('contrib1', '/path/to/compose.yaml');
+
+    expect(execComposeCommand).toHaveBeenCalledWith('/path/to', ['-p', 'podman-desktop-ext-contrib1', 'down']);
+    expect(contributionManager.hasStartedContribution('contrib1')).toBeFalsy();
+  });
 });
 
 describe('isPodmanDesktopServiceAlive', () => {

--- a/packages/main/src/plugin/contribution-manager.ts
+++ b/packages/main/src/plugin/contribution-manager.ts
@@ -222,23 +222,32 @@ export class ContributionManager {
       return;
     }
     this.startedContributions.set(extensionId, true);
+    try {
+      // need to start the compose file using docker-compose
+      const composeDirectory = path.dirname(vmCustomizedComposeFile);
+      const projectName = this.getComposeProjectNameFromId(extensionId);
 
-    // need to start the compose file using docker-compose
+      // then execute docker-compose in background
+      const composeArgs = ['-p', projectName, 'up', '-d'];
+      await this.execComposeCommand(composeDirectory, composeArgs);
 
-    // first, grab directory where to execute compose
+      if (monitorVM) {
+        // wait that it's in running state (or timeout)
+        await this.waitForRunningState(composeDirectory, projectName);
+      }
+    } catch (error) {
+      this.startedContributions.delete(extensionId);
+      throw error;
+    }
+  }
+
+  async stopVM(extensionId: string, vmCustomizedComposeFile: string): Promise<void> {
     const composeDirectory = path.dirname(vmCustomizedComposeFile);
-
-    const projectName = this.getComposeProjectNameFromId(extensionId);
-
-    // then execute docker-compose in background
-    const composeArgs = ['-p', projectName, 'up', '-d'];
-    await this.execComposeCommand(composeDirectory, composeArgs);
-
-    // if monitorVM is true, we need to monitor the VM
-
-    if (monitorVM) {
-      // wait that it's in running state (or timeout)
-      await this.waitForRunningState(composeDirectory, projectName);
+    const composeArgs = ['-p', this.getComposeProjectNameFromId(extensionId), 'down'];
+    try {
+      await this.execComposeCommand(composeDirectory, composeArgs);
+    } finally {
+      this.startedContributions.delete(extensionId);
     }
   }
 
@@ -462,19 +471,7 @@ export class ContributionManager {
 
     // need to remove all compose containers if any
     if (matching.vmCustomizedComposeFile) {
-      // need to stop the compose file using docker-compose
-
-      // first, grab directory where to execute compose
-      const composeDirectory = path.dirname(matching.vmCustomizedComposeFile);
-
-      // then execute docker-compose
-      const composeArgs = ['-p', this.getComposeProjectNameFromId(matching.extensionId), 'down'];
-
-      // execute the down command
-      await this.execComposeCommand(composeDirectory, composeArgs);
-
-      // flag as not started
-      this.startedContributions.delete(matching.extensionId);
+      await this.stopVM(matching.extensionId, matching.vmCustomizedComposeFile);
     }
 
     const extensionPath = matching.storagePath;

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
@@ -22,7 +22,7 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ContributionManager, DockerExtensionMetadata } from '/@/plugin/contribution-manager.js';
 
-import { DockerDesktopInstaller } from './docker-desktop-installer.js';
+import { DockerDesktopContribution, DockerDesktopInstaller } from './docker-desktop-installer.js';
 
 vi.mock(import('node:fs/promises'));
 
@@ -35,6 +35,8 @@ const contributionManager = {
   findComposeBinary: vi.fn(),
   enhanceComposeFile: vi.fn(),
   startVM: vi.fn(),
+  stopVM: vi.fn(),
+  deleteExtension: vi.fn(),
 } as unknown as ContributionManager;
 
 class TestDockerDesktopInstaller extends DockerDesktopInstaller {}
@@ -227,6 +229,45 @@ describe('Check setupContribution', async () => {
 
     // expect log with binary found
     expect(sendLog).toHaveBeenCalledWith(expect.stringContaining('Compose binary found at'));
+  });
+
+  test('stops the VM when contribution refresh fails', async () => {
+    const sendLog = vi.fn();
+    const sendError = vi.fn();
+    const metadata = {
+      name: 'My Extension',
+      ui: {},
+      vm: { composefile: 'docker-compose.yaml' },
+    } satisfies DockerExtensionMetadata;
+    vi.mocked(contributionManager.loadMetadata).mockResolvedValueOnce(metadata);
+    vi.mocked(contributionManager.findComposeBinary).mockResolvedValueOnce('found-docker-compose');
+    vi.mocked(contributionManager.enhanceComposeFile).mockResolvedValueOnce('/dest/vm-compose/docker-compose.yaml');
+    vi.mocked(contributionManager.init).mockRejectedValueOnce(new Error('refresh failed'));
+
+    const contribution = await dockerDesktopInstaller.setupContribution(
+      'My Extension',
+      'my-extension:latest',
+      'dest-folder',
+      sendLog,
+      sendError,
+    );
+
+    expect(contribution).toBeUndefined();
+    expect(contributionManager.stopVM).toHaveBeenCalledWith('My Extension', '/dest/vm-compose/docker-compose.yaml');
+    expect(sendError).toHaveBeenCalledWith('Error: refresh failed');
+  });
+
+  test('removes a registered contribution by its extension id', async () => {
+    const metadata = {
+      name: 'My Extension',
+      extensionId: 'publisher.extension',
+      ui: {},
+    } satisfies DockerExtensionMetadata;
+    const contribution = new DockerDesktopContribution('My Extension', 'dest-folder', metadata);
+
+    await dockerDesktopInstaller.removeContribution(contribution);
+
+    expect(contributionManager.deleteExtension).toHaveBeenCalledWith('publisher.extension');
   });
 });
 

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.spec.ts
@@ -236,6 +236,7 @@ describe('Check setupContribution', async () => {
     const sendError = vi.fn();
     const metadata = {
       name: 'My Extension',
+      extensionId: 'publisher.my-extension',
       ui: {},
       vm: { composefile: 'docker-compose.yaml' },
     } satisfies DockerExtensionMetadata;
@@ -253,7 +254,15 @@ describe('Check setupContribution', async () => {
     );
 
     expect(contribution).toBeUndefined();
-    expect(contributionManager.stopVM).toHaveBeenCalledWith('My Extension', '/dest/vm-compose/docker-compose.yaml');
+    expect(contributionManager.startVM).toHaveBeenCalledWith(
+      'publisher.my-extension',
+      '/dest/vm-compose/docker-compose.yaml',
+      true,
+    );
+    expect(contributionManager.stopVM).toHaveBeenCalledWith(
+      'publisher.my-extension',
+      '/dest/vm-compose/docker-compose.yaml',
+    );
     expect(sendError).toHaveBeenCalledWith('Error: refresh failed');
   });
 

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
@@ -19,14 +19,14 @@
 import { cp, readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 
-import type { ContributionManager } from '/@/plugin/contribution-manager.js';
+import type { ContributionManager, DockerExtensionMetadata } from '/@/plugin/contribution-manager.js';
 
 export class DockerDesktopContribution {
   readonly #title: string;
   readonly #extensionPath: string;
-  readonly #metadata: unknown;
+  readonly #metadata: DockerExtensionMetadata;
 
-  constructor(title: string, extensionPath: string, metadata: unknown) {
+  constructor(title: string, extensionPath: string, metadata: DockerExtensionMetadata) {
     this.#title = title;
     this.#extensionPath = extensionPath;
     this.#metadata = metadata;
@@ -40,7 +40,7 @@ export class DockerDesktopContribution {
     return this.#extensionPath;
   }
 
-  get metadata(): unknown {
+  get metadata(): DockerExtensionMetadata {
     return this.#metadata;
   }
 }
@@ -50,6 +50,11 @@ export class DockerDesktopInstaller {
 
   constructor(contributionManager: ContributionManager) {
     this.#contributionManager = contributionManager;
+  }
+
+  async removeContribution(contribution: DockerDesktopContribution): Promise<void> {
+    const extensionId = contribution.metadata.extensionId ?? contribution.metadata.name;
+    await this.#contributionManager.deleteExtension(extensionId);
   }
 
   async extractExtensionFiles(
@@ -162,7 +167,18 @@ export class DockerDesktopInstaller {
 
       // try to start the VM
       sendLog('Starting compose project...');
-      await this.#contributionManager.startVM(metadata.name, enhancedComposeFile, true);
+      try {
+        await this.#contributionManager.startVM(metadata.name, enhancedComposeFile, true);
+      } catch (error) {
+        if (enhancedComposeFile) {
+          try {
+            await this.#contributionManager.stopVM(metadata.name, enhancedComposeFile);
+          } catch (rollbackError) {
+            sendError(`Unable to clean up the compose project: ${rollbackError}`);
+          }
+        }
+        throw error;
+      }
     }
 
     sendLog('Extension Successfully installed.');
@@ -171,6 +187,13 @@ export class DockerDesktopInstaller {
     try {
       await this.#contributionManager.init();
     } catch (error) {
+      if (enhancedComposeFile) {
+        try {
+          await this.#contributionManager.stopVM(metadata.name, enhancedComposeFile);
+        } catch (rollbackError) {
+          sendError(`Unable to clean up the compose project: ${rollbackError}`);
+        }
+      }
       sendError(String(error));
       return;
     }

--- a/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
+++ b/packages/main/src/plugin/docker-extension/docker-desktop-installer.ts
@@ -142,6 +142,7 @@ export class DockerDesktopInstaller {
       metadata.name = title;
       await this.#contributionManager.saveMetadata(destFolderPath, metadata);
     }
+    const composeProjectId = metadata.extensionId ?? metadata.name;
 
     // if there is a VM, need to generate the updated compose file
     let enhancedComposeFile;
@@ -168,11 +169,11 @@ export class DockerDesktopInstaller {
       // try to start the VM
       sendLog('Starting compose project...');
       try {
-        await this.#contributionManager.startVM(metadata.name, enhancedComposeFile, true);
+        await this.#contributionManager.startVM(composeProjectId, enhancedComposeFile, true);
       } catch (error) {
         if (enhancedComposeFile) {
           try {
-            await this.#contributionManager.stopVM(metadata.name, enhancedComposeFile);
+            await this.#contributionManager.stopVM(composeProjectId, enhancedComposeFile);
           } catch (rollbackError) {
             sendError(`Unable to clean up the compose project: ${rollbackError}`);
           }
@@ -189,7 +190,7 @@ export class DockerDesktopInstaller {
     } catch (error) {
       if (enhancedComposeFile) {
         try {
-          await this.#contributionManager.stopVM(metadata.name, enhancedComposeFile);
+          await this.#contributionManager.stopVM(composeProjectId, enhancedComposeFile);
         } catch (rollbackError) {
           sendError(`Unable to clean up the compose project: ${rollbackError}`);
         }

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -23,10 +23,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import type { Registry } from '@podman-desktop/api';
+import type { CancellationToken, Registry } from '@podman-desktop/api';
 import type { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import * as fzstd from 'fzstd';
-import { http, HttpResponse } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
 import { type SetupServer, setupServer } from 'msw/node';
 import * as nodeTar from 'tar';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
@@ -686,6 +686,66 @@ test('expect downloadAndExtractImage works', async () => {
   }
 });
 
+test('downloadAndExtractImage aborts an in-flight layer download and removes its temporary file', async () => {
+  vi.spyOn(imageRegistry, 'getAuthInfo').mockResolvedValue({ authUrl: 'http://foobar', scheme: 'bearer' });
+  vi.spyOn(imageRegistry, 'getToken').mockResolvedValue('12345');
+
+  let notifyBlobStarted!: () => void;
+  const blobStarted = new Promise<void>(resolve => (notifyBlobStarted = resolve));
+  const handlers = [
+    http.get('https://my-podman-desktop-fake-registry.io/v2/my/extension/manifests/latest', () =>
+      HttpResponse.json(imageRegistryManifestMultiArchJson),
+    ),
+    http.get(
+      'https://my-podman-desktop-fake-registry.io/v2/my/extension/manifests/sha256:791352c5f8969387d576cae0586f24a12e716db584c117a15a6138812ddbaef0',
+      () => HttpResponse.json(imageRegistryManifestJson),
+    ),
+    http.get('https://my-podman-desktop-fake-registry.io/v2/my/extension/blobs/*', async () => {
+      notifyBlobStarted();
+      await delay('infinite');
+      return new HttpResponse();
+    }),
+  ];
+  server = setupServer(...handlers);
+  server.listen({ onUnhandledRequest: 'error' });
+
+  let cancellationListener!: () => void;
+  let canceled = false;
+  const dispose = vi.fn();
+  const cancellationToken = {
+    get isCancellationRequested() {
+      return canceled;
+    },
+    onCancellationRequested: vi.fn(listener => {
+      cancellationListener = listener;
+      return { dispose };
+    }),
+  } as unknown as CancellationToken;
+  const destination = path.resolve(os.tmpdir(), 'canceled-registry-extraction');
+  const temporaryDirectoryPrefix = 'sha256_ec4d84bbb887a9dba10a4551252dde152bbb42e3b02e501b44218c9c5425eac4-';
+  const temporaryDirectoriesBefore = (await fs.promises.readdir(os.tmpdir())).filter(entry =>
+    entry.startsWith(temporaryDirectoryPrefix),
+  );
+
+  const download = imageRegistry.downloadAndExtractImage(
+    'my-podman-desktop-fake-registry.io/my/extension',
+    destination,
+    vi.fn(),
+    cancellationToken,
+  );
+  await blobStarted;
+  canceled = true;
+  cancellationListener();
+
+  await expect(download).rejects.toThrow();
+  expect(dispose).toHaveBeenCalledOnce();
+  const temporaryDirectoriesAfter = (await fs.promises.readdir(os.tmpdir())).filter(entry =>
+    entry.startsWith(temporaryDirectoryPrefix),
+  );
+  expect(temporaryDirectoriesAfter).toEqual(temporaryDirectoriesBefore);
+  await fs.promises.rm(destination, { recursive: true, force: true });
+});
+
 test('expect downloadAndExtractImage works with zstd', async () => {
   // need to mock the http request
   const spyGetAuthInfo = vi.spyOn(imageRegistry, 'getAuthInfo');
@@ -767,7 +827,9 @@ test('expect downloadAndExtractImage works with zstd', async () => {
     // expect some traces in the logger
     expect(logFn).toHaveBeenCalled();
 
-    expect(spyExtract).toHaveBeenCalledWith({ cwd: destFolder, file: expect.stringContaining('.tar') });
+    expect(spyExtract).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: destFolder, file: expect.stringContaining('.tar') }),
+    );
   } finally {
     // remove the folders
     await fs.promises.rm(tmpTarFolder, { recursive: true });

--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -55,6 +55,28 @@ export interface RegistryAuthInfo {
   scheme: string;
 }
 
+function createCancellationSignal(token?: containerDesktopAPI.CancellationToken): {
+  signal: AbortSignal | undefined;
+  dispose: () => void;
+} {
+  if (!token) {
+    return { signal: undefined, dispose: (): void => {} };
+  }
+
+  const controller = new AbortController();
+  if (token.isCancellationRequested) {
+    controller.abort();
+  }
+  const disposable = token.onCancellationRequested(() => controller.abort());
+  return { signal: controller.signal, dispose: (): void => disposable.dispose() };
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new Error('Operation canceled');
+  }
+}
+
 @injectable()
 export class ImageRegistry {
   private registries: containerDesktopAPI.Registry[] = [];
@@ -497,18 +519,34 @@ export class ImageRegistry {
   }
 
   // Fetch the image Labels from the registry for a given image URL
-  async getImageConfigLabels(imageName: string): Promise<{ [key: string]: unknown }> {
+  async getImageConfigLabels(
+    imageName: string,
+    cancellationToken?: containerDesktopAPI.CancellationToken,
+  ): Promise<{ [key: string]: unknown }> {
+    const { signal, dispose } = createCancellationSignal(cancellationToken);
+    try {
+      return await this.getImageConfigLabelsWithSignal(imageName, signal);
+    } finally {
+      dispose();
+    }
+  }
+
+  private async getImageConfigLabelsWithSignal(
+    imageName: string,
+    signal?: AbortSignal,
+  ): Promise<{ [key: string]: unknown }> {
+    throwIfAborted(signal);
     const imageData = this.extractImageDataFromImageName(imageName);
 
     // grab auth info from the registry
-    const authInfo = await this.getAuthInfo(imageData.registry);
-    const token = await this.getToken(authInfo, imageData);
+    const authInfo = await this.getAuthInfo(imageData.registry, undefined, signal);
+    const token = await this.getToken(authInfo, imageData, signal);
     if (authInfo.scheme.toLowerCase() !== 'bearer') {
       throw new Error(`Unsupported auth scheme: ${authInfo.scheme}`);
     }
 
     // now, grab manifest for the given image URL
-    const manifest = await this.getManifest(imageData, token);
+    const manifest = await this.getManifest(imageData, token, signal);
 
     // now, search a config manifest
     const configManifest = manifest.config;
@@ -527,7 +565,7 @@ export class ImageRegistry {
     }
 
     // now pull the blob from the registry
-    const config = await this.fetchOciImageConfig(imageData, configManifest.digest, token);
+    const config = await this.fetchOciImageConfig(imageData, configManifest.digest, token, signal);
 
     // get labels from the config
     return config?.config?.Labels;
@@ -537,18 +575,34 @@ export class ImageRegistry {
     imageName: string,
     destFolder: string,
     logger: (event: { message: string; progress: number }) => void,
+    cancellationToken?: containerDesktopAPI.CancellationToken,
   ): Promise<void> {
+    const { signal, dispose } = createCancellationSignal(cancellationToken);
+    try {
+      await this.downloadAndExtractImageWithSignal(imageName, destFolder, logger, signal);
+    } finally {
+      dispose();
+    }
+  }
+
+  private async downloadAndExtractImageWithSignal(
+    imageName: string,
+    destFolder: string,
+    logger: (event: { message: string; progress: number }) => void,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    throwIfAborted(signal);
     const imageData = this.extractImageDataFromImageName(imageName);
 
     // grab auth info from the registry
-    const authInfo = await this.getAuthInfo(imageData.registry);
-    const token = await this.getToken(authInfo, imageData);
+    const authInfo = await this.getAuthInfo(imageData.registry, undefined, signal);
+    const token = await this.getToken(authInfo, imageData, signal);
     if (authInfo.scheme.toLowerCase() !== 'bearer') {
       throw new Error(`Unsupported auth scheme: ${authInfo.scheme}`);
     }
 
     // now, grab manifest for the given image URL
-    const manifest = await this.getManifest(imageData, token);
+    const manifest = await this.getManifest(imageData, token, signal);
 
     // now, get all layers 'application/vnd.oci.image.layer.v1.tar+gzip' and download and expand them
     const gzipLayers = manifest.layers.filter(
@@ -595,6 +649,7 @@ export class ImageRegistry {
         currentDownloaded,
         totalSize,
         logger,
+        signal,
       );
       currentDownloaded += layer.size;
     }
@@ -609,8 +664,11 @@ export class ImageRegistry {
     currentDownloaded: number,
     totalSize: number,
     logger: (event: { message: string; progress: number }) => void,
+    signal?: AbortSignal,
   ): Promise<void> {
+    throwIfAborted(signal);
     const options = this.getOptions();
+    options.signal = signal;
     options.headers = options.headers ?? {};
 
     // add the Bearer token
@@ -624,44 +682,65 @@ export class ImageRegistry {
     }
 
     const suffix = compressionType === 'gzip' ? '.tar' : '.zst';
-    const tmpFileName = path.resolve(os.tmpdir(), `${digestWithoutSpecialChars}${suffix}`);
-
-    // ensure the folder exists
-    const parentDir = path.dirname(tmpFileName);
-    if (!fs.existsSync(parentDir)) {
-      await fs.promises.mkdir(parentDir, { recursive: true });
-    }
+    const layerTemporaryDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), `${digestWithoutSpecialChars}-`));
+    const tmpFileName = path.join(layerTemporaryDirectory, `layer${suffix}`);
 
     const blobURL = `${imageData.registryURL}/${imageData.name}/blobs/${digest}`;
 
-    const readStream = got.stream(blobURL, options);
+    const unpackedFileName = compressionType === 'zstd' ? tmpFileName.replace('.zst', '.tar') : undefined;
+    try {
+      const readStream = got.stream(blobURL, options);
 
-    readStream.on('downloadProgress', ({ transferred }) => {
-      const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
-      logger({
-        message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
-        progress: globalPercentage,
+      readStream.on('downloadProgress', ({ transferred }) => {
+        const globalPercentage = Math.round(((transferred + currentDownloaded) / totalSize) * 100);
+        logger({
+          message: `Downloading ${digest}${suffix} - ${globalPercentage}% - (${transferred + currentDownloaded}/${totalSize})`,
+          progress: globalPercentage,
+        });
       });
-    });
-    await pipeline(readStream, createWriteStream(tmpFileName));
-    // in case of zstd, we need to unpack the file first
-    if (compressionType === 'zstd') {
-      //use fstd library to extract the file
-      const content = await fs.promises.readFile(tmpFileName);
-      const decompressed = fzstd.decompress(content);
-      const unpackedFileName = tmpFileName.replace('.zst', '.tar');
-      await fs.promises.writeFile(unpackedFileName, decompressed);
-      await nodeTar.extract({ file: unpackedFileName, cwd: destFolder });
-    } else {
-      await nodeTar.extract({ file: tmpFileName, cwd: destFolder });
+      await pipeline(readStream, createWriteStream(tmpFileName));
+      throwIfAborted(signal);
+      // in case of zstd, we need to unpack the file first
+      if (compressionType === 'zstd' && unpackedFileName) {
+        //use fstd library to extract the file
+        const content = await fs.promises.readFile(tmpFileName);
+        throwIfAborted(signal);
+        const decompressed = fzstd.decompress(content);
+        throwIfAborted(signal);
+        await fs.promises.writeFile(unpackedFileName, decompressed);
+        await nodeTar.extract({
+          file: unpackedFileName,
+          cwd: destFolder,
+          filter: (): boolean => {
+            throwIfAborted(signal);
+            return true;
+          },
+        });
+      } else {
+        await nodeTar.extract({
+          file: tmpFileName,
+          cwd: destFolder,
+          filter: (): boolean => {
+            throwIfAborted(signal);
+            return true;
+          },
+        });
+      }
+      throwIfAborted(signal);
+    } finally {
+      await fs.promises.rm(layerTemporaryDirectory, { recursive: true, force: true });
     }
-    // remove the temporary file
-    await fs.promises.rm(tmpFileName);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected async fetchOciImageConfig(imageData: ImageRegistryNameTag, digest: string, token: string): Promise<any> {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  protected async fetchOciImageConfig(
+    imageData: ImageRegistryNameTag,
+    digest: string,
+    token: string,
+    signal?: AbortSignal,
+  ): Promise<any> {
     const options = this.getOptions();
+    options.signal = signal;
     options.headers = options.headers ?? {};
     // add the Bearer token
     options.headers['Authorization'] = `Bearer ${token}`;
@@ -684,6 +763,7 @@ export class ImageRegistry {
     }
     return jsonConfig;
   }
+  /* eslint-enable @typescript-eslint/no-explicit-any */
 
   /**
    * Internal method to fetch and resolve manifests from a registry.
@@ -698,9 +778,11 @@ export class ImageRegistry {
     manifestURL: string,
     imageData: ImageRegistryNameTag,
     token: string,
+    signal?: AbortSignal,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<{ manifest: unknown; digest: string | undefined; listDigest?: string }> {
     const options = this.getOptions();
+    options.signal = signal;
     options.headers = options.headers ?? {};
 
     // add the Bearer token
@@ -794,6 +876,7 @@ export class ImageRegistry {
           platformManifestURL,
           imageData,
           token,
+          signal,
         );
         return { manifest, digest: platformDigest, listDigest };
       }
@@ -840,9 +923,9 @@ export class ImageRegistry {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async getManifest(imageData: ImageRegistryNameTag, token: string): Promise<any> {
+  async getManifest(imageData: ImageRegistryNameTag, token: string, signal?: AbortSignal): Promise<any> {
     const manifestURL = `${imageData.registryURL}/${imageData.name}/manifests/${imageData.tag}`;
-    const { manifest } = await this.getManifestFromURL(manifestURL, imageData, token);
+    const { manifest } = await this.getManifestFromURL(manifestURL, imageData, token, signal);
     return manifest;
   }
 
@@ -960,9 +1043,14 @@ export class ImageRegistry {
     };
   }
 
-  async getAuthInfo(serviceUrl: string, insecure?: boolean): Promise<{ authUrl: string; scheme: string }> {
+  async getAuthInfo(
+    serviceUrl: string,
+    insecure?: boolean,
+    signal?: AbortSignal,
+  ): Promise<{ authUrl: string; scheme: string }> {
     let registryUrl: string;
     const options = this.getOptions(insecure);
+    options.signal = signal;
 
     if (serviceUrl.includes('docker.io')) {
       registryUrl = 'https://index.docker.io/v2/';
@@ -1045,9 +1133,14 @@ export class ImageRegistry {
     }
   }
 
-  async getToken(authInfo: { authUrl: string; scheme: string }, imageData: ImageRegistryNameTag): Promise<string> {
+  async getToken(
+    authInfo: { authUrl: string; scheme: string },
+    imageData: ImageRegistryNameTag,
+    signal?: AbortSignal,
+  ): Promise<string> {
     let rawResponse: string | undefined;
     const options = this.getOptions();
+    options.signal = signal;
 
     // if we have auth for this registry, add basic auth to the headers
     const authServer = this.getAuthconfigForServer(imageData.registry);

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { rmSync } from 'node:fs';
+import { promises } from 'node:fs';
 import * as path from 'node:path';
 
 import type { ExtensionInfo } from '@podman-desktop/core-api';
@@ -25,8 +25,14 @@ import type { CatalogFetchableExtension } from '@podman-desktop/core-api/extensi
 import type { IpcMain, IpcMainEvent } from 'electron';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { CancellationTokenRegistry } from '/@/plugin/cancellation-token-registry.js';
+import type { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
 import type { ContributionManager } from '/@/plugin/contribution-manager.js';
 import type { Directories } from '/@/plugin/directories.js';
+import {
+  DockerDesktopContribution,
+  DockerDesktopInstaller,
+} from '/@/plugin/docker-extension/docker-desktop-installer.js';
 import type { ExtensionsCatalog } from '/@/plugin/extension/catalog/extensions-catalog.js';
 import type { AnalyzedExtension } from '/@/plugin/extension/extension-analyzer.js';
 import type { ExtensionLoader } from '/@/plugin/extension/extension-loader.js';
@@ -35,6 +41,7 @@ import type { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import type { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
 import { ExtensionInstaller } from './extension-installer.js';
+import { LocalExtensionImageLoader } from './local-extension-image-loader.js';
 
 let extensionInstaller: ExtensionInstaller;
 
@@ -84,10 +91,22 @@ const directories = {
 const contributionManager = {} as unknown as ContributionManager;
 const ipcMainOnMock = vi.fn();
 
+const containerRegistry = {
+  listImages: vi.fn(),
+} as unknown as ContainerProviderRegistry;
+
+const cancellationTokenRegistry = {
+  getCancellationTokenSource: vi.fn(),
+} as unknown as CancellationTokenRegistry;
+
 const createTaskMock = vi.fn();
 const taskManager = {
   createTask: createTaskMock,
 } as unknown as TaskManager;
+
+const findLocalImageMock = vi.spyOn(LocalExtensionImageLoader.prototype, 'findLocalImage');
+const downloadAndExtractLocalImageMock = vi.spyOn(LocalExtensionImageLoader.prototype, 'downloadAndExtractImage');
+const setupContributionMock = vi.spyOn(DockerDesktopInstaller.prototype, 'setupContribution');
 
 vi.mock(import('node:fs'));
 vi.mock(import('/@/plugin/docker-extension/docker-desktop-installer.js'));
@@ -95,18 +114,24 @@ vi.mock(import('/@/plugin/docker-extension/docker-desktop-installer.js'));
 beforeEach(() => {
   vi.resetAllMocks();
 
+  findLocalImageMock.mockResolvedValue(undefined);
+  downloadAndExtractLocalImageMock.mockResolvedValue(undefined);
+  setupContributionMock.mockResolvedValue(undefined);
+
   createTaskMock.mockReturnValue({
     status: 'in-progress',
     progress: undefined,
     error: undefined,
   });
 
-  vi.mocked(rmSync).mockReturnValue(undefined);
+  vi.mocked(promises.rm).mockResolvedValue(undefined);
+  vi.mocked(promises.mkdtemp).mockResolvedValue('/fake/tmp/directory');
   vi.mocked(directories.getPluginsDirectory).mockReturnValue('/fake/plugins/directory');
   vi.mocked(directories.getContributionStorageDir).mockReturnValue('/fake/dd/directory');
   extensionInstaller = new ExtensionInstaller(
     apiSender,
     extensionLoader,
+    containerRegistry,
     imageRegistry,
     extensionsCatalog,
     telemetryMock,
@@ -114,6 +139,7 @@ beforeEach(() => {
     contributionManager,
     ipcMainOnMock,
     taskManager,
+    cancellationTokenRegistry,
   );
 });
 
@@ -170,6 +196,179 @@ describe('installFromImage task lifecycle', () => {
     expect(createTaskMock).toHaveBeenCalledWith({ title: `Installing extension ${imageToPull}` });
     const task = createTaskMock.mock.results[0]?.value;
     expect(task.error).toBe('Error while analyzing image: Error: network failure');
+  });
+
+  test('should create a cancellable task and mark it canceled', async () => {
+    const token = { isCancellationRequested: true };
+    vi.mocked(cancellationTokenRegistry.getCancellationTokenSource).mockReturnValue({ token } as never);
+    findLocalImageMock.mockRejectedValueOnce(new Error('Extension installation canceled'));
+
+    await expect(
+      extensionInstaller.installFromImage(
+        vi.fn(),
+        vi.fn(),
+        vi.fn(),
+        'localhost/example/extension:latest',
+        undefined,
+        undefined,
+        42,
+      ),
+    ).rejects.toThrow('Extension installation canceled');
+
+    expect(createTaskMock).toHaveBeenCalledWith({
+      title: 'Installing extension localhost/example/extension:latest',
+      cancellable: true,
+      cancellationTokenSourceId: 42,
+    });
+    expect(createTaskMock.mock.results[0]?.value.status).toBe('canceled');
+  });
+
+  test('passes cancellation through remote label lookup and layer extraction', async () => {
+    const token = { isCancellationRequested: false };
+    vi.mocked(cancellationTokenRegistry.getCancellationTokenSource).mockReturnValue({ token } as never);
+    getImageConfigLabelsMock.mockResolvedValueOnce({
+      'org.opencontainers.image.title': 'title',
+      'org.opencontainers.image.description': 'desc',
+      'org.opencontainers.image.vendor': 'vendor',
+      'io.podman-desktop.api.version': '1.0.0',
+    });
+    listExtensionsMock.mockResolvedValueOnce([]);
+    vi.spyOn(extensionInstaller, 'extractExtensionFiles').mockResolvedValueOnce();
+    analyzeExtensionMock.mockResolvedValueOnce({ manifest: {} } as AnalyzedExtension);
+
+    await extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageToPull, undefined, undefined, 42);
+
+    expect(getImageConfigLabelsMock).toHaveBeenCalledWith(imageToPull, token);
+    expect(downloadAndExtractImageMock).toHaveBeenCalledWith(
+      imageToPull,
+      '/fake/tmp/directory',
+      expect.any(Function),
+      token,
+    );
+  });
+});
+
+describe('local image installation', () => {
+  const imageName = 'localhost/example/extension:latest';
+  const labels = {
+    'org.opencontainers.image.title': 'Local extension',
+    'org.opencontainers.image.description': 'Local extension description',
+    'org.opencontainers.image.vendor': 'Example',
+    'io.podman-desktop.api.version': '1.0.0',
+  };
+
+  test('uses the local engine for labels and layer extraction', async () => {
+    const localImage = {
+      engineId: 'podman-machine',
+      engineName: 'Podman Machine',
+      id: 'sha256:image',
+      labels,
+    };
+    findLocalImageMock.mockResolvedValueOnce(localImage);
+    listExtensionsMock.mockResolvedValueOnce([]);
+    vi.spyOn(extensionInstaller, 'extractExtensionFiles').mockResolvedValueOnce();
+    analyzeExtensionMock.mockResolvedValueOnce({ id: 'example.extension', manifest: {} } as AnalyzedExtension);
+
+    await extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageName);
+
+    expect(downloadAndExtractLocalImageMock).toHaveBeenCalledWith(
+      localImage,
+      imageName,
+      '/fake/tmp/directory',
+      expect.any(Function),
+      undefined,
+    );
+    expect(getImageConfigLabelsMock).not.toHaveBeenCalled();
+    expect(downloadAndExtractImageMock).not.toHaveBeenCalled();
+  });
+
+  test('preserves registry fallback when the localhost image is absent', async () => {
+    getImageConfigLabelsMock.mockResolvedValueOnce(labels);
+    listExtensionsMock.mockResolvedValueOnce([]);
+    vi.spyOn(extensionInstaller, 'extractExtensionFiles').mockResolvedValueOnce();
+    analyzeExtensionMock.mockResolvedValueOnce({ id: 'example.extension', manifest: {} } as AnalyzedExtension);
+
+    await extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageName);
+
+    expect(getImageConfigLabelsMock).toHaveBeenCalledWith(imageName, undefined);
+    expect(downloadAndExtractImageMock).toHaveBeenCalledWith(
+      imageName,
+      '/fake/tmp/directory',
+      expect.any(Function),
+      undefined,
+    );
+    expect(downloadAndExtractLocalImageMock).not.toHaveBeenCalled();
+  });
+
+  test('reports missing labels without contacting a registry', async () => {
+    findLocalImageMock.mockResolvedValueOnce({
+      engineId: 'podman-machine',
+      engineName: 'Podman Machine',
+      id: 'sha256:image',
+      labels: undefined,
+    });
+    const sendError = vi.fn();
+
+    await extensionInstaller.installFromImage(vi.fn(), sendError, vi.fn(), imageName);
+
+    expect(sendError).toHaveBeenCalledWith(
+      `Image ${imageName} is not a Podman Desktop Extension. Unable to grab image config labels.`,
+    );
+    expect(getImageConfigLabelsMock).not.toHaveBeenCalled();
+  });
+
+  test('reports local lookup ambiguity without contacting a registry', async () => {
+    findLocalImageMock.mockRejectedValueOnce(new Error('image exists in multiple running container engines'));
+    const sendError = vi.fn();
+
+    await extensionInstaller.installFromImage(vi.fn(), sendError, vi.fn(), imageName);
+
+    expect(sendError).toHaveBeenCalledWith(
+      'Error while analyzing image: Error: image exists in multiple running container engines',
+    );
+    expect(getImageConfigLabelsMock).not.toHaveBeenCalled();
+  });
+
+  test('removes temporary and partial final directories after extraction fails', async () => {
+    findLocalImageMock.mockResolvedValueOnce({
+      engineId: 'podman-machine',
+      engineName: 'Podman Machine',
+      id: 'sha256:image',
+      labels,
+    });
+    listExtensionsMock.mockResolvedValueOnce([]);
+    downloadAndExtractLocalImageMock.mockRejectedValueOnce(new Error('malformed saved image'));
+
+    await expect(extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageName)).rejects.toThrow(
+      'malformed saved image',
+    );
+
+    expect(promises.rm).toHaveBeenCalledWith('/fake/plugins/directory/localhostexampleextension', {
+      recursive: true,
+      force: true,
+    });
+    expect(promises.rm).toHaveBeenCalledWith('/fake/tmp/directory', { recursive: true, force: true });
+  });
+
+  test('removes extracted files when extension analysis returns no metadata', async () => {
+    findLocalImageMock.mockResolvedValueOnce({
+      engineId: 'podman-machine',
+      engineName: 'Podman Machine',
+      id: 'sha256:image',
+      labels,
+    });
+    listExtensionsMock.mockResolvedValueOnce([]);
+    vi.spyOn(extensionInstaller, 'extractExtensionFiles').mockResolvedValueOnce();
+    analyzeExtensionMock.mockResolvedValueOnce(undefined);
+    const sendError = vi.fn();
+
+    await extensionInstaller.installFromImage(vi.fn(), sendError, vi.fn(), imageName);
+
+    expect(sendError).toHaveBeenCalledWith('Error while analyzing extension: no extension metadata was returned');
+    expect(promises.rm).toHaveBeenCalledWith('/fake/plugins/directory/localhostexampleextension', {
+      recursive: true,
+      force: true,
+    });
   });
 });
 
@@ -233,6 +432,56 @@ test('should install an image (dd extensions) if labels are correct', async () =
   expect(sendError).not.toHaveBeenCalled();
 
   expect(spyExtractExtensionFiles).not.toHaveBeenCalled();
+});
+
+describe('Docker Desktop contribution cleanup', () => {
+  const imageName = 'fake.io/fake-image:fake-tag';
+  const finalFolderPath = '/fake/dd/directory/fakeiofakeimage';
+  const labels = {
+    'org.opencontainers.image.title': 'fake-title',
+    'org.opencontainers.image.description': 'fake-description',
+    'org.opencontainers.image.vendor': 'fake-vendor',
+    'com.docker.desktop.extension.api.version': '1.0.0',
+  };
+
+  test('removes an incomplete contribution and allows a retry when setup returns undefined', async () => {
+    getImageConfigLabelsMock.mockResolvedValue(labels);
+    const installed = new DockerDesktopContribution('fake-title', finalFolderPath, {});
+    setupContributionMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce(installed);
+
+    await expect(extensionInstaller.analyzeFromImage(vi.fn(), vi.fn(), imageName)).resolves.toBeUndefined();
+    expect(promises.rm).toHaveBeenCalledWith(finalFolderPath, { recursive: true, force: true });
+
+    await expect(extensionInstaller.analyzeFromImage(vi.fn(), vi.fn(), imageName)).resolves.toBe(installed);
+    expect(setupContributionMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('removes an incomplete contribution when setup throws', async () => {
+    getImageConfigLabelsMock.mockResolvedValue(labels);
+    setupContributionMock.mockRejectedValueOnce(new Error('setup failed'));
+
+    await expect(extensionInstaller.analyzeFromImage(vi.fn(), vi.fn(), imageName)).rejects.toThrow('setup failed');
+    expect(promises.rm).toHaveBeenCalledWith(finalFolderPath, { recursive: true, force: true });
+  });
+
+  test('removes an incomplete contribution when cancellation is requested during setup', async () => {
+    getImageConfigLabelsMock.mockResolvedValue(labels);
+    let canceled = false;
+    const token = {
+      get isCancellationRequested() {
+        return canceled;
+      },
+    } as never;
+    setupContributionMock.mockImplementationOnce(async () => {
+      canceled = true;
+      return new DockerDesktopContribution('fake-title', finalFolderPath, {});
+    });
+
+    await expect(
+      extensionInstaller.analyzeFromImage(vi.fn(), vi.fn(), imageName, undefined, undefined, token),
+    ).rejects.toThrow('Extension installation canceled');
+    expect(promises.rm).toHaveBeenCalledWith(finalFolderPath, { recursive: true, force: true });
+  });
 });
 
 test('should fail if extension with same id is already installed', async () => {

--- a/packages/main/src/plugin/install/extension-installer.spec.ts
+++ b/packages/main/src/plugin/install/extension-installer.spec.ts
@@ -57,12 +57,14 @@ const listExtensionsMock = vi.fn();
 const loadExtensionMock = vi.fn();
 const analyzeExtensionMock = vi.fn();
 const loadExtensionsMock = vi.fn();
+const removeExtensionMock = vi.fn();
 const ensureExtensionsMock = vi.fn();
 const extensionLoader: ExtensionLoader = {
   getPluginsDirectory: getPluginsDirectoryMock,
   listExtensions: listExtensionsMock,
   loadExtension: loadExtensionMock,
   loadExtensions: loadExtensionsMock,
+  removeExtension: removeExtensionMock,
   analyzeExtension: analyzeExtensionMock,
   ensureExtensionIsEnabled: ensureExtensionsMock,
 } as unknown as ExtensionLoader;
@@ -107,6 +109,7 @@ const taskManager = {
 const findLocalImageMock = vi.spyOn(LocalExtensionImageLoader.prototype, 'findLocalImage');
 const downloadAndExtractLocalImageMock = vi.spyOn(LocalExtensionImageLoader.prototype, 'downloadAndExtractImage');
 const setupContributionMock = vi.spyOn(DockerDesktopInstaller.prototype, 'setupContribution');
+const removeContributionMock = vi.spyOn(DockerDesktopInstaller.prototype, 'removeContribution');
 
 vi.mock(import('node:fs'));
 vi.mock(import('/@/plugin/docker-extension/docker-desktop-installer.js'));
@@ -117,6 +120,7 @@ beforeEach(() => {
   findLocalImageMock.mockResolvedValue(undefined);
   downloadAndExtractLocalImageMock.mockResolvedValue(undefined);
   setupContributionMock.mockResolvedValue(undefined);
+  removeContributionMock.mockResolvedValue(undefined);
 
   createTaskMock.mockReturnValue({
     status: 'in-progress',
@@ -125,6 +129,7 @@ beforeEach(() => {
   });
 
   vi.mocked(promises.rm).mockResolvedValue(undefined);
+  vi.mocked(promises.mkdir).mockResolvedValue(undefined);
   vi.mocked(promises.mkdtemp).mockResolvedValue('/fake/tmp/directory');
   vi.mocked(directories.getPluginsDirectory).mockReturnValue('/fake/plugins/directory');
   vi.mocked(directories.getContributionStorageDir).mockReturnValue('/fake/dd/directory');
@@ -350,6 +355,25 @@ describe('local image installation', () => {
     expect(promises.rm).toHaveBeenCalledWith('/fake/tmp/directory', { recursive: true, force: true });
   });
 
+  test('reports the reserved destination when another install already claimed it', async () => {
+    findLocalImageMock.mockResolvedValueOnce({
+      engineId: 'podman-machine',
+      engineName: 'Podman Machine',
+      id: 'sha256:image',
+      labels,
+    });
+    listExtensionsMock.mockResolvedValueOnce([]);
+    vi.mocked(promises.mkdir).mockRejectedValueOnce(Object.assign(new Error('already exists'), { code: 'EEXIST' }));
+    const sendError = vi.fn();
+
+    await extensionInstaller.installFromImage(vi.fn(), sendError, vi.fn(), imageName);
+
+    expect(sendError).toHaveBeenCalledWith(
+      `Unable to install image ${imageName}: the target extension directory /fake/plugins/directory/localhostexampleextension already exists. Remove it if no installed extension uses it, then retry.`,
+    );
+    expect(downloadAndExtractLocalImageMock).not.toHaveBeenCalled();
+  });
+
   test('removes extracted files when extension analysis returns no metadata', async () => {
     findLocalImageMock.mockResolvedValueOnce({
       engineId: 'podman-machine',
@@ -446,7 +470,10 @@ describe('Docker Desktop contribution cleanup', () => {
 
   test('removes an incomplete contribution and allows a retry when setup returns undefined', async () => {
     getImageConfigLabelsMock.mockResolvedValue(labels);
-    const installed = new DockerDesktopContribution('fake-title', finalFolderPath, {});
+    const installed = new DockerDesktopContribution('fake-title', finalFolderPath, {
+      name: 'fake-title',
+      ui: {},
+    });
     setupContributionMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce(installed);
 
     await expect(extensionInstaller.analyzeFromImage(vi.fn(), vi.fn(), imageName)).resolves.toBeUndefined();
@@ -468,19 +495,67 @@ describe('Docker Desktop contribution cleanup', () => {
     getImageConfigLabelsMock.mockResolvedValue(labels);
     let canceled = false;
     const token = {
-      get isCancellationRequested() {
+      get isCancellationRequested(): boolean {
         return canceled;
       },
     } as never;
     setupContributionMock.mockImplementationOnce(async () => {
       canceled = true;
-      return new DockerDesktopContribution('fake-title', finalFolderPath, {});
+      return new DockerDesktopContribution('fake-title', finalFolderPath, {
+        name: 'fake-title',
+        ui: {},
+      });
     });
 
     await expect(
       extensionInstaller.analyzeFromImage(vi.fn(), vi.fn(), imageName, undefined, undefined, token),
     ).rejects.toThrow('Extension installation canceled');
+    expect(removeContributionMock).toHaveBeenCalledOnce();
     expect(promises.rm).toHaveBeenCalledWith(finalFolderPath, { recursive: true, force: true });
+  });
+});
+
+describe('extension loading rollback', () => {
+  const imageName = 'fake.io/fake-image:fake-tag';
+  const analyzedExtension = {
+    id: 'example.extension',
+    path: '/fake/plugins/directory/example',
+    manifest: {},
+  } as AnalyzedExtension;
+
+  test('removes analyzed extensions when loading fails', async () => {
+    vi.spyOn(extensionInstaller, 'analyzeFromImage').mockResolvedValueOnce(analyzedExtension);
+    loadExtensionsMock.mockRejectedValueOnce(new Error('load failed'));
+
+    await expect(extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageName)).rejects.toThrow(
+      'load failed',
+    );
+
+    expect(removeExtensionMock).toHaveBeenCalledWith(analyzedExtension.id);
+    expect(promises.rm).toHaveBeenCalledWith(analyzedExtension.path, { recursive: true, force: true });
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('extension-started');
+  });
+
+  test('removes a loaded extension when cancellation is requested during loading', async () => {
+    let canceled = false;
+    const token = {
+      get isCancellationRequested(): boolean {
+        return canceled;
+      },
+    };
+    vi.mocked(cancellationTokenRegistry.getCancellationTokenSource).mockReturnValue({ token } as never);
+    vi.spyOn(extensionInstaller, 'analyzeFromImage').mockResolvedValueOnce(analyzedExtension);
+    loadExtensionsMock.mockImplementationOnce(async () => {
+      canceled = true;
+    });
+
+    await expect(
+      extensionInstaller.installFromImage(vi.fn(), vi.fn(), vi.fn(), imageName, undefined, undefined, 42),
+    ).rejects.toThrow('Extension installation canceled');
+
+    expect(removeExtensionMock).toHaveBeenCalledWith(analyzedExtension.id);
+    expect(promises.rm).toHaveBeenCalledWith(analyzedExtension.path, { recursive: true, force: true });
+    expect(apiSenderSendMock).not.toHaveBeenCalledWith('extension-started');
   });
 });
 
@@ -845,6 +920,9 @@ test('should install an image with extension pack with an existing dependency al
     expect.any(Function),
     expect.any(Function),
     'my-other-extension-link',
+    undefined,
+    undefined,
+    undefined,
   );
 
   // this extension is already installed, so we should not analyze it
@@ -852,5 +930,8 @@ test('should install an image with extension pack with an existing dependency al
     expect.any(Function),
     expect.any(Function),
     'my-another-extension-link',
+    undefined,
+    undefined,
+    undefined,
   );
 });

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -21,12 +21,15 @@ import { cp } from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import type { CancellationToken } from '@podman-desktop/api';
 import type { ExtensionInfo } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type { IpcMainEvent } from 'electron';
 import { inject, injectable } from 'inversify';
 
 import { IPCMainOn } from '/@/plugin/api.js';
+import { CancellationTokenRegistry } from '/@/plugin/cancellation-token-registry.js';
+import { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
 import { ContributionManager } from '/@/plugin/contribution-manager.js';
 import { Directories } from '/@/plugin/directories.js';
 import {
@@ -40,15 +43,27 @@ import { ImageRegistry } from '/@/plugin/image-registry.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
+import { LocalExtensionImageLoader } from './local-extension-image-loader.js';
+
+function getStringLabels(labels: Record<string, unknown> | undefined): Record<string, string> | undefined {
+  if (!labels || !Object.values(labels).every(label => typeof label === 'string')) {
+    return undefined;
+  }
+  return labels as Record<string, string>;
+}
+
 @injectable()
 export class ExtensionInstaller {
   #dockerDesktopInstaller: DockerDesktopInstaller;
+  #localExtensionImageLoader: LocalExtensionImageLoader;
 
   constructor(
     @inject(ApiSenderType)
     private apiSender: ApiSenderType,
     @inject(ExtensionLoader)
     private extensionLoader: ExtensionLoader,
+    @inject(ContainerProviderRegistry)
+    containerRegistry: ContainerProviderRegistry,
     @inject(ImageRegistry)
     private imageRegistry: ImageRegistry,
     @inject(ExtensionsCatalog)
@@ -63,8 +78,11 @@ export class ExtensionInstaller {
     private readonly ipcMainOn: IPCMainOn,
     @inject(TaskManager)
     private taskManager: TaskManager,
+    @inject(CancellationTokenRegistry)
+    private cancellationTokenRegistry: CancellationTokenRegistry,
   ) {
     this.#dockerDesktopInstaller = new DockerDesktopInstaller(contributionManager);
+    this.#localExtensionImageLoader = new LocalExtensionImageLoader(containerRegistry);
   }
 
   async extractExtensionFiles(
@@ -116,15 +134,36 @@ export class ExtensionInstaller {
     imageName: string,
     catatlogExtensionId?: string,
     onProgress?: (progress: number) => void,
+    token?: CancellationToken,
   ): Promise<AnalyzedExtension | DockerDesktopContribution | undefined> {
     imageName = imageName.trim();
     sendLog(`Analyzing image ${imageName}...`);
-    let imageConfigLabels;
+    let localImage;
     try {
-      imageConfigLabels = await this.imageRegistry.getImageConfigLabels(imageName);
+      localImage = await this.#localExtensionImageLoader.findLocalImage(imageName, token);
     } catch (error) {
+      if (token?.isCancellationRequested) {
+        throw new Error('Extension installation canceled');
+      }
       sendError('Error while analyzing image: ' + error);
       return;
+    }
+
+    let imageConfigLabels = getStringLabels(localImage?.labels);
+    if (!localImage) {
+      try {
+        imageConfigLabels = getStringLabels(await this.imageRegistry.getImageConfigLabels(imageName, token));
+      } catch (error) {
+        if (token?.isCancellationRequested) {
+          throw new Error('Extension installation canceled');
+        }
+        sendError(
+          this.#localExtensionImageLoader.isLocalImageReference(imageName)
+            ? `Local image ${imageName} was not found in a running container engine. Registry fallback failed: ${error}`
+            : 'Error while analyzing image: ' + error,
+        );
+        return;
+      }
     }
 
     if (!imageConfigLabels) {
@@ -154,24 +193,20 @@ export class ExtensionInstaller {
       unpackedFolder = this.directories.getContributionStorageDir();
     }
 
-    // strip the tag (ending with :something) from the image name if any
-    let imageNameWithoutTag: string;
-    if (imageName.includes(':')) {
-      const splitten = imageName.split(':')[0];
-      if (!splitten) {
-        sendError(`Image ${imageName} is not a Podman Desktop Extension`);
-        return;
-      }
-      imageNameWithoutTag = splitten;
-    } else {
-      imageNameWithoutTag = imageName;
+    // strip the digest and tag from the image name
+    let imageNameWithoutTag = imageName.split('@')[0];
+    if (!imageNameWithoutTag) {
+      sendError(`Image ${imageName} is not a Podman Desktop Extension`);
+      return;
+    }
+    const lastSlash = imageNameWithoutTag.lastIndexOf('/');
+    const lastColon = imageNameWithoutTag.lastIndexOf(':');
+    if (lastColon > lastSlash) {
+      imageNameWithoutTag = imageNameWithoutTag.slice(0, lastColon);
     }
 
     // remove all special characters from the image name
     const imageNameWithoutSpecialChars = imageNameWithoutTag.replace(/[^a-zA-Z0-9]/g, '');
-
-    // tmp folder
-    const tmpFolderPath = path.join(os.tmpdir(), `/tmp/${imageNameWithoutSpecialChars}-tmp`);
 
     // final folder
     const finalFolderPath = path.join(unpackedFolder, imageNameWithoutSpecialChars);
@@ -190,26 +225,52 @@ export class ExtensionInstaller {
       }
     }
 
-    sendLog('Downloading and extract layers...');
-    await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, event => {
-      sendLog(event.message);
-      onProgress?.(event.progress);
-    });
-
-    sendLog('Filtering image content...');
-    if (isPDExtension) {
-      await this.extractExtensionFiles(tmpFolderPath, finalFolderPath, sendLog);
-    } else if (isDDExtension) {
-      await this.#dockerDesktopInstaller.extractExtensionFiles(
-        tmpFolderPath,
-        finalFolderPath,
-        sendLog,
-        catatlogExtensionId,
-      );
+    if (fs.existsSync(finalFolderPath)) {
+      sendError(`Unable to install image ${imageName}: the target extension directory already exists`);
+      return;
     }
 
-    // delete the tmp folder
-    fs.rmSync(tmpFolderPath, { recursive: true });
+    // tmp folder
+    const tmpFolderPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), `${imageNameWithoutSpecialChars}-`));
+    try {
+      sendLog(localImage ? 'Extracting local image layers...' : 'Downloading and extract layers...');
+      const reportProgress = (event: { message: string; progress: number }): void => {
+        sendLog(event.message);
+        onProgress?.(event.progress);
+      };
+      if (localImage) {
+        await this.#localExtensionImageLoader.downloadAndExtractImage(
+          localImage,
+          imageName,
+          tmpFolderPath,
+          reportProgress,
+          token,
+        );
+      } else {
+        await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, reportProgress, token);
+      }
+
+      if (token?.isCancellationRequested) {
+        throw new Error('Extension installation canceled');
+      }
+
+      sendLog('Filtering image content...');
+      if (isPDExtension) {
+        await this.extractExtensionFiles(tmpFolderPath, finalFolderPath, sendLog);
+      } else if (isDDExtension) {
+        await this.#dockerDesktopInstaller.extractExtensionFiles(
+          tmpFolderPath,
+          finalFolderPath,
+          sendLog,
+          catatlogExtensionId,
+        );
+      }
+    } catch (error) {
+      await fs.promises.rm(finalFolderPath, { recursive: true, force: true });
+      throw error;
+    } finally {
+      await fs.promises.rm(tmpFolderPath, { recursive: true, force: true });
+    }
 
     if (isPDExtension) {
       let analyzedExtension: AnalyzedExtension | undefined;
@@ -220,18 +281,48 @@ export class ExtensionInstaller {
         });
       } catch (error) {
         sendError('Error while analyzing extension: ' + error);
+        await fs.promises.rm(finalFolderPath, { recursive: true, force: true });
+        return;
+      }
+      if (!analyzedExtension) {
+        sendError('Error while analyzing extension: no extension metadata was returned');
+        await fs.promises.rm(finalFolderPath, { recursive: true, force: true });
+        return;
       }
       if (analyzedExtension?.error) {
         sendError('Could not load extension: ' + analyzedExtension?.error);
+        await fs.promises.rm(finalFolderPath, { recursive: true, force: true });
         return;
       }
       if (extensions.find(extension => extension.id === analyzedExtension?.id)) {
         sendError(`Extension ${analyzedExtension?.id} is already installed.`);
+        await fs.promises.rm(finalFolderPath, { recursive: true, force: true });
         return;
       }
       return analyzedExtension;
     } else if (isDDExtension) {
-      return this.#dockerDesktopInstaller.setupContribution(titleLabel, imageName, finalFolderPath, sendLog, sendError);
+      try {
+        if (token?.isCancellationRequested) {
+          throw new Error('Extension installation canceled');
+        }
+        const contribution = await this.#dockerDesktopInstaller.setupContribution(
+          titleLabel,
+          imageName,
+          finalFolderPath,
+          sendLog,
+          sendError,
+        );
+        if (token?.isCancellationRequested) {
+          throw new Error('Extension installation canceled');
+        }
+        if (!contribution) {
+          await fs.promises.rm(finalFolderPath, { recursive: true, force: true });
+        }
+        return contribution;
+      } catch (error) {
+        await fs.promises.rm(finalFolderPath, { recursive: true, force: true });
+        throw error;
+      }
     }
     return undefined;
   }
@@ -242,6 +333,7 @@ export class ExtensionInstaller {
     errors: string[],
     sendLog: (message: string) => void,
     sendError: (message: string) => void,
+    token?: CancellationToken,
   ): Promise<boolean> {
     if (!analyzedExtension) {
       return false;
@@ -294,12 +386,25 @@ export class ExtensionInstaller {
       // now analyze all these dependencies
       for (const imageNameToAnalyze of imagesOfExtensionsToAnalyze) {
         try {
-          const imageToAnalyze = await this.analyzeFromImage(sendLog, sendError, imageNameToAnalyze);
+          const imageToAnalyze = token
+            ? await this.analyzeFromImage(sendLog, sendError, imageNameToAnalyze, undefined, undefined, token)
+            : await this.analyzeFromImage(sendLog, sendError, imageNameToAnalyze);
 
           if (!imageToAnalyze || imageToAnalyze instanceof DockerDesktopContribution) {
             return false;
           }
-          await this.analyzeTransitiveDependencies(imageToAnalyze, analyzedExtensions, errors, sendLog, sendError);
+          if (token) {
+            await this.analyzeTransitiveDependencies(
+              imageToAnalyze,
+              analyzedExtensions,
+              errors,
+              sendLog,
+              sendError,
+              token,
+            );
+          } else {
+            await this.analyzeTransitiveDependencies(imageToAnalyze, analyzedExtensions, errors, sendLog, sendError);
+          }
         } catch (error) {
           errors.push(`Error while analyzing extension ${imageNameToAnalyze}: ${error}`);
         }
@@ -315,14 +420,27 @@ export class ExtensionInstaller {
     imageName: string,
     extensionAnalyzed?: (extension: AnalyzedExtension) => void,
     catalogExtensionId?: string,
+    cancellationTokenSourceId?: number,
   ): Promise<void> {
+    const token = cancellationTokenSourceId
+      ? this.cancellationTokenRegistry.getCancellationTokenSource(cancellationTokenSourceId)?.token
+      : undefined;
+    if (cancellationTokenSourceId && !token) {
+      throw new Error(`Unknown cancellation token ${cancellationTokenSourceId}`);
+    }
+
     const task = this.taskManager.createTask({
       title: `Installing extension ${imageName}`,
+      ...(cancellationTokenSourceId ? { cancellable: true, cancellationTokenSourceId } : {}),
     });
 
     const wrappedSendError = (message: string): void => {
       sendError(message);
-      task.error = message;
+      if (token?.isCancellationRequested) {
+        task.status = 'canceled';
+      } else {
+        task.error = message;
+      }
     };
 
     try {
@@ -336,12 +454,17 @@ export class ExtensionInstaller {
         (progress: number) => {
           task.progress = progress;
         },
+        token,
       );
     } catch (error: unknown) {
-      task.error = String(error);
+      if (token?.isCancellationRequested) {
+        task.status = 'canceled';
+      } else {
+        task.error = String(error);
+      }
       throw error;
     } finally {
-      if (!task.error) {
+      if (!task.error && task.status !== 'canceled') {
         task.status = 'success';
       }
     }
@@ -355,6 +478,7 @@ export class ExtensionInstaller {
     extensionAnalyzed?: (extension: AnalyzedExtension) => void,
     catalogExtensionId?: string,
     onProgress?: (progress: number) => void,
+    token?: CancellationToken,
   ): Promise<void> {
     // now collect all transitive dependencies
     const analyzedExtensions: AnalyzedExtension[] = [];
@@ -365,10 +489,18 @@ export class ExtensionInstaller {
       imageName,
       catalogExtensionId,
       onProgress,
+      token,
     );
     if (analyzedExtension instanceof DockerDesktopContribution) {
       sendEnd('Docker Desktop Extension Successfully installed.');
       return;
+    }
+
+    if (token?.isCancellationRequested) {
+      if (analyzedExtension?.path) {
+        await fs.promises.rm(analyzedExtension.path, { recursive: true, force: true });
+      }
+      throw new Error('Extension installation canceled');
     }
 
     if (analyzedExtension) extensionAnalyzed?.(analyzedExtension);
@@ -379,23 +511,34 @@ export class ExtensionInstaller {
       errors,
       sendLog,
       sendError,
+      token,
     );
+
+    const cleanupAnalyzedExtensions = async (): Promise<void> => {
+      await Promise.all(
+        analyzedExtensions
+          .filter(extension => extension !== undefined)
+          .map(extension =>
+            extension?.path ? fs.promises.rm(extension.path, { recursive: true, force: true }) : Promise.resolve(),
+          ),
+      );
+    };
 
     // if we have some undefined objects, it is an error, cleanup extensions
     if (errors.length > 0) {
-      analyzedExtensions
-        .filter(extension => extension !== undefined)
-        .forEach(extension => {
-          if (extension?.path) {
-            fs.rmdirSync(extension.path, { recursive: true });
-          }
-        });
+      await cleanupAnalyzedExtensions();
       sendError(`Error while installing extension ${imageName}: ${errors.join('\n')}`);
       return;
     }
 
     if (!analyzeSuccessful) {
+      await cleanupAnalyzedExtensions();
       return;
+    }
+
+    if (token?.isCancellationRequested) {
+      await cleanupAnalyzedExtensions();
+      throw new Error('Extension installation canceled');
     }
 
     // load all extensions
@@ -410,7 +553,13 @@ export class ExtensionInstaller {
   async init(): Promise<void> {
     this.ipcMainOn(
       'extension-installer:install-from-image',
-      (event: IpcMainEvent, imageName: string, logCallbackId: number, catalogExtensionId?: string): void => {
+      (
+        event: IpcMainEvent,
+        imageName: string,
+        logCallbackId: number,
+        catalogExtensionId?: string,
+        cancellationTokenSourceId?: number,
+      ): void => {
         const telemetryData: {
           extensionId?: string;
           error?: string;
@@ -435,7 +584,15 @@ export class ExtensionInstaller {
           }
         };
 
-        this.installFromImage(sendLog, sendError, sendEnd, imageName, extAnalyzed, catalogExtensionId)
+        this.installFromImage(
+          sendLog,
+          sendError,
+          sendEnd,
+          imageName,
+          extAnalyzed,
+          catalogExtensionId,
+          cancellationTokenSourceId,
+        )
           .catch((error: unknown) => {
             sendError('' + error);
             telemetryData.error = `${error}`;

--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -43,7 +43,7 @@ import { ImageRegistry } from '/@/plugin/image-registry.js';
 import { TaskManager } from '/@/plugin/tasks/task-manager.js';
 import { Telemetry } from '/@/plugin/telemetry/telemetry.js';
 
-import { LocalExtensionImageLoader } from './local-extension-image-loader.js';
+import { type LocalExtensionImage, LocalExtensionImageLoader } from './local-extension-image-loader.js';
 
 function getStringLabels(labels: Record<string, unknown> | undefined): Record<string, string> | undefined {
   if (!labels || !Object.values(labels).every(label => typeof label === 'string')) {
@@ -136,11 +136,11 @@ export class ExtensionInstaller {
     onProgress?: (progress: number) => void,
     token?: CancellationToken,
   ): Promise<AnalyzedExtension | DockerDesktopContribution | undefined> {
-    imageName = imageName.trim();
-    sendLog(`Analyzing image ${imageName}...`);
-    let localImage;
+    const trimmedImageName = imageName.trim();
+    sendLog(`Analyzing image ${trimmedImageName}...`);
+    let localImage: LocalExtensionImage | undefined;
     try {
-      localImage = await this.#localExtensionImageLoader.findLocalImage(imageName, token);
+      localImage = await this.#localExtensionImageLoader.findLocalImage(trimmedImageName, token);
     } catch (error) {
       if (token?.isCancellationRequested) {
         throw new Error('Extension installation canceled');
@@ -152,22 +152,22 @@ export class ExtensionInstaller {
     let imageConfigLabels = getStringLabels(localImage?.labels);
     if (!localImage) {
       try {
-        imageConfigLabels = getStringLabels(await this.imageRegistry.getImageConfigLabels(imageName, token));
+        imageConfigLabels = getStringLabels(await this.imageRegistry.getImageConfigLabels(trimmedImageName, token));
       } catch (error) {
         if (token?.isCancellationRequested) {
           throw new Error('Extension installation canceled');
         }
         sendError(
-          this.#localExtensionImageLoader.isLocalImageReference(imageName)
-            ? `Local image ${imageName} was not found in a running container engine. Registry fallback failed: ${error}`
-            : 'Error while analyzing image: ' + error,
+          this.#localExtensionImageLoader.isLocalImageReference(trimmedImageName)
+            ? `Local image ${trimmedImageName} was not found in a running container engine. Registry fallback failed: ${error}`
+            : `Error while analyzing image: ${error}`,
         );
         return;
       }
     }
 
     if (!imageConfigLabels) {
-      sendError(`Image ${imageName} is not a Podman Desktop Extension. Unable to grab image config labels.`);
+      sendError(`Image ${trimmedImageName} is not a Podman Desktop Extension. Unable to grab image config labels.`);
       return;
     }
 
@@ -178,14 +178,14 @@ export class ExtensionInstaller {
     const apiDDVersion = imageConfigLabels['com.docker.desktop.extension.api.version'];
 
     if (!titleLabel || !descriptionLabel || !vendorLabel || (!apiVersion && !apiDDVersion)) {
-      sendError(`Image ${imageName} is not a Podman Desktop Extension`);
+      sendError(`Image ${trimmedImageName} is not a Podman Desktop Extension`);
       return;
     }
 
-    const isDDExtension = apiDDVersion ? true : false;
-    const isPDExtension = apiVersion ? true : false;
+    const isDDExtension = !!apiDDVersion;
+    const isPDExtension = !!apiVersion;
 
-    let unpackedFolder;
+    let unpackedFolder: string;
     // where to unpack the extension
     if (isPDExtension) {
       unpackedFolder = this.directories.getPluginsDirectory();
@@ -194,9 +194,9 @@ export class ExtensionInstaller {
     }
 
     // strip the digest and tag from the image name
-    let imageNameWithoutTag = imageName.split('@')[0];
+    let imageNameWithoutTag = trimmedImageName.split('@')[0];
     if (!imageNameWithoutTag) {
-      sendError(`Image ${imageName} is not a Podman Desktop Extension`);
+      sendError(`Image ${trimmedImageName} is not a Podman Desktop Extension`);
       return;
     }
     const lastSlash = imageNameWithoutTag.lastIndexOf('/');
@@ -225,14 +225,22 @@ export class ExtensionInstaller {
       }
     }
 
-    if (fs.existsSync(finalFolderPath)) {
-      sendError(`Unable to install image ${imageName}: the target extension directory already exists`);
-      return;
+    try {
+      // Claim the destination atomically so two installs cannot extract into the same directory.
+      await fs.promises.mkdir(finalFolderPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        sendError(
+          `Unable to install image ${trimmedImageName}: the target extension directory ${finalFolderPath} already exists. Remove it if no installed extension uses it, then retry.`,
+        );
+        return;
+      }
+      throw error;
     }
 
-    // tmp folder
-    const tmpFolderPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), `${imageNameWithoutSpecialChars}-`));
+    let tmpFolderPath: string | undefined;
     try {
+      tmpFolderPath = await fs.promises.mkdtemp(path.join(os.tmpdir(), `${imageNameWithoutSpecialChars}-`));
       sendLog(localImage ? 'Extracting local image layers...' : 'Downloading and extract layers...');
       const reportProgress = (event: { message: string; progress: number }): void => {
         sendLog(event.message);
@@ -241,13 +249,13 @@ export class ExtensionInstaller {
       if (localImage) {
         await this.#localExtensionImageLoader.downloadAndExtractImage(
           localImage,
-          imageName,
+          trimmedImageName,
           tmpFolderPath,
           reportProgress,
           token,
         );
       } else {
-        await this.imageRegistry.downloadAndExtractImage(imageName, tmpFolderPath, reportProgress, token);
+        await this.imageRegistry.downloadAndExtractImage(trimmedImageName, tmpFolderPath, reportProgress, token);
       }
 
       if (token?.isCancellationRequested) {
@@ -269,7 +277,9 @@ export class ExtensionInstaller {
       await fs.promises.rm(finalFolderPath, { recursive: true, force: true });
       throw error;
     } finally {
-      await fs.promises.rm(tmpFolderPath, { recursive: true, force: true });
+      if (tmpFolderPath) {
+        await fs.promises.rm(tmpFolderPath, { recursive: true, force: true });
+      }
     }
 
     if (isPDExtension) {
@@ -307,12 +317,15 @@ export class ExtensionInstaller {
         }
         const contribution = await this.#dockerDesktopInstaller.setupContribution(
           titleLabel,
-          imageName,
+          trimmedImageName,
           finalFolderPath,
           sendLog,
           sendError,
         );
         if (token?.isCancellationRequested) {
+          if (contribution) {
+            await this.#dockerDesktopInstaller.removeContribution(contribution);
+          }
           throw new Error('Extension installation canceled');
         }
         if (!contribution) {
@@ -386,25 +399,26 @@ export class ExtensionInstaller {
       // now analyze all these dependencies
       for (const imageNameToAnalyze of imagesOfExtensionsToAnalyze) {
         try {
-          const imageToAnalyze = token
-            ? await this.analyzeFromImage(sendLog, sendError, imageNameToAnalyze, undefined, undefined, token)
-            : await this.analyzeFromImage(sendLog, sendError, imageNameToAnalyze);
+          const imageToAnalyze = await this.analyzeFromImage(
+            sendLog,
+            sendError,
+            imageNameToAnalyze,
+            undefined,
+            undefined,
+            token,
+          );
 
           if (!imageToAnalyze || imageToAnalyze instanceof DockerDesktopContribution) {
             return false;
           }
-          if (token) {
-            await this.analyzeTransitiveDependencies(
-              imageToAnalyze,
-              analyzedExtensions,
-              errors,
-              sendLog,
-              sendError,
-              token,
-            );
-          } else {
-            await this.analyzeTransitiveDependencies(imageToAnalyze, analyzedExtensions, errors, sendLog, sendError);
-          }
+          await this.analyzeTransitiveDependencies(
+            imageToAnalyze,
+            analyzedExtensions,
+            errors,
+            sendLog,
+            sendError,
+            token,
+          );
         } catch (error) {
           errors.push(`Error while analyzing extension ${imageNameToAnalyze}: ${error}`);
         }
@@ -541,10 +555,30 @@ export class ExtensionInstaller {
       throw new Error('Extension installation canceled');
     }
 
-    // load all extensions
-    analyzedExtensions.forEach(extension => this.extensionLoader.ensureExtensionIsEnabled(extension.id));
+    try {
+      // load all extensions
+      analyzedExtensions.forEach(extension => {
+        this.extensionLoader.ensureExtensionIsEnabled(extension.id);
+      });
 
-    await this.extensionLoader.loadExtensions(analyzedExtensions);
+      await this.extensionLoader.loadExtensions(analyzedExtensions);
+      if (token?.isCancellationRequested) {
+        throw new Error('Extension installation canceled');
+      }
+    } catch (error) {
+      await Promise.allSettled(
+        [...analyzedExtensions].reverse().map(async extension => {
+          try {
+            await this.extensionLoader.removeExtension(extension.id);
+          } finally {
+            if (extension.path) {
+              await fs.promises.rm(extension.path, { recursive: true, force: true });
+            }
+          }
+        }),
+      );
+      throw error;
+    }
 
     sendEnd('Extension Successfully installed.');
     this.apiSender.send('extension-started');

--- a/packages/main/src/plugin/install/local-extension-image-loader.spec.ts
+++ b/packages/main/src/plugin/install/local-extension-image-loader.spec.ts
@@ -1,0 +1,435 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { copyFile, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { CancellationToken } from '@podman-desktop/api';
+import type { ImageInfo, ImageInspectInfo, ManifestInspectInfo } from '@podman-desktop/core-api';
+import * as fzstd from 'fzstd';
+import * as nodeTar from 'tar';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
+
+import { assertSafeArchiveEntry, LocalExtensionImageLoader } from './local-extension-image-loader.js';
+
+vi.mock(import('fzstd'), async importOriginal => {
+  const original = await importOriginal();
+  return { ...original, decompress: vi.fn(original.decompress) };
+});
+
+const listImagesMock = vi.fn<ContainerProviderRegistry['listImages']>();
+const getImageInspectMock = vi.fn<ContainerProviderRegistry['getImageInspect']>();
+const inspectManifestMock = vi.fn<ContainerProviderRegistry['inspectManifest']>();
+const saveImageMock = vi.fn<ContainerProviderRegistry['saveImage']>();
+
+const containerRegistry = {
+  listImages: listImagesMock,
+  getImageInspect: getImageInspectMock,
+  inspectManifest: inspectManifestMock,
+  saveImage: saveImageMock,
+} as unknown as ContainerProviderRegistry;
+
+let testDirectory: string;
+let loaderTemporaryDirectory: string;
+let loader: LocalExtensionImageLoader;
+
+function image(overrides: Partial<ImageInfo> = {}): ImageInfo {
+  return {
+    Id: 'sha256:image',
+    RepoTags: ['localhost/example/extension:latest'],
+    RepoDigests: [],
+    engineId: 'podman-machine',
+    engineName: 'Podman Machine',
+    engineType: 'podman',
+    ...overrides,
+  } as ImageInfo;
+}
+
+function inspect(labels: Record<string, unknown> | undefined): ImageInspectInfo {
+  return {
+    Config: { Labels: labels },
+  } as ImageInspectInfo;
+}
+
+interface SavedImageArchiveOptions {
+  manifest?: unknown;
+  gzipLayer?: boolean;
+  transformLayer?: (content: Buffer) => Buffer;
+}
+
+async function createSavedImageArchive(options: SavedImageArchiveOptions = {}): Promise<string> {
+  const archiveSource = await mkdtemp(path.join(testDirectory, 'archive-source-'));
+  const layerSource = await mkdtemp(path.join(testDirectory, 'layer-source-'));
+  await mkdir(path.join(layerSource, 'extension'), { recursive: true });
+  await writeFile(path.join(layerSource, 'extension', 'package.json'), '{"name":"local-extension"}');
+  await mkdir(archiveSource, { recursive: true });
+  const layerPath = path.join(archiveSource, 'layer.tar');
+  await nodeTar.create({ cwd: layerSource, file: layerPath, gzip: options.gzipLayer }, ['extension']);
+  if (options.transformLayer) {
+    await writeFile(layerPath, options.transformLayer(await readFile(layerPath)));
+  }
+  await writeFile(
+    path.join(archiveSource, 'manifest.json'),
+    JSON.stringify(
+      options.manifest ?? [
+        {
+          Config: 'config.json',
+          RepoTags: ['localhost/example/extension:latest'],
+          Layers: ['layer.tar'],
+        },
+      ],
+    ),
+  );
+  await writeFile(path.join(archiveSource, 'config.json'), '{}');
+
+  const archivePath = path.join(archiveSource, 'saved-image.tar');
+  await nodeTar.create({ cwd: archiveSource, file: archivePath }, ['manifest.json', 'config.json', 'layer.tar']);
+  return archivePath;
+}
+
+async function createWhiteoutImageArchive(): Promise<string> {
+  const archiveSource = await mkdtemp(path.join(testDirectory, 'whiteout-archive-source-'));
+  const lowerLayerSource = await mkdtemp(path.join(testDirectory, 'lower-layer-source-'));
+  const upperLayerSource = await mkdtemp(path.join(testDirectory, 'upper-layer-source-'));
+
+  await mkdir(path.join(lowerLayerSource, 'extension', 'opaque'), { recursive: true });
+  await writeFile(path.join(lowerLayerSource, 'extension', 'package.json'), '{"name":"local-extension"}');
+  await writeFile(path.join(lowerLayerSource, 'extension', 'removed.txt'), 'remove me');
+  await writeFile(path.join(lowerLayerSource, 'extension', 'kept.txt'), 'keep me');
+  await writeFile(path.join(lowerLayerSource, 'extension', 'opaque', 'old.txt'), 'remove opaque child');
+
+  await mkdir(path.join(upperLayerSource, 'extension', 'opaque'), { recursive: true });
+  await writeFile(path.join(upperLayerSource, 'extension', '.wh.removed.txt'), '');
+  await writeFile(path.join(upperLayerSource, 'extension', 'added.txt'), 'new file');
+  await writeFile(path.join(upperLayerSource, 'extension', 'opaque', '.wh..wh..opq'), '');
+  await writeFile(path.join(upperLayerSource, 'extension', 'opaque', 'new.txt'), 'new opaque child');
+
+  await nodeTar.create({ cwd: lowerLayerSource, file: path.join(archiveSource, 'lower.tar') }, ['extension']);
+  await nodeTar.create({ cwd: upperLayerSource, file: path.join(archiveSource, 'upper.tar') }, ['extension']);
+  await writeFile(
+    path.join(archiveSource, 'manifest.json'),
+    JSON.stringify([
+      {
+        Config: 'config.json',
+        RepoTags: ['localhost/example/extension:latest'],
+        Layers: ['lower.tar', 'upper.tar'],
+      },
+    ]),
+  );
+  await writeFile(path.join(archiveSource, 'config.json'), '{}');
+
+  const archivePath = path.join(archiveSource, 'saved-image.tar');
+  await nodeTar.create({ cwd: archiveSource, file: archivePath }, [
+    'manifest.json',
+    'config.json',
+    'lower.tar',
+    'upper.tar',
+  ]);
+  return archivePath;
+}
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  testDirectory = await mkdtemp(path.join(os.tmpdir(), 'local-extension-image-loader-test-'));
+  loaderTemporaryDirectory = path.join(testDirectory, 'loader-temporary');
+  await mkdir(loaderTemporaryDirectory);
+  loader = new LocalExtensionImageLoader(containerRegistry, loaderTemporaryDirectory, 'arm64', 'darwin');
+  listImagesMock.mockResolvedValue([]);
+});
+
+afterEach(async () => {
+  await rm(testDirectory, { recursive: true, force: true });
+});
+
+describe('local image lookup', () => {
+  test('does not inspect the container engines for a remote registry image', async () => {
+    await expect(loader.findLocalImage('quay.io/example/extension:latest')).resolves.toBeUndefined();
+    expect(listImagesMock).not.toHaveBeenCalled();
+  });
+
+  test('finds an exact localhost image and normalizes the latest tag', async () => {
+    listImagesMock.mockResolvedValue([image()]);
+    getImageInspectMock.mockResolvedValue(
+      inspect({
+        'org.opencontainers.image.title': 'Local extension',
+        'io.podman-desktop.api.version': '1.0.0',
+      }),
+    );
+
+    await expect(loader.findLocalImage('localhost/example/extension')).resolves.toEqual({
+      engineId: 'podman-machine',
+      engineName: 'Podman Machine',
+      id: 'sha256:image',
+      labels: {
+        'org.opencontainers.image.title': 'Local extension',
+        'io.podman-desktop.api.version': '1.0.0',
+      },
+    });
+    expect(getImageInspectMock).toHaveBeenCalledWith('podman-machine', 'sha256:image');
+  });
+
+  test('does not treat a similarly named registry as localhost', async () => {
+    await expect(loader.findLocalImage('localhost.example.com/extension:latest')).resolves.toBeUndefined();
+    expect(listImagesMock).not.toHaveBeenCalled();
+  });
+
+  test('returns undefined when no running engine has the image', async () => {
+    await expect(loader.findLocalImage('localhost/example/missing:latest')).resolves.toBeUndefined();
+  });
+
+  test('rejects an image that is ambiguous across engines', async () => {
+    listImagesMock.mockResolvedValue([
+      image(),
+      image({ Id: 'sha256:other', engineId: 'docker', engineName: 'Docker' }),
+    ]);
+
+    await expect(loader.findLocalImage('localhost/example/extension:latest')).rejects.toThrow(
+      'exists in multiple running container engines: Podman Machine (podman-machine), Docker (docker)',
+    );
+    expect(getImageInspectMock).not.toHaveBeenCalled();
+  });
+
+  test('uses the arm64 image from a multi-architecture manifest', async () => {
+    listImagesMock.mockResolvedValue([image({ isManifest: true })]);
+    inspectManifestMock.mockResolvedValue({
+      manifests: [
+        { digest: 'sha256:amd64', mediaType: '', platform: { architecture: 'amd64', os: 'linux' }, size: 1 },
+        { digest: 'sha256:arm64', mediaType: '', platform: { architecture: 'arm64', os: 'linux' }, size: 1 },
+      ],
+    } as ManifestInspectInfo);
+    getImageInspectMock.mockResolvedValue(inspect({ label: 'value' }));
+
+    await expect(loader.findLocalImage('localhost/example/extension:latest')).resolves.toMatchObject({
+      id: 'sha256:arm64',
+    });
+    expect(getImageInspectMock).toHaveBeenCalledWith('podman-machine', 'sha256:arm64');
+  });
+
+  test('rejects a multi-architecture manifest without the host architecture', async () => {
+    listImagesMock.mockResolvedValue([image({ isManifest: true })]);
+    inspectManifestMock.mockResolvedValue({
+      manifests: [{ digest: 'sha256:amd64', mediaType: '', platform: { architecture: 'amd64', os: 'linux' }, size: 1 }],
+    } as ManifestInspectInfo);
+
+    await expect(loader.findLocalImage('localhost/example/extension:latest')).rejects.toThrow(
+      'No local image for the current platform was found',
+    );
+    expect(getImageInspectMock).not.toHaveBeenCalled();
+  });
+
+  test('treats malformed label values as missing labels', async () => {
+    listImagesMock.mockResolvedValue([image()]);
+    getImageInspectMock.mockResolvedValue(inspect({ invalid: 42 }));
+
+    await expect(loader.findLocalImage('localhost/example/extension:latest')).resolves.toMatchObject({
+      labels: undefined,
+    });
+  });
+
+  test('checks cancellation before querying the engines', async () => {
+    const token = { isCancellationRequested: true } as CancellationToken;
+
+    await expect(loader.findLocalImage('localhost/example/extension:latest', token)).rejects.toThrow(
+      'Extension installation canceled',
+    );
+    expect(listImagesMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('saved image extraction', () => {
+  test('extracts the saved image layers and removes its private temporary directory', async () => {
+    const savedImageArchive = await createSavedImageArchive();
+    saveImageMock.mockImplementation(async (_engineId, _id, file) => copyFile(savedImageArchive, file));
+    const destination = path.join(testDirectory, 'destination');
+
+    await loader.downloadAndExtractImage(
+      { engineId: 'podman-machine', engineName: 'Podman Machine', id: 'sha256:image', labels: {} },
+      'localhost/example/extension:latest',
+      destination,
+      vi.fn(),
+    );
+
+    await expect(readFile(path.join(destination, 'extension', 'package.json'), 'utf8')).resolves.toContain(
+      'local-extension',
+    );
+    await expect(readdir(loaderTemporaryDirectory)).resolves.toEqual([]);
+  });
+
+  test('rejects a malformed saved-image manifest and still cleans up', async () => {
+    const savedImageArchive = await createSavedImageArchive({ manifest: { invalid: true } });
+    saveImageMock.mockImplementation(async (_engineId, _id, file) => copyFile(savedImageArchive, file));
+
+    await expect(
+      loader.downloadAndExtractImage(
+        { engineId: 'podman-machine', engineName: 'Podman Machine', id: 'sha256:image', labels: {} },
+        'localhost/example/extension:latest',
+        path.join(testDirectory, 'destination'),
+        vi.fn(),
+      ),
+    ).rejects.toThrow('Invalid image archive manifest');
+    await expect(readdir(loaderTemporaryDirectory)).resolves.toEqual([]);
+  });
+
+  test('extracts a single saved image whose platform-specific archive has no repository tag', async () => {
+    const savedImageArchive = await createSavedImageArchive({
+      manifest: [{ Config: 'config.json', RepoTags: null, Layers: ['layer.tar'] }],
+    });
+    saveImageMock.mockImplementation(async (_engineId, _id, file) => copyFile(savedImageArchive, file));
+    const destination = path.join(testDirectory, 'untagged-destination');
+
+    await loader.downloadAndExtractImage(
+      { engineId: 'podman-machine', engineName: 'Podman Machine', id: 'sha256:image', labels: {} },
+      'localhost/example/extension:latest',
+      destination,
+      vi.fn(),
+    );
+
+    await expect(readFile(path.join(destination, 'extension', 'package.json'), 'utf8')).resolves.toContain(
+      'local-extension',
+    );
+  });
+
+  test('passes cancellation to saveImage and cleans up when canceled', async () => {
+    let cancellationRequested = false;
+    const token = {
+      get isCancellationRequested() {
+        return cancellationRequested;
+      },
+    } as CancellationToken;
+    saveImageMock.mockImplementation(async () => {
+      cancellationRequested = true;
+    });
+
+    await expect(
+      loader.downloadAndExtractImage(
+        { engineId: 'podman-machine', engineName: 'Podman Machine', id: 'sha256:image', labels: {} },
+        'localhost/example/extension:latest',
+        path.join(testDirectory, 'destination'),
+        vi.fn(),
+        token,
+      ),
+    ).rejects.toThrow('Extension installation canceled');
+    expect(saveImageMock).toHaveBeenCalledWith(
+      'podman-machine',
+      'sha256:image',
+      expect.stringMatching(/image\.tar$/),
+      token,
+    );
+    await expect(readdir(loaderTemporaryDirectory)).resolves.toEqual([]);
+  });
+
+  test('extracts a gzip-compressed image layer', async () => {
+    const savedImageArchive = await createSavedImageArchive({ gzipLayer: true });
+    saveImageMock.mockImplementation(async (_engineId, _id, file) => copyFile(savedImageArchive, file));
+    const destination = path.join(testDirectory, 'gzip-destination');
+
+    await loader.downloadAndExtractImage(
+      { engineId: 'podman-machine', engineName: 'Podman Machine', id: 'sha256:image', labels: {} },
+      'localhost/example/extension:latest',
+      destination,
+      vi.fn(),
+    );
+
+    await expect(readFile(path.join(destination, 'extension', 'package.json'), 'utf8')).resolves.toContain(
+      'local-extension',
+    );
+  });
+
+  test('extracts a zstd-compressed image layer', async () => {
+    let uncompressedLayer: Buffer | undefined;
+    const savedImageArchive = await createSavedImageArchive({
+      transformLayer: content => {
+        uncompressedLayer = content;
+        return Buffer.from([0x28, 0xb5, 0x2f, 0xfd, 0x00]);
+      },
+    });
+    vi.mocked(fzstd.decompress).mockReturnValue(uncompressedLayer ?? Buffer.alloc(0));
+    saveImageMock.mockImplementation(async (_engineId, _id, file) => copyFile(savedImageArchive, file));
+    const destination = path.join(testDirectory, 'zstd-destination');
+
+    await loader.downloadAndExtractImage(
+      { engineId: 'podman-machine', engineName: 'Podman Machine', id: 'sha256:image', labels: {} },
+      'localhost/example/extension:latest',
+      destination,
+      vi.fn(),
+    );
+
+    expect(fzstd.decompress).toHaveBeenCalled();
+    await expect(readFile(path.join(destination, 'extension', 'package.json'), 'utf8')).resolves.toContain(
+      'local-extension',
+    );
+  });
+
+  test('applies file and opaque-directory whiteouts without leaving marker files', async () => {
+    const savedImageArchive = await createWhiteoutImageArchive();
+    saveImageMock.mockImplementation(async (_engineId, _id, file) => copyFile(savedImageArchive, file));
+    const destination = path.join(testDirectory, 'whiteout-destination');
+
+    await loader.downloadAndExtractImage(
+      { engineId: 'podman-machine', engineName: 'Podman Machine', id: 'sha256:image', labels: {} },
+      'localhost/example/extension:latest',
+      destination,
+      vi.fn(),
+    );
+
+    await expect(readFile(path.join(destination, 'extension', 'kept.txt'), 'utf8')).resolves.toBe('keep me');
+    await expect(readFile(path.join(destination, 'extension', 'added.txt'), 'utf8')).resolves.toBe('new file');
+    await expect(readFile(path.join(destination, 'extension', 'removed.txt'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(readFile(path.join(destination, 'extension', 'opaque', 'old.txt'), 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(readFile(path.join(destination, 'extension', 'opaque', 'new.txt'), 'utf8')).resolves.toBe(
+      'new opaque child',
+    );
+    await expect(readdir(path.join(destination, 'extension'))).resolves.not.toContain('.wh.removed.txt');
+    await expect(readdir(path.join(destination, 'extension', 'opaque'))).resolves.not.toContain('.wh..wh..opq');
+  });
+});
+
+describe('archive path validation', () => {
+  const destination = path.join(os.tmpdir(), 'extension-destination');
+
+  test.each(['../escape', 'extension/../../escape', path.resolve(destination, '..', 'escape')])(
+    'rejects traversal path %s',
+    entryPath => {
+      expect(() => assertSafeArchiveEntry(destination, entryPath)).toThrow('escapes the destination');
+    },
+  );
+
+  test('rejects an escaping symbolic link', () => {
+    expect(() => assertSafeArchiveEntry(destination, 'extension/link', 'SymbolicLink', '../../escape')).toThrow(
+      'link escapes the destination',
+    );
+  });
+
+  test('rejects an escaping hard link', () => {
+    expect(() => assertSafeArchiveEntry(destination, 'extension/link', 'Link', '../escape')).toThrow(
+      'link escapes the destination',
+    );
+  });
+
+  test('accepts normal files and internal links', () => {
+    expect(() => assertSafeArchiveEntry(destination, 'extension/package.json')).not.toThrow();
+    expect(() => assertSafeArchiveEntry(destination, 'extension/link', 'SymbolicLink', 'package.json')).not.toThrow();
+  });
+});

--- a/packages/main/src/plugin/install/local-extension-image-loader.ts
+++ b/packages/main/src/plugin/install/local-extension-image-loader.ts
@@ -1,0 +1,361 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as fs from 'node:fs';
+import { cp, mkdir, mkdtemp, open, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { CancellationToken } from '@podman-desktop/api';
+import type { ImageInfo, ManifestInspectInfo } from '@podman-desktop/core-api';
+import * as fzstd from 'fzstd';
+import * as nodeTar from 'tar';
+
+import type { ContainerProviderRegistry } from '/@/plugin/container-registry.js';
+
+interface DockerImageArchiveManifestEntry {
+  Config: string;
+  RepoTags: string[];
+  Layers: string[];
+}
+
+export interface LocalExtensionImage {
+  engineId: string;
+  engineName: string;
+  id: string;
+  labels: Record<string, string> | undefined;
+}
+
+function isPathInside(parent: string, candidate: string): boolean {
+  return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
+}
+
+export function assertSafeArchiveEntry(
+  destination: string,
+  entryPath: string,
+  entryType?: string,
+  linkPath?: string,
+): void {
+  if (entryPath.includes('\0')) {
+    throw new Error('Image archive contains an invalid path');
+  }
+
+  const destinationPath = path.resolve(destination);
+  const resolvedEntryPath = path.resolve(destinationPath, entryPath);
+  if (!isPathInside(destinationPath, resolvedEntryPath)) {
+    throw new Error(`Image archive entry escapes the destination: ${entryPath}`);
+  }
+
+  if (!linkPath || (entryType !== 'SymbolicLink' && entryType !== 'Link')) {
+    return;
+  }
+  if (linkPath.includes('\0')) {
+    throw new Error('Image archive contains an invalid link path');
+  }
+
+  const resolvedLinkPath =
+    entryType === 'SymbolicLink'
+      ? path.resolve(path.dirname(resolvedEntryPath), linkPath)
+      : path.resolve(destinationPath, linkPath);
+  if (!isPathInside(destinationPath, resolvedLinkPath)) {
+    throw new Error(`Image archive link escapes the destination: ${entryPath}`);
+  }
+}
+
+function throwIfCancelled(token?: CancellationToken): void {
+  if (token?.isCancellationRequested) {
+    throw new Error('Extension installation canceled');
+  }
+}
+
+function normalizeImageReferences(imageName: string): Set<string> {
+  const references = new Set([imageName]);
+  const lastSlash = imageName.lastIndexOf('/');
+  const lastColon = imageName.lastIndexOf(':');
+  if (!imageName.includes('@') && lastColon < lastSlash) {
+    references.add(`${imageName}:latest`);
+  }
+  return references;
+}
+
+function parseArchiveManifest(content: string): DockerImageArchiveManifestEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Invalid image archive manifest: ${String(error)}`);
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error('Invalid image archive manifest: expected a non-empty array');
+  }
+
+  return parsed.map((entry: unknown) => {
+    const repoTags =
+      typeof entry === 'object' && entry !== null && 'RepoTags' in entry && entry.RepoTags !== null
+        ? entry.RepoTags
+        : [];
+    if (
+      typeof entry !== 'object' ||
+      entry === null ||
+      !('Config' in entry) ||
+      typeof entry.Config !== 'string' ||
+      !Array.isArray(repoTags) ||
+      !repoTags.every((tag: unknown) => typeof tag === 'string') ||
+      !('Layers' in entry) ||
+      !Array.isArray(entry.Layers) ||
+      entry.Layers.length === 0 ||
+      !entry.Layers.every((layer: unknown) => typeof layer === 'string')
+    ) {
+      throw new Error('Invalid image archive manifest entry');
+    }
+    return { ...entry, RepoTags: repoTags } as DockerImageArchiveManifestEntry;
+  });
+}
+
+export class LocalExtensionImageLoader {
+  constructor(
+    private readonly containerRegistry: ContainerProviderRegistry,
+    private readonly temporaryDirectory = os.tmpdir(),
+    private readonly platformArchitecture = os.arch() === 'arm64' ? 'arm64' : 'amd64',
+    private readonly platformOs = process.platform === 'win32'
+      ? 'windows'
+      : process.platform === 'darwin'
+        ? 'darwin'
+        : 'linux',
+  ) {}
+
+  isLocalImageReference(imageName: string): boolean {
+    const firstSlash = imageName.indexOf('/');
+    if (firstSlash <= 0) {
+      return false;
+    }
+    const registry = imageName.slice(0, firstSlash);
+    return registry === 'localhost' || registry.startsWith('localhost:');
+  }
+
+  async findLocalImage(imageName: string, token?: CancellationToken): Promise<LocalExtensionImage | undefined> {
+    if (!this.isLocalImageReference(imageName)) {
+      return undefined;
+    }
+
+    throwIfCancelled(token);
+    const references = normalizeImageReferences(imageName);
+    const images = await this.containerRegistry.listImages();
+    throwIfCancelled(token);
+
+    const matchingImages = images.filter(image =>
+      [...(image.RepoTags ?? []), ...(image.RepoDigests ?? [])].some(reference => references.has(reference)),
+    );
+    const uniqueImages = [
+      ...new Map(matchingImages.map(image => [`${image.engineId}:${image.Id}`, image] as const)).values(),
+    ];
+
+    if (uniqueImages.length > 1) {
+      const engines = uniqueImages.map(image => `${image.engineName} (${image.engineId})`).join(', ');
+      throw new Error(`Image ${imageName} exists in multiple running container engines: ${engines}`);
+    }
+
+    const image = uniqueImages[0];
+    if (!image) {
+      return undefined;
+    }
+
+    const imageId = await this.resolvePlatformImageId(image);
+    throwIfCancelled(token);
+    const inspect = await this.containerRegistry.getImageInspect(image.engineId, imageId);
+    throwIfCancelled(token);
+    const rawLabels = inspect.Config?.Labels;
+    const labels =
+      rawLabels && Object.values(rawLabels).every(label => typeof label === 'string')
+        ? (rawLabels as Record<string, string>)
+        : undefined;
+
+    return {
+      engineId: image.engineId,
+      engineName: image.engineName,
+      id: imageId,
+      labels,
+    };
+  }
+
+  async downloadAndExtractImage(
+    image: LocalExtensionImage,
+    imageName: string,
+    destination: string,
+    logger: (event: { message: string; progress: number }) => void,
+    token?: CancellationToken,
+  ): Promise<void> {
+    const workingDirectory = await mkdtemp(path.join(this.temporaryDirectory, 'podman-desktop-extension-image-'));
+    const archivePath = path.join(workingDirectory, 'image.tar');
+    const archiveDirectory = path.join(workingDirectory, 'archive');
+
+    try {
+      throwIfCancelled(token);
+      logger({ message: `Saving local image ${imageName} from ${image.engineName}...`, progress: 0 });
+      await this.containerRegistry.saveImage(image.engineId, image.id, archivePath, token);
+      throwIfCancelled(token);
+
+      await this.extractTar(archivePath, archiveDirectory, token);
+      const manifest = parseArchiveManifest(await readFile(path.join(archiveDirectory, 'manifest.json'), 'utf8'));
+      const references = normalizeImageReferences(imageName);
+      const matchingEntries = manifest.filter(entry => entry.RepoTags.some(reference => references.has(reference)));
+      const manifestEntry = matchingEntries[0] ?? (manifest.length === 1 ? manifest[0] : undefined);
+      if (!manifestEntry || matchingEntries.length > 1) {
+        throw new Error(`Unable to identify image ${imageName} in the saved image archive`);
+      }
+
+      await mkdir(destination, { recursive: true });
+      for (const [index, layer] of manifestEntry.Layers.entries()) {
+        throwIfCancelled(token);
+        const layerPath = path.resolve(archiveDirectory, layer);
+        if (!isPathInside(path.resolve(archiveDirectory), layerPath) || !fs.existsSync(layerPath)) {
+          throw new Error(`Invalid image layer path: ${layer}`);
+        }
+        await this.extractLayerTar(layerPath, destination, workingDirectory, index, token);
+        const progress = Math.round(((index + 1) / manifestEntry.Layers.length) * 100);
+        logger({
+          message: `Extracting local image layer ${index + 1}/${manifestEntry.Layers.length} - ${progress}%`,
+          progress,
+        });
+      }
+      throwIfCancelled(token);
+    } finally {
+      await rm(workingDirectory, { recursive: true, force: true });
+    }
+  }
+
+  private async resolvePlatformImageId(image: ImageInfo): Promise<string> {
+    if (!image.isManifest) {
+      return image.Id;
+    }
+
+    const manifest = await this.containerRegistry.inspectManifest(image.engineId, image.Id);
+    const platformManifest = this.findBestManifest(manifest);
+    if (!platformManifest) {
+      throw new Error(
+        `No local image for the current platform was found in manifest ${image.RepoTags?.[0] ?? image.Id}`,
+      );
+    }
+    return platformManifest.digest;
+  }
+
+  private findBestManifest(manifest: ManifestInspectInfo): ManifestInspectInfo['manifests'][number] | undefined {
+    const manifestsByOs = manifest.manifests.filter(item => item.platform.os === this.platformOs);
+    const candidateManifests =
+      manifestsByOs.length > 0 ? manifestsByOs : manifest.manifests.filter(item => item.platform.os === 'linux');
+    return candidateManifests.find(item => item.platform.architecture === this.platformArchitecture);
+  }
+
+  private async extractTar(archivePath: string, destination: string, token?: CancellationToken): Promise<void> {
+    await mkdir(destination, { recursive: true });
+    await nodeTar.extract({
+      file: archivePath,
+      cwd: destination,
+      preservePaths: false,
+      strict: true,
+      filter: (entryPath, entry): boolean => {
+        throwIfCancelled(token);
+        const entryType = 'type' in entry ? entry.type : undefined;
+        const linkPath = 'linkpath' in entry ? entry.linkpath : undefined;
+        assertSafeArchiveEntry(destination, entryPath, entryType, linkPath);
+        return true;
+      },
+    });
+  }
+
+  private async extractLayerTar(
+    layerPath: string,
+    destination: string,
+    workingDirectory: string,
+    index: number,
+    token?: CancellationToken,
+  ): Promise<void> {
+    let archivePath = layerPath;
+    if (await this.isZstdArchive(layerPath)) {
+      throwIfCancelled(token);
+      const decompressedPath = path.join(workingDirectory, `layer-${index}.tar`);
+      await writeFile(decompressedPath, fzstd.decompress(await readFile(layerPath)));
+      archivePath = decompressedPath;
+      throwIfCancelled(token);
+    }
+
+    const layerDirectory = path.join(workingDirectory, `layer-${index}`);
+    const whiteouts: string[] = [];
+    await mkdir(layerDirectory, { recursive: true });
+    await nodeTar.extract({
+      file: archivePath,
+      cwd: layerDirectory,
+      preservePaths: false,
+      strict: true,
+      filter: (entryPath, entry): boolean => {
+        throwIfCancelled(token);
+        const entryType = 'type' in entry ? entry.type : undefined;
+        const linkPath = 'linkpath' in entry ? entry.linkpath : undefined;
+        assertSafeArchiveEntry(layerDirectory, entryPath, entryType, linkPath);
+        if (path.posix.basename(entryPath).startsWith('.wh.')) {
+          whiteouts.push(entryPath);
+          return false;
+        }
+        return true;
+      },
+    });
+
+    // Whiteouts describe removals from lower layers. Apply them before copying this
+    // layer so a same-layer replacement is never removed accidentally.
+    for (const whiteout of whiteouts.filter(entry => path.posix.basename(entry) === '.wh..wh..opq')) {
+      throwIfCancelled(token);
+      const relativeDirectory = path.posix.dirname(whiteout);
+      const opaqueDirectory = path.resolve(destination, relativeDirectory);
+      if (!isPathInside(path.resolve(destination), opaqueDirectory)) {
+        throw new Error(`Image layer whiteout escapes the destination: ${whiteout}`);
+      }
+      const children = await readdir(opaqueDirectory).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === 'ENOENT') return [];
+        throw error;
+      });
+      await Promise.all(children.map(child => rm(path.join(opaqueDirectory, child), { recursive: true, force: true })));
+    }
+    for (const whiteout of whiteouts.filter(entry => path.posix.basename(entry) !== '.wh..wh..opq')) {
+      throwIfCancelled(token);
+      const basename = path.posix.basename(whiteout);
+      const targetName = basename.slice('.wh.'.length);
+      const relativeTarget = path.posix.join(path.posix.dirname(whiteout), targetName);
+      const target = path.resolve(destination, relativeTarget);
+      if (!targetName || !isPathInside(path.resolve(destination), target)) {
+        throw new Error(`Image layer whiteout escapes the destination: ${whiteout}`);
+      }
+      await rm(target, { recursive: true, force: true });
+    }
+
+    throwIfCancelled(token);
+    await cp(layerDirectory, destination, { recursive: true });
+    throwIfCancelled(token);
+  }
+
+  private async isZstdArchive(archivePath: string): Promise<boolean> {
+    const file = await open(archivePath, 'r');
+    try {
+      const magic = Buffer.alloc(4);
+      const { bytesRead } = await file.read(magic, 0, magic.length, 0);
+      return bytesRead === magic.length && magic.equals(Buffer.from([0x28, 0xb5, 0x2f, 0xfd]));
+    } finally {
+      await file.close();
+    }
+  }
+}

--- a/packages/preload/src/index.spec.ts
+++ b/packages/preload/src/index.spec.ts
@@ -126,6 +126,52 @@ describe('collect calls to exposeInMainWorld and ipcRenderer.on and calls initEx
     initExposure();
   });
 
+  test('extension installation forwards cancellation and resolves only on completion', async () => {
+    const installExtension = getInMainWorld('extensionInstallFromImage');
+    const logCallback = vi.fn();
+    const errorCallback = vi.fn();
+    const installation = installExtension(
+      'localhost/example/extension:latest',
+      logCallback,
+      errorCallback,
+      undefined,
+      42,
+    ) as Promise<void>;
+
+    expect(ipcRenderer.send).toHaveBeenCalledWith(
+      'extension-installer:install-from-image',
+      'localhost/example/extension:latest',
+      1,
+      undefined,
+      42,
+    );
+    getRendererOn('extension-installer:install-from-image-log')({} as IpcRendererEvent, 1, 'Saving image');
+    expect(logCallback).toHaveBeenCalledWith('Saving image');
+
+    getRendererOn('extension-installer:install-from-image-end')({} as IpcRendererEvent, 1);
+    await expect(installation).resolves.toBeUndefined();
+    expect(errorCallback).not.toHaveBeenCalled();
+  });
+
+  test('extension installation rejects and reports errors', async () => {
+    const installExtension = getInMainWorld('extensionInstallFromImage');
+    const errorCallback = vi.fn();
+    const installation = installExtension(
+      'localhost/example/extension:latest',
+      vi.fn(),
+      errorCallback,
+    ) as Promise<void>;
+
+    getRendererOn('extension-installer:install-from-image-error')(
+      {} as IpcRendererEvent,
+      1,
+      'Extension installation canceled',
+    );
+
+    expect(errorCallback).toHaveBeenCalledWith('Extension installation canceled');
+    await expect(installation).rejects.toThrow('Extension installation canceled');
+  });
+
   test('openDialog', async () => {
     vi.mocked(ipcRenderer.invoke).mockResolvedValue({ error: undefined, result: undefined });
 

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -2526,6 +2526,14 @@ export function initExposure(): void {
   const onDataCallbacksShellInContainerExtension = new Map<number, (data: string) => void>();
   const onDataCallbacksShellInContainerExtensionError = new Map<number, (data: string) => void>();
   const onDataCallbacksShellInContainerExtensionResolve = new Map<number, (value: void | PromiseLike<void>) => void>();
+  const onDataCallbacksShellInContainerExtensionReject = new Map<number, (reason?: unknown) => void>();
+
+  function clearExtensionInstallCallbacks(callbackId: number): void {
+    onDataCallbacksShellInContainerExtension.delete(callbackId);
+    onDataCallbacksShellInContainerExtensionError.delete(callbackId);
+    onDataCallbacksShellInContainerExtensionResolve.delete(callbackId);
+    onDataCallbacksShellInContainerExtensionReject.delete(callbackId);
+  }
 
   contextBridge.exposeInMainWorld(
     'extensionInstallFromImage',
@@ -2534,6 +2542,7 @@ export function initExposure(): void {
       logCallback: (data: string) => void,
       errorCallback: (data: string) => void,
       catalogExtensionId?: string,
+      cancellationTokenSourceId?: number,
     ): Promise<void> => {
       onDataCallbacksShellInContainerExtensionInstallId++;
       onDataCallbacksShellInContainerExtension.set(onDataCallbacksShellInContainerExtensionInstallId, logCallback);
@@ -2546,10 +2555,12 @@ export function initExposure(): void {
         imageName,
         onDataCallbacksShellInContainerExtensionInstallId,
         catalogExtensionId,
+        cancellationTokenSourceId,
       );
 
-      return new Promise(resolve => {
+      return new Promise((resolve, reject) => {
         onDataCallbacksShellInContainerExtensionResolve.set(onDataCallbacksShellInContainerExtensionInstallId, resolve);
+        onDataCallbacksShellInContainerExtensionReject.set(onDataCallbacksShellInContainerExtensionInstallId, reject);
       });
     },
   );
@@ -2566,6 +2577,9 @@ export function initExposure(): void {
     if (callback) {
       callback(data);
     }
+    const rejectCallback = onDataCallbacksShellInContainerExtensionReject.get(callbackId);
+    rejectCallback?.(new Error(data));
+    clearExtensionInstallCallbacks(callbackId);
   });
 
   ipcRenderer.on('extension-installer:install-from-image-end', (_, callbackId: number) => {
@@ -2573,6 +2587,7 @@ export function initExposure(): void {
     if (resolveCallback) {
       resolveCallback();
     }
+    clearExtensionInstallCallbacks(callbackId);
   });
 
   contextBridge.exposeInMainWorld('getPodmanDesktopVersion', async (): Promise<string> => {

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts
@@ -28,10 +28,14 @@ const closeCallback = vi.fn();
 
 beforeAll(() => {
   Object.defineProperty(window, 'extensionInstallFromImage', { value: vi.fn() });
+  Object.defineProperty(window, 'getCancellableTokenSource', { value: vi.fn() });
+  Object.defineProperty(window, 'cancelToken', { value: vi.fn() });
 });
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(window.getCancellableTokenSource).mockResolvedValue(42);
+  vi.mocked(window.cancelToken).mockResolvedValue();
 });
 
 test('expect invalid field', async () => {
@@ -67,6 +71,8 @@ test('expect able to download an extension', async () => {
     'my-custom-image.io/foo',
     expect.anything(),
     expect.anything(),
+    undefined,
+    42,
   );
 
   // expect button done is there now
@@ -125,6 +131,21 @@ test('install button should always be disable when extensionInstallFromImage is 
 
   // expect button done to be disabled
   expect(installButton).toBeDisabled();
+});
+
+test('cancel should stop an installation before closing the modal', async () => {
+  mockExtensionInstallFromImage();
+
+  render(InstallManuallyExtensionModal, { closeCallback });
+  const input = screen.getByRole('textbox', { name: 'Image name to install custom extension' });
+  await userEvent.type(input, 'localhost/example/extension');
+  await userEvent.click(screen.getByRole('button', { name: 'Install' }));
+
+  await vi.waitFor(() => expect(window.extensionInstallFromImage).toHaveBeenCalled());
+  await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+  expect(window.cancelToken).toHaveBeenCalledWith(42);
+  expect(closeCallback).toHaveBeenCalled();
 });
 
 test('rejected installation should make the button visible', async () => {

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -16,6 +16,8 @@ let installInProgress = $state(false);
 let inputfieldError: string | undefined = $state('');
 let progressPercent = $state(0);
 let logs: string[] = [];
+let cancellationTokenSourceId: number | undefined;
+let closeRequested = false;
 
 const inputAriaLabel = 'Image name to install custom extension';
 
@@ -42,8 +44,12 @@ function validateImageName(event: Event): void {
 }
 
 async function installExtension(): Promise<void> {
+  if (installInProgress) {
+    return;
+  }
   inputfieldError = undefined;
   logs = [];
+  closeRequested = false;
 
   installInProgress = true;
 
@@ -51,6 +57,11 @@ async function installExtension(): Promise<void> {
   const ociImage = imageName?.trim();
 
   try {
+    cancellationTokenSourceId = await window.getCancellableTokenSource();
+    if (closeRequested) {
+      await window.cancelToken(cancellationTokenSourceId);
+      return;
+    }
     const percentageMatchRegexp = RegExp(/(\d+)%/);
     // download image
     await window.extensionInstallFromImage(
@@ -71,13 +82,29 @@ async function installExtension(): Promise<void> {
         installInProgress = false;
         inputfieldError = error;
       },
+      undefined,
+      cancellationTokenSourceId,
     );
     logs = [...logs, '☑️ installation finished!'];
     progressPercent = 100;
   } catch (error) {
     console.error('error', error);
+  } finally {
+    cancellationTokenSourceId = undefined;
+    installInProgress = false;
   }
-  installInProgress = false;
+}
+
+async function cancelOrClose(): Promise<void> {
+  closeRequested = true;
+  const tokenSourceId = cancellationTokenSourceId;
+  try {
+    if (installInProgress && tokenSourceId !== undefined) {
+      await window.cancelToken(tokenSourceId);
+    }
+  } finally {
+    closeCallback();
+  }
 }
 
 async function handleKeydown(e: KeyboardEvent): Promise<void> {
@@ -98,7 +125,7 @@ const showForm = $derived(installInProgress || progressPercent !== 100 || !!inpu
 
 <Dialog
   title="Install Custom Extension"
-  onclose={closeCallback}>
+  onclose={cancelOrClose}>
   {#snippet content()}
     <div  class="flex flex-col leading-5 space-y-5">
       <div>
@@ -142,7 +169,7 @@ const showForm = $derived(installInProgress || progressPercent !== 100 || !!inpu
   
       <Button
         type="link"
-        on:click={closeCallback}>Cancel</Button>
+        on:click={cancelOrClose}>Cancel</Button>
       {#if showForm}
         <Button
           type="primary"

--- a/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
+++ b/packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.svelte
@@ -15,9 +15,9 @@ let imageName = $state('');
 let installInProgress = $state(false);
 let inputfieldError: string | undefined = $state('');
 let progressPercent = $state(0);
-let logs: string[] = [];
-let cancellationTokenSourceId: number | undefined;
-let closeRequested = false;
+let logs = $state<string[]>([]);
+let cancellationTokenSourceId = $state<number | undefined>(undefined);
+let closeRequested = $state(false);
 
 const inputAriaLabel = 'Image name to install custom extension';
 
@@ -35,10 +35,9 @@ function validateImageName(event: Event): void {
     if (!name) {
       inputfieldError = 'Missing name';
       return;
-    } else {
-      inputfieldError = undefined;
-      return;
     }
+    inputfieldError = undefined;
+    return;
   }
   inputfieldError = 'Invalid input';
 }
@@ -74,7 +73,7 @@ async function installExtension(): Promise<void> {
         // data Downloading sha256:e8d2c9e5c69499c41ba39b7828c00e55087572884cac466b4d1b47243b085c7d.tar - 11% - (55132/521578)
         const percentageMatch = percentageMatchRegexp.exec(data);
         if (percentageMatch) {
-          progressPercent = parseInt(percentageMatch[1]);
+          progressPercent = Number.parseInt(percentageMatch[1], 10);
         }
       },
       (error: string) => {


### PR DESCRIPTION
### What does this PR do?

Installs extensions from images available in a running local container engine before falling back to the existing remote-registry flow.

The local-image path uses the container-provider API, supports OCI and Docker image manifests, multi-architecture images, gzip and zstd layers, cancellation, temporary-file cleanup, and reports ambiguous matches across container connections.

### Screenshot / video of UI
<img width="1050" height="700" alt="success" src="https://github.com/user-attachments/assets/388d7ce3-2db6-4160-a2a9-f04c01d59b4a" />


<img width="1050" height="700" alt="active" src="https://github.com/user-attachments/assets/499ffcc2-0184-4024-9f95-89a9a33f5ab8" />


### What issues does this PR fix or reference?

Fixes #17013

### How to test this PR?

1. Build and tag an extension image as `localhost/podman-desktop-local-e2e:latest` without pushing it to a registry.
2. Start Podman Desktop from this branch.
3. Open **Extensions**, select **Install custom**, and enter the local image name.
4. Verify the installation completes and the extension becomes **ACTIVE**.
5. Restart Podman Desktop and verify the extension remains installed and **ACTIVE**.

Focused automated tests:

- `pnpm exec vitest --run --project=@podman-desktop/main packages/main/src/plugin/image-registry.spec.ts packages/main/src/plugin/install/extension-installer.spec.ts packages/main/src/plugin/install/local-extension-image-loader.spec.ts`
- `pnpm exec vitest --run --project=@podman-desktop/preload packages/preload/src/index.spec.ts`
- `pnpm exec vitest --run --project=renderer packages/renderer/src/lib/extensions/InstallManuallyExtensionModal.spec.ts`

- [x] Tests are covering the bug fix or the new feature

Disclosure: AI was used to understand the codebase and review the fix.
