### PR TITLE
fix: use atomic writes and serialization for safe storage and configuration 

### DIFF
--- a/packages/main/src/plugin/configuration-registry.spec.ts
+++ b/packages/main/src/plugin/configuration-registry.spec.ts
@@ -17,8 +17,8 @@
  ***********************************************************************/
 
 // Import to access mocked functionionalities such as using vi.mock (we don't want to actually call node:fs methods)
-import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { access, copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { cpSync, existsSync, readFileSync } from 'node:fs';
+import { access, copyFile, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
@@ -42,7 +42,6 @@ import type { NotificationRegistry } from './tasks/notification-registry.js';
 // mock the fs module
 vi.mock(import('node:fs'), () => ({
   readFileSync: vi.fn(),
-  writeFileSync: vi.fn(),
   cpSync: vi.fn(),
   existsSync: vi.fn(),
 }));
@@ -60,6 +59,7 @@ vi.mock(import('node:fs/promises'), () => ({
   mkdir: vi.fn(),
   writeFile: vi.fn(),
   readFile: vi.fn(),
+  rename: vi.fn(),
   copyFile: vi.fn(),
 }));
 
@@ -413,8 +413,8 @@ describe('should be notified when a configuration is updated', async () => {
 });
 
 test('should remove the object configuration if value is equal to default one', async () => {
-  // Mock fs function needed for this specific test
-  const writeFileSyncMock = vi.mocked(writeFileSync);
+  const writeFileMock = vi.mocked(writeFile);
+  const renameMock = vi.mocked(rename);
 
   const node: IConfigurationNode = {
     id: 'custom',
@@ -454,20 +454,28 @@ test('should remove the object configuration if value is equal to default one', 
     { label: 'bar', value: 2 },
   ]);
 
-  expect(writeFileSyncMock).toHaveBeenNthCalledWith(
+  // wait for the serialized write chain to flush
+  await vi.waitFor(() => {
+    expect(renameMock).toHaveBeenCalledTimes(2);
+  });
+
+  // atomic write: the second call should persist an empty config (value matches default)
+  expect(writeFileMock).toHaveBeenNthCalledWith(
     2,
-    expect.anything(),
+    expect.stringMatching(/settings\.json\.tmp-/),
     expect.stringContaining(JSON.stringify({}, undefined, 2)),
+    'utf-8',
   );
 });
 
 // Tests for applyManagedDefaults method
 describe('applyManagedDefaults function tests', () => {
-  let writeFileSyncMock: ReturnType<typeof vi.mocked<typeof writeFileSync>>;
+  let writeFileMock: ReturnType<typeof vi.mocked<typeof writeFile>>;
+  let renameMock: ReturnType<typeof vi.mocked<typeof rename>>;
 
   beforeEach(() => {
-    writeFileSyncMock = vi.mocked(writeFileSync);
-    writeFileSyncMock.mockClear();
+    writeFileMock = vi.mocked(writeFile);
+    renameMock = vi.mocked(rename);
   });
 
   test('apply default-config.json values to undefined keys in config', async () => {
@@ -627,8 +635,10 @@ describe('applyManagedDefaults function tests', () => {
     const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
     await testRegistry.init();
 
-    // saveDefault should have been called (via writeFileSync)
-    expect(writeFileSync).toHaveBeenCalled();
+    // saveDefault should have been called (via atomic write)
+    await vi.waitFor(() => {
+      expect(renameMock).toHaveBeenCalled();
+    });
   });
 
   test('should NOT write to file when no managed defaults are applied', async () => {
@@ -638,8 +648,8 @@ describe('applyManagedDefaults function tests', () => {
     const testRegistry = new ConfigurationRegistry(apiSender, directories, defaultConfiguration, lockedConfiguration);
     await testRegistry.init();
 
-    // saveDefault should NOT have been called
-    expect(writeFileSync).not.toHaveBeenCalled();
+    // saveDefault should NOT have been called (no rename means no atomic write was scheduled)
+    expect(renameMock).not.toHaveBeenCalled();
   });
 
   test('should not persist managed default to settings.json if it matches schema default', async () => {
@@ -670,12 +680,18 @@ describe('applyManagedDefaults function tests', () => {
 
     // Clear previous calls and trigger saveDefault to check what would be written
     // now that configurations are registered
-    writeFileSyncMock.mockClear();
+    writeFileMock.mockClear();
+    renameMock.mockClear();
     testRegistry.saveDefault();
 
+    // wait for the serialized write chain to flush
+    await vi.waitFor(() => {
+      expect(renameMock).toHaveBeenCalled();
+    });
+
     // The value should NOT be in the settings.json since it matches the schema default
-    expect(writeFileSyncMock).toHaveBeenCalled();
-    const writtenContent = JSON.parse(writeFileSyncMock.mock.calls[0]?.[1] as string);
+    expect(writeFileMock).toHaveBeenCalled();
+    const writtenContent = JSON.parse(writeFileMock.mock.calls[0]?.[1] as string);
     expect(writtenContent['my.fake.property']).toBeUndefined();
   });
 
@@ -706,12 +722,18 @@ describe('applyManagedDefaults function tests', () => {
     testRegistry.registerConfigurations([node]);
 
     // Clear previous calls and trigger saveDefault to check what would be written
-    writeFileSyncMock.mockClear();
+    writeFileMock.mockClear();
+    renameMock.mockClear();
     testRegistry.saveDefault();
 
+    // wait for the serialized write chain to flush
+    await vi.waitFor(() => {
+      expect(renameMock).toHaveBeenCalled();
+    });
+
     // The value SHOULD be in the settings.json since it differs from schema default
-    expect(writeFileSyncMock).toHaveBeenCalled();
-    const writtenContent = JSON.parse(writeFileSyncMock.mock.calls[0]?.[1] as string);
+    expect(writeFileMock).toHaveBeenCalled();
+    const writtenContent = JSON.parse(writeFileMock.mock.calls[0]?.[1] as string);
     expect(writtenContent['my.fake.property']).toEqual('customValue');
   });
 });

--- a/packages/main/src/plugin/configuration-registry.ts
+++ b/packages/main/src/plugin/configuration-registry.ts
@@ -23,7 +23,7 @@ import * as path from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 
 import type * as containerDesktopAPI from '@podman-desktop/api';
-import type { Event, IDisposable, NotificationCardOptions } from '@podman-desktop/core-api';
+import type { Event, IAsyncDisposable, IDisposable, NotificationCardOptions } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import type {
   ConfigurationScope,
@@ -49,9 +49,10 @@ import { Emitter } from './events/emitter.js';
 import { LockedKeys } from './lock-configuration.js';
 import { LockedConfiguration } from './locked-configuration.js';
 import { Disposable } from './types/disposable.js';
+import { AtomicFileWriter } from './util/atomic-file-writer.js';
 
 @injectable()
-export class ConfigurationRegistry implements IConfigurationRegistry {
+export class ConfigurationRegistry implements IConfigurationRegistry, IAsyncDisposable {
   private readonly configurationContributors: IConfigurationNode[];
   private readonly configurationProperties: Record<string, IConfigurationPropertyRecordedSchema>;
 
@@ -68,6 +69,7 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   // Contains the value of the current configuration
   private configurationValues: Map<string, { [key: string]: unknown }>;
   private lockedKeys: LockedKeys;
+  #atomicWriter: AtomicFileWriter | undefined;
 
   constructor(
     @inject(ApiSenderType)
@@ -151,6 +153,18 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
 
     // Set the updated configuration data, this doesn't "save-to-disk" yet until we run saveDefault()...
     this.configurationValues.set(CONFIGURATION_DEFAULT_SCOPE, configData);
+
+    this.#atomicWriter = new AtomicFileWriter(settingsFile, () => {
+      const cloneConfig = { ...this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE) };
+      // for each key being already the default value, remove the entry
+      Object.keys(cloneConfig)
+        .filter(key => isDeepStrictEqual(cloneConfig[key], this.configurationProperties[key]?.default))
+        .filter(key => this.configurationProperties[key]?.type !== 'markdown')
+        .forEach(key => {
+          delete cloneConfig[key];
+        });
+      return JSON.stringify(cloneConfig, undefined, 2);
+    });
 
     // Note: saveDefault() will filter out any keys that match the schema default, so only non-default values will actually be persisted to settings.json
     if (listOfAppliedKeys.length > 0) {
@@ -456,15 +470,11 @@ export class ConfigurationRegistry implements IConfigurationRegistry {
   }
 
   public saveDefault(): void {
-    const cloneConfig = { ...this.configurationValues.get(CONFIGURATION_DEFAULT_SCOPE) };
-    // for each key being already the default value, remove the entry
-    Object.keys(cloneConfig)
-      .filter(key => isDeepStrictEqual(cloneConfig[key], this.configurationProperties[key]?.default))
-      .filter(key => this.configurationProperties[key]?.type !== 'markdown')
-      .forEach(key => {
-        delete cloneConfig[key];
-      });
-    fs.writeFileSync(this.getSettingsFile(), JSON.stringify(cloneConfig, undefined, 2));
+    this.#atomicWriter?.schedule();
+  }
+
+  async asyncDispose(): Promise<void> {
+    await this.#atomicWriter?.asyncDispose();
   }
 
   /**

--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.spec.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import { cpSync, existsSync } from 'node:fs';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, rename, writeFile } from 'node:fs/promises';
 
 import type Electron from 'electron';
 import { safeStorage } from 'electron';
@@ -95,10 +95,20 @@ test('should init safe storage', async () => {
     [fullKey]: base64Encrypted,
   };
 
+  // wait for the serialized write chain to flush
+  await vi.waitFor(() => {
+    expect(vi.mocked(rename)).toHaveBeenCalled();
+  });
+
+  // atomic write: data is written to a unique .tmp file, then renamed into place
   expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
-    expect.stringContaining('data.json'),
+    expect.stringMatching(/data\.json\.tmp-/),
     JSON.stringify(expectedData),
     'utf-8',
+  );
+  expect(vi.mocked(rename)).toHaveBeenCalledWith(
+    expect.stringMatching(/data\.json\.tmp-/),
+    expect.stringMatching(/data\.json$/),
   );
 
   // read again the value
@@ -107,8 +117,24 @@ test('should init safe storage', async () => {
 
   // check delete
   events.length = 0;
+  vi.mocked(writeFile).mockClear();
+  vi.mocked(rename).mockClear();
   await extensionSpecificStorage.delete('key1');
-  expect(vi.mocked(writeFile)).toHaveBeenCalledWith(expect.stringContaining('data.json'), JSON.stringify({}), 'utf-8');
+
+  // wait for the serialized write chain to flush
+  await vi.waitFor(() => {
+    expect(vi.mocked(rename)).toHaveBeenCalled();
+  });
+
+  expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
+    expect.stringMatching(/data\.json\.tmp-/),
+    JSON.stringify({}),
+    'utf-8',
+  );
+  expect(vi.mocked(rename)).toHaveBeenCalledWith(
+    expect.stringMatching(/data\.json\.tmp-/),
+    expect.stringMatching(/data\.json$/),
+  );
 
   // check change event
   expect(events).toEqual([{ key: 'key1' }]);
@@ -125,9 +151,18 @@ test('should init safe storage if error', async () => {
   expect(notifications).toBeDefined();
   expect(notifications.length).toBe(1);
 
-  expect(cpSync).toHaveBeenCalledWith(expect.stringContaining('data.json'), expect.stringContaining('.backup-'));
+  expect(cpSync).toHaveBeenCalledWith(expect.stringMatching(/data\.json$/), expect.stringMatching(/\.backup-/));
 
-  expect(writeFile).toHaveBeenCalledWith(expect.stringContaining('data.json'), JSON.stringify({}), 'utf-8');
+  expect(writeFile).toHaveBeenCalledWith(expect.stringMatching(/data\.json$/), JSON.stringify({}), 'utf-8');
+});
+
+test('should return notification when data.json is corrupt', async () => {
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFile).mockResolvedValue('');
+
+  const notifications = await safeStorageRegistry.init();
+  expect(notifications).toHaveLength(1);
+  expect(notifications[0]!.title).toBe('Corrupted secure storage');
 });
 
 test('should throw error if not initialized', async () => {

--- a/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
+++ b/packages/main/src/plugin/safe-storage/safe-storage-registry.ts
@@ -20,22 +20,24 @@ import { cpSync, existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { Event, NotificationCardOptions } from '@podman-desktop/core-api';
+import type { Event, IAsyncDisposable, NotificationCardOptions } from '@podman-desktop/core-api';
 import { safeStorage } from 'electron';
 import { inject, injectable } from 'inversify';
 
 import { Directories } from '/@/plugin/directories.js';
 import { Emitter } from '/@/plugin/events/emitter.js';
+import { AtomicFileWriter } from '/@/plugin/util/atomic-file-writer.js';
 
 /**
  * Manage the storage of string being encrypted on disk
  * It's only converted to readable content when getting the value
  */
 @injectable()
-export class SafeStorageRegistry {
+export class SafeStorageRegistry implements IAsyncDisposable {
   readonly #directories: Directories;
 
   #extensionStorage: SafeStorage | undefined;
+  #atomicWriter: AtomicFileWriter | undefined;
 
   constructor(@inject(Directories) directories: Directories) {
     this.#directories = directories;
@@ -87,10 +89,13 @@ export class SafeStorageRegistry {
     this.#extensionStorage = new SafeStorage(data);
 
     // in case of an update, persists the new data to the file
-    this.#extensionStorage.onDidChange(async () => {
-      await writeFile(safeStoragePath, JSON.stringify(data), 'utf-8');
-    });
+    this.#atomicWriter = new AtomicFileWriter(safeStoragePath, () => JSON.stringify(data));
+    this.#extensionStorage.onDidChange(() => this.#atomicWriter?.schedule());
     return notifications;
+  }
+
+  async asyncDispose(): Promise<void> {
+    await this.#atomicWriter?.asyncDispose();
   }
 
   getExtensionStorage(extensionId: string): ExtensionSecretStorage {

--- a/packages/main/src/plugin/util/atomic-file-writer.spec.ts
+++ b/packages/main/src/plugin/util/atomic-file-writer.spec.ts
@@ -1,0 +1,107 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { rename, writeFile } from 'node:fs/promises';
+
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { AtomicFileWriter } from './atomic-file-writer.js';
+
+vi.mock(import('node:fs/promises'));
+vi.mock(import('node:crypto'), () => ({
+  randomUUID: vi.fn().mockReturnValue('test-uuid'),
+}));
+
+let writer: AtomicFileWriter;
+const filePath = '/fake/data.json';
+let data: Record<string, string>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  data = {};
+  writer = new AtomicFileWriter(filePath, () => JSON.stringify(data));
+});
+
+test('should write to a unique tmp file then rename into place', async () => {
+  data = { key: 'value' };
+
+  writer.schedule();
+  await writer.flush();
+
+  expect(vi.mocked(writeFile)).toHaveBeenCalledWith('/fake/data.json.tmp-test-uuid', JSON.stringify(data), 'utf-8');
+  expect(vi.mocked(rename)).toHaveBeenCalledWith('/fake/data.json.tmp-test-uuid', filePath);
+});
+
+test('should serialize concurrent writes and persist latest data', async () => {
+  const writeOrder: string[] = [];
+  const payloads: string[] = [];
+  vi.mocked(writeFile).mockImplementation(async (filePath, content) => {
+    writeOrder.push(`write:${String(filePath)}`);
+    payloads.push(String(content));
+  });
+  vi.mocked(rename).mockImplementation(async (src, _dest) => {
+    writeOrder.push(`rename:${String(src)}`);
+  });
+
+  // Mutate data between schedules to simulate real usage
+  data = { a: '1' };
+  writer.schedule();
+  data = { a: '1', b: '2' };
+  writer.schedule();
+  data = { a: '1', b: '2', c: '3' };
+  writer.schedule();
+
+  await writer.flush();
+
+  // Each write+rename pair must complete before the next starts
+  expect(writeOrder).toHaveLength(6);
+  expect(writeOrder).toEqual([
+    expect.stringContaining('write:'),
+    expect.stringContaining('rename:'),
+    expect.stringContaining('write:'),
+    expect.stringContaining('rename:'),
+    expect.stringContaining('write:'),
+    expect.stringContaining('rename:'),
+  ]);
+
+  // The final persisted snapshot must contain all keys
+  expect(JSON.parse(payloads.at(-1)!)).toEqual({ a: '1', b: '2', c: '3' });
+});
+
+test('should recover after a write failure', async () => {
+  vi.mocked(writeFile).mockRejectedValueOnce(new Error('disk full'));
+  const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  writer.schedule();
+  await writer.flush();
+
+  expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Unable to persist'), expect.any(Error));
+
+  vi.mocked(writeFile).mockResolvedValue(undefined);
+  vi.mocked(rename).mockResolvedValue(undefined);
+
+  writer.schedule();
+  await writer.flush();
+
+  expect(vi.mocked(rename)).toHaveBeenCalled();
+  consoleSpy.mockRestore();
+});
+
+test('flush should resolve immediately when no writes are pending', async () => {
+  await expect(writer.flush()).resolves.toBeUndefined();
+});

--- a/packages/main/src/plugin/util/atomic-file-writer.ts
+++ b/packages/main/src/plugin/util/atomic-file-writer.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { randomUUID } from 'node:crypto';
+import { rename, writeFile } from 'node:fs/promises';
+
+import type { IAsyncDisposable } from '@podman-desktop/core-api';
+
+/**
+ * Serializes writes to a single file using an atomic write pattern:
+ * data is written to a unique temporary file, then renamed into place.
+ * This prevents data loss from concurrent writes or mid-write crashes.
+ */
+export class AtomicFileWriter implements IAsyncDisposable {
+  readonly #filePath: string;
+  readonly #getData: () => string;
+  readonly #encoding: BufferEncoding;
+  #writeChain: Promise<void> = Promise.resolve();
+
+  /**
+   * @param filePath - target file path
+   * @param getData - called at write time to get the current content to persist
+   * @param encoding - file encoding (defaults to 'utf-8')
+   */
+  constructor(filePath: string, getData: () => string, encoding: BufferEncoding = 'utf-8') {
+    this.#filePath = filePath;
+    this.#getData = getData;
+    this.#encoding = encoding;
+  }
+
+  /**
+   * Enqueue a write. Writes are serialized: each completes before the next starts.
+   * Errors are logged but do not break the chain.
+   */
+  schedule(): void {
+    this.#writeChain = this.#writeChain
+      .then(async () => {
+        const tmpPath = `${this.#filePath}.tmp-${randomUUID()}`;
+        await writeFile(tmpPath, this.#getData(), this.#encoding);
+        await rename(tmpPath, this.#filePath);
+      })
+      .catch(error => {
+        console.error(`Unable to persist ${this.#filePath}`, error);
+      });
+  }
+
+  /** Wait for all pending writes to complete. */
+  async flush(): Promise<void> {
+    await this.#writeChain;
+  }
+
+  async asyncDispose(): Promise<void> {
+    await this.flush();
+  }
+}


### PR DESCRIPTION
Prevent data loss from concurrent writes and mid-write crashes by serializing onDidChange writes through a promise chain and using a write-to-tmp + rename pattern for atomic file updates.

### What does this PR do?

- Make SafeStorageRegistry and ConfigurationRegistry implement IAsyncDisposable, wired into PluginSystem.asyncDispose() for proper shutdown flushing
- Extract reusable AtomicFileWriter utility class (write-to-tmp + rename, serialized promise chain, error recovery)
- Replace writeFileSync in ConfigurationRegistry.saveDefault() with AtomicFileWriter
- Sequential shutdown disposal: extensions are stopped before plugin system is flushed (extensions may write secrets during teardown)

### What issues does this PR fix or reference?

SafeStorageRegistry writes secrets to data.json using fs.promises.writeFile, which truncates the file before writing. If the process is killed mid-write (force-quit, SIGKILL, power loss), the file is left empty. On next launch, JSON.parse("") fails, triggering a "Corrupted secure storage" notification and losing all stored secrets.

A secondary risk is that rapid onDidChange events can race concurrent writeFile calls with no serialization.

This PR addresses both by chaining writes through a promise and using the write-to-tmp + rename() pattern, which is atomic on POSIX and on Windows within the same volume.

ConfigurationRegistry.saveDefault() used writeFileSync as well, so could also be affected by the same issue. At @benoitf 's request, the fix now covers both data.json (safe storage) and settings.json (configuration).

Ported from https://github.com/openkaiden/kaiden/issues/2735.

Test plan

- [x] Existing safe-storage tests updated and passing
- [x] ConfigurationRegistry tests updated to assert atomic write pattern instead of writeFileSync
- [x] New test: concurrent onDidChange writes are serialized (write+rename pairs interleave correctly)
- [x] New test: corrupt data.json returns notification
- [x] ESLint clean (no new warnings)

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature
