### PR TITLE
test(e2e): filter pods by environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "test:e2e:macos-sanity:run": "node tests/playwright/scripts/run-e2e-suite.mjs --all -g @macos_sanity",
     "test:e2e:pdmachine": "pnpm run test:e2e:build && pnpm run test:e2e:pdmachine:run",
     "test:e2e:pdmachine:run": "node tests/playwright/scripts/run-e2e-suite.mjs --all -g @pdmachine",
+    "test:e2e:pod-environment-filter": "pnpm run test:e2e:build && pnpm run test:e2e:pod-environment-filter:run",
+    "test:e2e:pod-environment-filter:run": "node tests/playwright/scripts/run-e2e-suite.mjs pod-environment-filter",
     "test:e2e:experimental": "pnpm run test:e2e:build && pnpm run test:e2e:experimental:run",
     "test:e2e:experimental:run": "node tests/playwright/scripts/run-e2e-suite.mjs --all -g @experimental",
     "test:e2e:extension": "pnpm run test:e2e:build && pnpm run test:e2e:extension:run",

--- a/tests/playwright/src/model/pages/main-page.ts
+++ b/tests/playwright/src/model/pages/main-page.ts
@@ -222,7 +222,7 @@ export abstract class MainPage extends BasePage {
     return test.step(`Filter ${this.title} by environment: ${environment}`, async () => {
       await playExpect(this.environmentDropdown).toBeVisible();
       await this.environmentDropdown.click();
-      const option = this.environmentDropdown.getByRole('button').filter({ hasText: environment });
+      const option = this.environmentDropdown.getByRole('button', { name: environment, exact: true });
       await playExpect(option).toBeVisible();
       await option.click();
     });

--- a/tests/playwright/src/model/pages/pull-image-page.ts
+++ b/tests/playwright/src/model/pages/pull-image-page.ts
@@ -37,6 +37,7 @@ export class PullImagePage extends BasePage {
   readonly viewDetailsButton: Locator;
   readonly runButton: Locator;
   readonly pullErrorMessage: Locator;
+  readonly containerEngineDropdown: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -62,14 +63,26 @@ export class PullImagePage extends BasePage {
     this.viewDetailsButton = this.tabContent.getByRole('button', { name: 'View details', exact: true });
     this.runButton = this.tabContent.getByRole('button', { name: 'Run', exact: true });
     this.pullErrorMessage = page.getByRole('alert').filter({ hasText: 'no running provider' });
+    this.containerEngineDropdown = this.tabContent.getByLabel('Container Engine');
   }
 
-  async pullImage(imageName: string, tag = '', timeout = 60_000): Promise<ImagesPage> {
+  async pullImage(imageName: string, tag = '', timeout = 60_000, connectionName?: string): Promise<ImagesPage> {
     return test.step(`Pulling image ${imageName}:${tag}`, async () => {
+      if (connectionName) await this.selectContainerEngine(connectionName);
       await this.startPull(imageName, tag);
       await this.waitForPullCompletion(timeout);
       await this.closeButton.click();
       return new ImagesPage(this.page);
+    });
+  }
+
+  async selectContainerEngine(connectionName: string): Promise<void> {
+    return test.step(`Select container engine: ${connectionName}`, async () => {
+      await playExpect(this.containerEngineDropdown).toBeVisible();
+      await this.containerEngineDropdown.click();
+      const option = this.page.getByRole('button', { name: connectionName, exact: true });
+      await playExpect(option).toBeVisible();
+      await option.click();
     });
   }
 

--- a/tests/playwright/src/specs/pod-environment-filter.spec.ts
+++ b/tests/playwright/src/specs/pod-environment-filter.spec.ts
@@ -1,0 +1,140 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { ContainerInteractiveParams } from '/@/model/core/types';
+import { CreateMachinePage } from '/@/model/pages/create-machine-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
+import { expect as playExpect, test } from '/@/utility/fixtures';
+import { deleteContainer, deleteImage, deletePod, deletePodmanMachine } from '/@/utility/operations';
+import { isLinux } from '/@/utility/platform';
+import { getVirtualizationProvider } from '/@/utility/provider';
+import { waitForPodmanMachineStartup, waitWhile } from '/@/utility/wait';
+
+const secondMachineVisibleName = 'podman-machine-second';
+const secondMachineDisplayName = 'Podman Machine second';
+const defaultMachineDisplayName = 'Podman Machine';
+const environmentFilterImage = 'ghcr.io/linuxcontainers/alpine';
+const environmentFilterContainer = 'environment-filter-container';
+const environmentFilterPod = 'environment-filter-pod';
+const containerStartParams: ContainerInteractiveParams = { attachTerminal: false };
+
+test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
+  runner.setVideoAndTraceName('pods-environment-filter-e2e');
+  await welcomePage.handleWelcomePage(true);
+  await waitForPodmanMachineStartup(page);
+  const images = await navigationBar.openImages();
+  await waitWhile(async () => await images.pageIsEmpty(), {
+    sendError: false,
+    message: 'Images page is empty, there are no images present',
+  });
+});
+
+test.describe
+  .serial('Verification of pod filtering by environment', { tag: '@pdmachine' }, () => {
+    test.skip(
+      isLinux || process.env.TEST_PODMAN_MACHINE !== 'true',
+      'Test suite requires a second Podman machine and should only run when TEST_PODMAN_MACHINE is true',
+    );
+
+    test.beforeAll(async ({ page }) => {
+      // The "set as default?" Podman dialog fires asynchronously when the
+      // second machine finishes starting — potentially in the middle of a
+      // later test. Register a locator handler so Playwright auto-dismisses
+      // it whenever it appears, before it can block any UI interaction.
+      const podmanDialog = page.getByRole('dialog', { name: 'Podman', exact: true });
+      await page.addLocatorHandler(podmanDialog, async () => {
+        await podmanDialog.getByRole('button', { name: 'Ignore' }).click();
+      });
+    });
+
+    test.afterAll(async ({ page, runner }) => {
+      test.setTimeout(120_000);
+
+      try {
+        await deletePod(page, environmentFilterPod);
+        await deleteContainer(page, environmentFilterContainer);
+        await deleteImage(page, environmentFilterImage);
+      } finally {
+        await deletePodmanMachine(page, secondMachineVisibleName);
+      }
+      await runner.close();
+    });
+
+    test('Creating a second Podman machine', async ({ navigationBar, page }) => {
+      test.setTimeout(200_000);
+
+      const settingsBar = await navigationBar.openSettings();
+      await settingsBar.resourcesTab.click();
+      const resourcesPage = new ResourcesPage(page);
+      await playExpect(resourcesPage.heading).toBeVisible();
+      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible('podman')).toBeTruthy();
+      await resourcesPage.goToCreateNewResourcePage('podman');
+
+      const createMachinePage = new CreateMachinePage(page);
+      await createMachinePage.createMachine(secondMachineVisibleName, {
+        isRootful: true,
+        startNow: true,
+        setAsDefault: false,
+        virtualizationProvider: getVirtualizationProvider(),
+      });
+    });
+
+    test('Environment filter becomes visible with two running machines', async ({ navigationBar }) => {
+      const pods = await navigationBar.openPods();
+      await playExpect.poll(async () => await pods.isEnvironmentFilterVisible(), { timeout: 30_000 }).toBeTruthy();
+    });
+
+    test('Filtering pods by environment', async ({ navigationBar }) => {
+      test.setTimeout(120_000);
+
+      let images = await navigationBar.openImages();
+      const pullImagePage = await images.openPullImage();
+      images = await pullImagePage.pullImage(environmentFilterImage, 'latest', 60_000, 'podman-machine-default');
+      await playExpect
+        .poll(async () => await images.waitForImageExists(environmentFilterImage), { timeout: 10_000 })
+        .toBeTruthy();
+
+      const imageDetails = await images.openImageDetails(environmentFilterImage);
+      const runImage = await imageDetails.openRunImage();
+      const containers = await runImage.startContainer(environmentFilterContainer, containerStartParams);
+      await playExpect(containers.header).toBeVisible();
+      await playExpect
+        .poll(async () => await containers.containerExists(environmentFilterContainer), { timeout: 15_000 })
+        .toBeTruthy();
+
+      const createPodPage = await containers.openCreatePodPage([environmentFilterContainer]);
+      const pods = await createPodPage.createPod(environmentFilterPod);
+      await playExpect(pods.heading).toBeVisible({ timeout: 60_000 });
+      await playExpect.poll(async () => await pods.podExists(environmentFilterPod), { timeout: 15_000 }).toBeTruthy();
+
+      await test.step(`Filter by ${secondMachineDisplayName} shows no pods`, async () => {
+        await pods.filterByEnvironment(secondMachineDisplayName);
+        await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(0);
+      });
+
+      await test.step(`Filter by ${defaultMachineDisplayName} shows the created pod`, async () => {
+        await pods.filterByEnvironment(defaultMachineDisplayName);
+        await playExpect
+          .poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 })
+          .toBeGreaterThanOrEqual(1);
+        await playExpect.poll(async () => await pods.podExists(environmentFilterPod), { timeout: 10_000 }).toBeTruthy();
+      });
+
+      await pods.clearFilterByEnvironment();
+    });
+  });

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -412,6 +412,17 @@ test.describe
       'Test suite requires a second Podman machine and should only run when TEST_PODMAN_MACHINE is true',
     );
 
