### PR TITLE
fix(windows): preserve disabled startup setting

### DIFF
--- a/packages/main/src/system/startup-install.spec.ts
+++ b/packages/main/src/system/startup-install.spec.ts
@@ -1,0 +1,102 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import * as os from 'node:os';
+
+import type { Configuration } from '@podman-desktop/api';
+import type { IConfigurationRegistry } from '@podman-desktop/core-api/configuration';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { StartupInstall } from './startup-install.js';
+
+vi.mock(import('node:os'));
+
+const windowsStartupMock = vi.hoisted(() => ({
+  shouldEnable: vi.fn(),
+  enable: vi.fn(),
+  disable: vi.fn(),
+  syncStartupPreference: vi.fn(),
+}));
+
+vi.mock(import('./windows-startup.js'), async importOriginal => {
+  const { WindowsStartup } = await importOriginal();
+  return {
+    WindowsStartup: class extends WindowsStartup {
+      override shouldEnable(): boolean {
+        return windowsStartupMock.shouldEnable();
+      }
+
+      override enable(): Promise<void> {
+        return windowsStartupMock.enable();
+      }
+
+      override disable(): Promise<void> {
+        return windowsStartupMock.disable();
+      }
+
+      override syncStartupPreference(): Promise<void> {
+        return windowsStartupMock.syncStartupPreference();
+      }
+    },
+  };
+});
+
+let startOnLogin: boolean;
+let configurationRegistry: IConfigurationRegistry;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubEnv('PROD', true);
+  vi.mocked(os.platform).mockReturnValue('win32');
+  windowsStartupMock.shouldEnable.mockReturnValue(true);
+  startOnLogin = true;
+  configurationRegistry = {
+    registerConfigurations: vi.fn(),
+    onDidChangeConfiguration: vi.fn(),
+    updateConfigurationValue: vi.fn(async (key, value) => {
+      if (key === 'preferences.login.start') {
+        startOnLogin = value as boolean;
+      }
+    }),
+    getConfiguration: vi.fn().mockReturnValue({
+      get: vi.fn().mockImplementation(key => (key === 'start' ? startOnLogin : undefined)),
+    } as unknown as Configuration),
+  } as unknown as IConfigurationRegistry;
+});
+
+test('Windows startup preference is synchronized before applying startup configuration', async () => {
+  windowsStartupMock.syncStartupPreference.mockImplementation(async () => {
+    await configurationRegistry.updateConfigurationValue('preferences.login.start', false);
+  });
+  const startupInstall = new StartupInstall(configurationRegistry);
+
+  await startupInstall.configure();
+
+  expect(windowsStartupMock.syncStartupPreference).toHaveBeenCalledOnce();
+  expect(windowsStartupMock.enable).not.toHaveBeenCalled();
+});
+
+test('Enabling startup from preferences re-enables the Windows startup item', async () => {
+  const startupInstall = new StartupInstall(configurationRegistry);
+  await startupInstall.configure();
+  const configurationListener = vi.mocked(configurationRegistry.onDidChangeConfiguration).mock.calls[0]?.[0];
+
+  await configurationListener?.({ key: 'preferences.login.start', value: true, scope: 'DEFAULT' });
+
+  expect(windowsStartupMock.enable).toHaveBeenCalledTimes(2);
+});

