### PR TITLE
fix(e2e): add Windows Defender exclusions for update e2e tests

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -299,7 +299,9 @@ jobs:
             Write-Warning "Failed to add Defender process exclusion: $_"
           }
           Write-Host "Current Defender path exclusions:"
-          try { (Get-MpPreference).ExclusionPath } catch { Write-Warning "Unable to read current Defender exclusions" }
+          try { (Get-MpPreference).ExclusionPath } catch { Write-Warning "Unable to read current Defender path exclusions" }
+          Write-Host "Current Defender process exclusions:"
+          try { (Get-MpPreference).ExclusionProcess } catch { Write-Warning "Unable to read current Defender process exclusions" }
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         name: Install pnpm

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -272,12 +272,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: github.event_name == 'push'
 
-      # Windows Defender real-time scanning can lock/quarantine files under the build,
-      # updater download and install directories, which prevents the Electron renderer
-      # from initializing during the update test. Exclude these paths proactively, before
-      # the app is built and installed, so Defender never scans files written there.
+      # Windows Defender locks newly-written executables via its behavior-monitoring subsystem
+      # even when the path is listed in ExclusionPath. Path exclusions only suppress
+      # signature-based real-time scanning; behavior monitoring is a separate kernel component
+      # that intercepts new-executable creation and is not affected by ExclusionPath.
+      # The NSIS installer build triggers this, locking dist/ files right before tests run
+      # and preventing the Electron preload bridge from attaching on the first cold start.
+      # DisableBehaviorMonitoring stops those locks; ExclusionPath keeps real-time scanning
+      # off for subsequent file access during the test run.
       - name: Add Windows Defender exclusions for build and install paths
         run: |
+          Write-Host "Disabling Defender behavior monitoring to prevent file locks during build/test"
+          try {
+            Set-MpPreference -DisableBehaviorMonitoring $true -ErrorAction Stop
+            Write-Host "Disabled Defender behavior monitoring"
+          } catch {
+            Write-Warning "Failed to disable Defender behavior monitoring: $_"
+          }
           Write-Host "Adding Windows Defender exclusions to prevent renderer initialization failures during update tests"
           $exclusions = @(
             "$env:GITHUB_WORKSPACE",
@@ -298,6 +309,8 @@ jobs:
           } catch {
             Write-Warning "Failed to add Defender process exclusion: $_"
           }
+          Write-Host "Current Defender behavior monitoring setting:"
+          try { (Get-MpPreference).DisableBehaviorMonitoring } catch { Write-Warning "Unable to read DisableBehaviorMonitoring" }
           Write-Host "Current Defender path exclusions:"
           try { (Get-MpPreference).ExclusionPath } catch { Write-Warning "Unable to read current Defender path exclusions" }
           Write-Host "Current Defender process exclusions:"

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -272,6 +272,35 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: github.event_name == 'push'
 
+      # Windows Defender real-time scanning can lock/quarantine files under the build,
+      # updater download and install directories, which prevents the Electron renderer
+      # from initializing during the update test. Exclude these paths proactively, before
+      # the app is built and installed, so Defender never scans files written there.
+      - name: Add Windows Defender exclusions for build and install paths
+        run: |
+          Write-Host "Adding Windows Defender exclusions to prevent renderer initialization failures during update tests"
+          $exclusions = @(
+            "$env:GITHUB_WORKSPACE",
+            "$env:LOCALAPPDATA\Programs\podman-desktop",
+            "$env:LOCALAPPDATA\podman-desktop-updater"
+          )
+          foreach ($path in $exclusions) {
+            try {
+              Add-MpPreference -ExclusionPath $path -ErrorAction Stop
+              Write-Host "Added Defender exclusion path: $path"
+            } catch {
+              Write-Warning "Failed to add Defender exclusion for ${path}: $_"
+            }
+          }
+          try {
+            Add-MpPreference -ExclusionProcess "Podman Desktop.exe" -ErrorAction Stop
+            Write-Host "Added Defender exclusion process: Podman Desktop.exe"
+          } catch {
+            Write-Warning "Failed to add Defender process exclusion: $_"
+          }
+          Write-Host "Current Defender path exclusions:"
+          try { (Get-MpPreference).ExclusionPath } catch { Write-Warning "Unable to read current Defender exclusions" }
+
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         name: Install pnpm
         with:


### PR DESCRIPTION
### What does this PR do?

Adds a step to the `win-update-e2e-test` job in `e2e-main.yaml` that registers Windows Defender exclusions **before** Podman Desktop is built and installed.

The `windows-2025` and `windows-11-arm` update e2e tests fail intermittently on the **first** Electron cold-start: Windows Defender's real-time scanner races with the freshly-written, unsigned Electron binary and locks/quarantines files, so the main process/renderer never initializes. On a restart (2nd Playwright worker) the scan has completed and the app launches fine.

By excluding the relevant paths up front, Defender never scans those files, removing the scan-vs-launch race:

- `$env:GITHUB_WORKSPACE` — the build output that runs on first launch (`dist\win-unpacked` / `dist\win-arm64-unpacked`)
- `%LOCALAPPDATA%\podman-desktop-updater` — where electron-updater downloads the NSIS `setup.exe`
- `%LOCALAPPDATA%\Programs\podman-desktop` — the NSIS per-user install target
- Process exclusion for `Podman Desktop.exe`

Each exclusion is wrapped in try/catch so a blocked call (e.g. Tamper Protection) logs a warning instead of failing the job.

Scope is intentionally limited to the `win-update-e2e-test` job in `e2e-main.yaml`; `pr-check` is deliberately left untouched (per @odockal).

### Screenshot / video of UI

N/A — CI workflow change only.

### What issues does this PR fix or reference?

Related to #18225 (one mitigation for the multi-cause cold-start flake; not a full fix, so not using a closing keyword).

### How to test this PR?

Dispatch the `e2e-tests-main` workflow from this branch (pushed to the upstream repo) and confirm the `windows-2025` / `windows-11-arm` update e2e jobs pass, and that the new "Add Windows Defender exclusions for build and install paths" step logs the registered exclusions.

- [ ] Tests are covering the bug fix or the new feature
