### PR TITLE
refactor(renderer): extract first-run enforcement into WelcomeUtils.enforceFirstRun()

### DIFF
--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -25,19 +25,11 @@ let welcomeMessages: WelcomeMessages;
 $: onboardingProviders = welcomeUtils.getSortedOnboardingExtensions($onboardingList, $providerInfos);
 
 onMount(async () => {
-  const ver = await welcomeUtils.getVersion();
-  if (!ver) {
-    await welcomeUtils.updateVersion('initial');
-    showWelcome = true;
-  }
+  const result = await welcomeUtils.enforceFirstRun();
+  podmanDesktopVersion = result.version;
+  showWelcome = result.firstRun;
   router.goto('/');
   welcomeMessages = await window.getWelcomeMessages();
-
-  podmanDesktopVersion = await window.getPodmanDesktopVersion();
-
-  if (showWelcome) {
-    await window.updateConfigurationValue(`releaseNotesBanner.show`, podmanDesktopVersion);
-  }
 });
 
 async function closeWelcome(): Promise<void> {

--- a/packages/renderer/src/lib/welcome/welcome-utils.spec.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.spec.ts
@@ -119,3 +119,30 @@ describe('getSortedOnboardingExtensions', () => {
     expect(extensions).toEqual(original);
   });
 });
+
+describe('enforceFirstRun', () => {
+  test('returns firstRun true and sets version on first run', async () => {
+    vi.mocked(window.getPodmanDesktopVersion).mockResolvedValue('1.2.3');
+    vi.mocked(window.getConfigurationValue).mockResolvedValue(undefined);
+
+    const result = await welcomeUtils.enforceFirstRun();
+
+    expect(result).toEqual({ version: '1.2.3', firstRun: true });
+    expect(vi.mocked(window.updateConfigurationValue)).toHaveBeenCalledWith(
+      WelcomeSettings.SectionName + '.' + WelcomeSettings.Version,
+      'initial',
+      'DEFAULT',
+    );
+    expect(vi.mocked(window.updateConfigurationValue)).toHaveBeenCalledWith('releaseNotesBanner.show', '1.2.3');
+  });
+
+  test('returns firstRun false when version already set', async () => {
+    vi.mocked(window.getPodmanDesktopVersion).mockResolvedValue('1.2.3');
+    vi.mocked(window.getConfigurationValue).mockResolvedValue('initial');
+
+    const result = await welcomeUtils.enforceFirstRun();
+
+    expect(result).toEqual({ version: '1.2.3', firstRun: false });
+    expect(vi.mocked(window.updateConfigurationValue)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/src/lib/welcome/welcome-utils.ts
+++ b/packages/renderer/src/lib/welcome/welcome-utils.ts
@@ -92,4 +92,21 @@ export class WelcomeUtils {
       }))
       .toSorted((a, b) => Number(b.containerEngine) - Number(a.containerEngine)); // Sort by containerEngine (true first)
   }
+
+  /**
+   * Checks if this is the first run. Fetches the current app version,
+   * and if no previous version is stored, marks it as 'initial' and
+   * suppresses the release notes banner.
+   * Returns the app version and whether this is the first run.
+   */
+  async enforceFirstRun(): Promise<{ version: string; firstRun: boolean }> {
+    const version = await window.getPodmanDesktopVersion();
+    const ver = await this.getVersion();
+    if (!ver) {
+      await this.updateVersion('initial');
+      await window.updateConfigurationValue('releaseNotesBanner.show', version);
+      return { version, firstRun: true };
+    }
+    return { version, firstRun: false };
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Extracts the first-run version check logic from `WelcomePage.svelte` into a reusable `checkFirstRun()` method on the `WelcomeUtils` class.

The method:
- Fetches the current app version via `window.getPodmanDesktopVersion()`
- Checks if a previous version is stored
- If not (first run), marks it as `initial` and sets `releaseNotesBanner.show` to the current version
- Returns `{ version, firstRun }` for the caller

This enables reuse in the upcoming onboarding welcome page without code duplication.

Related to #18925

### Screenshot / video of UI

No visual change — the welcome page renders identically to the previous inline implementation.

### How to test this PR?

1. Reset state in the dev console:
```js
window.updateConfigurationValue('telemetry.check', false, 'DEFAULT')
await resetOnboarding(['podman-desktop.compose', 'podman-desktop.kubectl-cli', 'podman-desktop.podman']);
await updateConfigurationValue('welcome.version', '');
location.reload();
```
2. The welcome page should appear — verify version is displayed and extensions are listed
3. On subsequent loads, the welcome page should not reappear (version is stored)

- [x] Tests are covering the bug fix or the new feature
