### PR TITLE
test(e2e): update serial declaration - part 9

### DIFF
--- a/tests/playwright/src/specs/pod-smoke.spec.ts
+++ b/tests/playwright/src/specs/pod-smoke.spec.ts
@@ -97,301 +97,299 @@ test.afterAll(async ({ page, runner }) => {
   }
 });
 
-test.describe
-  .serial('Verification of pod creation workflow', { tag: '@smoke' }, () => {
-    test('Pulling images', async ({ navigationBar }) => {
+test.describe('Verification of pod creation workflow', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Pulling images', async ({ navigationBar }) => {
+    test.setTimeout(180_000);
+
+    let images = await navigationBar.openImages();
+    let pullImagePage = await images.openPullImage();
+    images = await pullImagePage.pullImage(backendImage, imagesTag, 90_000);
+    const backendExists = await images.waitForImageExists(backendImage);
+    playExpect(backendExists, `${backendImage} image is not present in the list of images`).toBeTruthy();
+
+    await navigationBar.openImages();
+    pullImagePage = await images.openPullImage();
+    images = await pullImagePage.pullImage(frontendImage, imagesTag, 90_000);
+    const frontendExists = await images.waitForImageExists(frontendImage);
+    playExpect(frontendExists, `${frontendImage} image is not present in the list of images`).toBeTruthy();
+  });
+
+  test('Starting containers', async ({ navigationBar }) => {
+    let images = await navigationBar.openImages();
+    let imageDetails = await images.openImageDetails(backendImage);
+    let runImage = await imageDetails.openRunImage();
+    await runImage.setCustomPortMapping('6379:6379');
+    let containers = await runImage.startContainer(backendContainer, containerStartParams);
+    await playExpect(containers.header).toBeVisible();
+    await playExpect
+      .poll(async () => await containers.containerExists(backendContainer), { timeout: 15_000 })
+      .toBeTruthy();
+    let containerDetails = await containers.openContainersDetails(backendContainer);
+    await playExpect
+      .poll(async () => await containerDetails.getState(), { timeout: 15_000 })
+      .toBe(ContainerState.Running);
+    await waitUntil(async () => {
+      backendPort = await containerDetails.getContainerPort();
+      return backendPort.includes('6379');
+    });
+    images = await navigationBar.openImages();
+    imageDetails = await images.openImageDetails(frontendImage);
+    runImage = await imageDetails.openRunImage();
+    if (isMac) {
+      await runImage.setHostPortToExposedContainerPort('5000', '5101');
+    }
+    containers = await runImage.startContainer(frontendContainer, containerStartParams);
+    await playExpect(containers.header).toBeVisible();
+    await playExpect
+      .poll(async () => await containers.containerExists(frontendContainer), { timeout: 15_000 })
+      .toBeTruthy();
+    containerDetails = await containers.openContainersDetails(frontendContainer);
+    frontendPort = await containerDetails.getContainerPort();
+    const expectedPort = isMac ? '5101' : '5000';
+    playExpect(frontendPort).toContain(expectedPort);
+    await playExpect
+      .poll(async () => await containerDetails.getState(), { timeout: 15_000 })
+      .toBe(ContainerState.Running);
+  });
+
+  test('Podify containers', async ({ navigationBar }) => {
+    test.setTimeout(90000);
+
+    const containers = await navigationBar.openContainers();
+    const createPodPage = await containers.openCreatePodPage(Array.of(backendContainer, frontendContainer));
+    const pods = await createPodPage.createPod(podToRun);
+    await playExpect(pods.heading).toBeVisible({ timeout: 60_000 });
+    await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 15_000 }).toBeTruthy();
+    const podDetails = await pods.openPodDetails(podToRun);
+    await playExpect.poll(async () => await podDetails.getState(), { timeout: 15_000 }).toBe(PodState.Running);
+  });
+
+  test('Test navigation between pages', async ({ navigationBar }) => {
+    const pods = await navigationBar.openPods();
+    await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 10_000 }).toBeTruthy();
+
+    const podDetails = await pods.openPodDetails(podToRun);
+    await playExpect(podDetails.heading).toBeVisible();
+    await podDetails.backLink.click();
+    await playExpect(pods.heading).toBeVisible();
+
+    await pods.openPodDetails(podToRun);
+    await playExpect(podDetails.heading).toBeVisible();
+    await podDetails.closeButton.click();
+    await playExpect(pods.heading).toBeVisible();
+  });
+
+  test('Checking pod details', async ({ navigationBar }) => {
+    const pods = await navigationBar.openPods();
+    await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 10_000 }).toBeTruthy();
+    await playExpect.poll(async () => await pods.getPodEnvironment(podToRun), { timeout: 10_000 }).toContain('podman');
+
+    const podDetails = await pods.openPodDetails(podToRun);
+    await playExpect(podDetails.heading).toBeVisible();
+    await playExpect(podDetails.heading).toContainText(podToRun);
+    await podDetails.activateTab('Logs');
+
+    await podDetails.findInLogs('redis');
+    await playExpect
+      .poll(async () => podDetails.getCountOfSearchResults(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(1);
+
+    await podDetails.activateTab('Summary');
+    const row = podDetails.getPage().getByRole('table').getByRole('row');
+    const nameText = await row.getByRole('cell').allInnerTexts();
+    playExpect(nameText).toContain(podToRun);
+    await podDetails.activateTab('Inspect');
+    await podDetails.activateTab('Kube');
+  });
+
+  test('Checking original containers stopped', async ({ navigationBar }) => {
+    const containers = await navigationBar.openContainers();
+    const backendContainerDetails = await containers.openContainersDetails(backendContainer);
+    await playExpect
+      .poll(async () => await backendContainerDetails.getState(), { timeout: 15_000 })
+      .toBe(ContainerState.Exited);
+    await navigationBar.openContainers();
+    const frontendContainerDetails = await containers.openContainersDetails(frontendContainer);
+    await playExpect
+      .poll(async () => await frontendContainerDetails.getState(), { timeout: 15_000 })
+      .toBe(ContainerState.Exited);
+  });
+
+  test('Checking pods page options buttons', async ({ navigationBar }) => {
+    const pods = await navigationBar.openPods();
+    await pods.selectPod([podToRun]);
+    const deleteButton = pods.getPage().getByRole('button', { name: 'Delete 1 selected items', exact: true });
+    await playExpect(deleteButton).toBeVisible();
+
+    const actionsMenuButton = await pods.getPodActionsMenu(podToRun);
+    await playExpect(actionsMenuButton).toBeVisible();
+    await actionsMenuButton.click();
+    const kubeButton = pods.getPage().getByTitle('Generate Kube');
+    const kubernetesButton = pods.getPage().getByTitle('Deploy to Kubernetes');
+    const restartButton = pods.getPage().getByTitle('Restart Pod');
+    await playExpect(kubeButton).toBeVisible();
+    await playExpect(kubernetesButton).toBeVisible();
+    await playExpect(restartButton).toBeVisible();
+  });
+
+  test('Checking pods under containers', async ({ navigationBar, page }) => {
+    const containers = await navigationBar.openContainers();
+    await playExpect.poll(async () => containers.containerExists(podToRun), { timeout: 10_000 }).toBeTruthy();
+    await playExpect
+      .poll(async () => containers.containerExists(`${backendContainer}-podified`), { timeout: 10_000 })
+      .toBeTruthy();
+    await playExpect
+      .poll(async () => containers.containerExists(`${frontendContainer}-podified`), { timeout: 10_000 })
+      .toBeTruthy();
+
+    const containerDetailsPage = await containers.openContainersDetails(`${frontendContainer}-podified`);
+    await playExpect(containerDetailsPage.heading).toContainText(`${frontendContainer}-podified`);
+    await containerDetailsPage.activateTab('Terminal');
+
+    await playExpect(containerDetailsPage.terminalContent).toBeVisible();
+    await playExpect(containerDetailsPage.terminalContent).toContainText('@');
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests
+    await page.waitForTimeout(1_000);
+    await containerDetailsPage.terminalInput.pressSequentially('pwd', { delay: 15 });
+    await containerDetailsPage.terminalInput.press('Enter');
+    await playExpect(containerDetailsPage.terminalContent).toContainText('app');
+  });
+
+  test('Checking deployed application', async ({ navigationBar, page }) => {
+    test.setTimeout(90_000);
+
+    // Verify the frontend app from inside the pod's network namespace
+    // to avoid WSL2 host port-forwarding issues on Windows
+    const containers = await navigationBar.openContainers();
+    const containerDetailsPage = await containers.openContainersDetails(`${frontendContainer}-podified`);
+    await playExpect(containerDetailsPage.heading).toContainText(`${frontendContainer}-podified`);
+    await containerDetailsPage.activateTab('Terminal');
+
+    await playExpect(containerDetailsPage.terminalContent).toBeVisible();
+    await playExpect(containerDetailsPage.terminalContent).toContainText('@');
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests
+    await page.waitForTimeout(1_000);
+
+    // Use grep -q to avoid flooding the xterm buffer with the full HTML response,
+    // and echo a unique sentinel so the assertion can't false-match the typed command
+    const curlCheck =
+      'for i in $(seq 1 30); do curl -sf http://localhost:5000 | grep -q "Hello World" && echo DEPLOY_OK && break; sleep 2; done';
+    await containerDetailsPage.terminalInput.pressSequentially(curlCheck, { delay: 15 });
+    await containerDetailsPage.terminalInput.press('Enter');
+    await playExpect(containerDetailsPage.terminalContent).toContainText('DEPLOY_OK', { timeout: 60_000 });
+  });
+
+  test.describe(() => {
+    test.describe.configure({ retries: 1 });
+    test('Restarting pod', async ({ navigationBar }) => {
       test.setTimeout(180_000);
-
-      let images = await navigationBar.openImages();
-      let pullImagePage = await images.openPullImage();
-      images = await pullImagePage.pullImage(backendImage, imagesTag, 90_000);
-      const backendExists = await images.waitForImageExists(backendImage);
-      playExpect(backendExists, `${backendImage} image is not present in the list of images`).toBeTruthy();
-
-      await navigationBar.openImages();
-      pullImagePage = await images.openPullImage();
-      images = await pullImagePage.pullImage(frontendImage, imagesTag, 90_000);
-      const frontendExists = await images.waitForImageExists(frontendImage);
-      playExpect(frontendExists, `${frontendImage} image is not present in the list of images`).toBeTruthy();
-    });
-
-    test('Starting containers', async ({ navigationBar }) => {
-      let images = await navigationBar.openImages();
-      let imageDetails = await images.openImageDetails(backendImage);
-      let runImage = await imageDetails.openRunImage();
-      await runImage.setCustomPortMapping('6379:6379');
-      let containers = await runImage.startContainer(backendContainer, containerStartParams);
-      await playExpect(containers.header).toBeVisible();
-      await playExpect
-        .poll(async () => await containers.containerExists(backendContainer), { timeout: 15_000 })
-        .toBeTruthy();
-      let containerDetails = await containers.openContainersDetails(backendContainer);
-      await playExpect
-        .poll(async () => await containerDetails.getState(), { timeout: 15_000 })
-        .toBe(ContainerState.Running);
-      await waitUntil(async () => {
-        backendPort = await containerDetails.getContainerPort();
-        return backendPort.includes('6379');
-      });
-      images = await navigationBar.openImages();
-      imageDetails = await images.openImageDetails(frontendImage);
-      runImage = await imageDetails.openRunImage();
-      if (isMac) {
-        await runImage.setHostPortToExposedContainerPort('5000', '5101');
-      }
-      containers = await runImage.startContainer(frontendContainer, containerStartParams);
-      await playExpect(containers.header).toBeVisible();
-      await playExpect
-        .poll(async () => await containers.containerExists(frontendContainer), { timeout: 15_000 })
-        .toBeTruthy();
-      containerDetails = await containers.openContainersDetails(frontendContainer);
-      frontendPort = await containerDetails.getContainerPort();
-      const expectedPort = isMac ? '5101' : '5000';
-      playExpect(frontendPort).toContain(expectedPort);
-      await playExpect
-        .poll(async () => await containerDetails.getState(), { timeout: 15_000 })
-        .toBe(ContainerState.Running);
-    });
-
-    test('Podify containers', async ({ navigationBar }) => {
-      test.setTimeout(90000);
-
-      const containers = await navigationBar.openContainers();
-      const createPodPage = await containers.openCreatePodPage(Array.of(backendContainer, frontendContainer));
-      const pods = await createPodPage.createPod(podToRun);
-      await playExpect(pods.heading).toBeVisible({ timeout: 60_000 });
+      const pods = await navigationBar.openPods();
+      await playExpect(pods.heading).toBeVisible({ timeout: 15_000 });
       await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 15_000 }).toBeTruthy();
-      const podDetails = await pods.openPodDetails(podToRun);
-      await playExpect.poll(async () => await podDetails.getState(), { timeout: 15_000 }).toBe(PodState.Running);
-    });
-
-    test('Test navigation between pages', async ({ navigationBar }) => {
-      const pods = await navigationBar.openPods();
-      await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 10_000 }).toBeTruthy();
-
-      const podDetails = await pods.openPodDetails(podToRun);
-      await playExpect(podDetails.heading).toBeVisible();
-      await podDetails.backLink.click();
-      await playExpect(pods.heading).toBeVisible();
-
-      await pods.openPodDetails(podToRun);
-      await playExpect(podDetails.heading).toBeVisible();
-      await podDetails.closeButton.click();
-      await playExpect(pods.heading).toBeVisible();
-    });
-
-    test('Checking pod details', async ({ navigationBar }) => {
-      const pods = await navigationBar.openPods();
-      await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 10_000 }).toBeTruthy();
-      await playExpect
-        .poll(async () => await pods.getPodEnvironment(podToRun), { timeout: 10_000 })
-        .toContain('podman');
 
       const podDetails = await pods.openPodDetails(podToRun);
       await playExpect(podDetails.heading).toBeVisible();
       await playExpect(podDetails.heading).toContainText(podToRun);
