### PR TITLE
fix(renderer): welcome page onboarding checkboxes

### DIFF
--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -166,6 +166,39 @@ test('Expect welcome screen to show three checked onboarding providers', async (
   expect(checkbox3).toBeChecked();
 });
 
+test('Expect unchecking an onboarding provider to survive a providerInfos refresh', async () => {
+  onboardingList.set([
+    {
+      extension: 'id',
+      removable: true,
+      title: 'onboarding',
+      name: 'foobar1',
+      displayName: 'FooBar1',
+      icon: 'data:image/png;base64,foobar1',
+      steps: [],
+      enablement: 'true',
+    },
+  ]);
+  providerInfos.set([]);
+
+  await waitRender({ showWelcome: true });
+
+  const checkbox = screen.getByRole('checkbox', { name: 'FooBar1 checkbox' });
+  expect(checkbox).toBeChecked();
+
+  await fireEvent.click(checkbox);
+  expect(checkbox).not.toBeChecked();
+  expect(screen.queryByRole('button', { name: 'Start onboarding' })).not.toBeInTheDocument();
+
+  // providers emit whenever a provider status changes or an extension starts/stops, which
+  // recomputes the sorted list; the user's choice must not be reset
+  providerInfos.set([]);
+  await tick();
+
+  expect(checkbox).not.toBeChecked();
+  expect(screen.queryByRole('button', { name: 'Start onboarding' })).not.toBeInTheDocument();
+});
+
 test('Make sure the provider with name podman appears first even if its 2nd in the list', async () => {
   providerInfos.set([
     {

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -3,6 +3,7 @@ import type { WelcomeMessages } from '@podman-desktop/core-api';
 import { Button, Checkbox, Tooltip } from '@podman-desktop/ui-svelte';
 import { Icon } from '@podman-desktop/ui-svelte/icons';
 import { onMount } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import { router } from 'tinro';
 
 import DesktopIcon from '/@/lib/images/DesktopIcon.svelte';
@@ -25,8 +26,15 @@ let podmanDesktopVersion = $state<string>();
 
 let welcomeMessages = $state<WelcomeMessages>();
 
+// User selection is kept outside of the derived value below: the derived is recomputed on every
+// onboardingList/providerInfos emission (a provider status change or an extension starting is
+// enough), which would otherwise discard whatever the user checked or unchecked
+const selectionOverrides = new SvelteMap<string, boolean>();
+
 let onboardingProviders: OnboardingInfoWithAdditionalInfo[] = $derived(
-  welcomeUtils.getSortedOnboardingExtensions($onboardingList, $providerInfos),
+  welcomeUtils
+    .getSortedOnboardingExtensions($onboardingList, $providerInfos)
+    .map(provider => ({ ...provider, selected: selectionOverrides.get(provider.name) ?? provider.selected })),
 );
 
 onMount(async () => {
@@ -43,14 +51,8 @@ async function closeWelcome(): Promise<void> {
 
 // Function to toggle provider selection
 function toggleOnboardingSelection(providerName: string): void {
-  // Go through providers, find the provider name and toggle the selected value
-  // then update providers
-  onboardingProviders = onboardingProviders.map(provider => {
-    if (provider.name === providerName) {
-      provider.selected = !provider.selected;
-    }
-    return provider;
-  });
+  const current = onboardingProviders.find(provider => provider.name === providerName)?.selected ?? true;
+  selectionOverrides.set(providerName, !current);
 }
 
 function startOnboardingQueue(): void {
@@ -105,7 +107,7 @@ function startOnboardingQueue(): void {
                   <Checkbox
                     title="{onboarding.displayName} checkbox"
                     name="{onboarding.displayName} checkbox"
-                    bind:checked={onboarding.selected}
+                    checked={onboarding.selected}
                     on:click={(): void => toggleOnboardingSelection(onboarding.name)}
                     class="text-xl" />
                 </div>


### PR DESCRIPTION
### What does this PR do?

Fixes the onboarding extension checkboxes on the Welcome page. Unchecking an extension was silently reverted, so the selection was just reseted back to `true` each time.

**Root cause**: the selection was stored inside a value that gets rebuilt from the stores. `WelcomeUtils.getSortedOnboardingExtensions()` is a function that returns brand-new objects with `selected: true` as the default. The component **derived** its list from it - hence reverted the selection to true, right after it was changed. 

Also adds an unit test that checks if the change of checkbox state is persistent, so this bug would be caught in the future.

### Screenshot / video of UI

https://github.com/user-attachments/assets/0fd6589c-b232-4875-94af-75b0d0fcee1b

The added unit test before the fix:
<img width="896" height="533" alt="Screenshot 2026-09-11 at 13 21 34" src="https://github.com/user-attachments/assets/f501e11a-e650-4870-96bb-2089622de992" />

The added unit test after the fix:
<img width="439" height="90" alt="Screenshot 2026-09-11 at 13 24 04" src="https://github.com/user-attachments/assets/8a01d41f-c2fc-4093-991f-ed323dedaed9" />

### What issues does this PR fix or reference?

Fixes https://github.com/podman-desktop/podman-desktop/issues/19196

### How to test this PR?

1. Run from the developer console: 
```js
await resetOnboarding(["podman-desktop.compose", "podman-desktop.kubectl-cli", "podman-desktop.podman"]);
await updateConfigurationValue("welcome.version", "");
location.reload();
```

2. Try to uncheck any of the three onboarding extension checkboxes.
3. Clicking changes the checkbox state and if there is none checked, "Start onboarding" button should not be seen.

- [X] Tests are covering the bug fix or the new feature