+    test.beforeAll(async ({ page }) => {
+      // The "set as default?" Podman dialog fires asynchronously when the
+      // second machine finishes starting — potentially in the middle of a
+      // later test. Register a locator handler so Playwright auto-dismisses
+      // it whenever it appears, before it can block any UI interaction.
+      const podmanDialog = page.getByRole('dialog', { name: 'Podman', exact: true });
+      await page.addLocatorHandler(podmanDialog, async () => {
+        await podmanDialog.getByRole('button', { name: 'Ignore' }).click();
+      });
+    });
+
     test.afterAll(async ({ page }) => {
       test.setTimeout(120_000);
 

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -412,17 +412,6 @@ test.describe
       'Test suite requires a second Podman machine and should only run when TEST_PODMAN_MACHINE is true',
     );
 
-    test.beforeAll(async ({ page }) => {
-      // The "set as default?" Podman dialog fires asynchronously when the
-      // second machine finishes starting — potentially in the middle of a
-      // later test. Register a locator handler so Playwright auto-dismisses
-      // it whenever it appears, before it can block any UI interaction.
-      const podmanDialog = page.getByRole('dialog', { name: 'Podman', exact: true });
-      await page.addLocatorHandler(podmanDialog, async () => {
-        await podmanDialog.getByRole('button', { name: 'Ignore' }).click();
-      });
-    });
-
     test.afterAll(async ({ page }) => {
       test.setTimeout(120_000);
 

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -20,9 +20,13 @@ import * as os from 'node:os';
 
 import { ContainerState, PodState } from '/@/model/core/states';
 import type { ContainerInteractiveParams } from '/@/model/core/types';
+import { CreateMachinePage } from '/@/model/pages/create-machine-page';
 import { PodsPage } from '/@/model/pages/pods-page';
+import { ResourcesPage } from '/@/model/pages/resources-page';
 import { expect as playExpect, test } from '/@/utility/fixtures';
-import { deleteContainer, deleteImage, deletePod } from '/@/utility/operations';
+import { deleteContainer, deleteImage, deletePod, deletePodmanMachine } from '/@/utility/operations';
+import { isLinux } from '/@/utility/platform';
+import { getVirtualizationProvider } from '/@/utility/provider';
 import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '/@/utility/wait';
 
 let backendPort: string;
@@ -39,6 +43,13 @@ const containerNames = ['container1', 'container2', 'container3'];
 const podNames = ['pod1', 'pod2', 'pod3'];
 const containerStartParams: ContainerInteractiveParams = { attachTerminal: false };
 let resetTestData = true;
+
+const secondMachineVisibleName = 'podman-machine-second';
+const secondMachineDisplayName = 'Podman Machine second';
+const defaultMachineDisplayName = 'Podman Machine';
+const environmentFilterImage = 'ghcr.io/linuxcontainers/alpine';
+const environmentFilterContainer = 'environment-filter-container';
+const environmentFilterPod = 'environment-filter-pod';
 
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   runner.setVideoAndTraceName('pods-e2e');
@@ -391,5 +402,88 @@ test.describe
           await playExpect.poll(async () => await podsPage.podExists(pod), { timeout: 15_000 }).toBeFalsy();
         }
       });
