### PR TITLE
chore(test): add retries to unstable podman-install test on windows arm

### DIFF
--- a/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
+++ b/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
@@ -48,6 +48,7 @@ test.afterAll(async ({ runner }) => {
 
 test.describe
   .serial('Podman installer integration in Podman Desktop', { tag: '@update-install' }, () => {
+    test.describe.configure({ retries: 1 });
     test('Dashboard Podman provider card assets check', async ({ page }) => {
       test.skip(!isCI || process.env.GITHUB_ACTIONS !== 'true', 'Only run on macOS and Windows in GitHub Actions');
       const dashboardPage = await new NavigationBar(page).openDashboard();


### PR DESCRIPTION
### What does this PR do?
Tries to address instability where first windows update e2e test fails on windows-arm runners. Retries should help to make the test stable.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#18225
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
