### PR TITLE
fix(podman): register remote connections that have no Identity

### DIFF
--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as extensionApi from '@podman-desktop/api';
-import { beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { PodmanRemoteConnections } from './podman-remote-connections';
 import type { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
@@ -28,6 +28,10 @@ const provider = {} as extensionApi.Provider;
 
 beforeEach(() => {
   vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 class TestPodmanRemoteConnections extends PodmanRemoteConnections {
   createTunnel(
@@ -62,14 +66,17 @@ test('should do nothing if the configuration is disabled', async () => {
   // spy refreshRemoteConnections method
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
 
-  // start
-  await podmanRemoteConnections.start();
+  try {
+    // start
+    await podmanRemoteConnections.start();
 
-  // no connection should be created
-  expect(spyCreateTunnel).not.toHaveBeenCalled();
-  expect(spyRefreshRemoteConnections).not.toHaveBeenCalled();
-
-  podmanRemoteConnections.stop();
+    // no connection should be created
+    expect(spyCreateTunnel).not.toHaveBeenCalled();
+    expect(spyRefreshRemoteConnections).not.toHaveBeenCalled();
+  } finally {
+    // clear the recurring monitoring timer so it cannot fire in a later test
+    podmanRemoteConnections.stop();
+  }
 });
 
 test('should check connections if configuration is enabled', async () => {
@@ -89,14 +96,17 @@ test('should check connections if configuration is enabled', async () => {
   // spy refreshRemoteConnections method
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
 
-  // start
-  await podmanRemoteConnections.start();
+  try {
+    // start
+    await podmanRemoteConnections.start();
 
-  // no connection should be created
-  expect(spyCreateTunnel).not.toHaveBeenCalled();
-  expect(spyRefreshRemoteConnections).toHaveBeenCalled();
-
-  podmanRemoteConnections.stop();
+    // no connection should be created
+    expect(spyCreateTunnel).not.toHaveBeenCalled();
+    expect(spyRefreshRemoteConnections).toHaveBeenCalled();
+  } finally {
+    // clear the recurring monitoring timer so it cannot fire in a later test
+    podmanRemoteConnections.stop();
+  }
 });
 
 test('hasConnections should return false when no connections exist', () => {
@@ -327,44 +337,44 @@ test('should check connections if configuration is enabled and a system connecti
   // spy refreshRemoteConnections method
   const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
 
-  // start
-  await podmanRemoteConnections.start();
+  try {
+    // start
+    await podmanRemoteConnections.start();
 
-  // remote connection should trigger tunnel creation (machine is filtered out)
-  expect(spyCreateTunnel).toHaveBeenCalledOnce();
-  expect(spyRefreshRemoteConnections).toHaveBeenCalled();
-  expect(podmanRemoteConnections.hasConnections()).toBe(true);
-
-  podmanRemoteConnections.stop();
+    // remote connection should trigger tunnel creation (machine is filtered out)
+    expect(spyCreateTunnel).toHaveBeenCalledOnce();
+    expect(spyRefreshRemoteConnections).toHaveBeenCalled();
+    expect(podmanRemoteConnections.hasConnections()).toBe(true);
+  } finally {
+    // clear the recurring monitoring timer so it cannot fire in a later test
+    podmanRemoteConnections.stop();
+  }
 });
 
 test('stop should cancel the recurring monitoring timer', async () => {
+  // fake timers are restored by the afterEach hook (vi.useRealTimers)
   vi.useFakeTimers();
-  try {
-    vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
-      get: () => true,
-    } as unknown as extensionApi.Configuration);
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: () => true,
+  } as unknown as extensionApi.Configuration);
 
-    const podmanRemoteConnections = new TestPodmanRemoteConnections(extensionContext, provider);
+  const podmanRemoteConnections = new TestPodmanRemoteConnections(extensionContext, provider);
 
-    // no remote connections, so start() completes without creating any tunnel
-    vi.mocked(extensionApi.process.exec).mockResolvedValue({
-      stdout: JSON.stringify([]),
-    } as unknown as extensionApi.RunResult);
+  // no remote connections, so start() completes without creating any tunnel
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    stdout: JSON.stringify([]),
+  } as unknown as extensionApi.RunResult);
 
-    const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
+  const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
 
-    await podmanRemoteConnections.start();
-    expect(spyRefreshRemoteConnections).toHaveBeenCalledTimes(1);
+  await podmanRemoteConnections.start();
+  expect(spyRefreshRemoteConnections).toHaveBeenCalledTimes(1);
 
-    // stop() must clear the pending 5s timer
-    podmanRemoteConnections.stop();
-    spyRefreshRemoteConnections.mockClear();
+  // stop() must clear the pending 5s timer
+  podmanRemoteConnections.stop();
+  spyRefreshRemoteConnections.mockClear();
 
-    // advancing well past the interval must not trigger any further monitoring
-    await vi.advanceTimersByTimeAsync(15000);
-    expect(spyRefreshRemoteConnections).not.toHaveBeenCalled();
-  } finally {
-    vi.useRealTimers();
-  }
+  // advancing well past the interval must not trigger any further monitoring
+  await vi.advanceTimersByTimeAsync(15000);
+  expect(spyRefreshRemoteConnections).not.toHaveBeenCalled();
 });

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.spec.ts
@@ -16,15 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import * as fs from 'node:fs';
-
 import * as extensionApi from '@podman-desktop/api';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import { PodmanRemoteConnections } from './podman-remote-connections';
 import type { PodmanRemoteSshTunnel } from './podman-remote-ssh-tunnel';
-
-vi.mock(import('node:fs'));
 
 const extensionContext = {} as extensionApi.ExtensionContext;
 
@@ -48,6 +44,10 @@ class TestPodmanRemoteConnections extends PodmanRemoteConnections {
   async refreshRemoteConnections(): Promise<void> {
     return super.refreshRemoteConnections();
   }
+
+  async readPrivateKey(identity?: string): Promise<string | undefined> {
+    return super.readPrivateKey(identity);
+  }
 }
 
 test('should do nothing if the configuration is disabled', async () => {
@@ -68,6 +68,8 @@ test('should do nothing if the configuration is disabled', async () => {
   // no connection should be created
   expect(spyCreateTunnel).not.toHaveBeenCalled();
   expect(spyRefreshRemoteConnections).not.toHaveBeenCalled();
+
+  podmanRemoteConnections.stop();
 });
 
 test('should check connections if configuration is enabled', async () => {
@@ -93,6 +95,8 @@ test('should check connections if configuration is enabled', async () => {
   // no connection should be created
   expect(spyCreateTunnel).not.toHaveBeenCalled();
   expect(spyRefreshRemoteConnections).toHaveBeenCalled();
+
+  podmanRemoteConnections.stop();
 });
 
 test('hasConnections should return false when no connections exist', () => {
@@ -114,7 +118,7 @@ test('hasConnections should return true after remote connections are registered'
 
   const remoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
 
-  vi.spyOn(fs, 'readFileSync').mockReturnValue('fake-key');
+  vi.spyOn(remoteConnections, 'readPrivateKey').mockResolvedValue('fake-key');
   vi.spyOn(remoteConnections, 'createTunnel').mockReturnValue({
     connect: vi.fn(),
     disconnect: vi.fn(),
@@ -151,8 +155,8 @@ test('should skip broken connection and still register valid ones', async () => 
 
   const remoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
 
-  vi.spyOn(fs, 'readFileSync').mockImplementation((path: unknown) => {
-    if (String(path) === '/tmp/broken-key') {
+  vi.spyOn(remoteConnections, 'readPrivateKey').mockImplementation(async (identity?: string) => {
+    if (identity === '/tmp/broken-key') {
       throw new Error('ENOENT: no such file');
     }
     return 'fake-key';
@@ -185,6 +189,57 @@ test('should skip broken connection and still register valid ones', async () => 
   expect(remoteConnections.hasConnections()).toBe(true);
 });
 
+test('should register a connection with a missing Identity via the ssh-agent (no key read)', async () => {
+  vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+    get: () => true,
+  } as unknown as extensionApi.Configuration);
+
+  const mockProvider = {
+    registerContainerProviderConnection: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  } as unknown as extensionApi.Provider;
+  const mockContext = {
+    subscriptions: [],
+  } as unknown as extensionApi.ExtensionContext;
+
+  const remoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
+
+  // spy on the real readPrivateKey to prove it is not reading any key file
+  const readPrivateKeySpy = vi.spyOn(remoteConnections, 'readPrivateKey');
+  const createTunnelSpy = vi.spyOn(remoteConnections, 'createTunnel').mockReturnValue({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    status: () => 'started',
+  } as unknown as PodmanRemoteSshTunnel);
+
+  // podman >= 5.x omits the Identity field entirely when a connection was added
+  // without --identity, so connection.Identity is undefined here
+  vi.mocked(extensionApi.process.exec).mockResolvedValue({
+    stdout: JSON.stringify([
+      {
+        IsMachine: false,
+        URI: 'ssh://user@192.168.1.5:22/run/podman/podman.sock',
+        Name: 'NoIdentityRemote',
+      },
+    ]),
+  } as unknown as extensionApi.RunResult);
+
+  await remoteConnections.refreshRemoteConnections();
+
+  // the connection registers instead of being silently dropped
+  expect(remoteConnections.hasConnections()).toBe(true);
+  // no identity => readPrivateKey resolves to undefined (tunnel uses the ssh-agent)
+  await expect(readPrivateKeySpy.mock.results[0]?.value).resolves.toBeUndefined();
+  // the tunnel is created with an undefined private key
+  expect(createTunnelSpy).toHaveBeenCalledWith(
+    '192.168.1.5',
+    22,
+    'user',
+    undefined,
+    '/run/podman/podman.sock',
+    expect.any(String),
+  );
+});
+
 test('should disconnect tunnel if registration fails after connect', async () => {
   vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
     get: () => true,
@@ -201,7 +256,7 @@ test('should disconnect tunnel if registration fails after connect', async () =>
 
   const remoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
 
-  vi.spyOn(fs, 'readFileSync').mockReturnValue('fake-key');
+  vi.spyOn(remoteConnections, 'readPrivateKey').mockResolvedValue('fake-key');
   const mockDisconnect = vi.fn();
   vi.spyOn(remoteConnections, 'createTunnel').mockReturnValue({
     connect: vi.fn(),
@@ -240,8 +295,8 @@ test('should check connections if configuration is enabled and a system connecti
 
   const podmanRemoteConnections = new TestPodmanRemoteConnections(mockContext, mockProvider);
 
-  // mock readFileSync
-  vi.spyOn(fs, 'readFileSync').mockReturnValue('file');
+  // mock readPrivateKey
+  vi.spyOn(podmanRemoteConnections, 'readPrivateKey').mockResolvedValue('file');
 
   // mock createTunnel to return a mock tunnel
   const spyCreateTunnel = vi.spyOn(podmanRemoteConnections, 'createTunnel').mockReturnValue({
@@ -279,4 +334,37 @@ test('should check connections if configuration is enabled and a system connecti
   expect(spyCreateTunnel).toHaveBeenCalledOnce();
   expect(spyRefreshRemoteConnections).toHaveBeenCalled();
   expect(podmanRemoteConnections.hasConnections()).toBe(true);
+
+  podmanRemoteConnections.stop();
+});
+
+test('stop should cancel the recurring monitoring timer', async () => {
+  vi.useFakeTimers();
+  try {
+    vi.mocked(extensionApi.configuration.getConfiguration).mockReturnValue({
+      get: () => true,
+    } as unknown as extensionApi.Configuration);
+
+    const podmanRemoteConnections = new TestPodmanRemoteConnections(extensionContext, provider);
+
+    // no remote connections, so start() completes without creating any tunnel
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({
+      stdout: JSON.stringify([]),
+    } as unknown as extensionApi.RunResult);
+
+    const spyRefreshRemoteConnections = vi.spyOn(podmanRemoteConnections, 'refreshRemoteConnections');
+
+    await podmanRemoteConnections.start();
+    expect(spyRefreshRemoteConnections).toHaveBeenCalledTimes(1);
+
+    // stop() must clear the pending 5s timer
+    podmanRemoteConnections.stop();
+    spyRefreshRemoteConnections.mockClear();
+
+    // advancing well past the interval must not trigger any further monitoring
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(spyRefreshRemoteConnections).not.toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-connections.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -30,7 +30,9 @@ interface ConnectionListFormatJson {
   Name: string;
   IsMachine?: boolean;
   URI: string;
-  Identity: string;
+  // podman >= 5.x omits this field entirely when a connection was added
+  // without --identity, so it may be undefined
+  Identity?: string;
 }
 
 interface RemoteSystemConnection {
@@ -143,9 +145,7 @@ export class PodmanRemoteConnections {
         const host = uri.hostname;
         const port = Number.parseInt(uri.port, 10);
         const username = uri.username;
-        const privateKeyFile = connection.Identity;
-
-        const privateKey = readFileSync(privateKeyFile, 'utf8');
+        const privateKey = await this.readPrivateKey(connection.Identity);
         const remotePath = uri.pathname;
 
         let localPath: string;
@@ -197,11 +197,26 @@ export class PodmanRemoteConnections {
     }
   }
 
+  // Resolve the SSH private key for a connection. When the connection has no
+  // Identity, return undefined so the tunnel falls back to the ssh-agent,
+  // mirroring the podman CLI (containers/common pkg/ssh/connection_golang.go
+  // ValidateAndConfigure, which uses SSH_AUTH_SOCK when no identity is set:
+  // https://github.com/containers/common/blob/main/pkg/ssh/connection_golang.go#L249-L300).
+  // podman >= 5.x omits the Identity field entirely when a connection was added
+  // without --identity; reading it unconditionally previously threw and the
+  // connection was silently dropped from the UI (see issue #13286).
+  protected async readPrivateKey(identity?: string): Promise<string | undefined> {
+    if (!identity) {
+      return undefined;
+    }
+    return readFile(identity, 'utf8');
+  }
+
   protected createTunnel(
     host: string,
     port: number,
     username: string,
-    privateKey: string,
+    privateKey: string | undefined,
     remotePath: string,
     localPath: string,
   ): PodmanRemoteSshTunnel {
@@ -214,5 +229,11 @@ export class PodmanRemoteConnections {
 
   stop(): void {
     this.#stopMonitoring = true;
+    // clear any pending monitoring cycle, otherwise the already-scheduled
+    // setTimeout keeps firing (and re-arming itself) after stop()
+    if (this.#timeout) {
+      clearTimeout(this.#timeout);
+      this.#timeout = undefined;
+    }
   }
 }

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
@@ -21,7 +21,7 @@ import { type AddressInfo, createConnection, createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { Client, Server } from 'ssh2';
+import { Client, type ConnectConfig, Server } from 'ssh2';
 import { generatePrivateKey } from 'sshpk';
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from 'vitest';
 
@@ -39,6 +39,10 @@ afterEach(() => {
 class TestPodmanRemoteSshTunnel extends PodmanRemoteSshTunnel {
   isListening(): boolean {
     return super.isListening();
+  }
+
+  getSshConfig(): ConnectConfig {
+    return super.getSshConfig();
   }
 }
 
@@ -106,7 +110,7 @@ test('should be able to connect', async () => {
     'localhost',
     sshPort,
     'foo',
-    '',
+    dummyKey,
     socketOrNpipePathRemote,
     socketOrNpipePathLocal,
   );
@@ -148,4 +152,64 @@ test('disconnect should clear pending reconnect timeout', () => {
 
   vi.advanceTimersByTime(30000);
   expect(connectSpy).toHaveBeenCalledTimes(1);
+});
+
+test('should use the provided private key over the ssh-agent', () => {
+  const tunnel = new TestPodmanRemoteSshTunnel(
+    'localhost',
+    22,
+    'foo',
+    'my-private-key',
+    '/tmp/remote.sock',
+    '/tmp/local.sock',
+  );
+  const config = tunnel.getSshConfig();
+  expect(config.privateKey).toBe('my-private-key');
+  expect(config.agent).toBeUndefined();
+});
+
+test('should fall back to the ssh-agent when no private key is provided', () => {
+  const previous = process.env['SSH_AUTH_SOCK'];
+  process.env['SSH_AUTH_SOCK'] = '/tmp/agent.sock';
+  try {
+    const tunnel = new TestPodmanRemoteSshTunnel(
+      'localhost',
+      22,
+      'foo',
+      undefined,
+      '/tmp/remote.sock',
+      '/tmp/local.sock',
+    );
+    const config = tunnel.getSshConfig();
+    expect(config.privateKey).toBeUndefined();
+    expect(config.agent).toBe('/tmp/agent.sock');
+  } finally {
+    if (previous === undefined) {
+      delete process.env['SSH_AUTH_SOCK'];
+    } else {
+      process.env['SSH_AUTH_SOCK'] = previous;
+    }
+  }
+});
+
+test('should not set an agent when no private key and no ssh-agent are available', () => {
+  const previous = process.env['SSH_AUTH_SOCK'];
+  delete process.env['SSH_AUTH_SOCK'];
+  try {
+    const tunnel = new TestPodmanRemoteSshTunnel(
+      'localhost',
+      22,
+      'foo',
+      undefined,
+      '/tmp/remote.sock',
+      '/tmp/local.sock',
+    );
+    const config = tunnel.getSshConfig();
+    expect(config.privateKey).toBeUndefined();
+    expect(config.agent).toBeUndefined();
+  } finally {
+    if (previous !== undefined) {
+      process.env['SSH_AUTH_SOCK'] = previous;
+    }
+  }
 });

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.spec.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllEnvs();
 });
 
 class TestPodmanRemoteSshTunnel extends PodmanRemoteSshTunnel {
@@ -169,47 +170,31 @@ test('should use the provided private key over the ssh-agent', () => {
 });
 
 test('should fall back to the ssh-agent when no private key is provided', () => {
-  const previous = process.env['SSH_AUTH_SOCK'];
-  process.env['SSH_AUTH_SOCK'] = '/tmp/agent.sock';
-  try {
-    const tunnel = new TestPodmanRemoteSshTunnel(
-      'localhost',
-      22,
-      'foo',
-      undefined,
-      '/tmp/remote.sock',
-      '/tmp/local.sock',
-    );
-    const config = tunnel.getSshConfig();
-    expect(config.privateKey).toBeUndefined();
-    expect(config.agent).toBe('/tmp/agent.sock');
-  } finally {
-    if (previous === undefined) {
-      delete process.env['SSH_AUTH_SOCK'];
-    } else {
-      process.env['SSH_AUTH_SOCK'] = previous;
-    }
-  }
+  vi.stubEnv('SSH_AUTH_SOCK', '/tmp/agent.sock');
+  const tunnel = new TestPodmanRemoteSshTunnel(
+    'localhost',
+    22,
+    'foo',
+    undefined,
+    '/tmp/remote.sock',
+    '/tmp/local.sock',
+  );
+  const config = tunnel.getSshConfig();
+  expect(config.privateKey).toBeUndefined();
+  expect(config.agent).toBe('/tmp/agent.sock');
 });
 
 test('should not set an agent when no private key and no ssh-agent are available', () => {
-  const previous = process.env['SSH_AUTH_SOCK'];
-  delete process.env['SSH_AUTH_SOCK'];
-  try {
-    const tunnel = new TestPodmanRemoteSshTunnel(
-      'localhost',
-      22,
-      'foo',
-      undefined,
-      '/tmp/remote.sock',
-      '/tmp/local.sock',
-    );
-    const config = tunnel.getSshConfig();
-    expect(config.privateKey).toBeUndefined();
-    expect(config.agent).toBeUndefined();
-  } finally {
-    if (previous !== undefined) {
-      process.env['SSH_AUTH_SOCK'] = previous;
-    }
-  }
+  vi.stubEnv('SSH_AUTH_SOCK', undefined);
+  const tunnel = new TestPodmanRemoteSshTunnel(
+    'localhost',
+    22,
+    'foo',
+    undefined,
+    '/tmp/remote.sock',
+    '/tmp/local.sock',
+  );
+  const config = tunnel.getSshConfig();
+  expect(config.privateKey).toBeUndefined();
+  expect(config.agent).toBeUndefined();
 });

--- a/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
+++ b/extensions/podman/packages/extension/src/remote/podman-remote-ssh-tunnel.ts
@@ -44,7 +44,7 @@ export class PodmanRemoteSshTunnel {
     private host: string,
     private port: number,
     private username: string,
-    private privateKey: string,
+    private privateKey: string | undefined,
     private remotePath: string,
     private localPath: string,
   ) {
@@ -52,11 +52,26 @@ export class PodmanRemoteSshTunnel {
       host: this.host,
       port: this.port,
       username: this.username,
-      privateKey: this.privateKey,
     };
+    if (this.privateKey) {
+      this.#sshConfig.privateKey = this.privateKey;
+    } else {
+      // No identity/private key for this connection. Mirror the podman CLI,
+      // which falls back to the ssh-agent when no identity is set: see
+      // containers/common pkg/ssh/connection_golang.go ValidateAndConfigure
+      // https://github.com/containers/common/blob/main/pkg/ssh/connection_golang.go#L249-L300
+      const sshAuthSock = process.env['SSH_AUTH_SOCK'];
+      if (sshAuthSock) {
+        this.#sshConfig.agent = sshAuthSock;
+      }
+    }
     this.#connected = new Promise<boolean>((resolve, _reject) => {
       this.#resolveConnected = resolve;
     });
+  }
+
+  protected getSshConfig(): ConnectConfig {
+    return this.#sshConfig;
   }
 
   dispose(): void {


### PR DESCRIPTION
### What does this PR do?

Remote SSH podman *system connections* added **without `--identity`** silently disappear from the Podman Desktop UI (originally reported on Flatpak, but the root cause is platform-independent).

Since podman 5.x, `podman system connection list --format json` **omits the `Identity` field entirely** when a connection was added without `--identity` (older podman stored an empty string). The remote-connections extension read the key unconditionally:

```ts
const privateKeyFile = connection.Identity;              // undefined
const privateKey = readFileSync(privateKeyFile, 'utf8'); // throws
```

`readFileSync(undefined, …)` throws `TypeError [ERR_INVALID_ARG_TYPE]`. The per-connection `try/catch` (added in #17314) catches it and logs `Failed to register remote Podman connection <name>`, so the batch survives — but that connection is silently dropped from the UI.

#### Fix

When a connection has no `Identity`, we now register it and let the SSH tunnel fall back to the **ssh-agent**, matching how the podman CLI itself resolves an SSH connection when no identity is set. podman delegates to `containers/common`, whose `ValidateAndConfigure` uses `SSH_AUTH_SOCK` (the ssh-agent) before falling back to password auth — it does **not** read `~/.ssh/id_*` key files:

- https://github.com/containers/common/blob/main/pkg/ssh/connection_golang.go#L249-L300

Concretely:

- `readPrivateKey()` now returns `undefined` (instead of throwing) when `Identity` is missing, and reads the key file only when an identity is set. It is `async` (uses `fs/promises`) so a slow/blocking key read no longer stalls the monitoring loop.
- `PodmanRemoteSshTunnel` accepts `privateKey: string | undefined`. With no key it sets `agent: process.env.SSH_AUTH_SOCK` on the ssh2 `ConnectConfig` when an agent socket is available (mirroring the CLI); otherwise it leaves auth to ssh2's own defaults.
- `ConnectionListFormatJson.Identity` is typed `string | undefined` to reflect podman's actual output.

#### Drive-by fix: leaking monitoring timer

While adding tests I found `stop()` set the `#stopMonitoring` flag but never cleared the pending `setTimeout` scheduled by `monitorRemoteConnections()`. The already-scheduled 5s cycle kept firing (and re-arming itself) after `stop()`. `stop()` now clears `#timeout`. A regression test asserts no further refresh happens after `stop()`.

### Screenshot / video of UI

N/A — backend/extension logic only, no UI changes.

### What issues does this PR fix or reference?

Fixes #13286

### How to test this PR?

1. On a host with podman 5.x, add a remote SSH system connection **without** `--identity` (loading your key into the ssh-agent first, `ssh-add <key>`):
   `podman system connection add myremote ssh://user@host:22/run/user/1000/podman/podman.sock`
2. Enable the experimental preference `podman.system.connections.remote`.
3. Before this fix: the connection does not appear in the UI, and the log shows `Failed to register remote Podman connection myremote  TypeError [ERR_INVALID_ARG_TYPE] … Received undefined`.
4. After this fix: the connection is registered and the tunnel authenticates through the ssh-agent.

Automated coverage:
- `podman-remote-connections.spec.ts` registers a connection whose `Identity` is `undefined` and asserts it still registers, that `readPrivateKey` resolves to `undefined` (no key file is read), and that the tunnel is created with an `undefined` key. A second test covers `stop()` cancelling the monitoring timer.
- `podman-remote-ssh-tunnel.spec.ts` covers the three auth-config branches: explicit private key wins, ssh-agent fallback when `SSH_AUTH_SOCK` is set, and no agent when neither is present.

- [x] Tests are covering the bug fix or the new feature
