### PR TITLE
test(e2e): update serial declaration - part 7

### DIFF
--- a/tests/playwright/src/specs/kubernetes-networking.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-networking.spec.ts
@@ -125,109 +125,109 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe
-  .serial('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
-    test('Apply deployment, service, and ingress resources to the cluster', async ({ page }) => {
-      test.setTimeout(80_000);
-      await createKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, DEPLOYMENT_YAML_PATH);
-      await createKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME, SERVICE_YAML_PATH);
-      await createKubernetesResource(page, KubernetesResources.IngeressesRoutes, INGRESS_NAME, INGRESS_YAML_PATH);
-      await checkKubernetesResourceState(
-        page,
-        KubernetesResources.Deployments,
-        DEPLOYMENT_NAME,
-        KubernetesResourceState.Running,
-        80_000,
-      );
-      await checkKubernetesResourceState(
-        page,
-        KubernetesResources.Services,
-        SERVICE_NAME,
-        KubernetesResourceState.Running,
-        10_000,
-      );
-      await checkKubernetesResourceState(
+test.describe('Kubernetes networking E2E test', { tag: '@k8s_e2e' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Apply deployment, service, and ingress resources to the cluster', async ({ page }) => {
+    test.setTimeout(80_000);
+    await createKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, DEPLOYMENT_YAML_PATH);
+    await createKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME, SERVICE_YAML_PATH);
+    await createKubernetesResource(page, KubernetesResources.IngeressesRoutes, INGRESS_NAME, INGRESS_YAML_PATH);
+    await checkKubernetesResourceState(
+      page,
+      KubernetesResources.Deployments,
+      DEPLOYMENT_NAME,
+      KubernetesResourceState.Running,
+      80_000,
+    );
+    await checkKubernetesResourceState(
+      page,
+      KubernetesResources.Services,
+      SERVICE_NAME,
+      KubernetesResourceState.Running,
+      10_000,
+    );
+    await checkKubernetesResourceState(
+      page,
+      KubernetesResources.IngeressesRoutes,
+      INGRESS_NAME,
+      KubernetesResourceState.Running,
+      10_000,
+    );
+    // Get the first pod from the deployment
+    firstPodName = await getFirstPodFromDeployment(page, DEPLOYMENT_NAME);
+  });
+
+  test.describe('Ingress routing workflow verification', () => {
+    test('Verify Ingress controller pods are running', async ({ page }) => {
+      test.setTimeout(160_000);
+      await monitorPodStatusInClusterContainer(page, KIND_NODE, INGRESS_CONTROLLER_COMMAND);
+    });
+
+    test(`Verify the availability of the ${SERVICE_NAME} service.`, async () => {
+      await verifyLocalPortResponse(SERVICE_ADDRESS, RESPONSE_MESSAGE);
+    });
+  });
+
+  test.describe('Port forwarding workflow verification', () => {
+    test('Create port forwarding configurations for pod, service, and deployment', async ({ page }) => {
+      await configurePortForwarding(page, KubernetesResources.Pods, firstPodName);
+      await configurePortForwarding(page, KubernetesResources.Services, SERVICE_NAME);
+      await configurePortForwarding(page, KubernetesResources.Deployments, DEPLOYMENT_NAME);
+    });
+
+    test('Verify port forwarding configurations display correctly', async ({ page }) => {
+      await verifyPortForwardingConfiguration(page, firstPodName, LOCAL_PORT, REMOTE_PORT);
+      await verifyPortForwardingConfiguration(page, SERVICE_NAME, SECOND_LOCAL_PORT, SERVICE_REMOTE_PORT);
+      await verifyPortForwardingConfiguration(page, DEPLOYMENT_NAME, THIRD_LOCAL_PORT, DEPLOYMENT_REMOTE_PORT);
+    });
+
+    test('Verify forwarded ports respond correctly', async () => {
+      await verifyLocalPortResponse(PORT_FORWARDING_ADDRESS, RESPONSE_MESSAGE);
+      await verifyLocalPortResponse(SERVICE_PORT_ADDRESS, RESPONSE_MESSAGE);
+      await verifyLocalPortResponse(DEPLOYMENT_PORT_ADDRESS, RESPONSE_MESSAGE);
+    });
+
+    test('Delete configuration', async ({ page }) => {
+      await deleteKubernetesResource(page, KubernetesResources.PortForwarding, firstPodName);
+      await deleteKubernetesResource(page, KubernetesResources.PortForwarding, SERVICE_NAME);
+      await deleteKubernetesResource(page, KubernetesResources.PortForwarding, DEPLOYMENT_NAME);
+    });
+
+    test('Verify UI components after removal', async ({ page, navigationBar }) => {
+      //Verify Kubernetes port forwarding page
+      const noForwardingsMessage = page.getByText('No port forwarding configured');
+      await playExpect(noForwardingsMessage).toBeVisible();
+
+      //Verify Pod details page
+      const kubernetesBar = await navigationBar.openKubernetes();
+      const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);
+      await playExpect
+        .poll(async () => kubernetesPodsPage.getRowByName(firstPodName), {
+          timeout: 15_000,
+        })
+        .toBeTruthy();
+      const podDetailPage = await kubernetesPodsPage.openResourceDetails(firstPodName, KubernetesResources.Pods);
+      await podDetailPage.activateTab('Summary');
+      const forwardButton = page.getByRole('button', { name: 'Forward...' });
+      await playExpect(forwardButton).toBeVisible();
+    });
+
+    test('Verify forwarded port responses after configuration removal', async () => {
+      await verifyLocalPortResponse(PORT_FORWARDING_ADDRESS, RESPONSE_MESSAGE); // expect to contain to pass until #16529 is resolved
+      await verifyLocalPortResponse(SERVICE_PORT_ADDRESS, RESPONSE_MESSAGE); // expect to contain to pass until #16529 is resolved
+      await verifyLocalPortResponse(DEPLOYMENT_PORT_ADDRESS, RESPONSE_MESSAGE); // expect to contain to pass until #16529 is resolved
+    });
+
+    test('Delete Kubernetes resources', async ({ page }) => {
+      await deleteKubernetesResource(
         page,
         KubernetesResources.IngeressesRoutes,
         INGRESS_NAME,
-        KubernetesResourceState.Running,
-        10_000,
+        30_000,
+        'Delete Ingress?',
       );
-      // Get the first pod from the deployment
-      firstPodName = await getFirstPodFromDeployment(page, DEPLOYMENT_NAME);
-    });
-
-    test.describe('Ingress routing workflow verification', () => {
-      test('Verify Ingress controller pods are running', async ({ page }) => {
-        test.setTimeout(160_000);
-        await monitorPodStatusInClusterContainer(page, KIND_NODE, INGRESS_CONTROLLER_COMMAND);
-      });
-
-      test(`Verify the availability of the ${SERVICE_NAME} service.`, async () => {
-        await verifyLocalPortResponse(SERVICE_ADDRESS, RESPONSE_MESSAGE);
-      });
-    });
-
-    test.describe('Port forwarding workflow verification', () => {
-      test('Create port forwarding configurations for pod, service, and deployment', async ({ page }) => {
-        await configurePortForwarding(page, KubernetesResources.Pods, firstPodName);
-        await configurePortForwarding(page, KubernetesResources.Services, SERVICE_NAME);
-        await configurePortForwarding(page, KubernetesResources.Deployments, DEPLOYMENT_NAME);
-      });
-
-      test('Verify port forwarding configurations display correctly', async ({ page }) => {
-        await verifyPortForwardingConfiguration(page, firstPodName, LOCAL_PORT, REMOTE_PORT);
-        await verifyPortForwardingConfiguration(page, SERVICE_NAME, SECOND_LOCAL_PORT, SERVICE_REMOTE_PORT);
-        await verifyPortForwardingConfiguration(page, DEPLOYMENT_NAME, THIRD_LOCAL_PORT, DEPLOYMENT_REMOTE_PORT);
-      });
-
-      test('Verify forwarded ports respond correctly', async () => {
-        await verifyLocalPortResponse(PORT_FORWARDING_ADDRESS, RESPONSE_MESSAGE);
-        await verifyLocalPortResponse(SERVICE_PORT_ADDRESS, RESPONSE_MESSAGE);
-        await verifyLocalPortResponse(DEPLOYMENT_PORT_ADDRESS, RESPONSE_MESSAGE);
-      });
-
-      test('Delete configuration', async ({ page }) => {
-        await deleteKubernetesResource(page, KubernetesResources.PortForwarding, firstPodName);
-        await deleteKubernetesResource(page, KubernetesResources.PortForwarding, SERVICE_NAME);
-        await deleteKubernetesResource(page, KubernetesResources.PortForwarding, DEPLOYMENT_NAME);
-      });
-
-      test('Verify UI components after removal', async ({ page, navigationBar }) => {
-        //Verify Kubernetes port forwarding page
-        const noForwardingsMessage = page.getByText('No port forwarding configured');
-        await playExpect(noForwardingsMessage).toBeVisible();
-
-        //Verify Pod details page
-        const kubernetesBar = await navigationBar.openKubernetes();
-        const kubernetesPodsPage = await kubernetesBar.openTabPage(KubernetesResources.Pods);
-        await playExpect
-          .poll(async () => kubernetesPodsPage.getRowByName(firstPodName), {
-            timeout: 15_000,
-          })
-          .toBeTruthy();
-        const podDetailPage = await kubernetesPodsPage.openResourceDetails(firstPodName, KubernetesResources.Pods);
-        await podDetailPage.activateTab('Summary');
-        const forwardButton = page.getByRole('button', { name: 'Forward...' });
-        await playExpect(forwardButton).toBeVisible();
-      });
-
-      test('Verify forwarded port responses after configuration removal', async () => {
-        await verifyLocalPortResponse(PORT_FORWARDING_ADDRESS, RESPONSE_MESSAGE); // expect to contain to pass until #16529 is resolved
-        await verifyLocalPortResponse(SERVICE_PORT_ADDRESS, RESPONSE_MESSAGE); // expect to contain to pass until #16529 is resolved
-        await verifyLocalPortResponse(DEPLOYMENT_PORT_ADDRESS, RESPONSE_MESSAGE); // expect to contain to pass until #16529 is resolved
-      });
-
-      test('Delete Kubernetes resources', async ({ page }) => {
-        await deleteKubernetesResource(
-          page,
-          KubernetesResources.IngeressesRoutes,
-          INGRESS_NAME,
-          30_000,
-          'Delete Ingress?',
-        );
-        await deleteKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME);
-        await deleteKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME);
-      });
+      await deleteKubernetesResource(page, KubernetesResources.Services, SERVICE_NAME);
+      await deleteKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME);
     });
   });
