### PR TITLE
refactor(renderer): extract onboarding extensions sorting into utility

### DIFF
--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { OnboardingInfo, WelcomeMessages } from '@podman-desktop/core-api';
+import type { WelcomeMessages } from '@podman-desktop/core-api';
 import { Button, Checkbox, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
@@ -11,6 +11,7 @@ import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
 
 import bgImage from './background.png';
+import type { OnboardingInfoWithAdditionalInfo } from './welcome-utils';
 import { WelcomeUtils } from './welcome-utils';
 
 export let showWelcome = false;
@@ -18,34 +19,10 @@ export let showWelcome = false;
 const welcomeUtils = new WelcomeUtils();
 let podmanDesktopVersion: string;
 
-// Extend ProviderInfo to have a selected property
-interface OnboardingInfoWithAdditionalInfo extends OnboardingInfo {
-  selected?: boolean;
-  containerEngine?: boolean;
-}
-
 let onboardingProviders: OnboardingInfoWithAdditionalInfo[] = [];
 let welcomeMessages: WelcomeMessages;
 
-// Get every provider that has a container connections
-$: providersWithContainerConnections = $providerInfos.filter(provider => provider.containerConnections.length > 0);
-
-// Using providerInfos as well as the information we have from onboarding,
-// we will by default auto-select as well as add containerEngine to the list as true/false
-// so we can make sure that extensions with container engines are listed first
-$: onboardingProviders = $onboardingList
-  .map(provider => {
-    // Check if it's in the list, if it is, then it has a container engine
-    const hasContainerConnection = providersWithContainerConnections.some(
-      connectionProvider => connectionProvider.extensionId === provider.extension,
-    );
-    return {
-      ...provider,
-      selected: true,
-      containerEngine: hasContainerConnection,
-    };
-  })
-  .toSorted((a, b) => Number(b.containerEngine) - Number(a.containerEngine)); // Sort by containerEngine (true first)
+$: onboardingProviders = welcomeUtils.getSortedOnboardingExtensions($onboardingList, $providerInfos);
 
 onMount(async () => {
   const ver = await welcomeUtils.getVersion();

--- a/packages/renderer/src/lib/welcome/welcome-utils.spec.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.spec.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { OnboardingInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { WelcomeSettings } from '@podman-desktop/core-api/welcome';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { WelcomeUtils } from './welcome-utils';
 
@@ -44,4 +45,77 @@ test('should expect value', async () => {
   expect(vi.mocked(window.getConfigurationValue)).toHaveBeenCalledWith(
     WelcomeSettings.SectionName + '.' + WelcomeSettings.Version,
   );
+});
+
+const baseExtension: OnboardingInfo = {
+  extension: 'ext1',
+  name: 'ext1',
+  displayName: 'Extension 1',
+  icon: '',
+  description: 'First extension',
+  steps: [],
+  title: 'Extension 1',
+  removable: true,
+  enablement: '',
+};
+
+describe('getSortedOnboardingExtensions', () => {
+  test('returns empty array for empty inputs', () => {
+    expect(welcomeUtils.getSortedOnboardingExtensions([], [])).toEqual([]);
+  });
+
+  test('marks all extensions as selected by default', () => {
+    const extensions = [baseExtension];
+    const result = welcomeUtils.getSortedOnboardingExtensions(extensions, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.selected).toBe(true);
+  });
+
+  test('sets containerEngine true when provider has container connections', () => {
+    const extensions = [baseExtension];
+    const providers = [
+      { extensionId: 'ext1', containerConnections: [{ name: 'connection1' }] },
+    ] as unknown as ProviderInfo[];
+
+    const result = welcomeUtils.getSortedOnboardingExtensions(extensions, providers);
+
+    expect(result[0]?.containerEngine).toBe(true);
+  });
+
+  test('sets containerEngine false when provider has no container connections', () => {
+    const extensions = [baseExtension];
+    const providers = [{ extensionId: 'ext1', containerConnections: [] }] as unknown as ProviderInfo[];
+
+    const result = welcomeUtils.getSortedOnboardingExtensions(extensions, providers);
+
+    expect(result[0]?.containerEngine).toBe(false);
+  });
+
+  test('sorts extensions with container engines first', () => {
+    const extensions = [
+      { ...baseExtension, extension: 'no-engine', name: 'no-engine', displayName: 'No Engine' },
+      { ...baseExtension, extension: 'has-engine', name: 'has-engine', displayName: 'Has Engine' },
+    ];
+    const providers = [
+      { extensionId: 'has-engine', containerConnections: [{ name: 'conn' }] },
+    ] as unknown as ProviderInfo[];
+
+    const result = welcomeUtils.getSortedOnboardingExtensions(extensions, providers);
+
+    expect(result[0]?.extension).toBe('has-engine');
+    expect(result[1]?.extension).toBe('no-engine');
+  });
+
+  test('does not mutate the input array', () => {
+    const extensions = [
+      { ...baseExtension, extension: 'b' },
+      { ...baseExtension, extension: 'a' },
+    ];
+    const original = [...extensions];
+
+    welcomeUtils.getSortedOnboardingExtensions(extensions, []);
+
+    expect(extensions).toEqual(original);
+  });
 });

--- a/packages/renderer/src/lib/welcome/welcome-utils.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.ts
@@ -16,9 +16,16 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import type { OnboardingInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { CONFIGURATION_DEFAULT_SCOPE } from '@podman-desktop/core-api/configuration';
 import { TelemetrySettings } from '@podman-desktop/core-api/telemetry';
 import { WelcomeSettings } from '@podman-desktop/core-api/welcome';
+
+// Extend OnboardingInfo to have a selected and containerEngine property
+export interface OnboardingInfoWithAdditionalInfo extends OnboardingInfo {
+  selected?: boolean;
+  containerEngine?: boolean;
+}
 
 export class WelcomeUtils {
   async getVersion(): Promise<string | undefined> {
@@ -58,5 +65,31 @@ export class WelcomeUtils {
       true,
       CONFIGURATION_DEFAULT_SCOPE,
     );
+  }
+
+  /**
+   * Returns onboarding extensions sorted so that extensions with an active
+   * container engine connection appear first. Each entry is enriched with
+   * `selected` (default true) and `containerEngine` flags.
+   *
+   * Using providerInfos as well as the information we have from onboarding,
+   * we will by default auto-select as well as add containerEngine to the list as true/false
+   * so we can make sure that extensions with container engines are listed first.
+   */
+  getSortedOnboardingExtensions(
+    onboardingList: OnboardingInfo[],
+    providerInfos: ProviderInfo[],
+  ): OnboardingInfoWithAdditionalInfo[] {
+    // Get every provider that has container connections
+    const connectedExtensionIds = new Set(
+      providerInfos.filter(p => p.containerConnections.length > 0).map(p => p.extensionId),
+    );
+    return onboardingList
+      .map(o => ({
+        ...o,
+        selected: true,
+        containerEngine: connectedExtensionIds.has(o.extension),
+      }))
+      .toSorted((a, b) => Number(b.containerEngine) - Number(a.containerEngine)); // Sort by containerEngine (true first)
   }
 }


### PR DESCRIPTION
### What does this PR do?

Extracts the onboarding extensions sorting logic from `WelcomePage.svelte` into a reusable `getSortedOnboardingExtensions()` method on the `WelcomeUtils` class in `welcome-utils.ts`.

The method takes the raw onboarding list and provider infos, then returns extensions enriched with `selected` and `containerEngine` flags, sorted so that extensions with active container connections appear first.

This enables reuse in the upcoming onboarding welcome page without code duplication.

### Screenshot / video of UI

No visual change — the welcome page renders identically to the previous inline implementation.

### What issues does this PR fix or reference?

Related to #18925

### How to test this PR?

1. Reset onboarding state:
```js
window.updateConfigurationValue('telemetry.check', false, 'DEFAULT')
await resetOnboarding(['podman-desktop.compose', 'podman-desktop.kubectl-cli', 'podman-desktop.podman']);
await updateConfigurationValue('welcome.version', '');
location.reload();
```
2. The welcome page should appear with extensions listed — verify extensions with active container engines (e.g. Podman) appear first
3. Verify checkbox toggling and Start onboarding / Skip still work as before

- [x] Tests are covering the bug fix or the new feature
