### PR TITLE
fix: adapt clipboard API calls for Electron 44

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -481,7 +481,7 @@ export class PluginSystem {
         await shell.openExternal(url);
         return true;
       } else if (result.response === 'Copy Link') {
-        clipboard.writeText(url);
+        await clipboard.writeText(url);
       }
       return false;
     };
@@ -1966,8 +1966,8 @@ export class PluginSystem {
       },
     );
 
-    this.ipcHandle('clipboard:writeText', async (_, text: string, type?: 'selection' | 'clipboard'): Promise<void> => {
-      return clipboard.writeText(text, type);
+    this.ipcHandle('clipboard:writeText', async (_, text: string): Promise<void> => {
+      return clipboard.writeText(text);
     });
 
     this.ipcHandle(

--- a/packages/preload/src/index.ts
+++ b/packages/preload/src/index.ts
@@ -1512,12 +1512,9 @@ export function initExposure(): void {
     return ipcInvoke('command-registry:executeCommand', command, ...args);
   });
 
-  contextBridge.exposeInMainWorld(
-    'clipboardWriteText',
-    async (text: string, type?: 'selection' | 'clipboard'): Promise<void> => {
-      return ipcInvoke('clipboard:writeText', text, type);
-    },
-  );
+  contextBridge.exposeInMainWorld('clipboardWriteText', async (text: string): Promise<void> => {
+    return ipcInvoke('clipboard:writeText', text);
+  });
 
   let onDidUpdateProviderStatusId = 0;
   const onDidUpdateProviderStatuses = new Map<number, (providerInfo: ProviderInfo) => void>();


### PR DESCRIPTION
⚠️ PR is targeting a branch

### What does this PR do?
Electron 44 changed clipboard.writeText to be async and removed the optional type parameter. Await the now-async call and remove the unused type parameter from the IPC chain.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/pull/19008

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
