### PR TITLE
fix(renderer): expose feedback smiley rating as accessible group

### DIFF
--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.spec.ts
@@ -53,6 +53,31 @@ test('Expect that the button is disabled when loading the page', async () => {
   expect(button).toBeDisabled();
 });
 
+test('Expect smiley rating group to be exposed as a single-choice control', async () => {
+  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+
+  const group = await screen.findByRole('group', { name: 'How was your experience with Podman Desktop' });
+  expect(group).toBeInTheDocument();
+
+  for (const name of ['very-sad-smiley', 'sad-smiley', 'happy-smiley', 'very-happy-smiley']) {
+    const smiley = screen.getByRole('button', { name });
+    expect(smiley).toHaveAttribute('aria-pressed', 'false');
+  }
+});
+
+test('Expect aria-pressed to reflect the selected smiley and only that smiley', async () => {
+  render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
+  await screen.findByRole('button', { name: 'Send feedback' });
+
+  const sadSmiley = screen.getByRole('button', { name: 'sad-smiley' });
+  await fireEvent.click(sadSmiley);
+
+  expect(sadSmiley).toHaveAttribute('aria-pressed', 'true');
+  expect(screen.getByRole('button', { name: 'very-sad-smiley' })).toHaveAttribute('aria-pressed', 'false');
+  expect(screen.getByRole('button', { name: 'happy-smiley' })).toHaveAttribute('aria-pressed', 'false');
+  expect(screen.getByRole('button', { name: 'very-happy-smiley' })).toHaveAttribute('aria-pressed', 'false');
+});
+
 test('Expect that the button is enabled after clicking on a smiley', async () => {
   render(DirectFeedback, { category: 'developers', contentChange: vi.fn(), onCloseForm: vi.fn() });
   const button = await screen.findByRole('button', { name: 'Send feedback' });

--- a/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
+++ b/packages/renderer/src/lib/feedback/feedbackForms/DirectFeedback.svelte
@@ -89,9 +89,15 @@ async function openGitHub(): Promise<void> {
   <svelte:fragment slot="content">
     <label for="smiley" class="block mt-4 mb-2 text-sm font-medium text-[var(--pd-modal-text)]"
       >{feedbackMessages?.experienceLabel}</label>
-    <div class="flex space-x-4">
+    <div class="flex space-x-4" role="group" aria-label={feedbackMessages?.experienceLabel}>
       {#each SMILEYS as { rating, icon, label } (rating)}
-        <button aria-label={label} onclick={(): void => selectSmiley(rating)}>
+        <button
+          aria-label={label}
+          aria-pressed={smileyRating === rating ? 'true' : 'false'}
+          class="rounded-full p-1 border-2 {smileyRating === rating
+            ? 'border-(--pd-content-card-border-selected)'
+            : 'border-transparent'}"
+          onclick={(): void => selectSmiley(rating)}>
           <Icon
             size="1.5x"
             class="cursor-pointer {smileyRating === rating


### PR DESCRIPTION
### What does this PR do?

The direct-feedback "how was your experience" smiley rating exposed its selection only through an icon color swap, and the four buttons weren't marked up as a single-choice control, so screen reader users had no way to tell which rating was selected, or that the buttons formed one logical choice.

- Wraps the four smiley buttons in `role="group"` with the experience question as the accessible group name.
- Adds `aria-pressed` to each button, reflecting `smileyRating === rating`.
- Adds a non-color ring indicator for the selected smiley (reusing the existing `--pd-content-card-border-selected` token already used elsewhere for selected-state borders), so selection isn't conveyed by color alone.
- Keeps the existing static `aria-label`s (`very-sad-smiley`, etc.) unchanged - `aria-pressed` now conveys selection state, so no existing test or automation relying on those labels breaks.

Builds on #19181, which extracted the four smiley buttons into a `{#each}` loop over a `SMILEYS` array - this PR only touches that loop's markup, adding the group role and per-button ARIA/visual state.

### Screenshot / video of UI

Before:

<img width="1106" height="1106" alt="image" src="https://github.com/user-attachments/assets/bb983ee4-438a-4d18-95bb-e7a5c8c901f1" />

Now:

<img width="1106" height="1106" alt="image" src="https://github.com/user-attachments/assets/eb359de6-02e3-4200-ae28-6ead9a2c3904" />

**Note:** The trimmed "Read our privacy statement" is an artifact of the scrolling area, out of the scope of this PR.

### What issues does this PR fix or reference?

- Resolves: #18582

### How to test this PR?

1. Open Podman Desktop, click the "Share your feedback" status bar icon.
2. Pick any category, then use a screen reader (or inspect the DOM) on the smiley row.
3. Confirm the group announces as "How was your experience with Podman Desktop" and each smiley announces its pressed/not-pressed state.
4. Click a smiley and confirm only that button reports `aria-pressed="true"`, and a visible ring appears around it in addition to the existing color change.

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>