### PR TITLE
refactor(preload-webview): use vi.stubGlobal for document override in tests 

### DIFF
--- a/packages/preload-webview/src/webview-preload.spec.ts
+++ b/packages/preload-webview/src/webview-preload.spec.ts
@@ -167,13 +167,11 @@ describe('ipcInvoke', () => {
 });
 
 describe('changeContent', () => {
-  const originalDocument = document;
   beforeEach(() => {
-    // spy document.write method
-    document = originalDocument.implementation.createHTMLDocument('');
+    vi.stubGlobal('document', document.implementation.createHTMLDocument(''));
   });
   afterEach(() => {
-    document = originalDocument;
+    vi.unstubAllGlobals();
   });
 
   test('check with light theme', async () => {


### PR DESCRIPTION
### What does this PR do?

Vitest 5 jsdom environment exposes `document` as a read-only getter on `Window`, causing `changeContent` tests in `webview-preload.spec.ts` to fail with `TypeError: Cannot set property document of [object Window] which has only a getter`.

This replaces direct `document = ...` assignment with `vi.stubGlobal('document', ...)` and `vi.unstubAllGlobals()` for cleanup. Compatible with both Vitest 4 and 5.

### Screenshot / video of UI

N/A — test-only change.

### What issues does this PR fix or reference?

Fixes test failure introduced by the Vitest 5 upgrade.
https://github.com/podman-desktop/podman-desktop/issues/19099
https://github.com/podman-desktop/podman-desktop/pull/19108

### How to test this PR?

Run the test suite for the preload-webview package:
```
npx vitest run packages/preload-webview/src/webview-preload.spec.ts
```
All 6 tests should pass.

- [x] Tests are covering the bug fix or the new feature