### PR TITLE
feat(preferences): render explicit configuration display names

### DIFF
--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts
@@ -86,6 +86,21 @@ test('record should have short title by default', async () => {
   });
 });
 
+test.each(['short', 'full'] as const)('displayName overrides the %s title and follows record updates', async title => {
+  const record = { ...EXPERIMENTAL_RECORD, displayName: 'Path to Podman Binary' };
+  const { getByText, queryByText, rerender } = render(PreferencesRenderingItem, { record, title });
+
+  expect(getByText('Path to Podman Binary')).toHaveClass('font-semibold');
+
+  await rerender({ record: { ...record, displayName: 'Binary location' }, title });
+  expect(getByText('Binary location')).toHaveClass('font-semibold');
+  expect(queryByText('Path to Podman Binary')).not.toBeInTheDocument();
+
+  await rerender({ record: EXPERIMENTAL_RECORD, title });
+  expect(getByText(title === 'short' ? 'Foo Bar' : 'Hello world foo Bar')).toHaveClass('font-semibold');
+  expect(queryByText('Binary location')).not.toBeInTheDocument();
+});
+
 test('props title full should use full record id', async () => {
   const { getByText } = render(PreferencesRenderingItem, {
     record: EXPERIMENTAL_RECORD,

--- a/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
+++ b/packages/renderer/src/lib/preferences/PreferencesRenderingItem.svelte
@@ -49,7 +49,7 @@ const recordUI = $derived.by(() => {
   const breadCrumbUI = breadCrumb.replace(/\./g, ' > ').concat(':');
 
   return {
-    title: startCase(key),
+    title: record.displayName ?? startCase(key),
     breadCrumb: breadCrumbUI,
     description: record.description,
     markdownDescription: record.markdownDescription,


### PR DESCRIPTION
### What does this PR do?

Use a configuration property's optional `displayName` as its preference title. Without it, keep the existing title derived from the setting key. Setting identity, saved values and reset behavior are unchanged.

This is the renderer-only follow-up to merged schema/API PR #19186, following the split requested in #18546. Podman extension adoption remains separate.

### Screenshot / video of UI

[Screenshot from native Windows verification](https://github.com/podman-desktop/podman-desktop/pull/19203#issuecomment-5672967623). It shows a test-only extension with one explicit label and one fallback-only setting. The fixture is not part of this PR.

### What issues does this PR fix or reference?

References #3847 and #18546. This does not close #3847 before the extension-adoption follow-up.

### How to test this PR?

```sh
pnpm exec vitest run packages/renderer/src/lib/preferences/PreferencesRenderingItem.spec.ts --maxWorkers=2 --retry=0
```

All 10 component tests pass. The two added cases cover short/full titles, reactive label updates and fallback when the label is removed. Both fail on unchanged production code, and fail again when the one-line fix is removed.

Native Windows verification with Node 24.19.0 and pnpm 11.15.1:

- Preferences and schema/manifest modules: 498 passed, 2 existing skips.
- Full build, typecheck, lint, formatting and normal commit hooks passed; existing warnings remain.
- Real Electron acceptance passed using a no-op development-extension fixture and isolated settings: explicit label, fallback title, unchanged input/storage key, saved value after navigation, and reset to default.

To reproduce manually, load a development extension defining a string setting with `displayName` and one without it. Open Settings > Preferences > that extension. Verify the explicit label and generated fallback, edit the value, navigate away and back, and reset it. The original configuration key must remain unchanged.

Full `pnpm run test:unit --maxWorkers=2 --retry=0`: 7,054 passed, 3 failed, 9 skipped. The three final failures (navigation tab-history and ComposeDetails RUNNING/STOPPED) also fail with unchanged production code. The unchanged-production full run had those three plus the two new expected missing-label failures (7,052 passed, 5 failed, 9 skipped).

An earlier full run also failed a ContainerList search assertion; it passed in paired focused checks, the full baseline and the final full run. Its cause is not established, so this is not a claim that the whole repository is failure-free. All new renderer tests pass.

The Electron debugger launcher failed before UI assertions on unchanged code too. A standard Electron launch with local CDP attachment reached the real application and passed the acceptance check; no sandbox settings were weakened. Container-engine, screen-reader and other-platform tests are not claimed for this title-only change.

- [x] Tests cover the new behavior.

AI assistance was used for implementation, tests and review.
