### PR TITLE
fix(main): update stream-json import for v3 ESM migration

### DIFF
--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -83,7 +83,7 @@ import Dockerode from 'dockerode';
 import { inject, injectable } from 'inversify';
 import moment from 'moment';
 import { coerce, gtr, lt } from 'semver';
-import { withParserAsStream } from 'stream-json/streamers/stream-values.js';
+import streamValues from 'stream-json/streamers/stream-values.js';
 import type { Headers, Pack, PackOptions } from 'tar-fs';
 
 import { KubePlayContext } from '/@/plugin/podman/kube.js';
@@ -288,7 +288,7 @@ export class ContainerProviderRegistry {
         errorCallback(new Error('Error in handling events', error));
       });
 
-      const pipeline = stream?.pipe(withParserAsStream());
+      const pipeline = stream?.pipe(streamValues.withParserAsStream());
       pipeline?.on('error', error => {
         console.error('Error while parsing events', error);
         pipeline.destroy();
@@ -2717,7 +2717,7 @@ export class ContainerProviderRegistry {
         stream = (await containerObject.stats({ stream: true })) as unknown as NodeJS.ReadableStream;
         this.statsConsumer.set(this.statsConsumerId, stream);
 
-        const pipeline = stream?.pipe(withParserAsStream());
+        const pipeline = stream?.pipe(streamValues.withParserAsStream());
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         pipeline?.on('error', (error: any) => {
           console.error('Error while grabbing stats', error);


### PR DESCRIPTION
⚠️ this PR is targeting a dependabot branch

## What does this PR do?

Fixes the `stream-json` v3 import in `container-registry.ts`.

stream-json v3 migrated from CommonJS to ESM. The `withParserAsStream` function
is no longer a named export — it is now a method on the default export
`streamValues`. This updates the import and both call sites accordingly.

Fixes CI failures on #19036.

## Screenshot / video of UI

N/A — no UI changes.

## What issues does this PR fix or reference?

Fixes failing checks on #19036
fixes https://github.com/podman-desktop/podman-desktop/issues/17744

## How to test this PR?

- [x] `pnpm typecheck` passes
- [x] `npx vitest run packages/main/src/plugin/container-registry.spec.ts` — all 222 tests pass
- [x] Tests are covering the bug fix or the new feature