### PR TITLE
refactor(main): use parameterized tests for similar test groups

### DIFF
--- a/packages/main/src/open-dev-tools.spec.ts
+++ b/packages/main/src/open-dev-tools.spec.ts
@@ -56,38 +56,16 @@ test('should not open devtools if none', async () => {
   expect(browserWindowMock.webContents.openDevTools).not.toBeCalled();
 });
 
-test('should open devtools on left if left config', async () => {
+test.each([
+  { configValue: 'left', expectedMode: 'left' },
+  { configValue: 'right', expectedMode: 'right' },
+  { configValue: 'bottom', expectedMode: 'bottom' },
+  { configValue: 'detach', expectedMode: 'detach' },
+])('should open devtools with $expectedMode mode', async ({ configValue, expectedMode }) => {
   getConfigurationMock.mockReturnValue({
-    get: () => 'left',
+    get: () => configValue,
   });
   openDevTools.open(browserWindowMock, configurationRegistryMock);
 
-  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'left' });
-});
-
-test('should open devtools on right if right config', async () => {
-  getConfigurationMock.mockReturnValue({
-    get: () => 'right',
-  });
-  openDevTools.open(browserWindowMock, configurationRegistryMock);
-
-  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'right' });
-});
-
-test('should open devtools on left if bottom config', async () => {
-  getConfigurationMock.mockReturnValue({
-    get: () => 'bottom',
-  });
-  openDevTools.open(browserWindowMock, configurationRegistryMock);
-
-  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'bottom' });
-});
-
-test('should open devtools on left if detach config', async () => {
-  getConfigurationMock.mockReturnValue({
-    get: () => 'detach',
-  });
-  openDevTools.open(browserWindowMock, configurationRegistryMock);
-
-  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: 'detach' });
+  expect(browserWindowMock.webContents.openDevTools).toBeCalledWith({ mode: expectedMode });
 });

--- a/packages/main/src/plugin/appearance-init.spec.ts
+++ b/packages/main/src/plugin/appearance-init.spec.ts
@@ -138,46 +138,22 @@ test('Expect appearance configuration change to update searchbar when disabled',
   expect(spyOnSend).toHaveBeenCalled();
 });
 
