### PR TITLE
test(e2e): update serial declaration - part 11

### DIFF
--- a/tests/playwright/src/specs/preferred-registry.spec.ts
+++ b/tests/playwright/src/specs/preferred-registry.spec.ts
@@ -44,59 +44,59 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe
-  .serial('Preferred registry settings verification', { tag: '@smoke' }, () => {
-    test('Default search results for fedora are from docker.io', async ({ navigationBar }) => {
-      test.setTimeout(90_000);
+test.describe('Preferred registry settings verification', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Default search results for fedora are from docker.io', async ({ navigationBar }) => {
+    test.setTimeout(90_000);
 
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
 
-      const pullImagePage = await imagesPage.openPullImage();
-      await playExpect(pullImagePage.heading).toBeVisible();
+    const pullImagePage = await imagesPage.openPullImage();
+    await playExpect(pullImagePage.heading).toBeVisible();
 
-      await playExpect
-        .poll(async () => await pullImagePage.getFirstSearchResultFor(imageToSearch, false), { timeout: 10_000 })
-        .toContain('docker.io');
-    });
-
-    test('Add quay.io as preferred registry in front of docker.io', async ({ navigationBar }) => {
-      const settingsBar = await navigationBar.openSettings();
-      const registryPage = await settingsBar.openTabPage(RegistriesPage);
-      await playExpect(registryPage.heading).toBeVisible({ timeout: 10_000 });
-
-      await registryPage.addPreferredRepositories(['quay.io']);
-    });
-
-    test('Search results for fedora are from quay.io after preference change', async ({ navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const pullImagePage = await imagesPage.openPullImage();
-      await playExpect(pullImagePage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => await pullImagePage.getFirstSearchResultFor(imageToSearch, false), { timeout: 10_000 })
-        .toContain('quay.io');
-    });
-
-    test('Revert preferred registry to default docker.io', async ({ navigationBar }) => {
-      const settingsBar = await navigationBar.openSettings();
-      const registryPage = await settingsBar.openTabPage(RegistriesPage);
-      await playExpect(registryPage.heading).toBeVisible({ timeout: 10_000 });
-
-      await registryPage.updatePreferredRepositories(defaultPreferred);
-    });
-
-    test('Search results for fedora are back to docker.io after revert', async ({ navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible();
-
-      const pullImagePage = await imagesPage.openPullImage();
-      await playExpect(pullImagePage.heading).toBeVisible();
-
-      await playExpect
-        .poll(async () => await pullImagePage.getFirstSearchResultFor(imageToSearch, false), { timeout: 10_000 })
-        .toContain('docker.io');
-    });
+    await playExpect
+      .poll(async () => await pullImagePage.getFirstSearchResultFor(imageToSearch, false), { timeout: 10_000 })
+      .toContain('docker.io');
   });
+
+  test('Add quay.io as preferred registry in front of docker.io', async ({ navigationBar }) => {
+    const settingsBar = await navigationBar.openSettings();
+    const registryPage = await settingsBar.openTabPage(RegistriesPage);
+    await playExpect(registryPage.heading).toBeVisible({ timeout: 10_000 });
+
+    await registryPage.addPreferredRepositories(['quay.io']);
+  });
+
+  test('Search results for fedora are from quay.io after preference change', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const pullImagePage = await imagesPage.openPullImage();
+    await playExpect(pullImagePage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await pullImagePage.getFirstSearchResultFor(imageToSearch, false), { timeout: 10_000 })
+      .toContain('quay.io');
+  });
+
+  test('Revert preferred registry to default docker.io', async ({ navigationBar }) => {
+    const settingsBar = await navigationBar.openSettings();
+    const registryPage = await settingsBar.openTabPage(RegistriesPage);
+    await playExpect(registryPage.heading).toBeVisible({ timeout: 10_000 });
+
+    await registryPage.updatePreferredRepositories(defaultPreferred);
+  });
+
+  test('Search results for fedora are back to docker.io after revert', async ({ navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible();
+
+    const pullImagePage = await imagesPage.openPullImage();
+    await playExpect(pullImagePage.heading).toBeVisible();
+
+    await playExpect
+      .poll(async () => await pullImagePage.getFirstSearchResultFor(imageToSearch, false), { timeout: 10_000 })
+      .toContain('docker.io');
+  });
+});

--- a/tests/playwright/src/specs/proxy-smoke.spec.ts
+++ b/tests/playwright/src/specs/proxy-smoke.spec.ts
@@ -43,105 +43,105 @@ test.afterAll(async ({ navigationBar, runner }) => {
   await runner.close();
 });
 
-test.describe
-  .serial('Proxy settings ', { tag: ['@smoke', '@macos_sanity'] }, () => {
-    test.beforeEach(async ({ navigationBar }) => {
-      await navigationBar.openDashboard();
-      const settingsBar = await navigationBar.openSettings();
-      await settingsBar.proxyTab.click();
-      await playExpect(proxyPage.heading).toBeVisible();
-    });
-
-    test('Proxy page assets and System proxy setup', async () => {
-      await playExpect(proxyPage.toggleProxyButton).toBeVisible();
-      await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.System);
-      await playExpect(proxyPage.httpProxy).not.toBeEnabled();
-      await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
-      await playExpect(proxyPage.noProxy).not.toBeEnabled();
-      await playExpect(proxyPage.updateButton).toBeEnabled();
-    });
-
-    test('Manual proxy setup, validation and update', async () => {
-      await proxyPage.selectProxy(ProxyTypes.Manual);
-      await playExpect(proxyPage.httpProxy).toBeEnabled();
-      await playExpect(proxyPage.httpsProxy).toBeEnabled();
-      await playExpect(proxyPage.noProxy).toBeEnabled();
-      // validation for http proxy input
-      await proxyPage.fillHttpProxy(invalidProxyUrl);
-      await playExpect(proxyPage.proxyAlert).toBeVisible();
-      await playExpect(proxyPage.proxyAlert).toContainText(`value ${invalidProxyUrl} should be an URL`, {
-        ignoreCase: true,
-      });
-      await proxyPage.fillHttpProxy(httpProxyUrl);
-      await playExpect(proxyPage.proxyAlert).not.toBeVisible();
-      // validation for https proxy input
-      await proxyPage.fillHttpsProxy(invalidProxyUrl);
-      await playExpect(proxyPage.proxyAlert).toBeVisible();
-      await playExpect(proxyPage.proxyAlert).toContainText(`value ${invalidProxyUrl} should be an URL`, {
-        ignoreCase: true,
-      });
-      await proxyPage.fillHttpsProxy(httpsProxyUrl);
-      await playExpect(proxyPage.proxyAlert).not.toBeVisible();
-      // check domains for no proxy
-      await proxyPage.fillNoProxy(hostsDomains);
-      await proxyPage.updateProxySettings();
-    });
-
-    test('Proxy settings persists when proxy page is switched', async () => {
-      // given that we always switch to dashboard and back to the proxy page in before each hook
-      // we should check previous test setup - manual proxy
-      await playExpect(proxyPage.toggleProxyButton).toBeVisible();
-      await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.Manual);
-      await playExpect(proxyPage.httpProxy).toBeEnabled();
-      await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
-      await playExpect(proxyPage.httpsProxy).toBeEnabled();
-      await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
-      await playExpect(proxyPage.noProxy).toBeEnabled();
-      await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
-    });
-
-    test('Disabled proxy setup', async () => {
-      await proxyPage.selectProxy(ProxyTypes.Disabled);
-      await playExpect(proxyPage.httpProxy).not.toBeEnabled();
-      await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
-      await playExpect(proxyPage.noProxy).not.toBeEnabled();
-      await playExpect(proxyPage.updateButton).toBeEnabled();
-      await proxyPage.updateProxySettings();
-    });
-
-    test('Re-enabled Manual proxy settings persisted', async () => {
-      await proxyPage.selectProxy(ProxyTypes.Disabled);
-      await playExpect(proxyPage.httpProxy).not.toBeEnabled();
-      await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
-      await playExpect(proxyPage.noProxy).not.toBeEnabled();
-
-      await proxyPage.selectProxy(ProxyTypes.Manual);
-      await playExpect(proxyPage.httpProxy).toBeEnabled();
-      await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
-      await playExpect(proxyPage.httpsProxy).toBeEnabled();
-      await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
-      await playExpect(proxyPage.noProxy).toBeEnabled();
-      await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
-    });
-
-    test('System proxy preserves manual values for re-use', async ({ navigationBar }) => {
-      await proxyPage.selectProxy(ProxyTypes.System);
-      await proxyPage.updateProxySettings();
-      await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.System);
-      await playExpect(proxyPage.httpProxy).not.toBeEnabled();
-      await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
-      await playExpect(proxyPage.noProxy).not.toBeEnabled();
-      // navigate away and back to verify persistence
-      await navigationBar.openDashboard();
-      const settingsBar = await navigationBar.openSettings();
-      await settingsBar.proxyTab.click();
-      await playExpect(proxyPage.heading).toBeVisible();
-      // manual proxy values are preserved in System mode for easy re-enablement
-      await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
-      await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
-      await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
-      await playExpect(proxyPage.httpProxy).not.toBeEnabled();
-      await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
-      await playExpect(proxyPage.noProxy).not.toBeEnabled();
-    });
+test.describe('Proxy settings ', { tag: ['@smoke', '@macos_sanity'] }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test.beforeEach(async ({ navigationBar }) => {
+    await navigationBar.openDashboard();
+    const settingsBar = await navigationBar.openSettings();
+    await settingsBar.proxyTab.click();
+    await playExpect(proxyPage.heading).toBeVisible();
   });
+
+  test('Proxy page assets and System proxy setup', async () => {
+    await playExpect(proxyPage.toggleProxyButton).toBeVisible();
+    await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.System);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+    await playExpect(proxyPage.updateButton).toBeEnabled();
+  });
+
+  test('Manual proxy setup, validation and update', async () => {
+    await proxyPage.selectProxy(ProxyTypes.Manual);
+    await playExpect(proxyPage.httpProxy).toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).toBeEnabled();
+    await playExpect(proxyPage.noProxy).toBeEnabled();
+    // validation for http proxy input
+    await proxyPage.fillHttpProxy(invalidProxyUrl);
+    await playExpect(proxyPage.proxyAlert).toBeVisible();
+    await playExpect(proxyPage.proxyAlert).toContainText(`value ${invalidProxyUrl} should be an URL`, {
+      ignoreCase: true,
+    });
+    await proxyPage.fillHttpProxy(httpProxyUrl);
+    await playExpect(proxyPage.proxyAlert).not.toBeVisible();
+    // validation for https proxy input
+    await proxyPage.fillHttpsProxy(invalidProxyUrl);
+    await playExpect(proxyPage.proxyAlert).toBeVisible();
+    await playExpect(proxyPage.proxyAlert).toContainText(`value ${invalidProxyUrl} should be an URL`, {
+      ignoreCase: true,
+    });
+    await proxyPage.fillHttpsProxy(httpsProxyUrl);
+    await playExpect(proxyPage.proxyAlert).not.toBeVisible();
+    // check domains for no proxy
+    await proxyPage.fillNoProxy(hostsDomains);
+    await proxyPage.updateProxySettings();
+  });
+
+  test('Proxy settings persists when proxy page is switched', async () => {
+    // given that we always switch to dashboard and back to the proxy page in before each hook
+    // we should check previous test setup - manual proxy
+    await playExpect(proxyPage.toggleProxyButton).toBeVisible();
+    await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.Manual);
+    await playExpect(proxyPage.httpProxy).toBeEnabled();
+    await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
+    await playExpect(proxyPage.httpsProxy).toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
+    await playExpect(proxyPage.noProxy).toBeEnabled();
+    await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
+  });
+
+  test('Disabled proxy setup', async () => {
+    await proxyPage.selectProxy(ProxyTypes.Disabled);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+    await playExpect(proxyPage.updateButton).toBeEnabled();
+    await proxyPage.updateProxySettings();
+  });
+
+  test('Re-enabled Manual proxy settings persisted', async () => {
+    await proxyPage.selectProxy(ProxyTypes.Disabled);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+
+    await proxyPage.selectProxy(ProxyTypes.Manual);
+    await playExpect(proxyPage.httpProxy).toBeEnabled();
+    await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
+    await playExpect(proxyPage.httpsProxy).toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
+    await playExpect(proxyPage.noProxy).toBeEnabled();
+    await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
+  });
+
+  test('System proxy preserves manual values for re-use', async ({ navigationBar }) => {
+    await proxyPage.selectProxy(ProxyTypes.System);
+    await proxyPage.updateProxySettings();
+    await playExpect(proxyPage.toggleProxyButton).toHaveText(ProxyTypes.System);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+    // navigate away and back to verify persistence
+    await navigationBar.openDashboard();
+    const settingsBar = await navigationBar.openSettings();
+    await settingsBar.proxyTab.click();
+    await playExpect(proxyPage.heading).toBeVisible();
+    // manual proxy values are preserved in System mode for easy re-enablement
+    await playExpect(proxyPage.httpProxy).toHaveValue(httpProxyUrl);
+    await playExpect(proxyPage.httpsProxy).toHaveValue(httpsProxyUrl);
+    await playExpect(proxyPage.noProxy).toHaveValue(hostsDomains);
+    await playExpect(proxyPage.httpProxy).not.toBeEnabled();
+    await playExpect(proxyPage.httpsProxy).not.toBeEnabled();
+    await playExpect(proxyPage.noProxy).not.toBeEnabled();
+  });
+});