+    });
+  });
+
+test.describe
+  .serial('Verification of pod filtering by environment', { tag: '@pdmachine' }, () => {
+    test.skip(
+      isLinux || process.env.TEST_PODMAN_MACHINE !== 'true',
+      'Test suite requires a second Podman machine and should only run when TEST_PODMAN_MACHINE is true',
+    );
+
+    test.afterAll(async ({ page }) => {
+      test.setTimeout(120_000);
+
+      try {
+        await deletePod(page, environmentFilterPod);
+        await deleteContainer(page, environmentFilterContainer);
+        await deleteImage(page, environmentFilterImage);
+      } finally {
+        await deletePodmanMachine(page, secondMachineVisibleName);
+      }
+    });
+
+    test('Creating a second Podman machine', async ({ navigationBar, page }) => {
+      test.setTimeout(200_000);
+
+      const settingsBar = await navigationBar.openSettings();
+      await settingsBar.resourcesTab.click();
+      const resourcesPage = new ResourcesPage(page);
+      await playExpect(resourcesPage.heading).toBeVisible();
+      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible('podman')).toBeTruthy();
+      await resourcesPage.goToCreateNewResourcePage('podman');
+
+      const createMachinePage = new CreateMachinePage(page);
+      await createMachinePage.createMachine(secondMachineVisibleName, {
+        isRootful: true,
+        startNow: true,
+        setAsDefault: false,
+        virtualizationProvider: getVirtualizationProvider(),
+      });
+    });
+
+    test('Environment filter becomes visible with two running machines', async ({ navigationBar }) => {
+      const pods = await navigationBar.openPods();
+      await playExpect.poll(async () => await pods.isEnvironmentFilterVisible(), { timeout: 30_000 }).toBeTruthy();
+    });
+
+    test('Filtering pods by environment', async ({ navigationBar }) => {
+      test.setTimeout(120_000);
+
+      let images = await navigationBar.openImages();
+      const pullImagePage = await images.openPullImage();
+      images = await pullImagePage.pullImage(environmentFilterImage, 'latest', 60_000, 'podman-machine-default');
+      await playExpect
+        .poll(async () => await images.waitForImageExists(environmentFilterImage), { timeout: 10_000 })
+        .toBeTruthy();
+
+      const imageDetails = await images.openImageDetails(environmentFilterImage);
+      const runImage = await imageDetails.openRunImage();
+      const containers = await runImage.startContainer(environmentFilterContainer, containerStartParams);
+      await playExpect(containers.header).toBeVisible();
+      await playExpect
+        .poll(async () => await containers.containerExists(environmentFilterContainer), { timeout: 15_000 })
+        .toBeTruthy();
+
+      const createPodPage = await containers.openCreatePodPage([environmentFilterContainer]);
+      const pods = await createPodPage.createPod(environmentFilterPod);
+      await playExpect(pods.heading).toBeVisible({ timeout: 60_000 });
+      await playExpect.poll(async () => await pods.podExists(environmentFilterPod), { timeout: 15_000 }).toBeTruthy();
+
+      await test.step(`Filter by ${secondMachineDisplayName} shows no pods`, async () => {
+        await pods.filterByEnvironment(secondMachineDisplayName);
+        await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(0);
+      });
+
+      await test.step(`Filter by ${defaultMachineDisplayName} shows the created pod`, async () => {
+        await pods.filterByEnvironment(defaultMachineDisplayName);
+        await playExpect
+          .poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 })
+          .toBeGreaterThanOrEqual(1);
+        await playExpect.poll(async () => await pods.podExists(environmentFilterPod), { timeout: 10_000 }).toBeTruthy();
+      });
+
+      await pods.clearFilterByEnvironment();
     });
   });

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -20,13 +20,9 @@ import * as os from 'node:os';
 
 import { ContainerState, PodState } from '/@/model/core/states';
 import type { ContainerInteractiveParams } from '/@/model/core/types';
