### PR TITLE
test(e2e): update serial declaration - part 8

### DIFF
--- a/tests/playwright/src/specs/navigation-history-smoke.spec.ts
+++ b/tests/playwright/src/specs/navigation-history-smoke.spec.ts
@@ -30,200 +30,200 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Navigation History Smoke Tests', { tag: ['@smoke', '@macos_sanity', '@windows_sanity'] }, () => {
-    test('Back button navigates to previous page', async ({ navigationBar }) => {
-      // Navigate through pages: Dashboard → Containers → Images
-      await navigationBar.openDashboard();
-      const containersPage = await navigationBar.openContainers();
-      await navigationBar.openImages();
+test.describe('Navigation History Smoke Tests', { tag: ['@smoke', '@macos_sanity', '@windows_sanity'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Back button navigates to previous page', async ({ navigationBar }) => {
+    // Navigate through pages: Dashboard → Containers → Images
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await navigationBar.openImages();
 
-      // Click back button
-      await navigationBar.goBack();
+    // Click back button
+    await navigationBar.goBack();
 
-      // Verify on Containers page
-      await playExpect(containersPage.heading).toBeVisible();
+    // Verify on Containers page
+    await playExpect(containersPage.heading).toBeVisible();
 
-      // Verify button states
-      await playExpect(navigationBar.backButton).toBeEnabled();
-      await playExpect(navigationBar.forwardButton).toBeEnabled();
-    });
-
-    test('Forward button navigates to next page', async ({ navigationBar, page }) => {
-      // Continue from TC-001 state (on Containers, can go forward to Images)
-      const imagesPage = new ImagesPage(page);
-
-      // Click forward button
-      await navigationBar.goForward();
-
-      // Verify on Images page
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      // Verify forward button disabled (at end of history)
-      await playExpect(navigationBar.forwardButton).toBeDisabled();
-    });
-
-    test('Buttons disabled when navigation not possible', async ({ navigationBar, page }) => {
-      // Clear sessionStorage so route-restoration lands on Dashboard (default),
-      // not on whatever page a prior test happened to leave in storage.
-      await page.evaluate(() => sessionStorage.clear());
-      await page.reload();
-      await playExpect(navigationBar.backButton).toBeDisabled();
-      await playExpect(navigationBar.forwardButton).toBeDisabled();
-
-      const dashboardPage = new DashboardPage(page);
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-
-      await navigationBar.goBack();
-      await playExpect(dashboardPage.heading).toBeVisible();
-
-      await playExpect(navigationBar.forwardButton).toBeEnabled();
-      await playExpect(navigationBar.backButton).toBeDisabled();
-
-      // After one navigation, back should be enabled, forward disabled
-      await navigationBar.goForward();
-      await playExpect(navigationBar.backButton).toBeEnabled();
-      await playExpect(navigationBar.forwardButton).toBeDisabled();
-    });
-
-    test('Command palette Go Back navigates to previous page', async ({ navigationBar, page }) => {
-      // Navigate: Dashboard → Containers
-      await navigationBar.openDashboard();
-      await navigationBar.openContainers();
-
-      // Open command palette and execute Go Back
-      const commandPalette = new CommandPalette(page);
-      await commandPalette.executeCommand('Go Back');
-
-      // Verify on Dashboard
-      const dashboardPage = new DashboardPage(page);
-      await playExpect(dashboardPage.heading).toBeVisible({ timeout: 5_000 });
-    });
-
-    test('Command palette Go Forward navigates forward', async ({ navigationBar, page }) => {
-      // Setup: Navigate and go back
-      await navigationBar.openDashboard();
-      await navigationBar.openContainers();
-      await navigationBar.openImages();
-      await navigationBar.goBack(); // Now on Containers
-
-      // Open command palette and execute Go Forward
-      const commandPalette = new CommandPalette(page);
-      await commandPalette.executeCommand('Go Forward');
-
-      // Verify on Images page
-      const imagesPage = new ImagesPage(page);
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 5_000 });
-    });
-
-    test('History truncated when navigating to new page from middle of stack', async ({ navigationBar }) => {
-      // Navigate: Dashboard → Containers → Images → Volumes
-      await navigationBar.openDashboard();
-      await navigationBar.openContainers();
-      await navigationBar.openImages();
-      await navigationBar.openVolumes();
-
-      // Go back twice (now at Containers)
-      await navigationBar.goBack();
-      await navigationBar.goBack();
-
-      // Navigate to Pods (should truncate forward history)
-      const podsPage = await navigationBar.openPods();
-      await playExpect(podsPage.heading).toBeVisible();
-
-      // Forward button should be disabled (history truncated)
-      await playExpect(navigationBar.forwardButton).toBeDisabled();
-    });
-
-    test('Clicking same navigation link does not add duplicate', async ({ navigationBar, page }) => {
-      await navigationBar.openDashboard();
-      await navigationBar.openContainers();
-
-      // Click Containers again
-      await navigationBar.openContainers();
-
-      // Go back - should go to Dashboard, not Containers
-      await navigationBar.goBack();
-
-      const dashboardPage = new DashboardPage(page);
-      await playExpect(dashboardPage.heading).toBeVisible({ timeout: 5_000 });
-    });
-
-    test('Long press on back button shows history dropdown', async ({ navigationBar, page }) => {
-      await page.evaluate(() => sessionStorage.clear());
-      await page.reload();
-
-      await navigationBar.openDashboard();
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const dropdown = await navigationBar.longPressBack();
-
-      await playExpect(dropdown.getByRole('button', { name: 'Containers' })).toBeVisible();
-      await playExpect(dropdown.getByRole('button', { name: 'Dashboard' })).toBeVisible();
-    });
-
-    test('Selecting entry from back history dropdown navigates to that page', async ({ navigationBar, page }) => {
-      await page.evaluate(() => sessionStorage.clear());
-      await page.reload();
-
-      await navigationBar.openDashboard();
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const dropdown = await navigationBar.longPressBack();
-      await navigationBar.selectHistoryEntry(dropdown, 'Dashboard');
-
-      const dashboardPage = new DashboardPage(page);
-      await playExpect(dashboardPage.heading).toBeVisible({ timeout: 5_000 });
-    });
-
-    test('Long press on forward button shows forward history dropdown', async ({ navigationBar, page }) => {
-      await page.evaluate(() => sessionStorage.clear());
-      await page.reload();
-
-      const dashboardPage = new DashboardPage(page);
-      await navigationBar.openDashboard();
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await navigationBar.goBack();
-      await playExpect(containersPage.heading).toBeVisible();
-      await navigationBar.goBack();
-      await playExpect(dashboardPage.heading).toBeVisible();
-
-      const dropdown = await navigationBar.longPressForward();
-
-      await playExpect(dropdown.getByRole('button', { name: 'Containers' })).toBeVisible();
-      await playExpect(dropdown.getByRole('button', { name: 'Images' })).toBeVisible();
-    });
-
-    test('Selecting entry from forward history dropdown navigates to that page', async ({ navigationBar, page }) => {
-      await page.evaluate(() => sessionStorage.clear());
-      await page.reload();
-
-      const dashboardPage = new DashboardPage(page);
-      await navigationBar.openDashboard();
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await navigationBar.goBack();
-      await playExpect(containersPage.heading).toBeVisible();
-      await navigationBar.goBack();
-      await playExpect(dashboardPage.heading).toBeVisible();
-
-      const dropdown = await navigationBar.longPressForward();
-      await navigationBar.selectHistoryEntry(dropdown, 'Images');
-
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 5_000 });
-    });
+    // Verify button states
+    await playExpect(navigationBar.backButton).toBeEnabled();
+    await playExpect(navigationBar.forwardButton).toBeEnabled();
   });
