### PR TITLE
refactor(renderer): extract telemetry checkbox into reusable component

### DIFF
--- a/packages/renderer/src/lib/onboarding/OnboardingWelcomeTelemetry.spec.ts
+++ b/packages/renderer/src/lib/onboarding/OnboardingWelcomeTelemetry.spec.ts
@@ -1,0 +1,141 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import '@testing-library/jest-dom/vitest';
+
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { WelcomeUtils } from '/@/lib/welcome/welcome-utils';
+
+import OnboardingWelcomeTelemetry from './OnboardingWelcomeTelemetry.svelte';
+
+vi.mock(import('/@/lib/welcome/welcome-utils'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(WelcomeUtils.prototype.havePromptedForTelemetry).mockResolvedValue(false);
+  vi.mocked(WelcomeUtils.prototype.setTelemetry).mockResolvedValue();
+  vi.mocked(window.getTelemetryMessages).mockResolvedValue({
+    acceptMessage: 'Help us improve',
+    info: { url: 'https://example.com/privacy', link: 'Privacy statement' },
+  });
+});
+
+describe('OnboardingWelcomeTelemetry', () => {
+  test('shows telemetry checkbox when not previously prompted', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Enable telemetry' })).toBeInTheDocument();
+    });
+  });
+
+  test('persists default telemetry value (true) on mount when not previously prompted', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(WelcomeUtils.prototype.setTelemetry)).toHaveBeenCalledWith(true);
+    });
+  });
+
+  test('hides telemetry when already prompted', async () => {
+    vi.mocked(WelcomeUtils.prototype.havePromptedForTelemetry).mockResolvedValue(true);
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(WelcomeUtils.prototype.havePromptedForTelemetry)).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole('checkbox', { name: 'Enable telemetry' })).not.toBeInTheDocument();
+  });
+
+  test('displays telemetry accept message and privacy link', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Help us improve')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Privacy statement')).toBeInTheDocument();
+    expect(screen.getByText(/You can always modify this preference later/)).toBeInTheDocument();
+  });
+
+  test('checkbox is checked by default', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Enable telemetry' })).toBeChecked();
+    });
+  });
+
+  test('persists telemetry as false immediately when unchecked', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Enable telemetry' })).toBeInTheDocument();
+    });
+
+    vi.mocked(WelcomeUtils.prototype.setTelemetry).mockClear();
+    const checkbox = screen.getByRole('checkbox', { name: 'Enable telemetry' });
+    await fireEvent.click(checkbox);
+
+    expect(checkbox).not.toBeChecked();
+    expect(vi.mocked(WelcomeUtils.prototype.setTelemetry)).toHaveBeenCalledWith(false);
+  });
+
+  test('persists telemetry as true immediately when re-checked', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Enable telemetry' })).toBeInTheDocument();
+    });
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Enable telemetry' });
+    await fireEvent.click(checkbox);
+    vi.mocked(WelcomeUtils.prototype.setTelemetry).mockClear();
+    await fireEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+    expect(vi.mocked(WelcomeUtils.prototype.setTelemetry)).toHaveBeenCalledWith(true);
+  });
+
+  test('clicking the visible Telemetry label toggles the checkbox', async () => {
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Enable telemetry' })).toBeChecked();
+    });
+
+    vi.mocked(WelcomeUtils.prototype.setTelemetry).mockClear();
+    await fireEvent.click(screen.getByText('Telemetry:'));
+
+    expect(screen.getByRole('checkbox', { name: 'Enable telemetry' })).not.toBeChecked();
+    expect(vi.mocked(WelcomeUtils.prototype.setTelemetry)).toHaveBeenCalledWith(false);
+  });
+
+  test('does not show or persist telemetry when already prompted', async () => {
+    vi.mocked(WelcomeUtils.prototype.havePromptedForTelemetry).mockResolvedValue(true);
+    render(OnboardingWelcomeTelemetry);
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(WelcomeUtils.prototype.havePromptedForTelemetry)).toHaveBeenCalled();
+    });
+
+    expect(screen.queryByRole('checkbox', { name: 'Enable telemetry' })).not.toBeInTheDocument();
+    expect(vi.mocked(WelcomeUtils.prototype.setTelemetry)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/onboarding/OnboardingWelcomeTelemetry.svelte
+++ b/packages/renderer/src/lib/onboarding/OnboardingWelcomeTelemetry.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+import type { TelemetryMessages } from '@podman-desktop/core-api';
+import { Checkbox, Link } from '@podman-desktop/ui-svelte';
+import { onMount } from 'svelte';
+
+import { WelcomeUtils } from '/@/lib/welcome/welcome-utils';
+
+const welcomeUtils = new WelcomeUtils();
+let telemetry = $state(true);
+let showTelemetry = $state(false);
+let telemetryMessages: TelemetryMessages | undefined = $state(undefined);
+
+onMount(async () => {
+  const alreadyPrompted = await welcomeUtils.havePromptedForTelemetry();
+  if (!alreadyPrompted) {
+    telemetryMessages = await window.getTelemetryMessages();
+    await welcomeUtils.setTelemetry(telemetry);
+    showTelemetry = true;
+  }
+});
+
+async function toggleTelemetry(): Promise<void> {
+  telemetry = !telemetry;
+  await welcomeUtils.setTelemetry(telemetry);
+}
+</script>
+
+{#if showTelemetry}
+  <div class="flex flex-col justify-end flex-none p-4">
+    <div class="flex flex-row justify-center items-start p-1 text-sm">
+      <Checkbox
+        id="onboarding-telemetry"
+        checked={telemetry}
+        class="text-lg px-2"
+        title="Enable telemetry"
+        onclick={toggleTelemetry}>
+        <div class="text-base font-medium">Telemetry:</div>
+      </Checkbox>
+      <div class="w-2/5 text-[var(--pd-content-card-text)]">
+        {#if telemetryMessages}
+          {telemetryMessages.acceptMessage}
+          {#if telemetryMessages.info}
+            <Link
+              onclick={async (): Promise<void> => { await window.openExternal(telemetryMessages?.info?.url ?? ''); }}>
+              {telemetryMessages.info.link}
+            </Link>
+          {/if}
+        {:else}
+          Help us improve by allowing anonymous usage data to be collected.
+        {/if}
+      </div>
+    </div>
+    <div class="flex justify-center p-1 text-sm text-[var(--pd-content-card-text)]">
+      <div>
+        You can always modify this preference later in Settings &gt; Preferences
+      </div>
+    </div>
+  </div>
+{/if}

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import type { ProviderInfo, TelemetryMessages } from '@podman-desktop/core-api';
+import type { ProviderInfo } from '@podman-desktop/core-api';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 /* eslint-disable import/no-duplicates */
 import { tick } from 'svelte';
@@ -64,68 +64,12 @@ test('Expect that the close button closes the window', async () => {
   expect(button).not.toBeInTheDocument();
 });
 
-test('Expect that telemetry UI is hidden when telemetry has already been prompted', async () => {
-  vi.mocked(window.getConfigurationValue).mockResolvedValue('true');
-  await waitRender({ showWelcome: true, showTelemetry: false });
-  let checkbox;
-  try {
-    checkbox = screen.getByRole('checkbox', { name: 'Enable telemetry' });
-  } catch {
-    // ignore errors
-  }
-  expect(checkbox).toBe(undefined);
-});
-
-test('Expect that telemetry UI is visible when necessary', async () => {
+test('Expect that OnboardingWelcomeTelemetry component is rendered', async () => {
   vi.mocked(window.getTelemetryMessages).mockResolvedValue({ acceptMessage: 'Help improve the product' });
-  await waitRender({ showWelcome: true, showTelemetry: true });
-  const checkbox = screen.getByRole('checkbox', { name: 'Enable telemetry' });
-  expect(checkbox).toBeInTheDocument();
-});
-
-test('Expect that telemetry messages is visible', async () => {
-  const telem: TelemetryMessages = {
-    acceptMessage: 'Help improve the product',
-  };
-  vi.mocked(window.getTelemetryMessages).mockResolvedValue(telem);
-
-  await waitRender({ showWelcome: true, showTelemetry: true });
-
-  const accept = screen.getByText(telem.acceptMessage);
-  expect(accept).toBeInTheDocument();
-});
-
-test('Expect that telemetry link opens url', async () => {
-  const telem: TelemetryMessages = {
-    acceptMessage: 'Help improve the product',
-    info: {
-      link: 'Click here',
-      url: 'info-url',
-    },
-  };
-  vi.mocked(window.getTelemetryMessages).mockResolvedValue(telem);
-
-  await waitRender({ showWelcome: true, showTelemetry: true });
-  const accept = screen.getByText(telem.acceptMessage);
-  expect(accept).toBeInTheDocument();
-
-  const infoLink = screen.getByText(telem.info?.link ?? '');
-  expect(infoLink).toBeInTheDocument();
-
-  await fireEvent.click(infoLink);
-  await vi.waitFor(() => expect(vi.mocked(window.openExternal)).toBeCalledWith(telem.info?.url));
-});
-
-test('Expect that telemetry link is missing when info is not provided', async () => {
-  const telem = {
-    acceptMessage: 'Help improve the product',
-  } as TelemetryMessages;
-  vi.mocked(window.getTelemetryMessages).mockResolvedValue(telem);
-
-  await waitRender({ showWelcome: true, showTelemetry: true });
-
-  const infoLink = screen.queryByRole('link');
-  expect(infoLink).not.toBeInTheDocument();
+  await waitRender({ showWelcome: true });
+  // The telemetry section wrapper is always rendered; detailed behavior is tested in OnboardingWelcomeTelemetry.spec.ts
+  const settingsHint = screen.getByText(/You can always modify this preference later/);
+  expect(settingsHint).toBeInTheDocument();
 });
 
 test('Expect welcome screen to show three checked onboarding providers', async () => {

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-import type { OnboardingInfo, TelemetryMessages, WelcomeMessages } from '@podman-desktop/core-api';
-import { Button, Checkbox, Link, Tooltip } from '@podman-desktop/ui-svelte';
+import type { OnboardingInfo, WelcomeMessages } from '@podman-desktop/core-api';
+import { Button, Checkbox, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
 import { router } from 'tinro';
 
 import DesktopIcon from '/@/lib/images/DesktopIcon.svelte';
+import OnboardingWelcomeTelemetry from '/@/lib/onboarding/OnboardingWelcomeTelemetry.svelte';
 import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
 
@@ -13,10 +14,6 @@ import bgImage from './background.png';
 import { WelcomeUtils } from './welcome-utils';
 
 export let showWelcome = false;
-export let showTelemetry = false;
-
-let telemetry = true;
-let telemetryMessages: TelemetryMessages;
 
 const welcomeUtils = new WelcomeUtils();
 let podmanDesktopVersion: string;
@@ -59,11 +56,6 @@ onMount(async () => {
   router.goto('/');
   welcomeMessages = await window.getWelcomeMessages();
 
-  const telemetryPrompt = await welcomeUtils.havePromptedForTelemetry();
-  if (!telemetryPrompt) {
-    telemetryMessages = await window.getTelemetryMessages();
-    showTelemetry = true;
-  }
   podmanDesktopVersion = await window.getPodmanDesktopVersion();
 
   if (showWelcome) {
@@ -73,9 +65,6 @@ onMount(async () => {
 
 async function closeWelcome(): Promise<void> {
   showWelcome = false;
-  if (showTelemetry) {
-    await welcomeUtils.setTelemetry(telemetry);
-  }
 }
 
 // Function to toggle provider selection
@@ -157,34 +146,7 @@ function startOnboardingQueue(): void {
     </div>
 
     <!-- Telemetry -->
-    {#if showTelemetry}
-      <div class="flex flex-col justify-end flex-none p-4">
-        <div class="flex flex-row justify-center items-start p-1 text-sm">
-          <Checkbox
-            id="toggle-telemetry"
-            bind:checked={telemetry}
-            name="Enable telemetry"
-            class="text-lg px-2"
-            title="Enable telemetry"><div class="text-base font-medium">Telemetry:</div></Checkbox>
-          <div class="w-2/5 text-[var(--pd-content-card-text)]">
-            {#if telemetryMessages}
-              {telemetryMessages.acceptMessage}
-              {#if telemetryMessages?.info}
-                <Link
-                  on:click={async (): Promise<void> => {
-                    await window.openExternal(telemetryMessages.info?.url ?? '');
-                  }}>{telemetryMessages?.info.link}</Link>
-              {/if}
-            {/if}
-          </div>
-        </div>
-        <div class="flex justify-center p-1 text-sm text-[var(--pd-content-card-text)]">
-          <div>
-            You can always modify this preference later in Settings &gt; Preferences
-          </div>
-        </div>
-      </div>
-    {/if}
+    <OnboardingWelcomeTelemetry />
 
     <!-- Footer - button bar -->
     <div class="flex justify-end flex-none bg-[var(--pd-content-bg)] p-8">


### PR DESCRIPTION
### What does this PR do?

Extracts the inline telemetry checkbox from `WelcomePage.svelte` into a standalone `OnboardingWelcomeTelemetry` component. `WelcomePage` now imports and renders the new component, removing duplicated telemetry logic.

The component self-manages its state:
- Checks whether telemetry has already been prompted via `WelcomeUtils.havePromptedForTelemetry()`
- Persists the default value (`true`) on mount when first shown
- Persists immediately on every checkbox toggle (no deferred commit)

This extraction enables reuse in the upcoming onboarding welcome page without code duplication, as requested in https://github.com/podman-desktop/podman-desktop/pull/18925#pullrequestreview-3112849261.

### Screenshot / video of UI

No visual change — the telemetry section renders identically to the previous inline implementation.

### What issues does this PR fix or reference?

Related to #18925

### How to test this PR?

1. Reset onboarding and telemetry state:
```js
window.updateConfigurationValue("telemetry.check", false, "DEFAULT")
await resetOnboarding(["podman-desktop.compose", "podman-desktop.kubectl-cli", "podman-desktop.podman"]);
await updateConfigurationValue("welcome.version", "");
location.reload();
```
2. The welcome page should appear with the telemetry checkbox — verify it looks identical to `main`
3. Open the DevTools console — on load you should see:
```
Telemetry enablement: true
```
4. Uncheck the telemetry checkbox — the console should immediately log:
```
Telemetry enablement: false
```
5. Re-check the checkbox — the console should immediately log:
```
Telemetry enablement: true
```

- [x] Tests are covering the bug fix or the new feature
