### PR TITLE
fix(claude/settings): remove PostToolUse linting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,11 +3,6 @@
     "allow": ["mcp__podman-desktop-mcp__*", "Bash(gh issue view:*)", "Bash(gh pr view:*)"]
   },
   "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [{ "type": "command", "command": "npx eslint --cache --fix $FILEPATH 2>/dev/null || true" }]
-      }
-    ]
+    "PostToolUse": []
   }
 }


### PR DESCRIPTION
### What does this PR do?

As per discussion on our weekly meeting, removing the hook that is linting the files each time the agent is touching one.

### Screenshot / video of UI

N/A

### What issues does this PR fix or reference?

N/A

### How to test this PR?

N/A