+
+  test('Forward button navigates to next page', async ({ navigationBar, page }) => {
+    // Continue from TC-001 state (on Containers, can go forward to Images)
+    const imagesPage = new ImagesPage(page);
+
+    // Click forward button
+    await navigationBar.goForward();
+
+    // Verify on Images page
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    // Verify forward button disabled (at end of history)
+    await playExpect(navigationBar.forwardButton).toBeDisabled();
+  });
+
+  test('Buttons disabled when navigation not possible', async ({ navigationBar, page }) => {
+    // Clear sessionStorage so route-restoration lands on Dashboard (default),
+    // not on whatever page a prior test happened to leave in storage.
+    await page.evaluate(() => sessionStorage.clear());
+    await page.reload();
+    await playExpect(navigationBar.backButton).toBeDisabled();
+    await playExpect(navigationBar.forwardButton).toBeDisabled();
+
+    const dashboardPage = new DashboardPage(page);
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+
+    await navigationBar.goBack();
+    await playExpect(dashboardPage.heading).toBeVisible();
+
+    await playExpect(navigationBar.forwardButton).toBeEnabled();
+    await playExpect(navigationBar.backButton).toBeDisabled();
+
+    // After one navigation, back should be enabled, forward disabled
+    await navigationBar.goForward();
+    await playExpect(navigationBar.backButton).toBeEnabled();
+    await playExpect(navigationBar.forwardButton).toBeDisabled();
+  });
+
+  test('Command palette Go Back navigates to previous page', async ({ navigationBar, page }) => {
+    // Navigate: Dashboard → Containers
+    await navigationBar.openDashboard();
+    await navigationBar.openContainers();
+
+    // Open command palette and execute Go Back
+    const commandPalette = new CommandPalette(page);
+    await commandPalette.executeCommand('Go Back');
+
+    // Verify on Dashboard
+    const dashboardPage = new DashboardPage(page);
+    await playExpect(dashboardPage.heading).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Command palette Go Forward navigates forward', async ({ navigationBar, page }) => {
+    // Setup: Navigate and go back
+    await navigationBar.openDashboard();
+    await navigationBar.openContainers();
+    await navigationBar.openImages();
+    await navigationBar.goBack(); // Now on Containers
+
+    // Open command palette and execute Go Forward
+    const commandPalette = new CommandPalette(page);
+    await commandPalette.executeCommand('Go Forward');
+
+    // Verify on Images page
+    const imagesPage = new ImagesPage(page);
+    await playExpect(imagesPage.heading).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('History truncated when navigating to new page from middle of stack', async ({ navigationBar }) => {
+    // Navigate: Dashboard → Containers → Images → Volumes
+    await navigationBar.openDashboard();
+    await navigationBar.openContainers();
+    await navigationBar.openImages();
+    await navigationBar.openVolumes();
+
+    // Go back twice (now at Containers)
+    await navigationBar.goBack();
+    await navigationBar.goBack();
+
+    // Navigate to Pods (should truncate forward history)
+    const podsPage = await navigationBar.openPods();
+    await playExpect(podsPage.heading).toBeVisible();
+
+    // Forward button should be disabled (history truncated)
+    await playExpect(navigationBar.forwardButton).toBeDisabled();
+  });
+
+  test('Clicking same navigation link does not add duplicate', async ({ navigationBar, page }) => {
+    await navigationBar.openDashboard();
+    await navigationBar.openContainers();
+
+    // Click Containers again
+    await navigationBar.openContainers();
+
+    // Go back - should go to Dashboard, not Containers
+    await navigationBar.goBack();
+
+    const dashboardPage = new DashboardPage(page);
+    await playExpect(dashboardPage.heading).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Long press on back button shows history dropdown', async ({ navigationBar, page }) => {
+    await page.evaluate(() => sessionStorage.clear());
+    await page.reload();
+
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const dropdown = await navigationBar.longPressBack();
+
+    await playExpect(dropdown.getByRole('button', { name: 'Containers' })).toBeVisible();
+    await playExpect(dropdown.getByRole('button', { name: 'Dashboard' })).toBeVisible();
+  });
+
+  test('Selecting entry from back history dropdown navigates to that page', async ({ navigationBar, page }) => {
+    await page.evaluate(() => sessionStorage.clear());
+    await page.reload();
+
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const dropdown = await navigationBar.longPressBack();
+    await navigationBar.selectHistoryEntry(dropdown, 'Dashboard');
+
+    const dashboardPage = new DashboardPage(page);
+    await playExpect(dashboardPage.heading).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Long press on forward button shows forward history dropdown', async ({ navigationBar, page }) => {
+    await page.evaluate(() => sessionStorage.clear());
+    await page.reload();
+
+    const dashboardPage = new DashboardPage(page);
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await navigationBar.goBack();
+    await playExpect(containersPage.heading).toBeVisible();
+    await navigationBar.goBack();
+    await playExpect(dashboardPage.heading).toBeVisible();
+
+    const dropdown = await navigationBar.longPressForward();
+
+    await playExpect(dropdown.getByRole('button', { name: 'Containers' })).toBeVisible();
+    await playExpect(dropdown.getByRole('button', { name: 'Images' })).toBeVisible();
+  });
+
+  test('Selecting entry from forward history dropdown navigates to that page', async ({ navigationBar, page }) => {
+    await page.evaluate(() => sessionStorage.clear());
+    await page.reload();
+
+    const dashboardPage = new DashboardPage(page);
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await navigationBar.goBack();
+    await playExpect(containersPage.heading).toBeVisible();
+    await navigationBar.goBack();
+    await playExpect(dashboardPage.heading).toBeVisible();
+
+    const dropdown = await navigationBar.longPressForward();
+    await navigationBar.selectHistoryEntry(dropdown, 'Images');
+
+    await playExpect(imagesPage.heading).toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/tests/playwright/src/specs/navigation-history.spec.ts
+++ b/tests/playwright/src/specs/navigation-history.spec.ts
@@ -43,210 +43,209 @@ const SHORTCUTS = isMac
   ? ['Meta+BracketLeft', 'Meta+BracketRight', 'Meta+ArrowLeft', 'Meta+ArrowRight']
   : ['Alt+ArrowRight', 'Alt+ArrowLeft'];
 
-test.describe
-  .serial('Navigation History Comprehensive Tests', { tag: ['@smoke'] }, () => {
-    test.describe.configure({ retries: 1 });
+test.describe('Navigation History Comprehensive Tests', { tag: ['@smoke'] }, () => {
+  test.describe.configure({ mode: 'serial', retries: 1 });
 
-    SHORTCUTS.forEach(element => {
-      test(`${element} shortcut navigates correctly`, async ({ navigationBar, page }) => {
-        const containersPage = await navigationBar.openContainers();
-        await playExpect(containersPage.heading).toBeVisible();
-        const imagesPage = await navigationBar.openImages();
-        await playExpect(imagesPage.heading).toBeVisible();
-        // test back
-        if (element.toLocaleLowerCase().includes('left')) {
-          // press the shortcut
-          await page.keyboard.press(element);
-          await playExpect(containersPage.heading).toBeVisible();
-        } else if (element.toLocaleLowerCase().includes('right')) {
-          await navigationBar.goBack();
-          await playExpect(containersPage.heading).toBeVisible();
-          await page.keyboard.press(element);
-          await playExpect(imagesPage.heading).toBeVisible();
-        } else {
-          throw new Error(`Do not recognize the direction of ${element} shortcut`);
-        }
-      });
-    });
-
-    test('Mouse button 3 (back) navigates backward', async ({ navigationBar, page }) => {
-      // Navigate through pages
-      await navigationBar.openDashboard();
-      const containersPage = await navigationBar.openContainers();
-      await navigationBar.openImages();
-
-      // Simulate mouse button 3 click (back button)
-      await page.evaluate(() => {
-        const event = new MouseEvent('mouseup', {
-          button: 3, // button 3 = back
-          bubbles: true,
-        });
-        document.body.dispatchEvent(event);
-      });
-
-      // Verify on Containers page
-      await playExpect(containersPage.heading).toBeVisible({ timeout: 5_000 });
-    });
-
-    test('Trackpad swipe left navigates to previous page', async ({ navigationBar, page }) => {
-      // Navigate: Dashboard → Containers → Images
-      await navigationBar.openDashboard();
-      const containersPage = await navigationBar.openContainers();
-      await navigationBar.openImages();
-
-      // Simulate trackpad swipe right (deltaX < -30 for back)
-      await page.evaluate(() => {
-        const event = new WheelEvent('wheel', {
-          deltaX: -50, // < -30 threshold for back navigation
-          deltaY: 0,
-          bubbles: true,
-        });
-        document.body.dispatchEvent(event);
-      });
-
-      // Verify navigation occurred to Containers
-      await playExpect(containersPage.heading).toBeVisible({ timeout: 5_000 });
-    });
-
-    test('Trackpad swipe right navigates forward', async ({ navigationBar, page }) => {
-      // Setup: Navigate and go back to have forward available
-      await navigationBar.openDashboard();
-      const containerPage = await navigationBar.openContainers();
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 5_000 });
-      await navigationBar.goBack(); // Now on Containers with forward available
-      await playExpect(containerPage.heading).toBeVisible({ timeout: 5_000 });
-
-      const forwardButton = page.getByRole('button', { name: 'Forward (hold for history)' });
-      await playExpect(forwardButton).toBeEnabled({ timeout: 5_000 });
-
-      // The app has a 500ms swipe cooldown (NavigationButtons.handleWheel) that may
-      // still be active from the previous trackpad-swipe-left test. Poll the dispatch
-      // so the event is retried once the cooldown expires.
-      await playExpect
-        .poll(
-          async () => {
-            await page.evaluate(() => {
-              document.body.dispatchEvent(new WheelEvent('wheel', { deltaX: 50, deltaY: 0, bubbles: true }));
-            });
-            return imagesPage.heading.isVisible();
-          },
-          { timeout: 5_000 },
-        )
-        .toBeTruthy();
-    });
-
-    test('Navigation shortcuts blocked when focus in input field', async ({ navigationBar, page }) => {
-      await navigationBar.openDashboard();
+  SHORTCUTS.forEach(element => {
+    test(`${element} shortcut navigates correctly`, async ({ navigationBar, page }) => {
       const containersPage = await navigationBar.openContainers();
       await playExpect(containersPage.heading).toBeVisible();
-
-      // Find and focus on search input (if available)
-      const searchInput = page.getByPlaceholder(/search/i).first();
-      await playExpect(searchInput).toBeVisible();
-      const searchExists = await searchInput.count();
-
-      if (searchExists > 0) {
-        await searchInput.click();
-
-        // Try keyboard shortcut
-        const shortcut = isMac ? 'Meta+ArrowLeft' : 'Alt+ArrowLeft';
-        await page.keyboard.press(shortcut);
-
-        // Verify still on Containers page (no navigation occurred)
+      const imagesPage = await navigationBar.openImages();
+      await playExpect(imagesPage.heading).toBeVisible();
+      // test back
+      if (element.toLocaleLowerCase().includes('left')) {
+        // press the shortcut
+        await page.keyboard.press(element);
         await playExpect(containersPage.heading).toBeVisible();
+      } else if (element.toLocaleLowerCase().includes('right')) {
+        await navigationBar.goBack();
+        await playExpect(containersPage.heading).toBeVisible();
+        await page.keyboard.press(element);
+        await playExpect(imagesPage.heading).toBeVisible();
+      } else {
+        throw new Error(`Do not recognize the direction of ${element} shortcut`);
       }
     });
-
-    test('Vertical scroll does not trigger navigation', async ({ navigationBar, page }) => {
-      await navigationBar.openDashboard();
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-
-      // Simulate vertical scroll (deltaY only)
-      await page.evaluate(() => {
-        const event = new WheelEvent('wheel', {
-          deltaX: 0,
-          deltaY: 100, // Vertical scroll only
-          bubbles: true,
-        });
-        document.body.dispatchEvent(event);
-      });
-
-      // Verify still on Containers page (no navigation)
-      await playExpect(containersPage.heading).toBeVisible();
-    });
-
-    test('Can go to Kubernetes and back, regression check for #15636', async () => {
-      // Context exists: skip this test scenario
-      test.skip(true, 'Requires K8s context set');
-    });
-
-    test('Kubernetes submenu navigation', async () => {
-      // Context exists: skip this test scenario
-      test.skip(true, 'Requires K8s context set');
-    });
-
-    test('Navigating back to deleted container shows error placeholder', async ({ navigationBar, page }) => {
-      // Pull alpine image (minimal image for testing)
-      const imageName = 'ghcr.io/linuxcontainers/alpine';
-      const imagesPage = await navigationBar.openImages();
-      const pullImagePage = await imagesPage.openPullImage();
-      const updatedImages = await pullImagePage.pullImage(imageName, 'latest');
-
-      // Wait for image to be pulled
-      await playExpect
-        .poll(async () => await updatedImages.waitForImageExists(imageName), { timeout: 30_000 })
-        .toBeTruthy();
-
-      // Create and start container
-      const imageDetails = await imagesPage.openImageDetails(imageName);
-      const runImage = await imageDetails.openRunImage();
-      await runImage.startContainer(testContainerName, { attachTerminal: false });
-
-      // Navigate to container details
-      const containersPage = await navigationBar.openContainers();
-      await playExpect
-        .poll(async () => await containersPage.containerExists(testContainerName), { timeout: 30_000 })
-        .toBeTruthy();
-
-      await containersPage.openContainersDetails(testContainerName);
-
-      // Navigate away to Images
-      await navigationBar.openImages();
-
-      // Delete the container. it opens containers page
-      await deleteContainer(page, testContainerName);
-      // when container is deleted, it shows Containers Page
-      await playExpect(containersPage.heading).toBeVisible();
-
-      // Navigate back, should open images
-      await navigationBar.goBack();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      // Navigate back, will open empty page for deleted container
-      await navigationBar.goBack();
-
-      // App shows empty page, navigation bar, contentinfo and header.
-      await playExpect(imagesPage.heading).not.toBeVisible();
-      await playExpect(containersPage.heading).not.toBeVisible();
-      await playExpect(imagesPage.header).not.toBeVisible();
-      await playExpect(imagesPage.content).not.toBeVisible();
-    });
-
-    test('Navigating to stopped Podman machine shows current state', async () => {
-      // This test is complex and requires machine management
-      // Skipping for now as it requires specific machine state setup
-      test.skip(true, 'Machine state testing requires complex setup');
-    });
-
-    test('Navigating in the extension webView', async () => {
-      // advanced test case
-      test.skip(true, 'Machine state testing requires complex setup');
-    });
-
-    test('Navigating back from containers details with tty attached, regression #15994', async () => {
-      // Test will be implemented later based on bug fix
-      test.skip(true, 'Implement later when #15994 is resolved');
-    });
   });
+
+  test('Mouse button 3 (back) navigates backward', async ({ navigationBar, page }) => {
+    // Navigate through pages
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await navigationBar.openImages();
+
+    // Simulate mouse button 3 click (back button)
+    await page.evaluate(() => {
+      const event = new MouseEvent('mouseup', {
+        button: 3, // button 3 = back
+        bubbles: true,
+      });
+      document.body.dispatchEvent(event);
+    });
+
+    // Verify on Containers page
+    await playExpect(containersPage.heading).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Trackpad swipe left navigates to previous page', async ({ navigationBar, page }) => {
+    // Navigate: Dashboard → Containers → Images
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await navigationBar.openImages();
+
+    // Simulate trackpad swipe right (deltaX < -30 for back)
+    await page.evaluate(() => {
+      const event = new WheelEvent('wheel', {
+        deltaX: -50, // < -30 threshold for back navigation
+        deltaY: 0,
+        bubbles: true,
+      });
+      document.body.dispatchEvent(event);
+    });
+
+    // Verify navigation occurred to Containers
+    await playExpect(containersPage.heading).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('Trackpad swipe right navigates forward', async ({ navigationBar, page }) => {
+    // Setup: Navigate and go back to have forward available
+    await navigationBar.openDashboard();
+    const containerPage = await navigationBar.openContainers();
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible({ timeout: 5_000 });
+    await navigationBar.goBack(); // Now on Containers with forward available
+    await playExpect(containerPage.heading).toBeVisible({ timeout: 5_000 });
+
+    const forwardButton = page.getByRole('button', { name: 'Forward (hold for history)' });
+    await playExpect(forwardButton).toBeEnabled({ timeout: 5_000 });
+
+    // The app has a 500ms swipe cooldown (NavigationButtons.handleWheel) that may
+    // still be active from the previous trackpad-swipe-left test. Poll the dispatch
+    // so the event is retried once the cooldown expires.
+    await playExpect
+      .poll(
+        async () => {
+          await page.evaluate(() => {
+            document.body.dispatchEvent(new WheelEvent('wheel', { deltaX: 50, deltaY: 0, bubbles: true }));
+          });
+          return imagesPage.heading.isVisible();
+        },
+        { timeout: 5_000 },
+      )
+      .toBeTruthy();
+  });
+
+  test('Navigation shortcuts blocked when focus in input field', async ({ navigationBar, page }) => {
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+
+    // Find and focus on search input (if available)
+    const searchInput = page.getByPlaceholder(/search/i).first();
+    await playExpect(searchInput).toBeVisible();
+    const searchExists = await searchInput.count();
+
+    if (searchExists > 0) {
+      await searchInput.click();
+
+      // Try keyboard shortcut
+      const shortcut = isMac ? 'Meta+ArrowLeft' : 'Alt+ArrowLeft';
+      await page.keyboard.press(shortcut);
+
+      // Verify still on Containers page (no navigation occurred)
+      await playExpect(containersPage.heading).toBeVisible();
+    }
+  });
+
+  test('Vertical scroll does not trigger navigation', async ({ navigationBar, page }) => {
+    await navigationBar.openDashboard();
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+
+    // Simulate vertical scroll (deltaY only)
+    await page.evaluate(() => {
+      const event = new WheelEvent('wheel', {
+        deltaX: 0,
+        deltaY: 100, // Vertical scroll only
+        bubbles: true,
+      });
+      document.body.dispatchEvent(event);
+    });
+
+    // Verify still on Containers page (no navigation)
+    await playExpect(containersPage.heading).toBeVisible();
+  });
+
+  test('Can go to Kubernetes and back, regression check for #15636', async () => {
+    // Context exists: skip this test scenario
+    test.skip(true, 'Requires K8s context set');
+  });
+
+  test('Kubernetes submenu navigation', async () => {
+    // Context exists: skip this test scenario
+    test.skip(true, 'Requires K8s context set');
+  });
+
+  test('Navigating back to deleted container shows error placeholder', async ({ navigationBar, page }) => {
+    // Pull alpine image (minimal image for testing)
+    const imageName = 'ghcr.io/linuxcontainers/alpine';
+    const imagesPage = await navigationBar.openImages();
+    const pullImagePage = await imagesPage.openPullImage();
+    const updatedImages = await pullImagePage.pullImage(imageName, 'latest');
+
+    // Wait for image to be pulled
+    await playExpect
+      .poll(async () => await updatedImages.waitForImageExists(imageName), { timeout: 30_000 })
+      .toBeTruthy();
+
+    // Create and start container
+    const imageDetails = await imagesPage.openImageDetails(imageName);
+    const runImage = await imageDetails.openRunImage();
+    await runImage.startContainer(testContainerName, { attachTerminal: false });
+
+    // Navigate to container details
+    const containersPage = await navigationBar.openContainers();
+    await playExpect
+      .poll(async () => await containersPage.containerExists(testContainerName), { timeout: 30_000 })
+      .toBeTruthy();
+
+    await containersPage.openContainersDetails(testContainerName);
+
+    // Navigate away to Images
+    await navigationBar.openImages();
+
+    // Delete the container. it opens containers page
+    await deleteContainer(page, testContainerName);
+    // when container is deleted, it shows Containers Page
+    await playExpect(containersPage.heading).toBeVisible();
+
+    // Navigate back, should open images
+    await navigationBar.goBack();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    // Navigate back, will open empty page for deleted container
+    await navigationBar.goBack();
+
+    // App shows empty page, navigation bar, contentinfo and header.
+    await playExpect(imagesPage.heading).not.toBeVisible();
+    await playExpect(containersPage.heading).not.toBeVisible();
+    await playExpect(imagesPage.header).not.toBeVisible();
+    await playExpect(imagesPage.content).not.toBeVisible();
+  });
+
+  test('Navigating to stopped Podman machine shows current state', async () => {
+    // This test is complex and requires machine management
+    // Skipping for now as it requires specific machine state setup
+    test.skip(true, 'Machine state testing requires complex setup');
+  });
+
+  test('Navigating in the extension webView', async () => {
+    // advanced test case
+    test.skip(true, 'Machine state testing requires complex setup');
+  });
+
+  test('Navigating back from containers details with tty attached, regression #15994', async () => {
+    // Test will be implemented later based on bug fix
+    test.skip(true, 'Implement later when #15994 is resolved');
+  });
+});

--- a/tests/playwright/src/specs/network-smoke.spec.ts
+++ b/tests/playwright/src/specs/network-smoke.spec.ts
@@ -35,202 +35,202 @@ test.skip(
   'Skipping network smoke tests since Podman CLI version is less than 5.7.0 or not available',
 );
 
-test.describe
-  .serial('Network smoke tests', { tag: ['@smoke'] }, () => {
-    test.beforeAll(async ({ runner, welcomePage, page }) => {
-      runner.setVideoAndTraceName('network-smoke');
-      await welcomePage.handleWelcomePage(true);
-      await waitForPodmanMachineStartup(page);
-    });
+test.describe('Network smoke tests', { tag: ['@smoke'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test.beforeAll(async ({ runner, welcomePage, page }) => {
+    runner.setVideoAndTraceName('network-smoke');
+    await welcomePage.handleWelcomePage(true);
+    await waitForPodmanMachineStartup(page);
+  });
 
-    test.afterAll(async ({ runner, page }) => {
-      try {
-        await deleteContainer(page, testContainerName);
-        await deleteNetwork(page, testNetworkName);
-        await deleteImage(page, testImageName);
-        for (const network of networkList) {
-          await deleteNetwork(page, network);
-        }
-      } finally {
-        await runner.close();
+  test.afterAll(async ({ runner, page }) => {
+    try {
+      await deleteContainer(page, testContainerName);
+      await deleteNetwork(page, testNetworkName);
+      await deleteImage(page, testImageName);
+      for (const network of networkList) {
+        await deleteNetwork(page, network);
       }
-    });
+    } finally {
+      await runner.close();
+    }
+  });
 
-    test('Check default network exists', async ({ navigationBar }) => {
-      const networksPage = await navigationBar.openNetworks();
-      await playExpect(networksPage.heading).toBeVisible();
+  test('Check default network exists', async ({ navigationBar }) => {
+    const networksPage = await navigationBar.openNetworks();
+    await playExpect(networksPage.heading).toBeVisible();
 
-      await playExpect
-        .poll(async () => await networksPage.getNetworkRowByName(defaultNetworkName), { timeout: 30_000 })
-        .toBeTruthy();
-    });
+    await playExpect
+      .poll(async () => await networksPage.getNetworkRowByName(defaultNetworkName), { timeout: 30_000 })
+      .toBeTruthy();
+  });
 
-    test('Create network and verify it exists', async ({ navigationBar }) => {
-      let networksPage = await navigationBar.openNetworks();
-      await playExpect(networksPage.heading).toBeVisible();
+  test('Create network and verify it exists', async ({ navigationBar }) => {
+    let networksPage = await navigationBar.openNetworks();
+    await playExpect(networksPage.heading).toBeVisible();
 
-      const networkDetails = await networksPage.createNetwork(testNetworkName, testNetworkSubnet);
+    const networkDetails = await networksPage.createNetwork(testNetworkName, testNetworkSubnet);
+    await playExpect(networkDetails.heading).toBeVisible({ timeout: 30_000 });
+
+    networksPage = await navigationBar.openNetworks();
+    await playExpect(networksPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await networksPage.getNetworkRowByName(testNetworkName), {
+        timeout: 30_000,
+      })
+      .toBeTruthy();
+  });
+
+  test('Pull image for network container test', async ({ navigationBar }) => {
+    test.setTimeout(90_000);
+
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await imagesPage.pullImage(testImageName);
+
+    await playExpect
+      .poll(async () => await imagesPage.waitForImageExists(testImageName, 60_000), { timeout: 0 })
+      .toBeTruthy();
+  });
+
+  test('Start container using the network', async ({ navigationBar }) => {
+    test.setTimeout(90_000);
+
+    // Open the image and run it on the test network (network already exists from previous test)
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const imageDetails = await imagesPage.openImageDetails(testImageName);
+    await playExpect(imageDetails.heading).toBeVisible();
+
+    const runImagePage = await imageDetails.openRunImage();
+    await playExpect(runImagePage.heading).toBeVisible();
+
+    await runImagePage.selectUserDefinedNetwork(testNetworkName);
+    await runImagePage.startContainer(testContainerName);
+
+    // After startContainer(), alpine's /bin/sh causes the app to navigate to
+    // Container Details → Tty tab (interactive shell scenario). Explicitly navigate
+    // to the Containers page to verify the container was created.
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+
+    // Wait for container row to appear, then open details and verify it is running
+    await playExpect
+      .poll(async () => await containersPage.getContainerRowByName(testContainerName), { timeout: 60_000 })
+      .toBeTruthy();
+    const containerDetails = await containersPage.openContainersDetails(testContainerName);
+    await playExpect(containerDetails.heading).toContainText(testContainerName);
+    await playExpect
+      .poll(async () => await containerDetails.getState(), { timeout: 30_000 })
+      .toBe(ContainerState.Running);
+  });
+
+  test('Verify container inspect shows correct network', async ({ navigationBar }) => {
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+
+    const containerDetails = await containersPage.openContainersDetails(testContainerName);
+    await playExpect(containerDetails.heading).toContainText(testContainerName);
+
+    await playExpect
+      .poll(async () => await containerDetails.searchInInspectEditor(testNetworkName), { timeout: 10_000 })
+      .toBeTruthy();
+  });
+
+  test('Stop and delete the network container', async ({ navigationBar }) => {
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+
+    const containerDetails = await containersPage.openContainersDetails(testContainerName);
+    await playExpect(containerDetails.heading).toContainText(testContainerName);
+
+    await containerDetails.stopContainer();
+    const regexp = new RegExp(`${ContainerState.Stopped}|${ContainerState.Exited}`);
+    await playExpect.poll(async () => await containerDetails.getState(), { timeout: 30_000 }).toMatch(regexp);
+
+    const updatedContainersPage = await containerDetails.deleteContainer();
+    await playExpect(updatedContainersPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await updatedContainersPage.getContainerRowByName(testContainerName), { timeout: 30_000 })
+      .toBeFalsy();
+  });
+
+  test('Delete network from networks page and verify it was removed', async ({ navigationBar }) => {
+    const networksPage = await navigationBar.openNetworks();
+    await playExpect(networksPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await networksPage.getNetworkRowByName(testNetworkName), {
+        timeout: 30_000,
+      })
+      .toBeTruthy();
+
+    await networksPage.deleteNetwork(testNetworkName);
+    await playExpect
+      .poll(async () => await networksPage.getNetworkRowByName(testNetworkName), {
+        timeout: 30_000,
+      })
+      .toBeFalsy();
+  });
+
+  test('Delete network from details page and verify it was removed', async ({ navigationBar }) => {
+    const networksPage = await navigationBar.openNetworks();
+    await playExpect(networksPage.heading).toBeVisible();
+
+    const networkDetails = await networksPage.createNetwork(testNetworkName, testNetworkSubnet);
+    await playExpect(networkDetails.heading).toBeVisible({ timeout: 30_000 });
+
+    const updatedNetworksPage = await networkDetails.deleteNetwork();
+    await playExpect(updatedNetworksPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await updatedNetworksPage.getNetworkRowByName(testNetworkName), {
+        timeout: 30_000,
+      })
+      .toBeFalsy();
+  });
+
+  test('Filter and delete networks', async ({ page, navigationBar }) => {
+    test.setTimeout(120_000);
+
+    let networksPage = await navigationBar.openNetworks();
+    await playExpect(networksPage.heading).toBeVisible();
+
+    for (let i = 0; i < networkList.length; i++) {
+      const networkDetails = await networksPage.createNetwork(networkList[i], networkSubnets[i]);
       await playExpect(networkDetails.heading).toBeVisible({ timeout: 30_000 });
 
       networksPage = await navigationBar.openNetworks();
       await playExpect(networksPage.heading).toBeVisible();
-
       await playExpect
-        .poll(async () => await networksPage.getNetworkRowByName(testNetworkName), {
-          timeout: 30_000,
-        })
+        .poll(async () => await networksPage.getNetworkRowByName(networkList[i]), { timeout: 30_000 })
         .toBeTruthy();
-    });
+    }
 
-    test('Pull image for network container test', async ({ navigationBar }) => {
-      test.setTimeout(90_000);
-
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await imagesPage.pullImage(testImageName);
-
-      await playExpect
-        .poll(async () => await imagesPage.waitForImageExists(testImageName, 60_000), { timeout: 0 })
-        .toBeTruthy();
-    });
-
-    test('Start container using the network', async ({ navigationBar }) => {
-      test.setTimeout(90_000);
-
-      // Open the image and run it on the test network (network already exists from previous test)
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const imageDetails = await imagesPage.openImageDetails(testImageName);
-      await playExpect(imageDetails.heading).toBeVisible();
-
-      const runImagePage = await imageDetails.openRunImage();
-      await playExpect(runImagePage.heading).toBeVisible();
-
-      await runImagePage.selectUserDefinedNetwork(testNetworkName);
-      await runImagePage.startContainer(testContainerName);
-
-      // After startContainer(), alpine's /bin/sh causes the app to navigate to
-      // Container Details → Tty tab (interactive shell scenario). Explicitly navigate
-      // to the Containers page to verify the container was created.
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-
-      // Wait for container row to appear, then open details and verify it is running
-      await playExpect
-        .poll(async () => await containersPage.getContainerRowByName(testContainerName), { timeout: 60_000 })
-        .toBeTruthy();
-      const containerDetails = await containersPage.openContainersDetails(testContainerName);
-      await playExpect(containerDetails.heading).toContainText(testContainerName);
-      await playExpect
-        .poll(async () => await containerDetails.getState(), { timeout: 30_000 })
-        .toBe(ContainerState.Running);
-    });
-
-    test('Verify container inspect shows correct network', async ({ navigationBar }) => {
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-
-      const containerDetails = await containersPage.openContainersDetails(testContainerName);
-      await playExpect(containerDetails.heading).toContainText(testContainerName);
-
-      await playExpect
-        .poll(async () => await containerDetails.searchInInspectEditor(testNetworkName), { timeout: 10_000 })
-        .toBeTruthy();
-    });
-
-    test('Stop and delete the network container', async ({ navigationBar }) => {
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-
-      const containerDetails = await containersPage.openContainersDetails(testContainerName);
-      await playExpect(containerDetails.heading).toContainText(testContainerName);
-
-      await containerDetails.stopContainer();
-      const regexp = new RegExp(`${ContainerState.Stopped}|${ContainerState.Exited}`);
-      await playExpect.poll(async () => await containerDetails.getState(), { timeout: 30_000 }).toMatch(regexp);
-
-      const updatedContainersPage = await containerDetails.deleteContainer();
-      await playExpect(updatedContainersPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => await updatedContainersPage.getContainerRowByName(testContainerName), { timeout: 30_000 })
-        .toBeFalsy();
-    });
-
-    test('Delete network from networks page and verify it was removed', async ({ navigationBar }) => {
-      const networksPage = await navigationBar.openNetworks();
-      await playExpect(networksPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => await networksPage.getNetworkRowByName(testNetworkName), {
-          timeout: 30_000,
-        })
-        .toBeTruthy();
-
-      await networksPage.deleteNetwork(testNetworkName);
-      await playExpect
-        .poll(async () => await networksPage.getNetworkRowByName(testNetworkName), {
-          timeout: 30_000,
-        })
-        .toBeFalsy();
-    });
-
-    test('Delete network from details page and verify it was removed', async ({ navigationBar }) => {
-      const networksPage = await navigationBar.openNetworks();
-      await playExpect(networksPage.heading).toBeVisible();
-
-      const networkDetails = await networksPage.createNetwork(testNetworkName, testNetworkSubnet);
-      await playExpect(networkDetails.heading).toBeVisible({ timeout: 30_000 });
-
-      const updatedNetworksPage = await networkDetails.deleteNetwork();
-      await playExpect(updatedNetworksPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => await updatedNetworksPage.getNetworkRowByName(testNetworkName), {
-          timeout: 30_000,
-        })
-        .toBeFalsy();
-    });
-
-    test('Filter and delete networks', async ({ page, navigationBar }) => {
-      test.setTimeout(120_000);
-
-      let networksPage = await navigationBar.openNetworks();
-      await playExpect(networksPage.heading).toBeVisible();
-
-      for (let i = 0; i < networkList.length; i++) {
-        const networkDetails = await networksPage.createNetwork(networkList[i], networkSubnets[i]);
-        await playExpect(networkDetails.heading).toBeVisible({ timeout: 30_000 });
-
-        networksPage = await navigationBar.openNetworks();
-        await playExpect(networksPage.heading).toBeVisible();
-        await playExpect
-          .poll(async () => await networksPage.getNetworkRowByName(networkList[i]), { timeout: 30_000 })
-          .toBeTruthy();
-      }
-
-      networksPage = new NetworksPage(page);
-      await test.step('Verify search filtering works for each network', async () => {
-        for (const network of networkList) {
-          await networksPage.filterByName(network);
-          await playExpect
-            .poll(async () => await networksPage.countRowsFromTable(), { timeout: 10_000 })
-            .toBeGreaterThanOrEqual(1);
-          await playExpect.poll(async () => await networksPage.networkExists(network), { timeout: 5_000 }).toBeTruthy();
-        }
-        await networksPage.clearFilterByName();
+    networksPage = new NetworksPage(page);
+    await test.step('Verify search filtering works for each network', async () => {
+      for (const network of networkList) {
+        await networksPage.filterByName(network);
         await playExpect
           .poll(async () => await networksPage.countRowsFromTable(), { timeout: 10_000 })
-          .toBeGreaterThanOrEqual(networkList.length);
-      });
-
-      for (const network of networkList) {
-        await networksPage.deleteNetwork(network);
-        await playExpect
-          .poll(async () => await networksPage.getNetworkRowByName(network), { timeout: 30_000 })
-          .toBeFalsy();
+          .toBeGreaterThanOrEqual(1);
+        await playExpect.poll(async () => await networksPage.networkExists(network), { timeout: 5_000 }).toBeTruthy();
       }
+      await networksPage.clearFilterByName();
+      await playExpect
+        .poll(async () => await networksPage.countRowsFromTable(), { timeout: 10_000 })
+        .toBeGreaterThanOrEqual(networkList.length);
     });
+
+    for (const network of networkList) {
+      await networksPage.deleteNetwork(network);
+      await playExpect
+        .poll(async () => await networksPage.getNetworkRowByName(network), { timeout: 30_000 })
+        .toBeFalsy();
+    }
   });
+});


### PR DESCRIPTION
### What does this PR do?

Replace the deprecated `test.describe.serial(...)` syntax with the
recommended `test.describe(...)` + `test.describe.configure({ mode: 'serial' })`
pattern in three more spec files:

- `tests/playwright/src/specs/navigation-history-smoke.spec.ts`
- `tests/playwright/src/specs/navigation-history.spec.ts` (existing `retries: 1` merged into a single configure call)
- `tests/playwright/src/specs/network-smoke.spec.ts`

### Screenshot / video of UI

No UI changes.

### What issues does this PR fix or reference?

References #15697

### How to test this PR?

No behaviour changes — purely a syntax update as recommended by the Playwright team.

> **Tip:** use **Hide whitespace** in the Files changed view to review the actual changes, since the bulk of the diff is Biome re-indentation.

- [ ] Tests are covering the bug fix or the new feature

Made with [Cursor](https://cursor.com)