### PR TITLE
fix(podman): pass VMType when stopping machines before update

### DIFF
--- a/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.spec.ts
@@ -196,7 +196,7 @@ describe('update checks', () => {
     expect(extensionApi.window.showInformationMessage).toHaveBeenCalled();
 
     // check we called the stop command
-    expect(utils.execPodman).toHaveBeenCalledWith(['machine', 'stop', 'test']);
+    expect(utils.execPodman).toHaveBeenCalledWith(['machine', 'stop', 'test'], 'libkrun');
   });
 
   test('wipeAllDataBeforeMajorUpdate with podman 4.9 -> 5.0', async () => {

--- a/extensions/podman/packages/extension/src/installer/podman-install.ts
+++ b/extensions/podman/packages/extension/src/installer/podman-install.ts
@@ -175,7 +175,7 @@ export class PodmanInstall {
       if (answer === 'Yes') {
         for (const machine of machinesRunning) {
           try {
-            await execPodman(['machine', 'stop', machine.Name]);
+            await execPodman(['machine', 'stop', machine.Name], machine.VMType);
           } catch (error) {
             console.error('Error while stopping machine', error);
           }


### PR DESCRIPTION
### What does this PR do?

Passes the `VMType` (e.g. `hyperv`, `wsl`) to `execPodman` when stopping machines during the pre-update flow in `stopPodmanMachinesIfAnyBeforeUpdating()`.

Previously, the call was:
```typescript
await execPodman(['machine', 'stop', machine.Name]);
```

This omitted the `containersProvider` argument, so the `CONTAINERS_MACHINE_PROVIDER` environment variable was never set. On Windows systems, the Podman CLI defaults to whichever provider was selected during the Podman installer wizard (WSL or Hyper-V). When the default is WSL but the running machine is a Hyper-V machine, the stop command targets the wrong provider and fails — typically with "VM does not exist" — because WSL has no machine by that name.

The fix:
```typescript
await execPodman(['machine', 'stop', machine.Name], machine.VMType);
```

This matches how `stopMachine()` in `extension.ts` already works (passing `machineInfo.vmType`).

### Screenshot / video of UI

N/A — no UI changes.

### What issues does this PR fix or reference?

Fixes #18497

This is a follow-up to #18791 which addressed the Hyper-V VM cleanup (removal) part of the migration. This PR fixes the **stop** part: when the user confirms "Would you like to stop it now?" during the update flow, the stop command now correctly targets the machine's actual provider instead of relying on the Podman CLI default.

### How to test this PR?

Download the built artifacts from the CI checks and install on a Windows machine.

**Test 1 — Podman installer default set to Hyper-V:**

1. Have Podman 5.8.5 installed. During the Podman installer wizard, select **Hyper-V** as the default provider.
2. In Podman Desktop (run as administrator), create a **Hyper-V** Podman machine and confirm it is running (e.g. pull an image).
3. On the Resources page, click **Update** to Podman 6.
4. When prompted "Would you like to stop it now?", click **Yes**.
5. Verify in Hyper-V Manager that the machine is stopped (no error).

**Test 2 — Podman installer default set to WSL:**

1. Have Podman 5.8.5 installed. During the Podman installer wizard, select **WSL** as the default provider.
2. In Podman Desktop (run as administrator), create a **Hyper-V** Podman machine and confirm it is running (e.g. pull an image).
3. On the Resources page, click **Update** to Podman 6.
4. When prompted "Would you like to stop it now?", click **Yes**.
5. Verify in Hyper-V Manager that the machine is stopped (no error). **This is the scenario that was failing before the fix** — the stop command would default to WSL and fail with "VM does not exist".

- [x] Tests are covering the bug fix or the new feature

Made with Cursor