### PR TITLE
refactor(renderer): use parameterized tests for similar test groups

### DIFF
--- a/packages/renderer/src/lib/deployments/columns/Conditions.spec.ts
+++ b/packages/renderer/src/lib/deployments/columns/Conditions.spec.ts
@@ -66,88 +66,59 @@ test('Expect column styling unavailable', async () => {
   expect(svg).toHaveClass('text-[var(--pd-status-degraded)]');
 });
 
-test('Expect column styling updated', async () => {
-  const deployment = createDeploymentUI([
-    { type: 'Progressing', message: 'Running fine', reason: 'ReplicaSetUpdated' },
-  ]);
+test.each([
+  {
+    name: 'updated',
+    type: 'Progressing',
+    reason: 'ReplicaSetUpdated',
+    displayText: 'Updated',
+    statusClass: 'text-[var(--pd-status-updated)]',
+  },
+  {
+    name: 'new replica set',
+    type: 'Progressing',
+    reason: 'NewReplicaSetCreated',
+    displayText: 'New Replica Set',
+    statusClass: 'text-[var(--pd-status-updated)]',
+  },
+  {
+    name: 'progressed',
+    type: 'Progressing',
+    reason: 'NewReplicaSetAvailable',
+    displayText: 'Progressed',
+    statusClass: 'text-[var(--pd-status-running)]',
+  },
+  {
+    name: 'scaled up',
+    type: 'Progressing',
+    reason: 'ReplicaSetScaledUp',
+    displayText: 'Scaled Up',
+    statusClass: 'text-[var(--pd-status-updated)]',
+  },
+  {
+    name: 'scaled down',
+    type: 'Progressing',
+    reason: 'ReplicaSetScaledDown',
+    displayText: 'Scaled Down',
+    statusClass: 'text-[var(--pd-status-updated)]',
+  },
+  {
+    name: 'deadline exceeded',
+    type: 'Progressing',
+    reason: 'ProgressDeadlineExceeded',
+    displayText: 'Deadline Exceeded',
+    statusClass: 'text-[var(--pd-status-dead)]',
+  },
+])('Expect column styling $name', async ({ type, reason, displayText, statusClass }) => {
+  const deployment = createDeploymentUI([{ type, message: 'Running fine', reason }]);
   render(Conditions, { object: deployment });
 
-  const text = screen.getByText('Updated');
+  const text = screen.getByText(displayText);
   expect(text).toBeInTheDocument();
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
-});
-
-test('Expect column styling new replica set', async () => {
-  const deployment = createDeploymentUI([
-    { type: 'Progressing', message: 'Running fine', reason: 'NewReplicaSetCreated' },
-  ]);
-  render(Conditions, { object: deployment });
-
-  const text = screen.getByText('New Replica Set');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
-});
-
-test('Expect column styling progressed', async () => {
-  const deployment = createDeploymentUI([
-    { type: 'Progressing', message: 'Running fine', reason: 'NewReplicaSetAvailable' },
-  ]);
-  render(Conditions, { object: deployment });
-
-  const text = screen.getByText('Progressed');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
-});
-
-test('Expect column styling scaled up', async () => {
-  const deployment = createDeploymentUI([
-    { type: 'Progressing', message: 'Running fine', reason: 'ReplicaSetScaledUp' },
-  ]);
-  render(Conditions, { object: deployment });
-
-  const text = screen.getByText('Scaled Up');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
-});
-
-test('Expect column styling scaled down', async () => {
-  const deployment = createDeploymentUI([
-    { type: 'Progressing', message: 'Running fine', reason: 'ReplicaSetScaledDown' },
-  ]);
-  render(Conditions, { object: deployment });
-
-  const text = screen.getByText('Scaled Down');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-updated)]');
-});
-
-test('Expect column styling deadline exceeded', async () => {
-  const deployment = createDeploymentUI([
-    { type: 'Progressing', message: 'Running fine', reason: 'ProgressDeadlineExceeded' },
-  ]);
-  render(Conditions, { object: deployment });
-
-  const text = screen.getByText('Deadline Exceeded');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-dead)]');
+  expect(svg).toHaveClass(statusClass);
 });
 
 test('Expect column styling replica failure', async () => {

--- a/packages/renderer/src/lib/dialogs/DialogSpec.spec.ts
+++ b/packages/renderer/src/lib/dialogs/DialogSpec.spec.ts
@@ -23,30 +23,9 @@ import { expect, test } from 'vitest';
 
 import DialogSpec from './DialogSpec.svelte';
 
-test('Expect icon is defined', async () => {
+test.each(['icon', 'content', 'validation', 'buttons'])('Expect %s is defined', async label => {
   render(DialogSpec);
 
-  const element = screen.getByLabelText('icon');
-  expect(element).toBeInTheDocument();
-});
-
-test('Expect content is defined', async () => {
-  render(DialogSpec);
-
-  const element = screen.getByLabelText('content');
-  expect(element).toBeInTheDocument();
-});
-
-test('Expect validation is defined', async () => {
-  render(DialogSpec);
-
-  const element = screen.getByLabelText('validation');
-  expect(element).toBeInTheDocument();
-});
-
-test('Expect buttons is defined', async () => {
-  render(DialogSpec);
-
-  const element = screen.getByLabelText('buttons');
+  const element = screen.getByLabelText(label);
   expect(element).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts
@@ -29,47 +29,22 @@ beforeAll(() => {
   Object.defineProperty(window, 'startExtension', { value: vi.fn() });
 });
 
-test('Expect to start dd Extension if stopped', async () => {
+test.each([
+  { type: 'dd', name: 'foo', state: 'stopped', description: 'Expect to start dd Extension if stopped' },
+  { type: 'pd', name: 'fooName', state: 'stopped', description: 'Expect to start pd Extension if stopped' },
+  { type: 'pd', name: 'fooName', state: 'failed', description: 'Expect to start Extension if failed' },
+])('$description', async ({ type, name, state }) => {
   const extension: CombinedExtensionInfoUI = {
-    type: 'dd',
+    type: type as 'dd' | 'pd',
     id: 'idExtension',
-    name: 'foo',
+    name,
     description: 'my description',
     displayName: '',
     publisher: '',
     removable: true,
     devMode: false,
     version: 'v1.2.3',
-    state: 'stopped',
-    path: '',
-    readme: '',
-  };
-  render(InstalledExtensionCardLeftLifecycleStart, { extension });
-
-  // get button with label 'Start'
-
-  const button = screen.getByRole('button', { name: 'Start' });
-  expect(button).toBeInTheDocument();
-
-  // click the button
-  await fireEvent.click(button);
-
-  // expect the start function to be called
-  expect(vi.mocked(window.startExtension)).toHaveBeenCalledWith('idExtension');
-});
-
-test('Expect to start pd Extension if stopped', async () => {
-  const extension: CombinedExtensionInfoUI = {
-    type: 'pd',
-    id: 'idExtension',
-    name: 'fooName',
-    description: 'my description',
-    displayName: '',
-    publisher: '',
-    removable: true,
-    devMode: false,
-    version: 'v1.2.3',
-    state: 'stopped',
+    state: state as 'stopped' | 'failed',
     path: '',
     readme: '',
   };
@@ -106,32 +81,4 @@ test('Expect unable to start if already started', async () => {
   // get button with label 'Delete Extension foo'
   const button = screen.queryByRole('button', { name: 'Start' });
   expect(button).not.toBeInTheDocument();
-});
-
-test('Expect to start Extension if failed', async () => {
-  const extension: CombinedExtensionInfoUI = {
-    type: 'pd',
-    id: 'idExtension',
-    name: 'fooName',
-    description: 'my description',
-    displayName: '',
-    publisher: '',
-    removable: true,
-    devMode: false,
-    version: 'v1.2.3',
-    state: 'failed',
-    path: '',
-    readme: '',
-  };
-  render(InstalledExtensionCardLeftLifecycleStart, { extension });
-
-  // get button with label 'Start'
-  const button = screen.getByRole('button', { name: 'Start' });
-  expect(button).toBeInTheDocument();
-
-  // click the button
-  await fireEvent.click(button);
-
-  // expect the start function to be called
-  expect(vi.mocked(window.startExtension)).toHaveBeenCalledWith('idExtension');
 });

--- a/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
+++ b/packages/renderer/src/lib/extensions/extensions-utils.spec.ts
@@ -380,154 +380,56 @@ describe('filters', () => {
     },
   ] as unknown[] as CombinedExtensionInfoUI[];
 
-  test('filterCatalogExtensions with single word', () => {
+  test.each([
+    { description: 'single word', searchQuery: 'bar' },
+    { description: 'single word and installed', searchQuery: 'bar is:installed' },
+    {
+      description: 'single word and installed and not installed, only first boolean is used',
+      searchQuery: 'bar is:installed not:installed',
+    },
+    { description: 'multiple words found', searchQuery: 'bar word' },
+    { description: 'multiple words found and one category', searchQuery: 'bar word category:category1' },
+    {
+      description: 'multiple words found and multiple categories found',
+      searchQuery: 'bar word category:category1 category:category2',
+    },
+    { description: 'multiple words found and one keyword', searchQuery: 'bar word keyword:keyword1' },
+    {
+      description: 'multiple words found and multiple keywords found',
+      searchQuery: 'bar word keyword:keyword1 keyword:keyword2',
+    },
+  ])('filterCatalogExtensions with $description', ({ searchQuery }) => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
       extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
       ),
-      'bar',
+      searchQuery,
     );
     expect(filteredCatalogExtensions.length).toBe(1);
     expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
   });
 
-  test('filterCatalogExtensions with single word and installed', () => {
+  test.each([
+    { description: 'single word and not installed', searchQuery: 'bar not:installed' },
+    { description: 'multiple words and one is not found', searchQuery: 'bar notfound' },
+    {
+      description: 'multiple words found and multiple categories with one not found',
+      searchQuery: 'bar word category:category1 category:category3',
+    },
+    {
+      description: 'multiple words found and multiple keywords with one not found',
+      searchQuery: 'bar word keyword:keyword1 keyword:keyword3',
+    },
+  ])('filterCatalogExtensions with $description', ({ searchQuery }) => {
     const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
       extensionsUtils.extractCatalogExtensions(
         [aFakeExtension, bFakeExtension],
         featuredExtensions,
         installedExtensions,
       ),
-      'bar is:installed',
-    );
-    expect(filteredCatalogExtensions.length).toBe(1);
-    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
-  });
-
-  test('filterCatalogExtensions with single word and not installed', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar not:installed',
-    );
-    expect(filteredCatalogExtensions.length).toBe(0);
-  });
-
-  test('filterCatalogExtensions with single word and installed and not installed, only first boolean is used', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar is:installed not:installed',
-    );
-    expect(filteredCatalogExtensions.length).toBe(1);
-    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
-  });
-
-  test('filterCatalogExtensions with multiple words found', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar word',
-    );
-    expect(filteredCatalogExtensions.length).toBe(1);
-    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
-  });
-
-  test('filterCatalogExtensions with multiple words and one is not found', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar notfound',
-    );
-    expect(filteredCatalogExtensions.length).toBe(0);
-  });
-
-  test('filterCatalogExtensions with multiple words found and one category', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar word category:category1',
-    );
-    expect(filteredCatalogExtensions.length).toBe(1);
-    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
-  });
-
-  test('filterCatalogExtensions with multiple words found and multiple categories found', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar word category:category1 category:category2',
-    );
-    expect(filteredCatalogExtensions.length).toBe(1);
-    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
-  });
-
-  test('filterCatalogExtensions with multiple words found and multiple categories with one not found ', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar word category:category1 category:category3',
-    );
-    expect(filteredCatalogExtensions.length).toBe(0);
-  });
-
-  test('filterCatalogExtensions with multiple words found and one keyword', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar word keyword:keyword1',
-    );
-    expect(filteredCatalogExtensions.length).toBe(1);
-    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
-  });
-
-  test('filterCatalogExtensions with multiple words found and multiple keywords found', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar word keyword:keyword1 keyword:keyword2',
-    );
-    expect(filteredCatalogExtensions.length).toBe(1);
-    expect(filteredCatalogExtensions[0].id).toBe('idAInstalled');
-  });
-
-  test('filterCatalogExtensions with multiple words found and multiple keywords with one not found ', () => {
-    const filteredCatalogExtensions = extensionsUtils.filterCatalogExtensions(
-      extensionsUtils.extractCatalogExtensions(
-        [aFakeExtension, bFakeExtension],
-        featuredExtensions,
-        installedExtensions,
-      ),
-      'bar word keyword:keyword1 keyword:keyword3',
+      searchQuery,
     );
     expect(filteredCatalogExtensions.length).toBe(0);
   });
