### PR TITLE
refactor(extension-podman): move vi.mock to top-level scope in podman-download tests 

### DIFF
--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -32,7 +32,7 @@ import { http, HttpResponse } from 'msw';
 import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { Octokit } from 'octokit';
 
-vi.mock('node:fs');
+vi.mock(import('node:fs'));
 
 const mockedPodmanConfig = {
   versions: {

--- a/extensions/podman/packages/extension/scripts/podman-download.spec.ts
+++ b/extensions/podman/packages/extension/scripts/podman-download.spec.ts
@@ -32,6 +32,8 @@ import { http, HttpResponse } from 'msw';
 import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { Octokit } from 'octokit';
 
+vi.mock('node:fs');
+
 const mockedPodmanConfig = {
   versions: {
     v5: {
@@ -101,8 +103,6 @@ afterEach(() => {
 describe('macOS platform', () => {
   let currentPlatform: string;
   beforeEach(() => {
-    vi.mock('node:fs');
-
     currentPlatform = process.platform;
     // define using setProperty
     Object.defineProperty(process, 'platform', {


### PR DESCRIPTION
### What does this PR do?

Move `vi.mock('node:fs')` from inside a `beforeEach` block to the module's top-level scope in `podman-download.spec.ts`, ensuring compatibility with both Vitest 4 and Vitest 5.

Vitest 5 enforces that `vi.mock()` calls are placed at the module's top-level scope and errors when they are nested inside `describe` or `beforeEach` blocks. Since `vi.mock()` was already hoisted to the top of the file regardless of placement, this is a no-op behavioral change.

### Screenshot / video of UI

N/A — test-only change.

### What issues does this PR fix or reference?

Fixes test failure introduced by Vitest 5 upgrade:
```
Error: 1 call in "scripts/podman-download.spec.ts" was defined outside of the module's top level scope:
- vi.mock("node:fs") at scripts/podman-download.spec.ts:104:5
```
https://github.com/podman-desktop/podman-desktop/issues/19099
https://github.com/podman-desktop/podman-desktop/pull/19108

### How to test this PR?

```bash
npx vitest run extensions/podman/packages/extension/scripts/podman-download.spec.ts
```

- [x] Tests are covering the bug fix or the new feature