### PR TITLE
fix: resolve GHSA-5jgf-p345-68v8 in fast-uri

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ overrides:
   follow-redirects: ^1.16.0
   uuid: ^14.0.0
   ip-address: '>=10.3.1'
-  fast-uri: '>=4.1.2'
+  fast-uri: '>=4.1.3'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   mermaid: '>=11.16.1'
   ws@^8: '>=8.20.1'
@@ -7853,8 +7853,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.2:
-    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
+  fast-uri@4.1.4:
+    resolution: {integrity: sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -18319,7 +18319,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.2
+      fast-uri: 4.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20757,7 +20757,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.2: {}
+  fast-uri@4.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,7 @@ overrides:
   follow-redirects: ^1.16.0
   uuid: ^14.0.0
   ip-address: '>=10.3.1'
-  fast-uri: '>=4.1.2'
+  fast-uri: '>=4.1.3'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4'
   mermaid: '>=11.16.1'
   ws@^8: '>=8.20.1'


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-5jgf-p345-68v8 in `fast-uri`.

**Advisory**: fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references
**Vulnerable versions**: >=4.0.1 <4.1.3
**Patched versions**: >=4.1.3
**Advisory URL**: https://github.com/advisories/GHSA-5jgf-p345-68v8

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-5jgf-p345-68v8: _fast-uri vulnerable to host confusion via skipped IDN canonicalization on scheme-relative references_

### How to test this PR?

Run `pnpm audit` and verify GHSA-5jgf-p345-68v8 is no longer reported