### PR TITLE
feat(configuration): support optional display names

### DIFF
--- a/packages/api/src/configuration/models.ts
+++ b/packages/api/src/configuration/models.ts
@@ -66,6 +66,7 @@ export type ConfigurationScope = z.output<typeof ConfigurationScopeSchema>;
 
 const IConfigurationPropertySchemaSchema = z.object({
   id: z.string().optional(),
+  displayName: z.string().trim().min(1).regex(/\S/).optional(),
   type: z.union([IConfigurationPropertySchemaTypeSchema, z.array(IConfigurationPropertySchemaTypeSchema)]).optional(),
   default: z.unknown().optional(),
   group: z.string().optional(),

--- a/packages/main/src/plugin/extension/extension-manifest-json-schema.spec.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-json-schema.spec.ts
@@ -62,6 +62,18 @@ describe('generateExtensionManifestJsonSchema', () => {
     expect(extensionSchema['additionalProperties']).not.toBe(false);
   });
 
+  test('generates an optional nonblank configuration displayName', () => {
+    const schema = getExtensionSchema();
+    const path = 'properties.contributes.properties.configuration.properties.properties.additionalProperties';
+
+    expect(schema).toHaveProperty(`${path}.properties.displayName`, {
+      type: 'string',
+      minLength: 1,
+      pattern: '\\S',
+    });
+    expect(schema).not.toHaveProperty(`${path}.required`);
+  });
+
   test('requires mandatory extension fields', () => {
     const extensionSchema = getExtensionSchema();
     const required = extensionSchema['required'] as string[];

--- a/packages/main/src/plugin/extension/extension-manifest-schema.spec.ts
+++ b/packages/main/src/plugin/extension/extension-manifest-schema.spec.ts
@@ -139,6 +139,50 @@ describe('ExtensionManifestSchema', () => {
     expect(result.data.contributes?.commands).toHaveLength(1);
   });
 
+  test.each([
+    ['Path to Podman Binary', 'Path to Podman Binary'],
+    ['  Path to Podman Binary  ', 'Path to Podman Binary'],
+    [undefined, undefined],
+  ])('preserves optional configuration displayName %j', (displayName, expected) => {
+    const result = ExtensionManifestSchema.parse({
+      ...minimalValidManifest,
+      contributes: {
+        configuration: {
+          title: 'Podman',
+          properties: {
+            'podman.binary.path': { type: 'string', ...(displayName === undefined ? {} : { displayName }) },
+          },
+        },
+      },
+    });
+
+    expect(result.contributes?.configuration?.properties?.['podman.binary.path']).toEqual({
+      type: 'string',
+      ...(expected === undefined ? {} : { displayName: expected }),
+    });
+  });
+
+  test.each(['', '   ', '\t\n', 42, null])('rejects invalid configuration displayName %j', displayName => {
+    const result = ExtensionManifestSchema.safeParse({
+      ...minimalValidManifest,
+      contributes: {
+        configuration: {
+          title: 'Podman',
+          properties: { 'podman.binary.path': { type: 'string', displayName } },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual([
+      'contributes',
+      'configuration',
+      'properties',
+      'podman.binary.path',
+      'displayName',
+    ]);
+  });
+
   test('accepts contributes with menus', () => {
     const result = ExtensionManifestSchema.safeParse({
       ...minimalValidManifest,

--- a/schemas/extension-schema.json
+++ b/schemas/extension-schema.json
@@ -131,6 +131,11 @@
                       "id": {
                         "type": "string"
                       },
+                      "displayName": {
+                        "type": "string",
+                        "minLength": 1,
+                        "pattern": "\\S"
+                      },
                       "type": {
                         "anyOf": [
                           {


### PR DESCRIPTION
### What does this PR do?

Add optional `displayName` metadata to configuration properties and regenerate `extension-schema.json`. Supplied labels are trimmed and must contain non-whitespace text; existing manifests may omit the field.

This is the schema/API prerequisite requested in #18546. It does not change the renderer or any built-in extension setting.

### Screenshot / video of UI

Not applicable: this prerequisite has no UI change.

### What issues does this PR fix or reference?

References #3847 and the requested split in #18546. This prerequisite alone does not close the issue.

### How to test this PR?

On Windows with Node 24.19.0 and pnpm 11.15.1:

```text
pnpm run build:core-api
node node_modules/vitest/vitest.mjs run packages/main/src/plugin/extension/extension-manifest-schema.spec.ts packages/main/src/plugin/extension/extension-manifest-json-schema.spec.ts --maxWorkers=2 --retry=0
```

The two modules passed all 35 tests. The new tests first produced eight expected failures without the schema change; removing the change again reproduced those failures. Coverage includes omitted, visible, padded, blank, whitespace-only, and non-string values, plus generated-schema optionality.

Type checking, linting, formatting, full build, and generated-schema equality checks passed. Normal staged-file and commit hooks passed.

The full unit suite was not entirely green. The schema-only run had three assertion failures reproduced on unchanged production code, plus an initial worker-start timeout. A later combined schema/renderer/adoption run completed with 7,050 passed, the same three baseline failures, and nine skipped; no worker-start error was reported in that run. The baseline failures concern navigation history and two ComposeDetails status cases, not configuration labels. No assertions were weakened or tests disabled.

- [x] Tests are covering the bug fix or the new feature

AI assistance was used for implementation, tests, and review.
