### PR TITLE
chore: ignore few sonarlint rules in playwright tests

### DIFF
--- a/tests/playwright/src/specs/container-smoke.spec.ts
+++ b/tests/playwright/src/specs/container-smoke.spec.ts
@@ -140,6 +140,7 @@ test.describe('Verification of container creation workflow', { tag: ['@smoke'] }
 
     await playExpect(containersDetails.terminalContent).toBeVisible();
     await playExpect(containersDetails.terminalContent).toContainText('#');
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests
     await page.waitForTimeout(1_000);
     await containersDetails.terminalInput.pressSequentially('ps', { delay: 15 });
     await containersDetails.terminalInput.press('Enter');

--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -251,6 +251,7 @@ test.describe
 
       await playExpect(containerDetailsPage.terminalContent).toBeVisible();
       await playExpect(containerDetailsPage.terminalContent).toContainText('@');
+      // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests
       await page.waitForTimeout(1_000);
       await containerDetailsPage.terminalInput.pressSequentially('pwd', { delay: 15 });
       await containerDetailsPage.terminalInput.press('Enter');
@@ -269,6 +270,7 @@ test.describe
 
       await playExpect(containerDetailsPage.terminalContent).toBeVisible();
       await playExpect(containerDetailsPage.terminalContent).toContainText('@');
+      // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests
       await page.waitForTimeout(1_000);
 
       // Use grep -q to avoid flooding the xterm buffer with the full HTML response,


### PR DESCRIPTION
⚠️ this PR is targeting a dependabot branch

### What does this PR do?
I fixed other new linting rules reports, only 3 errors remain in tests/playwright

owners want to keep their timing wait vs conditional wait

ignore, adding comments, so it'll possible to update sonarjs eslint plug-in
(and I can't add comments if the rule is not defined this is why it's a PR against the dependabot branch)

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/pull/18368

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