-      await podDetails.activateTab('Logs');
 
-      await podDetails.findInLogs('redis');
-      await playExpect
-        .poll(async () => podDetails.getCountOfSearchResults(), { timeout: 10_000 })
-        .toBeGreaterThanOrEqual(1);
+      await playExpect(async () => {
+        await podDetails.restartPod();
+        await playExpect.poll(async () => await podDetails.getState(), { timeout: 15_000 }).toBe(PodState.Restarting);
+        await playExpect.poll(async () => await podDetails.getState(), { timeout: 30_000 }).toBe(PodState.Running);
+      }).toPass({ timeout: 120_000 });
 
-      await podDetails.activateTab('Summary');
-      const row = podDetails.getPage().getByRole('table').getByRole('row');
-      const nameText = await row.getByRole('cell').allInnerTexts();
-      playExpect(nameText).toContain(podToRun);
-      await podDetails.activateTab('Inspect');
-      await podDetails.activateTab('Kube');
+      await playExpect(podDetails.stopButton).toBeVisible();
     });
 
-    test('Checking original containers stopped', async ({ navigationBar }) => {
-      const containers = await navigationBar.openContainers();
-      const backendContainerDetails = await containers.openContainersDetails(backendContainer);
-      await playExpect
-        .poll(async () => await backendContainerDetails.getState(), { timeout: 15_000 })
-        .toBe(ContainerState.Exited);
-      await navigationBar.openContainers();
-      const frontendContainerDetails = await containers.openContainersDetails(frontendContainer);
-      await playExpect
-        .poll(async () => await frontendContainerDetails.getState(), { timeout: 15_000 })
-        .toBe(ContainerState.Exited);
-    });
-
-    test('Checking pods page options buttons', async ({ navigationBar }) => {
+    test('Stopping and starting pod', async ({ navigationBar }) => {
       const pods = await navigationBar.openPods();
-      await pods.selectPod([podToRun]);
-      const deleteButton = pods.getPage().getByRole('button', { name: 'Delete 1 selected items', exact: true });
-      await playExpect(deleteButton).toBeVisible();
+      await playExpect(pods.heading).toBeVisible({ timeout: 15_000 });
+      await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 15_000 }).toBeTruthy();
 
-      const actionsMenuButton = await pods.getPodActionsMenu(podToRun);
-      await playExpect(actionsMenuButton).toBeVisible();
-      await actionsMenuButton.click();
-      const kubeButton = pods.getPage().getByTitle('Generate Kube');
-      const kubernetesButton = pods.getPage().getByTitle('Deploy to Kubernetes');
-      const restartButton = pods.getPage().getByTitle('Restart Pod');
-      await playExpect(kubeButton).toBeVisible();
-      await playExpect(kubernetesButton).toBeVisible();
-      await playExpect(restartButton).toBeVisible();
+      const podDetailsPage = await pods.openPodDetails(podToRun);
+      await playExpect(podDetailsPage.heading).toBeVisible();
+      await playExpect(podDetailsPage.heading).toContainText(podToRun);
+      await podDetailsPage.stopPod();
+      await playExpect.poll(async () => await podDetailsPage.getState(), { timeout: 30_000 }).toBe(PodState.Exited);
+
+      await podDetailsPage.startPod();
+      await playExpect.poll(async () => await podDetailsPage.getState(), { timeout: 30_000 }).toBe(PodState.Running);
+      await playExpect(podDetailsPage.stopButton).toBeVisible();
     });
 