+});

--- a/tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts
+++ b/tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts
@@ -73,120 +73,115 @@ test.afterAll(async ({ runner, page, navigationBar }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Status bar providers feature verification', { tag: '@k8s_e2e' }, () => {
-    test('Enable status bar providers experimental feature', async ({ navigationBar, page }) => {
-      await setStatusBarProvidersFeature(page, navigationBar, true);
-    });
-    test('Verify default Podman provider in status bar', async ({ statusBar }) => {
-      const podmanStatusBarProviderButton = await statusBar.getProviderButton(podmanProviderName);
-      await playExpect(podmanStatusBarProviderButton).toBeVisible();
-    });
-    test('Verify clicking on provider', async ({ statusBar, page }) => {
-      const podmanStatusBarProviderButton = await statusBar.getProviderButton(podmanProviderName);
-      await podmanStatusBarProviderButton.click();
-      const resourcesPage = new ResourcesPage(page);
-      await playExpect(resourcesPage.heading).toBeVisible();
-    });
-    test('Verify provider pinning', async ({ statusBar }) => {
-      await statusBar.pinProvider(podmanProviderName, false);
-      await statusBar.pinProvider(podmanProviderName, true);
-    });
-    test('Verify hovering podman provider shows machine status', async ({ statusBar }) => {
-      if (isLinux) {
-        await playExpect
-          .poll(async () => await statusBar.isProviderResourceRunning(podmanProviderName, podmanProviderName))
-          .toBeTruthy();
-      } else {
-        await playExpect
-          .poll(async () => await statusBar.isProviderResourceRunning(podmanProviderName, defaultMachine))
-          .toBeTruthy();
-      }
-    });
-    test('Create and delete new resource and verify providers updated', async ({ page, statusBar }) => {
-      test.skip(isLinux, 'Not creating new machine on Linux');
-      test.skip(
-        getVirtualizationProvider() === PodmanVirtualizationProviders.HyperV,
-        'Podman Desktop is not able to have 2 HyperV machines running at the same time',
-      );
-      test.setTimeout(isMac ? 420_000 : 350_000);
+test.describe('Status bar providers feature verification', { tag: '@k8s_e2e' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Enable status bar providers experimental feature', async ({ navigationBar, page }) => {
+    await setStatusBarProvidersFeature(page, navigationBar, true);
+  });
+  test('Verify default Podman provider in status bar', async ({ statusBar }) => {
+    const podmanStatusBarProviderButton = await statusBar.getProviderButton(podmanProviderName);
+    await playExpect(podmanStatusBarProviderButton).toBeVisible();
+  });
+  test('Verify clicking on provider', async ({ statusBar, page }) => {
+    const podmanStatusBarProviderButton = await statusBar.getProviderButton(podmanProviderName);
+    await podmanStatusBarProviderButton.click();
+    const resourcesPage = new ResourcesPage(page);
+    await playExpect(resourcesPage.heading).toBeVisible();
+  });
+  test('Verify provider pinning', async ({ statusBar }) => {
+    await statusBar.pinProvider(podmanProviderName, false);
+    await statusBar.pinProvider(podmanProviderName, true);
+  });
+  test('Verify hovering podman provider shows machine status', async ({ statusBar }) => {
+    if (isLinux) {
+      await playExpect
+        .poll(async () => await statusBar.isProviderResourceRunning(podmanProviderName, podmanProviderName))
+        .toBeTruthy();
+    } else {
+      await playExpect
+        .poll(async () => await statusBar.isProviderResourceRunning(podmanProviderName, defaultMachine))
+        .toBeTruthy();
+    }
+  });
+  test('Create and delete new resource and verify providers updated', async ({ page, statusBar }) => {
+    test.skip(isLinux, 'Not creating new machine on Linux');
+    test.skip(
+      getVirtualizationProvider() === PodmanVirtualizationProviders.HyperV,
+      'Podman Desktop is not able to have 2 HyperV machines running at the same time',
+    );
+    test.setTimeout(isMac ? 420_000 : 350_000);
 
-      const settingsBar = new SettingsBar(page);
-      await settingsBar.resourcesTab.click();
+    const settingsBar = new SettingsBar(page);
+    await settingsBar.resourcesTab.click();
 
-      if (isMac) {
-        const defaultMachineCard = new ResourceConnectionCardPage(page, 'podman', defaultMachine);
-        await defaultMachineCard.performConnectionAction(ResourceElementActions.Stop);
-        await waitUntil(
-          async () =>
-            (await defaultMachineCard.resourceElementConnectionStatus.innerText()).includes(ResourceElementState.Off),
-          { timeout: 30_000, sendError: true },
-        );
-      }
-
-      const podmanResources = new ResourceConnectionCardPage(page, 'podman');
-      await podmanResources.createButton.click();
-      const createMachinePage = new CreateMachinePage(page);
-      await createMachinePage.createMachine(newMachineName, {
-        startNow: true,
-        setAsDefault: false,
-        virtualizationProvider: getVirtualizationProvider(),
-      });
-
-      const machineCard = new ResourceConnectionCardPage(page, 'podman', newMachineName);
-      playExpect(await machineCard.doesResourceElementExist()).toBeTruthy();
+    if (isMac) {
+      const defaultMachineCard = new ResourceConnectionCardPage(page, 'podman', defaultMachine);
+      await defaultMachineCard.performConnectionAction(ResourceElementActions.Stop);
       await waitUntil(
         async () =>
-          (await machineCard.resourceElementConnectionStatus.innerText()).includes(ResourceElementState.Running),
+          (await defaultMachineCard.resourceElementConnectionStatus.innerText()).includes(ResourceElementState.Off),
         { timeout: 30_000, sendError: true },
       );
+    }
 
-      await verifyMachinePrivileges(machineCard, PodmanMachinePrivileges.Rootful); //default privileges
+    const podmanResources = new ResourceConnectionCardPage(page, 'podman');
+    await podmanResources.createButton.click();
+    const createMachinePage = new CreateMachinePage(page);
+    await createMachinePage.createMachine(newMachineName, {
+      startNow: true,
+      setAsDefault: false,
+      virtualizationProvider: getVirtualizationProvider(),
+    });
 
-      await verifyVirtualizationProvider(
-        machineCard,
-        getVirtualizationProvider() ?? getDefaultVirtualizationProvider(),
-      );
+    const machineCard = new ResourceConnectionCardPage(page, 'podman', newMachineName);
+    playExpect(await machineCard.doesResourceElementExist()).toBeTruthy();
+    await waitUntil(
+      async () =>
+        (await machineCard.resourceElementConnectionStatus.innerText()).includes(ResourceElementState.Running),
+      { timeout: 30_000, sendError: true },
+    );
 
-      playExpect(await statusBar.isProviderResourceRunning(podmanProviderName, newMachineName)).toBeTruthy();
+    await verifyMachinePrivileges(machineCard, PodmanMachinePrivileges.Rootful); //default privileges
 
-      await deletePodmanMachine(page, newMachineName);
+    await verifyVirtualizationProvider(machineCard, getVirtualizationProvider() ?? getDefaultVirtualizationProvider());
+
+    playExpect(await statusBar.isProviderResourceRunning(podmanProviderName, newMachineName)).toBeTruthy();
+
+    await deletePodmanMachine(page, newMachineName);
+    await handlePodmanConfirmationDialogs(page);
+
+    playExpect(await statusBar.isProviderResourceRunning(podmanProviderName, newMachineName)).toBeFalsy();
+
+    if (isMac) {
+      const defaultMachineCard = new ResourceConnectionCardPage(page, 'podman', defaultMachine);
+      await defaultMachineCard.performConnectionAction(ResourceElementActions.Start);
       await handlePodmanConfirmationDialogs(page);
-
-      playExpect(await statusBar.isProviderResourceRunning(podmanProviderName, newMachineName)).toBeFalsy();
-
-      if (isMac) {
-        const defaultMachineCard = new ResourceConnectionCardPage(page, 'podman', defaultMachine);
-        await defaultMachineCard.performConnectionAction(ResourceElementActions.Start);
-        await handlePodmanConfirmationDialogs(page);
-        await waitUntil(
-          async () =>
-            (await defaultMachineCard.resourceElementConnectionStatus.innerText()).includes(
-              ResourceElementState.Running,
-            ),
-          { timeout: 60_000, sendError: true },
-        );
-      }
-    });
-    test('Create new provider (Kind) and verify providers updated', async ({ page, statusBar }) => {
-      test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
-      test.setTimeout(600_000);
-      await createKindCluster(page, kindClusterName, 550_000, {
-        providerType: providerTypeGHA,
-        useIngressController: false,
-      });
-
-      //Verify its not pinned by default
-      const kindStatusBarProviderButton = await statusBar.getProviderButton(kindProviderName);
-      await playExpect(kindStatusBarProviderButton).not.toBeVisible();
-
-      await statusBar.pinProvider(kindProviderName, true);
-      await playExpect
-        .poll(async () => await statusBar.isProviderResourceRunning(kindProviderName, kindClusterName))
-        .toBeTruthy();
-    });
-    test('Disable status bar providers feature', async ({ page, navigationBar, statusBar }) => {
-      await setStatusBarProvidersFeature(page, navigationBar, false);
-      await playExpect(statusBar.pinProvidersButton).not.toBeVisible();
-    });
+      await waitUntil(
+        async () =>
+          (await defaultMachineCard.resourceElementConnectionStatus.innerText()).includes(ResourceElementState.Running),
+        { timeout: 60_000, sendError: true },
+      );
+    }
   });
+  test('Create new provider (Kind) and verify providers updated', async ({ page, statusBar }) => {
+    test.skip(!canRunKindTests(), `This test can't run on a windows rootless machine`);
+    test.setTimeout(600_000);
+    await createKindCluster(page, kindClusterName, 550_000, {
+      providerType: providerTypeGHA,
+      useIngressController: false,
+    });
+
+    //Verify its not pinned by default
+    const kindStatusBarProviderButton = await statusBar.getProviderButton(kindProviderName);
+    await playExpect(kindStatusBarProviderButton).not.toBeVisible();
+
+    await statusBar.pinProvider(kindProviderName, true);
+    await playExpect
+      .poll(async () => await statusBar.isProviderResourceRunning(kindProviderName, kindClusterName))
+      .toBeTruthy();
+  });
+  test('Disable status bar providers feature', async ({ page, navigationBar, statusBar }) => {
+    await setStatusBarProvidersFeature(page, navigationBar, false);
+    await playExpect(statusBar.pinProvidersButton).not.toBeVisible();
+  });
+});

