### PR TITLE
fix(renderer): import IDisposable from @xterm/xterm instead of monaco-editor

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.svelte
@@ -7,8 +7,7 @@ import { TerminalSettings } from '@podman-desktop/core-api/terminal';
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { FitAddon } from '@xterm/addon-fit';
 import { SerializeAddon } from '@xterm/addon-serialize';
-import { Terminal } from '@xterm/xterm';
-import type { IDisposable } from 'monaco-editor';
+import { type IDisposable, Terminal } from '@xterm/xterm';
 import { onDestroy, onMount } from 'svelte';
 
 import { getTerminalTheme } from '/@/lib/terminal/terminal-theme';


### PR DESCRIPTION
### What does this PR do?

Import `IDisposable` from `@xterm/xterm` instead of `monaco-editor` in `PreferencesConnectionDetailsTerminal.svelte`.

This terminal component uses `@xterm/xterm` not `monaco-editor`. The `IDisposable` type was imported from `monaco-editor`, creating an unnecessary coupling to a heavy editor package from an unrelated terminal component. Both `@xterm/xterm` and `monaco-editor` export the same `IDisposable` interface, so the import is simply moved to the package that is already used (`@xterm/xterm` is imported on the same line for `Terminal`).

This also avoids a potential build issue when `monaco-editor` reorganizes its ESM exports (as happened in 0.56.0), since this file has no reason to depend on `monaco-editor` at all.

### Screenshot / video of UI

N/A — no UI change, type-only import fix.

### What issues does this PR fix or reference?

Related to #18471 (monaco-editor 0.56.0 upgrade) — reduces the surface area of monaco-editor imports across the codebase.

### How to test this PR?

1. `pnpm install`
2. `pnpm typecheck` — passes
3. `npx vitest run packages/renderer/src/lib/preferences/PreferencesConnectionDetailsTerminal.spec.ts` — 2 tests pass
4. `pnpm lint:check` — passes

- [x] Tests are covering the bug fix or the new feature