### PR TITLE
refactor(renderer): use OnboardingExtensionCard in WelcomePage 

### DIFF
--- a/packages/renderer/src/lib/onboarding/wizard/OnboardingExtensionCard.svelte
+++ b/packages/renderer/src/lib/onboarding/wizard/OnboardingExtensionCard.svelte
@@ -48,7 +48,7 @@ function handleKeydown(event: KeyboardEvent): void {
 
   {#if icon}
     <div aria-hidden="true" class="shrink-0">
-      <Icon icon={icon} class="h-10 w-10" />
+      <Icon icon={icon} class="h-10 w-10" title="{displayName} logo" />
     </div>
   {/if}
 

--- a/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
+++ b/packages/renderer/src/lib/welcome/WelcomePage.spec.ts
@@ -140,28 +140,28 @@ test('Expect welcome screen to show three checked onboarding providers', async (
   }
 
   // Check that the logos for foobar1, foobar2, and foobar3 are present
-  const image1 = screen.getByRole('img', { name: 'foobar1 logo' });
+  const image1 = screen.getByRole('img', { name: 'FooBar1 logo', hidden: true });
   expect(image1).toBeInTheDocument();
   expect(image1).toHaveAttribute('src', 'data:image/png;base64,foobar1');
 
-  const image2 = screen.getByRole('img', { name: 'foobar2 logo' });
+  const image2 = screen.getByRole('img', { name: 'FooBar2 logo', hidden: true });
   expect(image2).toBeInTheDocument();
   expect(image2).toHaveAttribute('src', 'data:image/png;base64,foobar2');
 
-  const image3 = screen.getByRole('img', { name: 'foobar3 logo' });
+  const image3 = screen.getByRole('img', { name: 'FooBar3 logo', hidden: true });
   expect(image3).toBeInTheDocument();
   expect(image3).toHaveAttribute('src', 'data:image/png;base64,foobar3');
 
   // Check that all three are checked as well
-  const checkbox1 = screen.getByRole('checkbox', { name: 'FooBar1 checkbox' });
+  const checkbox1 = screen.getByRole('checkbox', { name: 'FooBar1:' });
   expect(checkbox1).toBeInTheDocument();
   expect(checkbox1).toBeChecked();
 
-  const checkbox2 = screen.getByRole('checkbox', { name: 'FooBar2 checkbox' });
+  const checkbox2 = screen.getByRole('checkbox', { name: 'FooBar2:' });
   expect(checkbox2).toBeInTheDocument();
   expect(checkbox2).toBeChecked();
 
-  const checkbox3 = screen.getByRole('checkbox', { name: 'FooBar3 checkbox' });
+  const checkbox3 = screen.getByRole('checkbox', { name: 'FooBar3:' });
   expect(checkbox3).toBeInTheDocument();
   expect(checkbox3).toBeChecked();
 });
@@ -183,7 +183,7 @@ test('Expect unchecking an onboarding provider to survive a providerInfos refres
 
   await waitRender({ showWelcome: true });
 
-  const checkbox = screen.getByRole('checkbox', { name: 'FooBar1 checkbox' });
+  const checkbox = screen.getByRole('checkbox', { name: 'FooBar1:' });
   expect(checkbox).toBeChecked();
 
   await fireEvent.click(checkbox);

--- a/packages/renderer/src/lib/welcome/WelcomePage.svelte
+++ b/packages/renderer/src/lib/welcome/WelcomePage.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 import type { WelcomeMessages } from '@podman-desktop/core-api';
-import { Button, Checkbox, Tooltip } from '@podman-desktop/ui-svelte';
-import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { Button } from '@podman-desktop/ui-svelte';
 import { onMount } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { router } from 'tinro';
 
 import DesktopIcon from '/@/lib/images/DesktopIcon.svelte';
 import OnboardingWelcomeTelemetry from '/@/lib/onboarding/OnboardingWelcomeTelemetry.svelte';
+import OnboardingExtensionCard from '/@/lib/onboarding/wizard/OnboardingExtensionCard.svelte';
 import { onboardingList } from '/@/stores/onboarding';
 import { providerInfos } from '/@/stores/providers';
 
@@ -86,31 +86,12 @@ function startOnboardingQueue(): void {
             </div>
             <div aria-label="providerList" class="grid grid-cols-3 gap-3">
               {#each onboardingProviders as onboarding, index (index)}
-                <div
-                  class="rounded-md bg-[var(--pd-content-card-bg)] flex flex-row justify-between border-2 p-4 {onboarding.selected
-                    ? 'border-[var(--pd-content-card-border-selected)]'
-                    : 'border-[var(--pd-content-card-border)]'}">
-                  <div class="place-items-top flex flex-col flex-1">
-                    <div class="flex flex-row place-items-left flex-1">
-                      {#if onboarding.icon}
-                        <Icon icon={onboarding.icon} class="max-h-12 h-auto w-auto" title="{onboarding.name} logo" />
-                      {/if}
-                      <div
-                        class="flex flex-1 mx-2 underline decoration-2 decoration-dotted underline-offset-2 cursor-default justify-left text-capitalize">
-                        <Tooltip top tip={onboarding.description}>
-                          {onboarding.displayName}
-                        </Tooltip>
-                      </div>
-                    </div>
-                  </div>
-
-                  <Checkbox
-                    title="{onboarding.displayName} checkbox"
-                    name="{onboarding.displayName} checkbox"
-                    checked={onboarding.selected}
-                    on:click={(): void => toggleOnboardingSelection(onboarding.name)}
-                    class="text-xl" />
-                </div>
+                <OnboardingExtensionCard
+                  icon={onboarding.icon}
+                  displayName={onboarding.displayName}
+                  description={onboarding.description}
+                  checked={onboarding.selected ?? true}
+                  onToggle={(): void => toggleOnboardingSelection(onboarding.name)} />
               {/each}
             </div>
           </div>


### PR DESCRIPTION

### What does this PR do?

This PR is a step of the cosmetic changes in the Onboarding flow. It replace inline card markup with the new OnboardingExtensionCard component. Later we will display them vertically.

### Screenshot / video of UI

Before:

<img width="1159" height="800" alt="Screenshot 2026-09-11 at 14 21 06" src="https://github.com/user-attachments/assets/a26d1e37-b324-4c50-8b2b-15cbdd119a39" />

After:

<img width="1159" height="800" alt="Screenshot 2026-09-11 at 14 20 38" src="https://github.com/user-attachments/assets/e4147450-a750-47f0-850a-5629f8fabf71" />


<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

Relates to: https://github.com/podman-desktop/podman-desktop/issues/17465

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?


```js
window.updateConfigurationValue('telemetry.check', false, 'DEFAULT')
await resetOnboarding(['podman-desktop.compose', 'podman-desktop.kubectl-cli', 'podman-desktop.podman']);
await updateConfigurationValue('welcome.version', '');
location.reload();
```

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
