### PR TITLE
refactor(renderer): await async onMount in NetworkDetailsInspect test 

### DIFF
--- a/packages/renderer/src/lib/network/NetworkDetailsInspect.spec.ts
+++ b/packages/renderer/src/lib/network/NetworkDetailsInspect.spec.ts
@@ -82,8 +82,10 @@ test('Expect monaco editor component to be called with inspectNetwork info', asy
   delete inspectInfo.engineId;
   delete inspectInfo.engineName;
 
-  expect(MonacoEditor).toHaveBeenCalledWith(expect.anything(), {
-    content: JSON.stringify(inspectInfo, undefined, 2),
-    language: 'json',
+  await vi.waitFor(() => {
+    expect(MonacoEditor).toHaveBeenCalledWith(expect.anything(), {
+      content: JSON.stringify(inspectInfo, undefined, 2),
+      language: 'json',
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the `NetworkDetailsInspect.spec.ts` test that fails after the Vitest v5 upgrade. The component's `onMount` fetches network inspect data asynchronously, but the test asserted on `MonacoEditor` immediately after render without waiting. This worked in Vitest v4 but fails in v5 due to different microtask timing.

The fix wraps the `MonacoEditor` assertion in `vi.waitFor()` to wait for the async `onMount` to resolve.

### Screenshot / video of UI

N/A - test-only change.

### What issues does this PR fix or reference?

Fixes test failure introduced by the Vitest v5 upgrade.
https://github.com/podman-desktop/podman-desktop/issues/19099
https://github.com/podman-desktop/podman-desktop/pull/19108


### How to test this PR?

Run the test:
```bash
npx vitest run packages/renderer/src/lib/network/NetworkDetailsInspect.spec.ts
```

- [x] Tests are covering the bug fix or the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)