### PR TITLE
refactor(main): extract macOS login minimize preference helper

### DIFF
--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -28,10 +28,12 @@ import { DevelopmentModeTracker } from './development-mode-tracker.js';
 import { NavigationItemsMenuBuilder } from './navigation-items-menu-builder.js';
 import { OpenDevTools } from './open-dev-tools.js';
 import type { ConfigurationRegistry } from './plugin/configuration-registry.js';
+import { LoginMinimizeHandler } from './system/window/login-minimize-handler.js';
 import type { WindowHandler } from './system/window/window-handler.js';
 import { isLinux, isMac, stoppedExtensions } from './util.js';
 
 const openDevTools = new OpenDevTools();
+const loginMinimizeHandler = new LoginMinimizeHandler();
 let navigationItemsMenuBuilder: NavigationItemsMenuBuilder;
 
 // development mode for extensions
@@ -140,13 +142,7 @@ async function createWindow(): Promise<BrowserWindow> {
     // check the minimize preference and show or hide accordingly
     if (deferredShow) {
       deferredShow = false;
-      const preferencesConfig = configurationRegistry.getConfiguration('preferences');
-      const minimize = preferencesConfig.get<boolean>('login.minimize');
-      if (minimize) {
-        app.dock?.hide();
-      } else {
-        browserWindow.show();
-      }
+      loginMinimizeHandler.apply(browserWindow, configurationRegistry);
     }
 
     // refresh the value of the development mode config property

--- a/packages/main/src/system/window/login-minimize-handler.spec.ts
+++ b/packages/main/src/system/window/login-minimize-handler.spec.ts
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { BrowserWindow } from 'electron';
+import { app } from 'electron';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import type { ConfigurationRegistry } from '/@/plugin/configuration-registry.js';
+
+import { LoginMinimizeHandler } from './login-minimize-handler.js';
+
+let loginMinimizeHandler: LoginMinimizeHandler;
+
+const getConfigurationMock = vi.fn();
+const configurationRegistryMock = {
+  getConfiguration: getConfigurationMock,
+} as unknown as ConfigurationRegistry;
+
+const showMock = vi.fn();
+const browserWindowMock = {
+  show: showMock,
+} as unknown as BrowserWindow;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  loginMinimizeHandler = new LoginMinimizeHandler();
+});
+
+test('should hide the dock when login.minimize is true', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => true,
+  });
+
+  loginMinimizeHandler.apply(browserWindowMock, configurationRegistryMock);
+
+  expect(app.dock?.hide).toBeCalled();
+  expect(browserWindowMock.show).not.toBeCalled();
+});
+
+test('should show the window when login.minimize is false', async () => {
+  getConfigurationMock.mockReturnValue({
+    get: () => false,
+  });
+
+  loginMinimizeHandler.apply(browserWindowMock, configurationRegistryMock);
+
+  expect(browserWindowMock.show).toBeCalled();
+  expect(app.dock?.hide).not.toBeCalled();
+});

--- a/packages/main/src/system/window/login-minimize-handler.ts
+++ b/packages/main/src/system/window/login-minimize-handler.ts
@@ -1,0 +1,42 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import { app, type BrowserWindow } from 'electron';
+
+/**
+ * On macOS, app.setLoginItemSettings() does not support passing CLI arguments,
+ * so a login item launch cannot be told to start minimized the way the
+ * --minimize flag does on Windows. The preferences.login.minimize setting is
+ * the only signal available, and it is only readable once the configuration
+ * registry has been built.
+ *
+ * This class applies that setting to a window whose show was deferred until
+ * the registry arrived.
+ */
+export class LoginMinimizeHandler {
+  apply(browserWindow: BrowserWindow, configurationRegistry: IConfigurationRegistry): void {
+    const preferencesConfig = configurationRegistry.getConfiguration('preferences');
+    const minimize = preferencesConfig.get<boolean>('login.minimize');
+    if (minimize) {
+      app.dock?.hide();
+    } else {
+      browserWindow.show();
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Split out of #18728 at @simonrey1's request, so the behavior change there can be reviewed on
its own and bisected independently.

Extracts the show/hide decision for a macOS login item launch out of
`packages/main/src/mainWindow.ts` into `LoginMinimizeHandler` — a class with a single
`apply(browserWindow, configurationRegistry)` method in
`packages/main/src/system/window/login-minimize-handler.ts`, alongside the other window
helpers — so it can be reused and covered by its own unit tests (per @benoitf's review).

Also in `mainWindow.ts`:

- Types `configurationRegistry` as `ConfigurationRegistry | undefined`, matching the fact that
  it is unset until the `configuration-registry` IPC event arrives.
- Annotates that IPC payload as `ConfigurationRegistry` so the variable narrows after
  assignment (per https://github.com/podman-desktop/podman-desktop/pull/18728#discussion_r3914112249).

No behavior change: the extracted method has exactly one caller and runs the same code it
replaced.

### Screenshot / video of UI

N/A — no UI change.

### What issues does this PR fix or reference?

References #17551, refs #18728. Deliberately not `Fixes` — this PR alone changes no behavior;
the fix follows in #18728 once this merges.

### How to test this PR?

```
pnpm test:unit --filter @podman-desktop/main
```

`packages/main/src/system/window/login-minimize-handler.spec.ts` covers the extracted class
directly. The existing macOS login-item tests in `packages/main/src/mainWindow.spec.ts` are
unmodified and still pass — they exercise the same code through the `configuration-registry`
IPC handler.

- [x] Tests are covering the bug fix or the new feature

This PR was written in part with the assistance of generative AI.