--- a/tests/playwright/src/specs/registry-image.spec.ts
+++ b/tests/playwright/src/specs/registry-image.spec.ts
@@ -53,53 +53,54 @@ test.afterAll(async ({ runner, page }) => {
   }
 });
 
-test.describe
-  .serial('Pulling image from authenticated registry workflow verification', { tag: '@smoke' }, () => {
-    test('Cannot pull image from unauthenticated registry', async ({ page, navigationBar }) => {
-      const imagesPage = await navigationBar.openImages();
-      await playExpect(imagesPage.heading).toBeVisible({ timeout: 10_000 });
+test.describe('Pulling image from authenticated registry workflow verification', { tag: '@smoke' }, () => {
+  test.describe.configure({ mode: 'serial' });
+  test('Cannot pull image from unauthenticated registry', async ({ page, navigationBar }) => {
+    const imagesPage = await navigationBar.openImages();
+    await playExpect(imagesPage.heading).toBeVisible({ timeout: 10_000 });
 
-      const fullImageTitle = imageUrl.concat(':' + imageTag);
-      const errorAlert = page.getByLabel('Error Message Content');
+    const fullImageTitle = imageUrl.concat(':' + imageTag);
+    const errorAlert = page.getByLabel('Error Message Content');
 
-      const pullImagePage = await imagesPage.openPullImage();
-      await playExpect(pullImagePage.heading).toBeVisible({ timeout: 10_000 });
+    const pullImagePage = await imagesPage.openPullImage();
+    await playExpect(pullImagePage.heading).toBeVisible({ timeout: 10_000 });
 
-      await pullImagePage.imageNameInput.pressSequentially(fullImageTitle, { delay: 25 });
-      await playExpect(pullImagePage.imageNameInput).toHaveValue(fullImageTitle);
-      await playExpect(pullImagePage.pullImageButton).toBeEnabled();
-      await pullImagePage.pullImageButton.click();
+    await pullImagePage.imageNameInput.pressSequentially(fullImageTitle, { delay: 25 });
+    await playExpect(pullImagePage.imageNameInput).toHaveValue(fullImageTitle);
+    await playExpect(pullImagePage.pullImageButton).toBeEnabled();
+    await pullImagePage.pullImageButton.click();
 
-      await playExpect(errorAlert).toBeVisible({ timeout: 30_000 });
-      await playExpect(errorAlert).toContainText('Error while pulling image from');
-      await playExpect(errorAlert).toContainText(fullImageTitle);
-      await playExpect(errorAlert).toContainText('Can also be that the registry requires authentication');
+    await playExpect(errorAlert).toBeVisible({ timeout: 30_000 });
+    await playExpect(errorAlert).toContainText('Error while pulling image from');
+    await playExpect(errorAlert).toContainText(fullImageTitle);
+    await playExpect(errorAlert).toContainText('Can also be that the registry requires authentication');
+  });
+
+  test.describe(() => {
+    test.describe.configure({ mode: 'serial' });
+    test.skip(!canTestRegistry(), 'Registry tests are disabled');
+
+    test('Add registry', async ({ page, navigationBar }) => {
+      await navigationBar.openSettings();
+      const settingsBar = new SettingsBar(page);
+      const registryPage = await settingsBar.openTabPage(RegistriesPage);
+      await playExpect(registryPage.heading).toBeVisible({ timeout: 10_000 });
+      await registryPage.createRegistry(registryUrl, registryUsername, registryPswdSecret);
+
+      const registryBox = registryPage.registriesTable.getByLabel('GitHub');
+      const username = registryBox.getByText(registryUsername);
+      await playExpect(username).toBeVisible({ timeout: 15_000 });
     });
 
-    test.describe.serial(() => {
-      test.skip(!canTestRegistry(), 'Registry tests are disabled');
+    test('Image pulling from authenticated registry verification', async ({ navigationBar }) => {
+      const imagesPage = await navigationBar.openImages();
 
-      test('Add registry', async ({ page, navigationBar }) => {
-        await navigationBar.openSettings();
-        const settingsBar = new SettingsBar(page);
-        const registryPage = await settingsBar.openTabPage(RegistriesPage);
-        await playExpect(registryPage.heading).toBeVisible({ timeout: 10_000 });
-        await registryPage.createRegistry(registryUrl, registryUsername, registryPswdSecret);
+      const fullImageTitle = imageUrl.concat(`:${imageTag}`);
+      const pullImagePage = await imagesPage.openPullImage();
+      const updatedImages = await pullImagePage.pullImage(fullImageTitle);
 
-        const registryBox = registryPage.registriesTable.getByLabel('GitHub');
-        const username = registryBox.getByText(registryUsername);
-        await playExpect(username).toBeVisible({ timeout: 15_000 });
-      });
-
-      test('Image pulling from authenticated registry verification', async ({ navigationBar }) => {
-        const imagesPage = await navigationBar.openImages();
-
-        const fullImageTitle = imageUrl.concat(`:${imageTag}`);
-        const pullImagePage = await imagesPage.openPullImage();
-        const updatedImages = await pullImagePage.pullImage(fullImageTitle);
-
-        const exists = await updatedImages.waitForImageExists(imageUrl);
-        playExpect(exists, fullImageTitle + ' image not present in the list of images').toBeTruthy();
-      });
+      const exists = await updatedImages.waitForImageExists(imageUrl);
+      playExpect(exists, fullImageTitle + ' image not present in the list of images').toBeTruthy();
     });
   });
+});


### PR DESCRIPTION
## What this PR does / why we need it

Migrate `test.describe.serial(...)` to the recommended `test.describe.configure({ mode: 'serial' })` pattern for 3 more spec files, as part of the incremental cleanup tracked in #15697.

**Files changed:**
- `preferred-registry.spec.ts`
- `proxy-smoke.spec.ts`
- `registry-image.spec.ts` (outer block + nested anonymous block)

## Which issue(s) this PR fixes

Relates to #15697

## Screenshot / video of UI

N/A — test-only change, no UI impact.

> **Tip:** use **Hide whitespace** in the Files changed view to review the actual changes (the diff looks large due to indentation shifts).

## How to test this PR?

No functional changes — the tests themselves are unmodified; only the serial-mode declaration syntax changes. Verify by reviewing the diff with **Hide whitespace** enabled in the GitHub Files changed view.

Made with [Cursor](https://cursor.com)