-    test('Checking pods under containers', async ({ navigationBar, page }) => {
-      const containers = await navigationBar.openContainers();
-      await playExpect.poll(async () => containers.containerExists(podToRun), { timeout: 10_000 }).toBeTruthy();
-      await playExpect
-        .poll(async () => containers.containerExists(`${backendContainer}-podified`), { timeout: 10_000 })
-        .toBeTruthy();
-      await playExpect
-        .poll(async () => containers.containerExists(`${frontendContainer}-podified`), { timeout: 10_000 })
-        .toBeTruthy();
-
-      const containerDetailsPage = await containers.openContainersDetails(`${frontendContainer}-podified`);
-      await playExpect(containerDetailsPage.heading).toContainText(`${frontendContainer}-podified`);
-      await containerDetailsPage.activateTab('Terminal');
-
-      await playExpect(containerDetailsPage.terminalContent).toBeVisible();
-      await playExpect(containerDetailsPage.terminalContent).toContainText('@');
-      // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests
-      await page.waitForTimeout(1_000);
-      await containerDetailsPage.terminalInput.pressSequentially('pwd', { delay: 15 });
-      await containerDetailsPage.terminalInput.press('Enter');
-      await playExpect(containerDetailsPage.terminalContent).toContainText('app');
-    });
-
-    test('Checking deployed application', async ({ navigationBar, page }) => {
+    test('Stopping and deleting pod', async ({ navigationBar }) => {
       test.setTimeout(90_000);
 
-      // Verify the frontend app from inside the pod's network namespace
-      // to avoid WSL2 host port-forwarding issues on Windows
-      const containers = await navigationBar.openContainers();
-      const containerDetailsPage = await containers.openContainersDetails(`${frontendContainer}-podified`);
-      await playExpect(containerDetailsPage.heading).toContainText(`${frontendContainer}-podified`);
-      await containerDetailsPage.activateTab('Terminal');
+      const pods = await navigationBar.openPods();
+      await playExpect(pods.heading).toBeVisible({ timeout: 15_000 });
+      await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 15_000 }).toBeTruthy();
 
-      await playExpect(containerDetailsPage.terminalContent).toBeVisible();
-      await playExpect(containerDetailsPage.terminalContent).toContainText('@');
-      // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests
-      await page.waitForTimeout(1_000);
+      const podDetailsPage = await pods.openPodDetails(podToRun);
+      await playExpect(podDetailsPage.heading).toBeVisible();
+      await playExpect(podDetailsPage.heading).toContainText(podToRun);
 
-      // Use grep -q to avoid flooding the xterm buffer with the full HTML response,
-      // and echo a unique sentinel so the assertion can't false-match the typed command
-      const curlCheck =
-        'for i in $(seq 1 30); do curl -sf http://localhost:5000 | grep -q "Hello World" && echo DEPLOY_OK && break; sleep 2; done';
-      await containerDetailsPage.terminalInput.pressSequentially(curlCheck, { delay: 15 });
-      await containerDetailsPage.terminalInput.press('Enter');
-      await playExpect(containerDetailsPage.terminalContent).toContainText('DEPLOY_OK', { timeout: 60_000 });
+      await podDetailsPage.stopPod();
+      await playExpect.poll(async () => await podDetailsPage.getState(), { timeout: 30_000 }).toBe(PodState.Exited);
+
+      await playExpect(podDetailsPage.heading).toContainText(podToRun);
+      const podsPage = await podDetailsPage.deletePod();
+      await playExpect(podsPage.heading).toBeVisible({ timeout: 30_000 });
+      await playExpect.poll(async () => await podsPage.podExists(podToRun), { timeout: 30_000 }).toBeFalsy();
     });
 
