### PR TITLE
fix(preferences): use neutral color for slider unfilled track

### DIFF
--- a/packages/main/src/plugin/color-registry.spec.ts
+++ b/packages/main/src/plugin/color-registry.spec.ts
@@ -115,6 +115,10 @@ class TestColorRegistry extends ColorRegistry {
     super.initProgressBar();
   }
 
+  override initSlider(): void {
+    super.initSlider();
+  }
+
   override initActionButton(): void {
     super.initActionButton();
   }
@@ -1892,6 +1896,26 @@ describe('initProgressBar', () => {
       light: tailwindColorPalette.accent1[500],
       hcDark: tailwindColorPalette.white,
       hcLight: tailwindColorPalette.black,
+    });
+  });
+});
+
+describe('initSlider', () => {
+  let spyOnRegisterColor: MockInstance<(colorId: string, definition: ColorDefinition) => void>;
+
+  beforeEach(() => {
+    spyOnRegisterColor = vi.spyOn(colorRegistry, 'registerColor');
+    spyOnRegisterColor.mockReturnValue(undefined);
+
+    colorRegistry.initSlider();
+  });
+
+  test('registers input-slider-track-bg', () => {
+    expect(spyOnRegisterColor).toBeCalledWith('input-slider-track-bg', {
+      dark: tailwindColorPalette.stone[600],
+      light: tailwindColorPalette.stone[300],
+      hcDark: tailwindColorPalette.stone[600],
+      hcLight: tailwindColorPalette.stone[300],
     });
   });
 });

--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -360,6 +360,7 @@ export class ColorRegistry {
     this.initInputBox();
     this.initCheckbox();
     this.initToggle();
+    this.initSlider();
     this.initTable();
     this.initDetails();
     this.initTab();
@@ -1117,6 +1118,19 @@ export class ColorRegistry {
     this.registerColor(`${sNav}disabled-switch`, {
       dark: gray[200],
       light: gray[200],
+    });
+  }
+
+  // range sliders
+  protected initSlider(): void {
+    const sld = 'input-slider-';
+
+    // unfilled portion of the track (the filled portion comes from accent-color, see input-toggle-on-bg)
+    this.registerColor(`${sld}track-bg`, {
+      dark: stone[600],
+      light: stone[300],
+      hcDark: stone[600],
+      hcLight: stone[300],
     });
   }
 

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.spec.ts
@@ -64,6 +64,23 @@ test('Expect slider to be disabled when record.readonly is true', async () => {
   expect(input).toBeDisabled();
 });
 
+test('Expect track background to be neutral and fill/thumb to use accent color', async () => {
+  const record: IConfigurationPropertyRecordedSchema = {
+    id: 'record',
+    title: 'record',
+    parentId: 'parent.record',
+    description: 'record-description',
+    type: 'number',
+    minimum: 4,
+    maximum: 34,
+  };
+
+  render(SliderItem, { record, value: 15 });
+  const input = screen.getByLabelText('record-description');
+  expect(input).toHaveClass('bg-(--pd-input-slider-track-bg)');
+  expect(input).toHaveClass('accent-(--pd-input-toggle-on-bg)');
+});
+
 test('Expect slider to be disabled when record.locked is true', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
     id: 'record',

--- a/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
+++ b/packages/renderer/src/lib/preferences/item-formats/SliderItem.svelte
@@ -32,4 +32,4 @@ async function onInput(event: Event): Promise<void> {
   aria-label={record.description}
   oninput={onInput}
   disabled={!!record.readonly || !!record.locked}
-  class="w-full h-1 bg-[var(--pd-input-toggle-on-bg)] rounded-lg appearance-none accent-[var(--pd-input-toggle-on-bg)] cursor-pointer range-xs mt-2" />
+  class="w-full h-1 bg-(--pd-input-slider-track-bg) rounded-lg appearance-none accent-(--pd-input-toggle-on-bg) cursor-pointer range-xs mt-2" />


### PR DESCRIPTION
### What does this PR do?

Range sliders (e.g. CPU/Memory/Disk size sliders in the "Create Podman machine" wizard, and any other numeric preference rendered as a slider) painted their entire track in the accent violet color, regardless of the thumb position.

This happened because both the track background (`bg-*`) and the native `accent-color` were set to the same `--pd-input-toggle-on-bg` token – `accent-color` already colors the filled portion (left of the thumb) and the thumb itself, so having the same violet underneath the whole track made the filled and unfilled portions indistinguishable.

This PR adds a new neutral `input-slider-track-bg` color-registry token (following the same pattern as `progressBar-bg`) for the unfilled portion of the track, while the filled portion and thumb keep using the existing accent color. The result is a clear two-tone track: violet (filled, left of thumb) vs. neutral gray (unfilled, right of thumb), consistent across light, dark, hc-light, and hc-dark themes.

Since there is a single slider implementation (`SliderItem.svelte`) used by both the generic Preferences page and the resource-creation wizards, this fix applies everywhere without per-screen overrides.

### Screenshot / video of UI

#### Before:

<img width="2102" height="1453" alt="before-light-create-machine" src="https://github.com/user-attachments/assets/932a2373-656a-4cfb-a8f7-a05650ca27b9" />

<img width="1896" height="1453" alt="before-dark-create-machine" src="https://github.com/user-attachments/assets/8fe28f27-a6ab-4647-b1de-502a5e480021" />

<img width="1896" height="1453" alt="before-hc-light-create-machine" src="https://github.com/user-attachments/assets/bb6db049-da97-4a32-b54b-844ed49ee84d" />

<img width="1896" height="1453" alt="before-hc-dark-create-machine" src="https://github.com/user-attachments/assets/d679aedf-4626-46bb-8bef-717e7c94f08e" />

#### Now:

<img width="2102" height="1453" alt="after-light-create-machine" src="https://github.com/user-attachments/assets/35ae2d65-e58c-4d42-872d-9f31f44850e8" />

<img width="1896" height="1453" alt="after-dark-create-machine" src="https://github.com/user-attachments/assets/60b917c2-1c28-495f-9562-d9e25cd6a687" />

<img width="2102" height="1453" alt="after-light-create-machine" src="https://github.com/user-attachments/assets/ebd7df68-f4c5-4564-9daf-d6f84457447b" />

<img width="1896" height="1453" alt="after-hc-dark-create-machine" src="https://github.com/user-attachments/assets/a413a931-264d-42a9-9ca0-3de7e0b43b89" />

### What issues does this PR fix or reference?

- Resolves: #17715

### How to test this PR?

1. Open Settings → Resources → Podman → Create new... (or any other provider resource-creation form with numeric sliders, e.g. CPU(s), Memory, Disk size).
2. Confirm the track left of the thumb is the accent violet color and the track right of the thumb is a neutral gray.
3. Repeat in dark, hc-light, and hc-dark themes (Settings → Preferences → Appearance) and confirm the same two-tone behavior with appropriate contrast for each theme.
4. Confirm keyboard (arrow keys) and mouse drag interactions still update the value as before – no regression.

- [x] Tests are covering the bug fix or the new feature

Co-Authored-By: Claude <noreply@anthropic.com>