--- a/packages/main/src/system/startup-install.ts
+++ b/packages/main/src/system/startup-install.ts
@@ -91,6 +91,10 @@ export class StartupInstall {
 
     this.configurationRegistry.registerConfigurations([loginStartConfigurationNode, startMinimizeConfigurationNode]);
 
+    if (this.osStartup instanceof WindowsStartup) {
+      await this.osStartup.syncStartupPreference();
+    }
+
     // add notification handling
 
     this.configurationRegistry.onDidChangeConfiguration(async e => {

--- a/packages/main/src/system/windows-startup.spec.ts
+++ b/packages/main/src/system/windows-startup.spec.ts
@@ -63,6 +63,10 @@ beforeEach(() => {
   vi.restoreAllMocks();
   mockAppGetPath();
   minimizeOnStatup.mockReturnValue(true);
+  vi.mocked(app.getLoginItemSettings).mockReturnValue({
+    openAtLogin: false,
+    executableWillLaunchAtLogin: false,
+  } as Electron.LoginItemSettings);
 });
 
 test('Auto startup should not be enable for not portable installation in temp folder', async () => {
@@ -85,6 +89,7 @@ test('Autostart should be enabled for portable installation', async () => {
     openAtLogin: true,
     path: `"${portablePath}"`,
     args: ['--minimized'],
+    enabled: true,
   });
 });
 
@@ -98,6 +103,7 @@ test('Autostart should be enabled for updated application when present', async (
     openAtLogin: true,
     path: `"${resolvedUpdatedExecPath}"`,
     args: ['--minimized'],
+    enabled: true,
   });
 });
 
@@ -109,6 +115,7 @@ test('Autostart enable call should setup startup at login for normal installatio
     openAtLogin: true,
     path: `"${appExePath}"`,
     args: ['--minimized'],
+    enabled: true,
   });
 });
 
@@ -121,6 +128,29 @@ test('Autostart enable call should setup startup at login for normal installatio
     openAtLogin: true,
     path: `"${appExePath}"`,
     args: [],
+    enabled: true,
+  });
+});
+
+test('Autostart should remain disabled when disabled in Windows settings', async () => {
+  mockFsExists(false);
+  vi.mocked(app.getLoginItemSettings).mockReturnValue({
+    openAtLogin: true,
+    executableWillLaunchAtLogin: false,
+  } as Electron.LoginItemSettings);
+  windowsStartup = new WindowsStartup(configurationRegistry);
+
+  await windowsStartup.enable();
+
+  expect(app.getLoginItemSettings).toBeCalledWith({
+    path: `"${appExePath}"`,
+    args: ['--minimized'],
+  });
+  expect(app.setLoginItemSettings).toBeCalledWith({
+    openAtLogin: true,
+    path: `"${appExePath}"`,
+    args: ['--minimized'],
+    enabled: false,
   });
 });
 

--- a/packages/main/src/system/windows-startup.spec.ts
+++ b/packages/main/src/system/windows-startup.spec.ts
@@ -65,8 +65,11 @@ beforeEach(() => {
   minimizeOnStatup.mockReturnValue(true);
   vi.mocked(app.getLoginItemSettings).mockReturnValue({
     openAtLogin: false,
+    wasOpenedAtLogin: false,
+    status: 'not-registered',
     executableWillLaunchAtLogin: false,
-  } as Electron.LoginItemSettings);
+    launchItems: [],
+  });
 });
 
 test('Auto startup should not be enable for not portable installation in temp folder', async () => {
@@ -136,8 +139,19 @@ test('Autostart should remain disabled when disabled in Windows settings', async
   mockFsExists(false);
   vi.mocked(app.getLoginItemSettings).mockReturnValue({
     openAtLogin: true,
+    wasOpenedAtLogin: false,
+    status: 'enabled',
     executableWillLaunchAtLogin: false,
-  } as Electron.LoginItemSettings);
+    launchItems: [
+      {
+        name: 'Podman Desktop',
+        path: appExePath,
+        args: ['--minimized'],
+        scope: 'user',
+        enabled: false,
+      },
+    ],
+  });
   windowsStartup = new WindowsStartup(configurationRegistry);
 
   await windowsStartup.enable();
@@ -146,6 +160,35 @@ test('Autostart should remain disabled when disabled in Windows settings', async
     path: `"${appExePath}"`,
     args: ['--minimized'],
   });
