### PR TITLE
fix(images): resolve update digests in backend

### DIFF
--- a/packages/api/src/image-registry.ts
+++ b/packages/api/src/image-registry.ts
@@ -70,10 +70,6 @@ export interface ImageUpdateInfo {
   image: string;
   /** Image tag, e.g. "latest" */
   tag: string;
-  /** Current local digest of the image */
-  digest: string;
-  /** Current local repository digests of the image */
-  repoDigests?: string[];
 }
 
 /**

--- a/packages/main/src/plugin/container-registry.spec.ts
+++ b/packages/main/src/plugin/container-registry.spec.ts
@@ -7594,14 +7594,20 @@ describe('imageExist', () => {
 describe('updateImages', () => {
   const pullMock = vi.fn();
   const followProgressMock = vi.fn();
+  const imageInspectMock = vi.fn();
+  const getImageMock = vi.fn(() => ({ inspect: imageInspectMock }));
   const fakeDockerode = {
     pull: pullMock,
     modem: { followProgress: followProgressMock },
+    getImage: getImageMock,
   } as unknown as Dockerode;
 
   beforeEach(() => {
     pullMock.mockReset();
     followProgressMock.mockReset();
+    getImageMock.mockClear();
+    imageInspectMock.mockReset();
+    imageInspectMock.mockResolvedValue({ RepoDigests: ['nginx@sha256:old'] });
     telemetryTrackMock.mockReset();
     followProgressMock.mockImplementation((_s: unknown, f: (err: Error | null) => void) => f(null));
     containerRegistry.addInternalProvider('testEngine', {
@@ -7620,7 +7626,7 @@ describe('updateImages', () => {
     });
 
     const [result] = await containerRegistry.updateImages([
-      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest' },
     ]);
 
     expect(result).toEqual({ imageRef: 'nginx:latest', updated: false, status: 'normal', message: 'Up to date' });
@@ -7650,7 +7656,7 @@ describe('updateImages', () => {
 
     const abortController = new AbortController();
     const updatePromise = containerRegistry.updateImages(
-      [{ engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' }],
+      [{ engineId: 'testEngine', image: 'nginx:latest', tag: 'latest' }],
       abortController.signal,
     );
     await vi.waitFor(() => expect(followProgressMock).toHaveBeenCalledOnce());
@@ -7671,7 +7677,7 @@ describe('updateImages', () => {
     vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus').mockResolvedValue(mockStatus);
 
     const [result] = await containerRegistry.updateImages([
-      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest' },
     ]);
 
     expect(result!.updated).toBe(false);
@@ -7681,25 +7687,50 @@ describe('updateImages', () => {
     expect(telemetryTrackMock).toHaveBeenCalledWith('updateImages', expect.objectContaining({ skipped: 1 }));
   });
 
-  test('checks update status with repository digests when available', async () => {
+  test('checks update status with current repository digests from the backend', async () => {
     const checkImageUpdateStatusMock = vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus').mockResolvedValue({
       status: 'normal',
       updateAvailable: false,
       message: 'Up to date',
     });
 
-    await containerRegistry.updateImages([
-      {
-        engineId: 'testEngine',
-        image: 'nginx:latest',
-        tag: 'latest',
-        digest: 'sha256:configdigest',
-        repoDigests: ['nginx@sha256:manifestdigest'],
-      },
-    ]);
+    imageInspectMock.mockResolvedValue({ RepoDigests: ['nginx@sha256:manifestdigest'] });
 
+    await containerRegistry.updateImages([{ engineId: 'testEngine', image: 'nginx:latest', tag: 'latest' }]);
+
+    expect(imageInspectMock).toHaveBeenCalledOnce();
     expect(checkImageUpdateStatusMock).toHaveBeenCalledWith('nginx:latest', 'latest', ['nginx@sha256:manifestdigest']);
     expect(pullMock).not.toHaveBeenCalled();
+  });
+
+  test('checks and updates each tag independently when an image has multiple tags', async () => {
+    imageInspectMock.mockResolvedValue({ RepoDigests: ['example.com/app@sha256:old'] });
+    vi.spyOn(ImageRegistry.prototype, 'checkImageUpdateStatus')
+      .mockResolvedValueOnce({ status: 'normal', updateAvailable: false, message: 'Up to date' })
+      .mockResolvedValueOnce({ status: 'normal', updateAvailable: true, message: 'Update available' });
+    vi.spyOn(ImageRegistry.prototype, 'getAuthconfigForImage').mockReturnValue(undefined);
+    pullMock.mockResolvedValue({});
+
+    const results = await containerRegistry.updateImages([
+      { engineId: 'testEngine', image: 'example.com/app:stable', tag: 'stable' },
+      { engineId: 'testEngine', image: 'example.com/app:latest', tag: 'latest' },
+    ]);
+
+    expect(getImageMock).toHaveBeenCalledWith('example.com/app:stable');
+    expect(getImageMock).toHaveBeenCalledWith('example.com/app:latest');
+    expect(pullMock).toHaveBeenCalledExactlyOnceWith('example.com/app:latest', {
+      authconfig: undefined,
+      abortSignal: undefined,
+    });
+    expect(results).toEqual([
+      { imageRef: 'example.com/app:stable', updated: false, status: 'normal', message: 'Up to date' },
+      {
+        imageRef: 'example.com/app:latest',
+        updated: true,
+        status: 'updated',
+        message: 'Image updated successfully',
+      },
+    ]);
   });
 
   test('returns error when engine not found', async () => {
@@ -7708,7 +7739,7 @@ describe('updateImages', () => {
     checkImageUpdateStatusMock.mockClear();
 
     const [result] = await containerRegistry.updateImages([
-      { engineId: 'nonexistent', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+      { engineId: 'nonexistent', image: 'nginx:latest', tag: 'latest' },
     ]);
 
     expect(result!.updated).toBe(false);
@@ -7735,8 +7766,8 @@ describe('updateImages', () => {
     });
 
     const results = await containerRegistry.updateImages([
-      { engineId: 'nonexistent', image: 'missing:latest', tag: 'latest', digest: 'sha256:missing' },
-      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
+      { engineId: 'nonexistent', image: 'missing:latest', tag: 'latest' },
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest' },
     ]);
 
     expect(results).toEqual([
@@ -7767,8 +7798,8 @@ describe('updateImages', () => {
     pullMock.mockResolvedValue({});
 
     const results = await containerRegistry.updateImages([
-      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest', digest: 'sha256:old' },
-      { engineId: 'testEngine', image: 'redis:latest', tag: 'latest', digest: 'sha256:old2' },
+      { engineId: 'testEngine', image: 'nginx:latest', tag: 'latest' },
+      { engineId: 'testEngine', image: 'redis:latest', tag: 'latest' },
     ]);
 
     expect(results).toHaveLength(2);

--- a/packages/main/src/plugin/container-registry.ts
+++ b/packages/main/src/plugin/container-registry.ts
@@ -1424,7 +1424,8 @@ export class ContainerProviderRegistry {
       images.map(async (info): Promise<ImageUpdateResult> => {
         try {
           const matchingEngine = this.getMatchingEngine(info.engineId);
-          const localDigests = info.repoDigests?.length ? info.repoDigests : [info.digest];
+          const imageInspect = await matchingEngine.getImage(info.image).inspect();
+          const localDigests = imageInspect.RepoDigests ?? [];
           const status = await this.imageRegistry.checkImageUpdateStatus(info.image, info.tag, localDigests);
 
           if (status.status === 'error') {


### PR DESCRIPTION
### What does this PR do?

Resolve local image repository digests in `ContainerProviderRegistry.updateImages` at call time. Requests now contain only `engineId`, `image`, and `tag`, avoiding stale digest values supplied by callers.

This extracts the API and backend changes from #18996 into the dedicated prerequisite requested in review. Existing unit tests cover backend digest inspection and independent updates for multiple tags.

### Screenshot / video of UI

N/A — API and backend change.

### What issues does this PR fix or reference?

Prerequisite for #18996, following https://github.com/podman-desktop/podman-desktop/pull/18996#discussion_r3903109343.

### How to test this PR?

- `pnpm exec vitest run packages/main/src/plugin/container-registry.spec.ts` — 223 tests passed.
- `pnpm run typecheck:main` — passed.
- ESLint on the three changed files and `pnpm lint-staged` — passed.

- [x] Tests are covering the bug fix or the new feature
