### PR TITLE
chore(tests): use test.runIf for conditional test skip

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
@@ -415,11 +415,7 @@ describe.each([
     }
   });
 
-  test('Connect button is displayed on offline contexts', async () => {
-    if (!implemented.offline) {
-      return;
-    }
-
+  test.runIf(implemented.offline)('Connect button is displayed on offline contexts', async () => {
     initMocks();
     render(PreferencesKubernetesContextsRendering, {});
 


### PR DESCRIPTION
### What does this PR do?

Replace early `return` with `test.runIf()` in PreferencesKubernetesContextsRendering test to satisfy the `sonarjs/explicit-test-skip` ESLint rule.

### Screenshot / video of UI

N/A — test-only change, no UI impact.

### What issues does this PR fix or reference?

related to https://github.com/podman-desktop/podman-desktop/issues/18388

### How to test this PR?

First, update eslint-plugin-sonarjs to 4.2.0+ (this rule is not present in older versions):
```
pnpm add -D eslint-plugin-sonarjs@latest
```

Then run the test file and verify 14 pass, 1 skipped:
```
npx vitest run packages/renderer/src/lib/preferences/PreferencesKubernetesContextsRendering.spec.ts
```

Verify ESLint `sonarjs/explicit-test-skip` no longer reports on this file.

- [x] Tests are covering the bug fix or the new feature