### PR TITLE
chore(flatpak): upgrade runtime and SDK to 26.08

### DIFF
--- a/.electron-builder.config.cjs
+++ b/.electron-builder.config.cjs
@@ -237,7 +237,7 @@ const config = {
     ],
     useWaylandFlags: 'false',
     artifactName: `${product.artifactName}-\${version}.\${ext}`,
-    runtimeVersion: '25.08',
+    runtimeVersion: '26.08',
     branch: 'main',
     files: [
       ['.flatpak-appdata.xml', '/share/metainfo/io.podman_desktop.PodmanDesktop.metainfo.xml'],

--- a/.github/workflows/daily-testing-build.yaml
+++ b/.github/workflows/daily-testing-build.yaml
@@ -161,7 +161,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//26.08 org.freedesktop.Sdk//26.08
 
       - name: Run Windows Build and Compile
         if: runner.os == 'Windows' && env.BUILD_ALL != 'true'

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -166,7 +166,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder elfutils
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install --user -y flathub org.flatpak.Builder org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+          flatpak install --user -y flathub org.flatpak.Builder org.freedesktop.Platform//26.08 org.freedesktop.Sdk//26.08
 
       - name: Run E2E tests in Production Mode
         if: matrix.installation == 'source-build'

--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -133,7 +133,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --user -y org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+          flatpak install flathub --user -y org.freedesktop.Platform//26.08 org.freedesktop.Sdk//26.08
 
       - name: Set macOS environment variables
         if: startsWith(matrix.os, 'macos')

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -109,7 +109,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --user -y org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+          flatpak install flathub --user -y org.freedesktop.Platform//26.08 org.freedesktop.Sdk//26.08
 
       - name: Run Build
         timeout-minutes: 20

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -182,7 +182,7 @@ jobs:
           sudo apt-get install flatpak-builder -y
           sudo apt-get install elfutils -y
           flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+          flatpak install flathub --no-static-deltas --user -y org.freedesktop.Platform//26.08 org.freedesktop.Sdk//26.08
       - name: Set macOS environment variables
         if: startsWith(matrix.os, 'macos')
         run: |

--- a/website/docs/troubleshooting/troubleshooting-flatpak.md
+++ b/website/docs/troubleshooting/troubleshooting-flatpak.md
@@ -20,7 +20,7 @@ When you install Podman Desktop from Flathub, the permissions declared in [`io.p
 
   ```shell-session
   $ flatpak remote-add --if-not-exists flathub --user https://flathub.org/repo/flathub.flatpakrepo
-  $ flatpak install --user flathub org.flatpak.Builder org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08
+  $ flatpak install --user flathub org.flatpak.Builder org.freedesktop.Platform//26.08 org.freedesktop.Sdk//26.08
   ```
 
 #### Procedure: Testing a release bundle


### PR DESCRIPTION
### What does this PR do?

Bump the Flatpak `org.freedesktop.Platform` and `org.freedesktop.Sdk` from `25.08` to `26.08` in the electron-builder config, all CI workflows, and troubleshooting docs.

### Screenshot / video of UI

N/A — no UI changes.

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/19061

### How to test this PR?

- CI flatpak build (pr-check) passes with the 26.08 runtime
- Verify the flatpak bundle installs and launches correctly

- [ ] Tests are covering the bug fix or the new feature
