### PR TITLE
docs: add contribution expectations for AI-assisted PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,17 @@ storybook/              - UI component showcase
 8. We use semantic commits (e.g. `feat(renderer): add feature`)
 9. Every commit must be signed; mention AI assistance
 
+## Pull requests
+
+- Never make a PR unless the developer explicitly asks you to do so.
+- Conventional commit titles, plain language: `fix(renderer): new threads no longer spike CPU`.
+- Body: Use the template defined in `.github/PULL_REQUEST_TEMPLATE.md`. Fill in every required section — no empty or placeholder descriptions.
+- UI changes need before/after images. Use `mcp-testing` skill to capture screenshots
+- Disclose AI-assisted work — add a `Co-authored-by:` trailer or a brief note in the PR description, and flag if the change was made only by AI without human review.
+- Stand behind the change: the PR must be reviewable, explainable, and able to respond to review feedback.
+- One concern per PR. If the description says "also", split it.
+- See [CONTRIBUTING.md](CONTRIBUTING.md) -> "Contribution expectations" for the full policy.
+
 ## Pattern References
 
 - **Coding standards & Svelte patterns**: [CODE-GUIDELINES.md](CODE-GUIDELINES.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,6 +318,31 @@ Some tips for the PR process:
 - Any additional code changes should be in a new commit so we can see what has changed between reviews.
 - Squash your commits into logical pieces of work.
 
+### Contribution expectations (including AI-assisted contributions)
+
+AI-assisted contributions are welcome. Tools like Claude, Copilot, or other
+assistants can help you write code, tests, and docs — we only ask that every
+pull request, AI-assisted or not, is reviewable and that you stand behind it.
+
+To keep reviews fast and fair, every PR must meet the following expectations:
+
+- **Follow the pull request template.** Fill in every required section of
+  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+  Describe what the change does and how to test it — no empty or placeholder
+  descriptions.
+- **Include a screenshot or short video for UI changes.** Any change that
+  affects the UI must show the before/after (or the new behavior) so reviewers
+  can see the result without building the branch.
+- **Disclose AI-assisted tools.** If you used an AI assistant, say so — for
+  example with a `Co-authored-by:` trailer in your commit, or a brief note in
+  the PR description. Disclosure is expected, not penalized.
+- **Understand and stand behind your change.** Be able to explain what the
+  change does and why, and respond to review feedback. Do not open PRs for code
+  you have not read and cannot support.
+
+PRs that skip these steps may be asked for changes or closed until the
+expectations are met.
+
 ### Use the correct commit message semantics
 
 We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.


### PR DESCRIPTION
### What does this PR do?

Restructures the AI-contribution guidance into a standalone **`LLM_POLICY.md`** at the repo root, following CNCF conventions (per @cdrage's review feedback). `CONTRIBUTING.md` and `AGENTS.md` now carry short pointer links to it instead of duplicating the policy text.

Scope: one file added (`LLM_POLICY.md`), two small pointer edits.

Changes from the earlier version of this PR, per the team discussion:

- **Standalone policy file.** Moved from inline CONTRIBUTING/AGENTS prose to a dedicated `LLM_POLICY.md`; the two docs now just link to it.
- **AI-assisted code stays allowed.** The policy welcomes AI-assisted work; the contributor remains responsible for what they submit.
- **Direct-communication rule softened.** We keep the "communicate in your own words, don't paste raw LLM output verbatim" expectation, but dropped any ban/submission-closure penalty — enforcement is soft ("a maintainer may ask you to rephrase").
- **Screenshot requirement for UI changes** added under code-contribution requirements, framed as confirming a human ran and reviewed the change.
- **Open questions parked.** The questions about a contributor's first-ever submission being AI-free, and whether 100%-AI PRs are acceptable, are left unresolved in an "Under Discussion" section, at maintainer discretion.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Closes: containers/podman-desktop-internal#1110

### How to test this PR?

Documentation-only change. Review the rendered Markdown and confirm:

- `LLM_POLICY.md` renders and reads as a coherent standalone policy.
- The pointer links resolve: `CONTRIBUTING.md` ("AI-assisted contributions") and `AGENTS.md` ("Pull requests") both link to `LLM_POLICY.md`.

- [ ] Tests are covering the bug fix or the new feature — N/A (docs only)

---

> [!NOTE]
> This PR was authored with AI assistance (Claude) and reviewed by a human
> before submission.