--- a/tests/playwright/src/specs/kubernetes.spec.ts
+++ b/tests/playwright/src/specs/kubernetes.spec.ts
@@ -142,264 +142,258 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe
-  .serial('Kind provider creation page navigation', { tag: ['@k8s_e2e', '@k8s_sanity'] }, () => {
-    test('Resources breadcrumb navigates back to Resources page', async ({ page, navigationBar }) => {
-      await openKindCreationPage(page, navigationBar);
-      const creationPage = new ResourceCreationPage(page);
-      await creationPage.navigateToResourcesViaBreadcrumb();
-    });
+test.describe('Kind provider creation page navigation', { tag: ['@k8s_e2e', '@k8s_sanity'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Resources breadcrumb navigates back to Resources page', async ({ page, navigationBar }) => {
+    await openKindCreationPage(page, navigationBar);
+    const creationPage = new ResourceCreationPage(page);
+    await creationPage.navigateToResourcesViaBreadcrumb();
+  });
 
-    test('Close button navigates back to Resources page', async ({ page, navigationBar }) => {
-      await openKindCreationPage(page, navigationBar);
-      const creationPage = new ResourceCreationPage(page);
-      await creationPage.navigateToResourcesViaCloseButton();
+  test('Close button navigates back to Resources page', async ({ page, navigationBar }) => {
+    await openKindCreationPage(page, navigationBar);
+    const creationPage = new ResourceCreationPage(page);
+    await creationPage.navigateToResourcesViaCloseButton();
+  });
+});
+
+test.describe('Kubernetes resources End-to-End test', { tag: ['@k8s_e2e', '@k8s_sanity'] }, () => {
+  test.describe.configure({ mode: 'serial', retries: 1 });
+
+  test('Kubernetes Nodes test', async ({ page }) => {
+    await checkKubernetesResourceState(page, KubernetesResources.Nodes, KIND_NODE, KubernetesResourceState.Running);
+  });
+
+  test('Kubernetes dashboard and namespaces test', async ({ navigationBar }) => {
+    const kubernetesBar = await navigationBar.openKubernetes();
+    const dashboardPage = await kubernetesBar.openKubernetesDashboardPage();
+
+    await playExpect(dashboardPage.namespaceDropdownButton).toBeVisible({ timeout: 10_000 });
+    await playExpect(dashboardPage.currentNamespace).toHaveValue('default');
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.Nodes), { timeout: 10_000 })
+      .toBe(1);
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentActiveCountForResource(KubernetesResources.Nodes), {
+        timeout: 10_000,
+      })
+      .toBe(1);
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.Deployments), {
+        timeout: 10_000,
+      })
+      .toBe(0);
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentActiveCountForResource(KubernetesResources.Deployments), {
+        timeout: 10_000,
+      })
+      .toBe(0);
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.Pods), { timeout: 10_000 })
+      .toBe(0);
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.Services), {
+        timeout: 10_000,
+      })
+      .toBe(1);
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.ConfigMapsSecrets), {
+        timeout: 10_000,
+      })
+      .toBe(1);
+
+    await dashboardPage.changeNamespace('kube-public');
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.ConfigMapsSecrets), {
+        timeout: 10_000,
+      })
+      .toBe(2);
+
+    await dashboardPage.changeNamespace('default');
+
+    await playExpect
+      .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.ConfigMapsSecrets), {
+        timeout: 10_000,
+      })
+      .toBe(1);
+  });
+
+  test.describe('PVC lifecycle test', () => {
+    test.describe.configure({ mode: 'serial' });
+    test('Create a new PVC resource', async ({ page }) => {
+      await createKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, PVC_YAML_PATH);
+      await checkKubernetesResourceState(page, KubernetesResources.PVCs, PVC_NAME, KubernetesResourceState.Stopped);
+    });
+    test('Bind the PVC to a pod', async ({ page }) => {
+      await createKubernetesResource(page, KubernetesResources.Pods, PVC_POD_NAME, PVC_POD_YAML_PATH);
+      await checkKubernetesResourceState(page, KubernetesResources.Pods, PVC_POD_NAME, KubernetesResourceState.Running);
+    });
+    test('Delete the PVC resource', async ({ page }) => {
+      await deleteKubernetesResource(page, KubernetesResources.Pods, PVC_POD_NAME, 60_000);
+      await deleteKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, 60_000);
+    });
+  });
+  test.describe('ConfigMaps and Secrets lifecycle test', () => {
+    test.describe.configure({ mode: 'serial' });
+    test('Create ConfigMap resource', async ({ page }) => {
+      await createKubernetesResource(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        CONFIG_MAP_NAME,
+        CONFIG_MAP_YAML_PATH,
+      );
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        CONFIG_MAP_NAME,
+        KubernetesResourceState.Running,
+      );
+    });
+    test('Create Secret resource', async ({ page }) => {
+      await createKubernetesResource(page, KubernetesResources.ConfigMapsSecrets, SECRET_NAME, SECRET_YAML_PATH);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        SECRET_NAME,
+        KubernetesResourceState.Running,
+      );
+    });
+    test('Can load config and secrets via env. var in pod', async ({ page }) => {
+      test.setTimeout(120_000);
+
+      await createKubernetesResource(page, KubernetesResources.Pods, SECRET_POD_NAME, SECRET_POD_YAML_PATH);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Pods,
+        SECRET_POD_NAME,
+        KubernetesResourceState.Running,
+      );
+    });
+    test('Delete the ConfigMap and Secret resources', async ({ page }) => {
+      await deletePod(page, SECRET_POD_NAME);
+      await deleteKubernetesResource(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        SECRET_NAME,
+        60_000,
+        'Delete Secret?',
+      );
+      await deleteKubernetesResource(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        CONFIG_MAP_NAME,
+        60_000,
+        'Delete ConfigMap?',
+      );
     });
   });
 
