### PR TITLE
chore(main): use named import for validator

### DIFF
--- a/packages/main/src/plugin/image-registry.ts
+++ b/packages/main/src/plugin/image-registry.ts
@@ -38,7 +38,7 @@ import got, { HTTPError, RequestError } from 'got';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import { inject, injectable } from 'inversify';
 import * as nodeTar from 'tar';
-import validator from 'validator';
+import { isURL } from 'validator';
 
 import { isMac, isWindows } from '/@/util.js';
 
@@ -1021,7 +1021,7 @@ export class ImageRegistry {
       require_tld: false,
     };
     // Validate the URL
-    const isUrl = validator.default.isURL(serviceUrl, urlOptions);
+    const isUrl = isURL(serviceUrl, urlOptions);
 
     // Check if the URL is undefined or not a valid URL
     if (serviceUrl === undefined || !isUrl) {


### PR DESCRIPTION
### What does this PR do?

Use named import `{isURL}` from `validator` instead of the default import to satisfy the `sonarjs/no-default-utility-imports` ESLint rule.

Fixes the `sonarjs/no-default-utility-imports` ESLint rule violation.

### Screenshot / video of UI

N/A — no UI change.

### What issues does this PR fix or reference?

Related to https://github.com/podman-desktop/podman-desktop/issues/18388

### How to test this PR?

First, update eslint-plugin-sonarjs to 4.2.0+ (this rule is not present in older versions):
```
pnpm add -D eslint-plugin-sonarjs@latest
```

Verify ESLint `sonarjs/no-default-utility-imports` no longer reports on `packages/main/src/plugin/image-registry.ts`.

Run the unit tests:
```
npx vitest run packages/main/src/plugin/image-registry.spec.ts
```

- [x] Tests are covering the bug fix or the new feature