-import { CreateMachinePage } from '/@/model/pages/create-machine-page';
 import { PodsPage } from '/@/model/pages/pods-page';
-import { ResourcesPage } from '/@/model/pages/resources-page';
 import { expect as playExpect, test } from '/@/utility/fixtures';
-import { deleteContainer, deleteImage, deletePod, deletePodmanMachine } from '/@/utility/operations';
-import { isLinux } from '/@/utility/platform';
-import { getVirtualizationProvider } from '/@/utility/provider';
+import { deleteContainer, deleteImage, deletePod } from '/@/utility/operations';
 import { waitForPodmanMachineStartup, waitUntil, waitWhile } from '/@/utility/wait';
 
 let backendPort: string;
@@ -43,13 +39,6 @@ const containerNames = ['container1', 'container2', 'container3'];
 const podNames = ['pod1', 'pod2', 'pod3'];
 const containerStartParams: ContainerInteractiveParams = { attachTerminal: false };
 let resetTestData = true;
-
-const secondMachineVisibleName = 'podman-machine-second';
-const secondMachineDisplayName = 'Podman Machine second';
-const defaultMachineDisplayName = 'Podman Machine';
-const environmentFilterImage = 'ghcr.io/linuxcontainers/alpine';
-const environmentFilterContainer = 'environment-filter-container';
-const environmentFilterPod = 'environment-filter-pod';
 
 test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
   runner.setVideoAndTraceName('pods-e2e');
