### PR TITLE
fix(ci): temporary removal of windows-arm update test from pr-check

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -595,7 +595,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-2025", "windows-11-arm"]
+        # windows-arm runner has some issue starting the application, removing unless is resolved: https://github.com/podman-desktop/podman-desktop/issues/18225
+        os: ["windows-2025"]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
### What does this PR do?
It removed windows-11-arm runner from update e2e tests on pr-check due to their instability.
### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
#18225
<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
