### PR TITLE
fix(renderer): don't show dashboard dot for resources present at startup 

### DIFF
--- a/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
@@ -25,7 +25,7 @@ import { router } from 'tinro';
 import { expect, test } from 'vitest';
 
 import { notificationQueue } from '/@/stores/notifications';
-import { providerInfos } from '/@/stores/providers';
+import { providerInfos, providersLoaded } from '/@/stores/providers';
 
 import NewContentOnDashboardBadge from './NewContentOnDashboardBadge.svelte';
 
@@ -79,6 +79,7 @@ const providerInfo = {
 test('Expect to do not display any dot if active page is Dashboard', async () => {
   notificationQueue.set([]);
   providerInfos.set([]);
+  providersLoaded.set(true);
   await waitRender();
 
   notificationQueue.set([notification1]);
@@ -93,6 +94,7 @@ test('Expect to do not display any dot if active page is Dashboard', async () =>
 test('Expect to do not display any dot if active page is not Dashboard but there are no updates', async () => {
   notificationQueue.set([]);
   providerInfos.set([]);
+  providersLoaded.set(true);
   router.goto('/pods');
 
   await waitRender();
@@ -104,6 +106,7 @@ test('Expect to do not display any dot if active page is not Dashboard but there
 test('Expect to display the dot if active page is not Dashboard and there is a new notification', async () => {
   notificationQueue.set([]);
   providerInfos.set([]);
+  providersLoaded.set(true);
   router.goto('/pods');
   await waitRender();
 
@@ -118,9 +121,80 @@ test('Expect to display the dot if active page is not Dashboard and there is a n
 test('Expect to display the dot if active page is not Dashboard and there is a new provider', async () => {
   notificationQueue.set([]);
   providerInfos.set([]);
+  providersLoaded.set(true);
   router.goto('/pods');
   await waitRender();
 
+  providerInfos.set([providerInfo]);
+
+  await new Promise(resolve => setTimeout(resolve, 200));
+
+  const dot = screen.getByLabelText('New content available');
+  expect(dot).toBeInTheDocument();
+});
+
+test('Expect to do not display any dot if the provider was already there but the initial fetch resolves after mount', async () => {
+  // simulate the real startup race from #18563: the component mounts before the backend
+  // has answered, so providerInfos is still the initial empty value at render time
+  providersLoaded.set(false);
+  providerInfos.set([]);
+  notificationQueue.set([]);
+  router.goto('/pods');
+  await waitRender();
+
+  // the initial fetch resolves shortly after mount and reports a provider that already
+  // existed before the app was even opened - this is not new content
+  providersLoaded.set(true);
+  providerInfos.set([providerInfo]);
+
+  await new Promise(resolve => setTimeout(resolve, 200));
+
+  const dot = screen.queryByLabelText('New content available');
+  expect(dot).not.toBeInTheDocument();
+});
+
+test('Expect to do not display any dot when providers register progressively during startup before providersLoaded fires', async () => {
+  // simulate the real startup sequence: extensions activate one by one, each registering
+  // a provider and triggering a fetch, before providersLoaded is set (which only happens
+  // once every extension has finished starting)
+  const providerInfo2 = { ...providerInfo, internalId: 'id2' } as ProviderInfo;
+  providersLoaded.set(false);
+  providerInfos.set([]);
+  notificationQueue.set([]);
+  router.goto('/pods');
+  await waitRender();
+
+  // extension 1 finishes activating and registers its provider
+  providerInfos.set([providerInfo]);
+  await tick();
+
+  // extension 2 finishes activating and registers its provider - providerInfos grows again
+  providerInfos.set([providerInfo, providerInfo2]);
+  await tick();
+
+  // all extensions have now finished starting - this is not new content, just startup settling
+  providersLoaded.set(true);
+
+  await new Promise(resolve => setTimeout(resolve, 200));
+
+  const dot = screen.queryByLabelText('New content available');
+  expect(dot).not.toBeInTheDocument();
+});
+
+test('Expect to display the dot if a provider is added after the initial fetch has resolved', async () => {
+  providersLoaded.set(false);
+  providerInfos.set([]);
+  notificationQueue.set([]);
+  router.goto('/pods');
+  await waitRender();
+
+  // initial fetch resolves with no providers
+  providersLoaded.set(true);
+  providerInfos.set([]);
+
+  await tick();
+
+  // a provider is genuinely added afterwards
   providerInfos.set([providerInfo]);
 
   await new Promise(resolve => setTimeout(resolve, 200));

--- a/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
+++ b/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
@@ -21,8 +21,9 @@ import type { ProviderStatus } from '@podman-desktop/api';
 import type { NotificationCard, ProviderContainerConnectionInfo, ProviderInfo } from '@podman-desktop/core-api';
 import { render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
+import { get } from 'svelte/store';
 import { router } from 'tinro';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { notificationQueue } from '/@/stores/notifications';
 import { providerInfos, providersLoaded } from '/@/stores/providers';
@@ -131,6 +132,36 @@ test('Expect to display the dot if active page is not Dashboard and there is a n
 
   const dot = screen.getByLabelText('New content available');
   expect(dot).toBeInTheDocument();
+});
+
+test('Expect the extensions-started event to mark providers as loaded and enable new-content detection', async () => {
+  const receiveMock = vi.mocked(window.events.receive);
+  const extensionsStartedHandler = receiveMock.mock.calls.findLast(([event]) => event === 'extensions-started')?.[1] as
+    | (() => void)
+    | undefined;
+  expect(extensionsStartedHandler).toBeDefined();
+
+  providersLoaded.set(false);
+  providerInfos.set([]);
+  notificationQueue.set([]);
+  router.goto('/pods');
+  await waitRender();
+
+  providerInfos.set([providerInfo]);
+  await tick();
+
+  extensionsStartedHandler?.();
+  await tick();
+  expect(get(providersLoaded)).toBe(true);
+
+  providerInfos.set([providerInfo]);
+  await tick();
+  expect(screen.queryByLabelText('New content available')).not.toBeInTheDocument();
+
+  const providerInfo2 = { ...providerInfo, internalId: 'id2' } as ProviderInfo;
+  providerInfos.set([providerInfo, providerInfo2]);
+  await new Promise(resolve => setTimeout(resolve, 200));
+  expect(screen.getByLabelText('New content available')).toBeInTheDocument();
 });
 
 test('Expect to do not display any dot if the provider was already there but the initial fetch resolves after mount', async () => {

--- a/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.svelte
+++ b/packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.svelte
@@ -4,9 +4,10 @@ import type { Unsubscriber } from 'svelte/store';
 
 import NewContentBadge from '/@/lib/ui/NewContentBadge.svelte';
 import { notificationQueue } from '/@/stores/notifications';
-import { providerInfos } from '/@/stores/providers';
+import { providerInfos, providersLoaded } from '/@/stores/providers';
 
-let providersId: string[] = $state([]);
+let providersId: string[] = [];
+let providersBaselineSet = false;
 let notificationCount: number = $state(0);
 let hasNewProviders = $state(false);
 let hasNewNotifications = $state(false);
@@ -14,13 +15,27 @@ let hasNew = $derived(hasNewProviders || hasNewNotifications);
 
 let providersUnsubscribe: Unsubscriber;
 let notificationsUnsubscribe: Unsubscriber;
+let providersLoadedUnsubscribe: Unsubscriber;
 
 onMount(() => {
+  let providersHaveLoaded = false;
+
+  providersLoadedUnsubscribe = providersLoaded.subscribe(loaded => {
+    providersHaveLoaded = loaded;
+  });
+
   // if there is a new provider we display the dot
   providersUnsubscribe = providerInfos.subscribe(updatedProviders => {
+    if (!providersHaveLoaded) {
+      return;
+    }
     const updatedProvidersId = updatedProviders.map(prov => prov.internalId).toSorted();
+    if (!providersBaselineSet) {
+      providersId = updatedProvidersId;
+      providersBaselineSet = true;
+      return;
+    }
     if (!hasNewProviders) {
-      // if the user is in the dashboard page we do not check for new providers
       hasNewProviders = hasNewProvider(providersId, updatedProvidersId);
     }
     providersId = updatedProvidersId;
@@ -39,6 +54,7 @@ onMount(() => {
 onDestroy(() => {
   providersUnsubscribe?.();
   notificationsUnsubscribe?.();
+  providersLoadedUnsubscribe?.();
 });
 
 function hasNewProvider(oldProvidersId: string[], newProvidersId: string[]): boolean {

--- a/packages/renderer/src/stores/providers.ts
+++ b/packages/renderer/src/stores/providers.ts
@@ -57,6 +57,11 @@ export const eventStore = new EventStore<ProviderInfo[]>(
 );
 eventStore.setup();
 
+export const providersLoaded: Writable<boolean> = writable(false);
+window.events?.receive('extensions-started', () => {
+  providersLoaded.set(true);
+});
+
 const updateProviderCallbacks: string[] = [];
 export async function fetchProviders(): Promise<ProviderInfo[]> {
   const result = await window.getProviderInfos();


### PR DESCRIPTION
### What does this PR do?

Fixes a spurious "new content" notification dot on the Dashboard nav item that appeared on the **first navigation away** from the Dashboard, even though nothing new had arrived. It fired once per app launch and cleared when returning to the Dashboard.

> **Scope:** this PR handles only the **resources (providers)** part of the badge, which is what the issue reproduces. The **notifications** part of the badge is **not** addressed here and remains a follow-up.

**Root cause:** `NewContentOnDashboardBadge.svelte` seeded its provider baseline as an empty array (`providersId = []`) and only populated it once it subscribed in `onMount`. Svelte stores replay their current value to a new subscriber immediately, so the *first* emission from `providerInfos` already carried the providers that existed at startup (e.g. Podman). Comparing that first emission against the empty seed reported a spurious addition via `hasNewProvider([], ['podman'])`, and the flag latched on — nothing reset it except navigating back to the Dashboard.

**Fix:**
- Add a `providersLoaded` store (`packages/renderer/src/stores/providers.ts`), flipped to `true` by the one-shot `extensions-started` event — the same "startup settled" signal already used by most other renderer stores.
- In `NewContentOnDashboardBadge.svelte`, ignore `providerInfos` emissions until `providersLoaded` is `true`, then treat the first post-load emission as the baseline instead of diffing it against `[]`. Progressive provider registration during extension activation is now ignored; only providers that genuinely appear *after* startup light the dot.

The notification half of the badge is naturally guarded by the `readyToUpdate` gate in `notifications.ts` and is left unchanged in this PR.

### Screenshot / video of UI

This is a transient, timing-dependent startup dot rather than a static UI element, so it isn't meaningfully capturable in a before/after screenshot. The reproduced (pre-fix) behavior is shown in the linked issue. The fix is covered by unit tests (see below).

### What issues does this PR fix or reference?

Partially addresses #18563 (resources part only; the notifications part is a follow-up).

### How to test this PR?

Automated:

\`\`\`bash
npx vitest run packages/renderer/src/lib/dashboard/NewContentOnDashboardBadge.spec.ts
\`\`\`

Three new tests cover: (1) the initial fetch resolving after mount with a pre-existing provider → no dot; (2) providers registering progressively across multiple emissions before \`providersLoaded\` fires → no dot; (3) a provider added *after* \`providersLoaded\` fires → dot still shows (regression guard).

Manual (matches issue repro): start Podman Desktop with at least one configured container engine, land on the Dashboard, click "Containers" → the Dashboard nav item should show **no** notification dot.

- [x] Tests are covering the bug fix or the new feature

---

🤖 AI-assisted: analysis, implementation, and tests were produced with Claude Code and reviewed by the author.