-    test.describe(() => {
-      test.describe.configure({ retries: 1 });
-      test('Restarting pod', async ({ navigationBar }) => {
-        test.setTimeout(180_000);
-        const pods = await navigationBar.openPods();
-        await playExpect(pods.heading).toBeVisible({ timeout: 15_000 });
-        await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 15_000 }).toBeTruthy();
+    test('Pruning pods', async ({ page, navigationBar }) => {
+      test.setTimeout(120_000);
 
-        const podDetails = await pods.openPodDetails(podToRun);
-        await playExpect(podDetails.heading).toBeVisible();
-        await playExpect(podDetails.heading).toContainText(podToRun);
+      const portsList = [5001, 5002, 5003];
 
-        await playExpect(async () => {
-          await podDetails.restartPod();
-          await playExpect.poll(async () => await podDetails.getState(), { timeout: 15_000 }).toBe(PodState.Restarting);
-          await playExpect.poll(async () => await podDetails.getState(), { timeout: 30_000 }).toBe(PodState.Running);
-        }).toPass({ timeout: 120_000 });
+      for (let i = 0; i < 3; i++) {
+        const imagesPage = await navigationBar.openImages();
+        await playExpect(imagesPage.heading).toBeVisible();
+        const imageDetailsPage = await imagesPage.openImageDetails(backendImage);
+        await playExpect(imageDetailsPage.heading).toContainText(backendImage);
+        const runImagePage = await imageDetailsPage.openRunImage();
+        await playExpect(runImagePage.heading).toContainText(backendImage);
+        await runImagePage.setCustomPortMapping(`${portsList[i]}:${portsList[i]}`);
+        const containersPage = await runImagePage.startContainer(containerNames[i], containerStartParams);
+        await playExpect(containersPage.heading).toBeVisible();
+        await playExpect
+          .poll(async () => containersPage.containerExists(containerNames[i]), { timeout: 15_000 })
+          .toBeTruthy();
+        await containersPage.uncheckAllRows();
+        const createPodPage = await containersPage.openCreatePodPage(Array.of(containerNames[i]));
+        const podsPage = await createPodPage.createPod(podNames[i]);
+        await playExpect(podsPage.heading).toBeVisible({ timeout: 60_000 });
+        await playExpect.poll(async () => await podsPage.podExists(podNames[i]), { timeout: 15_000 }).toBeTruthy();
+      }
 
-        await playExpect(podDetails.stopButton).toBeVisible();
-      });
-
-      test('Stopping and starting pod', async ({ navigationBar }) => {
-        const pods = await navigationBar.openPods();
-        await playExpect(pods.heading).toBeVisible({ timeout: 15_000 });
-        await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 15_000 }).toBeTruthy();
-
-        const podDetailsPage = await pods.openPodDetails(podToRun);
-        await playExpect(podDetailsPage.heading).toBeVisible();
-        await playExpect(podDetailsPage.heading).toContainText(podToRun);
-        await podDetailsPage.stopPod();
-        await playExpect.poll(async () => await podDetailsPage.getState(), { timeout: 30_000 }).toBe(PodState.Exited);
-
-        await podDetailsPage.startPod();
-        await playExpect.poll(async () => await podDetailsPage.getState(), { timeout: 30_000 }).toBe(PodState.Running);
-        await playExpect(podDetailsPage.stopButton).toBeVisible();
-      });
-
-      test('Stopping and deleting pod', async ({ navigationBar }) => {
-        test.setTimeout(90_000);
-
-        const pods = await navigationBar.openPods();
-        await playExpect(pods.heading).toBeVisible({ timeout: 15_000 });
-        await playExpect.poll(async () => await pods.podExists(podToRun), { timeout: 15_000 }).toBeTruthy();
-
-        const podDetailsPage = await pods.openPodDetails(podToRun);
-        await playExpect(podDetailsPage.heading).toBeVisible();
-        await playExpect(podDetailsPage.heading).toContainText(podToRun);
-
-        await podDetailsPage.stopPod();
-        await playExpect.poll(async () => await podDetailsPage.getState(), { timeout: 30_000 }).toBe(PodState.Exited);
-
-        await playExpect(podDetailsPage.heading).toContainText(podToRun);
-        const podsPage = await podDetailsPage.deletePod();
-        await playExpect(podsPage.heading).toBeVisible({ timeout: 30_000 });
-        await playExpect.poll(async () => await podsPage.podExists(podToRun), { timeout: 30_000 }).toBeFalsy();
-      });
-
-      test('Pruning pods', async ({ page, navigationBar }) => {
-        test.setTimeout(120_000);
-
-        const portsList = [5001, 5002, 5003];
-
-        for (let i = 0; i < 3; i++) {
-          const imagesPage = await navigationBar.openImages();
-          await playExpect(imagesPage.heading).toBeVisible();
-          const imageDetailsPage = await imagesPage.openImageDetails(backendImage);
-          await playExpect(imageDetailsPage.heading).toContainText(backendImage);
-          const runImagePage = await imageDetailsPage.openRunImage();
-          await playExpect(runImagePage.heading).toContainText(backendImage);
-          await runImagePage.setCustomPortMapping(`${portsList[i]}:${portsList[i]}`);
-          const containersPage = await runImagePage.startContainer(containerNames[i], containerStartParams);
-          await playExpect(containersPage.heading).toBeVisible();
-          await playExpect
-            .poll(async () => containersPage.containerExists(containerNames[i]), { timeout: 15_000 })
-            .toBeTruthy();
-          await containersPage.uncheckAllRows();
-          const createPodPage = await containersPage.openCreatePodPage(Array.of(containerNames[i]));
-          const podsPage = await createPodPage.createPod(podNames[i]);
-          await playExpect(podsPage.heading).toBeVisible({ timeout: 60_000 });
-          await playExpect.poll(async () => await podsPage.podExists(podNames[i]), { timeout: 15_000 }).toBeTruthy();
-        }
-
-        const podsPageForFilter = new PodsPage(page);
-        await test.step('Verify search filtering works for each pod', async () => {
-          for (const pod of podNames) {
-            await podsPageForFilter.filterByName(pod);
-            await playExpect
-              .poll(async () => await podsPageForFilter.countRowsFromTable(), { timeout: 10_000 })
-              .toBeGreaterThanOrEqual(1);
-            await playExpect.poll(async () => await podsPageForFilter.podExists(pod), { timeout: 5_000 }).toBeTruthy();
-          }
-          await podsPageForFilter.clearFilterByName();
+      const podsPageForFilter = new PodsPage(page);
+      await test.step('Verify search filtering works for each pod', async () => {
+        for (const pod of podNames) {
+          await podsPageForFilter.filterByName(pod);
           await playExpect
             .poll(async () => await podsPageForFilter.countRowsFromTable(), { timeout: 10_000 })
-            .toBeGreaterThanOrEqual(podNames.length);
-        });
-
-        for (const pod of podNames) {
-          const podDetailsPage = await new PodsPage(page).openPodDetails(pod);
-          await playExpect(podDetailsPage.heading).toBeVisible();
-          await playExpect(podDetailsPage.heading).toContainText(pod);
-
-          await podDetailsPage.stopPod();
-          await playExpect.poll(async () => await podDetailsPage.getState(), { timeout: 30_000 }).toBe(PodState.Exited);
-
-          const podsPage = await navigationBar.openPods();
-          await playExpect(podsPage.heading).toBeVisible();
-          await podsPage.prunePods();
-          await playExpect.poll(async () => await podsPage.podExists(pod), { timeout: 15_000 }).toBeFalsy();
+            .toBeGreaterThanOrEqual(1);
+          await playExpect.poll(async () => await podsPageForFilter.podExists(pod), { timeout: 5_000 }).toBeTruthy();
         }
+        await podsPageForFilter.clearFilterByName();
+        await playExpect
+          .poll(async () => await podsPageForFilter.countRowsFromTable(), { timeout: 10_000 })
+          .toBeGreaterThanOrEqual(podNames.length);
       });
+
+      for (const pod of podNames) {
+        const podDetailsPage = await new PodsPage(page).openPodDetails(pod);
+        await playExpect(podDetailsPage.heading).toBeVisible();
+        await playExpect(podDetailsPage.heading).toContainText(pod);
+
+        await podDetailsPage.stopPod();
+        await playExpect.poll(async () => await podDetailsPage.getState(), { timeout: 30_000 }).toBe(PodState.Exited);
+
+        const podsPage = await navigationBar.openPods();
+        await playExpect(podsPage.heading).toBeVisible();
+        await podsPage.prunePods();
+        await playExpect.poll(async () => await podsPage.podExists(pod), { timeout: 15_000 }).toBeFalsy();
+      }
     });
   });
