### PR TITLE
test(e2e): add hc-dark and hc-light theme coverage

### DIFF
--- a/tests/playwright/src/specs/appearance-smoke.spec.ts
+++ b/tests/playwright/src/specs/appearance-smoke.spec.ts
@@ -98,6 +98,48 @@ test.describe('Appearance theme switching', { tag: ['@smoke', '@windows_sanity',
     playExpect(theme.colorScheme).toBe('light');
   });
 
+  test('Switching to hc-dark mode applies dark theme with high contrast', async ({ page, statusBar }) => {
+    await preferencesPage.setPreferenceDropdownValue(Preferences.Labels.APPEARANCE, 'hc-dark');
+
+    const dropdownValue = await preferencesPage.getPreferenceDropdownValue(Preferences.Labels.APPEARANCE);
+    playExpect(dropdownValue).toBe('hc-dark');
+
+    await playExpect
+      .poll(async () => (await getThemeState(page)).hasDarkClass, {
+        timeout: 15_000,
+        message: 'Expected dark class on document element after switching to hc-dark mode',
+      })
+      .toBe(true);
+
+    const theme = await getThemeState(page);
+    playExpect(theme.colorScheme).toBe('dark');
+
+    // the status bar exposes the high-contrast flag via data-pd-force-theme
+    await playExpect(statusBar.content).toHaveAttribute('data-pd-force-theme', 'hc-dark');
+  });
+
+  test('Switching to hc-light mode applies light theme with high contrast', async ({ page, statusBar }) => {
+    await preferencesPage.setPreferenceDropdownValue(Preferences.Labels.APPEARANCE, 'hc-light');
+
+    const dropdownValue = await preferencesPage.getPreferenceDropdownValue(Preferences.Labels.APPEARANCE);
+    playExpect(dropdownValue).toBe('hc-light');
+
+    await playExpect
+      .poll(async () => (await getThemeState(page)).hasDarkClass, {
+        timeout: 15_000,
+        message: 'Expected dark class removed from document element after switching to hc-light mode',
+      })
+      .toBe(false);
+
+    const theme = await getThemeState(page);
+    playExpect(theme.colorScheme).toBe('light');
+
+    // the status bar is always rendered with a dark palette, but still switches
+    // to its high-contrast variant when a high-contrast appearance is active,
+    // even though the rest of the app is in light mode
+    await playExpect(statusBar.content).toHaveAttribute('data-pd-force-theme', 'hc-dark');
+  });
+
   test('Switching back to dark mode re-applies dark theme', async ({ page }) => {
     await preferencesPage.setPreferenceDropdownValue(Preferences.Labels.APPEARANCE, 'dark');
 


### PR DESCRIPTION
### What does this PR do?

Extends the existing `appearance-smoke.spec.ts` E2E suite to cover the two high-contrast appearance modes (`hc-dark` and `hc-light`), which had no E2E coverage. The suite already covered `system`, `dark`, and `light`; this completes coverage for all 5 values of the `preferences.appearance` setting.

Each new test switches the Appearance preference via Settings > Preferences, and verifies:
- The dropdown value persists.
- `document.documentElement`'s `dark` class and `color-scheme` style match the expected base theme (dark for `hc-dark`, light for `hc-light`).
- The status bar's `data-pd-force-theme` attribute reflects the high-contrast flag (`hc-dark` in both cases — the status bar is always rendered with a dark palette and only toggles its own high-contrast variant, regardless of whether the overall theme is light or dark).

No production code changes; test-only.

### Screenshot / video of UI

No UI changes — this PR only adds test coverage.

### What issues does this PR fix or reference?

Fixes #18389

### How to test this PR?

- [x] Tests are covering the new feature

Run the extended suite:

​```bash
pnpm test:e2e:build
npx playwright test tests/playwright/src/specs/appearance-smoke.spec.ts
​```

All 7 tests (including the 2 new ones) pass locally against the built app.