-test.describe
-  .serial('Kubernetes resources End-to-End test', { tag: ['@k8s_e2e', '@k8s_sanity'] }, () => {
-    test.describe.configure({ retries: 1 });
-
-    test('Kubernetes Nodes test', async ({ page }) => {
-      await checkKubernetesResourceState(page, KubernetesResources.Nodes, KIND_NODE, KubernetesResourceState.Running);
+  test.describe('Apply YAML button test', () => {
+    test.describe.configure({ mode: 'serial' });
+    test('Apply a ConfigMap resource via Apply YAML button', async ({ page }) => {
+      await applyKubernetesYaml(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        APPLY_YAML_CONFIGMAP_NAME,
+        APPLY_YAML_CONFIGMAP_PATH,
+      );
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        APPLY_YAML_CONFIGMAP_NAME,
+        KubernetesResourceState.Running,
+      );
     });
-
-    test('Kubernetes dashboard and namespaces test', async ({ navigationBar }) => {
-      const kubernetesBar = await navigationBar.openKubernetes();
-      const dashboardPage = await kubernetesBar.openKubernetesDashboardPage();
-
-      await playExpect(dashboardPage.namespaceDropdownButton).toBeVisible({ timeout: 10_000 });
-      await playExpect(dashboardPage.currentNamespace).toHaveValue('default');
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.Nodes), { timeout: 10_000 })
-        .toBe(1);
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentActiveCountForResource(KubernetesResources.Nodes), {
-          timeout: 10_000,
-        })
-        .toBe(1);
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.Deployments), {
-          timeout: 10_000,
-        })
-        .toBe(0);
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentActiveCountForResource(KubernetesResources.Deployments), {
-          timeout: 10_000,
-        })
-        .toBe(0);
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.Pods), { timeout: 10_000 })
-        .toBe(0);
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.Services), {
-          timeout: 10_000,
-        })
-        .toBe(1);
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.ConfigMapsSecrets), {
-          timeout: 10_000,
-        })
-        .toBe(1);
-
-      await dashboardPage.changeNamespace('kube-public');
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.ConfigMapsSecrets), {
-          timeout: 10_000,
-        })
-        .toBe(2);
-
-      await dashboardPage.changeNamespace('default');
-
-      await playExpect
-        .poll(async () => dashboardPage.getCurrentTotalCountForResource(KubernetesResources.ConfigMapsSecrets), {
-          timeout: 10_000,
-        })
-        .toBe(1);
+    test('Delete the ConfigMap applied via Apply YAML', async ({ page }) => {
+      await deleteKubernetesResource(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        APPLY_YAML_CONFIGMAP_NAME,
+        60_000,
+        'Delete ConfigMap?',
+      );
     });
