### PR TITLE
fix: resolve GHSA-w27v-7q3p-w38r in svgo

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ overrides:
   webpack-dev-server: '>=5.2.6'
   '@babel/core': '>=7.29.6 <8.0.0'
   websocket-driver: '>=0.7.5'
-  svgo: '>=3.3.4 <4.0.0'
+  svgo: '>=3.3.5 <4.0.0'
   body-parser: '>=2.3.0'
   builder-util-runtime: '>=9.7.0'
   postcss: '>=8.5.18'
@@ -11607,8 +11607,8 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
-  svgo@3.3.4:
-    resolution: {integrity: sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==}
+  svgo@3.3.5:
+    resolution: {integrity: sha512-8SQMzdrvWaD8deUmrnYB+ASyxBVgWUOilg+A75nE/76WdLpj6LopCwiAVvkzkcqy/9b7t2Mg7faFLjg0ZRcZ3w==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -16981,7 +16981,7 @@ snapshots:
       '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       cosmiconfig: 8.3.6(typescript@6.0.3)
       deepmerge: 4.3.1
-      svgo: 3.3.4
+      svgo: 3.3.5
     transitivePeerDependencies:
       - typescript
 
@@ -23729,7 +23729,7 @@ snapshots:
     dependencies:
       postcss: 8.5.28
       postcss-value-parser: 4.2.0
-      svgo: 3.3.4
+      svgo: 3.3.5
 
   postcss-unique-selectors@6.0.4(postcss@8.5.28):
     dependencies:
@@ -25077,7 +25077,7 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svgo@3.3.4:
+  svgo@3.3.5:
     dependencies:
       commander: 7.2.0
       css-select: 5.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,7 +67,7 @@ overrides:
   webpack-dev-server: '>=5.2.6'
   '@babel/core': '>=7.29.6 <8.0.0'
   websocket-driver: '>=0.7.5'
-  svgo: '>=3.3.4 <4.0.0'
+  svgo: '>=3.3.5 <4.0.0'
   body-parser: '>=2.3.0'
   builder-util-runtime: '>=9.7.0'
   postcss: '>=8.5.18'


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-w27v-7q3p-w38r in `svgo`.

**Advisory**: SVGO: removeScripts allows executable links through namespace and control-character bypasses
**Vulnerable versions**: >=3.0.0 <3.3.5
**Patched versions**: >=3.3.5
**Advisory URL**: https://github.com/advisories/GHSA-w27v-7q3p-w38r

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-w27v-7q3p-w38r: _SVGO: removeScripts allows executable links through namespace and control-character bypasses_

### How to test this PR?

Run `pnpm audit` and verify GHSA-w27v-7q3p-w38r is no longer reported