### PR TITLE
feat(main): group the startup update dialog's dismiss buttons under a Later dropdown 

### DIFF
--- a/packages/main/src/plugin/updater.spec.ts
+++ b/packages/main/src/plugin/updater.spec.ts
@@ -598,12 +598,10 @@ test('expect command update not to be called when configuration value on never',
   expect(commandRegistryMock.executeCommand).not.toHaveBeenCalled();
 });
 
-test('clicking on "Update Never" should set the configuration value to never', async () => {
-  vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
-    response: `Don't show again`,
-  });
+type StartupUpdateListener = (context?: 'startup' | 'status-bar-entry') => Promise<void>;
 
-  let mListener: (() => Promise<void>) | undefined;
+const initUpdaterAndGetUpdateListener = (): StartupUpdateListener => {
+  let mListener: StartupUpdateListener | undefined;
   vi.mocked(commandRegistryMock.registerCommand).mockImplementation(
     (channel: string, listener: () => Promise<void>) => {
       if (channel === 'update') mListener = listener;
@@ -619,11 +617,38 @@ test('clicking on "Update Never" should set the configuration value to never', a
     taskManagerMock,
     apiSenderMock,
   ).init();
-  expect(mListener).toBeDefined();
 
-  await mListener?.();
+  if (mListener === undefined) throw new Error('mListener undefined');
+  return mListener;
+};
+
+test('clicking on "Later" then "Don\'t show again" should set the configuration value to never', async () => {
+  vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
+    response: 'Later',
+    dropdownIndex: 1,
+  });
+
+  const mListener = initUpdaterAndGetUpdateListener();
+
+  await mListener('startup');
 
   expect(configurationMock.update).toHaveBeenCalledWith('update.reminder', 'never');
+});
+
+test('clicking on "Later" then "Remind me later" should only dismiss the dialog', async () => {
+  vi.mocked(messageBoxMock.showMessageBox).mockResolvedValue({
+    response: 'Later',
+    dropdownIndex: 0,
+  });
+
+  const mListener = initUpdaterAndGetUpdateListener();
+
+  await mListener('startup');
+
+  expect(configurationMock.update).not.toHaveBeenCalled();
+  expect(taskManagerMock.createTask).not.toHaveBeenCalled();
+  expect(autoUpdater.downloadUpdate).not.toHaveBeenCalled();
+  expect(shell.openExternal).not.toHaveBeenCalled();
 });
 
 describe('expect update command to depends on context', async () => {
@@ -680,13 +705,43 @@ describe('expect update command to depends on context', async () => {
     await mListener?.('startup');
 
     expect(messageBoxMock.showMessageBox).toHaveBeenCalledWith({
-      cancelId: 2,
-      buttons: ['Update now', `What's new`, 'Remind me later', `Don't show again`],
+      cancelId: undefined,
+      buttons: [
+        'Update now',
+        `What's new`,
+        { type: 'dropdownButton', heading: 'Later', buttons: ['Remind me later', `Don't show again`] },
+      ],
       message:
         'A new version v@debug-next of Podman Desktop is available. Do you want to update your current version v@debug?',
       title: 'Update Podman Desktop?',
       type: 'info',
     });
+  });
+
+  test('startup context, clicking "Update now" should start the download', async () => {
+    const mListener = await getUpdateListener();
+
+    vi.mocked(messageBoxMock.showMessageBox).mockResolvedValueOnce({
+      response: 'Update now',
+    });
+
+    await mListener?.('startup');
+
+    expect(taskManagerMock.createTask).toHaveBeenCalled();
+    expect(autoUpdater.downloadUpdate).toHaveBeenCalled();
+  });
+
+  test(`startup context, clicking "What's new" should open release notes`, async () => {
+    const mListener = await getUpdateListener();
+
+    vi.mocked(messageBoxMock.showMessageBox).mockResolvedValueOnce({
+      response: `What's new`,
+    });
+    vi.mocked(shell.openExternal).mockResolvedValue();
+
+    await mListener?.('startup');
+
+    expect(shell.openExternal).toHaveBeenCalled();
   });
 
   test('status-bar-entry context', async () => {

--- a/packages/main/src/plugin/updater.ts
+++ b/packages/main/src/plugin/updater.ts
@@ -18,7 +18,7 @@
 
 import * as https from 'node:https';
 
-import type { ReleaseNotesInfo } from '@podman-desktop/core-api';
+import type { ButtonsType, ReleaseNotesInfo } from '@podman-desktop/core-api';
 import { ApiSenderType } from '@podman-desktop/core-api/api-sender';
 import { app, shell } from 'electron';
 import {
@@ -250,9 +250,10 @@ export class Updater {
       // Get the version of the update
       const updateVersion = this.#nextVersion ?? '';
 
-      let buttons: string[];
+      const laterOptions = ['Remind me later', `Don't show again`];
+      let buttons: ButtonsType[];
       if (context === 'startup') {
-        buttons = ['Update now', `What's new`, 'Remind me later', `Don't show again`];
+        buttons = ['Update now', `What's new`, { type: 'dropdownButton', heading: 'Later', buttons: laterOptions }];
       } else {
         buttons = ['Update now', `What's new`, 'Cancel'];
       }
@@ -262,9 +263,14 @@ export class Updater {
         title: `Update ${product.name}?`,
         message: `A new version ${updateVersion} of ${product.name} is available. Do you want to update your current version ${this.#currentVersion}?`,
         buttons: buttons,
-        cancelId: 2,
+        // a dropdown cannot be the cancel button, so the startup dialog is dismissed via Escape or the close button
+        cancelId: context === 'startup' ? undefined : 2,
       });
-      if (result.response === `Don't show again`) {
+      if (
+        result.response === 'Later' &&
+        result.dropdownIndex !== undefined &&
+        laterOptions[result.dropdownIndex] === `Don't show again`
+      ) {
         this.updateConfigurationValue('never');
       } else if (result.response === `What's new`) {
         await this.openReleaseNotes(updateVersion);

--- a/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
+++ b/tests/playwright/src/special-specs/installation/podman-installer.spec.ts
@@ -31,9 +31,9 @@ test.beforeAll(async ({ page, runner, welcomePage }) => {
   const updateAvailableDialog = page.getByRole('dialog', { name: /Update .*Podman Desktop.*/ });
   try {
     await playExpect(updateAvailableDialog).toBeVisible({ timeout: 20_000 });
-    const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });
-    await playExpect(cancelButton).toBeVisible();
-    await cancelButton.click();
+    const closeButton = updateAvailableDialog.getByRole('button', { name: 'Close' });
+    await playExpect(closeButton).toBeVisible();
+    await closeButton.click();
     await playExpect(updateAvailableDialog).not.toBeVisible();
   } catch (error) {
     console.log('No update dialog shown, continuing with the test');

--- a/tests/playwright/src/special-specs/installation/update-install.spec.ts
+++ b/tests/playwright/src/special-specs/installation/update-install.spec.ts
@@ -82,11 +82,15 @@ test.describe
       await playExpect(updateAvailableDialog).toBeVisible({ timeout: 20_000 });
       const updateNowButton = updateAvailableDialog.getByRole('button', { name: 'Update Now' });
       await playExpect(updateNowButton).toBeVisible();
-      const doNotshowButton = updateAvailableDialog.getByRole('button', { name: `Don't show again` });
-      await playExpect(doNotshowButton).toBeVisible();
-      const cancelButton = updateAvailableDialog.getByRole('button', { name: 'Cancel' });
-      await playExpect(cancelButton).toBeVisible();
-      await cancelButton.click();
+      const laterDropdownButton = updateAvailableDialog.getByRole('button', { name: 'Later' });
+      await playExpect(laterDropdownButton).toBeVisible();
+      await laterDropdownButton.click();
+      const remindLaterOption = updateAvailableDialog.getByRole('button', { name: 'Remind me later' });
+      await playExpect(remindLaterOption).toBeVisible();
+      const doNotShowAgainOption = updateAvailableDialog.getByRole('button', { name: `Don't show again` });
+      await playExpect(doNotShowAgainOption).toBeVisible();
+      const closeButton = updateAvailableDialog.getByRole('button', { name: 'Close' });
+      await closeButton.click();
       await playExpect(updateAvailableDialog).not.toBeVisible();
       // handle welcome page now
       await welcomePage.handleWelcomePage(true);


### PR DESCRIPTION
The startup "Update Podman Desktop?" dialog shows four buttons (#15960). This PR groups the two dismiss actions, `Remind me later` and `Don't show again`, under a single `Later` dropdown, so the dialog now has three top-level actions: `What's new` / `Later` / `Update now`.

This is a UI-only regrouping. Both options keep the exact behavior they have today:

- `Remind me later` dismisses the dialog and nothing is persisted (it shows again on the next startup).
- `Don't show again` sets `preferences.update.reminder` to `never`.

Because a dropdown cannot be the dialog's cancel button, `cancelId` is no longer set for the startup dialog. Escape and the close button still dismiss it, which is the same as picking `Remind me later`. The status-bar variant of the dialog (`Update now` / `What's new` / `Cancel`) is unchanged.

A note on the "before" screenshot: `MessageBox.svelte` renders whichever button index is `cancelId` as a hard-coded `Cancel` link, so the `Cancel` visible below is the `Remind me later` button from `updater.ts` under a different label.

This PR is the first of two. #18491 builds on top of it (I will update it soon, when this is merged), and adds the behavior change that is left out here, as requested in https://github.com/podman-desktop/podman-desktop/pull/18491#issuecomment-5509428665:

- rename `Remind me later` to `Remind me tomorrow`,
- a new hidden `preferences.update.nextReminderTimestamp` setting, written when that option is picked,
- a 24-hour snooze: the startup prompt stays suppressed until that timestamp has passed,
- tests for the snooze, the startup gate, and the error path when the setting cannot be saved.

### Screenshot / video of UI

Before (four buttons: `Cancel` (= `Remind me later`) / `What's new` / `Don't show again` / `Update now`):

<img width="1104" height="520" alt="image" src="https://github.com/user-attachments/assets/e224e853-460f-4f03-bb0d-f80d3680474d" />

Now (three actions: `What's new` / `Later` dropdown / `Update now`, dropdown open):

<img width="1104" height="584" alt="image" src="https://github.com/user-attachments/assets/31116b70-0b68-4c34-8e1e-bcaaf1861ecc" />

### What issues does this PR fix or reference?

- Part of: #15960
- Prepares: #18491

### How to test this PR?

- [x] Tests are covering the bug fix or the new feature

Unit tests in `updater.spec.ts` cover the new dialog shape, both dropdown options, and the `Update now` / `What's new` paths in the startup context. The `@update-install` E2E spec opens the dropdown and checks both options are present.

Co-Authored-By: Claude <noreply@anthropic.com>