-
-    test.describe
-      .serial('PVC lifecycle test', () => {
-        test('Create a new PVC resource', async ({ page }) => {
-          await createKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, PVC_YAML_PATH);
-          await checkKubernetesResourceState(page, KubernetesResources.PVCs, PVC_NAME, KubernetesResourceState.Stopped);
-        });
-        test('Bind the PVC to a pod', async ({ page }) => {
-          await createKubernetesResource(page, KubernetesResources.Pods, PVC_POD_NAME, PVC_POD_YAML_PATH);
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Pods,
-            PVC_POD_NAME,
-            KubernetesResourceState.Running,
-          );
-        });
-        test('Delete the PVC resource', async ({ page }) => {
-          await deleteKubernetesResource(page, KubernetesResources.Pods, PVC_POD_NAME, 60_000);
-          await deleteKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, 60_000);
-        });
-      });
-    test.describe
-      .serial('ConfigMaps and Secrets lifecycle test', () => {
-        test('Create ConfigMap resource', async ({ page }) => {
-          await createKubernetesResource(
-            page,
-            KubernetesResources.ConfigMapsSecrets,
-            CONFIG_MAP_NAME,
-            CONFIG_MAP_YAML_PATH,
-          );
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.ConfigMapsSecrets,
-            CONFIG_MAP_NAME,
-            KubernetesResourceState.Running,
-          );
-        });
-        test('Create Secret resource', async ({ page }) => {
-          await createKubernetesResource(page, KubernetesResources.ConfigMapsSecrets, SECRET_NAME, SECRET_YAML_PATH);
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.ConfigMapsSecrets,
-            SECRET_NAME,
-            KubernetesResourceState.Running,
-          );
-        });
-        test('Can load config and secrets via env. var in pod', async ({ page }) => {
-          test.setTimeout(120_000);
-
-          await createKubernetesResource(page, KubernetesResources.Pods, SECRET_POD_NAME, SECRET_POD_YAML_PATH);
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Pods,
-            SECRET_POD_NAME,
-            KubernetesResourceState.Running,
-          );
-        });
-        test('Delete the ConfigMap and Secret resources', async ({ page }) => {
-          await deletePod(page, SECRET_POD_NAME);
-          await deleteKubernetesResource(
-            page,
-            KubernetesResources.ConfigMapsSecrets,
-            SECRET_NAME,
-            60_000,
-            'Delete Secret?',
-          );
-          await deleteKubernetesResource(
-            page,
-            KubernetesResources.ConfigMapsSecrets,
-            CONFIG_MAP_NAME,
-            60_000,
-            'Delete ConfigMap?',
-          );
-        });
-      });
-
-    test.describe
-      .serial('Apply YAML button test', () => {
-        test('Apply a ConfigMap resource via Apply YAML button', async ({ page }) => {
-          await applyKubernetesYaml(
-            page,
-            KubernetesResources.ConfigMapsSecrets,
-            APPLY_YAML_CONFIGMAP_NAME,
-            APPLY_YAML_CONFIGMAP_PATH,
-          );
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.ConfigMapsSecrets,
-            APPLY_YAML_CONFIGMAP_NAME,
-            KubernetesResourceState.Running,
-          );
-        });
-        test('Delete the ConfigMap applied via Apply YAML', async ({ page }) => {
-          await deleteKubernetesResource(
-            page,
-            KubernetesResources.ConfigMapsSecrets,
-            APPLY_YAML_CONFIGMAP_NAME,
-            60_000,
-            'Delete ConfigMap?',
-          );
-        });
-      });
-
-    test.describe
-      .serial('Deployment lifecycle test', () => {
-        test('Create a Kubernetes deployment resource', async ({ page }) => {
-          test.setTimeout(90_000);
-          await createKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, DEPLOYMENT_YAML_PATH);
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Deployments,
-            DEPLOYMENT_NAME,
-            KubernetesResourceState.Running,
-          );
-          await checkDeploymentReplicasInfo(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, 3);
-        });
-        test('Edit the Kubernetes deployment YAML file', async ({ page }) => {
-          test.setTimeout(90_000);
-          await editDeploymentYamlFile(page, KubernetesResources.Deployments, DEPLOYMENT_NAME);
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Deployments,
-            DEPLOYMENT_NAME,
-            KubernetesResourceState.Running,
-          );
-          await checkDeploymentReplicasInfo(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, 5);
-        });
-        test('Delete the Kubernetes deployment resource', async ({ page }) => {
-          await deleteKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, 60_000);
-        });
-      });
-
-    test.describe
-      .serial('Cronjobs lifecycle test', () => {
-        test('Create and verify a running Kubernetes cronjob', async ({ page }) => {
-          await createKubernetesResource(page, KubernetesResources.Cronjobs, CRON_JOB_NAME, CRON_JOB_YAML_PATH);
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Cronjobs,
-            CRON_JOB_NAME,
-            KubernetesResourceState.Running,
-          );
-        });
-        test('Validate Job and Pod execution from CronJob', async ({ page }) => {
-          test.setTimeout(80_000);
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Jobs,
-            CRON_JOB_NAME,
-            KubernetesResourceState.Running,
-            70_000,
-          );
-
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Jobs,
-            CRON_JOB_NAME,
-            KubernetesResourceState.None, // Currently there is no 'Completed' state, using None which means the state column is empty
-            70_000,
-          );
-
-          await checkKubernetesResourceState(
-            page,
-            KubernetesResources.Pods,
-            CRON_JOB_NAME,
-            KubernetesResourceState.Succeeded,
-            70_000,
-          );
-        });
-        test('Delete CronJob resource', async ({ page }) => {
-          await deleteKubernetesResource(page, KubernetesResources.Cronjobs, CRON_JOB_NAME, 60_000);
-        });
-      });
   });
