### PR TITLE
fix(main): align permission type with Electron 44.1.0 in security-restrictions

### DIFF
--- a/packages/main/src/security-restrictions.ts
+++ b/packages/main/src/security-restrictions.ts
@@ -18,42 +18,19 @@
 
 import { URL } from 'node:url';
 
-import type { App as ElectronApp, Event as ElectronEvent, WebContents } from 'electron';
+import type { App as ElectronApp, Event as ElectronEvent, Session, WebContents } from 'electron';
 import { shell } from 'electron';
 
 import { securityRestrictionCurrentHandler } from './security-restrictions-handler.js';
+
+type PermissionRequestPermission = Parameters<NonNullable<Parameters<Session['setPermissionRequestHandler']>[0]>>[1];
 
 /**
  * List of origins that you allow open INSIDE the application and permissions for each of them.
  *
  * In development mode you need allow open `VITE_DEV_SERVER_URL`
  */
-const ALLOWED_ORIGINS_AND_PERMISSIONS = new Map<
-  string,
-  Set<
-    | 'clipboard-read'
-    | 'clipboard-sanitized-write'
-    | 'media'
-    | 'display-capture'
-    | 'keyboardLock'
-    | 'mediaKeySystem'
-    | 'geolocation'
-    | 'notifications'
-    | 'midi'
-    | 'midiSysex'
-    | 'pointerLock'
-    | 'fullscreen'
-    | 'openExternal'
-    | 'window-management'
-    | 'window-placement'
-    | 'idle-detection'
-    | 'speaker-selection'
-    | 'storage-access'
-    | 'top-level-storage-access'
-    | 'fileSystem'
-    | 'unknown'
-  >
->(
+const ALLOWED_ORIGINS_AND_PERMISSIONS = new Map<string, Set<PermissionRequestPermission>>(
   import.meta.env.DEV && import.meta.env.VITE_DEV_SERVER_URL
     ? [[new URL(import.meta.env.VITE_DEV_SERVER_URL).origin, new Set(['clipboard-sanitized-write', 'clipboard-read'])]]
     : [],


### PR DESCRIPTION
### What does this PR do?

Electron 44.1.0 expanded the `permission` union type in `Session.setPermissionRequestHandler()` with ~25 new values (e.g. `ar`, `usb`, `vr`, `nfc`, `serial`, etc.), causing `pnpm run typecheck:main` to fail.

Instead of manually updating the hardcoded permission union, this PR derives the type directly from Electron's `Session` type using `Parameters<>`, so it stays in sync automatically with future Electron upgrades.

### Screenshot / video of UI

N/A — no UI changes.

### What issues does this PR fix or reference?
Fixes typecheck failure introduced by #19084 (Electron 44.0.0 → 44.1.0 bump).


### How to test this PR?

Run `pnpm run typecheck:main` — it should pass without errors.

- [x] Tests are covering the bug fix or the new feature