@@ -402,99 +391,5 @@ test.describe
           await playExpect.poll(async () => await podsPage.podExists(pod), { timeout: 15_000 }).toBeFalsy();
         }
       });
-    });
-  });
-
-test.describe
-  .serial('Verification of pod filtering by environment', { tag: '@pdmachine' }, () => {
-    test.skip(
-      isLinux || process.env.TEST_PODMAN_MACHINE !== 'true',
-      'Test suite requires a second Podman machine and should only run when TEST_PODMAN_MACHINE is true',
-    );
-
-    test.beforeAll(async ({ page }) => {
-      // The "set as default?" Podman dialog fires asynchronously when the
-      // second machine finishes starting — potentially in the middle of a
-      // later test. Register a locator handler so Playwright auto-dismisses
-      // it whenever it appears, before it can block any UI interaction.
-      const podmanDialog = page.getByRole('dialog', { name: 'Podman', exact: true });
-      await page.addLocatorHandler(podmanDialog, async () => {
-        await podmanDialog.getByRole('button', { name: 'Ignore' }).click();
-      });
-    });
-
-    test.afterAll(async ({ page }) => {
-      test.setTimeout(120_000);
-
-      try {
-        await deletePod(page, environmentFilterPod);
-        await deleteContainer(page, environmentFilterContainer);
-        await deleteImage(page, environmentFilterImage);
-      } finally {
-        await deletePodmanMachine(page, secondMachineVisibleName);
-      }
-    });
-
-    test('Creating a second Podman machine', async ({ navigationBar, page }) => {
-      test.setTimeout(200_000);
-
-      const settingsBar = await navigationBar.openSettings();
-      await settingsBar.resourcesTab.click();
-      const resourcesPage = new ResourcesPage(page);
-      await playExpect(resourcesPage.heading).toBeVisible();
-      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible('podman')).toBeTruthy();
-      await resourcesPage.goToCreateNewResourcePage('podman');
-
-      const createMachinePage = new CreateMachinePage(page);
-      await createMachinePage.createMachine(secondMachineVisibleName, {
-        isRootful: true,
-        startNow: true,
-        setAsDefault: false,
-        virtualizationProvider: getVirtualizationProvider(),
-      });
-    });
-
-    test('Environment filter becomes visible with two running machines', async ({ navigationBar }) => {
-      const pods = await navigationBar.openPods();
-      await playExpect.poll(async () => await pods.isEnvironmentFilterVisible(), { timeout: 30_000 }).toBeTruthy();
-    });
-
-    test('Filtering pods by environment', async ({ navigationBar }) => {
-      test.setTimeout(120_000);
-
-      let images = await navigationBar.openImages();
-      const pullImagePage = await images.openPullImage();
-      images = await pullImagePage.pullImage(environmentFilterImage, 'latest', 60_000, 'podman-machine-default');
-      await playExpect
-        .poll(async () => await images.waitForImageExists(environmentFilterImage), { timeout: 10_000 })
-        .toBeTruthy();
-
-      const imageDetails = await images.openImageDetails(environmentFilterImage);
-      const runImage = await imageDetails.openRunImage();
-      const containers = await runImage.startContainer(environmentFilterContainer, containerStartParams);
-      await playExpect(containers.header).toBeVisible();
-      await playExpect
-        .poll(async () => await containers.containerExists(environmentFilterContainer), { timeout: 15_000 })
-        .toBeTruthy();
-
-      const createPodPage = await containers.openCreatePodPage([environmentFilterContainer]);
-      const pods = await createPodPage.createPod(environmentFilterPod);
-      await playExpect(pods.heading).toBeVisible({ timeout: 60_000 });
-      await playExpect.poll(async () => await pods.podExists(environmentFilterPod), { timeout: 15_000 }).toBeTruthy();
-
-      await test.step(`Filter by ${secondMachineDisplayName} shows no pods`, async () => {
-        await pods.filterByEnvironment(secondMachineDisplayName);
-        await playExpect.poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 }).toBe(0);
-      });
-
-      await test.step(`Filter by ${defaultMachineDisplayName} shows the created pod`, async () => {
-        await pods.filterByEnvironment(defaultMachineDisplayName);
-        await playExpect
-          .poll(async () => await pods.countRowsFromTable(), { timeout: 10_000 })
-          .toBeGreaterThanOrEqual(1);
-        await playExpect.poll(async () => await pods.podExists(environmentFilterPod), { timeout: 10_000 }).toBeTruthy();
-      });
-
-      await pods.clearFilterByEnvironment();
     });
   });


