### PR TITLE
chore(website): add new download cards for Windows, macOS, and Linux

### DIFF
--- a/website/src/components/downloads/OSDownloadCard.tsx
+++ b/website/src/components/downloads/OSDownloadCard.tsx
@@ -96,10 +96,10 @@ export function OSDownloadCard({
   const [expanded, setExpanded] = React.useState(false);
 
   const toggleExpanded = (): void => {
-    setExpanded(value => !value);
-    if (expanded) {
+    if (!expanded) {
       sendGoatCounterEvent('download', `expand-${osName}`);
     }
+    setExpanded(value => !value);
   };
 
   return (

--- a/website/src/components/downloads/OSDownloadCard.tsx
+++ b/website/src/components/downloads/OSDownloadCard.tsx
@@ -19,7 +19,7 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faCheck, faChevronDown, faDownload, faPaste, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { TelemetryLink } from '@site/src/components/TelemetryLink';
+import { sendGoatCounterEvent, TelemetryLink } from '@site/src/components/TelemetryLink';
 import React from 'react';
 
 function CopyButton({ onCopy }: { readonly onCopy: () => Promise<void> }): JSX.Element {
@@ -97,6 +97,9 @@ export function OSDownloadCard({
 
   const toggleExpanded = (): void => {
     setExpanded(value => !value);
+    if (expanded) {
+      sendGoatCounterEvent('download', `expand-${osName}`);
+    }
   };
 
   return (

--- a/website/src/components/downloads/OSDownloadCard.tsx
+++ b/website/src/components/downloads/OSDownloadCard.tsx
@@ -48,7 +48,7 @@ function CopyButton({ onCopy }: { readonly onCopy: () => Promise<void> }): JSX.E
         }}>
         <FontAwesomeIcon size="xs" icon={copied ? faCheck : faPaste} className="text-xl" />
       </button>
-      <span className="pointer-events-none absolute left-1/2 bottom-full z-20 mb-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-zinc-900 dark:bg-zinc-800 px-2.5 py-1 text-xs font-medium text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+      <span className="pointer-events-none absolute left-1/2 bottom-full z-20 mb-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-charcoal-800 dark:bg-charcoal-800 px-2.5 py-1 text-xs font-medium text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
         {copied ? 'Copied' : 'Copy to clipboard'}
       </span>
     </span>
@@ -57,7 +57,7 @@ function CopyButton({ onCopy }: { readonly onCopy: () => Promise<void> }): JSX.E
 
 function InstallCommand({ command }: { readonly command: string }): JSX.Element {
   return (
-    <code className="inline-flex items-center gap-1.5 w-full max-w-full min-w-0 box-border dark:bg-charcoal-800/50 bg-zinc-300/50 px-2 py-1 text-sm dark:text-purple-200 text-purple-600">
+    <code className="inline-flex items-center gap-1.5 w-full max-w-full min-w-0 box-border dark:bg-charcoal-800/50 bg-gray-400/50 px-2 py-1 text-sm dark:text-purple-200 text-purple-600">
       <FontAwesomeIcon size="xs" icon={faTerminal} className="shrink-0 mt-0.5" />
       <span className="min-w-0 flex-1 wrap-break-word text-left">{command}</span>
       <CopyButton onCopy={() => navigator.clipboard.writeText(command)} />
@@ -105,22 +105,23 @@ export function OSDownloadCard({
 
   return (
     <div
-      className={`rounded-lg dark:text-gray-400 text-charcoal-300 bg-zinc-300/25 dark:bg-zinc-700/25 ${
+      className={`rounded-lg dark:text-gray-400 text-charcoal-300 bg-gray-400/25 dark:bg-charcoal-450/25 ${
         highlighted ? 'ring-2 ring-purple-500' : ''
       }`}>
       <div
-        role="button"
-        tabIndex={0}
-        className="flex flex-col md:flex-row md:items-center gap-4 px-6 py-5 text-charcoal-300 dark:text-white cursor-pointer select-none"
-        onClick={toggleExpanded}
-        onKeyDown={event => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            toggleExpanded();
-          }
-        }}
+        className="flex flex-col md:flex-row md:items-center gap-4 text-charcoal-300 dark:text-white cursor-pointer select-none"
         aria-expanded={expanded}>
-        <div className="flex items-center gap-3 min-w-0 flex-1">
+        <div
+          className="flex items-center gap-3 min-w-0 flex-1 px-6 py-5 w-full self-stretch"
+          role="button"
+          tabIndex={0}
+          onClick={toggleExpanded}
+          onKeyDown={event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              toggleExpanded();
+            }
+          }}>
           <FontAwesomeIcon size="2x" icon={osIcon} className="shrink-0 text-purple-500" />
           <div className="min-w-0 flex-1 flex flex-col gap-0.5">
             <p className="text-lg md:text-xl font-medium leading-tight m-0">{osName}</p>
@@ -134,13 +135,13 @@ export function OSDownloadCard({
           </span>
         </div>
 
-        <div className="flex items-center gap-2 w-full md:w-auto md:shrink-0">
+        <div className="flex items-center gap-2 w-full md:w-auto md:shrink-0 px-6 py-5">
           <span
             className="flex flex-col items-stretch flex-1 md:flex-initial md:w-52 min-w-0"
             onClick={event => event.stopPropagation()}
             onKeyDown={event => event.stopPropagation()}>
             <TelemetryLink
-              className={`w-full no-underline hover:no-underline inline-flex justify-center border py-2 px-5 focus:outline-hidden rounded-sm text-md font-semibold items-center transition-colors ${
+              className={`w-full no-underline hover:no-underline inline-flex justify-center border py-2 px-5 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 rounded-sm text-md font-semibold items-center transition-colors ${
                 highlighted
                   ? 'border-purple-500 bg-purple-500 hover:bg-purple-600 hover:border-purple-600 text-white'
                   : 'border-purple-500 bg-transparent text-purple-600 dark:text-purple-500 hover:bg-purple-500 hover:text-white dark:hover:text-white'
@@ -151,13 +152,24 @@ export function OSDownloadCard({
               <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
               Download
             </TelemetryLink>
-            <p className="block w-full mt-1 text-[0.675rem] leading-tight text-center whitespace-nowrap opacity-65 m-0">
+            <p className="block w-full mt-1 text-[0.675rem] leading-tight text-center opacity-65 m-0">
               {primaryDownload.caption}
             </p>
           </span>
 
           {/* Desktop chevron */}
-          <span className="hidden md:flex shrink-0" aria-hidden="true">
+          <span
+            className="hidden md:flex shrink-0"
+            aria-hidden="true"
+            role="button"
+            tabIndex={0}
+            onClick={toggleExpanded}
+            onKeyDown={event => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                toggleExpanded();
+              }
+            }}>
             <FontAwesomeIcon icon={faChevronDown} className={`transition-transform ${expanded ? 'rotate-180' : ''}`} />
           </span>
         </div>

--- a/website/src/components/downloads/OSDownloadCard.tsx
+++ b/website/src/components/downloads/OSDownloadCard.tsx
@@ -19,7 +19,8 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faCheck, faChevronDown, faDownload, faPaste, faTerminal } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { sendGoatCounterEvent, TelemetryLink } from '@site/src/components/TelemetryLink';
+import { TelemetryLink } from '@site/src/components/TelemetryLink';
+import { sendGoatCounterEvent } from '@site/src/components/utils';
 import React from 'react';
 
 function CopyButton({ onCopy }: { readonly onCopy: () => Promise<void> }): JSX.Element {

--- a/website/src/components/downloads/OSDownloadCard.tsx
+++ b/website/src/components/downloads/OSDownloadCard.tsx
@@ -1,0 +1,179 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { faCheck, faChevronDown, faDownload, faPaste, faTerminal } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { TelemetryLink } from '@site/src/components/TelemetryLink';
+import React from 'react';
+
+function CopyButton({ onCopy }: { readonly onCopy: () => Promise<void> }): JSX.Element {
+  const [copied, setCopied] = React.useState(false);
+
+  React.useEffect((): (() => void) | undefined => {
+    if (!copied) return undefined;
+    const timeout = window.setTimeout((): void => setCopied(false), 1500);
+    return (): void => window.clearTimeout(timeout);
+  }, [copied]);
+
+  return (
+    <span className="relative shrink-0 group">
+      <button
+        type="button"
+        aria-label={copied ? 'Copied' : 'Copy to clipboard'}
+        className="p-1 bg-transparent border-0 cursor-pointer text-charcoal-300 dark:text-gray-300 hover:text-purple-500 dark:hover:text-purple-300"
+        onClick={event => {
+          event.stopPropagation();
+          onCopy()
+            .then(() => setCopied(true))
+            .catch((err: unknown) => {
+              console.error('unable to copy instructions', err);
+            });
+        }}>
+        <FontAwesomeIcon size="xs" icon={copied ? faCheck : faPaste} className="text-xl" />
+      </button>
+      <span className="pointer-events-none absolute left-1/2 bottom-full z-20 mb-2 -translate-x-1/2 whitespace-nowrap rounded-md bg-zinc-900 dark:bg-zinc-800 px-2.5 py-1 text-xs font-medium text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+        {copied ? 'Copied' : 'Copy to clipboard'}
+      </span>
+    </span>
+  );
+}
+
+function InstallCommand({ command }: { readonly command: string }): JSX.Element {
+  return (
+    <code className="inline-flex items-center gap-1.5 w-full max-w-full min-w-0 box-border dark:bg-charcoal-800/50 bg-zinc-300/50 px-2 py-1 text-sm dark:text-purple-200 text-purple-600">
+      <FontAwesomeIcon size="xs" icon={faTerminal} className="shrink-0 mt-0.5" />
+      <span className="min-w-0 flex-1 wrap-break-word text-left">{command}</span>
+      <CopyButton onCopy={() => navigator.clipboard.writeText(command)} />
+    </code>
+  );
+}
+
+export interface InstallCommandConfig {
+  readonly icon: IconProp;
+  readonly label: string | React.ReactNode;
+  readonly command: string;
+}
+
+export interface OSDownloadCardProps {
+  readonly osName: string;
+  readonly osIcon: IconProp;
+  readonly highlighted?: boolean;
+  readonly primaryDownload: {
+    readonly url: string;
+    readonly eventTitle: string;
+    readonly caption: string;
+  };
+  readonly otherDownloads?: React.ReactNode;
+  readonly installCommand?: InstallCommandConfig;
+  readonly additionalContent?: React.ReactNode;
+}
+
+export function OSDownloadCard({
+  osName,
+  osIcon,
+  highlighted = false,
+  primaryDownload,
+  otherDownloads,
+  installCommand,
+  additionalContent,
+}: OSDownloadCardProps): JSX.Element {
+  const [expanded, setExpanded] = React.useState(false);
+
+  const toggleExpanded = (): void => {
+    setExpanded(value => !value);
+  };
+
+  return (
+    <div
+      className={`rounded-lg dark:text-gray-400 text-charcoal-300 bg-zinc-300/25 dark:bg-zinc-700/25 ${
+        highlighted ? 'ring-2 ring-purple-500' : ''
+      }`}>
+      <div
+        role="button"
+        tabIndex={0}
+        className="flex flex-col md:flex-row md:items-center gap-4 px-6 py-5 text-charcoal-300 dark:text-white cursor-pointer select-none"
+        onClick={toggleExpanded}
+        onKeyDown={event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            toggleExpanded();
+          }
+        }}
+        aria-expanded={expanded}>
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <FontAwesomeIcon size="2x" icon={osIcon} className="shrink-0 text-purple-500" />
+          <div className="min-w-0 flex-1 flex flex-col gap-0.5">
+            <p className="text-lg md:text-xl font-medium leading-tight m-0">{osName}</p>
+            <p className="text-xs leading-tight m-0 text-charcoal-300 dark:text-gray-400">
+              Podman Desktop for {osName}
+            </p>
+          </div>
+          {/* Mobile chevron */}
+          <span className="md:hidden shrink-0" aria-hidden="true">
+            <FontAwesomeIcon icon={faChevronDown} className={`transition-transform ${expanded ? 'rotate-180' : ''}`} />
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 w-full md:w-auto md:shrink-0">
+          <span
+            className="flex flex-col items-stretch flex-1 md:flex-initial md:w-52 min-w-0"
+            onClick={event => event.stopPropagation()}
+            onKeyDown={event => event.stopPropagation()}>
+            <TelemetryLink
+              className={`w-full no-underline hover:no-underline inline-flex justify-center border py-2 px-5 focus:outline-hidden rounded-sm text-md font-semibold items-center transition-colors ${
+                highlighted
+                  ? 'border-purple-500 bg-purple-500 hover:bg-purple-600 hover:border-purple-600 text-white'
+                  : 'border-purple-500 bg-transparent text-purple-600 dark:text-purple-500 hover:bg-purple-500 hover:text-white dark:hover:text-white'
+              }`}
+              eventPath="download"
+              eventTitle={primaryDownload.eventTitle}
+              to={primaryDownload.url}>
+              <FontAwesomeIcon size="1x" icon={faDownload} className="mr-2" />
+              Download
+            </TelemetryLink>
+            <p className="block w-full mt-1 text-[0.675rem] leading-tight text-center whitespace-nowrap opacity-65 m-0">
+              {primaryDownload.caption}
+            </p>
+          </span>
+
+          {/* Desktop chevron */}
+          <span className="hidden md:flex shrink-0" aria-hidden="true">
+            <FontAwesomeIcon icon={faChevronDown} className={`transition-transform ${expanded ? 'rotate-180' : ''}`} />
+          </span>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="px-6 md:px-16 pr-4 pb-3 flex flex-col gap-2 border-t border-purple-500/40 pt-3">
+          {otherDownloads}
+
+          {installCommand && (
+            <div className="flex flex-nowrap items-center gap-2 min-w-0 max-w-full">
+              <FontAwesomeIcon size="sm" icon={installCommand.icon} className="shrink-0" />
+              <span className="text-sm shrink-0">{installCommand.label}:</span>
+              <InstallCommand command={installCommand.command} />
+            </div>
+          )}
+
+          {additionalContent}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/src/components/downloads/linux.tsx
+++ b/website/src/components/downloads/linux.tsx
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import Link from '@docusaurus/Link';
+import { usePluginData } from '@docusaurus/useGlobalData';
+import { faLinux } from '@fortawesome/free-brands-svg-icons';
+import { OSDownloadCard } from '@site/src/components/downloads/OSDownloadCard';
+import { TelemetryLink } from '@site/src/components/TelemetryLink';
+import type { GitHubMetadata } from '@site/src/plugins/github-metadata';
+import React from 'react';
+
+interface LinuxDownloadsProps {
+  readonly highlighted?: boolean;
+}
+
+export function LinuxDownloads({ highlighted = false }: LinuxDownloadsProps): JSX.Element {
+  const {
+    latestRelease: { linux, version },
+  } = usePluginData('docusaurus-plugin-github-metadata') as GitHubMetadata;
+
+  const otherDownloads = (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+      <span className="text-charcoal-300 dark:text-gray-400">Other:</span>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-linux"
+        to={linux.amd64}>
+        AMD64 binary
+      </TelemetryLink>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-linux"
+        to={linux.arm64}>
+        ARM64 binary
+      </TelemetryLink>
+    </div>
+  );
+
+  return (
+    <OSDownloadCard
+      osName="Linux"
+      osIcon={faLinux}
+      highlighted={highlighted}
+      primaryDownload={{
+        url: linux.flatpak,
+        eventTitle: 'download-linux',
+        caption: `Linux *.flatpak, version ${version}`,
+      }}
+      otherDownloads={otherDownloads}
+      installCommand={{
+        icon: faLinux,
+        label: (
+          <Link
+            className="underline text-purple-500 hover:text-purple-700 dark:text-purple-300 dark:hover:text-purple-200"
+            href="https://flathub.org/apps/details/io.podman_desktop.PodmanDesktop"
+            onClick={event => event.stopPropagation()}>
+            Flathub
+          </Link>
+        ),
+        command: 'flatpak install flathub io.podman_desktop.PodmanDesktop',
+      }}
+    />
+  );
+}

--- a/website/src/components/downloads/macos.tsx
+++ b/website/src/components/downloads/macos.tsx
@@ -1,0 +1,88 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { usePluginData } from '@docusaurus/useGlobalData';
+import { faApple } from '@fortawesome/free-brands-svg-icons';
+import { faBeer } from '@fortawesome/free-solid-svg-icons';
+import { OSDownloadCard } from '@site/src/components/downloads/OSDownloadCard';
+import { TelemetryLink } from '@site/src/components/TelemetryLink';
+import type { GitHubMetadata } from '@site/src/plugins/github-metadata';
+import React from 'react';
+
+interface MacOSDownloadsProps {
+  readonly highlighted?: boolean;
+}
+
+export function MacOSDownloads({ highlighted = false }: MacOSDownloadsProps): JSX.Element {
+  const {
+    latestRelease: { macos, version },
+  } = usePluginData('docusaurus-plugin-github-metadata') as GitHubMetadata;
+
+  const otherDownloads = (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+      <span className="text-charcoal-300 dark:text-gray-400">Other:</span>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-mac"
+        to={macos.x64}>
+        Intel
+      </TelemetryLink>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-mac"
+        to={macos.arm64}>
+        Apple silicon
+      </TelemetryLink>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-mac"
+        to={macos.airgapsetupX64}>
+        Air-gapped Intel
+      </TelemetryLink>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-mac"
+        to={macos.airgapsetupArm64}>
+        Air-gapped Apple silicon
+      </TelemetryLink>
+    </div>
+  );
+
+  return (
+    <OSDownloadCard
+      osName="macOS"
+      osIcon={faApple}
+      highlighted={highlighted}
+      primaryDownload={{
+        url: macos.universal,
+        eventTitle: 'download-mac',
+        caption: `Universal *.dmg, version ${version}`,
+      }}
+      otherDownloads={otherDownloads}
+      installCommand={{
+        icon: faBeer,
+        label: 'Brew',
+        command: 'brew install --cask podman-desktop',
+      }}
+    />
+  );
+}

--- a/website/src/components/downloads/windows.tsx
+++ b/website/src/components/downloads/windows.tsx
@@ -1,0 +1,109 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import Link from '@docusaurus/Link';
+import { usePluginData } from '@docusaurus/useGlobalData';
+import { faMicrosoft, faWindows } from '@fortawesome/free-brands-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { OSDownloadCard } from '@site/src/components/downloads/OSDownloadCard';
+import { TelemetryLink } from '@site/src/components/TelemetryLink';
+import type { GitHubMetadata } from '@site/src/plugins/github-metadata';
+import React from 'react';
+
+interface WindowsDownloadsProps {
+  readonly highlighted?: boolean;
+}
+
+export function WindowsDownloads({ highlighted = false }: WindowsDownloadsProps): JSX.Element {
+  const {
+    latestRelease: { windows, version },
+  } = usePluginData('docusaurus-plugin-github-metadata') as GitHubMetadata;
+
+  const otherDownloads = (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+      <span className="text-charcoal-300 dark:text-gray-400">Other:</span>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-windows"
+        to={windows.setupArm64}>
+        Arm64 installer
+      </TelemetryLink>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-windows"
+        to={windows.binaryX64}>
+        Portable x64
+      </TelemetryLink>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-windows"
+        to={windows.binaryArm64}>
+        Portable arm64
+      </TelemetryLink>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-windows"
+        to={windows.airgapsetupX64}>
+        Air-gapped x64
+      </TelemetryLink>
+      <TelemetryLink
+        className="underline dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 font-semibold"
+        eventPath="download"
+        eventTitle="download-windows"
+        to={windows.airgapsetupArm64}>
+        Air-gapped arm64
+      </TelemetryLink>
+    </div>
+  );
+
+  const additionalContent = (
+    <div>
+      <Link
+        className="underline inline-flex items-center dark:text-white text-purple-500 hover:text-purple-700 dark:hover:text-purple-300 py-1 font-semibold text-sm"
+        href="docs/installation/windows-install"
+        onClick={event => event.stopPropagation()}>
+        <FontAwesomeIcon size="1x" icon={faWindows} className="mr-2" />
+        Package Managers Guide
+      </Link>
+    </div>
+  );
+
+  return (
+    <OSDownloadCard
+      osName="Windows"
+      osIcon={faWindows}
+      highlighted={highlighted}
+      primaryDownload={{
+        url: windows.setupX64,
+        eventTitle: 'download-windows',
+        caption: `Windows installer x64, version ${version}`,
+      }}
+      otherDownloads={otherDownloads}
+      installCommand={{
+        icon: faMicrosoft,
+        label: 'winget',
+        command: 'winget install -e --id RedHat.Podman-Desktop',
+      }}
+      additionalContent={additionalContent}
+    />
+  );
+}


### PR DESCRIPTION
Signed-off-by: Sonia Sandler <ssandler@redhat.com>

### What does this PR do?
Adds the download card components for Windows, macOS, and Linux based on the website's new download page design 

### Screenshot / video of UI
Not visible in the website yet, but can be check in https://github.com/podman-desktop/podman-desktop/pull/19005
<img width="1582" height="972" alt="Screenshot 2026-09-01 at 12 19 50 AM" src="https://github.com/user-attachments/assets/3c7ebf64-74ae-4481-9134-05f916950b26" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?
Part of https://github.com/podman-desktop/podman-desktop/pull/19005
Related to https://github.com/podman-desktop/podman-desktop/issues/18554

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
