### PR TITLE
test(e2e): update serial declaration - part 10

### DIFF
--- a/tests/playwright/src/specs/build-image-registry-validation.spec.ts
+++ b/tests/playwright/src/specs/build-image-registry-validation.spec.ts
@@ -93,86 +93,86 @@ test.afterEach(async ({ page }) => {
   await deleteImage(page, BASE_IMAGE);
 });
 
-test.describe
-  .serial('Build image registry validation verification', () => {
-    test('Build succeeds with validation disabled and no credentials', async ({ navigationBar }) => {
-      test.setTimeout(120_000);
+test.describe('Build image registry validation verification', () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Build succeeds with validation disabled and no credentials', async ({ navigationBar }) => {
+    test.setTimeout(120_000);
 
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
 
-      const buildImagePage = await imagesPage.openBuildImage();
-      await playExpect(buildImagePage.heading).toBeVisible();
+    const buildImagePage = await imagesPage.openBuildImage();
+    await playExpect(buildImagePage.heading).toBeVisible();
 
-      await playExpect(buildImagePage.registryValidationCheckbox).toBeChecked();
-      await buildImagePage.toggleRegistryValidation(false);
-      await buildImagePage.toggleRegistryValidation(true);
-      await buildImagePage.toggleRegistryValidation(false);
+    await playExpect(buildImagePage.registryValidationCheckbox).toBeChecked();
+    await buildImagePage.toggleRegistryValidation(false);
+    await buildImagePage.toggleRegistryValidation(true);
+    await buildImagePage.toggleRegistryValidation(false);
 
-      const updatedImagesPage = await buildImagePage.buildImage(BUILD_IMAGE_TAG, CONTAINERFILE_PATH, CONTEXT_DIR);
+    const updatedImagesPage = await buildImagePage.buildImage(BUILD_IMAGE_TAG, CONTAINERFILE_PATH, CONTEXT_DIR);
 
-      await playExpect
-        .poll(async () => updatedImagesPage.waitForImageExists(BUILD_IMAGE, 30_000), {
-          timeout: 0,
-        })
-        .toBeTruthy();
-    });
-
-    test('Build succeeds with bad credentials when validation is enabled', async ({ navigationBar }) => {
-      test.setTimeout(120_000);
-
-      let imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      let buildImagePage = await imagesPage.openBuildImage();
-      await playExpect(buildImagePage.heading).toBeVisible();
-
-      await playExpect(buildImagePage.registryValidationCheckbox).toBeChecked();
-
-      await injectInvalidCredentials(TEST_REGISTRY_URL, INVALID_USERNAME, INVALID_PASSWORD);
-      const settingsBar = await navigationBar.openSettings();
-      const registriesPage = await settingsBar.openTabPage(RegistriesPage);
-      await playExpect(registriesPage.heading).toBeVisible();
-      await playExpect
-        .poll(async () => (await registriesPage.getRegistryRowByName(TEST_REGISTRY_DISPLAY_NAME)).isVisible(), {
-          timeout: 30_000,
-        })
-        .toBe(true);
-
-      imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      buildImagePage = await imagesPage.openBuildImage();
-      await playExpect(buildImagePage.heading).toBeVisible();
-
-      await playExpect(buildImagePage.registryValidationCheckbox).toBeChecked();
-
-      const updatedImagesPage = await buildImagePage.buildImage(BUILD_IMAGE_TAG, CONTAINERFILE_PATH, CONTEXT_DIR);
-
-      await playExpect
-        .poll(async () => updatedImagesPage.waitForImageExists(BUILD_IMAGE, 30_000), {
-          timeout: 0,
-        })
-        .toBeTruthy();
-    });
-
-    test('Build fails with bad credentials when validation is disabled', async ({ navigationBar }) => {
-      test.setTimeout(120_000);
-
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const buildImagePage = await imagesPage.openBuildImage();
-      await playExpect(buildImagePage.heading).toBeVisible();
-
-      await buildImagePage.toggleRegistryValidation(false);
-
-      const updatedImagesPage = await buildImagePage.buildImage(BUILD_IMAGE_TAG, CONTAINERFILE_PATH, CONTEXT_DIR);
-
-      await playExpect
-        .poll(async () => await updatedImagesPage.getImageRowByName(BUILD_IMAGE), {
-          timeout: 30_000,
-        })
-        .toBeFalsy();
-    });
+    await playExpect
+      .poll(async () => updatedImagesPage.waitForImageExists(BUILD_IMAGE, 30_000), {
+        timeout: 0,
+      })
+      .toBeTruthy();
   });
+
+  test('Build succeeds with bad credentials when validation is enabled', async ({ navigationBar }) => {
+    test.setTimeout(120_000);
+
+    let imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    let buildImagePage = await imagesPage.openBuildImage();
+    await playExpect(buildImagePage.heading).toBeVisible();
+
+    await playExpect(buildImagePage.registryValidationCheckbox).toBeChecked();
+
+    await injectInvalidCredentials(TEST_REGISTRY_URL, INVALID_USERNAME, INVALID_PASSWORD);
+    const settingsBar = await navigationBar.openSettings();
+    const registriesPage = await settingsBar.openTabPage(RegistriesPage);
+    await playExpect(registriesPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => (await registriesPage.getRegistryRowByName(TEST_REGISTRY_DISPLAY_NAME)).isVisible(), {
+        timeout: 30_000,
+      })
+      .toBe(true);
+
+    imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    buildImagePage = await imagesPage.openBuildImage();
+    await playExpect(buildImagePage.heading).toBeVisible();
+
+    await playExpect(buildImagePage.registryValidationCheckbox).toBeChecked();
+
+    const updatedImagesPage = await buildImagePage.buildImage(BUILD_IMAGE_TAG, CONTAINERFILE_PATH, CONTEXT_DIR);
+
+    await playExpect
+      .poll(async () => updatedImagesPage.waitForImageExists(BUILD_IMAGE, 30_000), {
+        timeout: 0,
+      })
+      .toBeTruthy();
+  });
+
+  test('Build fails with bad credentials when validation is disabled', async ({ navigationBar }) => {
+    test.setTimeout(120_000);
+
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const buildImagePage = await imagesPage.openBuildImage();
+    await playExpect(buildImagePage.heading).toBeVisible();
+
+    await buildImagePage.toggleRegistryValidation(false);
+
+    const updatedImagesPage = await buildImagePage.buildImage(BUILD_IMAGE_TAG, CONTAINERFILE_PATH, CONTEXT_DIR);
+
+    await playExpect
+      .poll(async () => await updatedImagesPage.getImageRowByName(BUILD_IMAGE), {
+        timeout: 30_000,
+      })
+      .toBeFalsy();
+  });
+});

