### PR TITLE
chore(ExtensionBadge): rename built-in to bundled

### DIFF
--- a/packages/main/src/plugin/color-registry.ts
+++ b/packages/main/src/plugin/color-registry.ts
@@ -2354,7 +2354,7 @@ export class ColorRegistry {
 
   protected initBadge(): void {
     const badge = 'badge-';
-    this.registerColor(`${badge}builtin-extension-bg`, {
+    this.registerColor(`${badge}bundled-extension-bg`, {
       dark: sky[200],
       light: sky[200],
     });

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.spec.ts
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.spec.ts
@@ -47,7 +47,7 @@ test('Expect to have badge for dd Extension', async () => {
   expect(labels[1]).toBeInTheDocument();
 });
 
-test('Expect to have badge for pd  built-in Extension', async () => {
+test('Expect to have badge for pd  bundled Extension', async () => {
   const extension: ExtensionType = {
     type: 'pd',
     removable: false,
@@ -55,13 +55,13 @@ test('Expect to have badge for pd  built-in Extension', async () => {
   };
   render(ExtensionBadge, { extension });
 
-  const visibleLabel = screen.getByText('built-in Extension');
+  const visibleLabel = screen.getByText('bundled Extension');
   expect(visibleLabel).toBeInTheDocument();
 
   const tooltipTrigger = screen.getByTestId('tooltip-trigger');
   await fireEvent.mouseEnter(tooltipTrigger);
 
-  const labels = await screen.findAllByText('built-in Extension');
+  const labels = await screen.findAllByText('bundled Extension');
   expect(labels).toHaveLength(2);
   expect(labels[0]).toBeInTheDocument();
   expect(labels[1]).toBeInTheDocument();

--- a/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
+++ b/packages/renderer/src/lib/extensions/ExtensionBadge.svelte
@@ -16,8 +16,8 @@ export let extension: { type: 'dd' | 'pd'; removable: boolean; devMode: boolean 
       <Badge class="text-[8px] text-[var(--pd-badge-text)]" color="bg-[var(--pd-badge-devmode-extension-bg)]" label="devMode Extension" />
     </Tooltip>
   {:else if !extension.removable}
-    <Tooltip right tip="built-in Extension">
-      <Badge class="text-[8px] text-[var(--pd-badge-text)]" color="bg-[var(--pd-badge-builtin-extension-bg)]" label="built-in Extension" />
+    <Tooltip right tip="bundled Extension">
+      <Badge class="text-[8px] text-[var(--pd-badge-text)]" color="bg-[var(--pd-badge-bundled-extension-bg)]" label="bundled Extension" />
     </Tooltip>
   {/if}
 </div>

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCard.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCard.spec.ts
@@ -74,5 +74,5 @@ test('Expect to see a div with extension id title', async () => {
   // get role Extension Badge
   const badge = await findByRole('region', { name: 'myExtensionId' });
   expect(badge).toBeInTheDocument();
-  expect(badge).toHaveTextContent('built-in');
+  expect(badge).toHaveTextContent('bundled');
 });

--- a/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts
+++ b/packages/renderer/src/lib/extensions/InstalledExtensionCardLeft.spec.ts
@@ -61,7 +61,7 @@ test('Expect to see icon, link, badge and actions', async () => {
   // get role Extension Badge
   const badge = await findByRole('region', { name: 'Extension Badge' });
   expect(badge).toBeInTheDocument();
-  expect(badge).toHaveTextContent('built-in');
+  expect(badge).toHaveTextContent('bundled');
 
   // check icon
   const icon = await findByRole('img');


### PR DESCRIPTION
### What does this PR do?

As discussed in https://github.com/podman-desktop/podman-desktop/pull/19146#discussion_r3959944816 we have `built-in` and `bundled` but fundamentally we only need one, and bundled is more appropriate so we can remove the built-in in favor of bundled.  

### Screenshot / video of UI

**Before**

<img width="942" height="441" alt="image" src="https://github.com/user-attachments/assets/dca3a796-86af-4c02-a7b0-de762dc68072" />

**After**

<img width="942" height="441" alt="Screenshot From 2026-09-09 09-25-11" src="https://github.com/user-attachments/assets/c60a4023-59dd-446a-a398-47f7d8fecbad" />

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/18750

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [x] Tests are covering the bug fix or the new feature