-test('Expect native theme to be set to light', async () => {
+test.each([
+  { inputTheme: 'light', expectedTheme: 'light', description: 'Expect native theme to be set to light' },
+  { inputTheme: 'dark', expectedTheme: 'dark', description: 'Expect native theme to be set to dark' },
+  { inputTheme: 'system', expectedTheme: 'system', description: 'Expect native theme to be set to system' },
+  {
+    inputTheme: 'hc-light',
+    expectedTheme: 'light',
+    description: 'Expect native theme to be set to light for hc-light',
+  },
+  { inputTheme: 'hc-dark', expectedTheme: 'dark', description: 'Expect native theme to be set to dark for hc-dark' },
+  { inputTheme: 'unknown', expectedTheme: 'system', description: 'Expect unknown theme to be set to system' },
+])('$description', async ({ inputTheme, expectedTheme }) => {
   const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
-  appearanceInit.updateNativeTheme('light');
+  appearanceInit.updateNativeTheme(inputTheme);
 
-  expect(nativeTheme.themeSource).toEqual('light');
-});
-
-test('Expect native theme to be set to dark', async () => {
-  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
-  appearanceInit.updateNativeTheme('dark');
-
-  expect(nativeTheme.themeSource).toEqual('dark');
-});
-
-test('Expect native theme to be set to system', async () => {
-  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
-  appearanceInit.updateNativeTheme('system');
-
-  expect(nativeTheme.themeSource).toEqual('system');
-});
-
-test('Expect native theme to be set to light for hc-light', async () => {
-  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
-  appearanceInit.updateNativeTheme('hc-light');
-
-  expect(nativeTheme.themeSource).toEqual('light');
-});
-
-test('Expect native theme to be set to dark for hc-dark', async () => {
-  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
-  appearanceInit.updateNativeTheme('hc-dark');
-
-  expect(nativeTheme.themeSource).toEqual('dark');
-});
-
-test('Expect unknown theme to be set to system', async () => {
-  const appearanceInit: AppearanceInit = new AppearanceInit(configurationRegistry, apiSender);
-  appearanceInit.updateNativeTheme('unknown');
-
-  expect(nativeTheme.themeSource).toEqual('system');
+  expect(nativeTheme.themeSource).toEqual(expectedTheme);
 });
 
 test('should register a configuration', async () => {

--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -463,39 +463,23 @@ describe('isDarkTheme', () => {
     ]);
   });
 
-  test('light', async () => {
-    const isDark = colorRegistry.isDarkTheme('light');
-    expect(isDark).toBeFalsy();
+  test.each([
+    { theme: 'light', expected: false },
+    { theme: 'hc-light', expected: false },
+    { theme: 'light-theme1', expected: false },
+  ])('$theme is not dark', async ({ theme, expected }) => {
+    const isDark = colorRegistry.isDarkTheme(theme);
+    expect(isDark).toBe(expected);
   });
 
-  test('dark', async () => {
-    const isDark = colorRegistry.isDarkTheme('dark');
-    expect(isDark).toBeTruthy();
-  });
-
-  test('hc-light is not dark (inherits from light)', async () => {
-    const isDark = colorRegistry.isDarkTheme('hc-light');
-    expect(isDark).toBeFalsy();
-  });
-
-  test('hc-dark is dark (inherits from dark)', async () => {
-    const isDark = colorRegistry.isDarkTheme('hc-dark');
-    expect(isDark).toBeTruthy();
-  });
-
-  test('custom with parent being dark', async () => {
-    const isDark = colorRegistry.isDarkTheme('dark-theme1');
-    expect(isDark).toBeTruthy();
-  });
-
-  test('custom with parent being light', async () => {
-    const isDark = colorRegistry.isDarkTheme('light-theme1');
-    expect(isDark).toBeFalsy();
-  });
-
-  test('unknown theme should be dark', async () => {
-    const isDark = colorRegistry.isDarkTheme('unknown-theme');
-    expect(isDark).toBeTruthy();
+  test.each([
+    { theme: 'dark', expected: true },
+    { theme: 'hc-dark', expected: true },
+    { theme: 'dark-theme1', expected: true },
+    { theme: 'unknown-theme', expected: true },
+  ])('$theme is dark', async ({ theme, expected }) => {
+    const isDark = colorRegistry.isDarkTheme(theme);
+    expect(isDark).toBe(expected);
   });
 });
 

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -1266,7 +1266,22 @@ describe('listContainers', () => {
   });
 });
 
-test('pull unknown image fails with error 403', async () => {
+test.each([
+  {
+    statusCode: 403,
+    expectedMessage: 'access to image "unknown-image" is denied (403 error). Can also be that image does not exist',
+  },
+  {
+    statusCode: 401,
+    expectedMessage:
+      'access to image "unknown-image" is denied (401 error). Can also be that the registry requires authentication.',
+  },
+  {
+    statusCode: 500,
+    expectedMessage:
+      'access to image "unknown-image" is denied (500 error). Can also be that the registry requires authentication.',
+  },
+])('pull unknown image fails with error $statusCode', async ({ statusCode, expectedMessage }) => {
   const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
 
   const pullMock = vi.fn();
@@ -1283,14 +1298,14 @@ test('pull unknown image fails with error 403', async () => {
   const containerConnectionInfo = {} as ProviderContainerConnectionInfo;
 
   // add statusCode on the error
-  const error = new DockerodeTestStatusError('access denied', 403);
+  const error = new DockerodeTestStatusError('access denied', statusCode);
 
   pullMock.mockRejectedValue(error);
 
   const callback = vi.fn();
   // check that we have a nice error message
   await expect(containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback)).rejects.toThrow(
-    'access to image "unknown-image" is denied (403 error). Can also be that image does not exist',
+    expectedMessage,
   );
 });
 
@@ -1353,62 +1368,6 @@ test('pulling an image with platform linux/arm64 will add platform to pull optio
     authconfig: undefined,
     platform: 'linux/arm64',
   });
-});
-
-test('pull unknown image fails with error 401', async () => {
-  const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
-
-  const pullMock = vi.fn();
-
-  const fakeDockerode = {
-    pull: pullMock,
-    modem: {
-      followProgress: vi.fn(),
-    },
-  } as unknown as Dockerode;
-
-  getMatchingEngineFromConnectionSpy.mockReturnValue(fakeDockerode);
-
-  const containerConnectionInfo = {} as ProviderContainerConnectionInfo;
-
-  // add statusCode on the error
-  const error = new DockerodeTestStatusError('access denied', 401);
-
-  pullMock.mockRejectedValue(error);
-
-  const callback = vi.fn();
-  // check that we have a nice error message
-  await expect(containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback)).rejects.toThrow(
-    'access to image "unknown-image" is denied (401 error). Can also be that the registry requires authentication.',
-  );
-});
-
-test('pull unknown image fails with error 500', async () => {
-  const getMatchingEngineFromConnectionSpy = vi.spyOn(containerRegistry, 'getMatchingEngineFromConnection');
-
-  const pullMock = vi.fn();
-
-  const fakeDockerode = {
-    pull: pullMock,
-    modem: {
-      followProgress: vi.fn(),
-    },
-  } as unknown as Dockerode;
-
-  getMatchingEngineFromConnectionSpy.mockReturnValue(fakeDockerode);
-
-  const containerConnectionInfo = {} as ProviderContainerConnectionInfo;
-
-  // add statusCode on the error
-  const error = new DockerodeTestStatusError('access denied', 500);
-
-  pullMock.mockRejectedValue(error);
-
-  const callback = vi.fn();
-  // check that we have a nice error message
-  await expect(containerRegistry.pullImage(containerConnectionInfo, 'unknown-image', callback)).rejects.toThrow(
-    'access to image "unknown-image" is denied (500 error). Can also be that the registry requires authentication.',
-  );
 });
 
 describe('buildImage', () => {

--- a/packages/main/src/plugin/experimental-configuration-manager.spec.ts
+++ b/packages/main/src/plugin/experimental-configuration-manager.spec.ts
@@ -57,32 +57,13 @@ describe('ExperimentalConfigurationManager', () => {
       });
     });
 
-    test('should return empty strings for key without dot', () => {
-      const result = experimentalConfigurationManager.parseKey('kubernetes');
-      expect(result).toEqual({
-        section: '',
-        property: '',
-      });
-    });
-
-    test('should return empty strings for key starting with dot', () => {
-      const result = experimentalConfigurationManager.parseKey('.kubernetes');
-      expect(result).toEqual({
-        section: '',
-        property: '',
-      });
-    });
-
-    test('should return empty strings for key ending with dot', () => {
-      const result = experimentalConfigurationManager.parseKey('kubernetes.');
-      expect(result).toEqual({
-        section: '',
-        property: '',
-      });
-    });
-
-    test('should return empty strings for empty string', () => {
-      const result = experimentalConfigurationManager.parseKey('');
+    test.each([
+      { key: 'kubernetes', description: 'should return empty strings for key without dot' },
+      { key: '.kubernetes', description: 'should return empty strings for key starting with dot' },
+      { key: 'kubernetes.', description: 'should return empty strings for key ending with dot' },
+      { key: '', description: 'should return empty strings for empty string' },
+    ])('$description', ({ key }) => {
+      const result = experimentalConfigurationManager.parseKey(key);
       expect(result).toEqual({
         section: '',
         property: '',

--- a/packages/main/src/plugin/image-registry.spec.ts
+++ b/packages/main/src/plugin/image-registry.spec.ts
@@ -249,80 +249,50 @@ describe('extract auth info', () => {
 });
 
 describe('extractImageDataFromImageName', () => {
-  test('library image', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName('httpd');
+  test.each([
+    { input: 'httpd', tag: 'latest', name: 'library/httpd' },
+    { input: 'httpd:1.2.3', tag: '1.2.3', name: 'library/httpd' },
+    { input: 'foo/bar', tag: 'latest', name: 'foo/bar' },
+    { input: 'foo/bar:myTag', tag: 'myTag', name: 'foo/bar' },
+  ])('docker hub image: $input', ({ input, tag, name }) => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName(input);
     expect(nameAndTag.registry).toBe('index.docker.io');
     expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
-    expect(nameAndTag.tag).toBe('latest');
-    expect(nameAndTag.name).toBe('library/httpd');
+    expect(nameAndTag.tag).toBe(tag);
+    expect(nameAndTag.name).toBe(name);
   });
 
-  test('library image with custom tag', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName('httpd:1.2.3');
-    expect(nameAndTag.registry).toBe('index.docker.io');
-    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
-    expect(nameAndTag.tag).toBe('1.2.3');
-    expect(nameAndTag.name).toBe('library/httpd');
+  test.each([
+    { input: 'quay.io/foo/bar', registry: 'quay.io', tag: 'latest', name: 'foo/bar' },
+    {
+      input: 'ghcr.io/redhat-developer/podman-desktop-sandbox-ext:latest',
+      registry: 'ghcr.io',
+      tag: 'latest',
+      name: 'redhat-developer/podman-desktop-sandbox-ext',
+    },
+    {
+      input: 'ghcr.io/redhat-developer/podman-desktop-sandbox-ext:myTag',
+      registry: 'ghcr.io',
+      tag: 'myTag',
+      name: 'redhat-developer/podman-desktop-sandbox-ext',
+    },
+  ])('custom registry image: $input', ({ input, registry, tag, name }) => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName(input);
+    expect(nameAndTag.registry).toBe(registry);
+    expect(nameAndTag.registryURL).toBe(`https://${registry}/v2`);
+    expect(nameAndTag.tag).toBe(tag);
+    expect(nameAndTag.name).toBe(name);
   });
 
-  test('simple image', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName('foo/bar');
-    expect(nameAndTag.registry).toBe('index.docker.io');
-    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
-    expect(nameAndTag.tag).toBe('latest');
-    expect(nameAndTag.name).toBe('foo/bar');
-  });
-
-  test('simple image with custom tag', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName('foo/bar:myTag');
-    expect(nameAndTag.registry).toBe('index.docker.io');
-    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
-    expect(nameAndTag.tag).toBe('myTag');
-    expect(nameAndTag.name).toBe('foo/bar');
-  });
-
-  test('quay.io image', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName('quay.io/foo/bar');
-    expect(nameAndTag.registry).toBe('quay.io');
-    expect(nameAndTag.registryURL).toBe('https://quay.io/v2');
-    expect(nameAndTag.tag).toBe('latest');
-    expect(nameAndTag.name).toBe('foo/bar');
-  });
-
-  test('ghcr.io image', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName(
-      'ghcr.io/redhat-developer/podman-desktop-sandbox-ext:latest',
-    );
-    expect(nameAndTag.registry).toBe('ghcr.io');
-    expect(nameAndTag.registryURL).toBe('https://ghcr.io/v2');
-    expect(nameAndTag.tag).toBe('latest');
-    expect(nameAndTag.name).toBe('redhat-developer/podman-desktop-sandbox-ext');
-  });
-
-  test('ghcr.io image with tag', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName(
-      'ghcr.io/redhat-developer/podman-desktop-sandbox-ext:myTag',
-    );
-    expect(nameAndTag.registry).toBe('ghcr.io');
-    expect(nameAndTag.registryURL).toBe('https://ghcr.io/v2');
-    expect(nameAndTag.tag).toBe('myTag');
-    expect(nameAndTag.name).toBe('redhat-developer/podman-desktop-sandbox-ext');
-  });
-
-  test('localhost image', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName('localhost/myimage');
-    expect(nameAndTag.registry).toBe('localhost');
-    expect(nameAndTag.registryURL).toBe('https://localhost/v2');
-    expect(nameAndTag.tag).toBe('latest');
-    expect(nameAndTag.name).toBe('myimage');
-  });
-
-  test('localhost custom port', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName('localhost:5000/myimage');
-    expect(nameAndTag.registry).toBe('localhost:5000');
-    expect(nameAndTag.registryURL).toBe('https://localhost:5000/v2');
-    expect(nameAndTag.tag).toBe('latest');
-    expect(nameAndTag.name).toBe('myimage');
+  test.each([
+    { input: 'localhost/myimage', registry: 'localhost', tag: 'latest', name: 'myimage' },
+    { input: 'localhost:5000/myimage', registry: 'localhost:5000', tag: 'latest', name: 'myimage' },
+  ])('localhost image: $input', ({ input, registry, tag, name }) => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName(input);
+    expect(nameAndTag.registry).toBe(registry);
+    expect(nameAndTag.registryURL).toBe(`https://${registry}/v2`);
+    expect(nameAndTag.tag).toBe(tag);
+    expect(nameAndTag.name).toBe(name);
   });
 
   test('invalid image protocol', () => {
@@ -371,44 +341,33 @@ describe('extractImageDataFromImageName', () => {
     expect(nameAndTag.name).toBe('level1/level2/level3/level4/myimage');
   });
 
-  test('digest format on library image', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName(
-      'httpd@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
-    );
-    expect(nameAndTag.registry).toBe('index.docker.io');
-    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
+  test.each([
+    {
+      input: 'httpd@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      registry: 'index.docker.io',
+      name: 'library/httpd',
+    },
+    {
+      input: 'foo/bar@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      registry: 'index.docker.io',
+      name: 'foo/bar',
+    },
+    {
+      input: 'quay.io/org/image@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      registry: 'quay.io',
+      name: 'org/image',
+    },
+    {
+      input: 'localhost:5000/myimage@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      registry: 'localhost:5000',
+      name: 'myimage',
+    },
+  ])('digest format: $input', ({ input, registry, name }) => {
+    const nameAndTag = imageRegistry.extractImageDataFromImageName(input);
+    expect(nameAndTag.registry).toBe(registry);
+    expect(nameAndTag.registryURL).toBe(`https://${registry}/v2`);
     expect(nameAndTag.tag).toBe('sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789');
-    expect(nameAndTag.name).toBe('library/httpd');
-  });
-
-  test('digest format on namespaced image', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName(
-      'foo/bar@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
-    );
-    expect(nameAndTag.registry).toBe('index.docker.io');
-    expect(nameAndTag.registryURL).toBe('https://index.docker.io/v2');
-    expect(nameAndTag.tag).toBe('sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789');
-    expect(nameAndTag.name).toBe('foo/bar');
-  });
-
-  test('digest format with explicit registry', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName(
-      'quay.io/org/image@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
-    );
-    expect(nameAndTag.registry).toBe('quay.io');
-    expect(nameAndTag.registryURL).toBe('https://quay.io/v2');
-    expect(nameAndTag.tag).toBe('sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789');
-    expect(nameAndTag.name).toBe('org/image');
-  });
-
-  test('digest format with localhost and port', () => {
-    const nameAndTag = imageRegistry.extractImageDataFromImageName(
-      'localhost:5000/myimage@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
-    );
-    expect(nameAndTag.registry).toBe('localhost:5000');
-    expect(nameAndTag.registryURL).toBe('https://localhost:5000/v2');
-    expect(nameAndTag.tag).toBe('sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789');
-    expect(nameAndTag.name).toBe('myimage');
+    expect(nameAndTag.name).toBe(name);
   });
 
   test('tag and digest format on library image', () => {
@@ -1329,42 +1288,20 @@ test('searchImages without limit', async () => {
   expect(result).toEqual(list);
 });
 
-test('searchImages with docker.io registry', async () => {
+test.each([
+  { registry: 'docker.io', expectedUrl: 'https://index.docker.io/v1/search' },
+  { registry: 'quay.io', expectedUrl: 'https://quay.io/v1/search' },
+  { registry: 'https://quay.io', expectedUrl: 'https://quay.io/v1/search' },
+])('searchImages with registry $registry', async ({ registry, expectedUrl }) => {
   const list = [
     {
       name: 'image1',
       description: 'desc',
     },
   ];
-  server = setupServer(http.get('https://index.docker.io/v1/search', () => HttpResponse.json({ results: list })));
+  server = setupServer(http.get(expectedUrl, () => HttpResponse.json({ results: list })));
   server.listen({ onUnhandledRequest: 'error' });
-  const result = await imageRegistry.searchImages({ registry: 'docker.io', query: 'http', limit: 10 });
-  expect(result).toEqual(list);
-});
-
-test('searchImages without https', async () => {
-  const list = [
-    {
-      name: 'image1',
-      description: 'desc',
-    },
-  ];
-  server = setupServer(http.get('https://quay.io/v1/search', () => HttpResponse.json({ results: list })));
-  server.listen({ onUnhandledRequest: 'error' });
-  const result = await imageRegistry.searchImages({ registry: 'quay.io', query: 'http', limit: 10 });
-  expect(result).toEqual(list);
-});
-
-test('searchImages with https', async () => {
-  const list = [
-    {
-      name: 'image1',
-      description: 'desc',
-    },
-  ];
-  server = setupServer(http.get('https://quay.io/v1/search', () => HttpResponse.json({ results: list })));
-  server.listen({ onUnhandledRequest: 'error' });
-  const result = await imageRegistry.searchImages({ registry: 'https://quay.io', query: 'http', limit: 10 });
+  const result = await imageRegistry.searchImages({ registry, query: 'http', limit: 10 });
   expect(result).toEqual(list);
 });
 

--- a/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
+++ b/packages/main/src/plugin/kubernetes/contexts-manager.spec.ts
@@ -2897,42 +2897,35 @@ describe('isContextInKubeconfig', () => {
     const exists = client.isContextInKubeconfig(context);
     expect(exists).toBeFalsy();
   });
-  test('return false if cluster on kubeconfig have different server', () => {
-    const context: KubeContext = {
-      name: 'context',
-      cluster: 'cluster',
-      user: 'user',
-      clusterInfo: {
-        server: 'server2',
-        name: 'cluster',
+  test.each([
+    {
+      description: 'cluster server is different',
+      context: {
+        name: 'context',
+        cluster: 'cluster',
+        user: 'user',
+        clusterInfo: { server: 'server2', name: 'cluster' },
       },
-    };
-    const exists = client.isContextInKubeconfig(context);
-    expect(exists).toBeFalsy();
-  });
-  test('return false if user does not exists on kubeconfig', () => {
-    const context: KubeContext = {
-      name: 'context',
-      cluster: 'cluster',
-      user: 'user2',
-      clusterInfo: {
-        server: 'server',
-        name: 'cluster',
+    },
+    {
+      description: 'user does not exist',
+      context: {
+        name: 'context',
+        cluster: 'cluster',
+        user: 'user2',
+        clusterInfo: { server: 'server', name: 'cluster' },
       },
-    };
-    const exists = client.isContextInKubeconfig(context);
-    expect(exists).toBeFalsy();
-  });
-  test('return false if context does not exists on kubeconfig', () => {
-    const context: KubeContext = {
-      name: 'context1',
-      cluster: 'cluster',
-      user: 'user',
-      clusterInfo: {
-        server: 'server',
-        name: 'cluster',
+    },
+    {
+      description: 'context does not exist',
+      context: {
+        name: 'context1',
+        cluster: 'cluster',
+        user: 'user',
+        clusterInfo: { server: 'server', name: 'cluster' },
       },
-    };
+    },
+  ])('return false if $description on kubeconfig', ({ context }) => {
     const exists = client.isContextInKubeconfig(context);
     expect(exists).toBeFalsy();
   });

--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -1021,96 +1021,36 @@ test('get release notes in dev mode', async () => {
   }
 });
 
-test('update is available when next version is greater then current version', async () => {
-  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
-    updateInfo: {
-      version: '1.5.1',
-    },
-  } as unknown as UpdateCheckResult);
+test.each([
+  { nextVersion: '1.5.1', currentVersion: '1.5.0', expected: true },
+  { nextVersion: '1.5.0', currentVersion: '1.5.0', expected: false },
+  { nextVersion: '1.5.0', currentVersion: '1.5.1', expected: false },
+  { nextVersion: '', currentVersion: '1.5.1', expected: false },
+])(
+  'update availability: next $nextVersion vs current $currentVersion',
+  async ({ nextVersion, currentVersion, expected }) => {
+    vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
+      updateInfo: {
+        version: nextVersion,
+      },
+    } as unknown as UpdateCheckResult);
 
-  vi.mocked(app.getVersion).mockReturnValue('1.5.0');
+    vi.mocked(app.getVersion).mockReturnValue(currentVersion);
 
-  const updater = new Updater(
-    messageBoxMock,
-    configurationRegistryMock,
-    statusBarRegistryMock,
-    commandRegistryMock,
-    taskManagerMock,
-    apiSenderMock,
-  );
-  updater.init();
+    const updater = new Updater(
+      messageBoxMock,
+      configurationRegistryMock,
+      statusBarRegistryMock,
+      commandRegistryMock,
+      taskManagerMock,
+      apiSenderMock,
+    );
+    updater.init();
 
-  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
-  expect(updater.updateAvailable()).toBeTruthy();
-});
-
-test('update is not available when next version is the same as the current version', async () => {
-  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
-    updateInfo: {
-      version: '1.5.0',
-    },
-  } as unknown as UpdateCheckResult);
-
-  vi.mocked(app.getVersion).mockReturnValue('1.5.0');
-  const updater = new Updater(
-    messageBoxMock,
-    configurationRegistryMock,
-    statusBarRegistryMock,
-    commandRegistryMock,
-    taskManagerMock,
-    apiSenderMock,
-  );
-  updater.init();
-
-  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
-  expect(updater.updateAvailable()).toBeFalsy();
-});
-
-test('update is not available when next version is less than the current version', async () => {
-  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
-    updateInfo: {
-      version: '1.5.0',
-    },
-  } as unknown as UpdateCheckResult);
-
-  vi.mocked(app.getVersion).mockReturnValue('1.5.1');
-  const updater = new Updater(
-    messageBoxMock,
-    configurationRegistryMock,
-    statusBarRegistryMock,
-    commandRegistryMock,
-    taskManagerMock,
-    apiSenderMock,
-  );
-  updater.init();
-
-  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
-
-  expect(updater.updateAvailable()).toBeFalsy();
-});
-
-test('update is not available when next version empty', async () => {
-  vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({
-    updateInfo: {
-      version: '',
-    },
-  } as unknown as UpdateCheckResult);
-
-  vi.mocked(app.getVersion).mockReturnValue('1.5.1');
-  const updater = new Updater(
-    messageBoxMock,
-    configurationRegistryMock,
-    statusBarRegistryMock,
-    commandRegistryMock,
-    taskManagerMock,
-    apiSenderMock,
-  );
-  updater.init();
-
-  await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
-
-  expect(updater.updateAvailable()).toBeFalsy();
-});
+    await vi.waitFor(() => expect(autoUpdater.checkForUpdates).toBeCalled());
+    expect(updater.updateAvailable()).toBe(expected);
+  },
+);
 
 test('update version is not full semver', async () => {
   vi.mocked(autoUpdater.checkForUpdates).mockResolvedValue({


### PR DESCRIPTION
### What does this PR do?

Converts groups of similar tests into `test.each()` parameterized tests across 8 files in `packages/main` to satisfy the `sonarjs/parameterized-tests` lint rule introduced in eslint-plugin-sonarjs 4.2.0.

- `open-dev-tools.spec.ts`: 4 devtools mode tests → 1 parameterized test
- `appearance-init.spec.ts`: 6 theme mapping tests → 1 parameterized test
- `color-registry.spec.ts`: 2 groups (3+4 isDarkTheme tests) → 2 parameterized tests
- `container-registry.spec.ts`: 3 error status code tests → 1 parameterized test
- `experimental-configuration-manager.spec.ts`: 4 invalid key tests → 1 parameterized test
- `image-registry.spec.ts`: 5 groups of image parsing/search tests → 5 parameterized tests
- `contexts-manager.spec.ts`: 3 kubeconfig tests → 1 parameterized test
- `updater.spec.ts`: 2 groups of update availability tests → 2 parameterized tests

### Screenshot / video of UI

N/A — test-only change.

### What issues does this PR fix or reference?

Partial fix for #18388

### How to test this PR?

```bash
npx vitest run packages/main/src/open-dev-tools.spec.ts packages/main/src/plugin/appearance-init.spec.ts packages/main/src/plugin/color-registry.spec.ts packages/main/src/plugin/container-registry.spec.ts packages/main/src/plugin/experimental-configuration-manager.spec.ts packages/main/src/plugin/image-registry.spec.ts packages/main/src/plugin/kubernetes/contexts-manager.spec.ts packages/main/src/plugin/updater.spec.ts
```

- [x] Tests are covering the bug fix or the new feature