### PR TITLE
chore(extension-installer): remove `hostFiles` dead-store

### DIFF
--- a/packages/main/src/plugin/install/extension-installer.ts
+++ b/packages/main/src/plugin/install/extension-installer.ts
@@ -67,14 +67,10 @@ export class ExtensionInstaller {
     this.#dockerDesktopInstaller = new DockerDesktopInstaller(contributionManager);
   }
 
-  async extractExtensionFiles(
-    tmpFolderPath: string,
-    finalFolderPath: string,
-    reportLog: (message: string) => void,
-  ): Promise<void> {
+  async extractExtensionFiles(tmpFolderPath: string, finalFolderPath: string): Promise<void> {
     // files or folder to grab
     const filesExtension: string[] = [];
-    const hostFiles: string[] = [];
+
     // do we have binaries in ${tmpFolderPath}/extension folder ?
     if (fs.existsSync(`${tmpFolderPath}/extension`)) {
       // list all files in the binaries/${platform} folder
@@ -96,16 +92,6 @@ export class ExtensionInstaller {
     await Promise.all(
       filesExtension.map(async (file: string) => {
         return cp(path.join(tmpFolderPath, 'extension', file), path.join(finalFolderPath, file), { recursive: true });
-      }),
-    );
-    // copy all host files
-    await Promise.all(
-      hostFiles.map(async (file: string) => {
-        const sourceFile = path.join(tmpFolderPath, file);
-        // get only the filename from the path
-        const destFile = path.basename(sourceFile);
-        reportLog(`Copying host file ${destFile}.`);
-        return cp(sourceFile, path.join(finalFolderPath, 'host', destFile), { recursive: true });
       }),
     );
   }
@@ -198,7 +184,7 @@ export class ExtensionInstaller {
 
     sendLog('Filtering image content...');
     if (isPDExtension) {
-      await this.extractExtensionFiles(tmpFolderPath, finalFolderPath, sendLog);
+      await this.extractExtensionFiles(tmpFolderPath, finalFolderPath);
     } else if (isDDExtension) {
       await this.#dockerDesktopInstaller.extractExtensionFiles(
         tmpFolderPath,


### PR DESCRIPTION
### What does this PR do?

The `hostFiles` is an array where we never put anything inside it (aka dead store), we try to read it, but the code reading will never do anything, because we never put anything in the store

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

Part of https://github.com/podman-desktop/podman-desktop/issues/19165

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle: 
