### PR TITLE
feat(renderer): support expandable sections with children in settings navigation 

### DIFF
--- a/packages/renderer/src/PreferencesNavigation.spec.ts
+++ b/packages/renderer/src/PreferencesNavigation.spec.ts
@@ -22,8 +22,9 @@ import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import type { TinroRouteMeta } from 'tinro';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { settingsNavigationEntries } from './PreferencesNavigation';
 import PreferencesNavigation from './PreferencesNavigation.svelte';
 import { configurationProperties } from './stores/configurationProperties';
 import { onDidChangeRegisteredFeatures, registeredFeatures } from './stores/registered-features';
@@ -588,5 +589,114 @@ describe('Navigation width measurement and calculation', () => {
 
     unmount();
     expect(disconnect).toHaveBeenCalled();
+  });
+});
+
+describe('Static navigation entry children', () => {
+  let originalLength: number;
+
+  beforeEach(() => {
+    originalLength = settingsNavigationEntries.length;
+    settingsNavigationEntries.push({
+      title: 'Test Parent',
+      href: '/preferences/test-parent',
+      visible: true,
+      children: [
+        { title: 'Child One', href: '/preferences/test-parent/child-one', visible: true },
+        { title: 'Child Two', href: '/preferences/test-parent/child-two', visible: true },
+        { title: 'Hidden Child', href: '/preferences/test-parent/hidden', visible: false },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    settingsNavigationEntries.length = originalLength;
+  });
+
+  test('should start expanded when entry has expanded set to true', async () => {
+    settingsNavigationEntries.push({
+      title: 'Auto Expanded',
+      href: '/preferences/auto-expanded',
+      visible: true,
+      expanded: true,
+      children: [{ title: 'Auto Child', href: '/preferences/auto-expanded/child', visible: true }],
+    });
+
+    renderPreferencesNavigation();
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Auto Expanded' })).toBeVisible();
+      expect(screen.getByRole('link', { name: 'Auto Child' })).toBeVisible();
+    });
+  });
+
+  test('should render parent entry with children as a link', async () => {
+    renderPreferencesNavigation();
+
+    const parentLink = await screen.findByRole('link', { name: 'Test Parent' });
+    expect(parentLink).toBeVisible();
+  });
+
+  test('should not show children before parent is expanded', async () => {
+    renderPreferencesNavigation();
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Test Parent' })).toBeVisible();
+    });
+
+    expect(screen.queryByRole('link', { name: 'Child One' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Child Two' })).toBeNull();
+  });
+
+  test('should show visible children when parent section is expanded', async () => {
+    renderPreferencesNavigation();
+
+    await fireEvent.click(await screen.findByRole('link', { name: 'Test Parent' }));
+
+    expect(await screen.findByRole('link', { name: 'Child One' })).toBeVisible();
+    expect(await screen.findByRole('link', { name: 'Child Two' })).toBeVisible();
+  });
+
+  test('should filter out children with visible set to false', async () => {
+    renderPreferencesNavigation();
+
+    await fireEvent.click(await screen.findByRole('link', { name: 'Test Parent' }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Child One' })).toBeVisible();
+      expect(screen.queryByRole('link', { name: 'Hidden Child' })).toBeNull();
+    });
+  });
+
+  test('should not select parent when current URL matches a child href', async () => {
+    render(PreferencesNavigation, {
+      meta: { url: '/preferences/test-parent/child-one' } as unknown as TinroRouteMeta,
+    });
+
+    await fireEvent.click(await screen.findByRole('link', { name: 'Test Parent' }));
+
+    await vi.waitFor(() => {
+      const parentRow = screen.getByRole('link', { name: 'Test Parent' }).querySelector('[data-settings-nav-row]');
+      expect(parentRow).not.toHaveClass('bg-[var(--pd-secondary-nav-selected-bg)]');
+
+      const childRow = screen.getByRole('link', { name: 'Child One' }).querySelector('[data-settings-nav-row]');
+      expect(childRow).toHaveClass('bg-[var(--pd-secondary-nav-selected-bg)]');
+    });
+  });
+
+  test('should select parent when URL matches parent href and no child matches', async () => {
+    render(PreferencesNavigation, {
+      meta: { url: '/preferences/test-parent' } as unknown as TinroRouteMeta,
+    });
+
+    await fireEvent.click(await screen.findByRole('link', { name: 'Test Parent' }));
+
+    await vi.waitFor(() => {
+      const parentRow = screen.getByRole('link', { name: 'Test Parent' }).querySelector('[data-settings-nav-row]');
+      expect(parentRow).toHaveClass('bg-[var(--pd-secondary-nav-selected-bg)]');
+
+      const childRow = screen.getByRole('link', { name: 'Child One' }).querySelector('[data-settings-nav-row]');
+      expect(childRow).not.toHaveClass('bg-[var(--pd-secondary-nav-selected-bg)]');
+    });
   });
 });

--- a/packages/renderer/src/PreferencesNavigation.svelte
+++ b/packages/renderer/src/PreferencesNavigation.svelte
@@ -19,7 +19,9 @@ interface Props {
 let { meta }: Props = $props();
 
 let configProperties: Map<string, NavItem[]> = $state(new Map<string, NavItem[]>());
-let sectionExpanded: { [key: string]: boolean } = $state({});
+let sectionExpanded: { [key: string]: boolean } = $state(
+  Object.fromEntries(settingsNavigationEntries.filter(e => e.expanded).map(e => [e.title, true])),
+);
 
 let experimentalSection: boolean = $state(false);
 
@@ -230,9 +232,13 @@ onMount(() => {
 
     configProperties = nextConfigProperties;
 
-    // Drop expansion flags for sections no longer present to avoid stale widened width.
+    // Drop expansion flags for dynamic config sections no longer present to avoid stale widened width.
+    // Preserve expansion state for static navigation entries.
     sectionExpanded = Object.fromEntries(
-      Object.entries(sectionExpanded).filter(([sectionId]) => nextConfigProperties.has(sectionId)),
+      Object.entries(sectionExpanded).filter(
+        ([sectionId]) =>
+          nextConfigProperties.has(sectionId) || settingsNavigationItems.some(e => e.title === sectionId),
+      ),
     );
 
     scheduleNavigationWidthUpdate();
@@ -268,13 +274,26 @@ onMount(() => {
   <div class="h-full overflow-y-auto" style="margin-bottom:auto">
     {#each settingsNavigationItems as navItem, index (index)}
       {#if navItem.visible}
-        <SettingsNavItem 
-          title={navItem.title} 
-          href={navItem.href} 
+        {@const visibleChildren = navItem.children?.filter(c => c.visible) ?? []}
+        <SettingsNavItem
+          title={navItem.title}
+          href={navItem.href}
           icon={navItem.icon}
+          section={visibleChildren.length > 0}
+          selected={meta.url === navItem.href && !visibleChildren.some(c => c.href === meta.url)}
           onClick={scheduleNavigationWidthUpdate}
-          selected={meta.url === navItem.href} 
-        />
+          bind:expanded={sectionExpanded[navItem.title]} />
+        {#if sectionExpanded[navItem.title]}
+          {#each visibleChildren as child (child.href)}
+            <SettingsNavItem
+              title={child.title}
+              href={child.href}
+              icon={child.icon}
+              child={true}
+              selected={meta.url === child.href}
+              onClick={scheduleNavigationWidthUpdate} />
+          {/each}
+        {/if}
       {/if}
     {/each}
 

--- a/packages/renderer/src/PreferencesNavigation.ts
+++ b/packages/renderer/src/PreferencesNavigation.ts
@@ -37,6 +37,8 @@ export interface SettingsNavItemConfig {
   href: string;
   visible?: boolean;
   icon?: Component;
+  children?: Omit<SettingsNavItemConfig, 'children'>[];
+  expanded?: boolean;
 }
 
 // Static navigation entries for routes not in the main navigation registry


### PR DESCRIPTION
### What does this PR do?
Add children and expanded properties to SettingsNavItemConfig so static navigation entries can define nested, collapsible sub-items. The parent is not highlighted when a child route is active.

### Screenshot / video of UI

<img width="1162" height="812" alt="image" src="https://github.com/user-attachments/assets/42314e92-f928-42ce-8f5d-14fa7770a52f" />

### What issues does this PR fix or reference?

fixes #19123 

### How to test this PR?

add in `packages/renderer/src/PreferencesNavigation.ts` files to the `settingsNavigationEntries` variable:

```ts
 {
    title: 'Florent',
    href: '/preferences/openshell/gateways',
    visible: true,
    icon: CLIToolsIcon,
    expanded: true,
    children: [{ title: 'test 1', href: '/preferences/openshell/gateways', visible: true }, { title: 'test 2', href: '/preferences/openshell/gateways2', visible: true }],
  },
```

- [x] Tests are covering the bug fix or the new feature
