### PR TITLE
fix(podman): resolve airgap validation versions via versionRef

### DIFF
--- a/tests/playwright/scripts/validate-airgap-assets.sh
+++ b/tests/playwright/scripts/validate-airgap-assets.sh
@@ -78,23 +78,18 @@ verify_installer_checksums() {
     return
   fi
 
+  if [ -z "${PK}" ]; then
+    echo "SKIP: no installer checksums to verify on ${OS}"
+    return
+  fi
+
   local files=()
-  case "${OS}" in
-    Darwin)
-      while IFS= read -r fname; do
-        files+=("${fname}")
-      done < <(jq -r '.platform.darwin.arch | to_entries[].value.fileName' "${PODMAN_JSON}" | tr -d '\r')
-      ;;
-    MINGW*|MSYS*|CYGWIN*|Windows_NT)
-      while IFS= read -r fname; do
-        files+=("${fname}")
-      done < <(jq -r '.platform.win32.arch | to_entries[].value.fileName' "${PODMAN_JSON}" | tr -d '\r')
-      ;;
-    *)
-      echo "SKIP: no installer checksums to verify on ${OS}"
-      return
-      ;;
-  esac
+  while IFS= read -r fname; do
+    [ -n "${fname}" ] && files+=("${fname}")
+  done < <(jq -r --arg pk "${PK}" --arg ver "${version}" '
+    .versions as $v | .platform[$pk].arch | to_entries[] |
+    select($v[.value.versionRef].version == $ver) | .value.fileName
+  ' "${PODMAN_JSON}" | tr -d '\r')
 
   echo "Files to verify: ${files[*]:-none}"
 
@@ -172,10 +167,20 @@ verify_oci_checksums() {
     return
   fi
 
+  local allowed_arches
+  allowed_arches=$(jq -r --arg pk "${PK}" --arg ver "${version}" '
+    .versions as $v | .platform[$pk].arch | to_entries[] |
+    select($v[.value.versionRef].version == $ver) |
+    (if .key == "x64" then "x86_64" elif .key == "arm64" then "aarch64" else .key end)
+  ' "${PODMAN_JSON}" 2>/dev/null || true)
+
   echo "Found OCI entries for: $(echo "${arch_digests}" | awk '{printf "%s ", $1}')"
 
   while IFS=' ' read -r arch digest; do
     [ -z "${arch}" ] && continue
+    if ! echo "${allowed_arches}" | grep -qF "${arch}"; then
+      continue
+    fi
 
     local local_name
     case "${arch}" in
@@ -244,11 +249,26 @@ if [ ! -d "${ASSETS_DIR}" ]; then
   exit 1
 fi
 
-VERSION=$(jq -r '.version' "${PODMAN_JSON}" | tr -d '\r')
-echo "Podman version: ${VERSION}"
-
 OS="$(uname -s)"
 ARCH="$(uname -m)"
+
+case "${OS}" in
+  Darwin) PK="darwin" ;;
+  MINGW*|MSYS*|CYGWIN*|Windows_NT) PK="win32" ;;
+  *) PK="" ;;
+esac
+
+VERSIONS=()
+if [ -n "${PK}" ]; then
+  while IFS= read -r v; do
+    [ -n "$v" ] && VERSIONS+=("$v")
+  done < <(jq -r --arg pk "${PK}" '
+    .versions as $vers |
+    [.platform[$pk].arch | to_entries[].value.versionRef] | unique[] |
+    $vers[.].version
+  ' "${PODMAN_JSON}" | sort -u)
+fi
+echo "Podman version(s): ${VERSIONS[*]:-none}"
 echo "Platform: ${OS} / ${ARCH}"
 echo ""
 
@@ -256,7 +276,7 @@ echo "--- DEBUG: assets directory listing ---"
 ls -la "${ASSETS_DIR}/" 2>&1 || echo "(empty or inaccessible)"
 echo ""
 
-echo "--- DEBUG: podman5.json platform structure ---"
+echo "--- DEBUG: podman.json platform structure ---"
 jq '.platform' "${PODMAN_JSON}"
 echo ""
 
@@ -295,9 +315,11 @@ esac
 
 echo ""
 echo "--- Checksum verification ---"
-verify_installer_checksums "${VERSION}"
-echo ""
-verify_oci_checksums "${VERSION}"
+for ver in "${VERSIONS[@]}"; do
+  verify_installer_checksums "${ver}"
+  echo ""
+  verify_oci_checksums "${ver}"
+done
 
 echo ""
 if [ "${ERRORS}" -gt 0 ]; then


### PR DESCRIPTION
### What does this PR do?

Fixes the `validate-airgap-assets.sh` script so it resolves Podman versions through the `versionRef` → `versions` indirection introduced by #18408, instead of reading the now-absent top-level `.version` field from `podman.json`.

Since #18856 retargeted the script from `podman5.json` to `podman.json` without adapting the version read, `jq -r '.version'` returns `null`, which propagates as `vnull` into the GitHub shasums URL and `null` into the Quay OCI manifest URL — both 404, failing every daily build.

**Changes:**
- Resolve unique Podman versions per platform by following each architecture entry's `versionRef` into the `versions` map
- Loop installer and OCI checksum verification per version, filtering files and OCI arches to only those belonging to each version
- This correctly handles macOS where `x64` → Podman v5 and `arm64` → Podman v6
- Fix a stale `podman5.json` debug label → `podman.json`

Closes #19030

### How to test

Run the script locally on macOS (it resolves versions and fetches real checksums from GitHub/Quay):

```bash
bash tests/playwright/scripts/validate-airgap-assets.sh
```

You should see:
- `Podman version(s): 5.8.6 6.1.0` (two versions resolved, not `null`)
- Installer shasums fetched per version (`v5.8.6` for x64, `v6.1.0` for arm64)
- OCI manifest fetched per `major.minor` (`5.8` for x86_64, `6.1` for aarch64)
- Installer checksum verification passes for any `.pkg`/`.msi` files present in `assets/`
- The only failures should be missing `podman-image-*.zst` files (not downloaded locally)

The full end-to-end validation runs in the Daily testing build workflow (`.github/workflows/daily-testing-build.yaml`) where the assets directory is fully populated.

You can also verify the version resolution independently:

```bash
PODMAN_JSON=extensions/podman/packages/extension/src/podman.json

# Should print 5.8.6 and 6.1.0 (not "null")
jq -r --arg pk darwin \
  '.versions as $v | [.platform[$pk].arch | to_entries[].value.versionRef] | unique[] | $v[.].version' \
  "$PODMAN_JSON"

# Should print only the x64 .pkg for v5
jq -r --arg pk darwin --arg ver 5.8.6 \
  '.versions as $v | .platform[$pk].arch | to_entries[] | select($v[.value.versionRef].version == $ver) | .value.fileName' \
  "$PODMAN_JSON"
```

### Browsers

N/A — this is a CI shell script, no UI changes.

### Screenshot / video of UI changes

N/A

Made with [Cursor](https://cursor.com)