### PR TITLE
feat(ui): add create + cancel button to run image

### DIFF
--- a/packages/main/src/plugin/index.ts
+++ b/packages/main/src/plugin/index.ts
@@ -1301,7 +1301,6 @@ export class PluginSystem {
     this.ipcHandle(
       'container-provider-registry:createAndStartContainer',
       async (_listener, engine: string, options: ContainerCreateOptions): Promise<{ id: string }> => {
-        options.start = true;
         return containerProviderRegistry.createContainer(engine, options);
       },
     );

--- a/packages/renderer/src/lib/image/RunImage.spec.ts
+++ b/packages/renderer/src/lib/image/RunImage.spec.ts
@@ -209,7 +209,7 @@ describe('RunImage', () => {
   test('Expect that entrypoint is sent to API', async () => {
     await createRunImage('entrypoint', []);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -222,7 +222,7 @@ describe('RunImage', () => {
   test('Expect that single array entrypoint is sent to API', async () => {
     await createRunImage(['entrypoint'], []);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -235,7 +235,7 @@ describe('RunImage', () => {
   test('Expect that single array entrypoint with space is sent to API', async () => {
     await createRunImage(['entrypoint with space'], []);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -248,7 +248,7 @@ describe('RunImage', () => {
   test('Expect that two elements array entrypoint is sent to API', async () => {
     await createRunImage(['entrypoint1', 'entrypoint2'], []);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -261,7 +261,7 @@ describe('RunImage', () => {
   test('Expect that image without cmd is sent to API', async () => {
     await createRunImage(['entrypoint1', 'entrypoint2']);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -274,7 +274,7 @@ describe('RunImage', () => {
   test('Expect that single array command is sent to API', async () => {
     await createRunImage([], ['command']);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -287,7 +287,7 @@ describe('RunImage', () => {
   test('Expect that single array command with space is sent to API', async () => {
     await createRunImage([], ['command with space']);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -299,7 +299,7 @@ describe('RunImage', () => {
   test('Expect that two elements array command is sent to API', async () => {
     await createRunImage([], ['command1', 'command2']);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -312,7 +312,7 @@ describe('RunImage', () => {
   test('Expect that image without entrypoint is sent to API', async () => {
     await createRunImage(undefined, ['command1', 'command2']);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -346,7 +346,7 @@ describe('RunImage', () => {
     // wait onPortInputTimeout (500ms) triggers
     await new Promise(resolve => setTimeout(resolve, 600));
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -361,7 +361,7 @@ describe('RunImage', () => {
 
     await createRunImage('entrypoint', []);
 
-    const link = screen.getByRole('button', { name: 'Start Container' });
+    const link = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(link);
 
@@ -399,7 +399,7 @@ describe('RunImage', () => {
     const openStdinCheckbox = screen.getByRole('checkbox', { name: 'Use interactive' });
     await fireEvent.click(openStdinCheckbox);
 
-    const link = screen.getByRole('button', { name: 'Start Container' });
+    const link = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(link);
 
@@ -447,7 +447,7 @@ describe('RunImage', () => {
 
     // now click on start
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -490,7 +490,7 @@ describe('RunImage', () => {
     expect(error).toBeInTheDocument();
   });
 
-  test('Expect "start container" button to be disabled when port is not free', async () => {
+  test('Expect "Create and start" button to be disabled when port is not free', async () => {
     (window.isFreePort as Mock).mockRejectedValue(new Error('Error Message'));
     router.goto('/basic');
 
@@ -516,7 +516,7 @@ describe('RunImage', () => {
     // wait onPortInputTimeout (500ms) triggers
     await new Promise(resolve => setTimeout(resolve, 600));
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
     await tick();
     expect((button as HTMLButtonElement).disabled).toBeTruthy();
   });
@@ -562,7 +562,7 @@ describe('RunImage', () => {
     await userEvent.clear(targetInput);
     await userEvent.type(targetInput, '/run/secrets/my-secret');
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
@@ -597,7 +597,7 @@ describe('RunImage', () => {
     await userEvent.clear(targetInput);
     await userEvent.type(targetInput, 'FOO_SECRET');
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
@@ -624,7 +624,7 @@ describe('RunImage', () => {
     const removeButton = screen.getByRole('button', { name: 'Remove secret' });
     await fireEvent.click(removeButton);
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
     await fireEvent.click(button);
 
     expect(window.createAndStartContainer).toHaveBeenCalledWith(
@@ -670,7 +670,7 @@ describe('RunImage', () => {
 
     // now click on start
 
-    const button = screen.getByRole('button', { name: 'Start Container' });
+    const button = screen.getByRole('button', { name: 'Create and start' });
 
     await fireEvent.click(button);
 
@@ -694,6 +694,64 @@ describe('RunImage', () => {
         }),
       }),
     );
+  });
+
+  test('Expect "Create" button calls createAndStartContainer with start false', async () => {
+    const gotoSpy = vi.spyOn(router, 'goto');
+
+    await createRunImage('entrypoint', []);
+
+    const button = screen.getByRole('button', { name: 'Create' });
+
+    await fireEvent.click(button);
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    expect(window.createAndStartContainer).toHaveBeenCalledWith(
+      'engineid',
+      expect.objectContaining({ Entrypoint: ['entrypoint'], start: false }),
+    );
+    expect(gotoSpy).toHaveBeenCalledWith('/containers/1234/summary');
+  });
+
+  test('Expect "Create" button to be disabled when invalidFields is true', async () => {
+    vi.mocked(window.isFreePort).mockRejectedValue(new Error('Error Message'));
+    router.goto('/basic');
+
+    await createRunImage(undefined, ['command1', 'command2']);
+
+    const link1 = screen.getByRole('link', { name: 'Basic' });
+    await fireEvent.click(link1);
+
+    const customMappingButton = screen.getByRole('button', { name: 'Add custom port mapping' });
+    await fireEvent.click(customMappingButton);
+
+    const hostInput = screen.getByLabelText('host port');
+    await userEvent.click(hostInput);
+    await userEvent.clear(hostInput);
+    await userEvent.keyboard('8080');
+
+    const containerInput = screen.getByLabelText('container port');
+    await userEvent.click(containerInput);
+    await userEvent.clear(containerInput);
+    await userEvent.keyboard('80');
+
+    await new Promise(resolve => setTimeout(resolve, 600));
+
+    const createButton = screen.getByRole('button', { name: 'Create' });
+    await tick();
+    expect((createButton as HTMLButtonElement).disabled).toBeTruthy();
+  });
+
+  test('Expect Cancel button navigates to images page', async () => {
+    const gotoSpy = vi.spyOn(router, 'goto');
+
+    await createRunImage('', []);
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    await fireEvent.click(cancelButton);
+
+    expect(gotoSpy).toHaveBeenCalledWith('/images/');
   });
 });
 

--- a/packages/renderer/src/lib/image/RunImage.svelte
+++ b/packages/renderer/src/lib/image/RunImage.svelte
@@ -255,8 +255,8 @@ async function getPort(portDescriptor: string): Promise<number | undefined> {
   }
 }
 
-async function startContainer(): Promise<void> {
-  if (!image) return;
+function buildCreateOptions(): ContainerCreateOptions | undefined {
+  if (!image) return undefined;
 
   createError = undefined;
   // create ExposedPorts objects
@@ -288,7 +288,7 @@ async function startContainer(): Promise<void> {
   } catch (e) {
     createError = String(e);
     console.error('Error while creating container', e);
-    return;
+    return undefined;
   }
 
   const Env = options.basic.environmentVariables
@@ -425,19 +425,34 @@ async function startContainer(): Promise<void> {
     createOptions.Hostname = options.networking.hostname;
   }
 
+  return createOptions;
+}
+
+async function submitContainer(start: boolean): Promise<void> {
+  const createOptions = buildCreateOptions();
+  if (!createOptions) return;
+
+  createOptions.start = start;
+
   try {
     const data = await window.createAndStartContainer(imageInspectInfo.engineId, createOptions);
 
-    // redirect to containers if no tty, else redirect to the container details
-    if (Tty && OpenStdin) {
+    if (start && createOptions.Tty && createOptions.OpenStdin) {
       handleNavigation({
         page: NavigationPage.CONTAINER_TTY,
         parameters: {
           id: data.id,
         },
       });
-    } else {
+    } else if (start) {
       handleNavigation({ page: NavigationPage.CONTAINERS });
+    } else {
+      handleNavigation({
+        page: NavigationPage.CONTAINER_SUMMARY,
+        parameters: {
+          id: data.id,
+        },
+      });
     }
   } catch (e) {
     createError = String(e);
@@ -1205,11 +1220,19 @@ const envDialogOptions: OpenDialogOptions = {
             Cancel
           </Button>
           <Button
-            on:click={startContainer}
+            type="secondary"
+            on:click={(): void => {submitContainer(false).catch((e: unknown) => console.error(e));}}
+            aria-label="Create"
+            disabled={invalidFields}
+            icon={faPlusCircle}>
+            Create
+          </Button>
+          <Button
+            on:click={(): void => {submitContainer(true).catch((e: unknown) => console.error(e));}}
             icon={faPlay}
-            aria-label="Start Container"
+            aria-label="Create and start"
             disabled={invalidFields}>
-            Start Container
+            Create and start
           </Button>
         </div>
         <div aria-label="createError">

--- a/tests/playwright/src/model/pages/run-image-page.ts
+++ b/tests/playwright/src/model/pages/run-image-page.ts
@@ -52,7 +52,7 @@ export class RunImagePage extends BasePage {
     this.backToImageDetailsLink = page.getByRole('link', {
       name: 'Go back to Image Details',
     });
-    this.startContainerButton = page.getByLabel('Start Container', {
+    this.startContainerButton = page.getByLabel('Create and start', {
       exact: true,
     });
     this.containerNameInput = page.getByLabel('Container Name');


### PR DESCRIPTION
feat(ui): add create + cancel button to run image

### What does this PR do?

Previously we only had "Start Container".

This change renames it to "Create and start" as well as adds a new
button "Create" which will create the container without initially
starting it.

We also add a "cancel" button as well which reflects how other forms are
layed out.

When you "Create" it'll take you to the summary page after creation.
When you do "Create and start" it takes you to the TTY (default).

### Screenshot / video of UI

https://github.com/user-attachments/assets/51bf234d-1fe4-4c75-9f22-fa271ecea23d

<img width="1299" height="967" alt="1788898466-screenshot-hc-light" src="https://github.com/user-attachments/assets/7d100d1e-9d7a-4f9a-b2f1-6759dc3176c7" />
<img width="1299" height="967" alt="1788898466-screenshot-hc-dark" src="https://github.com/user-attachments/assets/504b74bf-98b4-4068-bc53-797ddfba8501" />
<img width="1299" height="967" alt="1788898466-screenshot-light" src="https://github.com/user-attachments/assets/04a0acc4-ddd1-4b32-942f-d22914f6acf6" />
<img width="1299" height="967" alt="1788898466-screenshot-dark" src="https://github.com/user-attachments/assets/0e89cd24-b235-4e34-b993-2352e89a8614" />



### What issues does this PR fix or reference?

Closes https://github.com/podman-desktop/podman-desktop/issues/17998

### How to test this PR?

1. Go to Run Image
2. Press "Create" after selecting an image
3. Should create it and bring you to the summary page.

- [X] Tests are covering the bug fix or the new feature
