### PR TITLE
fix(ci): add missing installer for windows and mac in daily testing builds

### DIFF
--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -171,7 +171,7 @@ jobs:
       - name: Run macOS Build and Compile - next
         if: runner.os == 'macOS' && env.BUILD_ALL != 'true'
         timeout-minutes: 60
-        run: pnpm compile:next --mac default --arm64
+        run: pnpm compile:next --mac default --x64 --arm64
 
       - name: Run Linux Build and Compile
         if: runner.os == 'Linux' && env.BUILD_ALL != 'true'

--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -166,7 +166,7 @@ jobs:
       - name: Run Windows Build and Compile
         if: runner.os == 'Windows' && env.BUILD_ALL != 'true'
         timeout-minutes: 60
-        run: pnpm compile:next --win nsis --x64
+        run: pnpm compile:next --win nsis --x64 --arm64
 
       - name: Run macOS Build and Compile - next
         if: runner.os == 'macOS' && env.BUILD_ALL != 'true'


### PR DESCRIPTION
### What does this PR do?
Currently we are missing arm64 installer for windows which breaks PR checks.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