--- a/tests/playwright/src/specs/podman-kube-play-smoke.spec.ts
+++ b/tests/playwright/src/specs/podman-kube-play-smoke.spec.ts
@@ -51,109 +51,109 @@ test.skip(
   'Test is not supported with CDP runner',
 );
 
-test.describe
-  .serial('Podman Kube Play Yaml - Create Pod from Scratch', { tag: '@smoke' }, () => {
-    test.beforeAll(async ({ runner, page, welcomePage }) => {
-      runner.setVideoAndTraceName('podman-kube-play-from-scratch-smoke');
-      await welcomePage.handleWelcomePage(true);
-      await waitForPodmanMachineStartup(page);
-    });
+test.describe('Podman Kube Play Yaml - Create Pod from Scratch', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test.beforeAll(async ({ runner, page, welcomePage }) => {
+    runner.setVideoAndTraceName('podman-kube-play-from-scratch-smoke');
+    await welcomePage.handleWelcomePage(true);
+    await waitForPodmanMachineStartup(page);
+  });
 
-    test.afterAll(async ({ page, runner }) => {
-      try {
-        await deletePod(page, POD_NAME_FROM_SCRATCH);
-        await deleteImage(page, NGINX_IMAGE_NAME);
-      } finally {
-        await runner.close(); // closes the app
-      }
-    });
-
-    test('Create pod and verify it is running ', async ({ page, navigationBar }) => {
-      test.setTimeout(180_000);
-
-      const podsPage = await navigationBar.openPods();
-      const podmanKubePlayPage = await podsPage.openPodmanKubePlay();
-      await podmanKubePlayPage.playYaml({
-        podmanKubePlayOption: PodmanKubePlayOptions.CreateYamlFileFromScratch,
-        jsonResourceDefinition: JSON_RESOURCE_DEFINITION,
-      });
-      await playExpect
-        .poll(async () => await podsPage.podExists(POD_NAME_FROM_SCRATCH), { timeout: 15_000 })
-        .toBeTruthy();
-      const podDetails = await podsPage.openPodDetails(POD_NAME_FROM_SCRATCH);
-      await playExpect.poll(async () => await podDetails.getState(), { timeout: 30_000 }).toBe(PodState.Running);
-
+  test.afterAll(async ({ page, runner }) => {
+    try {
       await deletePod(page, POD_NAME_FROM_SCRATCH);
-      const imagesPage = await navigationBar.openImages();
-      await playExpect
-        .poll(async () => await imagesPage.getCurrentStatusOfImage(NGINX_IMAGE_NAME))
-        .toEqual(ImageState.Unused);
-    });
+      await deleteImage(page, NGINX_IMAGE_NAME);
+    } finally {
+      await runner.close(); // closes the app
+    }
   });
 
-test.describe
-  .serial('Podman Kube Play Yaml - with Build flag', { tag: '@smoke' }, () => {
-    test.skip(!!isCI && isLinux, 'Skipping E2E test on GitHub Actions due to an outdated Podman version');
+  test('Create pod and verify it is running ', async ({ page, navigationBar }) => {
+    test.setTimeout(180_000);
 
-    //restarting the app between suites due to issue: https://github.com/podman-desktop/podman-desktop/issues/14273
-    test.beforeAll(async ({ runner, page, welcomePage }) => {
-      runner.setVideoAndTraceName('podman-kube-play-build-smoke');
-      await welcomePage.handleWelcomePage(true);
-      await waitForPodmanMachineStartup(page);
+    const podsPage = await navigationBar.openPods();
+    const podmanKubePlayPage = await podsPage.openPodmanKubePlay();
+    await podmanKubePlayPage.playYaml({
+      podmanKubePlayOption: PodmanKubePlayOptions.CreateYamlFileFromScratch,
+      jsonResourceDefinition: JSON_RESOURCE_DEFINITION,
     });
+    await playExpect
+      .poll(async () => await podsPage.podExists(POD_NAME_FROM_SCRATCH), { timeout: 15_000 })
+      .toBeTruthy();
+    const podDetails = await podsPage.openPodDetails(POD_NAME_FROM_SCRATCH);
+    await playExpect.poll(async () => await podDetails.getState(), { timeout: 30_000 }).toBe(PodState.Running);
 
-    test.afterAll(async ({ page, runner }) => {
-      try {
-        await deletePod(page, POD_NAME_BUILD_OPTION);
-        await deleteImage(page, LOCAL_IMAGE_NAME);
-        await deleteImage(page, NGINX_IMAGE_NAME);
-      } finally {
-        await runner.close();
-      }
-    });
-    test('Create pod and verify it is running', async ({ navigationBar }) => {
-      test.setTimeout(180_000);
+    await deletePod(page, POD_NAME_FROM_SCRATCH);
+    const imagesPage = await navigationBar.openImages();
+    await playExpect
+      .poll(async () => await imagesPage.getCurrentStatusOfImage(NGINX_IMAGE_NAME))
+      .toEqual(ImageState.Unused);
+  });
+});
 
-      const podsPage = await navigationBar.openPods();
-      await playExpect(podsPage.heading).toBeVisible();
-      const podmanKubePlayPage = await podsPage.openPodmanKubePlay();
-      await playExpect(podmanKubePlayPage.heading).toBeVisible();
+test.describe('Podman Kube Play Yaml - with Build flag', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test.skip(!!isCI && isLinux, 'Skipping E2E test on GitHub Actions due to an outdated Podman version');
 
-      await podmanKubePlayPage.playYaml(
-        { podmanKubePlayOption: PodmanKubePlayOptions.SelectYamlFile, pathToYaml: POD_BUILD_YAML_PATH },
-        true,
-      );
-      await playExpect(podsPage.heading).toBeVisible();
-      await playExpect
-        .poll(async () => await podsPage.podExists(POD_NAME_BUILD_OPTION), { timeout: 40_000 })
-        .toBeTruthy();
-      const podDetails = await podsPage.openPodDetails(POD_NAME_BUILD_OPTION);
-      await playExpect(podDetails.heading).toBeVisible();
-      await playExpect.poll(async () => await podDetails.getState(), { timeout: 15_000 }).toBe(PodState.Running);
-    });
-    test('Verify created pod uses localhost image', async ({ page, navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-      await playExpect
-        .poll(async () => await imagesPage.waitForImageExists(LOCAL_IMAGE_NAME), { timeout: 40_000 })
-        .toBeTruthy();
-      await playExpect
-        .poll(async () => await imagesPage.getCurrentStatusOfImage(LOCAL_IMAGE_NAME), { timeout: 15_000 })
-        .toBe(ImageState.Used);
+  //restarting the app between suites due to issue: https://github.com/podman-desktop/podman-desktop/issues/14273
+  test.beforeAll(async ({ runner, page, welcomePage }) => {
+    runner.setVideoAndTraceName('podman-kube-play-build-smoke');
+    await welcomePage.handleWelcomePage(true);
+    await waitForPodmanMachineStartup(page);
+  });
 
-      const containersPage = await navigationBar.openContainers();
-      await playExpect(containersPage.heading).toBeVisible();
-      await playExpect.poll(async () => containersPage.getContainerImage(CONTAINER_NAME)).toBe(CONTAINER_IMAGE);
-
-      // delete applied pod, check the images now have unused state
+  test.afterAll(async ({ page, runner }) => {
+    try {
       await deletePod(page, POD_NAME_BUILD_OPTION);
-      await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-      await playExpect
-        .poll(async () => await imagesPage.getCurrentStatusOfImage(LOCAL_IMAGE_NAME))
-        .toEqual(ImageState.Unused);
-      await playExpect
-        .poll(async () => await imagesPage.getCurrentStatusOfImage(NGINX_IMAGE_NAME))
-        .toEqual(ImageState.Unused);
-    });
+      await deleteImage(page, LOCAL_IMAGE_NAME);
+      await deleteImage(page, NGINX_IMAGE_NAME);
+    } finally {
+      await runner.close();
+    }
   });
+  test('Create pod and verify it is running', async ({ navigationBar }) => {
+    test.setTimeout(180_000);
+
+    const podsPage = await navigationBar.openPods();
+    await playExpect(podsPage.heading).toBeVisible();
+    const podmanKubePlayPage = await podsPage.openPodmanKubePlay();
+    await playExpect(podmanKubePlayPage.heading).toBeVisible();
+
+    await podmanKubePlayPage.playYaml(
+      { podmanKubePlayOption: PodmanKubePlayOptions.SelectYamlFile, pathToYaml: POD_BUILD_YAML_PATH },
+      true,
+    );
+    await playExpect(podsPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => await podsPage.podExists(POD_NAME_BUILD_OPTION), { timeout: 40_000 })
+      .toBeTruthy();
+    const podDetails = await podsPage.openPodDetails(POD_NAME_BUILD_OPTION);
+    await playExpect(podDetails.heading).toBeVisible();
+    await playExpect.poll(async () => await podDetails.getState(), { timeout: 15_000 }).toBe(PodState.Running);
+  });
+  test('Verify created pod uses localhost image', async ({ page, navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => await imagesPage.waitForImageExists(LOCAL_IMAGE_NAME), { timeout: 40_000 })
+      .toBeTruthy();
+    await playExpect
+      .poll(async () => await imagesPage.getCurrentStatusOfImage(LOCAL_IMAGE_NAME), { timeout: 15_000 })
+      .toBe(ImageState.Used);
+
+    const containersPage = await navigationBar.openContainers();
+    await playExpect(containersPage.heading).toBeVisible();
+    await playExpect.poll(async () => containersPage.getContainerImage(CONTAINER_NAME)).toBe(CONTAINER_IMAGE);
+
+    // delete applied pod, check the images now have unused state
+    await deletePod(page, POD_NAME_BUILD_OPTION);
+    await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+    await playExpect
+      .poll(async () => await imagesPage.getCurrentStatusOfImage(LOCAL_IMAGE_NAME))
+      .toEqual(ImageState.Unused);
+    await playExpect
+      .poll(async () => await imagesPage.getCurrentStatusOfImage(NGINX_IMAGE_NAME))
+      .toEqual(ImageState.Unused);
+  });
+});

--- a/tests/playwright/src/specs/preferences.spec.ts
+++ b/tests/playwright/src/specs/preferences.spec.ts
@@ -30,24 +30,24 @@ test.afterAll(async ({ runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Preferences text persistence validation', { tag: '@macos_sanity' }, () => {
-    test('Check preferences text persistence', async ({ page, navigationBar }) => {
-      //Open Settings/Preferences page
-      const settingsBar = await navigationBar.openSettings();
-      await settingsBar.preferencesTab.click();
+test.describe('Preferences text persistence validation', { tag: '@macos_sanity' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Check preferences text persistence', async ({ page, navigationBar }) => {
+    //Open Settings/Preferences page
+    const settingsBar = await navigationBar.openSettings();
+    await settingsBar.preferencesTab.click();
 
-      //Change kubeconfig path
-      const preferencesPage = new PreferencesPage(page);
-      await playExpect(preferencesPage.heading).toBeVisible();
-      await preferencesPage.kubePathInput.scrollIntoViewIfNeeded();
-      await preferencesPage.selectKubeFile(preferencesTestString);
-      await playExpect(preferencesPage.kubePathInput).toHaveValue(preferencesTestString);
+    //Change kubeconfig path
+    const preferencesPage = new PreferencesPage(page);
+    await playExpect(preferencesPage.heading).toBeVisible();
+    await preferencesPage.kubePathInput.scrollIntoViewIfNeeded();
+    await preferencesPage.selectKubeFile(preferencesTestString);
+    await playExpect(preferencesPage.kubePathInput).toHaveValue(preferencesTestString);
 
-      //Change page and check new kubeconfig path persists
-      await settingsBar.resourcesTab.click();
-      await settingsBar.preferencesTab.click();
-      await playExpect(preferencesPage.heading).toBeVisible();
-      await playExpect(preferencesPage.kubePathInput).toHaveValue(preferencesTestString);
-    });
+    //Change page and check new kubeconfig path persists
+    await settingsBar.resourcesTab.click();
+    await settingsBar.preferencesTab.click();
+    await playExpect(preferencesPage.heading).toBeVisible();
+    await playExpect(preferencesPage.kubePathInput).toHaveValue(preferencesTestString);
   });
+});


### PR DESCRIPTION
## What this PR does / why we need it

Migrate `test.describe.serial(...)` to the recommended `test.describe.configure({ mode: 'serial' })` pattern for 3 more spec files, as part of the incremental cleanup tracked in #15697.

**Files changed:**
- `build-image-registry-validation.spec.ts`
- `podman-kube-play-smoke.spec.ts` (2 blocks)
- `preferences.spec.ts`

## Which issue(s) this PR fixes

Relates to #15697

## Screenshot / video of UI

N/A — test-only change, no UI impact.

> **Tip:** use **Hide whitespace** in the Files changed view to review the actual changes (the diff looks large due to indentation shifts).

## How to test this PR?

No functional changes — the tests themselves are unmodified; only the serial-mode declaration syntax changes. Verify by reviewing the diff with **Hide whitespace** enabled in the GitHub Files changed view.

Made with [Cursor](https://cursor.com)