### PR TITLE
refactor(ui): use parameterized tests for similar test groups

### DIFF
--- a/packages/ui/src/lib/button/Button.spec.ts
+++ b/packages/ui/src/lib/button/Button.spec.ts
@@ -236,11 +236,14 @@ test('Button should not have aria-busy when not inProgress', async () => {
   expect(button).toHaveAttribute('aria-busy', 'false');
 });
 
-test('Button should have cursor-pointer class by default', async () => {
-  render(Button);
-  const button = screen.getByRole('button');
-  expect(button).toHaveClass('cursor-pointer');
-});
+test.each(['cursor-pointer', 'motion-reduce:transition-none', 'min-w-[28px]', 'min-h-[28px]'])(
+  'Button should have %s class',
+  async className => {
+    render(Button);
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass(className);
+  },
+);
 
 test('Button should have cursor-not-allowed class when disabled', async () => {
   render(Button, { disabled: true });
@@ -254,24 +257,6 @@ test('Button should have cursor-wait class when inProgress', async () => {
   const button = screen.getByRole('button');
   expect(button).toHaveClass('cursor-wait');
   expect(button).not.toHaveClass('cursor-pointer');
-});
-
-test('Button should have motion-reduce:transition-none class', async () => {
-  render(Button);
-  const button = screen.getByRole('button');
-  expect(button).toHaveClass('motion-reduce:transition-none');
-});
-
-test('Button should have min-w-[28px] class', async () => {
-  render(Button);
-  const button = screen.getByRole('button');
-  expect(button).toHaveClass('min-w-[28px]');
-});
-
-test('Button should have min-h-[28px] class', async () => {
-  render(Button);
-  const button = screen.getByRole('button');
-  expect(button).toHaveClass('min-h-[28px]');
 });
 
 test('Icon-only button without aria-label should throw an error', () => {

--- a/packages/ui/src/lib/layouts/FormPageSpec.spec.ts
+++ b/packages/ui/src/lib/layouts/FormPageSpec.spec.ts
@@ -23,23 +23,9 @@ import { expect, test } from 'vitest';
 
 import FormPageSpec from './FormPageSpec.svelte';
 
-test('Expect icon slot is defined', async () => {
+test.each(['icon', 'actions', 'content'])('Expect %s slot is defined', async label => {
   render(FormPageSpec);
 
-  const element = screen.getByLabelText('icon');
-  expect(element).toBeInTheDocument();
-});
-
-test('Expect actions slot is defined', async () => {
-  render(FormPageSpec);
-
-  const element = screen.getByLabelText('actions');
-  expect(element).toBeInTheDocument();
-});
-
-test('Expect content slot is defined', async () => {
-  render(FormPageSpec);
-
-  const element = screen.getByLabelText('content');
+  const element = screen.getByLabelText(label);
   expect(element).toBeInTheDocument();
 });

--- a/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
+++ b/packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
@@ -23,36 +23,17 @@ import { expect, test } from 'vitest';
 
 import StatusIcon from './StatusIcon.svelte';
 
-test('Expect starting styling', async () => {
-  const status = 'STARTING';
+test.each([
+  { status: 'STARTING', expectedClass: 'bg-[var(--pd-status-starting)]' },
+  { status: 'RUNNING', expectedClass: 'bg-[var(--pd-status-running)]' },
+  { status: 'DEGRADED', expectedClass: 'bg-[var(--pd-status-degraded)]' },
+])('Expect $status styling', async ({ status, expectedClass }) => {
   render(StatusIcon, { status });
   const icon = screen.getByRole('status');
   expect(icon).toBeInTheDocument();
   expect(icon).toHaveAttribute('title', status);
 
-  expect(icon).toHaveClass('bg-[var(--pd-status-starting)]');
-  expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
-});
-
-test('Expect running styling', async () => {
-  const status = 'RUNNING';
-  render(StatusIcon, { status });
-  const icon = screen.getByRole('status');
-  expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('title', status);
-
-  expect(icon).toHaveClass('bg-[var(--pd-status-running)]');
-  expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
-});
-
-test('Expect degraded styling', async () => {
-  const status = 'DEGRADED';
-  render(StatusIcon, { status });
-  const icon = screen.getByRole('status');
-  expect(icon).toBeInTheDocument();
-  expect(icon).toHaveAttribute('title', status);
-
-  expect(icon).toHaveClass('bg-[var(--pd-status-degraded)]');
+  expect(icon).toHaveClass(expectedClass);
   expect(icon).toHaveClass('text-[var(--pd-status-contrast)]');
 });
 


### PR DESCRIPTION
### What does this PR do?

Converts groups of similar tests into `test.each()` parameterized tests across 3 files in `packages/ui` to satisfy the `sonarjs/parameterized-tests` lint rule introduced in eslint-plugin-sonarjs 4.2.0.

- `Button.spec.ts`: 4 CSS class tests → 1 parameterized test
- `FormPageSpec.spec.ts`: 3 slot tests → 1 parameterized test
- `StatusIcon.spec.ts`: 3 status styling tests → 1 parameterized test

### Screenshot / video of UI

N/A — test-only change.

### What issues does this PR fix or reference?

Partial fix for #18388

### How to test this PR?

```bash
npx vitest run packages/ui/src/lib/button/Button.spec.ts packages/ui/src/lib/layouts/FormPageSpec.spec.ts packages/ui/src/lib/statusIcon/StatusIcon.spec.ts
```

- [x] Tests are covering the bug fix or the new feature