+});

--- a/tests/playwright/src/specs/podman-compose-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-compose-smoke.spec.ts
@@ -63,63 +63,63 @@ test.skip(
   'Tests suite should not run on Mac platform in CICD due to being unable  to ensure Compose is installed',
 );
 
-test.describe
-  .serial('Compose compose workflow verification', { tag: '@smoke' }, () => {
-    test.beforeEach(async () => {
-      if (cliToolsPage.wasRateLimitReached()) {
-        test.info().annotations.push({ type: 'skip', description: 'Rate limit exceeded for current environment' });
-        test.skip(true, 'Rate limit exceeded; skipping remaining CLI tools checks');
-      }
-    });
-
-    test('Verify Compose was installed', async ({ page, navigationBar }) => {
-      test.skip(!!isCI && isLinux, 'This test should not run on Ubuntu platform in Github Actions');
-
-      await navigationBar.openSettings();
-      const settingsBar = new SettingsBar(page);
-      const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
-      await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
-
-      const composeBox = new ResourceCliCardPage(page, RESOURCE_NAME);
-      const setupButton = composeBox.setupButton;
-
-      if ((await setupButton.count()) > 0 && !isMac) {
-        await settingsBar.cliToolsTab.click();
-        await playExpect(cliToolsPage.toolsTable).toBeVisible({ timeout: 10_000 });
-        await playExpect.poll(async () => await cliToolsPage.toolsTable.count()).toBeGreaterThan(0);
-        await cliToolsPage.installTool('Compose');
-      }
-
-      await navigationBar.openSettings();
-      cliToolsPage = await settingsBar.openTabPage(CLIToolsPage);
-      const composeRow = cliToolsPage.toolsTable.getByLabel(RESOURCE_NAME);
-      const composeVersionInfo = composeRow.getByLabel('cli-version');
-      await playExpect(composeVersionInfo).toContainText('docker-compose');
-    });
-
-    test('Check Podman Desktop autorefresh when using podman compose up', async ({ navigationBar }) => {
-      test.setTimeout(300_000);
-
-      const composeFilePath = path.resolve(__dirname, '..', '..', 'resources', 'compose.yaml');
-      await runComposeUpFromCLI(composeFilePath);
-
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => await containersPage.containerExists(composeContainer), { timeout: 120_000 })
-        .toBeTruthy();
-      await playExpect
-        .poll(async () => await containersPage.containerExists(backendContainerName), { timeout: 120_000 })
-        .toBeTruthy();
-      await playExpect
-        .poll(async () => await containersPage.containerExists(frontendContainerName), { timeout: 120_000 })
-        .toBeTruthy();
-
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      await playExpect.poll(async () => await imagesPage.waitForImageExists(backendImageName)).toBeTruthy();
-      await playExpect.poll(async () => await imagesPage.waitForImageExists(frontendImageName)).toBeTruthy();
-    });
+test.describe('Compose compose workflow verification', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test.beforeEach(async () => {
+    if (cliToolsPage.wasRateLimitReached()) {
+      test.info().annotations.push({ type: 'skip', description: 'Rate limit exceeded for current environment' });
+      test.skip(true, 'Rate limit exceeded; skipping remaining CLI tools checks');
+    }
   });
+
+  test('Verify Compose was installed', async ({ page, navigationBar }) => {
+    test.skip(!!isCI && isLinux, 'This test should not run on Ubuntu platform in Github Actions');
+
+    await navigationBar.openSettings();
+    const settingsBar = new SettingsBar(page);
+    const resourcesPage = await settingsBar.openTabPage(ResourcesPage);
+    await playExpect.poll(async () => await resourcesPage.resourceCardIsVisible(RESOURCE_NAME)).toBeTruthy();
+
+    const composeBox = new ResourceCliCardPage(page, RESOURCE_NAME);
+    const setupButton = composeBox.setupButton;
+
+    if ((await setupButton.count()) > 0 && !isMac) {
+      await settingsBar.cliToolsTab.click();
+      await playExpect(cliToolsPage.toolsTable).toBeVisible({ timeout: 10_000 });
+      await playExpect.poll(async () => await cliToolsPage.toolsTable.count()).toBeGreaterThan(0);
+      await cliToolsPage.installTool('Compose');
+    }
+
+    await navigationBar.openSettings();
+    cliToolsPage = await settingsBar.openTabPage(CLIToolsPage);
+    const composeRow = cliToolsPage.toolsTable.getByLabel(RESOURCE_NAME);
+    const composeVersionInfo = composeRow.getByLabel('cli-version');
+    await playExpect(composeVersionInfo).toContainText('docker-compose');
+  });
+
+  test('Check Podman Desktop autorefresh when using podman compose up', async ({ navigationBar }) => {
+    test.setTimeout(300_000);
+
+    const composeFilePath = path.resolve(__dirname, '..', '..', 'resources', 'compose.yaml');
+    await runComposeUpFromCLI(composeFilePath);
+
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await containersPage.containerExists(composeContainer), { timeout: 120_000 })
+      .toBeTruthy();
+    await playExpect
+      .poll(async () => await containersPage.containerExists(backendContainerName), { timeout: 120_000 })
+      .toBeTruthy();
+    await playExpect
+      .poll(async () => await containersPage.containerExists(frontendContainerName), { timeout: 120_000 })
+      .toBeTruthy();
+
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    await playExpect.poll(async () => await imagesPage.waitForImageExists(backendImageName)).toBeTruthy();
+    await playExpect.poll(async () => await imagesPage.waitForImageExists(frontendImageName)).toBeTruthy();
+  });
+});

