### PR TITLE
refactor(renderer): fix EditableConnectionResourceItem test for vitest v4/v5 compatibility

### DIFF
--- a/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
@@ -21,11 +21,15 @@ import '@testing-library/jest-dom/vitest';
 import type { IConfigurationPropertyRecordedSchema } from '@podman-desktop/core-api/configuration';
 import { render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
-import { expect, test, vi } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import EditableConnectionResourceItem from './EditableConnectionResourceItem.svelte';
 
 const onSave = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
 
 test('Expect onSave is called with normalized value if record uses GB and input is updated', async () => {
   const record: IConfigurationPropertyRecordedSchema = {
@@ -96,7 +100,8 @@ test('Expect onSave to be called with initial value if input is cancelled', asyn
     minimum: 1000000000,
     maximum: 34000000000,
   };
-  const value = 2000000000;
+  const INITIAL_VALUE = 2000000000;
+  const value = INITIAL_VALUE;
   render(EditableConnectionResourceItem, { record, value, onSave });
 
   const buttonEdit = screen.getByRole('button', { name: 'Edit' });
@@ -118,5 +123,5 @@ test('Expect onSave to be called with initial value if input is cancelled', asyn
 
   await userEvent.click(buttonCancel);
 
-  expect(onSave).toBeCalledWith('record', 20000000000);
+  expect(onSave).toBeCalledWith('record', INITIAL_VALUE);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `EditableConnectionResourceItem.spec.ts` cancel test that was
relying on mock call history leaking between tests.

Vitest v5 changed the `clearMocks` default from `false` to `true`,
exposing a pre-existing bug: the cancel test asserted against a value
(20 GB) that came from a previous test, not the current one.

- Add `beforeEach` with `vi.resetAllMocks()` for explicit mock isolation
- Fix expected value from `20000000000` (20 GB) to `INITIAL_VALUE`
  (2 GB) — the actual value cancel should restore

These changes are compatible with both vitest v4 and v5.

### Screenshot / video of UI

N/A — test-only change.

### What issues does this PR fix or reference?

https://github.com/podman-desktop/podman-desktop/issues/19099
https://github.com/podman-desktop/podman-desktop/pull/19108

### How to test this PR?

```bash
npx vitest run packages/renderer/src/lib/preferences/item-formats/EditableConnectionResourceItem.spec.ts
```

- [x] Tests are covering the bug fix or the new feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)