### PR TITLE
refactor(renderer/test): refactor the test to use as const instead of cast

### DIFF
--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeftLifecycleStart.spec.ts
@@ -33,9 +33,9 @@ test.each([
   { type: 'dd', name: 'foo', state: 'stopped', description: 'Expect to start dd Extension if stopped' },
   { type: 'pd', name: 'fooName', state: 'stopped', description: 'Expect to start pd Extension if stopped' },
   { type: 'pd', name: 'fooName', state: 'failed', description: 'Expect to start Extension if failed' },
-])('$description', async ({ type, name, state }) => {
+] as const)('$description', async ({ type, name, state }) => {
   const extension: CombinedExtensionInfoUI = {
-    type: type as 'dd' | 'pd',
+    type,
     id: 'idExtension',
     name,
     description: 'my description',
@@ -44,7 +44,7 @@ test.each([
     removable: true,
     devMode: false,
     version: 'v1.2.3',
-    state: state as 'stopped' | 'failed',
+    state,
     path: '',
     readme: '',
   };


### PR DESCRIPTION
### What does this PR do?

This PR is a simple refactor of a renderer test that uses `as const` instead of cast. It is a follow up of #19028.

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Follow up of my comment here: https://github.com/podman-desktop/podman-desktop/pull/19028#discussion_r3895185023

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