+
+  test.describe('Deployment lifecycle test', () => {
+    test.describe.configure({ mode: 'serial' });
+    test('Create a Kubernetes deployment resource', async ({ page }) => {
+      test.setTimeout(90_000);
+      await createKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, DEPLOYMENT_YAML_PATH);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Deployments,
+        DEPLOYMENT_NAME,
+        KubernetesResourceState.Running,
+      );
+      await checkDeploymentReplicasInfo(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, 3);
+    });
+    test('Edit the Kubernetes deployment YAML file', async ({ page }) => {
+      test.setTimeout(90_000);
+      await editDeploymentYamlFile(page, KubernetesResources.Deployments, DEPLOYMENT_NAME);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Deployments,
+        DEPLOYMENT_NAME,
+        KubernetesResourceState.Running,
+      );
+      await checkDeploymentReplicasInfo(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, 5);
+    });
+    test('Delete the Kubernetes deployment resource', async ({ page }) => {
+      await deleteKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME, 60_000);
+    });
+  });
+
+  test.describe('Cronjobs lifecycle test', () => {
+    test.describe.configure({ mode: 'serial' });
+    test('Create and verify a running Kubernetes cronjob', async ({ page }) => {
+      await createKubernetesResource(page, KubernetesResources.Cronjobs, CRON_JOB_NAME, CRON_JOB_YAML_PATH);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Cronjobs,
+        CRON_JOB_NAME,
+        KubernetesResourceState.Running,
+      );
+    });
+    test('Validate Job and Pod execution from CronJob', async ({ page }) => {
+      test.setTimeout(80_000);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Jobs,
+        CRON_JOB_NAME,
+        KubernetesResourceState.Running,
+        70_000,
+      );
+
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Jobs,
+        CRON_JOB_NAME,
+        KubernetesResourceState.None, // Currently there is no 'Completed' state, using None which means the state column is empty
+        70_000,
+      );
+
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Pods,
+        CRON_JOB_NAME,
+        KubernetesResourceState.Succeeded,
+        70_000,
+      );
+    });
+    test('Delete CronJob resource', async ({ page }) => {
+      await deleteKubernetesResource(page, KubernetesResources.Cronjobs, CRON_JOB_NAME, 60_000);
+    });
+  });
+});
 
 // Helper functions
 


### PR DESCRIPTION
### What does this PR do?

Replace the deprecated `test.describe.serial(...)` syntax with the
recommended `test.describe(...)` + `test.describe.configure({ mode: 'serial' })`
pattern in three more spec files:

- `tests/playwright/src/specs/kubernetes-networking.spec.ts`
- `tests/playwright/src/specs/kubernetes-status-bar-providers.spec.ts`
- `tests/playwright/src/specs/kubernetes.spec.ts` (7 blocks; the outer `Kubernetes resources` block already had `test.describe.configure({ retries: 1 })`, so `mode: 'serial'` was merged into it)

### Screenshot / video of UI

No UI changes.

### What issues does this PR fix or reference?

References #15697

### How to test this PR?

No behaviour changes — purely a syntax update as recommended by the Playwright team.

> **Tip:** use **Hide whitespace** in the Files changed view to review the actual changes, since the bulk of the diff is Biome re-indentation.

- [ ] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)