### PR DESCRIPTION
### What does this PR do?

Adds the missing e2e test coverage requested in #18035: verifying that the Pods
page updates correctly when filtering by environment (Podman machine).

The environment filter dropdown only appears once two or more container
connections are running, so the test provisions a second Podman machine
(`podman-machine-second`), pulls/runs/podifies a small image on the default
machine, and asserts that:
- filtering by the second machine shows 0 pods
- filtering by the default machine shows the created pod

Like the existing multi-machine suite (`z-podman-machine-tests.spec.ts`), this
is gated to run only on non-Linux platforms with `TEST_PODMAN_MACHINE=true`,
and tagged `@pdmachine` so it runs alongside the other Podman machine tests.

Also includes two small supporting fixes discovered while writing the test:
- `PullImagePage.pullImage()` now accepts an optional `connectionName` (via a
  new `selectContainerEngine()` helper) so a test can deterministically choose
  which provider connection an image is pulled onto, instead of relying on
  whatever the UI defaults to when multiple connections exist.
- `MainPage.filterByEnvironment()` (added earlier but never exercised by a
  test) matched the dropdown option by substring (`hasText`), which is
  ambiguous once machine names collide as substrings, e.g. "Podman Machine"
  vs. "Podman Machine second". Switched to an exact accessible-name match.

### Screenshot / video of UI

N/A — test-only change, no UI changes.

### What issues does this PR fix or reference?

Fixes #18035
Related: #14106

### How to test this PR?

On macOS or Windows:

```bash
pnpm test:e2e:suite:build pod-smoke -g @pdmachine
# or, if already built:
TEST_PODMAN_MACHINE=true pnpm test:e2e:suite pod-smoke -g @pdmachine
```

- [x] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)