+  expect(app.setLoginItemSettings).toBeCalledWith({
+    openAtLogin: true,
+    path: `"${appExePath}"`,
+    args: ['--minimized'],
+    enabled: false,
+  });
+});
+
+test('Autostart should remain disabled when startup arguments change', async () => {
+  mockFsExists(false);
+  vi.mocked(app.getLoginItemSettings).mockReturnValue({
+    openAtLogin: false,
+    wasOpenedAtLogin: false,
+    status: 'not-registered',
+    executableWillLaunchAtLogin: false,
+    launchItems: [
+      {
+        name: 'Podman Desktop',
+        path: appExePath,
+        args: [],
+        scope: 'user',
+        enabled: false,
+      },
+    ],
+  });
+  windowsStartup = new WindowsStartup(configurationRegistry);
+
+  await windowsStartup.enable();
+
   expect(app.setLoginItemSettings).toBeCalledWith({
     openAtLogin: true,
     path: `"${appExePath}"`,

--- a/packages/main/src/system/windows-startup.spec.ts
+++ b/packages/main/src/system/windows-startup.spec.ts
@@ -33,6 +33,7 @@ const configurationRegistry = {
   getConfiguration: () => ({
     get: minimizeOnStatup,
   }),
+  updateConfigurationValue: vi.fn(),
 } as unknown as ConfigurationRegistry;
 
 function mockAppGetPath(exe = appExePath, temp = tempPath, appData = appDataPath): void {
@@ -61,6 +62,7 @@ const appDataPath = 'AppData';
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.clearAllMocks();
   mockAppGetPath();
   minimizeOnStatup.mockReturnValue(true);
   vi.mocked(app.getLoginItemSettings).mockReturnValue({
@@ -135,7 +137,7 @@ test('Autostart enable call should setup startup at login for normal installatio
   });
 });
 
-test('Autostart should remain disabled when disabled in Windows settings', async () => {
+test('Autostart should be re-enabled from Podman Desktop settings', async () => {
   mockFsExists(false);
   vi.mocked(app.getLoginItemSettings).mockReturnValue({
     openAtLogin: true,
@@ -156,19 +158,15 @@ test('Autostart should remain disabled when disabled in Windows settings', async
 
   await windowsStartup.enable();
 
-  expect(app.getLoginItemSettings).toBeCalledWith({
-    path: `"${appExePath}"`,
-    args: ['--minimized'],
-  });
   expect(app.setLoginItemSettings).toBeCalledWith({
     openAtLogin: true,
     path: `"${appExePath}"`,
     args: ['--minimized'],
-    enabled: false,
+    enabled: true,
   });
 });
 
-test('Autostart should remain disabled when startup arguments change', async () => {
+test('Autostart should be re-enabled when startup arguments change', async () => {
   mockFsExists(false);
   vi.mocked(app.getLoginItemSettings).mockReturnValue({
     openAtLogin: false,
@@ -193,8 +191,66 @@ test('Autostart should remain disabled when startup arguments change', async () 
     openAtLogin: true,
     path: `"${appExePath}"`,
     args: ['--minimized'],
-    enabled: false,
+    enabled: true,
   });
+});
+
+test('Autostart preference should reflect a disabled Windows startup item with different arguments', async () => {
+  mockFsExists(false);
+  vi.mocked(app.getLoginItemSettings).mockReturnValue({
+    openAtLogin: true,
+    wasOpenedAtLogin: false,
+    status: 'enabled',
+    executableWillLaunchAtLogin: false,
+    launchItems: [
+      {
+        name: 'Podman Desktop',
+        path: appExePath,
+        args: [],
+        scope: 'user',
+        enabled: false,
+      },
+    ],
+  });
+  windowsStartup = new WindowsStartup(configurationRegistry);
+
+  await windowsStartup.syncStartupPreference();
+
+  expect(configurationRegistry.updateConfigurationValue).toBeCalledWith('preferences.login.start', false);
+  expect(app.setLoginItemSettings).not.toHaveBeenCalled();
+});
+
+test('Autostart preference should reflect an enabled Windows startup item', async () => {
+  mockFsExists(false);
+  vi.mocked(app.getLoginItemSettings).mockReturnValue({
+    openAtLogin: true,
+    wasOpenedAtLogin: false,
+    status: 'enabled',
+    executableWillLaunchAtLogin: true,
+    launchItems: [
+      {
+        name: 'Podman Desktop',
+        path: appExePath,
+        args: [],
+        scope: 'user',
+        enabled: true,
+      },
+    ],
+  });
+  windowsStartup = new WindowsStartup(configurationRegistry);
+
+  await windowsStartup.syncStartupPreference();
+
+  expect(configurationRegistry.updateConfigurationValue).toBeCalledWith('preferences.login.start', true);
+});
+
+test('Autostart preference should not change when no Windows startup item exists', async () => {
+  mockFsExists(false);
+  windowsStartup = new WindowsStartup(configurationRegistry);
+
+  await windowsStartup.syncStartupPreference();
+
+  expect(configurationRegistry.updateConfigurationValue).not.toHaveBeenCalled();
 });
 
 test('Autostart enable call should remove existing startup file when present', async () => {

--- a/packages/main/src/system/windows-startup.ts
+++ b/packages/main/src/system/windows-startup.ts
@@ -88,13 +88,16 @@ export class WindowsStartup {
       path: loginItemPath,
       args,
     });
-    const enabled = !(loginItemSettings.openAtLogin && loginItemSettings.executableWillLaunchAtLogin === false);
+    const startupExecutablePath = path.normalize(this.podmanDesktopBinaryPath).toLowerCase();
+    const matchingLaunchItem = loginItemSettings.launchItems.find(
+      launchItem => path.normalize(launchItem.path).toLowerCase() === startupExecutablePath,
+    );
 
     app.setLoginItemSettings({
       openAtLogin: true,
       path: loginItemPath,
       args,
-      enabled,
+      enabled: matchingLaunchItem?.enabled ?? true,
     });
   }
 

--- a/packages/main/src/system/windows-startup.ts
+++ b/packages/main/src/system/windows-startup.ts
@@ -83,10 +83,18 @@ export class WindowsStartup {
       this.podmanDesktopBinaryPath = podmanDesktopInPrograms;
     }
 
+    const loginItemPath = `"${this.podmanDesktopBinaryPath}"`;
+    const loginItemSettings = app.getLoginItemSettings({
+      path: loginItemPath,
+      args,
+    });
+    const enabled = !(loginItemSettings.openAtLogin && loginItemSettings.executableWillLaunchAtLogin === false);
+
     app.setLoginItemSettings({
       openAtLogin: true,
-      path: `"${this.podmanDesktopBinaryPath}"`,
+      path: loginItemPath,
       args,
+      enabled,
     });
   }
 

--- a/packages/main/src/system/windows-startup.ts
+++ b/packages/main/src/system/windows-startup.ts
@@ -67,43 +67,48 @@ export class WindowsStartup {
 
     // We pass in "--minimize" so electron can read the flag on first startup.
     const args = minimize ? ['--minimized'] : [];
-    // check if we are using the portable mode.
-    // in that case we need to register the binary path to the portable file
-    // and not where it is being expanded
-    if (process.env['PORTABLE_EXECUTABLE_FILE']) {
-      this.podmanDesktopBinaryPath = process.env['PORTABLE_EXECUTABLE_FILE'];
-    }
-
-    // do we have an updated version of the binary being installed in AppData/Local
-    // if so, we need to update the startup file to point to the new binary
-    // this is the case when we update the app
-    const programsData = path.resolve(app.getPath('appData'), '..', 'local/Programs/podman-desktop');
-    const podmanDesktopInPrograms = path.resolve(programsData, 'Podman Desktop.exe');
-    if (existsSync(podmanDesktopInPrograms)) {
-      this.podmanDesktopBinaryPath = podmanDesktopInPrograms;
-    }
-
-    const loginItemPath = `"${this.podmanDesktopBinaryPath}"`;
-    const loginItemSettings = app.getLoginItemSettings({
-      path: loginItemPath,
-      args,
-    });
-    const startupExecutablePath = path.normalize(this.podmanDesktopBinaryPath).toLowerCase();
-    const matchingLaunchItem = loginItemSettings.launchItems.find(
-      launchItem => path.normalize(launchItem.path).toLowerCase() === startupExecutablePath,
-    );
+    const loginItemPath = `"${this.resolveBinaryPath()}"`;
 
     app.setLoginItemSettings({
       openAtLogin: true,
       path: loginItemPath,
       args,
-      enabled: matchingLaunchItem?.enabled ?? true,
+      enabled: true,
     });
+  }
+
+  async syncStartupPreference(): Promise<void> {
+    const startupExecutablePath = path.normalize(this.resolveBinaryPath()).toLowerCase();
+    const matchingLaunchItem = app
+      .getLoginItemSettings()
+      .launchItems.find(launchItem => path.normalize(launchItem.path).toLowerCase() === startupExecutablePath);
+
+    if (matchingLaunchItem) {
+      await this.configurationRegistry.updateConfigurationValue('preferences.login.start', matchingLaunchItem.enabled);
+    }
   }
 
   async disable(): Promise<void> {
     app.setLoginItemSettings({
       openAtLogin: false,
     });
+  }
+
+  private resolveBinaryPath(): string {
+    // In portable mode, register the portable file rather than the temporary
+    // directory where it is expanded.
+    if (process.env['PORTABLE_EXECUTABLE_FILE']) {
+      this.podmanDesktopBinaryPath = process.env['PORTABLE_EXECUTABLE_FILE'];
+      return this.podmanDesktopBinaryPath;
+    }
+
+    // An update can install a new binary in AppData/Local before it is running.
+    const programsData = path.resolve(app.getPath('appData'), '..', 'local/Programs/podman-desktop');
+    const podmanDesktopInPrograms = path.resolve(programsData, 'Podman Desktop.exe');
+    if (existsSync(podmanDesktopInPrograms)) {
+      this.podmanDesktopBinaryPath = podmanDesktopInPrograms;
+    }
+
+    return this.podmanDesktopBinaryPath;
   }
 }

--- a/packages/main/src/system/windows-startup.ts
+++ b/packages/main/src/system/windows-startup.ts
@@ -77,6 +77,11 @@ export class WindowsStartup {
     });
   }
 
+  /**
+   * Reflects the matching Windows startup item's enabled state in preferences.
+   * Run before registering preference listeners to preserve external overrides
+   * without changing the Windows startup item. Missing entries leave the preference unchanged.
+   */
   async syncStartupPreference(): Promise<void> {
     const startupExecutablePath = path.normalize(this.resolveBinaryPath()).toLowerCase();
     const matchingLaunchItem = app
@@ -94,6 +99,7 @@ export class WindowsStartup {
     });
   }
 
+  /** Returns the portable or installed executable path used for Windows startup. */
   private resolveBinaryPath(): string {
     // In portable mode, register the portable file rather than the temporary
     // directory where it is expanded.


### PR DESCRIPTION
### What does this PR do?

Synchronizes the **Start on login** preference with the matching Windows startup item when Podman Desktop starts. If the item was disabled in Task Manager, the preference is changed to disabled before startup configuration is applied.

Enabling **Start on login** from Podman Desktop still enables the Windows startup item, including when its startup arguments have changed. A missing startup item continues to be created and enabled by default when the preference is enabled.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Fixes the Windows behavior where opening Podman Desktop re-enabled a startup item that the user had disabled in Task Manager, while keeping the setting capable of re-enabling it explicitly.

### How to test this PR?

1. Enable **Start on login** in Podman Desktop.
2. Disable **Podman Desktop** in Task Manager under **Startup apps**.
3. Open Podman Desktop manually and verify that **Start on login** is disabled in its settings.
4. Enable **Start on login** in Podman Desktop and verify that Task Manager shows the startup item as enabled.
5. Run `pnpm exec vitest run packages/main/src/system/windows-startup.spec.ts packages/main/src/system/startup-install.spec.ts`.

- [x] Tests are covering the bug fix or the new feature

AI assistance was used.
