### PR TITLE
fix: resolve GHSA-6gmq-8vp8-gcm6 in @xmldom/xmldom

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   extract-zip>yauzl: ^3.3.1
-  '@xmldom/xmldom': ^0.8.12
+  '@xmldom/xmldom': ^0.8.15
   rollup: ^4.59.0
   react-router>path-to-regexp: ^1.9.0
   serve-handler>path-to-regexp: ^3.3.0
@@ -5650,10 +5650,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -18072,7 +18071,7 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.15': {}
 
   '@xterm/addon-fit@0.11.0': {}
 
@@ -23301,7 +23300,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ packages:
 minimumReleaseAge: 1440
 overrides:
   extract-zip>yauzl: ^3.3.1
-  '@xmldom/xmldom': ^0.8.12
+  '@xmldom/xmldom': ^0.8.15
   rollup: ^4.59.0
   react-router>path-to-regexp: ^1.9.0
   serve-handler>path-to-regexp: ^3.3.0


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability GHSA-6gmq-8vp8-gcm6 in `@xmldom/xmldom`.

**Advisory**: xmldom: XML fragment injection via invalid EntityReference.nodeName during requireWellFormed serialization
**Vulnerable versions**: >=0.7.0 <=0.8.14
**Patched versions**: >=0.8.15
**Advisory URL**: https://github.com/advisories/GHSA-6gmq-8vp8-gcm6

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-6gmq-8vp8-gcm6: _xmldom: XML fragment injection via invalid EntityReference.nodeName during requireWellFormed serialization_

### How to test this PR?

Run `pnpm audit` and verify GHSA-6gmq-8vp8-gcm6 is no longer reported