@@ -560,23 +462,13 @@ describe('filters', () => {
       ],
     };
 
-    test('filterCatalogExtensions with quoted category containing spaces', () => {
+    test.each([
+      { description: 'quoted category containing spaces', searchQuery: 'category:"Extension Packs"' },
+      { description: 'quoted keyword containing spaces', searchQuery: 'keyword:"Vulnerability Scanner"' },
+      { description: 'quoted category and additional search term', searchQuery: 'spaced category:"Extension Packs"' },
+    ])('filterCatalogExtensions with $description', ({ searchQuery }) => {
       const extensions = extensionsUtils.extractCatalogExtensions([extWithSpacedCategory, bFakeExtension], [], []);
-      const filtered = extensionsUtils.filterCatalogExtensions(extensions, 'category:"Extension Packs"');
-      expect(filtered.length).toBe(1);
-      expect(filtered[0].id).toBe('idSpacedCategory');
-    });
-
-    test('filterCatalogExtensions with quoted keyword containing spaces', () => {
-      const extensions = extensionsUtils.extractCatalogExtensions([extWithSpacedCategory, bFakeExtension], [], []);
-      const filtered = extensionsUtils.filterCatalogExtensions(extensions, 'keyword:"Vulnerability Scanner"');
-      expect(filtered.length).toBe(1);
-      expect(filtered[0].id).toBe('idSpacedCategory');
-    });
-
-    test('filterCatalogExtensions with quoted category and additional search term', () => {
-      const extensions = extensionsUtils.extractCatalogExtensions([extWithSpacedCategory, bFakeExtension], [], []);
-      const filtered = extensionsUtils.filterCatalogExtensions(extensions, 'spaced category:"Extension Packs"');
+      const filtered = extensionsUtils.filterCatalogExtensions(extensions, searchQuery);
       expect(filtered.length).toBe(1);
       expect(filtered[0].id).toBe('idSpacedCategory');
     });

--- a/packages/renderer/src/lib/feedback/feedbackForms/FeedbackFormTest.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/FeedbackFormTest.spec.ts
@@ -23,23 +23,9 @@ import { expect, test } from 'vitest';
 
 import FeedbackFormTest from './FeedbackFormTest.svelte';
 
-test('Expect content is defined', async () => {
+test.each(['Content', 'Validation', 'Buttons'])('Expect %s is defined', async text => {
   render(FeedbackFormTest);
 
-  const element = screen.getByText('Content');
-  expect(element).toBeInTheDocument();
-});
-
-test('Expect validation is defined', async () => {
-  render(FeedbackFormTest);
-
-  const element = screen.getByText('Validation');
-  expect(element).toBeInTheDocument();
-});
-
-test('Expect buttons is defined', async () => {
-  render(FeedbackFormTest);
-
-  const element = screen.getByText('Buttons');
+  const element = screen.getByText(text);
   expect(element).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/job/columns/Conditions.spec.ts
+++ b/packages/renderer/src/lib/job/columns/Conditions.spec.ts
@@ -38,62 +38,20 @@ function createJobUI(condition: JobCondition): JobUI {
   };
 }
 
-test('Expect column styling completed', async () => {
-  const job = createJobUI('completed');
+test.each([
+  { condition: 'completed' as const, displayText: 'Completed', statusClass: 'text-[var(--pd-status-running)]' },
+  { condition: 'failed' as const, displayText: 'Failed', statusClass: 'text-[var(--pd-status-dead)]' },
+  { condition: 'running' as const, displayText: 'Running', statusClass: 'text-[var(--pd-status-running)]' },
+  { condition: 'pending' as const, displayText: 'Pending', statusClass: 'text-[var(--pd-status-starting)]' },
+  { condition: 'unknown' as const, displayText: 'Unknown', statusClass: 'text-[var(--pd-status-degraded)]' },
+])('Expect column styling $condition', async ({ condition, displayText, statusClass }) => {
+  const job = createJobUI(condition);
   render(Conditions, { object: job });
 
-  const text = screen.getByText('Completed');
+  const text = screen.getByText(displayText);
   expect(text).toBeInTheDocument();
 
   const svg = text.parentElement?.querySelector('svg');
   expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
-});
-
-test('Expect column styling failed', async () => {
-  const job = createJobUI('failed');
-  render(Conditions, { object: job });
-
-  const text = screen.getByText('Failed');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-dead)]');
-});
-
-test('Expect column styling running', async () => {
-  const job = createJobUI('running');
-  render(Conditions, { object: job });
-
-  const text = screen.getByText('Running');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-running)]');
-});
-
-test('Expect column styling pending', async () => {
-  const job = createJobUI('pending');
-  render(Conditions, { object: job });
-
-  const text = screen.getByText('Pending');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-starting)]');
-});
-
-test('Expect column styling unknown', async () => {
-  const job = createJobUI('unknown');
-  render(Conditions, { object: job });
-
-  const text = screen.getByText('Unknown');
-  expect(text).toBeInTheDocument();
-
-  const svg = text.parentElement?.querySelector('svg');
-  expect(svg).toBeInTheDocument();
-  expect(svg).toHaveClass('text-[var(--pd-status-degraded)]');
+  expect(svg).toHaveClass(statusClass);
 });

--- a/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts
@@ -218,33 +218,26 @@ describe('delete', () => {
   });
 });
 
