### PR TITLE
refactor(podman): use parameterized tests for binary location and pipe name tests

### DIFF
--- a/extensions/podman/packages/extension/src/helpers/podman-binary-location-helper.spec.ts
+++ b/extensions/podman/packages/extension/src/helpers/podman-binary-location-helper.spec.ts
@@ -29,40 +29,18 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('should grab podman from the installer', async () => {
+test.each([
+  { stdout: '/opt/podman/bin/podman', expectedSource: 'installer', name: 'should grab podman from the installer' },
+  { stdout: '/opt/homebrew/bin/podman', expectedSource: 'brew', name: 'should grab podman from brew' },
+  { stdout: '/foo/bin/podman', expectedSource: 'unknown', name: 'should grab podman from unknown location' },
+])('$name', async ({ stdout, expectedSource }) => {
   (extensionApi.process.exec as Mock).mockResolvedValue({
-    stdout: '/opt/podman/bin/podman',
+    stdout,
   } as extensionApi.RunResult);
 
   const podmanBinaryResult = await podmanBinaryLocationHelper.getPodmanLocationMac();
 
-  expect(podmanBinaryResult.source).toBe('installer');
-
-  // expect called with which podman command
-  expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['podman']);
-});
-
-test('should grab podman from brew', async () => {
-  (extensionApi.process.exec as Mock).mockResolvedValue({
-    stdout: '/opt/homebrew/bin/podman',
-  } as extensionApi.RunResult);
-
-  const podmanBinaryResult = await podmanBinaryLocationHelper.getPodmanLocationMac();
-
-  expect(podmanBinaryResult.source).toBe('brew');
-
-  // expect called with which podman command
-  expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['podman']);
-});
-
-test('should grab podman from unknown location', async () => {
-  (extensionApi.process.exec as Mock).mockResolvedValue({
-    stdout: '/foo/bin/podman',
-  } as extensionApi.RunResult);
-
-  const podmanBinaryResult = await podmanBinaryLocationHelper.getPodmanLocationMac();
-
-  expect(podmanBinaryResult.source).toBe('unknown');
+  expect(podmanBinaryResult.source).toBe(expectedSource);
 
   // expect called with which podman command
   expect(extensionApi.process.exec).toHaveBeenCalledWith('which', ['podman']);

--- a/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
+++ b/extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
@@ -167,23 +167,23 @@ test('isWSLEnabled is independent of BIOS virtualization firmware check', async 
 });
 
 describe('calcPipeName', () => {
-  test('calcPipeName should prepend "podman-" if machine name does not start with "podman"', () => {
-    const machineName = 'my-machine';
-    const expectedPipeName = '//./pipe/podman-my-machine';
-    const result = winPlatform.calcPipeName(machineName);
-    expect(result).toBe(expectedPipeName);
-  });
-
-  test('calcPipeName should not prepend "podman-" if machine name already starts with "podman"', () => {
-    const machineName = 'podman-machine';
-    const expectedPipeName = '//./pipe/podman-machine';
-    const result = winPlatform.calcPipeName(machineName);
-    expect(result).toBe(expectedPipeName);
-  });
-
-  test('calcPipeName should handle machine name that is just "podman"', () => {
-    const machineName = 'podman';
-    const expectedPipeName = '//./pipe/podman';
+  test.each([
+    {
+      machineName: 'my-machine',
+      expectedPipeName: '//./pipe/podman-my-machine',
+      description: 'should prepend "podman-" if machine name does not start with "podman"',
+    },
+    {
+      machineName: 'podman-machine',
+      expectedPipeName: '//./pipe/podman-machine',
+      description: 'should not prepend "podman-" if machine name already starts with "podman"',
+    },
+    {
+      machineName: 'podman',
+      expectedPipeName: '//./pipe/podman',
+      description: 'should handle machine name that is just "podman"',
+    },
+  ])('$description', ({ machineName, expectedPipeName }) => {
     const result = winPlatform.calcPipeName(machineName);
     expect(result).toBe(expectedPipeName);
   });


### PR DESCRIPTION
### What does this PR do?

Converts similar test groups into `test.each()` parameterized tests in two files:
- `podman-binary-location-helper.spec.ts`: 3 tests for installer/brew/unknown podman locations → 1 parameterized test
- `win-platform.spec.ts`: 3 tests for `calcPipeName` with different machine names → 1 parameterized test

This satisfies the `sonarjs/parameterized-tests` lint rule introduced in eslint-plugin-sonarjs 4.2.0.

### Screenshot / video of UI

N/A — test-only change.

### What issues does this PR fix or reference?

Partial fix for #18388

### How to test this PR?

```bash
npx vitest run extensions/podman/packages/extension/src/helpers/podman-binary-location-helper.spec.ts
npx vitest run extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
npx eslint extensions/podman/packages/extension/src/helpers/podman-binary-location-helper.spec.ts
npx eslint extensions/podman/packages/extension/src/platforms/win-platform.spec.ts
```

- [x] Tests are covering the bug fix or the new feature