--- a/tests/playwright/src/specs/podman-extension-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-extension-smoke.spec.ts
@@ -43,22 +43,22 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Verification of Podman extension', { tag: ['@smoke', '@macos_sanity'] }, () => {
-    test('Podman is enabled and present', async () => {
-      await verifyPodmanExtensionStatus(true);
-    });
-    test('Podman extension can be disabled from Podman Extension Page', async () => {
-      const podmanExtensionPage = await openExtensionsPodmanPage();
-      await podmanExtensionPage.disableExtension();
-      await verifyPodmanExtensionStatus(false);
-    });
-    test('Podman extension can be re-enabled from Extension Page', async () => {
-      const podmanExtensionPage = await openExtensionsPodmanPage(); // enable the extension
-      await podmanExtensionPage.enableExtension();
-      await verifyPodmanExtensionStatus(true);
-    });
+test.describe('Verification of Podman extension', { tag: ['@smoke', '@macos_sanity'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Podman is enabled and present', async () => {
+    await verifyPodmanExtensionStatus(true);
   });
+  test('Podman extension can be disabled from Podman Extension Page', async () => {
+    const podmanExtensionPage = await openExtensionsPodmanPage();
+    await podmanExtensionPage.disableExtension();
+    await verifyPodmanExtensionStatus(false);
+  });
+  test('Podman extension can be re-enabled from Extension Page', async () => {
+    const podmanExtensionPage = await openExtensionsPodmanPage(); // enable the extension
+    await podmanExtensionPage.enableExtension();
+    await verifyPodmanExtensionStatus(true);
+  });
+});
 
 async function verifyPodmanExtensionStatus(enabled: boolean): Promise<void> {
   dashboardPage = await navigationBar.openDashboard();


### PR DESCRIPTION
## What this PR does / why we need it

Migrate `test.describe.serial(...)` to the recommended `test.describe.configure({ mode: 'serial' })` pattern for 3 more spec files, as part of the incremental cleanup tracked in #15697.

**Files changed:**
- `pod-smoke.spec.ts`
- `podman-compose-smoke.spec.ts`
- `podman-extension-smoke.spec.ts`

## Which issue(s) this PR fixes

Relates to #15697

## Screenshot / video of UI

N/A — test-only change, no UI impact.

> **Tip:** use **Hide whitespace** in the Files changed view to review the actual changes (the diff looks large due to indentation shifts).

## How to test this PR?

No functional changes — the tests themselves are unmodified; only the serial-mode declaration syntax changes. Verify by reviewing the diff with **Hide whitespace** enabled in the GitHub Files changed view.

Made with [Cursor](https://cursor.com)