-test('if kubernetes connection has start lifecycle method, start button has to be visible', () => {
-  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
+test.each([
+  { buttonName: 'Start', lifecycle: 'start' },
+  { buttonName: 'Stop', lifecycle: 'stop' },
+  { buttonName: 'Delete', lifecycle: 'delete' },
+])(
+  'if kubernetes connection has $lifecycle lifecycle method, $buttonName button has to be visible',
+  ({ buttonName }) => {
+    const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
 
-  render(PreferencesConnectionActions, {
-    connectionStatus,
-    provider: customProviderInfo,
-    connection: kubernetesConnection,
-    updateConnectionStatus,
-    addConnectionToRestartingQueue,
-  });
-  const button = screen.getByRole('button', { name: 'Start' });
-  expect(button).toBeInTheDocument();
-});
-
-test('if kubernetes connection has stop lifecycle method, stop button has to be visible', () => {
-  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
-
-  render(PreferencesConnectionActions, {
-    connectionStatus,
-    provider: customProviderInfo,
-    connection: kubernetesConnection,
-    updateConnectionStatus,
-    addConnectionToRestartingQueue,
-  });
-  const button = screen.getByRole('button', { name: 'Stop' });
-  expect(button).toBeInTheDocument();
-});
+    render(PreferencesConnectionActions, {
+      connectionStatus,
+      provider: customProviderInfo,
+      connection: kubernetesConnection,
+      updateConnectionStatus,
+      addConnectionToRestartingQueue,
+    });
+    const button = screen.getByRole('button', { name: buttonName });
+    expect(button).toBeInTheDocument();
+  },
+);
 
 test('if kubernetes connection has start and stop lifecycle methods, restart button has to be visible', () => {
   const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
@@ -262,18 +255,4 @@ test('if kubernetes connection has start and stop lifecycle methods, restart but
   expect(stopButton).toBeInTheDocument();
   const restartButton = screen.getByRole('button', { name: 'Restart' });
   expect(restartButton).toBeInTheDocument();
-});
-
-test('if kubernetes connection has delete lifecycle method, delete button has to be visible', () => {
-  const customProviderInfo: ProviderInfo = { ...containerProviderInfo, name: 'kube' };
-
-  render(PreferencesConnectionActions, {
-    connectionStatus,
-    provider: customProviderInfo,
-    connection: kubernetesConnection,
-    updateConnectionStatus,
-    addConnectionToRestartingQueue,
-  });
-  const button = screen.getByRole('button', { name: 'Delete' });
-  expect(button).toBeInTheDocument();
 });

--- a/packages/renderer/src/lib/service/columns/Type.spec.ts
+++ b/packages/renderer/src/lib/service/columns/Type.spec.ts
@@ -48,8 +48,12 @@ test('Expect basic column styling', async () => {
   result.unmount();
 });
 
-test('Expect column styling ClusterIP', async () => {
-  service.type = 'ClusterIP';
+test.each([
+  { type: 'ClusterIP', badgeClass: 'text-[var(--pd-badge-sky)]' },
+  { type: 'LoadBalancer', badgeClass: 'text-[var(--pd-badge-purple)]' },
+  { type: 'NodePort', badgeClass: 'text-[var(--pd-badge-fuchsia)]' },
+])('Expect column styling $type', async ({ type, badgeClass }) => {
+  service.type = type;
   render(Type, { object: JSON.parse(JSON.stringify(service)) });
 
   const text = screen.getByText(service.type);
@@ -57,29 +61,5 @@ test('Expect column styling ClusterIP', async () => {
 
   const dot = text.parentElement?.children[0];
   expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-[var(--pd-badge-sky)]');
-});
-
-test('Expect column styling LoadBalancer', async () => {
-  service.type = 'LoadBalancer';
-  render(Type, { object: JSON.parse(JSON.stringify(service)) });
-
-  const text = screen.getByText(service.type);
-  expect(text).toBeInTheDocument();
-
-  const dot = text.parentElement?.children[0];
-  expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-[var(--pd-badge-purple)]');
-});
-
-test('Expect column styling NodePort', async () => {
-  service.type = 'NodePort';
-  render(Type, { object: JSON.parse(JSON.stringify(service)) });
-
-  const text = screen.getByText(service.type);
-  expect(text).toBeInTheDocument();
-
-  const dot = text.parentElement?.children[0];
-  expect(dot).toBeInTheDocument();
-  expect(dot).toHaveClass('text-[var(--pd-badge-fuchsia)]');
+  expect(dot).toHaveClass(badgeClass);
 });

--- a/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
+++ b/packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts
@@ -34,34 +34,30 @@ beforeEach(() => {
   vi.resetAllMocks();
 });
 
-test('check iconClass with font awesome icons', () => {
-  const statusBarEntry: StatusBarEntry = {
-    enabled: true,
+test.each([
+  {
     activeIconClass: 'fas fa-podman',
-  };
-
-  const icon = iconClass(statusBarEntry);
-  expect(icon).toBe('fas fa-podman');
-});
-
-test('check iconClass with custom icon name', () => {
-  const statusBarEntry: StatusBarEntry = {
-    enabled: true,
+    expectedIcon: 'fas fa-podman',
+    description: 'check iconClass with font awesome icons',
+  },
+  {
     activeIconClass: '${podman}',
-  };
-
-  const icon = iconClass(statusBarEntry);
-  expect(icon).toBe('podman-desktop-icon-podman');
-});
-
-test('check iconClass with font awesome icons and spinning', () => {
+    expectedIcon: 'podman-desktop-icon-podman',
+    description: 'check iconClass with custom icon name',
+  },
+  {
+    activeIconClass: 'fas fa-sync~spin',
+    expectedIcon: 'fas fa-sync animate-spin',
+    description: 'check iconClass with font awesome icons and spinning',
+  },
+])('$description', ({ activeIconClass, expectedIcon }) => {
   const statusBarEntry: StatusBarEntry = {
     enabled: true,
-    activeIconClass: 'fas fa-sync~spin',
+    activeIconClass,
   };
 
   const icon = iconClass(statusBarEntry);
-  expect(icon).toBe('fas fa-sync animate-spin');
+  expect(icon).toBe(expectedIcon);
 });
 
 test('expect dot not rendered', async () => {

--- a/packages/renderer/src/lib/ui/ProviderInfo.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfo.spec.ts
@@ -23,46 +23,21 @@ import { expect, test } from 'vitest';
 
 import ProviderInfo from './ProviderInfo.svelte';
 
-test('Expect podman is purple', async () => {
-  const provider = 'podman';
+test.each([
+  { provider: 'podman', expectedClass: 'bg-(--pd-provider-podman)', description: 'Expect podman is purple' },
+  {
+    provider: 'Podman',
+    expectedClass: 'bg-(--pd-provider-podman)',
+    description: 'Expect Podman (different case) is purple',
+  },
+  { provider: 'docker', expectedClass: 'bg-(--pd-provider-docker)', description: 'Expect docker is blue' },
+  { provider: 'Kubernetes', expectedClass: 'bg-(--pd-provider-kubernetes)', description: 'Expect kubernetes is blue' },
+])('$description', async ({ provider, expectedClass }) => {
   render(ProviderInfo, {
     provider,
   });
   const label = screen.getByText(provider);
   expect(label).toBeInTheDocument();
   expect(label.parentElement?.firstChild).toBeInTheDocument();
-  expect(label.parentElement?.firstChild).toHaveClass('bg-(--pd-provider-podman)');
-});
-
-test('Expect Podman (different case) is purple', async () => {
-  const provider = 'Podman';
-  render(ProviderInfo, {
-    provider,
-  });
-  const label = screen.getByText(provider);
-  expect(label).toBeInTheDocument();
-  expect(label.parentElement?.firstChild).toBeInTheDocument();
-  expect(label.parentElement?.firstChild).toHaveClass('bg-(--pd-provider-podman)');
-});
-
-test('Expect docker is blue', async () => {
-  const provider = 'docker';
-  render(ProviderInfo, {
-    provider,
-  });
-  const label = screen.getByText(provider);
-  expect(label).toBeInTheDocument();
-  expect(label.parentElement?.firstChild).toBeInTheDocument();
-  expect(label.parentElement?.firstChild).toHaveClass('bg-(--pd-provider-docker)');
-});
-
-test('Expect kubernetes is blue', async () => {
-  const provider = 'Kubernetes';
-  render(ProviderInfo, {
-    provider,
-  });
-  const label = screen.getByText(provider);
-  expect(label).toBeInTheDocument();
-  expect(label.parentElement?.firstChild).toBeInTheDocument();
-  expect(label.parentElement?.firstChild).toHaveClass('bg-(--pd-provider-kubernetes)');
+  expect(label.parentElement?.firstChild).toHaveClass(expectedClass);
 });

--- a/packages/renderer/src/lib/ui/ProviderInfoCircle.spec.ts
+++ b/packages/renderer/src/lib/ui/ProviderInfoCircle.spec.ts
@@ -23,35 +23,18 @@ import { expect, test } from 'vitest';
 
 import ProviderInfoCircle from './ProviderInfoCircle.svelte';
 
-test('Expect podman is purple', async () => {
-  const type = 'podman';
+test.each([
+  { type: 'podman', expectedClass: 'bg-(--pd-provider-podman)', description: 'Expect podman is purple' },
+  { type: 'kubernetes', expectedClass: 'bg-(--pd-provider-kubernetes)', description: 'Expect kubernetes is sky blue' },
+  { type: 'docker', expectedClass: 'bg-(--pd-provider-docker)', description: 'Expect docker is sky blue' },
+] as const)('$description', async ({ type, expectedClass }) => {
   render(ProviderInfoCircle, {
     type,
   });
 
   const circle = screen.getByLabelText('Provider info circle');
   expect(circle).toBeInTheDocument();
-  expect(circle).toHaveClass('bg-(--pd-provider-podman)');
-});
-
-test('Expect kubernetes is sky blue', async () => {
-  const type = 'kubernetes';
-  render(ProviderInfoCircle, {
-    type,
-  });
-  const circle = screen.getByLabelText('Provider info circle');
-  expect(circle).toBeInTheDocument();
-  expect(circle).toHaveClass('bg-(--pd-provider-kubernetes)');
-});
-
-test('Expect docker is sky blue', async () => {
-  const type = 'docker';
-  render(ProviderInfoCircle, {
-    type,
-  });
-  const circle = screen.getByLabelText('Provider info circle');
-  expect(circle).toBeInTheDocument();
-  expect(circle).toHaveClass('bg-(--pd-provider-docker)');
+  expect(circle).toHaveClass(expectedClass);
 });
 
 test('Expect unknown is gray', async () => {


### PR DESCRIPTION
### What does this PR do?

Converts groups of similar tests into `test.each()` parameterized tests across 11 files in `packages/renderer` to satisfy the `sonarjs/parameterized-tests` lint rule introduced in eslint-plugin-sonarjs 4.2.0.

- `Conditions.spec.ts` (deployments): 6 condition styling tests → 1 parameterized test
- `DialogSpec.spec.ts`: 4 element tests → 1 parameterized test
- `InstalledExtensionCardLeftLifecycleStart.spec.ts`: 3 lifecycle tests → 1 parameterized test
- `extensions-utils.spec.ts`: 3 groups of filter tests → 3 parameterized tests
- `FeedbackFormTest.spec.ts`: 3 element tests → 1 parameterized test
- `Conditions.spec.ts` (jobs): 5 condition styling tests → 1 parameterized test
- `PreferencesConnectionActions.spec.ts`: 3 lifecycle button tests → 1 parameterized test
- `Type.spec.ts`: 3 service type tests → 1 parameterized test
- `StatusBarItem.spec.ts`: 3 icon rendering tests → 1 parameterized test
- `ProviderInfo.spec.ts`: 4 provider styling tests → 1 parameterized test
- `ProviderInfoCircle.spec.ts`: 3 provider circle tests → 1 parameterized test

### Screenshot / video of UI

N/A — test-only change.

### What issues does this PR fix or reference?

Partial fix for #18388

### How to test this PR?

```bash
npx vitest run packages/renderer/src/lib/deployments/columns/Conditions.spec.ts packages/renderer/src/lib/dialogs/DialogSpec.spec.ts packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts packages/renderer/src/lib/extensions/extensions-utils.spec.ts packages/renderer/src/lib/feedback/feedbackForms/FeedbackFormTest.spec.ts packages/renderer/src/lib/job/columns/Conditions.spec.ts packages/renderer/src/lib/preferences/PreferencesConnectionActions.spec.ts packages/renderer/src/lib/service/columns/Type.spec.ts packages/renderer/src/lib/statusbar/StatusBarItem.spec.ts packages/renderer/src/lib/ui/ProviderInfo.spec.ts packages/renderer/src/lib/ui/ProviderInfoCircle.spec.ts
```

- [x] Tests are covering the bug fix or the new feature