### PR TITLE
fix(renderer): update monaco-editor worker imports for 0.56.0 module reorganization

### DIFF
--- a/packages/renderer/src/lib/editor/MonacoEditor.svelte
+++ b/packages/renderer/src/lib/editor/MonacoEditor.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import { EditorSettings } from '@podman-desktop/core-api/editor';
 import type monaco from 'monaco-editor';
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
-import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import editorWorker from 'monaco-editor/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/language/json/json.worker?worker';
 import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 import type { Unsubscriber } from 'svelte/store';
 


### PR DESCRIPTION
⚠️ targeting a dependabot branch

### What does this PR do?

Update monaco-editor worker import paths for the 0.56.0 ESM module reorganization.

Monaco-editor 0.56.0 changed its `exports` map from `"./*": "./*"` (passthrough) to `"./*": "./esm/vs/*.js"` (remapped). This means imports using the old `esm/vs/` prefix now resolve to a doubled, non-existent path (`esm/vs/esm/vs/...`), breaking the build.

The fix drops the `esm/vs/` prefix from the two worker imports:
- `monaco-editor/esm/vs/editor/editor.worker` → `monaco-editor/editor/editor.worker`
- `monaco-editor/esm/vs/language/json/json.worker` → `monaco-editor/language/json/json.worker`

### Screenshot / video of UI

N/A — no UI change, import path fix only.

### What issues does this PR fix or reference?

Fixes the build failure introduced by #18471 (monaco-editor 0.55.1 → 0.56.0).

Same fix as applied in [extension-kubernetes-dashboard#1199](https://github.com/podman-desktop/extension-kubernetes-dashboard/pull/1199).

### How to test this PR?

1. `pnpm install`
2. `pnpm build` — should succeed (currently fails without this fix)
3. `pnpm typecheck` — passes

- [x] Tests are covering the bug fix or the new feature